### PR TITLE
Merge fix-f-drive-parity: single-pass MFT pipeline matching C++ architecture

### DIFF
--- a/crates/uffs-mft/src/commands/load.rs
+++ b/crates/uffs-mft/src/commands/load.rs
@@ -244,8 +244,15 @@ pub fn cmd_load(
         println!("🔨 BUILDING MFTINDEX...");
 
         let build_start = Instant::now();
-        let index = MftReader::load_raw_to_index_with_options(input, &data_load_options)
-            .with_context(|| format!("Failed to build index from {}", input.display()))?;
+        // Use new direct-to-index parser by default, legacy multi-pass with env var
+        let index = if std::env::var("UFFS_LEGACY_PARSE").is_ok() {
+            println!("  Using legacy multi-pass parser (UFFS_LEGACY_PARSE=1)");
+            MftReader::load_raw_to_index_with_options(input, &data_load_options)
+                .with_context(|| format!("Failed to build index from {}", input.display()))?
+        } else {
+            MftReader::load_raw_to_index_direct(input, &data_load_options)
+                .with_context(|| format!("Failed to build index from {}", input.display()))?
+        };
         let build_time = build_start.elapsed();
 
         println!();
@@ -436,8 +443,15 @@ pub fn cmd_load(
 
     // Build MftIndex (includes tree metrics computation)
     let build_start = Instant::now();
-    let index = MftReader::load_raw_to_index_with_options(input, &data_load_options)
-        .with_context(|| format!("Failed to build index from {}", input.display()))?;
+    // Use new direct-to-index parser by default, legacy multi-pass with env var
+    let index = if std::env::var("UFFS_LEGACY_PARSE").is_ok() {
+        println!("  Using legacy multi-pass parser (UFFS_LEGACY_PARSE=1)");
+        MftReader::load_raw_to_index_with_options(input, &data_load_options)
+            .with_context(|| format!("Failed to build index from {}", input.display()))?
+    } else {
+        MftReader::load_raw_to_index_direct(input, &data_load_options)
+            .with_context(|| format!("Failed to build index from {}", input.display()))?
+    };
     let build_time = build_start.elapsed();
 
     println!(

--- a/crates/uffs-mft/src/index/base.rs
+++ b/crates/uffs-mft/src/index/base.rs
@@ -35,6 +35,58 @@ impl MftIndex {
         }
     }
 
+    /// Create with optimized pre-allocation matching C++ ratios.
+    ///
+    /// This method pre-allocates all vectors based on the MFT bitmap popcount
+    /// to eliminate Vec resizing during the parse loop. The sizing ratios match
+    /// the C++ implementation in `ntfs_index_accessors.hpp` lines 525-544.
+    ///
+    /// # Arguments
+    ///
+    /// * `volume` - Volume letter (e.g., 'C')
+    /// * `estimated_records` - Number of valid records from bitmap popcount
+    /// * `max_frs` - Highest FRS number from bitmap (used for `frs_to_idx`
+    ///   sizing)
+    ///
+    /// # Pre-allocation Strategy
+    ///
+    /// - `records`: `estimated_records * 1.05` (5% safety margin for
+    ///   placeholders)
+    /// - `frs_to_idx`: `max_frs + 1` (sparse array indexed by FRS)
+    /// - `names`: `estimated_records * 23` (~23 chars avg per name)
+    /// - `links`: `estimated_records / 16` (~6% have hardlinks)
+    /// - `streams`: `estimated_records / 4` (~25% have additional streams)
+    /// - `internal_streams`: `estimated_records / 20` (~5% have internal
+    ///   streams)
+    /// - `children`: `estimated_records * 3 / 2` (directories have multiple
+    ///   children)
+    #[must_use]
+    pub fn with_capacity_optimized(volume: char, estimated_records: usize, max_frs: u64) -> Self {
+        // Safety margin for placeholder records added during path resolution
+        let records_capacity = estimated_records + (estimated_records / 20);
+
+        // frs_to_idx is a sparse lookup array indexed by FRS
+        let frs_to_idx_capacity = usize::try_from(max_frs)
+            .ok()
+            .and_then(|max_frs_usize| max_frs_usize.checked_add(1))
+            .unwrap_or(estimated_records);
+
+        Self {
+            volume,
+            records: Vec::with_capacity(records_capacity),
+            frs_to_idx: Vec::with_capacity(frs_to_idx_capacity),
+            names: String::with_capacity(estimated_records * 23),
+            links: Vec::with_capacity(estimated_records / 16),
+            streams: Vec::with_capacity(estimated_records / 4),
+            internal_streams: Vec::with_capacity(estimated_records / 20),
+            children: Vec::with_capacity(estimated_records * 3 / 2),
+            stats: MftStats::new(),
+            extensions: ExtensionTable::new(),
+            extension_index: None,
+            forensic_mode: false,
+        }
+    }
+
     /// Recompute stats from the current index data.
     ///
     /// This is useful after deserializing an index from disk,

--- a/crates/uffs-mft/src/index/builder.rs
+++ b/crates/uffs-mft/src/index/builder.rs
@@ -12,8 +12,19 @@ use super::{
 impl MftIndex {
     /// Build an `MftIndex` from a vector of parsed records.
     ///
-    /// This is the fast path - directly builds the lean index without
-    /// going through Polars `DataFrame`.
+    /// **LEGACY MULTI-PASS PIPELINE:** This function is the final stage of the
+    /// old `parse_record_full → MftRecordMerger → from_parsed_records`
+    /// pipeline. The hot path (`SlidingIocpInline`) now uses direct-to-index
+    /// parsers that build the index incrementally during I/O, skipping this
+    /// separate build phase. This function is still used by:
+    /// - Legacy read modes (`Parallel`, `Pipelined`, `PipelinedParallel`,
+    ///   `SlidingIocp`)
+    /// - File-based readers (`load_raw_to_index_with_options`)
+    /// - Tests and diagnostic tools
+    /// - `UFFS_LEGACY_PARSE=1` escape hatch
+    ///
+    /// This directly builds the lean index without going through Polars
+    /// `DataFrame`.
     ///
     /// Works on all platforms - uses cross-platform `ParsedRecord` from parse
     /// module.

--- a/crates/uffs-mft/src/io/parser/index.rs
+++ b/crates/uffs-mft/src/io/parser/index.rs
@@ -1,5 +1,14 @@
-//! Legacy direct-to-index parser bridge.
-//! Preserves the `io` parser surface for the IOCP fast path.
+//! Single-pass direct-to-index parser (C++-style inline approach).
+//!
+//! Exception: This file is intentionally monolithic (840+ LOC) because it
+//! implements a performance-critical hot path that handles all NTFS attribute
+//! types inline. Splitting would introduce indirection overhead and hurt
+//! performance. See `scripts/ci/file_size_exceptions.txt`.
+//!
+//! This module implements the high-performance single-pass parser that matches
+//! the C++ architecture. It parses MFT records directly into `MftIndex` without
+//! creating intermediate `ParsedRecord` allocations, which is critical for IOCP
+//! performance.
 
 use core::mem::size_of;
 
@@ -9,19 +18,31 @@ use zerocopy::FromBytes;
 use super::index_extension::parse_extension_to_index;
 use crate::ntfs::is_internal_windows_stream;
 
-/// Parses a record directly into MftIndex (inline parsing for IOCP).
+/// Parses a record directly into `MftIndex` (single-pass inline parsing).
 ///
 /// This function parses the record and adds it directly to the index,
-/// creating parent placeholders on-demand. This is the legacy-output parity
+/// creating parent placeholders on-demand. This is the C++-style single-pass
 /// approach that eliminates the intermediate `ParsedRecord` allocation.
+///
+/// Handles ALL attribute types that `parse_record_full()` handles, including:
+/// - `$STANDARD_INFORMATION`, `$FILE_NAME`, `$DATA` (default + ADS)
+/// - `$REPARSE_POINT` (for WoF detection and junctions/symlinks)
+/// - `$INDEX_ROOT`, `$INDEX_ALLOCATION`, `$BITMAP` (directory indexes)
+/// - `$OBJECT_ID`, `$VOLUME_NAME`, `$VOLUME_INFORMATION`, `$PROPERTY_SET`
+/// - `$EA`, `$EA_INFORMATION`, `$LOGGED_UTILITY_STREAM`
+/// - `$SECURITY_DESCRIPTOR`, `$ATTRIBUTE_LIST`
+/// - Unknown attribute types (counted as streams for C++ parity)
 ///
 /// # Returns
 ///
 /// `true` if a record was added to the index, `false` if skipped.
-#[deprecated(note = "Use parse_record_full() + MftRecordMerger + from_parsed_records() instead")]
 #[expect(
     clippy::too_many_lines,
     reason = "monolithic parser kept for performance-critical hot path"
+)]
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "NTFS attribute dispatch is inherently complex"
 )]
 #[expect(
     clippy::cast_possible_truncation,
@@ -78,6 +99,9 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
     let mut default_allocated = 0u64;
     // ADS: (stream_name, size, allocated)
     let mut additional_streams: SmallVec<[(String, u64, u64); 4]> = SmallVec::new();
+    let mut reparse_tag: u32 = 0;
+    let mut dir_index_size: u64 = 0;
+    let mut dir_index_allocated: u64 = 0;
 
     while offset + size_of::<AttributeRecordHeader>() <= max_offset {
         let attr_header = match AttributeRecordHeader::read_from_prefix(&data[offset..]) {
@@ -93,7 +117,8 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
             break;
         }
 
-        match AttributeType::from_u32(attr_header.type_code) {
+        let attr_type = AttributeType::from_u32(attr_header.type_code);
+        match attr_type {
             Some(AttributeType::StandardInformation) => {
                 if attr_header.is_non_resident == 0 {
                     // Parse $STANDARD_INFORMATION
@@ -257,7 +282,319 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                     }
                 }
             }
-            _ => {}
+            Some(AttributeType::ReparsePoint) => {
+                // Parse $REPARSE_POINT to get the reparse tag
+                // C++ handles both resident and non-resident reparse points
+                // C++ also counts $REPARSE_POINT as a stream (for descendants)
+                let (rp_size, rp_allocated) = if attr_header.is_non_resident == 0 {
+                    // Resident reparse point (common case)
+                    let value_length_bytes = &data[offset + 16..offset + 20];
+                    let value_length =
+                        u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0, 0, 0, 0]))
+                            as u64;
+
+                    let value_offset_bytes = &data[offset + 20..offset + 22];
+                    let value_offset =
+                        u16::from_le_bytes(value_offset_bytes.try_into().unwrap_or([0, 0]))
+                            as usize;
+                    let rp_offset = offset + value_offset;
+                    if rp_offset + 4 <= data.len() {
+                        // Read reparse tag (first 4 bytes of reparse point data)
+                        let tag_bytes = &data[rp_offset..rp_offset + 4];
+                        reparse_tag =
+                            u32::from_le_bytes(tag_bytes.try_into().unwrap_or([0, 0, 0, 0]));
+                    }
+                    (value_length, 0_u64) // Resident, allocated=0
+                } else {
+                    // Non-resident reparse point (rare - large reparse data)
+                    let nr_offset = offset + 16;
+                    if nr_offset + 48 <= data.len() {
+                        let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                        let allocated =
+                            i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                        let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                        let data_size = i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                        (data_size.max(0) as u64, allocated.max(0) as u64)
+                    } else {
+                        (0_u64, 0_u64)
+                    }
+                };
+
+                // Add $REPARSE_POINT as a stream (matches C++ stream counting)
+                additional_streams.push((String::from("$REPARSE"), rp_size, rp_allocated));
+            }
+            Some(
+                AttributeType::IndexRoot | AttributeType::IndexAllocation | AttributeType::Bitmap,
+            ) => {
+                // C++ includes $INDEX_ROOT and $INDEX_ALLOCATION with name $I30
+                // in directory size. For non-$I30 indexes, C++ counts them as streams.
+
+                // Extract attribute name
+                let name_len = attr_header.name_length as usize;
+                let (is_i30, attr_name) = if name_len > 0 {
+                    let name_offset = offset + attr_header.name_offset as usize;
+                    if name_offset + name_len * 2 <= data.len() {
+                        let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                        // Check for "$I30" in UTF-16LE
+                        let is_i30 =
+                            attr_header.name_length == 4 && name_bytes == b"$\x00I\x003\x000\x00";
+                        // Decode name for non-$I30 indexes
+                        let name = if is_i30 {
+                            String::new()
+                        } else {
+                            let name_u16: SmallVec<[u16; 64]> = name_bytes
+                                .chunks_exact(2)
+                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .collect();
+                            String::from_utf16_lossy(&name_u16)
+                        };
+                        (is_i30, name)
+                    } else {
+                        (false, String::new())
+                    }
+                } else {
+                    (false, String::new())
+                };
+
+                if is_i30 {
+                    // Accumulate $I30 sizes for directories
+                    if attr_header.is_non_resident == 0 {
+                        let value_length_bytes = &data[offset + 16..offset + 20];
+                        let value_length =
+                            u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                as u64;
+                        dir_index_size += value_length;
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 48 <= data.len() {
+                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                            let allocated =
+                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                            let data_size =
+                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                            dir_index_size += data_size.max(0) as u64;
+                            dir_index_allocated += allocated.max(0) as u64;
+                        }
+                    }
+                } else {
+                    // Non-$I30 index - count as stream
+                    // Check if primary attribute (LowestVCN == 0)
+                    let is_primary = if attr_header.is_non_resident == 0 {
+                        true
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 8 <= data.len() {
+                            let lowest_vcn = i64::from_le_bytes(
+                                data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
+                            );
+                            lowest_vcn == 0
+                        } else {
+                            false
+                        }
+                    };
+
+                    if is_primary {
+                        let (size, allocated) = if attr_header.is_non_resident == 0 {
+                            let value_length_bytes = &data[offset + 16..offset + 20];
+                            let value_length =
+                                u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                    as u64;
+                            (value_length, 0_u64)
+                        } else {
+                            let nr_offset = offset + 16;
+                            if nr_offset + 48 <= data.len() {
+                                let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                                let allocated =
+                                    i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                                let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                                let data_size =
+                                    i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                                (data_size.max(0) as u64, allocated.max(0) as u64)
+                            } else {
+                                (0_u64, 0_u64)
+                            }
+                        };
+
+                        let stream_name = if attr_name.is_empty() {
+                            match attr_type {
+                                Some(AttributeType::Bitmap) => String::from("$BITMAP"),
+                                Some(AttributeType::IndexRoot) => String::from("$INDEX_ROOT"),
+                                Some(AttributeType::IndexAllocation) => {
+                                    String::from("$INDEX_ALLOCATION")
+                                }
+                                _ => String::new(),
+                            }
+                        } else {
+                            attr_name
+                        };
+                        additional_streams.push((stream_name, size, allocated));
+                    }
+                }
+            }
+            Some(
+                AttributeType::ObjectId
+                | AttributeType::VolumeName
+                | AttributeType::VolumeInformation
+                | AttributeType::PropertySet
+                | AttributeType::Ea
+                | AttributeType::EaInformation
+                | AttributeType::LoggedUtilityStream
+                | AttributeType::SecurityDescriptor
+                | AttributeType::AttributeList,
+            ) => {
+                // All these are counted as streams in C++
+                // Check if primary attribute (LowestVCN == 0)
+                let is_primary = if attr_header.is_non_resident == 0 {
+                    true
+                } else {
+                    let nr_offset = offset + 16;
+                    if nr_offset + 8 <= data.len() {
+                        let lowest_vcn = i64::from_le_bytes(
+                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
+                        );
+                        lowest_vcn == 0
+                    } else {
+                        false
+                    }
+                };
+
+                if is_primary {
+                    // Extract attribute name (if any)
+                    let attr_name = if attr_header.name_length > 0 {
+                        let name_offset = offset + attr_header.name_offset as usize;
+                        let name_len = attr_header.name_length as usize;
+                        if name_offset + name_len * 2 <= data.len() {
+                            let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                            let name_u16: SmallVec<[u16; 64]> = name_bytes
+                                .chunks_exact(2)
+                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .collect();
+                            String::from_utf16_lossy(&name_u16)
+                        } else {
+                            String::new()
+                        }
+                    } else {
+                        String::new()
+                    };
+
+                    let (size, allocated) = if attr_header.is_non_resident == 0 {
+                        let value_length_bytes = &data[offset + 16..offset + 20];
+                        let value_length =
+                            u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                as u64;
+                        (value_length, 0_u64)
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 48 <= data.len() {
+                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                            let allocated =
+                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                            let data_size =
+                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                            (data_size.max(0) as u64, allocated.max(0) as u64)
+                        } else {
+                            (0_u64, 0_u64)
+                        }
+                    };
+
+                    let stream_name = if attr_name.is_empty() {
+                        match attr_type {
+                            Some(AttributeType::ObjectId) => String::from("$OBJECT_ID"),
+                            Some(AttributeType::VolumeName) => String::from("$VOLUME_NAME"),
+                            Some(AttributeType::VolumeInformation) => {
+                                String::from("$VOLUME_INFORMATION")
+                            }
+                            Some(AttributeType::PropertySet) => String::from("$PROPERTY_SET"),
+                            Some(AttributeType::Ea) => String::from("$EA"),
+                            Some(AttributeType::EaInformation) => String::from("$EA_INFORMATION"),
+                            Some(AttributeType::LoggedUtilityStream) => {
+                                String::from("$LOGGED_UTILITY_STREAM")
+                            }
+                            Some(AttributeType::SecurityDescriptor) => {
+                                String::from("$SECURITY_DESCRIPTOR")
+                            }
+                            Some(AttributeType::AttributeList) => String::from("$ATTRIBUTE_LIST"),
+                            _ => String::new(),
+                        }
+                    } else {
+                        attr_name
+                    };
+                    additional_streams.push((stream_name, size, allocated));
+                }
+            }
+            Some(AttributeType::StandardInformation | AttributeType::FileName) => {
+                // Already handled above
+            }
+            _ => {
+                // C++ counts ALL attribute types as streams via default: case
+                // This includes truly unknown types
+                let type_code = attr_header.type_code;
+
+                // Check if primary attribute (LowestVCN == 0)
+                let is_primary = if attr_header.is_non_resident == 0 {
+                    true
+                } else {
+                    let nr_offset = offset + 16;
+                    if nr_offset + 8 <= data.len() {
+                        let lowest_vcn = i64::from_le_bytes(
+                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
+                        );
+                        lowest_vcn == 0
+                    } else {
+                        false
+                    }
+                };
+
+                if is_primary {
+                    // Extract attribute name (if any)
+                    let attr_name = if attr_header.name_length > 0 {
+                        let name_offset = offset + attr_header.name_offset as usize;
+                        let name_len = attr_header.name_length as usize;
+                        if name_offset + name_len * 2 <= data.len() {
+                            let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                            let name_u16: SmallVec<[u16; 64]> = name_bytes
+                                .chunks_exact(2)
+                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .collect();
+                            String::from_utf16_lossy(&name_u16)
+                        } else {
+                            String::new()
+                        }
+                    } else {
+                        String::new()
+                    };
+
+                    let (size, allocated) = if attr_header.is_non_resident == 0 {
+                        let value_length_bytes = &data[offset + 16..offset + 20];
+                        let value_length =
+                            u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                as u64;
+                        (value_length, 0_u64)
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 48 <= data.len() {
+                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                            let allocated =
+                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                            let data_size =
+                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                            (data_size.max(0) as u64, allocated.max(0) as u64)
+                        } else {
+                            (0_u64, 0_u64)
+                        }
+                    };
+
+                    let stream_name = if attr_name.is_empty() {
+                        format!("$UNKNOWN_0x{type_code:X}")
+                    } else {
+                        attr_name
+                    };
+                    additional_streams.push((stream_name, size, allocated));
+                }
+            }
         }
 
         offset += attr_header.length as usize;
@@ -267,6 +604,11 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
     // This ensures is_directory is set even when $FILE_NAME is in extension record
     if is_directory {
         std_info.set_directory(true);
+        // For directories, set default size to directory index size
+        if dir_index_size > 0 {
+            default_size = dir_index_size;
+            default_allocated = dir_index_allocated;
+        }
     }
 
     // Handle records without a filename in the base record
@@ -419,6 +761,11 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
     record.name_count = 1 + additional_count as u16;
     // stream_count = 1 (default) + additional ADS
     record.stream_count = 1 + additional_stream_count as u16;
+    // total_stream_count includes all streams (including internal ones like
+    // $REPARSE)
+    record.total_stream_count = 1 + additional_stream_count as u16;
+    // Set reparse tag if this is a reparse point
+    record.reparse_tag = reparse_tag;
 
     // Chain the additional links: first_name -> link[0] -> link[1] -> ... ->
     // NO_ENTRY The links were pushed with next_entry = NO_ENTRY, now we chain

--- a/crates/uffs-mft/src/io/parser/index.rs
+++ b/crates/uffs-mft/src/io/parser/index.rs
@@ -161,7 +161,8 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                         if name_bytes_offset + name_len * 2 <= data.len() {
                             let name_bytes =
                                 &data[name_bytes_offset..name_bytes_offset + name_len * 2];
-                            let name_u16: Vec<u16> = name_bytes
+                            // SmallVec avoids heap allocation for typical filenames (<= 64 chars)
+                            let name_u16: SmallVec<[u16; 64]> = name_bytes
                                 .chunks_exact(2)
                                 .map(|c| u16::from_le_bytes([c[0], c[1]]))
                                 .collect();

--- a/crates/uffs-mft/src/io/parser/index_extension.rs
+++ b/crates/uffs-mft/src/io/parser/index_extension.rs
@@ -1,5 +1,12 @@
-//! Legacy extension-record helper for direct-to-index parsing.
-//! Extracts names and streams from extension records into the index.
+//! Extension record parser for direct-to-index path.
+//!
+//! Exception: This file is intentionally large (720+ LOC) to match the
+//! completeness of `index.rs` - it handles all the same attribute types that
+//! can appear in extension records. See `scripts/ci/file_size_exceptions.txt`.
+//!
+//! This module handles extension records for the single-pass parser, extracting
+//! names, streams, and all attribute types from extension records and merging
+//! them into base records in the index.
 
 use core::mem::size_of;
 
@@ -11,9 +18,16 @@ use crate::ntfs::is_internal_windows_stream;
 /// Parses an extension record and adds its names/streams to the base record.
 ///
 /// Extension records contain additional `$FILE_NAME` attributes (hard links)
-/// and `$DATA` attributes (ADS) that don't fit in the base record. This
-/// function extracts those attributes and adds them to the base record in the
-/// index.
+/// and additional attributes (ADS, system attributes, etc.) that don't fit
+/// in the base record. This function extracts those attributes and adds them
+/// to the base record in the index.
+///
+/// Handles ALL attribute types that `parse_record_full()` handles, including:
+/// - `$FILE_NAME` (hard links)
+/// - `$DATA` (ADS)
+/// - `$REPARSE_POINT`, `$INDEX_ROOT`, `$INDEX_ALLOCATION`, `$BITMAP`
+/// - `$OBJECT_ID`, `$EA`, `$LOGGED_UTILITY_STREAM`, etc.
+/// - Unknown attribute types
 ///
 /// # Arguments
 ///
@@ -24,10 +38,17 @@ use crate::ntfs::is_internal_windows_stream;
 /// # Returns
 ///
 /// `true` if any names/streams were added, `false` otherwise.
-#[deprecated(note = "Use parse_record_full() + MftRecordMerger instead")]
 #[expect(
     clippy::cast_possible_truncation,
     reason = "NTFS field sizes are bounded by u16/u32 record layout"
+)]
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "NTFS attribute dispatch is inherently complex"
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "monolithic extension parser for performance"
 )]
 pub(super) fn parse_extension_to_index(
     data: &[u8],
@@ -55,6 +76,8 @@ pub(super) fn parse_extension_to_index(
     // Collect names and streams from extension record
     let mut names: SmallVec<[(String, u64); 4]> = SmallVec::new();
     let mut streams: SmallVec<[(String, u64, u64); 4]> = SmallVec::new();
+    let mut dir_index_size: u64 = 0;
+    let mut dir_index_allocated: u64 = 0;
 
     while offset + size_of::<AttributeRecordHeader>() <= max_offset {
         let attr_header = match AttributeRecordHeader::read_from_prefix(&data[offset..]) {
@@ -70,7 +93,8 @@ pub(super) fn parse_extension_to_index(
             break;
         }
 
-        match AttributeType::from_u32(attr_header.type_code) {
+        let attr_type = AttributeType::from_u32(attr_header.type_code);
+        match attr_type {
             Some(AttributeType::FileName) => {
                 // Parse $FILE_NAME attribute
                 if attr_header.is_non_resident == 0 {
@@ -178,7 +202,289 @@ pub(super) fn parse_extension_to_index(
                     }
                 }
             }
-            _ => {}
+            Some(AttributeType::ReparsePoint) => {
+                // Parse $REPARSE_POINT - add as stream
+                let (rp_size, rp_allocated) = if attr_header.is_non_resident == 0 {
+                    let value_length_bytes = &data[offset + 16..offset + 20];
+                    let value_length =
+                        u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4])) as u64;
+                    (value_length, 0_u64)
+                } else {
+                    let nr_offset = offset + 16;
+                    if nr_offset + 48 <= data.len() {
+                        let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                        let allocated =
+                            i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                        let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                        let data_size = i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                        (data_size.max(0) as u64, allocated.max(0) as u64)
+                    } else {
+                        (0_u64, 0_u64)
+                    }
+                };
+                streams.push((String::from("$REPARSE"), rp_size, rp_allocated));
+            }
+            Some(
+                AttributeType::IndexRoot | AttributeType::IndexAllocation | AttributeType::Bitmap,
+            ) => {
+                // Extract attribute name
+                let name_len = attr_header.name_length as usize;
+                let (is_i30, attr_name) = if name_len > 0 {
+                    let name_offset = offset + attr_header.name_offset as usize;
+                    if name_offset + name_len * 2 <= data.len() {
+                        let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                        let is_i30 =
+                            attr_header.name_length == 4 && name_bytes == b"$\x00I\x003\x000\x00";
+                        let name = if is_i30 {
+                            String::new()
+                        } else {
+                            let name_u16: SmallVec<[u16; 64]> = name_bytes
+                                .chunks_exact(2)
+                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .collect();
+                            String::from_utf16_lossy(&name_u16)
+                        };
+                        (is_i30, name)
+                    } else {
+                        (false, String::new())
+                    }
+                } else {
+                    (false, String::new())
+                };
+
+                if is_i30 {
+                    // Accumulate $I30 sizes
+                    if attr_header.is_non_resident == 0 {
+                        let value_length_bytes = &data[offset + 16..offset + 20];
+                        let value_length =
+                            u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                as u64;
+                        dir_index_size += value_length;
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 48 <= data.len() {
+                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                            let allocated =
+                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                            let data_size =
+                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                            dir_index_size += data_size.max(0) as u64;
+                            dir_index_allocated += allocated.max(0) as u64;
+                        }
+                    }
+                } else {
+                    // Non-$I30 index - count as stream
+                    let is_primary = if attr_header.is_non_resident == 0 {
+                        true
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 8 <= data.len() {
+                            let lowest_vcn = i64::from_le_bytes(
+                                data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
+                            );
+                            lowest_vcn == 0
+                        } else {
+                            false
+                        }
+                    };
+
+                    if is_primary {
+                        let (size, allocated) = if attr_header.is_non_resident == 0 {
+                            let value_length_bytes = &data[offset + 16..offset + 20];
+                            let value_length =
+                                u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                    as u64;
+                            (value_length, 0_u64)
+                        } else {
+                            let nr_offset = offset + 16;
+                            if nr_offset + 48 <= data.len() {
+                                let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                                let allocated =
+                                    i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                                let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                                let data_size =
+                                    i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                                (data_size.max(0) as u64, allocated.max(0) as u64)
+                            } else {
+                                (0_u64, 0_u64)
+                            }
+                        };
+
+                        let stream_name = if attr_name.is_empty() {
+                            match attr_type {
+                                Some(AttributeType::Bitmap) => String::from("$BITMAP"),
+                                Some(AttributeType::IndexRoot) => String::from("$INDEX_ROOT"),
+                                Some(AttributeType::IndexAllocation) => {
+                                    String::from("$INDEX_ALLOCATION")
+                                }
+                                _ => String::new(),
+                            }
+                        } else {
+                            attr_name
+                        };
+                        streams.push((stream_name, size, allocated));
+                    }
+                }
+            }
+            Some(
+                AttributeType::ObjectId
+                | AttributeType::VolumeName
+                | AttributeType::VolumeInformation
+                | AttributeType::PropertySet
+                | AttributeType::Ea
+                | AttributeType::EaInformation
+                | AttributeType::LoggedUtilityStream
+                | AttributeType::SecurityDescriptor
+                | AttributeType::AttributeList,
+            ) => {
+                // All counted as streams
+                let is_primary = if attr_header.is_non_resident == 0 {
+                    true
+                } else {
+                    let nr_offset = offset + 16;
+                    if nr_offset + 8 <= data.len() {
+                        let lowest_vcn = i64::from_le_bytes(
+                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
+                        );
+                        lowest_vcn == 0
+                    } else {
+                        false
+                    }
+                };
+
+                if is_primary {
+                    let attr_name = if attr_header.name_length > 0 {
+                        let name_offset = offset + attr_header.name_offset as usize;
+                        let name_len = attr_header.name_length as usize;
+                        if name_offset + name_len * 2 <= data.len() {
+                            let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                            let name_u16: SmallVec<[u16; 64]> = name_bytes
+                                .chunks_exact(2)
+                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .collect();
+                            String::from_utf16_lossy(&name_u16)
+                        } else {
+                            String::new()
+                        }
+                    } else {
+                        String::new()
+                    };
+
+                    let (size, allocated) = if attr_header.is_non_resident == 0 {
+                        let value_length_bytes = &data[offset + 16..offset + 20];
+                        let value_length =
+                            u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                as u64;
+                        (value_length, 0_u64)
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 48 <= data.len() {
+                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                            let allocated =
+                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                            let data_size =
+                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                            (data_size.max(0) as u64, allocated.max(0) as u64)
+                        } else {
+                            (0_u64, 0_u64)
+                        }
+                    };
+
+                    let stream_name = if attr_name.is_empty() {
+                        match attr_type {
+                            Some(AttributeType::ObjectId) => String::from("$OBJECT_ID"),
+                            Some(AttributeType::VolumeName) => String::from("$VOLUME_NAME"),
+                            Some(AttributeType::VolumeInformation) => {
+                                String::from("$VOLUME_INFORMATION")
+                            }
+                            Some(AttributeType::PropertySet) => String::from("$PROPERTY_SET"),
+                            Some(AttributeType::Ea) => String::from("$EA"),
+                            Some(AttributeType::EaInformation) => String::from("$EA_INFORMATION"),
+                            Some(AttributeType::LoggedUtilityStream) => {
+                                String::from("$LOGGED_UTILITY_STREAM")
+                            }
+                            Some(AttributeType::SecurityDescriptor) => {
+                                String::from("$SECURITY_DESCRIPTOR")
+                            }
+                            Some(AttributeType::AttributeList) => String::from("$ATTRIBUTE_LIST"),
+                            _ => String::new(),
+                        }
+                    } else {
+                        attr_name
+                    };
+                    streams.push((stream_name, size, allocated));
+                }
+            }
+            Some(AttributeType::StandardInformation) => {
+                // Skip - not expected in extension records
+            }
+            _ => {
+                // Unknown attribute types - count as streams (C++ default: case)
+                let type_code = attr_header.type_code;
+
+                let is_primary = if attr_header.is_non_resident == 0 {
+                    true
+                } else {
+                    let nr_offset = offset + 16;
+                    if nr_offset + 8 <= data.len() {
+                        let lowest_vcn = i64::from_le_bytes(
+                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
+                        );
+                        lowest_vcn == 0
+                    } else {
+                        false
+                    }
+                };
+
+                if is_primary {
+                    let attr_name = if attr_header.name_length > 0 {
+                        let name_offset = offset + attr_header.name_offset as usize;
+                        let name_len = attr_header.name_length as usize;
+                        if name_offset + name_len * 2 <= data.len() {
+                            let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                            let name_u16: SmallVec<[u16; 64]> = name_bytes
+                                .chunks_exact(2)
+                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .collect();
+                            String::from_utf16_lossy(&name_u16)
+                        } else {
+                            String::new()
+                        }
+                    } else {
+                        String::new()
+                    };
+
+                    let (size, allocated) = if attr_header.is_non_resident == 0 {
+                        let value_length_bytes = &data[offset + 16..offset + 20];
+                        let value_length =
+                            u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                as u64;
+                        (value_length, 0_u64)
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 48 <= data.len() {
+                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                            let allocated =
+                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                            let data_size =
+                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                            (data_size.max(0) as u64, allocated.max(0) as u64)
+                        } else {
+                            (0_u64, 0_u64)
+                        }
+                    };
+
+                    let stream_name = if attr_name.is_empty() {
+                        format!("$UNKNOWN_0x{type_code:X}")
+                    } else {
+                        attr_name
+                    };
+                    streams.push((stream_name, size, allocated));
+                }
+            }
         }
 
         offset += attr_header.length as usize;
@@ -351,6 +657,15 @@ pub(super) fn parse_extension_to_index(
             let record = &mut index.records[record_idx as usize];
             record.stream_count += stream_indices.len() as u16;
             record.total_stream_count += stream_indices.len() as u16;
+        }
+
+        // Merge directory index sizes from extension records
+        if dir_index_size > 0 || dir_index_allocated > 0 {
+            let record = &mut index.records[record_idx as usize];
+            // Add to the first_stream size (which represents the default stream for
+            // directories)
+            record.first_stream.size.length += dir_index_size;
+            record.first_stream.size.allocated += dir_index_allocated;
         }
 
         // Build parent-child relationship for names added from extension records

--- a/crates/uffs-mft/src/io/readers/parallel/mod.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/mod.rs
@@ -218,6 +218,12 @@ impl ParallelMftReader {
 
     /// Reads and parses all MFT records in parallel with progress callback.
     ///
+    /// **LEGACY MULTI-PASS PIPELINE:** This function uses
+    /// `parse_record_full → MftRecordMerger → Vec<ParsedRecord>`.
+    /// The hot path (`SlidingIocpInline`) uses direct-to-index parsing instead.
+    /// This function is used by legacy read modes (`Parallel`, `Auto` when not
+    /// inline).
+    ///
     /// This function handles extension records by merging their attributes
     /// into the base records, matching the legacy implementation behavior.
     /// The progress callback is called during the I/O phase with (bytes_read,

--- a/crates/uffs-mft/src/io/readers/parallel/to_index.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/to_index.rs
@@ -181,10 +181,11 @@ impl ParallelMftReader {
         }
 
         let total_io_ops = io_ops.len();
-        let estimated_records = if let Some(ref bm) = self.bitmap {
-            bm.count_in_use()
+        let (estimated_records, max_frs) = if let Some(ref bm) = self.bitmap {
+            (bm.count_in_use(), bm.max_frs_in_use())
         } else {
-            total_records
+            // No bitmap: use total records as both count and max FRS
+            (total_records, total_records.saturating_sub(1) as u64)
         };
 
         // Calculate total bytes to read and max I/O size for buffer allocation
@@ -198,14 +199,16 @@ impl ParallelMftReader {
         info!(
             io_ops = total_io_ops,
             estimated_records,
+            max_frs,
             bytes_to_read_mb = total_bytes_to_read / (1024 * 1024),
             max_io_size_kb = max_io_size / 1024,
             direct_io = use_direct_chunk_io,
             "📊 Generated I/O operations for inline parsing"
         );
 
-        // Pre-allocate MftIndex and build it incrementally during I/O
-        let mut index = MftIndex::with_capacity(volume, estimated_records);
+        // Pre-allocate MftIndex with C++-matching ratios to eliminate resizing during
+        // parse
+        let mut index = MftIndex::with_capacity_optimized(volume, estimated_records, max_frs);
 
         // Create IOCP
         let read_start = std::time::Instant::now();

--- a/crates/uffs-mft/src/io/readers/parallel/to_index.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/to_index.rs
@@ -177,8 +177,8 @@ impl ParallelMftReader {
             "📊 Generated I/O operations for inline parsing"
         );
 
-        // Create merger to accumulate parsed records (unified pipeline)
-        let mut merger = MftRecordMerger::with_capacity(total_records);
+        // Pre-allocate MftIndex and build it incrementally during I/O
+        let mut index = MftIndex::with_capacity(volume, estimated_records);
 
         // Create IOCP
         let read_start = std::time::Instant::now();
@@ -338,7 +338,7 @@ impl ParallelMftReader {
                     // only project a mutable reference without moving the allocation.
                     let op_mut = unsafe { completed_op.as_mut().get_unchecked_mut() };
 
-                    // UNIFIED PIPELINE: parse_record_full() → MftRecordMerger
+                    // DIRECT-TO-INDEX: parse records directly into MftIndex
                     let buffer_slice =
                         &mut op_mut.buffer.as_mut_slice()[..bytes_transferred as usize];
                     let records_in_buffer = bytes_transferred as usize / record_size;
@@ -361,12 +361,10 @@ impl ParallelMftReader {
                             continue;
                         }
 
-                        // Parse using unified pipeline and accumulate in merger
-                        let result = parse_record_full(record_slice, frs);
-                        if !matches!(result, ParseResult::Skip) {
+                        // Parse directly into index (single-pass, no intermediates)
+                        if parse_record_to_index(record_slice, frs, &mut index) {
                             records_parsed += 1;
                         }
-                        merger.add_result(result);
                     }
 
                     bytes_read_total += bytes_transferred as u64;
@@ -432,27 +430,13 @@ impl ParallelMftReader {
             }
         }
 
-        let io_ms = read_start.elapsed().as_millis();
-        info!(
-            io_ms,
-            bytes_mb = bytes_read_total / (1024 * 1024),
-            records_parsed,
-            base_records = merger.base_count(),
-            extensions = merger.extension_count(),
-            "✅ Sliding window IOCP I/O + parse complete, merging..."
-        );
-
-        // Merge extensions and build index using unified pipeline
-        let parsed_records = merger.merge();
-        let index = MftIndex::from_parsed_records(volume, parsed_records);
-
         let total_ms = read_start.elapsed().as_millis();
         info!(
             total_ms,
-            io_ms,
-            merge_ms = total_ms - io_ms,
+            bytes_mb = bytes_read_total / (1024 * 1024),
+            records_parsed,
             index_entries = index.records.len(),
-            "✅ Sliding window IOCP with unified pipeline complete"
+            "✅ Sliding window IOCP with direct-to-index parsing complete"
         );
 
         Ok(index)

--- a/crates/uffs-mft/src/io/readers/parallel/to_index.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/to_index.rs
@@ -13,6 +13,33 @@ impl ParallelMftReader {
     /// This eliminates the separate parse and index build phases, saving ~7s
     /// on large MFTs by overlapping CPU work with I/O.
     ///
+    /// # I/O Overlap Architecture
+    ///
+    /// This function achieves true I/O-compute overlap using IOCP's sliding
+    /// window:
+    ///
+    /// 1. **Multiple I/O in flight**: Maintains 2-8 concurrent I/O operations
+    ///    (adaptive based on drive type). While one operation completes, others
+    ///    are still reading from disk.
+    ///
+    /// 2. **Inline parsing**: When `GetQueuedCompletionStatus` returns, the
+    ///    completion handler immediately applies fixup and parses records
+    ///    directly into the index. Critically, this parse happens while other
+    ///    I/O operations remain in flight.
+    ///
+    /// 3. **Immediate requeue**: After parsing completes, the buffer is
+    ///    recycled and the next I/O operation is queued immediately,
+    ///    maintaining the sliding window.
+    ///
+    /// Parse time per chunk is typically <1ms, so parsing on the IOCP
+    /// completion thread is optimal—it avoids thread synchronization
+    /// overhead and maintains cache locality. The overlap comes from having
+    /// multiple chunks in flight, not from multi-threaded parsing.
+    ///
+    /// Timing instrumentation (added for profiling) logs `wait_ms`, `parse_ms`,
+    /// and `overlap_pct` to quantify how much parse work was hidden behind
+    /// I/O latency.
+    ///
     /// # Arguments
     ///
     /// * `overlapped_handle` - IOCP handle for async I/O
@@ -263,6 +290,10 @@ impl ParallelMftReader {
         let bitmap_ref = self.bitmap.as_ref();
         let mut last_completion_at = Instant::now();
 
+        // Timing instrumentation for I/O overlap analysis
+        let mut total_wait_time_ns = 0u64;
+        let mut total_parse_time_ns = 0u64;
+
         const WAIT_OPERATION: &str = "read_all_sliding_window_iocp_to_index";
 
         while completed_count < total_io_ops {
@@ -270,6 +301,9 @@ impl ParallelMftReader {
             let mut completion_key: usize = 0;
             let mut overlapped_ptr: *mut windows::Win32::System::IO::OVERLAPPED =
                 std::ptr::null_mut();
+
+            // Time I/O wait (GetQueuedCompletionStatus)
+            let wait_start = Instant::now();
 
             // SAFETY: `iocp.raw_handle()` is a live completion port and all out-pointers
             // reference writable stack storage for the duration of the wait.
@@ -282,6 +316,8 @@ impl ParallelMftReader {
                     IOCP_WAIT_POLL_INTERVAL_MS,
                 )
             };
+
+            total_wait_time_ns += wait_start.elapsed().as_nanos() as u64;
 
             if result.is_err() {
                 let last_error = unsafe { GetLastError() };
@@ -338,6 +374,9 @@ impl ParallelMftReader {
                     // only project a mutable reference without moving the allocation.
                     let op_mut = unsafe { completed_op.as_mut().get_unchecked_mut() };
 
+                    // Time parse phase (fixup + parse_record_to_index)
+                    let parse_start = Instant::now();
+
                     // DIRECT-TO-INDEX: parse records directly into MftIndex
                     let buffer_slice =
                         &mut op_mut.buffer.as_mut_slice()[..bytes_transferred as usize];
@@ -366,6 +405,8 @@ impl ParallelMftReader {
                             records_parsed += 1;
                         }
                     }
+
+                    total_parse_time_ns += parse_start.elapsed().as_nanos() as u64;
 
                     bytes_read_total += bytes_transferred as u64;
                     completed_count += 1;
@@ -431,12 +472,26 @@ impl ParallelMftReader {
         }
 
         let total_ms = read_start.elapsed().as_millis();
+        let wait_ms = total_wait_time_ns / 1_000_000;
+        let parse_ms = total_parse_time_ns / 1_000_000;
+
+        // Calculate overlap efficiency: if wait_ms + parse_ms > total_ms,
+        // then we had effective overlap (parse happened while other I/O was in flight)
+        let overlap_pct = if total_ms > 0 {
+            ((wait_ms + parse_ms).saturating_sub(total_ms) as f64 / total_ms as f64) * 100.0
+        } else {
+            0.0
+        };
+
         info!(
             total_ms,
+            wait_ms,
+            parse_ms,
+            overlap_pct = format!("{:.1}%", overlap_pct),
             bytes_mb = bytes_read_total / (1024 * 1024),
             records_parsed,
             index_entries = index.records.len(),
-            "✅ Sliding window IOCP with direct-to-index parsing complete"
+            "✅ Sliding window IOCP with direct-to-index parsing complete (I/O overlap analysis)"
         );
 
         Ok(index)

--- a/crates/uffs-mft/src/parse.rs
+++ b/crates/uffs-mft/src/parse.rs
@@ -44,6 +44,8 @@
 
 mod attribute_helpers;
 mod columns;
+mod direct_index;
+mod direct_index_extension;
 mod fixup;
 mod forensic;
 mod full;
@@ -59,6 +61,7 @@ use attribute_helpers::{
     parse_data_attribute_full, parse_file_name_full, parse_standard_info_full,
 };
 pub use columns::ParsedColumns;
+pub use direct_index::parse_record_to_index;
 pub use fixup::apply_fixup;
 pub use forensic::parse_record_forensic;
 pub use full::{parse_record, parse_record_full};

--- a/crates/uffs-mft/src/parse/direct_index.rs
+++ b/crates/uffs-mft/src/parse/direct_index.rs
@@ -198,7 +198,8 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                         if name_bytes_offset + name_len * 2 <= data.len() {
                             let name_bytes =
                                 &data[name_bytes_offset..name_bytes_offset + name_len * 2];
-                            let name_u16: Vec<u16> = name_bytes
+                            // SmallVec avoids heap allocation for typical filenames (<= 64 chars)
+                            let name_u16: SmallVec<[u16; 64]> = name_bytes
                                 .chunks_exact(2)
                                 .map(|c| u16::from_le_bytes([c[0], c[1]]))
                                 .collect();

--- a/crates/uffs-mft/src/parse/direct_index.rs
+++ b/crates/uffs-mft/src/parse/direct_index.rs
@@ -39,24 +39,12 @@
     reason = "reusing common names like 'record' in nested scopes is idiomatic here"
 )]
 #![expect(
-    clippy::single_call_fn,
-    reason = "parse_extension_to_index is a separate function for code organization"
-)]
-#![expect(
     clippy::let_underscore_untyped,
     reason = "let _ = expr is used for intentionally ignoring results"
 )]
 #![expect(
-    clippy::if_not_else,
-    reason = "!condition checks are clearer for NTFS flag testing"
-)]
-#![expect(
     clippy::explicit_iter_loop,
     reason = ".iter() is explicit and intentional"
-)]
-#![expect(
-    clippy::if_then_some_else_none,
-    reason = "explicit if/else is clearer than bool::then in complex NTFS logic"
 )]
 
 use core::mem::size_of;

--- a/crates/uffs-mft/src/parse/direct_index.rs
+++ b/crates/uffs-mft/src/parse/direct_index.rs
@@ -7,15 +7,64 @@
 //!
 //! This module implements the high-performance single-pass parser that matches
 //! the C++ architecture. It parses MFT records directly into `MftIndex` without
-//! creating intermediate `ParsedRecord` allocations, which is critical for IOCP
-//! performance.
+//! creating intermediate `ParsedRecord` allocations.
+//!
+//! This is a cross-platform parser used for both Windows IOCP and file-based
+//! loading.
+
+// Performance-critical hot-path parser — lint suppressions match the style of
+// other NTFS parser modules in this crate.
+#![expect(
+    clippy::unseparated_literal_suffix,
+    reason = "literal suffixes like 0u32 are common in NTFS struct parsing"
+)]
+#![expect(
+    clippy::doc_markdown,
+    reason = "NTFS terminology like MftIndex does not need backticks in internal docs"
+)]
+#![expect(
+    clippy::manual_let_else,
+    reason = "explicit match is clearer in NTFS attribute dispatch"
+)]
+#![expect(
+    clippy::missing_asserts_for_indexing,
+    reason = "bounds are verified by size checks before all index access"
+)]
+#![expect(
+    clippy::single_match_else,
+    reason = "explicit match arms are clearer for attribute type dispatch"
+)]
+#![expect(
+    clippy::shadow_unrelated,
+    reason = "reusing common names like 'record' in nested scopes is idiomatic here"
+)]
+#![expect(
+    clippy::single_call_fn,
+    reason = "parse_extension_to_index is a separate function for code organization"
+)]
+#![expect(
+    clippy::let_underscore_untyped,
+    reason = "let _ = expr is used for intentionally ignoring results"
+)]
+#![expect(
+    clippy::if_not_else,
+    reason = "!condition checks are clearer for NTFS flag testing"
+)]
+#![expect(
+    clippy::explicit_iter_loop,
+    reason = ".iter() is explicit and intentional"
+)]
+#![expect(
+    clippy::if_then_some_else_none,
+    reason = "explicit if/else is clearer than bool::then in complex NTFS logic"
+)]
 
 use core::mem::size_of;
 
 use smallvec::SmallVec;
 use zerocopy::FromBytes;
 
-use super::index_extension::parse_extension_to_index;
+use super::direct_index_extension::parse_extension_to_index;
 use crate::ntfs::is_internal_windows_stream;
 
 /// Parses a record directly into `MftIndex` (single-pass inline parsing).

--- a/crates/uffs-mft/src/parse/direct_index_extension.rs
+++ b/crates/uffs-mft/src/parse/direct_index_extension.rs
@@ -31,20 +31,12 @@
     reason = "!condition checks are clearer for NTFS flag testing"
 )]
 #![expect(
-    clippy::unseparated_literal_suffix,
-    reason = "literal suffixes like 0u32 are common in NTFS struct parsing"
-)]
-#![expect(
-    clippy::doc_markdown,
-    reason = "NTFS terminology like MftIndex does not need backticks in internal docs"
-)]
-#![expect(
     clippy::if_then_some_else_none,
     reason = "explicit if/else is clearer than bool::then in complex NTFS logic"
 )]
 #![expect(
-    clippy::explicit_iter_loop,
-    reason = ".iter() is explicit and intentional"
+    clippy::single_call_fn,
+    reason = "parse_extension_to_index is a separate function for code organization"
 )]
 
 use core::mem::size_of;

--- a/crates/uffs-mft/src/parse/direct_index_extension.rs
+++ b/crates/uffs-mft/src/parse/direct_index_extension.rs
@@ -1,0 +1,763 @@
+//! Extension record parser for direct-to-index path.
+//!
+//! Exception: This file is intentionally large (720+ LOC) to match the
+//! completeness of `index.rs` - it handles all the same attribute types that
+//! can appear in extension records. See `scripts/ci/file_size_exceptions.txt`.
+//!
+//! This module handles extension records for the single-pass parser, extracting
+//! names, streams, and all attribute types from extension records and merging
+//! them into base records in the index.
+
+// Performance-critical hot-path parser — lint suppressions match the style of
+// other NTFS parser modules in this crate.
+#![expect(
+    clippy::manual_let_else,
+    reason = "explicit match is clearer in NTFS attribute dispatch"
+)]
+#![expect(
+    clippy::missing_asserts_for_indexing,
+    reason = "bounds are verified by size checks before all index access"
+)]
+#![expect(
+    clippy::shadow_unrelated,
+    reason = "reusing common names like 'record' in nested scopes is idiomatic here"
+)]
+#![expect(
+    clippy::let_underscore_untyped,
+    reason = "let _ = expr is used for intentionally ignoring results"
+)]
+#![expect(
+    clippy::if_not_else,
+    reason = "!condition checks are clearer for NTFS flag testing"
+)]
+#![expect(
+    clippy::unseparated_literal_suffix,
+    reason = "literal suffixes like 0u32 are common in NTFS struct parsing"
+)]
+#![expect(
+    clippy::doc_markdown,
+    reason = "NTFS terminology like MftIndex does not need backticks in internal docs"
+)]
+#![expect(
+    clippy::if_then_some_else_none,
+    reason = "explicit if/else is clearer than bool::then in complex NTFS logic"
+)]
+#![expect(
+    clippy::explicit_iter_loop,
+    reason = ".iter() is explicit and intentional"
+)]
+
+use core::mem::size_of;
+
+use smallvec::SmallVec;
+use zerocopy::FromBytes;
+
+use crate::ntfs::is_internal_windows_stream;
+
+/// Parses an extension record and adds its names/streams to the base record.
+///
+/// Extension records contain additional `$FILE_NAME` attributes (hard links)
+/// and additional attributes (ADS, system attributes, etc.) that don't fit
+/// in the base record. This function extracts those attributes and adds them
+/// to the base record in the index.
+///
+/// Handles ALL attribute types that `parse_record_full()` handles, including:
+/// - `$FILE_NAME` (hard links)
+/// - `$DATA` (ADS)
+/// - `$REPARSE_POINT`, `$INDEX_ROOT`, `$INDEX_ALLOCATION`, `$BITMAP`
+/// - `$OBJECT_ID`, `$EA`, `$LOGGED_UTILITY_STREAM`, etc.
+/// - Unknown attribute types
+///
+/// # Arguments
+///
+/// * `data` - The raw extension record data (after fixup)
+/// * `base_frs` - The FRS of the base record this extension belongs to
+/// * `index` - The MFT index to update
+///
+/// # Returns
+///
+/// `true` if any names/streams were added, `false` otherwise.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "NTFS field sizes are bounded by u16/u32 record layout"
+)]
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "NTFS attribute dispatch is inherently complex"
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "monolithic extension parser for performance"
+)]
+pub(super) fn parse_extension_to_index(
+    data: &[u8],
+    base_frs: u64,
+    index: &mut crate::index::MftIndex,
+) -> bool {
+    use crate::index::{ChildInfo, IndexNameRef, IndexStreamInfo, LinkInfo, NO_ENTRY, SizeInfo};
+    use crate::ntfs::{
+        AttributeRecordHeader, AttributeType, FileNameAttribute, FileRecordSegmentHeader,
+    };
+
+    if data.len() < size_of::<FileRecordSegmentHeader>() {
+        return false;
+    }
+
+    let header = match FileRecordSegmentHeader::read_from_prefix(data) {
+        Ok((header, _)) => header,
+        Err(_) => return false,
+    };
+
+    // Parse attributes to find $FILE_NAME and $DATA
+    let mut offset = header.first_attribute_offset as usize;
+    let max_offset = core::cmp::min(header.bytes_in_use as usize, data.len());
+
+    // Collect names and streams from extension record
+    let mut names: SmallVec<[(String, u64); 4]> = SmallVec::new();
+    let mut streams: SmallVec<[(String, u64, u64); 4]> = SmallVec::new();
+    let mut dir_index_size: u64 = 0;
+    let mut dir_index_allocated: u64 = 0;
+
+    while offset + size_of::<AttributeRecordHeader>() <= max_offset {
+        let attr_header = match AttributeRecordHeader::read_from_prefix(&data[offset..]) {
+            Ok((attr_header, _)) => attr_header,
+            Err(_) => break,
+        };
+
+        if attr_header.type_code == AttributeType::End as u32 {
+            break;
+        }
+
+        if attr_header.length == 0 || offset + attr_header.length as usize > max_offset {
+            break;
+        }
+
+        let attr_type = AttributeType::from_u32(attr_header.type_code);
+        match attr_type {
+            Some(AttributeType::FileName) => {
+                // Parse $FILE_NAME attribute
+                if attr_header.is_non_resident == 0 {
+                    let value_offset_bytes = &data[offset + 20..offset + 22];
+                    let value_offset =
+                        u16::from_le_bytes(value_offset_bytes.try_into().unwrap_or([0, 0]))
+                            as usize;
+                    let fn_offset = offset + value_offset;
+                    if fn_offset + size_of::<FileNameAttribute>() <= data.len() {
+                        let fn_attr = match FileNameAttribute::read_from_prefix(&data[fn_offset..])
+                        {
+                            Ok((fn_attr, _)) => fn_attr,
+                            Err(_) => break,
+                        };
+
+                        // Skip DOS-only names (namespace 2)
+                        if fn_attr.file_name_namespace != 2 {
+                            let name_len = fn_attr.file_name_length as usize;
+                            let name_start = fn_offset + size_of::<FileNameAttribute>();
+                            if name_start + name_len * 2 <= data.len() {
+                                let name_bytes = &data[name_start..name_start + name_len * 2];
+                                let name_u16: SmallVec<[u16; 64]> = name_bytes
+                                    .chunks_exact(2)
+                                    .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                    .collect();
+                                let name = String::from_utf16_lossy(&name_u16);
+                                let parent_frs = fn_attr.parent_directory & 0x0000_FFFF_FFFF_FFFF;
+                                names.push((name, parent_frs));
+                            }
+                        }
+                    }
+                }
+            }
+            Some(AttributeType::Data) => {
+                // legacy-output parity: Only primary attributes (LowestVCN == 0) count as
+                // streams. Continuation extents (LowestVCN > 0) are skipped.
+                // See ntfs_index_load.hpp:358
+                let is_primary = if attr_header.is_non_resident == 0 {
+                    true // Resident attributes are always primary
+                } else {
+                    let nr_offset = offset + 16;
+                    if nr_offset + 8 <= data.len() {
+                        let lowest_vcn = i64::from_le_bytes(
+                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
+                        );
+                        lowest_vcn == 0
+                    } else {
+                        false // Can't verify, skip to be safe
+                    }
+                };
+
+                if !is_primary {
+                    // Skip continuation extents - they don't count as new streams
+                    offset += attr_header.length as usize;
+                    continue;
+                }
+
+                // Parse $DATA attribute (ADS only - named streams)
+                let name_len = attr_header.name_length as usize;
+                if name_len > 0 {
+                    // This is an ADS (named stream)
+                    let (size, allocated) = if attr_header.is_non_resident != 0 {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 48 <= data.len() {
+                            let allocated = i64::from_le_bytes(
+                                data[nr_offset + 24..nr_offset + 32]
+                                    .try_into()
+                                    .unwrap_or([0; 8]),
+                            );
+                            let size = i64::from_le_bytes(
+                                data[nr_offset + 32..nr_offset + 40]
+                                    .try_into()
+                                    .unwrap_or([0; 8]),
+                            );
+                            (size.max(0) as u64, allocated.max(0) as u64)
+                        } else {
+                            (0, 0)
+                        }
+                    } else {
+                        let len_offset = offset + 16;
+                        if len_offset + 4 <= data.len() {
+                            let len = u32::from_le_bytes(
+                                data[len_offset..len_offset + 4]
+                                    .try_into()
+                                    .unwrap_or([0; 4]),
+                            ) as u64;
+                            (len, 0)
+                        } else {
+                            (0, 0)
+                        }
+                    };
+
+                    let name_offset = offset + attr_header.name_offset as usize;
+                    if name_offset + name_len * 2 <= data.len() {
+                        let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                        let name_u16: SmallVec<[u16; 64]> = name_bytes
+                            .chunks_exact(2)
+                            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                            .collect();
+                        let stream_name = String::from_utf16_lossy(&name_u16);
+                        // Filter out internal Windows streams (names starting with $)
+                        if !is_internal_windows_stream(&stream_name) {
+                            streams.push((stream_name, size, allocated));
+                        }
+                    }
+                }
+            }
+            Some(AttributeType::ReparsePoint) => {
+                // Parse $REPARSE_POINT - add as stream
+                let (rp_size, rp_allocated) = if attr_header.is_non_resident == 0 {
+                    let value_length_bytes = &data[offset + 16..offset + 20];
+                    let value_length =
+                        u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4])) as u64;
+                    (value_length, 0_u64)
+                } else {
+                    let nr_offset = offset + 16;
+                    if nr_offset + 48 <= data.len() {
+                        let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                        let allocated =
+                            i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                        let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                        let data_size = i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                        (data_size.max(0) as u64, allocated.max(0) as u64)
+                    } else {
+                        (0_u64, 0_u64)
+                    }
+                };
+                streams.push((String::from("$REPARSE"), rp_size, rp_allocated));
+            }
+            Some(
+                AttributeType::IndexRoot | AttributeType::IndexAllocation | AttributeType::Bitmap,
+            ) => {
+                // Extract attribute name
+                let name_len = attr_header.name_length as usize;
+                let (is_i30, attr_name) = if name_len > 0 {
+                    let name_offset = offset + attr_header.name_offset as usize;
+                    if name_offset + name_len * 2 <= data.len() {
+                        let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                        let is_i30 =
+                            attr_header.name_length == 4 && name_bytes == b"$\x00I\x003\x000\x00";
+                        let name = if is_i30 {
+                            String::new()
+                        } else {
+                            let name_u16: SmallVec<[u16; 64]> = name_bytes
+                                .chunks_exact(2)
+                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .collect();
+                            String::from_utf16_lossy(&name_u16)
+                        };
+                        (is_i30, name)
+                    } else {
+                        (false, String::new())
+                    }
+                } else {
+                    (false, String::new())
+                };
+
+                if is_i30 {
+                    // Accumulate $I30 sizes
+                    if attr_header.is_non_resident == 0 {
+                        let value_length_bytes = &data[offset + 16..offset + 20];
+                        let value_length =
+                            u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                as u64;
+                        dir_index_size += value_length;
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 48 <= data.len() {
+                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                            let allocated =
+                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                            let data_size =
+                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                            dir_index_size += data_size.max(0) as u64;
+                            dir_index_allocated += allocated.max(0) as u64;
+                        }
+                    }
+                } else {
+                    // Non-$I30 index - count as stream
+                    let is_primary = if attr_header.is_non_resident == 0 {
+                        true
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 8 <= data.len() {
+                            let lowest_vcn = i64::from_le_bytes(
+                                data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
+                            );
+                            lowest_vcn == 0
+                        } else {
+                            false
+                        }
+                    };
+
+                    if is_primary {
+                        let (size, allocated) = if attr_header.is_non_resident == 0 {
+                            let value_length_bytes = &data[offset + 16..offset + 20];
+                            let value_length =
+                                u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                    as u64;
+                            (value_length, 0_u64)
+                        } else {
+                            let nr_offset = offset + 16;
+                            if nr_offset + 48 <= data.len() {
+                                let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                                let allocated =
+                                    i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                                let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                                let data_size =
+                                    i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                                (data_size.max(0) as u64, allocated.max(0) as u64)
+                            } else {
+                                (0_u64, 0_u64)
+                            }
+                        };
+
+                        let stream_name = if attr_name.is_empty() {
+                            match attr_type {
+                                Some(AttributeType::Bitmap) => String::from("$BITMAP"),
+                                Some(AttributeType::IndexRoot) => String::from("$INDEX_ROOT"),
+                                Some(AttributeType::IndexAllocation) => {
+                                    String::from("$INDEX_ALLOCATION")
+                                }
+                                _ => String::new(),
+                            }
+                        } else {
+                            attr_name
+                        };
+                        streams.push((stream_name, size, allocated));
+                    }
+                }
+            }
+            Some(
+                AttributeType::ObjectId
+                | AttributeType::VolumeName
+                | AttributeType::VolumeInformation
+                | AttributeType::PropertySet
+                | AttributeType::Ea
+                | AttributeType::EaInformation
+                | AttributeType::LoggedUtilityStream
+                | AttributeType::SecurityDescriptor
+                | AttributeType::AttributeList,
+            ) => {
+                // All counted as streams
+                let is_primary = if attr_header.is_non_resident == 0 {
+                    true
+                } else {
+                    let nr_offset = offset + 16;
+                    if nr_offset + 8 <= data.len() {
+                        let lowest_vcn = i64::from_le_bytes(
+                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
+                        );
+                        lowest_vcn == 0
+                    } else {
+                        false
+                    }
+                };
+
+                if is_primary {
+                    let attr_name = if attr_header.name_length > 0 {
+                        let name_offset = offset + attr_header.name_offset as usize;
+                        let name_len = attr_header.name_length as usize;
+                        if name_offset + name_len * 2 <= data.len() {
+                            let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                            let name_u16: SmallVec<[u16; 64]> = name_bytes
+                                .chunks_exact(2)
+                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .collect();
+                            String::from_utf16_lossy(&name_u16)
+                        } else {
+                            String::new()
+                        }
+                    } else {
+                        String::new()
+                    };
+
+                    let (size, allocated) = if attr_header.is_non_resident == 0 {
+                        let value_length_bytes = &data[offset + 16..offset + 20];
+                        let value_length =
+                            u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                as u64;
+                        (value_length, 0_u64)
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 48 <= data.len() {
+                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                            let allocated =
+                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                            let data_size =
+                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                            (data_size.max(0) as u64, allocated.max(0) as u64)
+                        } else {
+                            (0_u64, 0_u64)
+                        }
+                    };
+
+                    let stream_name = if attr_name.is_empty() {
+                        match attr_type {
+                            Some(AttributeType::ObjectId) => String::from("$OBJECT_ID"),
+                            Some(AttributeType::VolumeName) => String::from("$VOLUME_NAME"),
+                            Some(AttributeType::VolumeInformation) => {
+                                String::from("$VOLUME_INFORMATION")
+                            }
+                            Some(AttributeType::PropertySet) => String::from("$PROPERTY_SET"),
+                            Some(AttributeType::Ea) => String::from("$EA"),
+                            Some(AttributeType::EaInformation) => String::from("$EA_INFORMATION"),
+                            Some(AttributeType::LoggedUtilityStream) => {
+                                String::from("$LOGGED_UTILITY_STREAM")
+                            }
+                            Some(AttributeType::SecurityDescriptor) => {
+                                String::from("$SECURITY_DESCRIPTOR")
+                            }
+                            Some(AttributeType::AttributeList) => String::from("$ATTRIBUTE_LIST"),
+                            _ => String::new(),
+                        }
+                    } else {
+                        attr_name
+                    };
+                    streams.push((stream_name, size, allocated));
+                }
+            }
+            Some(AttributeType::StandardInformation) => {
+                // Skip - not expected in extension records
+            }
+            _ => {
+                // Unknown attribute types - count as streams (C++ default: case)
+                let type_code = attr_header.type_code;
+
+                let is_primary = if attr_header.is_non_resident == 0 {
+                    true
+                } else {
+                    let nr_offset = offset + 16;
+                    if nr_offset + 8 <= data.len() {
+                        let lowest_vcn = i64::from_le_bytes(
+                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
+                        );
+                        lowest_vcn == 0
+                    } else {
+                        false
+                    }
+                };
+
+                if is_primary {
+                    let attr_name = if attr_header.name_length > 0 {
+                        let name_offset = offset + attr_header.name_offset as usize;
+                        let name_len = attr_header.name_length as usize;
+                        if name_offset + name_len * 2 <= data.len() {
+                            let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                            let name_u16: SmallVec<[u16; 64]> = name_bytes
+                                .chunks_exact(2)
+                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .collect();
+                            String::from_utf16_lossy(&name_u16)
+                        } else {
+                            String::new()
+                        }
+                    } else {
+                        String::new()
+                    };
+
+                    let (size, allocated) = if attr_header.is_non_resident == 0 {
+                        let value_length_bytes = &data[offset + 16..offset + 20];
+                        let value_length =
+                            u32::from_le_bytes(value_length_bytes.try_into().unwrap_or([0; 4]))
+                                as u64;
+                        (value_length, 0_u64)
+                    } else {
+                        let nr_offset = offset + 16;
+                        if nr_offset + 48 <= data.len() {
+                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
+                            let allocated =
+                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
+                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
+                            let data_size =
+                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
+                            (data_size.max(0) as u64, allocated.max(0) as u64)
+                        } else {
+                            (0_u64, 0_u64)
+                        }
+                    };
+
+                    let stream_name = if attr_name.is_empty() {
+                        format!("$UNKNOWN_0x{type_code:X}")
+                    } else {
+                        attr_name
+                    };
+                    streams.push((stream_name, size, allocated));
+                }
+            }
+        }
+
+        offset += attr_header.length as usize;
+    }
+
+    // If no names or streams found, nothing to do
+    if names.is_empty() && streams.is_empty() {
+        return false;
+    }
+
+    // Add names to the base record
+    // First, add all names to the names buffer and create LinkInfo entries
+    let mut link_indices: Vec<u32> = Vec::with_capacity(names.len());
+    for (name, parent_frs) in &names {
+        let name_offset = index.add_name(name);
+        let name_len = name.len();
+        let is_ascii = name.is_ascii();
+        let extension_id = index.intern_extension(name);
+        let name_ref = IndexNameRef::new(name_offset, name_len as u16, is_ascii, extension_id);
+
+        let link_idx = index.links.len() as u32;
+        index.links.push(LinkInfo {
+            next_entry: NO_ENTRY,
+            name: name_ref,
+            parent_frs: *parent_frs,
+        });
+        link_indices.push(link_idx);
+    }
+
+    // Add streams to the streams buffer
+    let mut stream_indices: Vec<u32> = Vec::with_capacity(streams.len());
+    for (stream_name, size, allocated) in &streams {
+        let name_offset = index.add_name(stream_name);
+        let name_len = stream_name.len();
+        let is_ascii = stream_name.is_ascii();
+        let extension_id = index.intern_extension(stream_name);
+        let name_ref = IndexNameRef::new(name_offset, name_len as u16, is_ascii, extension_id);
+
+        let stream_idx = index.streams.len() as u32;
+        index.streams.push(IndexStreamInfo {
+            size: SizeInfo {
+                length: *size,
+                allocated: *allocated,
+            },
+            next_entry: NO_ENTRY,
+            name: name_ref,
+            flags: 0,
+        });
+        stream_indices.push(stream_idx);
+    }
+
+    // Ensure parent directories exist for the new names
+    for (_, parent_frs) in &names {
+        if *parent_frs != base_frs && *parent_frs != 0 {
+            let _ = index.get_or_create(*parent_frs);
+        }
+    }
+
+    // Get the base record and add the names/streams to it
+    let base_frs_usize = base_frs as usize;
+    if base_frs_usize >= index.frs_to_idx.len() {
+        // Base record doesn't exist yet - create a placeholder
+        let _ = index.get_or_create(base_frs);
+    }
+
+    let record_idx = index.frs_to_idx[base_frs_usize];
+    if record_idx == NO_ENTRY {
+        // Base record doesn't exist - create it
+        let _ = index.get_or_create(base_frs);
+    }
+
+    // Now get the record and chain the new links/streams
+    let record_idx = index.frs_to_idx[base_frs_usize];
+    if record_idx != NO_ENTRY {
+        let record = &mut index.records[record_idx as usize];
+
+        // Add new links to the record
+        if !link_indices.is_empty() {
+            // Check if base record has no name (first_name is empty)
+            // This happens when the $FILE_NAME attribute is ONLY in extension records
+            if !record.first_name.name.is_valid() {
+                // Copy the first extension name directly into first_name
+                // This matches established behavior (ntfs_index.hpp lines 559-567)
+                let first_link = &index.links[link_indices[0] as usize];
+                record.first_name.name = first_link.name;
+                record.first_name.parent_frs = first_link.parent_frs;
+                // Don't increment name_count for the first name (it's already counted as 1)
+
+                // Chain remaining links (if any) to first_name.next_entry
+                if link_indices.len() > 1 {
+                    // Chain the remaining links together
+                    for i in 1..link_indices.len().saturating_sub(1) {
+                        let current_idx = link_indices[i] as usize;
+                        let next_idx = link_indices[i + 1];
+                        index.links[current_idx].next_entry = next_idx;
+                    }
+                    // Attach remaining links to first_name
+                    let record = &mut index.records[record_idx as usize];
+                    record.first_name.next_entry = link_indices[1];
+                    // Update name count for additional links only
+                    record.name_count += (link_indices.len() - 1) as u16;
+                }
+            } else {
+                // Base record already has a name - chain extension names as additional hard
+                // links Find the end of the current link chain
+                let last_link_idx = if record.first_name.next_entry != NO_ENTRY {
+                    let mut idx = record.first_name.next_entry;
+                    while index.links[idx as usize].next_entry != NO_ENTRY {
+                        idx = index.links[idx as usize].next_entry;
+                    }
+                    Some(idx)
+                } else {
+                    None
+                };
+
+                // Chain the new links together
+                for i in 0..link_indices.len().saturating_sub(1) {
+                    let current_idx = link_indices[i] as usize;
+                    let next_idx = link_indices[i + 1];
+                    index.links[current_idx].next_entry = next_idx;
+                }
+
+                // Attach to the chain
+                if let Some(last_idx) = last_link_idx {
+                    index.links[last_idx as usize].next_entry = link_indices[0];
+                } else {
+                    // first_name has no next_entry, attach directly
+                    let record = &mut index.records[record_idx as usize];
+                    record.first_name.next_entry = link_indices[0];
+                }
+
+                // Update name count
+                let record = &mut index.records[record_idx as usize];
+                record.name_count += link_indices.len() as u16;
+            }
+        }
+
+        // Chain new streams to the end of the existing stream chain
+        if !stream_indices.is_empty() {
+            let record = &mut index.records[record_idx as usize];
+
+            // Find the end of the current stream chain
+            let last_stream_idx = if record.first_stream.next_entry != NO_ENTRY {
+                let mut idx = record.first_stream.next_entry;
+                while index.streams[idx as usize].next_entry != NO_ENTRY {
+                    idx = index.streams[idx as usize].next_entry;
+                }
+                Some(idx)
+            } else {
+                None
+            };
+
+            // Chain the new streams together
+            for i in 0..stream_indices.len().saturating_sub(1) {
+                let current_idx = stream_indices[i] as usize;
+                let next_idx = stream_indices[i + 1];
+                index.streams[current_idx].next_entry = next_idx;
+            }
+
+            // Attach to the chain
+            if let Some(last_idx) = last_stream_idx {
+                index.streams[last_idx as usize].next_entry = stream_indices[0];
+            } else {
+                // first_stream has no next_entry, attach directly
+                let record = &mut index.records[record_idx as usize];
+                record.first_stream.next_entry = stream_indices[0];
+            }
+
+            // Update stream count
+            let record = &mut index.records[record_idx as usize];
+            record.stream_count += stream_indices.len() as u16;
+            record.total_stream_count += stream_indices.len() as u16;
+        }
+
+        // Merge directory index sizes from extension records
+        if dir_index_size > 0 || dir_index_allocated > 0 {
+            let record = &mut index.records[record_idx as usize];
+            // Add to the first_stream size (which represents the default stream for
+            // directories)
+            record.first_stream.size.length += dir_index_size;
+            record.first_stream.size.allocated += dir_index_allocated;
+        }
+
+        // Build parent-child relationship for names added from extension records
+        // This is critical for compute_tree_metrics() to work correctly.
+        // Get the current name_count to determine the name_index for each new name
+        let record = &index.records[record_idx as usize];
+        let existing_name_count = record.name_count;
+
+        for (name_idx, (_, parent_frs)) in names.iter().enumerate() {
+            let p_frs = *parent_frs;
+            if p_frs == base_frs || p_frs == 0 || p_frs == u64::from(NO_ENTRY) {
+                continue;
+            }
+
+            // Ensure parent exists
+            let parent_idx = {
+                let p_frs_usize = p_frs as usize;
+                if p_frs_usize >= index.frs_to_idx.len() {
+                    index.frs_to_idx.resize(p_frs_usize + 1, NO_ENTRY);
+                }
+                if index.frs_to_idx[p_frs_usize] == NO_ENTRY {
+                    // Create placeholder parent
+                    let new_idx = index.records.len() as u32;
+                    index.frs_to_idx[p_frs_usize] = new_idx;
+                    index.records.push(crate::index::FileRecord::new(p_frs));
+                }
+                index.frs_to_idx[p_frs_usize]
+            };
+
+            // Add child entry
+            // name_index is the position in the combined name list (existing + new)
+            // For extension records, the first name might replace first_name (if empty),
+            // so we need to account for that
+            let effective_name_idx = if existing_name_count == 0 {
+                // First extension name became first_name, so name_index starts at 0
+                name_idx as u16
+            } else {
+                // Extension names are appended after existing names
+                existing_name_count - 1 + name_idx as u16
+            };
+
+            let child_idx = index.children.len() as u32;
+            let parent = &mut index.records[parent_idx as usize];
+            let old_first_child = parent.first_child;
+            parent.first_child = child_idx;
+
+            index.children.push(ChildInfo {
+                next_entry: old_first_child,
+                child_frs: base_frs,
+                name_index: effective_name_idx,
+            });
+        }
+    }
+
+    !names.is_empty() || !streams.is_empty()
+}

--- a/crates/uffs-mft/src/parse/full.rs
+++ b/crates/uffs-mft/src/parse/full.rs
@@ -15,7 +15,8 @@ use crate::ntfs::{ExtendedStandardInfo, NameInfo, ReparsePointHeader, StreamInfo
 /// `parse_record_full → MftRecordMerger → from_parsed_records` pipeline.
 /// The hot path (`SlidingIocpInline`) now uses direct-to-index parsers that
 /// skip this intermediate allocation. This function is still used by:
-/// - Legacy read modes (`Parallel`, `Pipelined`, `PipelinedParallel`, `SlidingIocp`)
+/// - Legacy read modes (`Parallel`, `Pipelined`, `PipelinedParallel`,
+///   `SlidingIocp`)
 /// - File-based readers (`load_raw_to_index_with_options`)
 /// - Tests and diagnostic tools
 /// - `UFFS_LEGACY_PARSE=1` escape hatch

--- a/crates/uffs-mft/src/parse/full.rs
+++ b/crates/uffs-mft/src/parse/full.rs
@@ -11,6 +11,15 @@ use crate::ntfs::{ExtendedStandardInfo, NameInfo, ReparsePointHeader, StreamInfo
 
 /// Parses an MFT record and extracts relevant information.
 ///
+/// **LEGACY MULTI-PASS PIPELINE:** This function is part of the old
+/// `parse_record_full → MftRecordMerger → from_parsed_records` pipeline.
+/// The hot path (`SlidingIocpInline`) now uses direct-to-index parsers that
+/// skip this intermediate allocation. This function is still used by:
+/// - Legacy read modes (`Parallel`, `Pipelined`, `PipelinedParallel`, `SlidingIocp`)
+/// - File-based readers (`load_raw_to_index_with_options`)
+/// - Tests and diagnostic tools
+/// - `UFFS_LEGACY_PARSE=1` escape hatch
+///
 /// This function handles both base records and extension records.
 /// Extension records return `ParseResult::Extension` which must be
 /// merged into the base record later.

--- a/crates/uffs-mft/src/parse/merger.rs
+++ b/crates/uffs-mft/src/parse/merger.rs
@@ -10,7 +10,8 @@ use crate::ntfs::StreamInfo;
 /// The hot path (`SlidingIocpInline`) now uses direct-to-index parsers that
 /// create parent placeholders on-demand without this intermediate allocation.
 /// This merger is still used by:
-/// - Legacy read modes (`Parallel`, `Pipelined`, `PipelinedParallel`, `SlidingIocp`)
+/// - Legacy read modes (`Parallel`, `Pipelined`, `PipelinedParallel`,
+///   `SlidingIocp`)
 /// - File-based readers (`load_raw_to_index_with_options`)
 /// - Tests and diagnostic tools
 /// - `UFFS_LEGACY_PARSE=1` escape hatch

--- a/crates/uffs-mft/src/parse/merger.rs
+++ b/crates/uffs-mft/src/parse/merger.rs
@@ -5,6 +5,16 @@ use crate::ntfs::StreamInfo;
 
 /// Merges extension record attributes into base records.
 ///
+/// **LEGACY MULTI-PASS PIPELINE:** This type is part of the old
+/// `parse_record_full → MftRecordMerger → from_parsed_records` pipeline.
+/// The hot path (`SlidingIocpInline`) now uses direct-to-index parsers that
+/// create parent placeholders on-demand without this intermediate allocation.
+/// This merger is still used by:
+/// - Legacy read modes (`Parallel`, `Pipelined`, `PipelinedParallel`, `SlidingIocp`)
+/// - File-based readers (`load_raw_to_index_with_options`)
+/// - Tests and diagnostic tools
+/// - `UFFS_LEGACY_PARSE=1` escape hatch
+///
 /// This implements the C++ behavior where attributes from extension
 /// records are merged into their base records.
 ///

--- a/crates/uffs-mft/src/platform/bitmap.rs
+++ b/crates/uffs-mft/src/platform/bitmap.rs
@@ -59,6 +59,23 @@ impl MftBitmap {
             .sum()
     }
 
+    /// Returns the highest FRS number that is marked as in use.
+    ///
+    /// This scans the bitmap backwards to find the last set bit.
+    /// Returns 0 if no records are in use.
+    #[must_use]
+    pub fn max_frs_in_use(&self) -> u64 {
+        // Scan backwards through bytes to find the last non-zero byte
+        for (byte_idx, &byte) in self.data.iter().enumerate().rev() {
+            if byte != 0 {
+                // Found a non-zero byte, find the highest bit set
+                let bit_idx = 7 - byte.leading_zeros() as usize;
+                return (byte_idx * 8 + bit_idx) as u64;
+            }
+        }
+        0
+    }
+
     /// Returns the total number of records this bitmap covers.
     #[must_use]
     pub fn record_count(&self) -> usize {

--- a/crates/uffs-mft/src/reader/index_read.rs
+++ b/crates/uffs-mft/src/reader/index_read.rs
@@ -262,6 +262,15 @@ impl MftReader {
         use crate::platform::detect_drive_type;
 
         tracing::debug!(volume = %self.volume, "[TRIP] reader::read_mft_index_internal ENTER");
+
+        // Check for legacy parse mode escape hatch
+        // UFFS_LEGACY_PARSE=1 forces the old multi-pass pipeline for
+        // debugging/comparison
+        let use_legacy_parse = std::env::var("UFFS_LEGACY_PARSE").is_ok();
+        if use_legacy_parse {
+            warn!(volume = %self.volume, "⚠️  UFFS_LEGACY_PARSE=1 detected - using legacy multi-pass pipeline");
+        }
+
         info!(volume = %self.volume, "Starting MFT read (lean index)");
 
         let start_time = Instant::now();
@@ -328,7 +337,13 @@ impl MftReader {
         // For lean index (MftIndex), use SlidingIocpInline for NVMe/SSD - this uses
         // IOCP with multiple reads in flight and inline parsing, matching C++
         // performance.
-        let effective_mode = index_effective_mode(self.mode, drive_type);
+        let mut effective_mode = index_effective_mode(self.mode, drive_type);
+
+        // Apply legacy parse mode override if escape hatch is set
+        if use_legacy_parse && effective_mode == MftReadMode::SlidingIocpInline {
+            warn!("🔄 Forcing SlidingIocp mode (legacy pipeline) due to UFFS_LEGACY_PARSE=1");
+            effective_mode = MftReadMode::SlidingIocp;
+        }
 
         info!(mode = %effective_mode, "🚀 Using read mode (lean index)");
 

--- a/crates/uffs-mft/src/reader/persistence.rs
+++ b/crates/uffs-mft/src/reader/persistence.rs
@@ -553,4 +553,80 @@ impl MftReader {
             }
         }
     }
+
+    /// Load raw MFT from file and build `MftIndex` using direct-to-index
+    /// parser.
+    ///
+    /// This is a single-pass implementation that parses records directly into
+    /// the index without creating intermediate `ParsedRecord` allocations. It
+    /// uses the modernized `parse_record_to_index()` from Wave 1.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the raw file cannot be loaded or if record parsing
+    /// or index construction fails.
+    pub fn load_raw_to_index_direct<P: AsRef<Path>>(
+        path: P,
+        options: &crate::raw::LoadRawOptions,
+    ) -> Result<crate::index::MftIndex> {
+        use std::time::Instant;
+
+        use tracing::info;
+
+        use crate::index::MftIndex;
+        use crate::parse::{apply_fixup, parse_record_to_index};
+
+        let parse_start = Instant::now();
+
+        // Load raw MFT data
+        let mut raw = crate::raw::load_raw_mft(path, options)?;
+        let capacity = usize::try_from(raw.header.record_count).unwrap_or(0);
+        let total_records_in_file = capacity;
+        let record_size = raw.header.record_size as usize;
+
+        // Create index with pre-allocated capacity
+        let mut index = MftIndex::with_capacity(raw.header.volume_letter, capacity);
+
+        // Parse records directly into index
+        let mut fixup_success: u64 = 0;
+        let mut fixup_failed: u64 = 0;
+        let mut records_added: u64 = 0;
+
+        let buffer_slice = raw.data.as_mut_slice();
+        for (frs, chunk) in buffer_slice.chunks_exact_mut(record_size).enumerate() {
+            // Apply fixup in place
+            if !apply_fixup(chunk) {
+                fixup_failed += 1;
+                continue;
+            }
+            fixup_success += 1;
+
+            // Parse record directly into index
+            // parse_record_to_index handles both base and extension records internally
+            let added = parse_record_to_index(chunk, frs as u64, &mut index);
+            if added {
+                records_added += 1;
+            }
+        }
+
+        // Compute tree metrics
+        index.compute_tree_metrics();
+
+        // Sort directory children
+        index.sort_directory_children();
+
+        let parse_time = parse_start.elapsed();
+
+        info!(
+            total_records_in_file,
+            parse_ms = parse_time.as_millis(),
+            fixup_success,
+            fixup_failed,
+            records_added,
+            final_index_size = index.len(),
+            "Direct-to-index parse complete"
+        );
+
+        Ok(index)
+    }
 }

--- a/scripts/ci/file_size_exceptions.txt
+++ b/scripts/ci/file_size_exceptions.txt
@@ -5,4 +5,4 @@ crates/uffs-diag/src/bin/compare_scan_parity.rs|Diagnostic parity pipeline remai
 crates/uffs-cli/src/commands/output.rs|Output formatting module with comprehensive test suite for DataFrame/native output parity and footer formatting.
 crates/uffs-cli/src/commands/raw_io.rs|I/O coordination module consolidating MFT reading, query filtering, and multi-drive orchestration logic.
 crates/uffs-mft/src/io/parser/index.rs|Single-pass direct-to-index parser (C++-style inline approach). Monolithic by design for IOCP hot path - handles all NTFS attribute types inline.
-crates/uffs-mft/src/io/parser/index_extension.rs|Extension record parser for direct-to-index path. Handles all attribute types from extension records - matches index.rs completeness.
+crates/uffs-mft/src/parse/direct_index.rs|Cross-platform single-pass direct-to-index parser. Monolithic by design for hot path - handles all NTFS attribute types inline.

--- a/scripts/ci/file_size_exceptions.txt
+++ b/scripts/ci/file_size_exceptions.txt
@@ -4,3 +4,5 @@
 crates/uffs-diag/src/bin/compare_scan_parity.rs|Diagnostic parity pipeline remains consolidated because the end-to-end workflow is reviewed as one unit.
 crates/uffs-cli/src/commands/output.rs|Output formatting module with comprehensive test suite for DataFrame/native output parity and footer formatting.
 crates/uffs-cli/src/commands/raw_io.rs|I/O coordination module consolidating MFT reading, query filtering, and multi-drive orchestration logic.
+crates/uffs-mft/src/io/parser/index.rs|Single-pass direct-to-index parser (C++-style inline approach). Monolithic by design for IOCP hot path - handles all NTFS attribute types inline.
+crates/uffs-mft/src/io/parser/index_extension.rs|Extension record parser for direct-to-index path. Handles all attribute types from extension records - matches index.rs completeness.


### PR DESCRIPTION
## Summary

This PR merges the fix-f-drive-parity branch which implements:

- Single-pass MFT pipeline matching C++ architecture
- Extension record merging for multi-attribute files
- Proper handling of hard links, ADS, and sparse files
- F: drive parity fixes

## Testing

- Cross-platform CI passes
- Ready for Windows parity testing