### PR TITLE
fix(ship): auto-merge must be --squash, not --rebase

### DIFF
--- a/scripts/ci/ci-pipeline.rs
+++ b/scripts/ci/ci-pipeline.rs
@@ -919,12 +919,17 @@ async fn git_push(ctx: &PipelineContext) -> Result<()> {
              GitHub Release v{version} are already live (step 09).  This PR \
              routes the corresponding commit through branch-protection rules.\n\n\
              ## Auto-merge\n\n\
-             `--auto --rebase` is queued — GitHub will merge as soon as the \
-             required status checks pass.  Rebase preserves the GPG signature \
-             on single-commit release PRs.\n\n\
+             `--auto --squash` is queued — GitHub will merge as soon as the \
+             required status checks pass.  Squash is required because \
+             `main-protection` mandates signed commits, and GitHub's \
+             rebase-auto-merge cannot sign the rebased commit; the \
+             squash-merge commit is signed by GitHub's own key, which \
+             satisfies `required_signatures: true`.  The original author's \
+             signed commit remains verifiable in the PR branch history.\n\n\
              ## After merge\n\n\
-             Local `{current_branch}` already contains this commit; \
-             `git pull` will fast-forward cleanly once CI merges the PR."
+             Local `{current_branch}` had this commit with a different SHA \
+             before squash rewrote it onto main; recover with \
+             `git fetch origin && git reset --hard origin/{current_branch}`."
         );
 
         println!("📬 Opening release PR");
@@ -953,12 +958,22 @@ async fn git_push(ctx: &PipelineContext) -> Result<()> {
         );
     }
 
-    // Enable auto-merge (rebase).  If the 6 required status checks are already
-    // green by this point, GitHub merges immediately.  Rebase-merging a
-    // single-commit release PR preserves the author's GPG signature on the
-    // commit that lands on `main` — matching the pre-refactor semantics where
-    // the pipeline pushed the signed commit directly.
-    println!("⚡ Ensuring auto-merge is enabled (rebase strategy)");
+    // Enable auto-merge (squash).  Squash is mandatory on this repo because:
+    //
+    //   1. `main-protection` ruleset requires `required_signatures: true`
+    //      (every commit on main must be signed).
+    //   2. GitHub's rebase-auto-merge cannot sign the rebased commit; it
+    //      fails with `GraphQL: Base branch requires signed commits.
+    //      Rebase merges cannot be automatically signed by GitHub`
+    //      (observed on PR #36, the first real `just ship` for v0.5.69).
+    //   3. GitHub signs the squash-merge commit with its own key, which
+    //      satisfies `required_signatures: true` on main.
+    //
+    // Trust trade-off: the author's GPG signature is lost on the commit
+    // that lands on main (it becomes a GitHub-signed squash).  The
+    // original signed commit remains verifiable in the PR branch history,
+    // and every prior merged PR on this repo uses the same pattern.
+    println!("⚡ Ensuring auto-merge is enabled (squash strategy)");
     execute_command(
         "Enable auto-merge",
         "gh",
@@ -967,7 +982,7 @@ async fn git_push(ctx: &PipelineContext) -> Result<()> {
             "merge",
             &release_branch,
             "--auto",
-            "--rebase",
+            "--squash",
         ],
         ctx,
     )
@@ -984,7 +999,11 @@ async fn git_push(ctx: &PipelineContext) -> Result<()> {
     );
     println!(
         "   💡 After merge:  {}",
-        format!("git pull origin {} --rebase", current_branch).cyan()
+        format!(
+            "git fetch origin && git reset --hard origin/{} (squash rewrites commit SHA)",
+            current_branch
+        )
+        .cyan()
     );
 
     Ok(())


### PR DESCRIPTION
## Root cause

Observed on **PR #36** — the first real `just ship` end-to-end for v0.5.69:

```
gh pr merge 36 --rebase --auto
→ GraphQL: Base branch requires signed commits.
  Rebase merges cannot be automatically signed by GitHub
  (mergePullRequest)
```

`main-protection` ruleset has `required_signatures: true`.  GitHub's rebase-auto-merge cannot sign the rebased commit, so it refuses outright.  PR #36 was blocked and had to be **manually switched to `--squash`** to unblock the release.

## Why every prior PR worked

PRs #25-#35 were all squash-merged (GitHub's default when enabled).  GitHub signs the squash commit with its own bot key, which satisfies `required_signatures: true`.

The `--rebase` in `ci-pipeline.rs` was an untested assumption from the PR #28 comment _"Rebase preserves the GPG signature on single-commit release PRs"_ — technically true for a manual `git rebase`, but GitHub's auto-rebase-merge path can't do it when `required_signatures` is on.

## Changes

- `git_push()` auto-merge command: `--auto --rebase` → `--auto --squash`
- Comment rewritten with the three-point root cause (ruleset / GitHub limitation / squash works)
- PR body template: matches the new flag + rationale inline
- Post-merge recovery hint: `git pull --rebase` → `git fetch && git reset --hard` (squash rewrites the commit SHA, so fast-forward won't work)

## Trust trade-off

- **Intended (never worked)**: author's GPG signature preserved on commit landing on main
- **What we actually do now**: commit on main is a GitHub-signed squash; author's original signed commit remains verifiable in the PR branch history (same as every prior PR on this repo)

## Verification

No smoke test needed — the change is purely a flag flip (`--rebase` → `--squash`) plus cosmetic comment/print updates.  Next `just ship` will exercise the new path cleanly.

## Related

- PR #36 (v0.5.69 release, merged via manual `--squash` unblock)
- PR #35 (posture-doc follow-ups)