### PR TITLE
Fix Drive D/S parity: remove premature metrics + child sorting

### DIFF
--- a/crates/uffs-mft/src/index/builder.rs
+++ b/crates/uffs-mft/src/index/builder.rs
@@ -465,14 +465,7 @@ impl MftIndex {
         tracing::debug!("[TRIP] MftIndex::from_parsed_records -> Phase 2: ExtensionIndex::build");
         index.extension_index = Some(ExtensionIndex::build(&index));
 
-        // 2. Sort directory children for natural ordering (Phase 4)
-        // CRITICAL: Must run BEFORE computing tree metrics for correct size
-        // aggregation.
-        tracing::debug!("[TRIP] MftIndex::from_parsed_records -> Phase 4: sort_directory_children");
-        index.sort_directory_children();
-
-        // 3. Compute tree metrics for directory statistics (Phase 5)
-        // Must run AFTER sorting - depends on sorted child traversal order.
+        // 2. Compute tree metrics for directory statistics (Phase 5)
         tracing::debug!("[TRIP] MftIndex::from_parsed_records -> Phase 5: compute_tree_metrics");
         index.compute_tree_metrics();
 

--- a/crates/uffs-mft/src/index/merge.rs
+++ b/crates/uffs-mft/src/index/merge.rs
@@ -54,9 +54,6 @@ impl MftIndex {
         debug!("🔨 Building extension index...");
         self.extension_index = Some(ExtensionIndex::build(self));
 
-        debug!("🔨 Sorting directory children...");
-        self.sort_directory_children();
-
         debug!("🔨 Computing tree metrics...");
         self.compute_tree_metrics();
 

--- a/crates/uffs-mft/src/io/readers/parallel/to_index.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/to_index.rs
@@ -486,13 +486,6 @@ impl ParallelMftReader {
             "✅ Sliding window IOCP with direct-to-index parsing complete (I/O overlap analysis)"
         );
 
-        // Compute tree metrics (size/allocated_size/descendant_count) for all
-        // directories This is required for parity with the legacy multi-pass
-        // pipeline, which called this in MftIndex::from_parsed_records(). The
-        // direct-to-index path must call it explicitly after all records are
-        // parsed and parent-child relationships are built.
-        index.compute_tree_metrics();
-
         Ok(index)
     }
 }

--- a/crates/uffs-mft/src/io/readers/parallel/to_index_parallel.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/to_index_parallel.rs
@@ -525,13 +525,6 @@ impl ParallelMftReader {
             "✅ Parallel parsing IOCP with unified pipeline complete"
         );
 
-        // Compute tree metrics (size/allocated_size/descendant_count) for all
-        // directories This is required for parity with the legacy multi-pass
-        // pipeline, which called this in MftIndex::from_parsed_records(). The
-        // direct-to-index path must call it explicitly after all records are
-        // parsed and parent-child relationships are built.
-        index.compute_tree_metrics();
-
         Ok(index)
     }
 }

--- a/crates/uffs-mft/src/reader/index_read.rs
+++ b/crates/uffs-mft/src/reader/index_read.rs
@@ -620,11 +620,6 @@ impl MftReader {
 
                 let mut index = result?;
 
-                // Sort directory children first so tree metrics traverse in correct order.
-                // Tree metrics computation depends on children being in sorted order to
-                // produce accurate directory sizes and descendant counts.
-                index.sort_directory_children();
-
                 // Compute tree metrics (directory sizes, descendant counts).
                 // The legacy path gets this from `from_parsed_records()`, but the
                 // inline path bypasses that, so we must call it explicitly.

--- a/crates/uffs-mft/src/reader/persistence.rs
+++ b/crates/uffs-mft/src/reader/persistence.rs
@@ -609,9 +609,6 @@ impl MftReader {
             }
         }
 
-        // Sort directory children
-        index.sort_directory_children();
-
         // Compute tree metrics
         index.compute_tree_metrics();
 


### PR DESCRIPTION
## Summary

- **Drive D fix**: Remove premature `compute_tree_metrics()` from IOCP inline readers (`to_index.rs`, `to_index_parallel.rs`). These called metrics before sort, producing wrong directory sizes. Now metrics are computed exactly once in the caller.
- **Drive S fix**: Remove ALL `sort_directory_children()` calls. C++ outputs children in reverse MFT parse order (no sorting). Rust was sorting alphabetically, causing 99.96% diff rate on Drive S.

## Expected Impact

| Drive | Before (diffs) | After (expected) |
|-------|---------------|------------------|
| D | 5,756,841 | ~0 |
| S | 8,275,020 | ~0 |
| G | 1 | 1 |

## Test plan

- [ ] `just check` passes
- [ ] All 105 MFT tests pass
- [ ] Windows trial_run.ps1 on all drives
- [ ] Verify Drive D directory sizes match C++
- [ ] Verify Drive S output order matches C++