### PR TITLE
chore: release v0.5.69 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     packaging configuration lives under the tracked `packaging/`
     root (new top-level folder).  End-to-end verified on macOS:
     `dist/UFFS.app/Contents/MacOS/uffs --version` returns
-    `uffs 0.5.68` with the plist version fields templated correctly.
+    `uffs 0.5.69` with the plist version fields templated correctly.
   - **Linux `.desktop` + installer** (Phase 4 —
     `packaging/linux/uffs.desktop`,
     `packaging/linux/install.sh`, `just/packaging.just`).  New
@@ -479,7 +479,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   search"; `ensure_drives_loaded` as "tree metrics computation").
   Replaced with accurate per-function justifications.
 
-## [0.5.68] - 2026-04-19
+## [0.5.69] - 2026-04-19
 
 ### Added
 - **Phase 2 performance measurement series** (closed): 11 instrumented
@@ -637,8 +637,8 @@ thin clients over a unified `uffsd` process.
 ### Fixed
 - Various MFT parsing edge cases
 
-[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.5.68...HEAD
-[0.5.68]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.5.0...v0.5.68
+[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.5.69...HEAD
+[0.5.69]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.5.0...v0.5.69
 [0.5.0]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.2.208...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.68"
+version = "0.5.69"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@
 
 **A benchmark-driven NTFS search engine for Windows.** UFFS reads the Master File Table directly, builds a compact persisted index, and keeps large NTFS estates searchable through a background daemon.
 
-> Proven on a real 7-drive, 25.9M-record Windows system; scale-ceiling tested to **100.4M records** with offline MFT clones (v0.5.4 baseline; v0.5.68 current):
-> - **68.5 s COLD** — raw MFT read + compact index build (v0.5.68, flat ± 4 % vs v0.5.4)
-> - **5.7 s WARM CACHE** — restart from serialized cache (v0.5.62/v0.5.68, **−17 %** vs v0.5.4)
+> Proven on a real 7-drive, 25.9M-record Windows system; scale-ceiling tested to **100.4M records** with offline MFT clones (v0.5.4 baseline; v0.5.69 current):
+> - **68.5 s COLD** — raw MFT read + compact index build (v0.5.69, flat ± 4 % vs v0.5.4)
+> - **5.7 s WARM CACHE** — restart from serialized cache (v0.5.62/v0.5.69, **−17 %** vs v0.5.4)
 > - **0–3 ms daemon-side** for targeted queries — exact/prefix/ext/substring, unchanged from v0.5.4
-> - **29–32 ms CLI end-to-end** for targeted queries on v0.5.68 (v0.5.4 measured 9–13 ms e2e before the post-Phase-1 thin-client spawn floor settled at ~28 ms)
-> - **vs Everything on v0.5.68**: UFFS wins **12/12 head-to-head cells** at p50 on C+D, median ratio **0.51× (~1.96× faster)** — see the [**benchmark hub**](docs/benchmarks/) and the [full v0.5.68 report](docs/benchmarks/2026-04-v0.5.68-vs-everything-and-cpp.md)
+> - **29–32 ms CLI end-to-end** for targeted queries on v0.5.69 (v0.5.4 measured 9–13 ms e2e before the post-Phase-1 thin-client spawn floor settled at ~28 ms)
+> - **vs Everything on v0.5.69**: UFFS wins **12/12 head-to-head cells** at p50 on C+D, median ratio **0.51× (~1.96× faster)** — see the [**benchmark hub**](docs/benchmarks/) and the [full v0.5.69 report](docs/benchmarks/2026-04-v0.5.69-vs-everything-and-cpp.md)
 
 UFFS is built for **exact filename, path, and metadata search** at scales where directory walking, shell search, and some automation surfaces become the bottleneck. It is open source, written in Rust, and designed first for deterministic local search; CLI, TUI, API, and MCP are all interfaces on top of the same engine.
 
@@ -47,11 +47,11 @@ UFFS is built for **exact filename, path, and metadata search** at scales where 
 
 ---
 
-## Benchmark snapshot (v0.5.68)
+## Benchmark snapshot (v0.5.69)
 
 Measured on AMD Ryzen 9 3900XT, 64 GB RAM, Windows 11 Pro 24H2, 7 NTFS volumes totaling 26.1 M records; scaled to 100.4 M with offline MFT clones (v0.5.4 era). Full captures in [`docs/benchmarks/raw/2026-04-v0.5.66_cross-tool-vs-everything.txt`](docs/benchmarks/raw/2026-04-v0.5.66_cross-tool-vs-everything.txt) + [`docs/benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt`](docs/benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt). Publication-grade report: [**docs/benchmarks/**](docs/benchmarks/).
 
-| Phase | What happens | ALL 7 drives (v0.5.68) | Single NVMe (v0.5.4) |
+| Phase | What happens | ALL 7 drives (v0.5.69) | Single NVMe (v0.5.4) |
 |-------|--------------|-----------------------:|---------------------:|
 | **COLD** | Raw MFT read, parse, compact index build, cache write | 68.5 s | 7.7 s |
 | **WARM CACHE** | Daemon restart + serialized cache load | **5.7 s** | 6.4 s |
@@ -60,14 +60,14 @@ Measured on AMD Ryzen 9 3900XT, 64 GB RAM, Windows 11 Pro 24H2, 7 NTFS volumes t
 
 ¹ The `*` top-100 path regressed from the v0.5.4 163 ms figure after the Phase 2 sort rewrite ([`docs/benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt:657`](docs/benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt), n=30, StdDev 21 ms). Daemon-side is 1 081 ms — CLI tax is negligible here. Bounded-heap top-N fix is Phase 5 target #2 in the [cross-tool analysis](docs/benchmarks/2026-04-v0.5.66-vs-everything-and-cpp.md#known-regressions) doc.
 
-Hot-path context (v0.5.68, 30 rounds, p50):
+Hot-path context (v0.5.69, 30 rounds, p50):
 - **0–3 ms daemon-side** for targeted queries (exact, prefix, ext, substring, combined) — unchanged since v0.5.4
 - **29–32 ms CLI end-to-end** for targeted queries across all 7 drives (~28 ms post-Phase-1 cold-spawn floor + 0–3 ms daemon)
 - **UFFS wins 12/12 cells vs Everything** at p50 on C+D, median ratio **0.51×** — see the [benchmark hub](docs/benchmarks/)
 - **Direct stdout redirect crossover**: UFFS **0.27×–0.53×** vs ES across 4 size classes (34 K → 167 K rows)
 - **323 k rows/sec** bulk export throughput (CSV, `--out-dir`)
 - **Full-scan export** `*` → CSV at 26 M records: **13.6 s p50** (1.72 M rec/s through the full pipeline)
-- **100.4 M records** tested (v0.5.4 synthetic-clone data; not re-verified on v0.5.68): targeted queries stayed at 11–13 ms e2e
+- **100.4 M records** tested (v0.5.4 synthetic-clone data; not re-verified on v0.5.69): targeted queries stayed at 11–13 ms e2e
 
 > 📖 **[Benchmark hub](docs/benchmarks/)** — dated competitive-benchmark reports, fairness methodology, archive of prior versions, reproduction scripts.
 > 📖 **[Full benchmark data](docs/user-manual/performance.md)** — methodology, per-drive tables, interactive search percentiles, bulk retrieval, scale ceiling, and caveats.


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.69**.  Binaries + GitHub Release v0.5.69 are already live (step 09).  This PR routes the corresponding commit through branch-protection rules.

## Auto-merge

`--auto --rebase` is queued — GitHub will merge as soon as the required status checks pass.  Rebase preserves the GPG signature on single-commit release PRs.

## After merge

Local `main` already contains this commit; `git pull` will fast-forward cleanly once CI merges the PR.