### PR TITLE
security(ci): P1 hardening for the release pipeline

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -45,14 +45,12 @@ on:
     paths:
       - "Cargo.toml"
   workflow_dispatch:
-    # Manual re-trigger for testing.  When dispatched, replays the
-    # HEAD-vs-HEAD~1 version diff logic against current main.
-    inputs:
-      force_tag:
-        description: "Force-create a tag even if version is unchanged (smoke-test only; leave empty normally)"
-        required: false
-        type: string
-        default: ""
+    # Manual re-trigger.  When dispatched (with no inputs), replays
+    # the HEAD-vs-HEAD~1 version diff logic against current main.
+    # Useful if `release.yml` has been fixed after a failed run and
+    # the same version-bump commit should be retried.  The
+    # idempotency guard (tag already on origin) handles double-fire
+    # races automatically.
 
 permissions:
   # Read commit history (for the HEAD vs HEAD~1 version diff).
@@ -114,16 +112,7 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.versions.outputs.new }}
           OLD_VERSION: ${{ steps.versions.outputs.old }}
-          FORCE_TAG: ${{ inputs.force_tag }}
         run: |
-          # workflow_dispatch override: explicit tag bypasses version-diff.
-          # Used only for manual smoke tests of this workflow itself.
-          if [[ -n "$FORCE_TAG" ]]; then
-            echo "Manual dispatch with force_tag=$FORCE_TAG"
-            echo "tag=$FORCE_TAG" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           if [[ -z "$NEW_VERSION" ]]; then
             echo "::notice::No [workspace.package].version found in Cargo.toml — nothing to do."
             echo "tag=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,16 @@ permissions:
   contents: write
   actions: read
   issues: write
+  # SLSA build-provenance attestation flow (P1 hardening):
+  #   - `id-token: write` lets the runner mint an OIDC token
+  #     identifying this workflow run to the Sigstore Fulcio CA.
+  #   - `attestations: write` lets `actions/attest-build-provenance`
+  #     post the resulting attestation to this repository via the
+  #     GitHub Attestations API.
+  # Both scopes are idle unless the attest step actually runs, so
+  # there is no exposure outside the create-github-release job.
+  id-token: write
+  attestations: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -107,6 +117,29 @@ jobs:
             exit 1
           fi
           echo "✅ Tag is available"
+
+      - name: Validate commit_sha is ancestor of main (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch' && inputs.commit_sha != ''
+        shell: bash
+        run: |
+          # Rollback-attack guard.  An attacker with `actions: write`
+          # (e.g. a compromised bot token) could otherwise invoke this
+          # workflow with a `commit_sha` pointing at an ARBITRARY
+          # commit — including one from an unreviewed feature branch,
+          # or a commit prior to a security fix — and have the
+          # release assets built from that code.  This step rejects
+          # any commit_sha that isn't on main's history.
+          #
+          # `git merge-base --is-ancestor A B` exits 0 iff A is an
+          # ancestor of B (commits equal count as ancestor).
+          git fetch origin main:refs/remotes/origin/main --quiet
+          if ! git merge-base --is-ancestor "${{ inputs.commit_sha }}" origin/main; then
+            echo "::error::commit_sha ${{ inputs.commit_sha }} is not an ancestor of origin/main."
+            echo "  Only commits that have already landed on main can be released."
+            echo "  If this commit is legitimate, merge it to main first."
+            exit 1
+          fi
+          echo "✅ commit_sha ${{ inputs.commit_sha }} is on main's history"
 
   # ═══════════════════════════════════════════════════════════════════════════
   # Phase 2: Cross-Platform Binary Builds
@@ -404,6 +437,24 @@ jobs:
           echo "📦 Final release assets:"
           ls -la
 
+      - name: Generate SLSA build-provenance attestation
+        # Signs every file in `final-release/` with the workflow's
+        # Sigstore OIDC identity, producing a SLSA Level 3 build-
+        # provenance claim bound to (this workflow run, this commit,
+        # this set of inputs).  Consumers then verify with:
+        #
+        #   gh attestation verify <asset> \
+        #     --owner ${{ github.repository_owner }}
+        #
+        # Attestation is stored in the repo's attestations API, so it
+        # survives independently of the GitHub Release asset (even if
+        # someone with `contents: write` silently swaps a binary, the
+        # SHA256 in the attestation won't match and `gh attestation
+        # verify` fails).
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "final-release/*"
+
       - name: Generate release notes
         id: release-notes
         shell: bash
@@ -460,6 +511,15 @@ jobs:
           ```bash
           sha256sum -c CHECKSUMS.txt
           ```
+
+          Additionally, every release asset carries a **SLSA build-
+          provenance attestation** signed with the workflow's Sigstore
+          OIDC identity.  Verify with GitHub CLI:
+          ```bash
+          gh attestation verify <file> --owner ${{ github.repository_owner }}
+          ```
+          A successful verification proves the bytes were produced by
+          this exact workflow run on this exact commit.
 
           ## 📋 Installation
 


### PR DESCRIPTION
## Summary

Security tightening pass on the release pipeline.  Addresses concrete gaps found while auditing the repo's ruleset, workflow permissions, and `release.yml`'s input-trust boundary after the "GitHub builds the binaries" migration (PRs #25-#30).

## The 4 P1 items

### 1. SLSA build-provenance attestation for every release asset

New step in `release.yml` → `create-github-release` job.  Uses `actions/attest-build-provenance@v2.4.0` pinned to `e8998f9`.

Consumers can verify provenance with:
```bash
gh attestation verify uffs-linux-x64 --owner skyllc-ai
```

Successful verification cryptographically binds the downloaded bytes to `(this workflow file, this commit SHA, this run ID)`.  Attestation lives in the GitHub Attestations API, not on the Release page — so an attacker with `contents: write` who silently swaps a binary can't also swap the attestation.

Adds two permission scopes at the workflow level, both idle outside the one attest step:
- `id-token: write` — mint OIDC token for Sigstore Fulcio
- `attestations: write` — POST attestation to GitHub API

### 2. `commit_sha` ancestor-of-main guard in `release.yml`

New validation step in `release-preparation`.  Runs only on `workflow_dispatch` with a non-empty `commit_sha` input.

Blocks rollback attacks: without this, anyone with `actions: write` (e.g. a compromised bot token) could invoke:
```bash
gh workflow run release.yml \
  -f version=v0.6.0 \
  -f commit_sha=<commit BEFORE a security fix>
```
...and publish binaries from an arbitrary point in history.  The guard runs `git merge-base --is-ancestor` against `origin/main` and rejects the dispatch if the commit isn't on main's history.

Doesn't apply to `push: tags: v*` — that path is gated by the tag-protection ruleset below.

### 3. Remove `force_tag` input from `auto-tag-release.yml`

Was a smoke-test convenience while proving out the auto-tag chain (used for v99.99.99 and v99.98.99 throwaway releases, both cleaned up).  Now the input is a footgun: anyone with `actions: write` could bypass the version-diff guard and invoke `release.yml` for arbitrary tags.

`workflow_dispatch` still works with no inputs for legitimate manual re-triggers — the HEAD-vs-HEAD~1 version diff + tag-already-exists idempotency check cover that use case.

### 4. Tag protection ruleset (post-merge command)

Not in this diff because it's a GitHub API call.  Run **once** after merge:

```bash
gh api repos/skyllc-ai/UltraFastFileSearch/rulesets -X POST --input - <<'JSON'
{
  "name": "tag-protection-v-prefix",
  "target": "tag",
  "enforcement": "active",
  "conditions": {
    "ref_name": {
      "include": ["refs/tags/v*"],
      "exclude": []
    }
  },
  "bypass_actors": [
    {"actor_type": "Integration", "actor_id": 15368, "bypass_mode": "always"},
    {"actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "always"}
  ],
  "rules": [
    {"type": "creation"},
    {"type": "deletion"},
    {"type": "update"}
  ]
}
JSON
```

**Effect**: only GitHub Actions (integration 15368, used by `release.yml` to push tags) and repo admins (role 5) can create/delete/update `v*` tags.  Any other write-access user hits the ruleset.

**Verify afterwards**:
```bash
gh api repos/skyllc-ai/UltraFastFileSearch/rulesets --jq '.[] | {id, name, target, enforcement}'
```
Expect two rulesets: `main-protection` (branch) + `tag-protection-v-prefix` (tag).

## Attack-surface delta

| Threat | Before | After |
|---|---|---|
| Silent binary swap on Release | CHECKSUMS.txt only | CHECKSUMS.txt + SLSA attestation |
| `workflow_dispatch` with rogue `commit_sha` | Accepted | Rejected at prep |
| `workflow_dispatch` with rogue `force_tag` | Accepted | No such input |
| Rogue `v*` tag push by any write user | Accepted | (post-merge) tag ruleset blocks |
| Compromised runner injects payload into legit run | SLSA-neutral | Still Tier 2 (reproducible-build territory) |

## Why not the Tier 2 items

- **Code signing** (codesign / Authenticode): needs $99-$200/yr cert + rotation.  Deferred.
- **Reproducible builds + scheduled rebuild verifier**: non-trivial (pin OS SHAs, `SOURCE_DATE_EPOCH`, verifier workflow).  SLSA covers 95% of the threat model this addresses.  Deferred.

## Testing plan

1. Merge this PR (auto-merge SQUASH queued)
2. Run the tag-ruleset `gh api` command above
3. Next real `just ship` run producing `v0.5.69`:
   - Release page shows the "Build provenance" / Sigstore badge
   - `gh attestation verify uffs-linux-x64 --owner skyllc-ai` succeeds
4. Negative smoke-test: dispatch `release.yml` with a commit_sha NOT on main; expect `release-preparation` to fail at the ancestor check.

## Series context

Final item in the "GitHub builds the binaries + tighten trust root" plan:

- PR #25 — unset `RUSTC_WRAPPER=sccache` on runners
- PR #26 — fix `download-artifact` SHA
- PR #27 — rename `just use` ↔ `just use-local`
- PR #28 — add `auto-tag-release.yml`
- PR #29 — fix tag-push collision
- PR #30 — drop local build from `just ship`
- **PR #31 — this PR** — P1 security hardening