### PR TITLE
fix(release-workflow): correct actions/download-artifact SHA pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,7 +354,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b04936ee2ba37f5960c29b0ffda4e1e04f # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: release-artifacts
 


### PR DESCRIPTION
## Summary

One-char-class SHA typo on the `actions/download-artifact@v8` pin blocked the final publish job of the release pipeline.  Detected end-to-end in the sccache-smoke-test run #24787186588.

## The bug

```diff
- uses: actions/download-artifact@3e5f45b04936ee2ba37f5960c29b0ffda4e1e04f # v8
+ uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
```

First 7 chars (`3e5f45b`) match — classic truncated-then-padded copy-paste error.

## Evidence

PR #25 landed the `RUSTC_WRAPPER: ""` override.  I then kicked the release workflow via `workflow_dispatch` with throwaway version `v99.99.99` to validate it end-to-end.  Run [#24787186588](https://github.com/skyllc-ai/UltraFastFileSearch/actions/runs/24787186588):

| Job | Result | Time |
|---|---|---|
| `📋 Release Preparation` | success | 45s |
| `🔨 Build (x86_64-unknown-linux-gnu)` | **success** | ~22 min |
| `🔨 Build (aarch64-apple-darwin)` | **success** | ~25 min |
| `🔨 Build (x86_64-pc-windows-msvc)` | **success** | ~29 min |
| `📦 Create GitHub Release` | **failure** | <10s |
| `🔔 Notify on Failure` | success | — |

Failure message from the publish job:
```
Error: Unable to resolve action `actions/download-artifact@3e5f45b04936ee2ba37f5960c29b0ffda4e1e04f`,
unable to find version `3e5f45b04936ee2ba37f5960c29b0ffda4e1e04f`
```

## Other pins audited

I verified every pinned SHA in `release.yml` against `repos/{org}/{repo}/commits/{sha}`:

| Pin | Verified |
|---|---|
| `actions/checkout@de0fac2e…` v6.0.2 | ✓ |
| `Swatinem/rust-cache@e18b4977…` v2 | ✓ |
| `actions/upload-artifact@043fb46d…` v7 | ✓ |
| `actions/download-artifact@3e5f45b0…` v8 | **FAIL** — fix in this PR |
| `softprops/action-gh-release@b430933…` v3 | ✓ |
| `actions/github-script@3a2844b7…` v9 | ✓ |

## Post-merge smoke test

Once this lands I'll re-trigger the release workflow with `v99.99.99` (or you can):

```bash
gh workflow run release.yml --repo skyllc-ai/UltraFastFileSearch --ref main \
  -f version=v99.99.99 -f triggered_by=post-sha-fix-smoke-test

# After success:
gh release delete v99.99.99 --repo skyllc-ai/UltraFastFileSearch --cleanup-tag --yes
```

## Auto-merge

`--auto --squash` queued (workflow-only YAML change, GitHub auto-signs squash commits).