### PR TITLE
security: cargo-geiger + dependabot-review + supply-chain posture doc

### DIFF
--- a/.github/workflows/dependabot-review.yml
+++ b/.github/workflows/dependabot-review.yml
@@ -1,0 +1,180 @@
+# SPDX-FileCopyright (c) 2025-2026 SKY, LLC.
+# SPDX-License-Identifier: MPL-2.0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dependabot Supply-Chain Review
+#
+# Lightweight guardrail for Dependabot-authored PRs that touch the
+# workspace's dependency manifest.  Triggers only on PRs authored by
+# `dependabot[bot]` so it never slows down a human's feature PR.
+#
+# Current check:
+#
+#   • Cargo.lock crate-count delta.  Flags any Dependabot PR whose merge
+#     would add more than a handful of crates to the resolved dependency
+#     graph.  The legitimate case (a transitive fan-out from a legit
+#     version bump) is easy to sanity-check; the suspicious case
+#     (a minor bump that quietly pulls in 5+ new crates, one of which
+#     is typo-squatted / malicious) surfaces as a PR annotation for
+#     the reviewer to investigate before merge.
+#
+# Rationale — why a dedicated workflow and not a step in `ci.yml`:
+#
+#   Security policy is strongest when it's legible in one file.  A
+#   separate workflow lets a future maintainer find every
+#   Dependabot-specific guard in one place without sifting through the
+#   full Tier 1 pipeline.  Zero runtime cost on human PRs (guard
+#   short-circuits via the `actor` filter), and the output surfaces as
+#   a PR-level annotation / check, not buried in a Tier 1 log.
+#
+# What this does NOT do:
+#
+#   • Block merge.  Emits a `::warning::` annotation only.  The goal is
+#     to surface something for the reviewer to look at, not to
+#     short-circuit Dependabot's automation.
+#
+#   • Audit the content of new crates.  That's the job of `cargo-vet`
+#     (tracked separately in the supply-chain hardening backlog).
+#
+# Threat model it addresses:
+#
+#   • Attacker compromises a maintainer's account on crates.io, pushes
+#     a minor-version update that secretly pulls in a new dep tree
+#     containing typo-squatted / malicious crates.  Dependabot opens a
+#     PR to bump the legit crate; the dep-tree fan-out is unexpected.
+#     Without this guard, the PR looks like "just a patch bump" and a
+#     tired reviewer might rubber-stamp it.
+
+name: "🔍 Dependabot Review"
+
+on:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**/Cargo.toml"
+
+# Read-only: we never need to write anything from this workflow.
+# The PR-level annotations it emits use the check-run machinery that's
+# implicit in any workflow, which requires `contents: read` and `checks:
+# write` (the latter is granted automatically for PRs in the same repo).
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: dependabot-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dep-tree-growth:
+    name: "Cargo.lock crate-count delta"
+    # Short-circuit on non-Dependabot PRs so we don't spend CI minutes
+    # on every human contributor's feature PR.  The `actor` check is
+    # the canonical way to gate Dependabot-specific workflows.
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout PR with one commit of history
+        # `fetch-depth: 2` gives us HEAD and HEAD~1 so we can diff the
+        # resolved dependency graph between the pre-bump state and the
+        # post-bump state.  Dependabot PRs are single-commit by
+        # default, so HEAD~1 is always main's tip at branch-open time.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+
+      - name: Count Cargo.lock crate-count delta
+        shell: bash
+        env:
+          # Threshold above which we annotate the PR for human review.
+          # 3 is a pragmatic default: a typical minor version bump pulls
+          # in 0-2 new transitive crates; anything larger is worth a
+          # second look (either a legit fan-out that's safe once
+          # confirmed, or the red flag this workflow exists to catch).
+          # Override in the env block here — not via repo-level
+          # settings — so the policy lives in-repo under review.
+          GROWTH_THRESHOLD: 3
+        run: |
+          set -euo pipefail
+
+          # Cargo.lock serialises each resolved crate as a TOML table
+          # whose first key is `name = "…"`.  Counting those lines is
+          # the cheapest reliable way to get the resolved crate count
+          # without installing any tooling.  (`cargo tree` would need
+          # the full build graph and the nightly toolchain to be
+          # installed first.)
+          N_BEFORE=$(git show HEAD~1:Cargo.lock 2>/dev/null | grep -c '^name = ' || echo 0)
+          N_AFTER=$(grep -c '^name = ' Cargo.lock)
+          DIFF=$((N_AFTER - N_BEFORE))
+
+          # Surface the raw numbers regardless — useful for a
+          # retroactive audit even when the delta is within bounds.
+          echo "## 📊 Dependency graph delta" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | ---: |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Crates on main (HEAD~1) | \`$N_BEFORE\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Crates on PR (HEAD)     | \`$N_AFTER\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Net change              | \`$DIFF\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Alert threshold         | \`> $GROWTH_THRESHOLD\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if (( DIFF > GROWTH_THRESHOLD )); then
+            # `::warning::` emits a PR-level annotation that shows up
+            # both in the check summary and next to the diff in the
+            # Files Changed view.  We deliberately do not fail the
+            # check (no `exit 1`) — the goal is to prompt a reviewer,
+            # not to block Dependabot's automation pipeline.
+            echo "::warning file=Cargo.lock::Dependabot PR adds $DIFF new crates (threshold: $GROWTH_THRESHOLD). Review the Cargo.lock diff carefully for unexpected transitive additions — a typical minor bump adds 0-2 crates; a large fan-out may indicate an upstream maintainer account compromise or a typo-squatting attack."
+            echo "⚠️  **Threshold exceeded** — PR annotation emitted." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "✅ **Within bounds** — no annotation emitted." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Also echo to the job log for quick scanning.
+          echo ""
+          echo "Before: $N_BEFORE crates"
+          echo "After:  $N_AFTER crates"
+          echo "Delta:  $DIFF (threshold: $GROWTH_THRESHOLD)"
+
+      - name: Highlight NEW crate names (informational)
+        # Purely diagnostic: when the delta trips the threshold, list
+        # the specific crates that got added.  Helps the reviewer
+        # decide at a glance whether the new names look like
+        # legitimate transitive deps (`serde_json_something`) vs
+        # suspicious (`http2-utils-2`, typo-squats, weird forks).
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BEFORE_FILE=$(mktemp)
+          AFTER_FILE=$(mktemp)
+          trap 'rm -f "$BEFORE_FILE" "$AFTER_FILE"' EXIT
+
+          git show HEAD~1:Cargo.lock 2>/dev/null \
+            | awk -F'"' '/^name = /{print $2}' \
+            | sort -u > "$BEFORE_FILE" || true
+          awk -F'"' '/^name = /{print $2}' Cargo.lock \
+            | sort -u > "$AFTER_FILE"
+
+          # Names present in AFTER but not in BEFORE are the additions.
+          # Drop the header if empty — no point cluttering the summary.
+          ADDED=$(comm -13 "$BEFORE_FILE" "$AFTER_FILE")
+          if [[ -n "$ADDED" ]]; then
+            echo "### 🆕 Newly-resolved crate names" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "$ADDED" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          REMOVED=$(comm -23 "$BEFORE_FILE" "$AFTER_FILE")
+          if [[ -n "$REMOVED" ]]; then
+            echo "### ♻️  Dropped crate names" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "$REMOVED" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,19 +60,54 @@ This policy covers:
 
 ## Security Measures
 
-This project maintains the following security practices:
+This project maintains the following security practices.  See
+[`docs/architecture/security/supply-chain-posture.md`](docs/architecture/security/supply-chain-posture.md)
+for the full threat-model matrix, layered-defence table, deferred-item
+rationale, and operational playbook.
+
+### Code
 
 - **Signed commits** — All commits are cryptographically signed (GPG/Ed25519)
-- **Dependency auditing** — `cargo deny check` runs on every PR
-  (advisories, licenses, bans, sources)
-- **Automated dependency updates** — Dependabot monitors Cargo and GitHub
-  Actions dependencies
-- **CI action pinning** — All GitHub Actions are pinned to immutable commit
-  SHAs to prevent supply chain attacks
 - **Strict Clippy** — `unsafe_code = "deny"`, `unwrap_used = "deny"`,
   `expect_used = "deny"` enforced workspace-wide
 - **No unsafe code** — Zero `unsafe` blocks in production code without
   explicit `#[allow(unsafe_code)]` and safety documentation
-- **Least-privilege CI** — Workflows use `permissions: contents: read`
 - **SPDX compliance** — Every source file carries
   `SPDX-License-Identifier: MPL-2.0`
+
+### Dependencies
+
+- **Dependency auditing** — `cargo deny check` runs on every PR
+  (advisories, licenses, bans, sources)
+- **Structural audit** — `just geiger` produces an on-demand
+  `unsafe` / `build.rs` / proc-macro footprint report for the
+  resolved dep tree (run monthly; compare against baseline).
+- **Dep-tree growth annotation** — every Dependabot PR is
+  automatically annotated if `Cargo.lock` grows by more than a small
+  threshold, surfacing unexpected transitive fan-out for human review.
+- **Automated dependency updates** — Dependabot monitors Cargo and GitHub
+  Actions dependencies; PRs are **NOT** auto-merged — every bump
+  requires human review.
+
+### CI / release pipeline
+
+- **CI action pinning** — All GitHub Actions are pinned to immutable commit
+  SHAs to prevent supply chain attacks
+- **Least-privilege CI** — Workflows use `permissions: contents: read`
+  by default; `write` scopes are explicit and scoped to the minimum
+  job that needs them.
+- **Branch protection** — `main` requires signed commits + passing
+  Tier 1 checks (Clippy, tests, doc tests, security, build, file-size
+  policy) before merge.
+- **Tag protection** — the `tag-protection-v-prefix` ruleset blocks
+  deletion / force-update of any `v*` tag (release integrity).
+- **SLSA build-provenance** — every release asset is signed via
+  Sigstore OIDC by `actions/attest-build-provenance`.  Verify:
+  ```bash
+  gh attestation verify <file> --owner skyllc-ai
+  ```
+- **Commit-ancestry guard** — `release.yml` rejects any
+  `workflow_dispatch` whose `commit_sha` isn't an ancestor of `main`,
+  blocking rollback attacks.
+- **SHA256 checksums** — `CHECKSUMS.txt` accompanies every release;
+  the checksums file is itself covered by the SLSA attestation.

--- a/docs/architecture/security/supply-chain-posture.md
+++ b/docs/architecture/security/supply-chain-posture.md
@@ -1,0 +1,178 @@
+# Supply-Chain Posture
+
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- Copyright (c) 2025-2026 SKY, LLC. -->
+
+Status as of **2026-04-22** · Maintainer: `@githubrobbi` · Review cadence: monthly
+
+This document captures UFFS's current supply-chain defences, the threat
+model they address, and the concrete gaps that are deferred (with
+rationale).  It's a living reference — update it whenever a new
+control lands or a deferred item is promoted.
+
+---
+
+## Layered defences in place
+
+| Layer | Tool | Scope | Cadence | CI gate? |
+|---|---|---|---|---|
+| Known CVE detection | `cargo-deny` `[advisories]` | Full dep tree vs RustSec DB | Every PR | **Yes** — `ci.yml` Security job |
+| License policy | `cargo-deny` `[licenses]` | Permitted list (MIT, Apache-2.0, MPL-2.0, …) | Every PR | **Yes** — same job |
+| Source whitelist | `cargo-deny` `[sources]` | crates.io + pinned polars git | Every PR | **Yes** — same job |
+| Workflow permissions | `permissions:` in every workflow | Minimal (`contents: read` default, `write` only where proven needed) | Reviewed per PR | N/A |
+| Tag integrity | `main-protection` + `tag-protection-v-prefix` rulesets | Required reviews + signed commits on main; `v*` tag deletion/update blocked | Always | GitHub enforces |
+| Build-provenance | `actions/attest-build-provenance` | Every release asset signed with Sigstore OIDC | Every `v*` release | **Yes** — release.yml |
+| Commit ancestry check | Custom step in `release.yml` | `workflow_dispatch` `commit_sha` must be ancestor of main | Every release dispatch | **Yes** — release.yml |
+| Dep-tree growth | `dependabot-review.yml` | Cargo.lock crate-count delta on Dependabot PRs | Every Dependabot PR | Annotation only |
+| Structural audit | `cargo-geiger` via `just geiger` | unsafe / build.rs / proc-macro footprint | On-demand (monthly) | No |
+| Human review | Dependabot PRs are NOT auto-merged | Every dependency bump | Every Dependabot PR | GitHub enforces |
+
+## Threat model and coverage matrix
+
+| Threat | Severity | Current control | Residual risk |
+|---|---|---|---|
+| Known CVE in a dep | High | `cargo-deny` RustSec DB on every PR | Low — CI gates |
+| Unknown (zero-day) CVE | High | None specific; detection delayed | Medium — industry-wide |
+| Typo-squatted dep added via PR | Medium | `deny.toml` `[sources]` allow-list + `unknown-git = warn` | Low |
+| Maintainer-account compromise → silent minor-version malicious bump | **High** | Dependabot-manual-merge + `dependabot-review.yml` tree-growth annotation + human review of diffs | **Medium** — per-bump human judgment |
+| Malicious `build.rs` / proc-macro executing in CI | **High** | Dependabot PRs run with **read-only `GITHUB_TOKEN`** + no repo secrets (GitHub default); `permissions:` block denies writes elsewhere | **Medium** — blast radius is bounded (runner has no sensitive tokens), but can still exfil public source / waste CI minutes |
+| Release binary swapped on GitHub Release page | Medium | SHA256 `CHECKSUMS.txt` + SLSA build-provenance attestation via `gh attestation verify` | Low — requires attacker to also swap attestation, which is stored in GitHub Attestations API (separate audit trail) |
+| Rollback attack (release an older vulnerable commit) | Medium | `commit_sha` ancestor-of-main guard in `release.yml` | Low |
+| Rogue `v*` tag push by write-access user | Low | `tag-protection-v-prefix` ruleset blocks deletion + update | **Medium on creation** — GitHub API does not support `Integration` bypass for user-owned repos, so `creation` rule not enforced (bot couldn't push tags if it were).  Partial protection only. |
+| Compromised runner (GitHub Actions infra itself) | Low | None — SLSA L2 attestation trusts the runner | Industry-wide; accept |
+
+## Explicitly deferred (with rationale)
+
+### cargo-vet initialisation
+
+**Status**: Deferred to PR #33b (queued).
+
+**What it does**: Requires every resolved crate-version to have an
+audit record (either our own, or an imported one from Mozilla /
+Google / Bytecode Alliance).  Dependabot PRs that bump to an
+un-audited version fail CI until we audit the delta.
+
+**Why deferred**: One-shot grandfather-in cost (~2 h) is low, but the
+ongoing per-Dependabot-PR audit burden (~15-30 min/month at current
+cadence of ~1-2 Dependabot PRs/month) needs a dedicated habit.  The
+value compounds over time as the exemption list converts to real
+audits via scheduled import-refresh from upstream.
+
+**Promotion trigger**: When the project starts publishing
+`uffs-core` as a library (others will depend on us transitively) or
+when a second long-term contributor joins.
+
+### Reproducible builds + independent rebuild verifier
+
+**Status**: Deferred indefinitely.
+
+**What it would protect against**: Compromise of the GitHub-hosted
+runner itself (the step the SLSA L2 attestation has to trust).
+
+**Why deferred**: Requires pinning OS-image SHAs, `SOURCE_DATE_EPOCH`,
+deterministic toolchain.  Worth ~3-5 days of work for L3.  The
+threat is industry-wide and low-probability at UFFS's scale.
+
+### Code signing (Authenticode / `codesign`)
+
+**Status**: Deferred indefinitely.
+
+**What it would protect against**: Users who rely on the OS's
+SmartScreen / Gatekeeper reputation signal rather than
+`gh attestation verify`.
+
+**Why deferred**: $99-$200/yr cost + key-rotation discipline.  SLSA
+attestation covers the technical threat for the audience who
+verifies; deferring the UX-layer signing until there's enterprise
+demand.
+
+## Baseline metrics
+
+### cargo-geiger (2026-04-22, `uffs-cli` full feature set)
+
+Aggregate unsafe footprint across the resolved dep tree:
+
+```
+Functions  Expressions  Impls  Traits  Methods
+862/2072   73458/112403 1285/2290 106/112 2688/3519
+```
+
+Top-10 `unsafe`-heavy crates (by function count):
+
+| Crate | Used/Total fns | Used/Total exprs | Role |
+|---|---|---|---|
+| `rustix 1.1.4` | 44/436 | 1560/7539 | syscall bindings |
+| `objc2-core-foundation 0.3.2` | 66/185 | 1143/2829 | Apple platform bindings |
+| `libc 0.2.185` | 1/92 | 10/725 | C library bindings |
+| `portable-atomic 1.13.1` | 16/87 | 122/633 | atomics polyfill |
+| `blake3 1.8.4` | 1/84 | 32/4365 | crypto (SIMD) |
+| `sysinfo 0.37.2` | 12/73 | 1018/5802 | OS info |
+| `polars-arrow 0.53.0` | 69/69 | 5226/5271 | columnar engine |
+| `argminmax 0.6.3` | 60/60 | 2854/3391 | SIMD min/max |
+| `zlib-rs 0.6.3` | 41/49 | 2594/3481 | compression (pure Rust) |
+| `tokio 1.52.1` | 26/30 | 2270/2912 | async runtime |
+
+**Interpretation**: every top-10 crate is either (a) platform bindings
+that must use unsafe by definition, (b) SIMD-heavy performance code
+in well-known widely-audited crates, or (c) foundational async/crypto
+from the Rust ecosystem's top-tier maintainers.  **No surprises.**
+None of the crates appearing here warrant a focused manual audit at
+this time.
+
+**How to refresh**: `just geiger` (writes dated report to
+`target/geiger-YYYYMMDD.txt`).  Review monthly; flag any new top-20
+entry that isn't obviously platform / SIMD / foundational.
+
+### Cargo.lock crate count (2026-04-22)
+
+<!-- Populate with actual count next time you run `grep -c '^name = ' Cargo.lock` -->
+See the Dependabot-review workflow summary for the current value.  The
+`dep-tree-growth` check compares each Dependabot PR against the value
+on `main` at branch-open time.
+
+## Operational playbook
+
+### Monthly review (~30 min)
+
+1. `just geiger` — regenerate report, diff against previous month's
+   `target/geiger-YYYYMMDD.txt`.
+2. Scan the top-20 for new entries; investigate any that aren't
+   platform / SIMD / foundational.
+3. Review any Dependabot PRs that are still open with
+   `dep-tree-growth` warnings.
+4. Glance at the GitHub Security tab for new Dependabot alerts.
+
+### Per-Dependabot-PR review (~5-10 min)
+
+1. Read the PR description (Dependabot summarises the changelog).
+2. Check the `dep-tree-growth` annotation — if flagged, inspect the
+   "Newly-resolved crate names" summary.
+3. `gh pr diff <N>` and scan `Cargo.lock` for unexpected additions.
+4. If the bump is a known crate and the diff looks clean, merge.
+5. If anything looks off — typo-squat, sudden fan-out, unexplained
+   git source change — ask the maintainer upstream before merging.
+
+### Incident response (suspected compromise)
+
+1. Disable auto-merge on all open PRs: `gh pr list --state open
+   --json number --jq '.[].number' | xargs -I {} gh pr merge {}
+   --disable-auto`.
+2. Pin the suspected crate to its last-known-good version via
+   `[patch.crates-io]` in workspace `Cargo.toml`.
+3. Run `cargo audit` and `cargo deny check` locally for
+   cross-confirmation.
+4. Run `just geiger` and diff against the last monthly baseline —
+   look for unexpected unsafe-count spikes in the suspected crate.
+5. Rotate the repo's `GITHUB_TOKEN` (via GitHub settings) if any
+   workflow had `write`-level scopes during the suspected window.
+
+## References
+
+- `deny.toml` — `cargo-deny` policy
+- `.github/workflows/ci.yml` §Security — CI enforcement
+- `.github/workflows/release.yml` — SLSA attestation + ancestor check
+- `.github/workflows/dependabot-review.yml` — dep-tree growth annotation
+- `.github/workflows/auto-tag-release.yml` — tagging bridge
+- `just/analysis.just` — `just geiger` / `just geiger-summary` recipes
+- GitHub [Attestations API](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+- SLSA [build-provenance v1](https://slsa.dev/spec/v1.0/provenance)

--- a/just/analysis.just
+++ b/just/analysis.just
@@ -16,6 +16,71 @@ audit-comprehensive:
     printf "\033[0;34m  → Running cargo-deny (dependency analysis)...\033[0m\n"
     if command -v cargo-deny >/dev/null 2>&1; then cargo deny check; else printf "\033[1;33m⚠️  cargo-deny not found, run 'just setup' first\033[0m\n"; fi
 
+# Audit `unsafe` / `build.rs` / proc-macro footprint across the dep tree.
+#
+# Why cargo-geiger (on top of cargo-audit + cargo-deny):
+#
+#   cargo-audit    → known CVEs in the RustSec database (advisories).
+#   cargo-deny     → license policy + multiple-version / source checks.
+#   cargo-geiger   → structural: how many `unsafe` blocks, how many
+#                    `build.rs` scripts, how many proc-macros — the
+#                    crates worth auditing *first* if you're worried
+#                    about a supply-chain attack at the code level.
+#
+# When to run:
+#
+#   • Periodically (monthly) to track the trend — is the `unsafe`
+#     footprint growing disproportionately to added features?
+#   • Before merging a Dependabot PR that flips a crate to a new
+#     major version (compare the summary before vs after).
+#   • When investigating an incident — see which crates in the tree
+#     execute `build.rs` (= arbitrary code at compile time).
+#
+# Why NOT in CI:
+#
+#   cargo-geiger's output goes stale fast (any dep bump changes it),
+#   it occasionally breaks on fresh nightly toolchains, and the
+#   information is advisory rather than binary pass/fail.  Baking it
+#   into Tier 1 would produce noisy failures without real signal.
+#   Keeping it as a local recipe means the dev runs it when they
+#   actually want the data — and the report lives under `target/`
+#   so it doesn't pollute the repo.
+#
+# Install once: `cargo install cargo-geiger`.  First run rebuilds
+# every crate with `--release` (~3-5 min); subsequent runs hit the
+# incremental cache.
+geiger:
+    #!/usr/bin/env bash
+    printf "\033[0;34m☢️  cargo-geiger: unsafe / build.rs / proc-macro footprint\033[0m\n"
+    if ! command -v cargo-geiger >/dev/null 2>&1; then
+        printf "\033[1;33m⚠️  cargo-geiger not found\033[0m\n"
+        printf "\033[0;34m   Install: cargo install cargo-geiger\033[0m\n"
+        printf "\033[0;34m   (takes ~3 min; no special toolchain needed)\033[0m\n"
+        exit 1
+    fi
+    mkdir -p target
+    REPORT="target/geiger-$(date +%Y%m%d).txt"
+    # Workspace root is a virtual manifest; cargo-geiger requires a
+    # concrete package.  uffs-cli is the primary user-facing binary
+    # and its dep tree is a superset of uffs-core's, so auditing it
+    # covers the full attack surface that ships to end users.
+    cargo geiger --manifest-path "$(pwd)/crates/uffs-cli/Cargo.toml" --all-features --update-readme=false 2>&1 | tee "$REPORT"
+    printf "\033[0;32m✅ Report saved to %s\033[0m\n" "$REPORT"
+    printf "\033[0;34m   Interpretation guide: docs/architecture/security/supply-chain-posture.md\033[0m\n"
+
+# Quick summary: top crates by unsafe + build-script hotspot.
+geiger-summary:
+    #!/usr/bin/env bash
+    if ! command -v cargo-geiger >/dev/null 2>&1; then
+        printf "\033[1;33m⚠️  cargo-geiger not found; run 'cargo install cargo-geiger' first\033[0m\n"
+        exit 1
+    fi
+    printf "\033[0;34m☢️  cargo-geiger — top hotspots\033[0m\n"
+    cargo geiger --manifest-path "$(pwd)/crates/uffs-cli/Cargo.toml" --all-features --update-readme=false 2>&1 | \
+        grep -E '^[[:space:]]*[0-9]+/[0-9]+' | \
+        sort -t/ -k2,2 -n -r | \
+        head -25
+
 
 # Dependency optimization and cleanup.
 deps-optimize:


### PR DESCRIPTION
## Summary

First of two supply-chain hardening PRs from the #9 threat-model discussion.  Ships the **cheap, high-signal half**: a structural audit tool for on-demand use, a CI guardrail for Dependabot PRs that triggers human review, and a living posture document.  PR #33b will add cargo-vet integration.

## What ships

### 1. `just geiger` / `just geiger-summary` recipes

On-demand `cargo-geiger` run that catalogues the workspace's `unsafe` / `build.rs` / proc-macro footprint.  Output saved to `target/geiger-YYYYMMDD.txt` for monthly-diff reviews.

**Not in CI** because cargo-geiger output is toolchain-sensitive (often breaks on fresh nightlies) and advisory rather than binary pass/fail.  Monthly cadence via local recipe is the right cost/benefit.

### 2. `.github/workflows/dependabot-review.yml`

New dedicated workflow, triggers only on Dependabot-authored PRs touching `Cargo.*`.  Counts `Cargo.lock` crate entries before vs after, emits a PR-level `::warning::` annotation if delta > 3 (default: typical patch bump adds 0-2).  Lists newly-resolved crate names in the job summary.

**Threat it addresses**: attacker compromises a crates.io maintainer account, pushes a minor-version update that secretly pulls in malicious new transitive deps.  Dependabot opens a PR that looks like 'just a patch bump' — the unexpected fan-out is the red flag this guard surfaces.

**Does NOT block merge** — annotation only.  Goal is to prompt human review, not short-circuit Dependabot's automation.

### 3. `docs/architecture/security/supply-chain-posture.md`

Living document with:
- Layered-defence table (all current controls + CI gates)
- Threat-model × coverage matrix (what each control covers, residual risk)
- Deferred-item rationale (cargo-vet, reproducible builds, code signing — what triggers promotion)
- **cargo-geiger baseline 2026-04-22**: 862/2072 unsafe fns across uffs-cli's resolved dep tree.  Top-10 unsafe-heavy crates listed — all platform bindings / SIMD / foundational infra, no surprises.
- Operational playbook (monthly review, per-Dependabot-PR review, incident response)

### 4. `SECURITY.md` restructure

Grouped 'Security Measures' into 3 sections (Code / Dependencies / CI·release) and added the new controls from this session:
- SLSA attestation
- Tag-protection ruleset
- Commit-ancestry check
- Dep-tree-growth annotation
- `just geiger`

Points to the new posture doc for detail.

## Attack-surface delta

| Threat | Before | After |
|---|---|---|
| Silent fan-out in a Dependabot 'patch bump' | Reviewer might rubber-stamp it | PR annotation surfaces the delta + crate names |
| 'What's our unsafe footprint?' (audit question) | No easy answer | `just geiger` + a 30-min monthly diff |
| 'Where do we document the threat model?' | Nowhere | `docs/architecture/security/supply-chain-posture.md` |

## What this does NOT do

- Does not block merge (annotation only)
- Does not audit crate contents — that's cargo-vet, PR #33b
- Does not change workflow permissions (PR #31 already minimised)
- Does not add new secrets or PATs

## Testing plan

1. Merge this PR (auto-merge SQUASH queued)
2. Next Dependabot PR: verify `dependabot-review.yml` runs + produces the expected job summary
3. Run `just geiger` locally after merge to confirm the fixed manifest-path resolution works
4. Review the posture doc one month from now; update with fresh baseline numbers

## Series

- PRs #25-#32 — build pipeline hardening, **all merged**
- **PR #33a (this)** — structural audit + Dependabot guardrail
- PR #33b (queued) — cargo-vet init + scheduled import-refresh