### PR TITLE
chore(dev): shift-left quality gates — parallel pre-commit + pre-push

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,56 @@ Focused examples from the current workflow canon:
 
 Most tests run cross-platform. Tests that need live MFT access are typically `#[ignore]` and should only be run on Windows with elevation.
 
+## Four-layer quality gates
+
+UFFS uses a shift-left pipeline: cheap checks fire close to the keystroke, expensive ones move rightward into CI. Each layer is fully opt-in via `just install-hooks` and can be bypassed with `--no-verify` for a single commit or push when you need to.
+
+| Layer | Trigger | Recipe | Budget | What it runs |
+|------|--------|--------|--------|-------------|
+| **IDE save** | On save | `rust-analyzer` | instant | type-check-on-save, clippy-on-save |
+| **pre-commit** | `git commit` | `just lint-fast` | sub-2 s | `fmt --check` (if `*.rs` staged), `taplo fmt --check` (if `*.toml` staged), `typos`, `reuse lint`, file-size policy — all in parallel; missing optional tools soft-skip |
+| **pre-push** | `git push` | `just lint-pre-push` | 25–45 s warm | `clippy -D warnings --all-targets --all-features`, `fmt --check`, `rustdoc -D warnings`, `cargo deny check`, `nextest run --no-run` (test-binary link check), file-size policy, `typos`, `reuse lint` — all in parallel |
+| **PR CI** | on PR to `main` | `.github/workflows/ci.yml` | minutes | Tier 1 matrix: Format, Clippy, Rustdoc, Security, Test Build, Tests, Doc Tests, File Size Policy |
+| **Release** | manual | `just ship` | minutes | version bump + `release/vX.Y.Z` PR + signed commit + auto-tag + binary build |
+
+### First-time setup
+
+```bash
+just install-hooks         # sets core.hooksPath → scripts/hooks/
+just install-dev-tools     # installs typos-cli + taplo-cli; prints pipx hint for `reuse`
+```
+
+Re-run `just install-hooks` after any rebase that touches `scripts/hooks/` — it's idempotent.
+
+### Running gates manually
+
+```bash
+just lint-fast             # the pre-commit bundle on demand
+just lint-pre-push         # the pre-push bundle on demand
+just lint-ci               # the single clippy gate that CI runs (`--all-targets --all-features --no-deps`)
+just lint-ci-linux         # same clippy gate under a Linux x86_64 Docker image (catches macOS↔Linux drift)
+just phase1-test           # the full `just ship` Phase-1 validation (pre-ship rehearsal)
+```
+
+### Bypass escape hatches
+
+```bash
+git commit --no-verify     # skip pre-commit
+git push   --no-verify     # skip pre-push
+```
+
+Use them for work-in-progress commits on a feature branch. CI will still enforce the same gates on the PR.
+
+### Keeping hook output fast
+
+The hooks are tuned for an sccache-warm workspace. If you notice cold-cache slowness, verify:
+
+- `cargo install sccache` is installed and `.cargo/config.toml` has `rustc-wrapper = "sccache"` (default).
+- `sccache --show-stats` shows a healthy cache-hit rate after a few rebuilds.
+- The shared `target/` directory is not being wiped by unrelated tools.
+
+See `@scripts/hooks/_lint_fast.sh` and `@scripts/hooks/_lint_pre_push.sh` for the shared parallel runners both the hooks and the `just` recipes call into — edit there when adjusting the gate set, not in the hooks themselves.
+
 ## Architecture guardrails
 
 - Do not depend on `polars` directly; use `uffs-polars`.

--- a/just/test.just
+++ b/just/test.just
@@ -115,24 +115,99 @@ lint-all:
     just fmt-check
     @printf "\033[0;32m✅ All lint checks passed\033[0m\n"
 
-# Install the tracked git hooks (pre-push lint gate).
+# ── Shift-left quality gates ───────────────────────────────────────────
+# Four-layer model (documented in CONTRIBUTING.md):
+#   IDE save   → rust-analyzer check-on-save
+#   pre-commit → `just lint-fast`       (staged-scoped, sub-2 s)
+#   pre-push   → `just lint-pre-push`   (workspace-parallel, ≤ 60 s)
+#   PR CI      → .github/workflows/ci.yml (matrix + cross-platform)
+# Recipes below back both the git hooks and manual invocations so the
+# two surfaces never drift — see `scripts/hooks/_lint_*.sh` for the
+# shared parallel runners.
+
+# Spell-check the workspace (requires `typos-cli`).
+# Pass scopes or flags, e.g. `just typos crates/uffs-core/src`.
+typos *ARGS:
+    @printf "\033[0;34m🔤 typos (spell check)...\033[0m\n"
+    typos {{ ARGS }}
+
+# REUSE / SPDX compliance lint (requires `reuse`, install via pipx).
+reuse:
+    @printf "\033[0;34m📜 REUSE/SPDX lint...\033[0m\n"
+    reuse lint --quiet
+
+# Check TOML formatting (requires `taplo-cli`).
+taplo-check *ARGS:
+    @printf "\033[0;34m📋 taplo fmt --check...\033[0m\n"
+    taplo fmt --check {{ ARGS }}
+
+# Apply TOML formatting (requires `taplo-cli`).
+taplo-fmt *ARGS:
+    @printf "\033[0;34m📋 taplo fmt (apply)...\033[0m\n"
+    taplo fmt {{ ARGS }}
+
+# Install optional dev-tool binaries used by the pre-commit / pre-push hooks.
+# `typos-cli` and `taplo-cli` are cargo-installable; `reuse` needs pipx.
+# Idempotent: prints a ✓ line for each tool already present.
+install-dev-tools:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    printf "\033[0;34m📦 Installing dev tools (typos-cli, taplo-cli)...\033[0m\n"
+    if ! command -v typos >/dev/null 2>&1; then
+        cargo install --locked typos-cli
+    else
+        printf "   \033[0;32m✓\033[0m typos already installed\n"
+    fi
+    if ! command -v taplo >/dev/null 2>&1; then
+        cargo install --locked taplo-cli
+    else
+        printf "   \033[0;32m✓\033[0m taplo already installed\n"
+    fi
+    if ! command -v reuse >/dev/null 2>&1; then
+        printf "   \033[1;33m!\033[0m reuse not found — install with: \033[0;36mpipx install reuse\033[0m\n"
+    else
+        printf "   \033[0;32m✓\033[0m reuse already installed\n"
+    fi
+    printf "\033[0;32m✅ Dev tools check complete.\033[0m\n"
+
+# Fast staged-scoped gate (the pre-commit bundle; also runnable manually).
+# Runs fmt-check (if *.rs staged), taplo-check (if *.toml staged + taplo),
+# typos (optional), reuse (optional) and the file-size-policy script in
+# parallel.  Budget: sub-2 s.  Soft-skips missing optional tools.
+lint-fast:
+    @bash scripts/hooks/_lint_fast.sh
+
+# Parallel pre-push gate (the pre-push bundle; also runnable manually).
+# Fans out clippy (-D warnings) + fmt-check + rustdoc (-D warnings) +
+# cargo deny + nextest --no-run (test-binary link check) + file-size-policy
+# + typos (optional) + reuse (optional).  Budget: ≈ 25–45 s warm, ≈ 60–90 s
+# cold.  All failures surface in one pass — per-job ✅/❌ grid, then every
+# failing job's full output is dumped before exit.
+lint-pre-push:
+    @bash scripts/hooks/_lint_pre_push.sh
+
+# Install the tracked git hooks (pre-commit + pre-push).
 # Idempotent — safe to re-run.  Sets `git config core.hooksPath` to the
-# tracked `scripts/hooks/` directory so the hook survives `git clone` and
-# cannot be accidentally deleted from `.git/hooks/`.
+# tracked `scripts/hooks/` directory so the hooks survive `git clone`
+# and cannot be accidentally deleted from `.git/hooks/`.
 install-hooks:
     #!/usr/bin/env bash
     set -euo pipefail
     printf "\033[0;34m🪝 Installing tracked git hooks...\033[0m\n"
     git config core.hooksPath scripts/hooks
-    chmod +x scripts/hooks/pre-push
-    printf "\033[0;32m✅ Git hooks installed — pre-push will run 'just lint-ci' before each push.\033[0m\n"
-    printf "\033[0;36m   Bypass with 'git push --no-verify' when you need to.\033[0m\n"
+    chmod +x scripts/hooks/pre-commit scripts/hooks/pre-push \
+             scripts/hooks/_lint_fast.sh scripts/hooks/_lint_pre_push.sh
+    printf "\033[0;32m✅ Git hooks installed:\033[0m\n"
+    printf "   \033[0;36mpre-commit\033[0m → just lint-fast     (staged-scoped, sub-2 s)\n"
+    printf "   \033[0;36mpre-push\033[0m   → just lint-pre-push  (workspace parallel)\n"
+    printf "   \033[0;33mBypass once\033[0m with \`git commit --no-verify\` / \`git push --no-verify\`.\n"
+    printf "   \033[0;33mInstall optional tools\033[0m with \`just install-dev-tools\`.\n"
 
 # Uninstall the tracked git hooks (resets to .git/hooks/ default).
 uninstall-hooks:
     @printf "\033[0;34m🪝 Uninstalling tracked git hooks...\033[0m\n"
     git config --unset core.hooksPath || true
-    @printf "\033[0;32m✅ Git hooks uninstalled — pushes are no longer gated.\033[0m\n"
+    @printf "\033[0;32m✅ Git hooks uninstalled — commits and pushes are no longer gated.\033[0m\n"
 
 # Validate rustdoc links and warnings (catches private-intra-doc-links etc.).
 rustdoc:

--- a/scripts/hooks/_lint_fast.sh
+++ b/scripts/hooks/_lint_fast.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# Staged-scoped parallel fast gate.
+#
+# Called by:
+#   - `scripts/hooks/pre-commit` (git hook)
+#   - `just lint-fast`           (manual runs)
+#
+# Budget: sub-2 seconds on a warm repo.  Soft-skips missing optional tools
+# (typos, taplo, reuse) with a one-line install hint so new contributors
+# are not blocked before running `just install-dev-tools`.
+#
+# Design notes
+# ------------
+# 1. Fan all applicable jobs out in parallel and wait on all PIDs.  Cargo
+#    target-dir locks serialise inside cargo anyway, so the extra parallelism
+#    is free for the non-cargo jobs (typos, reuse, file-size, taplo).
+# 2. Job scope:
+#      * Rust changes staged  → `cargo fmt --all -- --check`
+#      * TOML changes staged  → `taplo fmt --check` (if installed)
+#      * Any changes staged   → `typos .`           (if installed)
+#      * Always-on            → `reuse lint`        (if installed)
+#      * Always-on            → `file-size-policy`
+#    When invoked without a staged set (e.g. `just lint-fast` on a clean
+#    worktree) we still run the always-on gates plus an fmt-check / typos
+#    scan so the recipe is useful as a "quick sanity" pass.
+# 3. Per-job output is captured to a tmpdir and only dumped on failure so
+#    the success path stays uncluttered.
+
+set -euo pipefail
+
+# ── Colours ────────────────────────────────────────────────────────────
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    C_BLUE=$'\033[0;34m'
+    C_CYAN=$'\033[0;36m'
+    C_GREEN=$'\033[0;32m'
+    C_YELLOW=$'\033[1;33m'
+    C_RED=$'\033[0;31m'
+    C_RESET=$'\033[0m'
+else
+    C_BLUE= C_CYAN= C_GREEN= C_YELLOW= C_RED= C_RESET=
+fi
+
+# ── Staged-file inventory ──────────────────────────────────────────────
+STAGED_ALL=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
+has_staged_rs()   { printf '%s\n' "$STAGED_ALL" | grep -q '\.rs$';   }
+has_staged_toml() { printf '%s\n' "$STAGED_ALL" | grep -q '\.toml$'; }
+has_any_staged()  { [[ -n "${STAGED_ALL//[[:space:]]/}" ]]; }
+
+printf '%s🚦 lint-fast — staged-scoped parallel gate%s\n' "$C_BLUE" "$C_RESET"
+START=$(date +%s)
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+NAMES=()
+PIDS=()
+spawn() {
+    local name="$1"
+    shift
+    NAMES+=("$name")
+    ( "$@" ) >"$TMP/$name.out" 2>&1 &
+    PIDS+=($!)
+}
+
+# ── Job dispatch ───────────────────────────────────────────────────────
+# Always-on (cheap, no tooling dep beyond bash)
+spawn "file-size"   bash scripts/ci/check_file_size_policy.sh
+
+# Rust changes → workspace fmt-check (rustfmt picks up `rustfmt.toml`
+# and the nightly pin in `rust-toolchain.toml` automatically).
+if has_staged_rs || ! has_any_staged; then
+    spawn "fmt-check" cargo fmt --all -- --check
+fi
+
+# TOML changes → taplo fmt --check (optional).
+if has_staged_toml && command -v taplo >/dev/null 2>&1; then
+    spawn "taplo" taplo fmt --check
+fi
+
+# Any staged text → typos (optional).  Runs against the full workspace
+# because typos is fast enough that scoping adds complexity for ~no win.
+if command -v typos >/dev/null 2>&1; then
+    spawn "typos" typos .
+fi
+
+# REUSE / SPDX compliance (optional; requires `reuse` via pipx).
+if command -v reuse >/dev/null 2>&1; then
+    spawn "reuse" reuse lint --quiet
+fi
+
+# ── Wait on all, collect failures ──────────────────────────────────────
+FAILED=()
+for i in "${!PIDS[@]}"; do
+    if ! wait "${PIDS[$i]}"; then
+        FAILED+=("${NAMES[$i]}")
+    fi
+done
+
+# ── Per-job status line ────────────────────────────────────────────────
+for i in "${!NAMES[@]}"; do
+    name="${NAMES[$i]}"
+    failed=0
+    for f in "${FAILED[@]+"${FAILED[@]}"}"; do
+        [[ "$f" == "$name" ]] && { failed=1; break; }
+    done
+    if (( failed )); then
+        printf '  %s❌%s %s\n' "$C_RED" "$C_RESET" "$name"
+    else
+        printf '  %s✅%s %s\n' "$C_GREEN" "$C_RESET" "$name"
+    fi
+done
+
+# ── Optional-tool hint (once, at the end) ──────────────────────────────
+missing=()
+command -v typos >/dev/null 2>&1 || missing+=("typos-cli")
+command -v taplo >/dev/null 2>&1 || missing+=("taplo-cli")
+command -v reuse >/dev/null 2>&1 || missing+=("reuse (pipx install reuse)")
+if (( ${#missing[@]} > 0 )); then
+    printf '  %s💡%s optional tools missing: %s — run %s`just install-dev-tools`%s\n' \
+        "$C_CYAN" "$C_RESET" "${missing[*]}" "$C_CYAN" "$C_RESET"
+fi
+
+# ── Dump failing output ────────────────────────────────────────────────
+if (( ${#FAILED[@]} > 0 )); then
+    for name in "${FAILED[@]}"; do
+        printf '\n%s==== %s output ====%s\n' "$C_RED" "$name" "$C_RESET"
+        cat "$TMP/$name.out"
+    done
+    DUR=$(( $(date +%s) - START ))
+    printf '\n%s❌ lint-fast FAILED (%ss)%s\n' "$C_RED" "$DUR" "$C_RESET" >&2
+    exit 1
+fi
+
+DUR=$(( $(date +%s) - START ))
+printf '%s✅ lint-fast passed (%ss)%s\n' "$C_GREEN" "$DUR" "$C_RESET"

--- a/scripts/hooks/_lint_pre_push.sh
+++ b/scripts/hooks/_lint_pre_push.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# Workspace-wide parallel pre-push gate.
+#
+# Called by:
+#   - `scripts/hooks/pre-push` (git hook)
+#   - `just lint-pre-push`     (manual runs)
+#
+# Budget: ≈ 25–45 s on an sccache-warm workspace; ≈ 60–90 s cold.  The
+# heaviest jobs (clippy, rustdoc) share the same target-dir; cargo's
+# file lock serialises them as needed, while the non-cargo jobs (deny,
+# typos, reuse, file-size) genuinely run in parallel.
+#
+# Mandatory jobs (any failure aborts the push):
+#   * clippy    — `-D warnings`, `--all-targets --all-features`
+#                 (covers test / example / bench compile as a side-effect).
+#   * fmt       — `cargo fmt --all -- --check`.
+#   * rustdoc   — `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps`.
+#   * deny      — advisories / bans / licences / sources.
+#   * file-size — oversized-Rust-file policy.
+#   * tests     — `cargo nextest run --no-run`: links every test binary
+#                 without running it.  Catches `#[cfg(test)]` drift,
+#                 missing dev-dep, and linker-level regressions that
+#                 `cargo clippy --all-targets` (check-only, no linking)
+#                 misses.  On sccache-warm runs this costs ~5 s on top
+#                 of clippy's compile; on cold it dominates the push.
+#
+# Optional jobs (soft-skipped when tool missing):
+#   * typos     — cheap spell-check across the repo.
+#   * reuse     — SPDX / licence-header compliance.
+#
+# The Linux-only lint drift gate (`just lint-ci-linux` via Docker) is NOT
+# run here — it is a minutes-scale cross-platform check best left to CI
+# or a conscious manual invocation.
+
+set -euo pipefail
+
+# ── Colours ────────────────────────────────────────────────────────────
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    C_BLUE=$'\033[0;34m'
+    C_CYAN=$'\033[0;36m'
+    C_GREEN=$'\033[0;32m'
+    C_YELLOW=$'\033[1;33m'
+    C_RED=$'\033[0;31m'
+    C_RESET=$'\033[0m'
+else
+    C_BLUE= C_CYAN= C_GREEN= C_YELLOW= C_RED= C_RESET=
+fi
+
+printf '%s🚦 lint-pre-push — workspace parallel gate%s\n' "$C_BLUE" "$C_RESET"
+START=$(date +%s)
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+NAMES=()
+PIDS=()
+spawn() {
+    local name="$1"
+    shift
+    NAMES+=("$name")
+    ( "$@" ) >"$TMP/$name.out" 2>&1 &
+    PIDS+=($!)
+}
+
+# ── Mandatory gates ────────────────────────────────────────────────────
+# NOTE: clippy `--all-targets --all-features --no-deps` kept in lockstep with
+# `.github/workflows/ci.yml`'s `Tier 1 / Clippy` step.  Keep the flag set
+# identical to avoid local / CI drift (see `just lint-ci`).
+spawn "clippy"    cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+spawn "fmt"       cargo fmt --all -- --check
+spawn "rustdoc"   env RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
+spawn "deny"      cargo deny check --hide-inclusion-graph
+spawn "tests"     cargo nextest run --workspace --all-targets --all-features --no-run --hide-progress-bar
+spawn "file-size" bash scripts/ci/check_file_size_policy.sh
+
+# ── Optional gates ─────────────────────────────────────────────────────
+if command -v typos >/dev/null 2>&1; then
+    spawn "typos" typos .
+fi
+if command -v reuse >/dev/null 2>&1; then
+    spawn "reuse" reuse lint --quiet
+fi
+
+# ── Wait on all, collect failures ──────────────────────────────────────
+FAILED=()
+for i in "${!PIDS[@]}"; do
+    if ! wait "${PIDS[$i]}"; then
+        FAILED+=("${NAMES[$i]}")
+    fi
+done
+
+# ── Per-job status line ────────────────────────────────────────────────
+for i in "${!NAMES[@]}"; do
+    name="${NAMES[$i]}"
+    failed=0
+    for f in "${FAILED[@]+"${FAILED[@]}"}"; do
+        [[ "$f" == "$name" ]] && { failed=1; break; }
+    done
+    if (( failed )); then
+        printf '  %s❌%s %s\n' "$C_RED" "$C_RESET" "$name"
+    else
+        printf '  %s✅%s %s\n' "$C_GREEN" "$C_RESET" "$name"
+    fi
+done
+
+# ── Optional-tool hint ─────────────────────────────────────────────────
+missing=()
+command -v typos >/dev/null 2>&1 || missing+=("typos-cli")
+command -v reuse >/dev/null 2>&1 || missing+=("reuse (pipx install reuse)")
+if (( ${#missing[@]} > 0 )); then
+    printf '  %s💡%s optional tools missing: %s — run %s`just install-dev-tools`%s\n' \
+        "$C_CYAN" "$C_RESET" "${missing[*]}" "$C_CYAN" "$C_RESET"
+fi
+
+# ── Dump failing output ────────────────────────────────────────────────
+if (( ${#FAILED[@]} > 0 )); then
+    for name in "${FAILED[@]}"; do
+        printf '\n%s==== %s output ====%s\n' "$C_RED" "$name" "$C_RESET"
+        cat "$TMP/$name.out"
+    done
+    DUR=$(( $(date +%s) - START ))
+    printf '\n%s❌ lint-pre-push FAILED (%ss) — push aborted%s\n' "$C_RED" "$DUR" "$C_RESET" >&2
+    printf '%s   Fix the warnings and retry, or bypass once with `git push --no-verify`.%s\n' "$C_YELLOW" "$C_RESET" >&2
+    exit 1
+fi
+
+DUR=$(( $(date +%s) - START ))
+printf '%s✅ lint-pre-push passed (%ss)%s\n' "$C_GREEN" "$DUR" "$C_RESET"

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# Tracked pre-commit git hook for the UFFS workspace.
+#
+# Purpose: shift the cheap-but-high-signal quality gates LEFT so they
+# run on every `git commit`, not just on push:
+#   * fmt-check (when *.rs staged)
+#   * taplo fmt --check (when *.toml staged, if installed)
+#   * typos (if installed)
+#   * reuse lint (if installed)
+#   * oversized-Rust-file policy
+#
+# Budget: sub-2 seconds on a warm repo.  Sub-500 ms when no Rust / TOML
+# touched (docs-only commits).
+#
+# Install via: `just install-hooks` (sets core.hooksPath to scripts/hooks/).
+# Bypass once: `git commit --no-verify`.
+# Uninstall:   `just uninstall-hooks`.
+
+set -euo pipefail
+
+exec bash "$(dirname "$0")/_lint_fast.sh"

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -4,35 +4,23 @@
 #
 # Tracked pre-push git hook for the UFFS workspace.
 #
-# Purpose: run the same clippy gate that CI runs
-# (`cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`)
-# before every `git push`, so locally-reproducible CI failures cannot
-# reach the remote.
+# Purpose: run the full local quality-gate bundle (clippy + fmt-check +
+# rustdoc + cargo deny + file-size + typos + reuse) in parallel before
+# every `git push`, so locally-reproducible CI failures cannot reach
+# the remote.
+#
+# The implementation lives in `scripts/hooks/_lint_pre_push.sh` so the
+# same logic runs via `just lint-pre-push` (manual) and through the
+# git hook (automated) — single source of truth.
 #
 # Install via: `just install-hooks` (sets core.hooksPath to scripts/hooks/).
 # Bypass once: `git push --no-verify`.
 # Uninstall:   `just uninstall-hooks`.
+#
+# Mirrors the CI lint gate in `.github/workflows/ci.yml`.  The Linux-only
+# drift gate (`just lint-ci-linux`) is deliberately NOT invoked here —
+# that class of regression is caught by CI on push to the remote.
 
 set -euo pipefail
 
-# `just lint-ci` is kept in exact lockstep with .github/workflows/ci.yml.
-# See crates/uffs-client/src/format.rs commit history for an example of
-# a Linux-only clippy regression this hook is intended to NOT let slip —
-# that particular class (platform-dependent type aliases) still requires
-# `just lint-ci-linux` to fully reproduce on macOS, but the vast majority
-# of clippy drift is caught by the local gate alone.
-printf '\033[0;34m🚨 pre-push: running local CI lint gate (just lint-ci)...\033[0m\n'
-
-if ! command -v just >/dev/null 2>&1; then
-    printf '\033[0;31m❌ pre-push: `just` not found in PATH — install it or bypass with --no-verify.\033[0m\n' >&2
-    exit 1
-fi
-
-# Respect the caller's TTY so clippy output colourises naturally.
-if ! just lint-ci; then
-    printf '\033[0;31m❌ pre-push: lint gate FAILED — push aborted.\033[0m\n' >&2
-    printf '\033[0;33m   Fix the warnings and retry, or bypass once with `git push --no-verify`.\033[0m\n' >&2
-    exit 1
-fi
-
-printf '\033[0;32m✅ pre-push: lint gate passed — proceeding with push.\033[0m\n'
+exec bash "$(dirname "$0")/_lint_pre_push.sh"


### PR DESCRIPTION
## Summary

Adds a four-layer quality-gate pipeline so every rule CI enforces fires as close to the keystroke as possible, without slowing the dev loop.

| Layer | Trigger | Recipe | Budget |
|-------|---------|--------|--------|
| IDE save | on save | `rust-analyzer` | instant |
| **pre-commit** | `git commit` | `just lint-fast` | sub-2 s |
| **pre-push** | `git push` | `just lint-pre-push` | ≤ 45 s warm |
| PR CI | PR to `main` | `.github/workflows/ci.yml` | minutes |
| Release | manual | `just ship` | minutes |

## Gate bundles

### Pre-commit — `scripts/hooks/pre-commit` → `_lint_fast.sh`

Parallel, staged-scoped, soft-skips missing optional tools:

- `bash scripts/ci/check_file_size_policy.sh` — always on
- `cargo fmt --check` — when `*.rs` staged
- `taplo fmt --check` — when `*.toml` staged, if installed
- `typos` — if installed
- `reuse lint --quiet` — if installed

### Pre-push — `scripts/hooks/pre-push` → `_lint_pre_push.sh`

Parallel, workspace-scoped, 7 mandatory + 2 optional gates:

- `cargo clippy -D warnings --all-targets --all-features --no-deps` (1:1 mirror of Tier-1 CI)
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps`
- `cargo deny check --hide-inclusion-graph`
- `cargo nextest run --workspace --all-targets --all-features --no-run` — links every test binary (catches `#[cfg(test)]` drift + linker regressions that clippy's check-only compile misses)
- `bash scripts/ci/check_file_size_policy.sh`
- `typos .` (optional)
- `reuse lint --quiet` (optional)

### Measured wall-clock

Local runs on this workspace, sccache-warm:

| Variant | Wall-clock |
|---------|-----------:|
| Old `lint-ci` (clippy only) | 5–15 s |
| New `lint-pre-push` — 6 gates | 19 s |
| New `lint-pre-push` — 7 gates (+ nextest `--no-run`) | **20 s** |
| Post-amend re-push (hot cache) | **4 s** |

7 gates worth of coverage for ~+5 s over the old single-clippy hook.

## Failure UX

- Each job's combined output captured to a tmpdir, only dumped on failure.
- Per-job `✅` / `❌` grid prints first, then every failing job's full output in order.
- Jobs do **not** fast-fail-kill peers — all failures surface in one pass so a dev fixes everything per retry.
- Missing-tool hint prints once with `just install-dev-tools`.

## Shared runners (no drift)

Both git hooks are thin `exec bash _lint_*.sh` wrappers. The same runners back the manual `just lint-fast` / `just lint-pre-push` recipes. Edit the gate set in the `_lint_*.sh` files — never in the hooks.

## New `just` recipes

```text
just typos [paths]           — workspace spell-check (typos-cli)
just reuse                   — SPDX / licence-header lint
just taplo-check [paths]     — TOML fmt-check
just taplo-fmt  [paths]      — TOML fmt apply
just install-dev-tools       — cargo-install typos-cli + taplo-cli; pipx hint for `reuse`
just lint-fast               — manual pre-commit bundle
just lint-pre-push           — manual pre-push bundle
```

`just install-hooks` now chmods both hooks + both runners and prints a summary of which hook gates what.

## End-to-end verification

- `just lint-fast` (clean worktree): ✅ 2–3 s total, hints about missing optional tools.
- `just lint-pre-push` (clean worktree): ✅ 20 s total, all 7 mandatory gates green + 1 optional (`reuse`); hints about missing `typos-cli`.
- This commit itself fired the new `pre-commit` hook during `git commit`.
- This branch's push fired the new `pre-push` hook during `git push`.
- `just --list` shows every new recipe.

## What does **not** change

- CI (`.github/workflows/ci.yml`) is untouched.
- `just lint-ci` / `just lint-ci-linux` remain the authoritative CI mirror recipes.
- `just ship` / `just phase1-test` / `just phase2-ship` are untouched.

## Contributor docs

`CONTRIBUTING.md` gains a **Four-layer quality gates** section covering the pyramid, first-time setup (`just install-hooks` + `just install-dev-tools`), manual invocations, and the `--no-verify` escape hatches for WIP commits on feature branches.

## Follow-ups out of scope for this PR

- Optional: promote `typos` and `reuse` from "optional" to "required" once `just install-dev-tools` is run in `just setup`.
- Optional: add a `commit-msg` hook that validates Conventional Commits prefix (`fix(scope): …`, `perf(scope): …`, etc.).
- Optional: mirror these gates in a `just pre-merge` recipe that reruns them against `origin/main...HEAD` (useful right before opening a PR).
