### PR TITLE
refactor(ship): drop STEP_BUILD_RELEASE + STEP_DEPLOY_BINARY

### DIFF
--- a/scripts/ci/ci-pipeline.rs
+++ b/scripts/ci/ci-pipeline.rs
@@ -63,8 +63,12 @@ const STEP_COVERAGE_TESTS: &str = "04-coverage-tests";
 const STEP_PARALLEL_VALIDATION: &str = "05-parallel-validation";
 const STEP_FORMAT_CHECK: &str = "06-format-check";
 const STEP_VERSION_INCREMENT: &str = "07-version-increment";
-const STEP_BUILD_RELEASE: &str = "08-build-release";
-const STEP_DEPLOY_BINARY: &str = "09-deploy-binary"; // Upload to GitHub Release
+// Steps 08 (build-release) and 09 (deploy-binary) were removed: `just ship`
+// no longer produces binaries locally.  The release branch PR (step 11)
+// lands the version bump on main; `auto-tag-release.yml` then tags the
+// commit and invokes `release.yml`, which builds + publishes from GitHub
+// Actions.  Step numbering is preserved to keep in-flight resumable-ship
+// state files compatible with older pipeline runs.
 const STEP_GIT_COMMIT: &str = "10-git-commit";
 const STEP_GIT_PUSH: &str = "11-git-push";
 
@@ -76,8 +80,6 @@ const ALL_STEPS: &[&str] = &[
     STEP_PARALLEL_VALIDATION,
     STEP_FORMAT_CHECK,
     STEP_VERSION_INCREMENT,
-    STEP_BUILD_RELEASE,
-    STEP_DEPLOY_BINARY,
     STEP_GIT_COMMIT,
     STEP_GIT_PUSH,
 ];
@@ -792,19 +794,18 @@ async fn phase2_optimized(ctx: &PipelineContext) -> Result<()> {
     state.save().context("Failed to save workflow state")?;
     println!("✅ Workflow state updated with new version: {}", state.current_version);
 
-    // Step 2: Build release binary
-    build_release(ctx).await?;
-
-    // Step 3: Deploy binary
-    deploy_binary(ctx).await?;
-
-    // Step 4: Git commit
+    // Step 2: Git commit (signed version-bump commit on the working branch).
     git_commit(ctx).await?;
 
-    // Step 5: Git push
+    // Step 3: Git push -- opens release/vX.Y.Z PR with auto-merge queued.
+    //
+    // Binaries are NOT built here.  Once the PR merges to main,
+    // `auto-tag-release.yml` tags the commit and invokes `release.yml`,
+    // which produces the reproducible cross-platform binaries on
+    // GitHub-hosted runners.
     git_push(ctx).await?;
 
-    println!("{}", "✅ PHASE 2 COMPLETE: Versioned, deployed, committed, and pushed!".green().bold());
+    println!("{}", "✅ PHASE 2 COMPLETE: Versioned, committed, and release PR opened!".green().bold());
     Ok(())
 }
 
@@ -824,70 +825,16 @@ async fn version_bump(ctx: &PipelineContext) -> Result<()> {
     Ok(())
 }
 
-/// Check if release build mode is explicitly disabled via UFFS_DEV_BUILD env var.
-/// Default is RELEASE mode for the ship lane (phase2).
-/// Set UFFS_DEV_BUILD=1 to force dev mode in ship lane (not recommended).
-fn is_release_build() -> bool {
-    // Only build dev if explicitly requested via UFFS_DEV_BUILD=1
-    let force_dev = std::env::var("UFFS_DEV_BUILD")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-    !force_dev
-}
-
-async fn build_release(ctx: &PipelineContext) -> Result<()> {
-    let release_build = is_release_build();
-    let build_type = if release_build { "release" } else { "dev" };
-    println!("{}", format!("🔨 Building {} binary...", build_type).blue());
-
-    let args: Vec<&str> = if release_build {
-        vec!["build", "--release", "--workspace"]
-    } else {
-        vec!["build", "--workspace"]
-    };
-
-    execute_command(
-        &format!("Build {}", build_type),
-        "cargo",
-        &args,
-        ctx,
-    ).await?;
-    println!("{} {} binary built successfully", "✅".green(), build_type);
-    Ok(())
-}
-
-/// Deploy binary: cross-compile and upload to GitHub Release.
-/// On macOS ARM64, runs cross-compilation for Windows and uploads to GitHub Release.
-/// On other platforms, runs local build only.
-async fn deploy_binary(ctx: &PipelineContext) -> Result<()> {
-    println!("{}", "📦 Building and uploading to GitHub Release...".blue());
-
-    // Detect if we're on macOS ARM64 for cross-compilation
-    let is_macos_arm64 = std::env::consts::OS == "macos" && std::env::consts::ARCH == "aarch64";
-
-    if is_macos_arm64 {
-        // Cross-compile for Windows from macOS
-        // Note: The xwin-dev profile handles COFF archive size limits for polars crates
-        println!("{} Running cross-platform build...", "🌍".blue());
-        execute_command(
-            "Cross-platform build",
-            "rust-script",
-            &["scripts/ci/build-cross-all.rs"],
-            ctx,
-        ).await?;
-    } else {
-        println!("{} Running local build...", "🖥️".blue());
-        execute_command(
-            "Local build & install",
-            "rust-script",
-            &["scripts/dev/build-local.rs"],
-            ctx,
-        ).await?;
-    }
-
-    println!("{} Binary built and uploaded to GitHub Release", "✅".green());
-    Ok(())
-}
+// `build_release` + `deploy_binary` + `is_release_build` were removed in the
+// "GitHub builds the binaries" hardening pass.  Binaries are now produced
+// exclusively by `.github/workflows/release.yml` on GitHub-hosted runners
+// (triggered by `auto-tag-release.yml` on version-bump merge to main), so
+// the developer's laptop is no longer the trust root for shipped bytes.
+//
+// For a local dev build, run `just use-local` (renamed from `just use` in
+// the same refactor).  For release-parity smoke testing run
+// `gh workflow run release.yml --ref main -f version=vX.Y.Z` against a
+// throwaway version and clean up with `gh release delete vX.Y.Z --cleanup-tag --yes`.
 
 async fn git_commit(ctx: &PipelineContext) -> Result<()> {
     println!("{}", "📝 Creating auto-generated commit...".blue());
@@ -1341,9 +1288,9 @@ async fn run_enhanced_phase1(state: &mut WorkflowState, ctx: &PipelineContext) -
 }
 
 async fn run_enhanced_phase2(state: &mut WorkflowState, ctx: &PipelineContext) -> Result<()> {
-    println!("{}", "📦 PHASE 2: Version Increment, Build & Deploy".blue().bold());
+    println!("{}", "📦 PHASE 2: Version Increment + Release PR".blue().bold());
 
-    // Step 6: Version increment
+    // Step 07: Version increment
     execute_step_with_tracking(state, STEP_VERSION_INCREMENT, || async {
         increment_version().await
     }).await?;
@@ -1355,23 +1302,18 @@ async fn run_enhanced_phase2(state: &mut WorkflowState, ctx: &PipelineContext) -
         state.save()?;
     }
 
-    // Step 7: Build release
-    execute_step_with_tracking(state, STEP_BUILD_RELEASE, || async {
-        build_release(ctx).await
-    }).await?;
-
-    // Step 8: Deploy binary (upload to GitHub Release)
-    execute_step_with_tracking(state, STEP_DEPLOY_BINARY, || async {
-        deploy_binary(ctx).await
-    }).await?;
-
-    // Step 9: Git commit
+    // Step 10: Git commit (signed version-bump commit on the working branch).
     execute_step_with_tracking(state, STEP_GIT_COMMIT, || async { git_commit(ctx).await }).await?;
 
-    // Step 10: Git push
+    // Step 11: Git push -- opens release/vX.Y.Z PR with auto-merge queued.
+    //
+    // Binaries are NOT built here.  Once the PR merges to main,
+    // `auto-tag-release.yml` tags the commit and invokes `release.yml`,
+    // which produces the reproducible cross-platform binaries on
+    // GitHub-hosted runners.
     execute_step_with_tracking(state, STEP_GIT_PUSH, || async { git_push(ctx).await }).await?;
 
-    println!("{}", "✅ PHASE 2 COMPLETE - Build and deploy successful!".green().bold());
+    println!("{}", "✅ PHASE 2 COMPLETE - Release PR opened; GitHub Actions will produce binaries.".green().bold());
     Ok(())
 }
 
@@ -1422,9 +1364,10 @@ async fn run_ship_pipeline(ctx: &PipelineContext) -> Result<()> {
     println!("{}", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━".dimmed());
     run_enhanced_phase1(&mut state, ctx).await.context("Phase 1 (validation) failed")?;
 
-    // Run Phase 2: Deploy
+    // Run Phase 2: Version bump + release PR open (GitHub Actions takes
+    // over from there via `auto-tag-release.yml` -> `release.yml`).
     println!("{}", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━".dimmed());
-    run_enhanced_phase2(&mut state, ctx).await.context("Phase 2 (deploy) failed")?;
+    run_enhanced_phase2(&mut state, ctx).await.context("Phase 2 (release PR) failed")?;
 
     // Mark workflow as completed
     state.advance_phase(WorkflowPhase::Completed)?;
@@ -1465,8 +1408,11 @@ async fn run_ship_pipeline(ctx: &PipelineContext) -> Result<()> {
     }
 
     println!();
-    println!("{} Binary uploaded to GitHub Release", "📦".green());
-    println!("{} Changes committed and pushed", "📤".green());
+    println!("{} Release PR opened; auto-merge queued", "📤".green());
+    println!("{} GitHub Actions will build + publish v{} on merge",
+        "👷".green(), state.current_version);
+    println!("   💡 Watch: {}",
+        "gh run list --repo <owner>/<repo> --workflow=release.yml --limit 5".cyan());
 
     Ok(())
 }
@@ -1576,10 +1522,6 @@ async fn main() -> Result<()> {
     if let Some(log_path) = &ctx.log_file {
         println!("{} Log file: {}", "📝".blue(), log_path.display());
     }
-
-    // Show build mode (RELEASE is default for ship lane, set UFFS_DEV_BUILD=1 to force dev)
-    let build_mode = if is_release_build() { "RELEASE (default for ship)" } else { "DEV (forced via UFFS_DEV_BUILD=1)" };
-    println!("{} Build mode: {}", "🔧".blue(), build_mode);
 
     // Start sccache server early (no-op if already running). This is safe and fast.
     if ctx.sccache_enabled {


### PR DESCRIPTION
## Summary

**Delta 1** (final) of the "GitHub builds the binaries" hardening plan.  Drops local binary build + upload from `just ship`.  Binaries become the sole output of `release.yml` running on GitHub-hosted runners.

Prior work in the series:
- **PR #25** — unset `RUSTC_WRAPPER=sccache` on runners
- **PR #26** — fix `actions/download-artifact` SHA
- **PR #27** — rename `just use` ↔ `just use-local`
- **PR #28** — add `auto-tag-release.yml`
- **PR #29** — fix auto-tag / release.yml tag-push collision (delegate tag to release.yml)
- **PR #30** — **this PR**: drop local binary build from `just ship`

## Flow change

**Before**:
```
just ship
├─ Phase 1: validation
└─ Phase 2: version bump + LOCAL BUILD + LOCAL UPLOAD + commit + push
                                ↑
                    trust root = developer's laptop env
```

**After**:
```
just ship
├─ Phase 1: validation
└─ Phase 2: version bump + commit + push (PR)
                                          |
                                          v
                            PR auto-merges to main
                                          |
                                          v
                            auto-tag-release.yml (PR #28, #29)
                                          |
                                          v
                            release.yml (builds + publishes)
                                          ↑
                              trust root = GitHub Actions
```

## Changes

- Remove `STEP_BUILD_RELEASE` + `STEP_DEPLOY_BINARY` constants.  Step numbering preserved as `07, 10, 11` (non-contiguous) so in-flight `just ship` resumable-state files stay compatible.
- Remove `build_release()`, `deploy_binary()`, `is_release_build()` functions.  Replaced with an archaeological-marker comment pointing at this refactor.
- Remove the `UFFS_DEV_BUILD`-switched "Build mode" banner line in `main()` (env var no longer read).
- Update `phase2_optimized()` and `run_enhanced_phase2()` banners + comments.
- Update the final Ship-Pipeline summary:
  - Old: "📦 Binary uploaded to GitHub Release"
  - New: "📤 Release PR opened; auto-merge queued" + "👷 GitHub Actions will build + publish vX.Y.Z on merge"

## Proof the downstream chain works (done before this PR)

Smoke test of the post-#29 `auto-tag-release.yml`:
- Run: [`24795618898`](https://github.com/skyllc-ai/UltraFastFileSearch/actions/runs/24795618898) — all 5 steps succeeded
- Downstream `release.yml` run: [`24795626228`](https://github.com/skyllc-ai/UltraFastFileSearch/actions/runs/24795626228) invoked successfully
- Earlier full-pipeline smoke test v99.99.99: published 16 cross-platform release assets (cleaned up)

## Wall-clock impact

`just ship` Phase 2 shrinks from ~8-12 min (local cross-build + upload) to ~30-60s (version bump + commit + PR).  Total wall-clock to "bytes available for download" stays roughly the same (~30 min) but now visible in the Actions UI instead of consuming the dev's laptop.

## Auto-merge

`--auto --squash` queued.