### PR TITLE
chore(repo): transfer ownership to skyllc-ai — update URL references

### DIFF
--- a/.github/workflows/optimized-ci.yml
+++ b/.github/workflows/optimized-ci.yml
@@ -78,7 +78,7 @@ jobs:
           # Explicit slug so the uploader doesn't have to infer the repo
           # from GitHub Actions env vars (more robust on fork PRs, workflow
           # renames, etc.).  Recommended by the Codecov setup wizard.
-          slug: githubrobbi/UltraFastFileSearch
+          slug: skyllc-ai/UltraFastFileSearch
           # Token is optional: the Codecov org currently allows tokenless
           # uploads.  If `CODECOV_TOKEN` is ever added as a repo secret,
           # this reference picks it up automatically without a YAML edit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -534,11 +534,11 @@ thin clients over a unified `uffsd` process.
 ### Fixed
 - Various MFT parsing edge cases
 
-[Unreleased]: https://github.com/githubrobbi/UltraFastFileSearch/compare/v0.5.67...HEAD
-[0.5.67]: https://github.com/githubrobbi/UltraFastFileSearch/compare/v0.5.0...v0.5.67
-[0.5.0]: https://github.com/githubrobbi/UltraFastFileSearch/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/githubrobbi/UltraFastFileSearch/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/githubrobbi/UltraFastFileSearch/compare/v0.2.208...v0.3.0
-[0.2.208]: https://github.com/githubrobbi/UltraFastFileSearch/compare/v0.2.114...v0.2.208
-[0.2.114]: https://github.com/githubrobbi/UltraFastFileSearch/releases/tag/v0.2.114
+[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.5.67...HEAD
+[0.5.67]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.5.0...v0.5.67
+[0.5.0]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.2.208...v0.3.0
+[0.2.208]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.2.114...v0.2.208
+[0.2.114]: https://github.com/skyllc-ai/UltraFastFileSearch/releases/tag/v0.2.114
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ edition = "2024"
 # a nightly toolchain. See rust-toolchain.toml for the pinned nightly channel.
 rust-version = "1.91"
 license = "MPL-2.0"
-repository = "https://github.com/githubrobbi/UltraFastFileSearch"
+repository = "https://github.com/skyllc-ai/UltraFastFileSearch"
 authors = ["Robert Nio <50460704+githubrobbi@users.noreply.github.com>"]
 description = "UFFS - Ultra Fast File Search using direct NTFS MFT reading and Polars DataFrames"
 documentation = "https://docs.rs/uffs"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # UFFS — Ultra Fast File Search
 
-[![CI](https://github.com/githubrobbi/UltraFastFileSearch/actions/workflows/ci.yml/badge.svg)](https://github.com/githubrobbi/UltraFastFileSearch/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/githubrobbi/UltraFastFileSearch?label=release)](https://github.com/githubrobbi/UltraFastFileSearch/releases/latest)
+[![CI](https://github.com/skyllc-ai/UltraFastFileSearch/actions/workflows/ci.yml/badge.svg)](https://github.com/skyllc-ai/UltraFastFileSearch/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/skyllc-ai/UltraFastFileSearch?label=release)](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
-[![Platform: Windows](https://img.shields.io/badge/platform-Windows-blue.svg)](https://github.com/githubrobbi/UltraFastFileSearch/releases/latest)
+[![Platform: Windows](https://img.shields.io/badge/platform-Windows-blue.svg)](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest)
 
 **A benchmark-driven NTFS search engine for Windows.** UFFS reads the Master File Table directly, builds a compact persisted index, and keeps large NTFS estates searchable through a background daemon.
 
@@ -195,4 +195,4 @@ See [LICENSES/MPL-2.0.txt](LICENSES/MPL-2.0.txt) for the full license text and [
 
 UFFS benefits from the broader NTFS tooling ecosystem, including [SwiftSearch](https://sourceforge.net/projects/swiftsearch/) by wfunction.
 
-**Author:** Robert Nio · [github.com/githubrobbi/UltraFastFileSearch](https://github.com/githubrobbi/UltraFastFileSearch)
+**Author:** Robert Nio · [github.com/skyllc-ai/UltraFastFileSearch](https://github.com/skyllc-ai/UltraFastFileSearch)

--- a/docs/user-manual/installation.md
+++ b/docs/user-manual/installation.md
@@ -1,7 +1,7 @@
 # Installation
 
 Pre-built Windows binaries are available from
-[GitHub Releases](https://github.com/githubrobbi/UltraFastFileSearch/releases).
+[GitHub Releases](https://github.com/skyllc-ai/UltraFastFileSearch/releases).
 Most users do not need to build from source.
 
 > **See also:** [Getting Started](getting-started.md) ·
@@ -13,7 +13,7 @@ Most users do not need to build from source.
 ## 1  Pre-Built Binaries (Recommended)
 
 Download the latest Windows x64 binaries from the
-[GitHub Releases page](https://github.com/githubrobbi/UltraFastFileSearch/releases/latest).
+[GitHub Releases page](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest).
 
 Each release includes:
 - `uffs-windows-x64.exe` — main CLI (starts daemon + MCP)
@@ -35,7 +35,7 @@ This downloads the latest release binaries and installs them to `~/bin`.
 **Option B — Manual download:**
 
 1. Download `uffs-windows-x64.exe` from the
-   [latest release](https://github.com/githubrobbi/UltraFastFileSearch/releases/latest).
+   [latest release](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest).
 
 2. Copy to a directory on your PATH and **rename to `uffs.exe`**.
 
@@ -159,7 +159,7 @@ running on macOS/Linux.
 ### Build
 
 ```bash
-git clone https://github.com/githubrobbi/UltraFastFileSearch.git
+git clone https://github.com/skyllc-ai/UltraFastFileSearch.git
 cd UltraFastFileSearch
 
 # Build release binaries (Rust nightly installs automatically)


### PR DESCRIPTION
Repository ownership moved from githubrobbi/UltraFastFileSearch to
skyllc-ai/UltraFastFileSearch on 2026-04-21. GitHub's built-in redirect
forwards old URLs automatically (for stars, clones, issues, PRs, forks,
and releases), so no external link breaks. This commit cleans up
in-tree URL references so new readers land on the canonical org URL
from the start.

Why Sky, LLC owns this now:

  UFFS is the flagship product of Sky, LLC (the legal entity behind the
  project, holder of the copyright, and the entity that will carry any
  future commercial offerings built on top of the open core). Moving
  the repository to the Sky, LLC-owned skyllc-ai organization aligns
  ownership with the entity that actually owns the asset, unblocks
  org-level GitHub Sponsors (which expects the sponsored org to own
  its primary public repositories), and makes enterprise-sponsor
  workflows (AP-department invoicing from a named business entity)
  possible.

  The core license does not change — MPL 2.0, open source, forever.

Scope of this commit (5 files, 17 lines):

  README.md              — CI/release badges + repo URL in footer
  Cargo.toml             — workspace [package].repository URL (crates.io metadata)
  CHANGELOG.md           — all version compare links (7 references)
  docs/user-manual/installation.md — GitHub Releases URLs + git clone command
  .github/workflows/optimized-ci.yml — Codecov slug

Not changed (intentionally):

  - docs/benchmarks/raw/*.txt: verbatim PowerShell capture logs.
    Per the raw-logs-never-edited policy documented in
    docs/benchmarks/raw/README.md and docs/benchmarks/methodology.md,
    these preserve the URL as captured at benchmark time. Future
    re-captures will naturally have the new URL.
  - build/logs/*.log: local CI pipeline logs (gitignored anyway).
  - _trash/, .idea/: gitignored.
  - .github/CODEOWNERS: '@githubrobbi' stays as the human reviewer
    (Robin Nio remains the individual maintainer — only the org-level
    ownership changed).
  - .github/dependabot.yml: same reasoning — '@githubrobbi' reviewer.
  - SECURITY.md: '@githubrobbi' as security-disclosure contact stays.
  - docs/dev/architecture/brand-kit/IMPLEMENTATION_GUIDE.md: the
    'io.github.githubrobbi.uffs' bundle identifier is a packaging
    identity that affects signed-build update channels. A separate
    decision (and separate commit) governs whether/when to rename
    that to a Sky, LLC-based reverse-DNS ID.
  - docs/dev/architecture/UFFS_licensing_implementation_plan_2026-04-12.md:
    references a future 'uffs-products' repo (different repository
    from this one). That rename happens separately if/when that repo
    is created.

Local workflow impact:

  Anyone with an existing clone should run:
    git remote set-url origin https://github.com/skyllc-ai/UltraFastFileSearch.git

  GitHub's transfer redirect keeps the old URL working for fetch/push
  indefinitely (GitHub documents the redirect as 'forever unless the
  old slug is reclaimed by a new account'), so re-pointing is
  recommended but not urgent.

Follow-up work (tracked separately):

  - Apply for Sky, LLC org-level GitHub Sponsors (skyllc-ai)
  - Apply for @githubrobbi individual GitHub Sponsors
  - Add .github/FUNDING.yml once applications approve
  - Add a 'Sponsor UFFS' section to the README
  - Optional: rename io.github.githubrobbi.uffs bundle ID in brand-kit
  - Optional: re-anchor any pre-transfer external blog/social posts to
    the new canonical URL (just a redirect; no urgency)
