### PR TITLE
fix(mft): restore OFFLINE path sorting (5/6 SORTED MATCH)

### DIFF
--- a/crates/uffs-mft/src/index/builder.rs
+++ b/crates/uffs-mft/src/index/builder.rs
@@ -465,7 +465,15 @@ impl MftIndex {
         tracing::debug!("[TRIP] MftIndex::from_parsed_records -> Phase 2: ExtensionIndex::build");
         index.extension_index = Some(ExtensionIndex::build(&index));
 
-        // 2. Compute tree metrics for directory statistics (Phase 5)
+        // 2. Sort directory children for deterministic OFFLINE output (Phase 4)
+        // CRITICAL: OFFLINE path (from_parsed_records) requires sorted children
+        // for deterministic CSV output order. LIVE paths (to_index.rs) do NOT
+        // sort to match C++ behavior (reverse MFT parse order).
+        tracing::debug!("[TRIP] MftIndex::from_parsed_records -> Phase 4: sort_directory_children");
+        index.sort_directory_children();
+
+        // 3. Compute tree metrics for directory statistics (Phase 5)
+        // Must run AFTER sorting in OFFLINE path for deterministic results.
         tracing::debug!("[TRIP] MftIndex::from_parsed_records -> Phase 5: compute_tree_metrics");
         index.compute_tree_metrics();
 

--- a/crates/uffs-mft/src/index/merge.rs
+++ b/crates/uffs-mft/src/index/merge.rs
@@ -54,6 +54,9 @@ impl MftIndex {
         debug!("🔨 Building extension index...");
         self.extension_index = Some(ExtensionIndex::build(self));
 
+        debug!("🔨 Sorting directory children...");
+        self.sort_directory_children();
+
         debug!("🔨 Computing tree metrics...");
         self.compute_tree_metrics();
 

--- a/crates/uffs-mft/src/reader/persistence.rs
+++ b/crates/uffs-mft/src/reader/persistence.rs
@@ -609,6 +609,10 @@ impl MftReader {
             }
         }
 
+        // Sort directory children for deterministic output
+        // CRITICAL for OFFLINE path: ensures consistent ordering across runs
+        index.sort_directory_children();
+
         // Compute tree metrics
         index.compute_tree_metrics();
 

--- a/scripts/verify_parity.rs
+++ b/scripts/verify_parity.rs
@@ -994,6 +994,8 @@ fn regenerate_rust_output(
             drive_letter,
             "--tz-offset",
             &tz_str,
+            "--format",
+            "custom",  // Match C++ baseline footer format
             "--out",
             &rust_output.to_string_lossy(),
         ])


### PR DESCRIPTION
## Summary

Restores OFFLINE MFT processing to 5/6 SORTED MATCH state after regression from commit 90ee522ed.

### What was broken
- Commit 90ee522ed removed ALL sort_directory_children() calls for C++ parity (Drive S fix)
- This broke OFFLINE path — all 6 drives went from 5/6 SORTED MATCH to 0/6 output

### Fix
1. Re-added sort_directory_children() to OFFLINE paths:
   - persistence.rs (loading saved index)
   - merge.rs (post-processing)
   - builder.rs (already fixed by previous agent)

2. Fixed verify_parity.rs to use --format custom for C++ footer parity

### Result
- ✅ Drive D: SORTED MATCH (7,065,330 lines)
- ✅ Drive E: SORTED MATCH (2,929,497 lines)  
- ❌ Drive F: MISMATCH (Bug 3 - extension records, deferred)
- ✅ Drive G: SORTED MATCH (15,071 lines)
- ✅ Drive M: SORTED MATCH (1,908,783 lines)
- ✅ Drive S: SORTED MATCH (8,278,080 lines)

**5/6 SORTED MATCH** restored ✅