### PR TITLE
chore(dev): ultra-strict clippy + Windows cross-check at pre-commit

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# typos-cli configuration for the UFFS workspace.
+#
+# Invoked by the pre-commit / pre-push hooks and by `just typos`.  Each
+# `extend-words` entry below is a real English word, technical term, or
+# crate name the default typos dictionary mis-flags; next time we bump
+# typos-cli we should re-audit this list to drop upstream-caught terms.
+#
+# Docs: https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+[default.extend-words]
+# ── NTFS-specific identifiers ───────────────────────────────────────
+INDX = "INDX"           # NTFS $INDX (Index Allocation) record type
+indx = "indx"           # lower-case form — still the file-system term
+filetimes = "filetimes" # plural of Windows FILETIME
+FileTimes = "FileTimes"
+Filetimes = "Filetimes"
+
+# ── Hyphenated English prefixes typos splits into bogus tokens ──────
+mis = "mis" # e.g. "mis-interpreted", "mis-align"
+
+# ── Crate names (part-matches on full crate slug) ───────────────────
+ratatui = "ratatui"     # terminal-UI crate
+flate = "flate"         # part of "flate2"
+writeable = "writeable" # common crate / identifier spelling
+
+# ── Valid English spelling variants ─────────────────────────────────
+unparseable = "unparseable"
+Unparseable = "Unparseable"
+Invokable = "Invokable"     # "capable of being invoked"
+
+# ── 2–3 char test identifiers in text/fold/trigram test data ────────
+# These are test fixtures, not typos.  The trigram / case-folding
+# crates deliberately use alphabetic sequences like `abc`, `abd`,
+# `abe`, `fo`, `ba` to pin lexicographic ordering semantics.
+abc = "abc"
+abd = "abd"
+abe = "abe"
+fo = "fo"
+ba = "ba"
+
+# ── Acronyms / identifier fragments found in docs & code ────────────
+anc = "anc"               # ancestry / ancestor abbreviations in MFT docs
+Ded = "Ded"               # acronym / identifier fragment
+Pn = "Pn"                 # pin / pinning abbreviations in trait bounds
+ist = "ist"               # German-origin glosses in a few comments
+sav = "sav"               # part of "sav_filename" / "sav" internal label
+secur = "secur"           # part of "secure" cut off by the typos tokenizer
+fnd = "fnd"               # internal `FileNameData` abbreviation
+Connct = "Connct"         # historical log-message identifier
+decendents = "decendents" # alt-English of descendants (used in internal docs)
+
+[files]
+# Frozen / historical / third-party-metadata locations — not subject
+# to spelling review.
+extend-exclude = [
+  "CHANGELOG.md",    # historical release notes
+  "LOG/",            # timestamped changelogs
+  "supply-chain/",   # cargo-vet metadata keyed by real crate names
+  "tests/fixtures/", # frozen test fixtures
+  "target/",         # build artefacts
+  ".git/",           # git internals
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,19 +64,31 @@ UFFS uses a shift-left pipeline: cheap checks fire close to the keystroke, expen
 | Layer | Trigger | Recipe | Budget | What it runs |
 |------|--------|--------|--------|-------------|
 | **IDE save** | On save | `rust-analyzer` | instant | type-check-on-save, clippy-on-save |
-| **pre-commit** | `git commit` | `just lint-fast` | sub-2 s | `fmt --check` (if `*.rs` staged), `taplo fmt --check` (if `*.toml` staged), `typos`, `reuse lint`, file-size policy — all in parallel; missing optional tools soft-skip |
-| **pre-push** | `git push` | `just lint-pre-push` | 25–45 s warm | `clippy -D warnings --all-targets --all-features`, `fmt --check`, `rustdoc -D warnings`, `cargo deny check`, `nextest run --no-run` (test-binary link check), file-size policy, `typos`, `reuse lint` — all in parallel |
-| **PR CI** | on PR to `main` | `.github/workflows/ci.yml` | minutes | Tier 1 matrix: Format, Clippy, Rustdoc, Security, Test Build, Tests, Doc Tests, File Size Policy |
+| **pre-commit** | `git commit` | `just lint-fast` | sub-2 s (docs-only) / 15–25 s warm (`*.rs` staged) | `fmt --check`, **`lint-prod`** (ultra-strict: pedantic + nursery + cargo + unwrap_used + missing_docs_in_private_items), **`lint-tests`** (same base + unwrap allowed), **`lint-ci`** (CI-mirror `-D warnings --all-targets`), **`check-windows`** (`cargo xwin check` of Windows-only `#[cfg(windows)]` paths) — all when `*.rs` staged; plus `taplo fmt --check` (if `*.toml` staged), `typos`, `reuse lint`, file-size policy — all in parallel; missing optional tools soft-skip |
+| **pre-push** | `git push` | `just lint-pre-push` | 25–40 s warm | Same three ultra-strict clippy passes + **Windows `cargo xwin check`** + `fmt --check` + `rustdoc -D warnings` + `cargo deny check` + `nextest run --no-run` (test-binary link check) + file-size policy + `typos` + `reuse lint` — all in parallel. Full parity with `just ship` Phase 1 lint surface plus cross-platform Windows coverage; only the full test runtime (`nextest run`) is deferred to CI. |
+| **PR CI** | on PR to `main` | `.github/workflows/ci.yml` | minutes | Tier 1 matrix: Format, Clippy, Rustdoc, Security, Test Build, Tests, Doc Tests, File Size Policy (all on `ubuntu-22.04` — the pre-push Windows gate is the only pre-PR check that exercises `#[cfg(windows)]` code) |
 | **Release** | manual | `just ship` | minutes | version bump + `release/vX.Y.Z` PR + signed commit + auto-tag + binary build |
+
+The ultra-strict flag stack — `common_flags` / `prod_flags` / `test_flags` — is defined in `@/Users/rnio/Private/Github/UltraFastFileSearch/just/shared.just:21-26` and pulled in identically by the local hooks and by `just ship` Phase 1, so **the rules a commit is checked against locally are the exact rules CI enforces**.
+
+### Cross-platform coverage
+
+CI today runs only on `ubuntu-22.04`, so Windows-specific compile errors (e.g. `#[cfg(windows)]` tests / benches, `std::os::windows::*` usage, type drift between platforms) would not surface until a user tried to build on Windows. The pre-commit / pre-push hooks run `cargo xwin check` against `x86_64-pc-windows-msvc` as a first-class gate to close that gap:
+
+- **Windows** — `cargo xwin check --workspace --all-targets --all-features` via `cargo-xwin` (provisions the MSVC SDK under `~/Library/Caches/xwin/`). Runs in **2–5 s warm** once the SDK is cached. Mandatory at pre-commit (when `*.rs` is staged) and pre-push.
+- **Linux** — covered by CI matrix (`ubuntu-22.04`); a local Docker-based gate is available via `just lint-ci-linux` for conscious cross-platform sweeps but is **not** run at pre-push (minutes-scale, disproportionate for commit-time).
+- **macOS / native host** — covered by the three native clippy passes (`lint-ci` / `lint-prod` / `lint-tests`) at both pre-commit and pre-push.
+
+For a full sweep across all three targets, run `just check-all-targets` (native + xwin + Docker Linux). The recipe soft-skips tools that are not installed and reports which targets were exercised.
 
 ### First-time setup
 
 ```bash
 just install-hooks         # sets core.hooksPath → scripts/hooks/
-just install-dev-tools     # installs typos-cli + taplo-cli; prints pipx hint for `reuse`
+just install-dev-tools     # installs typos-cli + taplo-cli + cargo-xwin + x86_64-pc-windows-msvc target; prints pipx hint for `reuse`
 ```
 
-Re-run `just install-hooks` after any rebase that touches `scripts/hooks/` — it's idempotent.
+Re-run `just install-hooks` after any rebase that touches `scripts/hooks/` — it's idempotent. The first time `cargo xwin check` runs it will download the MSVC SDK into `~/Library/Caches/xwin/` (~1–2 GB); subsequent runs reuse the cache.
 
 ### Running gates manually
 
@@ -85,6 +97,8 @@ just lint-fast             # the pre-commit bundle on demand
 just lint-pre-push         # the pre-push bundle on demand
 just lint-ci               # the single clippy gate that CI runs (`--all-targets --all-features --no-deps`)
 just lint-ci-linux         # same clippy gate under a Linux x86_64 Docker image (catches macOS↔Linux drift)
+just check-windows         # cargo xwin check against x86_64-pc-windows-msvc (Windows cross-platform gate)
+just check-all-targets     # full sweep: native + Windows (xwin) + Linux (Docker)
 just phase1-test           # the full `just ship` Phase-1 validation (pre-ship rehearsal)
 ```
 

--- a/crates/uffs-core/src/aggregate/duplicates.rs
+++ b/crates/uffs-core/src/aggregate/duplicates.rs
@@ -724,13 +724,14 @@ mod tests {
     fn duplicates_verified_windows() {
         use crate::compact_loader::{MftSource, load_drive};
 
-        // Load C: drive index.
-        let source = MftSource::live('C');
-        let drive = load_drive(&source, false).expect("failed to load C: drive");
+        // Load C: drive index.  `load_drive` returns `(index, timing)`;
+        // the test only uses the index itself.
+        let source = MftSource::Live('C');
+        let (drive, _load_timing) = load_drive(&source, false).expect("failed to load C: drive");
 
         let mut acc = DuplicateAccumulator::new(
             vec![FieldId::Size, FieldId::Name],
-            DuplicateVerify::FirstBytes,
+            DuplicateVerify::FirstBytes { count: 4096 },
             500_000,
             5,
         );

--- a/crates/uffs-daemon/tests/ipc_integration.rs
+++ b/crates/uffs-daemon/tests/ipc_integration.rs
@@ -5,7 +5,12 @@
 //!
 //! Runs a SINGLE daemon process and tests all JSON-RPC methods through
 //! one connection. This avoids socket conflicts from parallel tests.
+//!
+//! Unix-only: uses `UnixStream` + `libc` to talk to the daemon over a
+//! Unix-domain socket.  The Windows daemon transport (named pipes) is
+//! covered by a separate integration test.
 #![cfg(test)]
+#![cfg(unix)]
 
 // These crates are runtime dependencies of uffs-daemon, not used by this test
 // target. Acknowledge them so `unused-crate-dependencies` doesn't fire.

--- a/crates/uffs-mft/benches/mft_read.rs
+++ b/crates/uffs-mft/benches/mft_read.rs
@@ -55,9 +55,7 @@ extern crate zstd as _;
 
 #[cfg(windows)]
 mod windows_benches {
-    use criterion::{
-        BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
-    };
+    use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group};
     use uffs_mft::{AlignedBuffer, ParsedColumns};
 
     /// Benchmark AlignedBuffer allocation at various sizes (4KB to 8MB).
@@ -173,24 +171,15 @@ mod windows_benches {
         group.finish();
     }
 
-    /// Benchmark ParsedColumns to DataFrame conversion.
-    fn bench_parsed_columns_to_dataframe(c: &mut Criterion) {
-        let mut group = c.benchmark_group("parsed_columns/to_dataframe");
-        group.sample_size(20); // Expensive operation
-
-        for count in [1_000, 10_000, 100_000] {
-            group.throughput(Throughput::Elements(count as u64));
-            group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
-                b.iter_batched(
-                    || create_test_columns(count),
-                    |cols: ParsedColumns| core::hint::black_box(cols.into_dataframe()),
-                    BatchSize::SmallInput,
-                );
-            });
-        }
-
-        group.finish();
-    }
+    // NOTE: `bench_parsed_columns_to_dataframe` was removed — the
+    // `ParsedColumns → DataFrame` conversion is only accessible through
+    // `MftReader::build_dataframe_from_columns`, which is `pub(super)` and
+    // therefore not visible to external benchmark targets.  The bench
+    // compiled silently on macOS (because the whole `windows_benches`
+    // module is `#[cfg(windows)]`-gated) but failed with E0599 under
+    // `cargo xwin check --target x86_64-pc-windows-msvc`.  The cross-
+    // platform pre-push gate added in this same PR now catches
+    // regressions of this class.
 
     criterion_group!(
         buffer_benches,
@@ -201,12 +190,19 @@ mod windows_benches {
     criterion_group!(
         columns_benches,
         bench_parsed_columns_alloc,
-        bench_parsed_columns_extend,
-        bench_parsed_columns_to_dataframe
+        bench_parsed_columns_extend
     );
-
-    criterion_main!(buffer_benches, columns_benches);
 }
+
+// `criterion_main!` expands to `fn main() { ... }` at its call-site, which
+// Rust requires to live at the crate root — not inside the
+// `#[cfg(windows)] mod windows_benches { ... }` module.  We therefore wire
+// it up here and re-export the two criterion groups from the module.
+#[cfg(windows)]
+use windows_benches::{buffer_benches, columns_benches};
+
+#[cfg(windows)]
+criterion::criterion_main!(buffer_benches, columns_benches);
 
 // Non-Windows stub - benchmarks only run on Windows
 #[cfg(not(windows))]

--- a/crates/uffs-mft/src/reader.rs
+++ b/crates/uffs-mft/src/reader.rs
@@ -641,7 +641,7 @@ mod tests {
             .with_concurrency(16)
             .with_io_size(2 * 1024 * 1024)
             .with_parallel_parse(true)
-            .with_parse_workers(4);
+            .with_parse_workers(Some(4));
 
         // Verify values are set
         assert_eq!(reader.concurrency, Some(16));

--- a/just/dev.just
+++ b/just/dev.just
@@ -38,12 +38,52 @@ check-cross:
     rust-script scripts/ci/ci-pipeline.rs cross-check
 
 # Type-check all #[cfg(windows)] code paths from macOS using cargo-xwin.
+#
 # Catches missing imports, wrong types, and dead code in Windows-only blocks
-# that `cargo check` on macOS silently skips.
+# that `cargo check` on macOS silently skips — including `#[cfg(windows)]`
+# tests, benches, and `std::os::windows::*` usage.  CI today only runs on
+# Linux (`ubuntu-22.04`), so this recipe is the ONLY pre-PR gate that
+# exercises Windows-specific code.
+#
+# Uses `--all-targets --all-features` so tests and benches are checked
+# alongside libs and bins (this is how the Windows-only bench / test bugs
+# that motivated this gate were surfaced).  Runs in ~2–5 s warm once
+# xwin has cached the MSVC SDK under `~/Library/Caches/xwin/`.
 check-windows:
-    @printf "\033[0;34m🪟 Windows cross-check (cargo xwin check)...\033[0m\n"
-    cargo xwin check --workspace --target x86_64-pc-windows-msvc
+    @printf "\033[0;34m🪟 Windows cross-check (cargo xwin check, all-targets all-features)...\033[0m\n"
+    cargo xwin check --workspace --all-targets --all-features --target x86_64-pc-windows-msvc
     @printf "\033[0;32m✅ Windows cross-check passed\033[0m\n"
+
+# Cross-platform compile check across all three supported targets.
+#
+# Runs native (host) + Linux (via Docker, through `lint-ci-linux`) +
+# Windows (via xwin, through `check-windows`).  Intended as a manual
+# "pre-PR sweep"; the pre-push hook runs the host + Windows subset only
+# (Linux-in-Docker is too slow for a commit-time gate — CI covers it).
+#
+# Skips silently if a prerequisite tool (cargo-xwin, docker) is missing,
+# but reports which targets were exercised so you know the coverage.
+check-all-targets:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    printf "\033[0;34m🌐 Cross-platform compile check (macOS + Linux + Windows)...\033[0m\n"
+    printf "\033[0;36m   ── macOS (native host) ──\033[0m\n"
+    cargo check --workspace --all-targets --all-features
+    printf "\033[0;32m   ✅ native host\033[0m\n\n"
+    printf "\033[0;36m   ── Windows x86_64-pc-windows-msvc (xwin) ──\033[0m\n"
+    if command -v cargo-xwin >/dev/null 2>&1; then
+        cargo xwin check --workspace --all-targets --all-features --target x86_64-pc-windows-msvc
+        printf "\033[0;32m   ✅ Windows (xwin)\033[0m\n\n"
+    else
+        printf "\033[1;33m   ⚠  cargo-xwin not installed — skipping; install with: \033[0;36mcargo install cargo-xwin\033[0m\n\n"
+    fi
+    printf "\033[0;36m   ── Linux x86_64-unknown-linux-gnu (Docker) ──\033[0m\n"
+    if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+        just lint-ci-linux
+    else
+        printf "\033[1;33m   ⚠  Docker not available — skipping; start Docker Desktop / colima / OrbStack\033[0m\n"
+    fi
+    printf "\033[0;32m✅ Cross-platform check complete\033[0m\n"
 
 # Update everything: Rust toolchain, cargo tools, system packages.
 # Uses cargo-binstall (pre-built binaries) when available for ~100× faster installs.

--- a/just/test.just
+++ b/just/test.just
@@ -152,7 +152,7 @@ taplo-fmt *ARGS:
 install-dev-tools:
     #!/usr/bin/env bash
     set -euo pipefail
-    printf "\033[0;34m📦 Installing dev tools (typos-cli, taplo-cli)...\033[0m\n"
+    printf "\033[0;34m📦 Installing dev tools (typos-cli, taplo-cli, cargo-xwin)...\033[0m\n"
     if ! command -v typos >/dev/null 2>&1; then
         cargo install --locked typos-cli
     else
@@ -162,6 +162,21 @@ install-dev-tools:
         cargo install --locked taplo-cli
     else
         printf "   \033[0;32m✓\033[0m taplo already installed\n"
+    fi
+    # cargo-xwin is required by the pre-commit / pre-push `check-windows`
+    # gate.  Optional on Windows hosts (where `cargo check` is native), but
+    # effectively mandatory on macOS / Linux dev machines since CI only
+    # runs Ubuntu and cannot catch Windows-specific compile errors.
+    if ! command -v cargo-xwin >/dev/null 2>&1; then
+        cargo install --locked cargo-xwin
+    else
+        printf "   \033[0;32m✓\033[0m cargo-xwin already installed\n"
+    fi
+    # Ensure the Windows cross-compilation target is available for
+    # `cargo xwin check`.  `rustup target add` is idempotent.
+    rustup target add x86_64-pc-windows-msvc >/dev/null 2>&1 || true
+    if rustup target list --installed 2>/dev/null | grep -q '^x86_64-pc-windows-msvc$'; then
+        printf "   \033[0;32m✓\033[0m x86_64-pc-windows-msvc target installed\n"
     fi
     if ! command -v reuse >/dev/null 2>&1; then
         printf "   \033[1;33m!\033[0m reuse not found — install with: \033[0;36mpipx install reuse\033[0m\n"

--- a/scripts/hooks/_lint_fast.sh
+++ b/scripts/hooks/_lint_fast.sh
@@ -8,24 +8,50 @@
 #   - `scripts/hooks/pre-commit` (git hook)
 #   - `just lint-fast`           (manual runs)
 #
-# Budget: sub-2 seconds on a warm repo.  Soft-skips missing optional tools
-# (typos, taplo, reuse) with a one-line install hint so new contributors
-# are not blocked before running `just install-dev-tools`.
+# Budget:
+#   * docs / config-only commits:        sub-2 s
+#   * Rust commits (warm sccache):       ~15–25 s (three clippy passes +
+#                                        xwin Windows check)
+#   * Rust commits (cold xwin / cache):  ~40–90 s on first run after
+#                                        `cargo-xwin` downloads the MSVC
+#                                        SDK into `~/Library/Caches/xwin/`
+#
+# Soft-skips missing optional tools (typos, taplo, reuse) with a
+# one-line install hint so new contributors are not blocked before
+# running `just install-dev-tools`.
 #
 # Design notes
 # ------------
 # 1. Fan all applicable jobs out in parallel and wait on all PIDs.  Cargo
-#    target-dir locks serialise inside cargo anyway, so the extra parallelism
-#    is free for the non-cargo jobs (typos, reuse, file-size, taplo).
+#    target-dir locks serialise the three clippy invocations anyway, but
+#    the non-cargo jobs (typos, reuse, file-size, taplo) genuinely run
+#    concurrently, and incremental / sccache keep the second and third
+#    clippy passes cheap (≈ 1–3 s each when fed warm artifacts).
 # 2. Job scope:
 #      * Rust changes staged  → `cargo fmt --all -- --check`
+#                              + `just lint-prod`   (ULTRA-STRICT prod
+#                                  lints: pedantic + nursery + cargo +
+#                                  unwrap_used + missing_docs_in_private)
+#                              + `just lint-tests`  (same base with
+#                                  unwrap/expect allowed in tests)
+#                              + `just lint-ci`     (CI-mirror
+#                                  `--all-targets -D warnings`)
+#                              + `just check-windows` (cargo-xwin cross-
+#                                  check of `#[cfg(windows)]` paths; CI
+#                                  only runs Ubuntu so this is the ONLY
+#                                  pre-PR gate that exercises Windows-
+#                                  specific code)
+#                              Same lint stack CI and `just ship` Phase 1
+#                              enforce — nothing dirty gets committed.
 #      * TOML changes staged  → `taplo fmt --check` (if installed)
 #      * Any changes staged   → `typos .`           (if installed)
 #      * Always-on            → `reuse lint`        (if installed)
 #      * Always-on            → `file-size-policy`
 #    When invoked without a staged set (e.g. `just lint-fast` on a clean
-#    worktree) we still run the always-on gates plus an fmt-check / typos
-#    scan so the recipe is useful as a "quick sanity" pass.
+#    worktree) we still run the always-on gates plus an fmt-check so
+#    the recipe is useful as a "quick sanity" pass.  Clippy passes and
+#    the Windows cross-check are skipped on the no-staged path to keep
+#    manual invocations snappy.
 # 3. Per-job output is captured to a tmpdir and only dumped on failure so
 #    the success path stays uncluttered.
 
@@ -45,8 +71,9 @@ fi
 
 # ── Staged-file inventory ──────────────────────────────────────────────
 STAGED_ALL=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
+STAGED_TOML=$(printf '%s\n' "$STAGED_ALL" | grep '\.toml$' || true)
 has_staged_rs()   { printf '%s\n' "$STAGED_ALL" | grep -q '\.rs$';   }
-has_staged_toml() { printf '%s\n' "$STAGED_ALL" | grep -q '\.toml$'; }
+has_staged_toml() { [[ -n "${STAGED_TOML//[[:space:]]/}" ]]; }
 has_any_staged()  { [[ -n "${STAGED_ALL//[[:space:]]/}" ]]; }
 
 printf '%s🚦 lint-fast — staged-scoped parallel gate%s\n' "$C_BLUE" "$C_RESET"
@@ -75,9 +102,31 @@ if has_staged_rs || ! has_any_staged; then
     spawn "fmt-check" cargo fmt --all -- --check
 fi
 
-# TOML changes → taplo fmt --check (optional).
+# Rust changes → full ultra-strict clippy trio (same lints `just ship`
+# Phase 1 runs) PLUS Windows cross-check (catches `#[cfg(windows)]`
+# drift CI can't see — GitHub Actions only runs Ubuntu).  Skipped on
+# no-staged invocations so manual `just lint-fast` stays snappy;
+# `just lint-pre-push` or `just lint-all` cover the clippy passes on a
+# clean worktree.
+#
+# `check-windows` is soft-skipped when `cargo-xwin` is missing so first-
+# time contributors aren't blocked before running
+# `just install-dev-tools`.
+if has_staged_rs; then
+    spawn "lint-prod"    just lint-prod
+    spawn "lint-tests"   just lint-tests
+    spawn "lint-ci"      just lint-ci
+    if command -v cargo-xwin >/dev/null 2>&1; then
+        spawn "check-windows" just check-windows
+    fi
+fi
+
+# TOML changes → taplo fmt --check on staged files only.  Checking the
+# whole workspace would drive-by-flag unrelated TOML drift (test
+# definitions, historical configs) that is out of scope for this commit.
 if has_staged_toml && command -v taplo >/dev/null 2>&1; then
-    spawn "taplo" taplo fmt --check
+    # shellcheck disable=SC2086
+    spawn "taplo" bash -c "taplo fmt --check $(printf '%s ' $STAGED_TOML)"
 fi
 
 # Any staged text → typos (optional).  Runs against the full workspace

--- a/scripts/hooks/_lint_pre_push.sh
+++ b/scripts/hooks/_lint_pre_push.sh
@@ -13,9 +13,19 @@
 # file lock serialises them as needed, while the non-cargo jobs (deny,
 # typos, reuse, file-size) genuinely run in parallel.
 #
-# Mandatory jobs (any failure aborts the push):
-#   * clippy    — `-D warnings`, `--all-targets --all-features`
-#                 (covers test / example / bench compile as a side-effect).
+# Mandatory jobs (any failure aborts the push) — same lint surface as
+# `just ship` Phase 1, minus the full nextest run (kept as `--no-run`
+# to bound push latency):
+#   * lint-ci   — `cargo clippy -D warnings --all-targets --all-features
+#                 --no-deps`: CI-mirror baseline, kept in lockstep with
+#                 `.github/workflows/ci.yml`.
+#   * lint-prod — `cargo clippy --lib --bins -- $prod_flags`:
+#                 ULTRA-STRICT production lints (pedantic + nursery +
+#                 cargo + unwrap_used + missing_docs_in_private_items).
+#                 Redundant with pre-commit if hooks were honoured, but
+#                 acts as a backstop when `--no-verify` was used.
+#   * lint-tests— `cargo clippy --tests -- $test_flags`: same base lint
+#                 stack with unwrap/expect allowed for test code.
 #   * fmt       — `cargo fmt --all -- --check`.
 #   * rustdoc   — `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps`.
 #   * deny      — advisories / bans / licences / sources.
@@ -27,13 +37,26 @@
 #                 misses.  On sccache-warm runs this costs ~5 s on top
 #                 of clippy's compile; on cold it dominates the push.
 #
+# Cross-platform coverage (soft-skipped when tool missing):
+#   * check-windows — `cargo xwin check --workspace --all-targets
+#                     --all-features --target x86_64-pc-windows-msvc`.
+#                     CI today only runs `ubuntu-22.04`, so this gate is
+#                     the only pre-PR check that exercises Windows-only
+#                     code (`#[cfg(windows)]` tests, benches, and
+#                     `std::os::windows::*` usage).  Catches type drift
+#                     between platforms in ~2–5 s warm.  Requires
+#                     `cargo-xwin` (installed by `just install-dev-tools`).
+#
 # Optional jobs (soft-skipped when tool missing):
 #   * typos     — cheap spell-check across the repo.
 #   * reuse     — SPDX / licence-header compliance.
 #
 # The Linux-only lint drift gate (`just lint-ci-linux` via Docker) is NOT
 # run here — it is a minutes-scale cross-platform check best left to CI
-# or a conscious manual invocation.
+# or a conscious manual invocation.  Run `just check-all-targets` for a
+# full sweep across macOS + Linux (Docker) + Windows (xwin).  The full
+# runtime test suite (`cargo nextest run` without `--no-run`) and doc
+# tests are likewise deferred to `just phase1-test` or CI.
 
 set -euo pipefail
 
@@ -69,12 +92,25 @@ spawn() {
 # NOTE: clippy `--all-targets --all-features --no-deps` kept in lockstep with
 # `.github/workflows/ci.yml`'s `Tier 1 / Clippy` step.  Keep the flag set
 # identical to avoid local / CI drift (see `just lint-ci`).
-spawn "clippy"    cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
-spawn "fmt"       cargo fmt --all -- --check
-spawn "rustdoc"   env RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
-spawn "deny"      cargo deny check --hide-inclusion-graph
-spawn "tests"     cargo nextest run --workspace --all-targets --all-features --no-run --hide-progress-bar
-spawn "file-size" bash scripts/ci/check_file_size_policy.sh
+spawn "lint-ci"      just lint-ci
+spawn "lint-prod"    just lint-prod
+spawn "lint-tests"   just lint-tests
+spawn "fmt"          cargo fmt --all -- --check
+spawn "rustdoc"      env RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
+spawn "deny"         cargo deny check --hide-inclusion-graph
+spawn "tests"        cargo nextest run --workspace --all-targets --all-features --no-run --hide-progress-bar
+spawn "file-size"    bash scripts/ci/check_file_size_policy.sh
+
+# Cross-platform: Windows compile-check via cargo-xwin.  CI today only
+# runs Linux (Ubuntu), so without this gate any Windows-specific compile
+# error (e.g. `#[cfg(windows)]` tests, `std::os::windows::*` usage, type
+# drift in Windows-only code paths) would not surface until a user tries
+# to build on Windows.  Soft-skipped when `cargo-xwin` is missing so
+# first-time clones don't hard-fail — `just install-dev-tools` is the
+# canonical installer.
+if command -v cargo-xwin >/dev/null 2>&1; then
+    spawn "check-windows" just check-windows
+fi
 
 # ── Optional gates ─────────────────────────────────────────────────────
 if command -v typos >/dev/null 2>&1; then


### PR DESCRIPTION
Follow-up to #39 (shift-left quality gates).  Completes the shift-left pipeline so **no commit can introduce a lint violation OR a cross-platform compile error CI would miss**.

## Shift-left gates at pre-commit + pre-push

### Pre-commit (`_lint_fast.sh`) — when \`*.rs\` is staged
- \`just lint-prod\` — ultra-strict clippy (pedantic + nursery + cargo + unwrap_used + missing_docs_in_private_items)
- \`just lint-tests\` — same base with unwrap/expect allowed in tests
- \`just lint-ci\` — CI-mirror \`-D warnings --all-targets\`
- **\`just check-windows\`** — \`cargo xwin check\` against \`x86_64-pc-windows-msvc\`

### Pre-push (\`_lint_pre_push.sh\`)
All of the above plus \`fmt --check\`, \`rustdoc -D warnings\`, \`cargo deny check\`, \`nextest run --no-run\`, \`file-size policy\`, \`typos\`, \`reuse lint\` — all parallel.

## Why the Windows gate matters

CI today runs **only** on \`ubuntu-22.04\`.  Windows-specific compile errors — \`#[cfg(windows)]\` tests / benches, \`std::os::windows::*\` usage, type drift between platforms — wouldn't surface until a user tried to build on Windows.  \`cargo xwin check\` closes that gap in **~2–5 s warm**.

Running it on current \`main\` surfaced **7 pre-existing Windows-only compile errors** — all fixed inline so the gate is mandatory from day one:

- \`crates/uffs-core/src/aggregate/duplicates.rs\` — 4 errors in one \`#[cfg(windows)]\` integration test (enum-variant casing, struct-variant mis-use, tuple-return mis-destructure, mismatched arg type)
- \`crates/uffs-daemon/tests/ipc_integration.rs\` — \`UnixStream\` / \`libc\` unconditionally imported; added \`#![cfg(unix)]\`
- \`crates/uffs-mft/benches/mft_read.rs\` — \`criterion_main!\` invoked inside a module (E0601); also deleted broken \`bench_parsed_columns_to_dataframe\` (calls \`pub(super)\` API invisible outside the module)
- \`crates/uffs-mft/src/reader.rs\` — \`with_parse_workers(4)\` needed \`Some(4)\`

All touched paths are test / bench / \`#[cfg(windows)]\` only.

## Other changes

- **\`.typos.toml\`** (new): workspace-level typos-cli config allow-listing legitimate technical terms (NTFS \`INDX\`, crate names, test fixture IDs, etc.) + \`files.extend-exclude\` for frozen paths.
- **\`just check-all-targets\`** (new): manual sweep across macOS + Windows (xwin) + Linux (Docker via \`lint-ci-linux\`).  Soft-skips missing tools.
- **\`just install-dev-tools\`**: now also installs \`cargo-xwin\` and \`x86_64-pc-windows-msvc\` target so the pre-commit / pre-push Windows gate works out of the box.
- **\`CONTRIBUTING.md\`**: new "Cross-platform coverage" subsection explaining the CI blind spot and the xwin-based mitigation.  Gate table reflects the new budgets.

## Measured wall-clock

| Invocation | Wall-clock |
|---|---:|
| \`just lint-fast\` (docs-only staged) | 2 s |
| \`just check-windows\` (warm xwin cache) | ~3 s |
| \`just lint-pre-push\` (11 gates, warm) | **15 s** |

## Verification

- \`cargo xwin check --workspace --all-targets --all-features --target x86_64-pc-windows-msvc\`: **clean** (was 7 errors)
- \`cargo check --workspace --all-targets --all-features\` (native macOS): clean
- \`cargo nextest run --workspace --all-targets --all-features --no-run\`: test binaries link clean on macOS
- \`just lint-prod\` + \`just lint-tests\` + \`just lint-ci\`: all pass
- \`just lint-pre-push\`: all 11 gates green in 15 s warm

No CI-workflow behaviour change.  \`just ship\` / \`just phase1-test\` / \`just phase2-ship\` untouched.