### PR TITLE
fix(ci): release.yml creates tag via REST API, not git push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -548,20 +548,41 @@ jobs:
           **Full Changelog**: https://github.com/${{ github.repository }}/commits/${{ needs.release-preparation.outputs.version }}
           EOF
 
-      - name: Create Git tag (workflow_dispatch only)
-        if: github.event_name == 'workflow_dispatch'
-        shell: bash
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-          git tag -a "${{ needs.release-preparation.outputs.tag }}" -m "Release ${{ needs.release-preparation.outputs.version }}"
-          git push origin "${{ needs.release-preparation.outputs.tag }}"
-
-      - name: Create GitHub Release
+      - name: Create GitHub Release (creates tag via REST API)
+        # Tag creation is handled by action-gh-release's built-in
+        # logic rather than an explicit `git push origin $TAG`.
+        # Rationale — avoid GitHub's workflow-file protection:
+        #
+        # The git protocol-level tag push is rejected by GitHub's
+        # server-side check whenever the tag's target commit has
+        # different workflow files than the default branch's current
+        # HEAD.  That race fires whenever any PR touching
+        # `.github/workflows/*` merges while a release.yml run is
+        # in flight.  Observed with run #24795626228 (v99.98.99)
+        # where PR #31's merge at 19:00:55Z made the 19:01:37Z tag
+        # push fail with:
+        #
+        #   remote rejected: refusing to allow a GitHub App to
+        #   create or update workflow `.github/workflows/
+        #   auto-tag-release.yml` without `workflows` permission
+        #
+        # The REST API path (creating a `refs/tags/*` via
+        # `POST /repos/:owner/:repo/git/refs`, which action-gh-
+        # release uses internally when `tag_name` is set and the
+        # tag does not yet exist) is not subject to the same
+        # server-side guard, so it succeeds with just the default
+        # `contents: write` permission.
+        #
+        # `target_commitish` pins the tag to the specific commit
+        # we built from, not whatever main's HEAD happens to be at
+        # action runtime.  Falls back to `github.sha` when
+        # invoked via `push: tags: v*` (where `inputs.commit_sha`
+        # is unset — the tag already exists so this field is
+        # ignored anyway).
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ needs.release-preparation.outputs.tag }}
+          target_commitish: ${{ inputs.commit_sha || github.sha }}
           name: ${{ needs.release-preparation.outputs.release-name }}
           body_path: release-notes.md
           files: final-release/*


### PR DESCRIPTION
## Summary

v99.98.99 smoke test failed at the 'Create Git tag' step:

```
remote rejected: refusing to allow a GitHub App to create or update
workflow `.github/workflows/auto-tag-release.yml` without `workflows`
permission
```

## Root cause

GitHub's **git-protocol-level** server-side guard rejects any push (including tag-only pushes) where the push's reachable set introduces workflow-file changes relative to the default branch's current HEAD — unless the pushing token carries the `workflow` scope, which the default `GITHUB_TOKEN` does not.

The failure window:
1. `release.yml` invoked via `workflow_dispatch` with `commit_sha = C` (some main commit).
2. During the ~20 min build phase, another PR touching `.github/workflows/*` merges to main.
3. `Create Git tag` step runs `git push origin vX.Y.Z`.
4. GitHub compares workflow files at `C` vs main's new HEAD, sees a diff, rejects.

## Observed race (v99.98.99 — run #24795626228)

| Time (UTC) | Event |
|---|---|
| 18:30:47 | release.yml dispatched for `v99.98.99 @ ea4df81ae` |
| 18:30:47 | release-preparation validated ✅ |
| 18:30:47 | build-release-binaries: start |
| **18:43:23** | **PR #30 merges** |
| **19:00:55** | **PR #31 merges** (updates `auto-tag-release.yml`) |
| 19:01:37 | `Create Git tag`: `git push origin v99.98.99` ❌ |

v99.99.99's earlier smoke test (#24790034721) didn't hit this because that run happened *before* any workflow-touching PR landed, so the tag's commit had the same workflow files as main's HEAD.

## Fix

Remove the explicit `git push origin $TAG` step.  Let `softprops/action-gh-release` create the tag via REST API:

```
POST /repos/:owner/:repo/git/refs
{"ref": "refs/tags/vX.Y.Z", "sha": "..."}
```

The REST API enforces authorization at the ref level — creating a new tag ref pointing at an already-on-main commit doesn't trip the workflow-file guard, because no new workflow-file content is being *introduced*; the content is already reachable via `refs/heads/main`.

Plus: add `target_commitish: ${{ inputs.commit_sha || github.sha }}` so the tag is pinned to the specific commit we built from.

## Verification plan

1. **Merge this PR** (auto-merge SQUASH queued)
2. **Smoke-test the exact race**:
   ```bash
   gh workflow run release.yml \
     -f version=v99.97.99 \
     -f commit_sha=a07411bfd   # PR #30's commit
   ```
   `a07411bfd` is behind current main (PR #31 bumped it), so it has the pre-#31 version of `auto-tag-release.yml`.  Pre-fix: `Create Git tag` would reject.  Post-fix: REST API creates tag, release publishes.
3. **Cleanup**: `gh release delete v99.97.99 --cleanup-tag --yes`

## Side-effects

- Removes the `git config user.name/email` dance (no longer needed without git push)
- Tag annotation message changes from `Release vX.Y.Z` (from `git tag -a -m`) to the generated release body (softprops uses release body as tag message).  Cosmetic.
- **No permission changes**: still `contents: write` + `id-token: write` + `attestations: write`.

## Related

Refs #29 (which introduced the now-removed git-push step when consolidating tag creation into release.yml).  The semantic goal of #29 — "release.yml owns tag creation so failed releases don't leave orphan tags" — is preserved; only the implementation mechanism changes.