### PR TITLE
chore(dev + ci): pre-commit ultra-strict lints + CI supply-chain hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,17 @@ permissions:
   contents: read
   issues: write
 
+# Cancel superseded CI runs on a PR branch (new push supersedes the
+# previous), but do NOT cancel in-progress runs on `main` / `develop`
+# pushes — those feed into required checks and cancelling them can
+# deadlock branch protection on a fast-follow merge.  Same keying
+# scheme as the other workflows in this repo (auto-tag-release,
+# dependabot-review, cargo-vet-refresh) so GitHub's cross-workflow
+# concurrency display stays consistent.
+concurrency:
+  group: tier-1-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -99,6 +110,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Free up disk space
+        # `--all-targets --all-features` on a Polars-heavy workspace consumes
+        # significant disk on ubuntu-22.04's default ~14 GB free budget.
+        # Reclaim ~20 GB from preinstalled SDKs we do not use in CI so that
+        # future dep-tree growth does not push the job over the edge.  Same
+        # block as test-build / rustdoc / tests / doc-tests.
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          sudo rm -rf /usr/local/share/boost /usr/local/graalvm
+          df -h /
 
       - name: Install pinned nightly (from rust-toolchain.toml)
         run: rustup show
@@ -350,12 +372,19 @@ jobs:
               `📧 Notification sent to: githubrobbi@nios.net`,
             ].join('\n');
 
+            // Per-workflow label so Tier 1 / Tier 2 / Release failures
+            // triage to distinct issues.  Previously all three workflows
+            // deduped onto a single `ci-failure` label, which meant a
+            // release failure could end up buried as a comment on an
+            // old Tier 2 flake issue.
+            const label = 'ci-failure-tier-1';
+
             // Check for existing open issue to avoid duplicates
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'ci-failure',
+              labels: label,
               per_page: 1,
             });
 
@@ -374,7 +403,7 @@ jobs:
                 repo: context.repo.repo,
                 title: title,
                 body: body,
-                labels: ['ci-failure'],
+                labels: [label, 'ci-failure'],
                 assignees: ['githubrobbi'],
               });
               core.info('Created new failure issue');

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# CodeQL — static-analysis (SAST) for Rust
+#
+# What this catches that the other gates don't:
+#
+#   * cargo-deny   → known CVEs + license policy + source allow-list
+#   * cargo-vet    → trust chain for every resolved crate-version
+#   * cargo-geiger → structural unsafe / build.rs / proc-macro footprint
+#   * clippy       → lint-level correctness + idiom issues
+#   * CodeQL       → *semantic* bug patterns (path injection, SQL/regex
+#                    injection, cryptographic misuse, unsafe cryptographic
+#                    default picks, unvalidated URL redirections, …) that
+#                    fire on whole-program dataflow rather than local AST
+#                    shape.
+#
+# Rust support status:
+#
+#   CodeQL 2.22.1 (July 2025) brought Rust to **public preview**; CodeQL
+#   2.23.3 / 2.23.7 / 2.23.8 added additional queries.  Treat failures as
+#   informational on first rollout — the query pack is still maturing.
+#   Not wired into branch protection for this reason.
+#
+# Triggers:
+#
+#   * `schedule` — weekly baseline, independent of PR traffic.  Tuesday
+#     06:30 UTC is a deliberate offset from the Monday 06:00 Tier 2 cron
+#     and the Monday 08:00 cargo-vet-refresh cron so the three weekly
+#     jobs don't share a runner queue.
+#   * `push: main` — capture the baseline on every merge.
+#   * `pull_request: main` — catches regressions before merge.  If the
+#     query pack gets noisy on a PR and blocks a human, the workflow can
+#     be re-run or temporarily disabled via `workflow_dispatch`; it is
+#     deliberately NOT added to required checks.
+#
+# Cost:
+#
+#   ~15-25 min per run on ubuntu-22.04; builds the workspace once for
+#   CodeQL's extractor.  Re-uses the Swatinem rust-cache key namespace
+#   so subsequent runs warm in 5-8 min.
+
+name: "🔍 CodeQL (Rust SAST)"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/codeql.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/codeql.yml'
+  schedule:
+    # Weekly baseline — Tuesday 06:30 UTC (offset from Monday Tier 2 +
+    # Monday cargo-vet refresh so they don't share a runner queue).
+    - cron: '30 6 * * 2'
+  workflow_dispatch:
+
+permissions:
+  # Read source + write SARIF to the repo's code-scanning panel.
+  # `security-events: write` is the permission that lets
+  # `codeql-action/analyze` post findings to the Security tab.
+  contents: read
+  security-events: write
+  # Required by codeql-action for CI artifact publishing on old runners.
+  actions: read
+
+# Cancel superseded PR runs; let scheduled / main-push runs complete.
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [rust]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Free up disk space
+        # CodeQL's extractor materialises a large intermediate database on
+        # top of a full workspace build.  Reclaim the same ~20 GB that
+        # the other Tier 1 heavy jobs free, so we stay well clear of the
+        # ubuntu-22.04 14 GB default budget.
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          sudo rm -rf /usr/local/share/boost /usr/local/graalvm
+          df -h /
+
+      - name: Install pinned nightly (from rust-toolchain.toml)
+        run: rustup show
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Dedicated cache namespace so CodeQL's full-debuginfo build
+          # doesn't evict the release-profile caches used by the Tier 1
+          # jobs (different fingerprint anyway, but be explicit).
+          shared-key: codeql
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          languages: ${{ matrix.language }}
+          # `manual` build mode: we invoke cargo ourselves below so the
+          # extractor observes the real workspace graph, including all
+          # feature-gated code paths.
+          build-mode: manual
+          # security-extended adds higher-recall queries at the cost of
+          # more findings to triage; start with the default `security`
+          # pack and upgrade once we've seen a few weeks of baseline.
+          # queries: security-and-quality
+
+      - name: Build workspace for CodeQL extractor
+        # `--all-features --all-targets` so every gated module (live MFT,
+        # IOCP, USN journal, polars integration, etc.) is visible to the
+        # CodeQL dataflow analysis.
+        env:
+          # CodeQL benefits from full debuginfo.  The x86-64-v3 CPU
+          # baseline still applies (workflow-level default in ci.yml does
+          # NOT propagate here — this is a separate workflow).
+          RUSTFLAGS: "-C debuginfo=2 -C target-cpu=x86-64-v3"
+        run: cargo build --workspace --all-features --all-targets
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Dependabot auto-merge — narrowly-scoped reviewer-time reclaim
+#
+# Enables GitHub's native "auto-merge" on a Dependabot PR if — and ONLY
+# if — EVERY one of the following is true:
+#
+#   1. The PR author is `dependabot[bot]`.
+#   2. `dependabot/fetch-metadata` reports
+#        update-type = `version-update:semver-patch`
+#      (patch-level bumps only — no minor, no major).
+#   3. The change is NOT a security update that would need human
+#      review for its advisory notes (severity `high` / `critical`).
+#   4. The `Dependabot Review / Cargo.lock crate-count delta` annotation
+#      (emitted by dependabot-review.yml) did not flag unexpected
+#      transitive fan-out.  Enforced implicitly: auto-merge waits on all
+#      required status checks, so if `dependabot-review.yml` annotates a
+#      warning the maintainer sees it BEFORE the merge proceeds, and
+#      branch protection still requires their approval.
+#   5. Every required branch-protection check (`cargo vet check
+#      --locked`, `cargo-deny`, clippy, tests, doc-tests, file-size
+#      policy) passes.  GitHub's auto-merge engine gates this
+#      automatically.
+#
+# What this workflow DOES NOT do:
+#
+#   * It does NOT bypass review.  `main` branch protection still
+#     requires a human approval.  If the repo's "allow Dependabot to
+#     bypass required reviews" setting is off (default), a maintainer
+#     still has to click Approve.  What this saves is the "merge when
+#     green" clickwork — GitHub queues the merge and executes as soon
+#     as checks pass AND reviews are satisfied.
+#
+#   * It does NOT touch minor / major bumps.  Those continue the
+#     existing manual-review flow documented in
+#     `docs/architecture/security/supply-chain-posture.md`.
+#
+#   * It does NOT bypass `cargo vet check`.  If the bumped version is
+#     not covered by an imported audit or an exemption, CI goes red
+#     and auto-merge is blocked — exactly the same gate as a manual
+#     Dependabot review.
+#
+# Policy rationale:
+#
+#   This change narrows (but does not abolish) the previous policy of
+#   "every Dependabot PR is human-reviewed and human-merged."  Patch-
+#   level bumps covered by the existing audit trail are the lowest-
+#   risk, highest-volume category — they pile up without delivering
+#   any net security signal that the automated gates have not already
+#   checked.  Reclaiming the reviewer time for minor / major bumps is
+#   a net-positive shift; see the updated threat model in
+#   `docs/architecture/security/supply-chain-posture.md`.
+#
+# Failure mode (intentional no-op):
+#
+#   If ANY condition fails, the workflow finishes successfully without
+#   calling `gh pr merge --auto`.  The PR sits open for manual review
+#   exactly like today — zero regression in the default path.
+
+name: "🤖 Dependabot auto-merge (patch-level)"
+
+on:
+  pull_request:
+    # Only events we care about.  `labeled` is included so a
+    # maintainer can trigger a re-evaluation by re-labeling the PR
+    # after a failed auto-merge attempt.
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+
+# Read PR metadata + enable auto-merge.  No other writes.
+permissions:
+  contents: write
+  pull-requests: write
+
+# One evaluation per PR at a time.  `cancel-in-progress: true` because
+# a superseded Dependabot sync (new commit lands) means the previous
+# evaluation's metadata is stale.
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge if eligible
+    # Short-circuit on non-Dependabot PRs so human contributors pay
+    # zero CI minutes when this workflow fires.
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        # Extracts `update-type`, `dependency-names`,
+        # `package-ecosystem`, etc. from the Dependabot PR body.
+        # Pinned to a commit SHA like every other action in this repo.
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Evaluate eligibility
+        id: gate
+        shell: bash
+        env:
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+          ALERT_STATE: ${{ steps.meta.outputs.alert-state }}
+        run: |
+          set -euo pipefail
+
+          echo "Dependabot metadata:"
+          echo "  update-type        = $UPDATE_TYPE"
+          echo "  package-ecosystem  = $ECOSYSTEM"
+          echo "  dependency-names   = $DEP_NAMES"
+          echo "  alert-state        = $ALERT_STATE"
+
+          eligible=false
+          reason=""
+
+          if [[ "$UPDATE_TYPE" == "version-update:semver-patch" ]]; then
+            # Security-advisory updates get manual review regardless of
+            # semver level, so the reviewer sees the advisory notes.
+            if [[ -z "$ALERT_STATE" || "$ALERT_STATE" == "AUTO_DISMISSED" ]]; then
+              eligible=true
+              reason="patch-level bump, no active security advisory \u2192 auto-merge eligible"
+            else
+              reason="security-advisory bump (alert=$ALERT_STATE) \u2192 manual review"
+            fi
+          else
+            reason="update-type=$UPDATE_TYPE (not patch-level) \u2192 manual review"
+          fi
+
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason"     >> "$GITHUB_OUTPUT"
+
+          echo ""
+          echo "Decision: $eligible ($reason)"
+
+          # Surface the decision in the PR check summary so reviewers
+          # can see at a glance whether auto-merge is on.
+          {
+            echo "## 🤖 Dependabot auto-merge evaluation"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| update-type | \`$UPDATE_TYPE\` |"
+            echo "| package-ecosystem | \`$ECOSYSTEM\` |"
+            echo "| dependency-names | \`$DEP_NAMES\` |"
+            echo "| alert-state | \`${ALERT_STATE:-none}\` |"
+            echo "| eligible | **$eligible** |"
+            echo "| reason | $reason |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enable auto-merge via gh CLI
+        # Only call `gh pr merge --auto` when the gate is green.
+        # `--squash` matches the repo's preferred merge style; flip to
+        # --rebase or --merge if the repo convention changes.
+        if: steps.gate.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          echo "Enabling auto-merge on $PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+          echo "::notice::Auto-merge enabled \u2014 will merge when all required checks pass and reviews (if any) are satisfied."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,16 @@ on:
     tags:
       - 'v*'
 
+# Serialise release dispatches so two version bumps landing in quick
+# succession (or a tag-push colliding with an auto-tag-release dispatch)
+# queue cleanly.  `cancel-in-progress: false` because a half-finished
+# release must either complete or fail with an attestation — never be
+# killed mid-upload — so the SLSA provenance in the Attestations API
+# can never claim an artifact that was not actually published.
+concurrency:
+  group: release-${{ inputs.version || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   actions: read
@@ -429,12 +439,89 @@ jobs:
             done
           done
 
-          # Create combined checksums across every release asset
-          # (both the ZIP bundles and the raw binaries).
+          echo "📦 Staged release assets (pre-SBOM, pre-checksum):"
+          ls -la final-release/
+
+      # ─── CycloneDX SBOM ──────────────────────────────────────────────────
+      #
+      # Emits one `sbom-<crate>.cdx.json` per workspace crate into
+      # `final-release/` so every shipped binary has a machine-readable
+      # inventory of its resolved transitive dependencies.  cargo-cyclonedx
+      # reads `Cargo.lock` — which is committed — so the SBOMs are
+      # deterministic for (commit, features) and bit-identical across
+      # re-runs.
+      #
+      # The SBOMs are produced BEFORE `CHECKSUMS.txt` is written and
+      # BEFORE the SLSA attestation step so that:
+      #
+      #   1. `CHECKSUMS.txt` lists them, giving downloaders a single
+      #      sha256-verifiable manifest.
+      #   2. The SLSA attestation (`subject-path: final-release/*`) covers
+      #      the SBOM bytes too, so a downstream consumer can:
+      #
+      #        gh attestation verify sbom-uffs-cli.cdx.json \
+          #          --owner ${{ github.repository_owner }}
+      #
+      #      and prove the SBOM came from this exact workflow run.
+      - name: Install cargo-cyclonedx
+        uses: taiki-e/install-action@dfc84ffb7254b048a0a843316ff5a2714dcdc7bd # v2
+        with:
+          tool: cargo-cyclonedx
+
+      - name: Install pinned nightly (needed by cargo-cyclonedx to read workspace)
+        # cargo-cyclonedx shells out to `cargo metadata`, which requires
+        # the workspace's pinned toolchain to be resolvable (rust-toolchain.toml).
+        # `rustup show` installs & activates it in one step.
+        run: rustup show
+
+      - name: Generate CycloneDX SBOMs for every workspace crate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "📋 Generating CycloneDX 1.5 SBOMs for workspace..."
+          # --format json           : machine-readable
+          # --all-features          : match the release-build feature set
+          # --spec-version 1.5      : newest stable CycloneDX schema
+          # default --describe=crate: one SBOM per crate, Cargo targets as subcomponents
+          #
+          # Output goes adjacent to each `Cargo.toml` as `<crate>.cdx.json`.
+          cargo cyclonedx \
+            --format json \
+            --all-features \
+            --spec-version 1.5
+
+          # Collect the per-crate SBOMs into final-release/ with a uniform
+          # `sbom-<crate>.cdx.json` prefix so downloaders can tell at a
+          # glance which files are SBOMs.  `find` is used instead of a
+          # glob because crates live one level down under crates/<crate>/.
+          count=0
+          while IFS= read -r sbom; do
+            crate=$(basename "$(dirname "$sbom")")
+            dest="final-release/sbom-${crate}.cdx.json"
+            cp "$sbom" "$dest"
+            count=$((count + 1))
+          done < <(find crates -name '*.cdx.json' -type f)
+
+          if (( count == 0 )); then
+            echo "::error::cargo-cyclonedx produced no SBOMs — investigate the log above"
+            exit 1
+          fi
+
+          echo "✅ Emitted $count SBOM(s):"
+          ls -lh final-release/sbom-*.cdx.json
+
+      - name: Finalize CHECKSUMS.txt (covers binaries, ZIP bundles, and SBOMs)
+        shell: bash
+        run: |
           cd final-release
+          # Regenerate AFTER SBOMs are placed so the manifest is complete.
+          # The SLSA attestation runs next and covers every file in this
+          # directory, so there is no window where CHECKSUMS.txt is stale
+          # relative to what ships.
           sha256sum * > CHECKSUMS.txt
 
-          echo "📦 Final release assets:"
+          echo "📦 Final release assets (SBOMs + checksums included):"
           ls -la
 
       - name: Generate SLSA build-provenance attestation
@@ -520,6 +607,17 @@ jobs:
           ```
           A successful verification proves the bytes were produced by
           this exact workflow run on this exact commit.
+
+          ### 📋 SBOM (Software Bill of Materials)
+
+          Each workspace crate ships a CycloneDX 1.5 SBOM alongside the
+          binaries: `sbom-<crate>.cdx.json`.  The SBOMs are covered by
+          the same SLSA attestation as the binaries, so you can verify
+          the inventory with the same command above.  Inspect with any
+          CycloneDX-aware tool, e.g.:
+          ```bash
+          jq '.components[] | {name, version, purl}' sbom-uffs-cli.cdx.json
+          ```
 
           ## 📋 Installation
 
@@ -628,6 +726,9 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
+            // Per-workflow label so Release / Tier 1 / Tier 2 failures
+            // triage to distinct issues instead of piling onto one.
+            const label = 'ci-failure-release';
             const title = `🔴 Release Pipeline Failed — ${context.sha.substring(0, 7)}`;
             const body = [
               `## Release Pipeline Failed`,
@@ -649,7 +750,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'ci-failure',
+              labels: label,
               per_page: 1,
             });
 
@@ -667,7 +768,7 @@ jobs:
                 repo: context.repo.repo,
                 title: title,
                 body: body,
-                labels: ['ci-failure'],
+                labels: [label, 'ci-failure'],
                 assignees: ['githubrobbi'],
               });
               core.info('Created new failure issue');

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -16,6 +16,15 @@ permissions:
   contents: read
   issues: write
 
+# Tier 2 runs on a weekly cron; a manual `workflow_dispatch` landing
+# on top of a cron run should queue, not cancel — we want the full
+# Miri / coverage report to complete.  Keyed the same way as the
+# other workflows in this repo so GitHub's concurrency UI stays
+# consistent across the pipeline.
+concurrency:
+  group: tier-2-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -86,16 +95,51 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
-  # NOTE: A `Tier 2 / Windows Cross-Check` job lived here until 2026-04-21.
-  # It ran `cargo check --target x86_64-pc-windows-msvc` from `ubuntu-latest`,
-  # which has no MSVC linker / import libraries, so the check could never
-  # succeed without a full `xwin` SDK install (see
-  # `docs/xwin-msvc-rlib-size-root-cause-and-workarounds.md`).  Real Windows
-  # validation happens on `windows-latest` in `release.yml` and on the user's
-  # Windows hardware via `cross-tool-benchmark.rs`; cross-compiling the
-  # workspace from Linux added no signal and permanently red-X'd Tier 2.
-  # The job has been removed from both the job list and the summary
-  # `needs:` array below.
+  # ══════════════════════════════════════════════════════════════════════════
+  # Windows Compile Check — catches Windows-only build regressions between
+  # releases.  Runs NATIVELY on `windows-latest` (not Linux → MSVC cross),
+  # so it picks up any breakage that would otherwise first surface 10-15
+  # minutes into a `just ship` release build.  `cargo check` (not `build`)
+  # because we only care about type-checks / linking metadata; full builds
+  # happen in `release.yml`.
+  #
+  # History: an earlier `Tier 2 / Windows Cross-Check` cross-compiled from
+  # ubuntu-latest and permanently red-X'd Tier 2 because ubuntu has no MSVC
+  # linker / import libraries (see
+  # `docs/xwin-msvc-rlib-size-root-cause-and-workarounds.md`).  Running on
+  # `windows-latest` sidesteps that entirely.
+  # ══════════════════════════════════════════════════════════════════════════
+  windows-check:
+    name: Tier 2 / Windows Compile Check
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      # Mirror the release-time Windows rustflags so the check runs under
+      # the same compilation conditions as a real release build.  If a
+      # target-cpu bump starts breaking compilation, this job fails
+      # BEFORE `just ship` does.
+      RUSTFLAGS: "-C target-cpu=x86-64-v3"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install pinned nightly (from rust-toolchain.toml)
+        run: rustup show
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Dedicated cache key — the Linux Tier 2 jobs below have fragments
+          # that make the default key hash to something different on Windows
+          # anyway, but be explicit so a future refactor does not cross the
+          # streams.
+          shared-key: tier-2-windows-check
+
+      - name: cargo check --workspace --all-features
+        # --all-features to exercise every feature-gated path that only
+        # compiles on Windows (e.g. live MFT / USN / IOCP code paths).
+        # --tests so test-only Windows code is also type-checked.
+        run: cargo check --workspace --all-features --all-targets
 
   build-validation:
     name: Tier 2 / Build Validation
@@ -180,16 +224,18 @@ jobs:
   tier-2-summary:
     name: Tier 2 / Summary
     runs-on: ubuntu-latest
-    needs: [coverage, build-validation, udeps, miri]
+    needs: [file-size-policy, coverage, build-validation, udeps, miri, windows-check]
     if: always()
     timeout-minutes: 5
     steps:
       - name: Check pipeline success
         run: |
-          if [[ "${{ needs.coverage.result }}" == "success" && \
+          if [[ "${{ needs.file-size-policy.result }}" == "success" && \
+                "${{ needs.coverage.result }}" == "success" && \
                 "${{ needs.build-validation.result }}" == "success" && \
                 "${{ needs.udeps.result }}" == "success" && \
-                "${{ needs.miri.result }}" == "success" ]]; then
+                "${{ needs.miri.result }}" == "success" && \
+                "${{ needs.windows-check.result }}" == "success" ]]; then
             echo "✅ All Tier 2 nightly checks passed!"
           else
             echo "❌ Some Tier 2 nightly checks failed - review above"
@@ -203,10 +249,12 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| File size policy | ✅ |" >> $GITHUB_STEP_SUMMARY
           echo "| Coverage | ✅ |" >> $GITHUB_STEP_SUMMARY
           echo "| Build validation | ✅ |" >> $GITHUB_STEP_SUMMARY
           echo "| cargo-udeps | ✅ |" >> $GITHUB_STEP_SUMMARY
           echo "| Miri | ✅ |" >> $GITHUB_STEP_SUMMARY
+          echo "| Windows Compile Check | ✅ |" >> $GITHUB_STEP_SUMMARY
 
   # ═══════════════════════════════════════════════════════════════════════════
   # Failure Notification — opens a GitHub Issue on any job failure
@@ -215,7 +263,7 @@ jobs:
   notify-failure:
     name: 🔔 Notify on Failure
     runs-on: ubuntu-latest
-    needs: [coverage, build-validation, udeps, miri]
+    needs: [file-size-policy, coverage, build-validation, udeps, miri, windows-check]
     if: failure()
     permissions:
       issues: write
@@ -224,6 +272,9 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
+            // Per-workflow label so Tier 1 / Tier 2 / Release failures
+            // triage to distinct issues instead of piling onto one.
+            const label = 'ci-failure-tier-2';
             const title = `🔴 CI Failure: Tier 2 Nightly CI — ${context.sha.substring(0, 7)}`;
             const body = [
               `## CI Pipeline Failed`,
@@ -243,7 +294,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'ci-failure',
+              labels: label,
               per_page: 1,
             });
 
@@ -261,7 +312,7 @@ jobs:
                 repo: context.repo.repo,
                 title: title,
                 body: body,
-                labels: ['ci-failure'],
+                labels: [label, 'ci-failure'],
                 assignees: ['githubrobbi'],
               });
               core.info('Created new failure issue');

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# typos-cli configuration for the UFFS workspace.
+#
+# Invoked by the pre-commit / pre-push hooks and by `just typos`.  Each
+# `extend-words` entry below is a real English word, technical term, or
+# crate name the default typos dictionary mis-flags; next time we bump
+# typos-cli we should re-audit this list to drop upstream-caught terms.
+#
+# Docs: https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+[default.extend-words]
+# ── NTFS-specific identifiers ───────────────────────────────────────
+INDX = "INDX"           # NTFS $INDX (Index Allocation) record type
+indx = "indx"           # lower-case form — still the file-system term
+filetimes = "filetimes" # plural of Windows FILETIME
+FileTimes = "FileTimes"
+Filetimes = "Filetimes"
+
+# ── Hyphenated English prefixes typos splits into bogus tokens ──────
+mis = "mis" # e.g. "mis-interpreted", "mis-align"
+
+# ── Crate names (part-matches on full crate slug) ───────────────────
+ratatui = "ratatui"     # terminal-UI crate
+flate = "flate"         # part of "flate2"
+writeable = "writeable" # common crate / identifier spelling
+
+# ── Valid English spelling variants ─────────────────────────────────
+unparseable = "unparseable"
+Unparseable = "Unparseable"
+Invokable = "Invokable"     # "capable of being invoked"
+
+# ── 2–3 char test identifiers in text/fold/trigram test data ────────
+# These are test fixtures, not typos.  The trigram / case-folding
+# crates deliberately use alphabetic sequences like `abc`, `abd`,
+# `abe`, `fo`, `ba` to pin lexicographic ordering semantics.
+abc = "abc"
+abd = "abd"
+abe = "abe"
+fo = "fo"
+ba = "ba"
+
+# ── Acronyms / identifier fragments found in docs & code ────────────
+anc = "anc"               # ancestry / ancestor abbreviations in MFT docs
+Ded = "Ded"               # acronym / identifier fragment
+Pn = "Pn"                 # pin / pinning abbreviations in trait bounds
+ist = "ist"               # German-origin glosses in a few comments
+sav = "sav"               # part of "sav_filename" / "sav" internal label
+secur = "secur"           # part of "secure" cut off by the typos tokenizer
+fnd = "fnd"               # internal `FileNameData` abbreviation
+Connct = "Connct"         # historical log-message identifier
+decendents = "decendents" # alt-English of descendants (used in internal docs)
+
+[files]
+# Frozen / historical / third-party-metadata locations — not subject
+# to spelling review.
+extend-exclude = [
+  "CHANGELOG.md",    # historical release notes
+  "LOG/",            # timestamped changelogs
+  "supply-chain/",   # cargo-vet metadata keyed by real crate names
+  "tests/fixtures/", # frozen test fixtures
+  "target/",         # build artefacts
+  ".git/",           # git internals
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **CI / release supply-chain hardening batch** (2026-04-22 —
+  `.github/workflows/*.yml`, `SECURITY.md`,
+  `docs/architecture/security/supply-chain-posture.md`).  Closes
+  the gaps + nits from the 2026-04-22 supply-chain review:
+  - **Concurrency groups** on `ci.yml` and `release.yml`.  Tier 1
+    now cancels superseded PR runs (but queues on `main` pushes so
+    branch-protection required checks stay stable); `release.yml`
+    queues instead of cancelling, so a half-signed release asset
+    can never ship.
+  - **`optimized-ci.yml` → `tier-2.yml`** rename for clarity; the
+    filename now matches the workflow's advertised "Tier 2" identity.
+  - **Tier 2 / Windows Compile Check** runs
+    `cargo check --workspace --all-features --all-targets` natively
+    on `windows-latest` weekly.  Previously Windows-only build
+    regressions only surfaced 10-15 minutes into a `just ship`
+    release build; the earlier Linux-hosted MSVC cross-check was
+    removed because ubuntu has no MSVC linker.  Tier 2 summary +
+    `notify-failure` are now wired to this job AND to the
+    pre-existing `file-size-policy` job (which was dangling before
+    this change, so a file-size-policy Tier 2 failure used to be
+    silent).
+  - **CycloneDX 1.5 SBOMs on every release** via `cargo-cyclonedx`,
+    emitted as `sbom-<crate>.cdx.json` into `final-release/` BEFORE
+    `CHECKSUMS.txt` is regenerated and BEFORE the SLSA attestation
+    step, so the SBOMs are in the checksum manifest AND covered by
+    the Sigstore OIDC attestation.  Verify with the same
+    `gh attestation verify` flow that already exists for binaries.
+  - **CodeQL (Rust SAST)** workflow
+    (`.github/workflows/codeql.yml`) on every PR and weekly
+    Tuesday 06:30 UTC baseline.  Pinned to
+    `github/codeql-action` v3.35.2.  Rust is in CodeQL's public
+    preview since CodeQL 2.22.1 (July 2025) — findings are
+    informational until a clean baseline settles, so this is NOT
+    yet a required branch-protection gate.
+  - **Narrowly-scoped Dependabot auto-merge**
+    (`.github/workflows/dependabot-auto-merge.yml`) — only
+    `version-update:semver-patch` bumps with no active security
+    advisory queue for auto-merge, and only once every required
+    check is green (`cargo-deny`, `cargo vet check --locked`,
+    clippy, tests, doc-tests, file-size policy).  Branch
+    protection (signed commits, required reviews) is NOT
+    bypassed — this just saves the "merge when green" clickwork.
+    Minor / major / security-advisory bumps keep the existing
+    manual-review flow.  Updates
+    `docs/architecture/security/supply-chain-posture.md` +
+    `SECURITY.md` to reflect the narrowed policy.
+  - **Free-up-disk-space step on the clippy job** matching the
+    other heavy Tier 1 jobs, so future dep-tree fan-out does not
+    tip `--all-features` clippy past ubuntu-22.04's default disk
+    budget.
+  - **Per-workflow `notify-failure` labels**
+    (`ci-failure-tier-1`, `ci-failure-tier-2`,
+    `ci-failure-release`) so a release failure is never buried
+    as a comment on a week-old Tier 2 flake issue.  Keeps the
+    legacy `ci-failure` label as a secondary label for
+    backwards-compatible issue queries.
+  - **Updated threat-model + layered-defences tables** in
+    `docs/architecture/security/supply-chain-posture.md` with
+    rows for SBOM, SAST, Windows regression check, and the split
+    between manual-review (minor/major) vs gated auto-merge
+    (patch) on Dependabot PRs.
+
 ### Added
 - **Brand identity pass** (chore, 2026-04-21) — publishing-grade brand
   and trademark layer:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,19 +64,31 @@ UFFS uses a shift-left pipeline: cheap checks fire close to the keystroke, expen
 | Layer | Trigger | Recipe | Budget | What it runs |
 |------|--------|--------|--------|-------------|
 | **IDE save** | On save | `rust-analyzer` | instant | type-check-on-save, clippy-on-save |
-| **pre-commit** | `git commit` | `just lint-fast` | sub-2 s | `fmt --check` (if `*.rs` staged), `taplo fmt --check` (if `*.toml` staged), `typos`, `reuse lint`, file-size policy — all in parallel; missing optional tools soft-skip |
-| **pre-push** | `git push` | `just lint-pre-push` | 25–45 s warm | `clippy -D warnings --all-targets --all-features`, `fmt --check`, `rustdoc -D warnings`, `cargo deny check`, `nextest run --no-run` (test-binary link check), file-size policy, `typos`, `reuse lint` — all in parallel |
-| **PR CI** | on PR to `main` | `.github/workflows/ci.yml` | minutes | Tier 1 matrix: Format, Clippy, Rustdoc, Security, Test Build, Tests, Doc Tests, File Size Policy |
+| **pre-commit** | `git commit` | `just lint-fast` | sub-2 s (docs-only) / 15–25 s warm (`*.rs` staged) | `fmt --check`, **`lint-prod`** (ultra-strict: pedantic + nursery + cargo + unwrap_used + missing_docs_in_private_items), **`lint-tests`** (same base + unwrap allowed), **`lint-ci`** (CI-mirror `-D warnings --all-targets`), **`check-windows`** (`cargo xwin check` of Windows-only `#[cfg(windows)]` paths) — all when `*.rs` staged; plus `taplo fmt --check` (if `*.toml` staged), `typos`, `reuse lint`, file-size policy — all in parallel; missing optional tools soft-skip |
+| **pre-push** | `git push` | `just lint-pre-push` | 25–40 s warm | Same three ultra-strict clippy passes + **Windows `cargo xwin check`** + `fmt --check` + `rustdoc -D warnings` + `cargo deny check` + `nextest run --no-run` (test-binary link check) + file-size policy + `typos` + `reuse lint` — all in parallel. Full parity with `just ship` Phase 1 lint surface plus cross-platform Windows coverage; only the full test runtime (`nextest run`) is deferred to CI. |
+| **PR CI** | on PR to `main` | `.github/workflows/ci.yml` | minutes | Tier 1 matrix: Format, Clippy, Rustdoc, Security, Test Build, Tests, Doc Tests, File Size Policy (all on `ubuntu-22.04` — the pre-push Windows gate is the only pre-PR check that exercises `#[cfg(windows)]` code) |
 | **Release** | manual | `just ship` | minutes | version bump + `release/vX.Y.Z` PR + signed commit + auto-tag + binary build |
+
+The ultra-strict flag stack — `common_flags` / `prod_flags` / `test_flags` — is defined in `@/Users/rnio/Private/Github/UltraFastFileSearch/just/shared.just:21-26` and pulled in identically by the local hooks and by `just ship` Phase 1, so **the rules a commit is checked against locally are the exact rules CI enforces**.
+
+### Cross-platform coverage
+
+CI today runs only on `ubuntu-22.04`, so Windows-specific compile errors (e.g. `#[cfg(windows)]` tests / benches, `std::os::windows::*` usage, type drift between platforms) would not surface until a user tried to build on Windows. The pre-commit / pre-push hooks run `cargo xwin check` against `x86_64-pc-windows-msvc` as a first-class gate to close that gap:
+
+- **Windows** — `cargo xwin check --workspace --all-targets --all-features` via `cargo-xwin` (provisions the MSVC SDK under `~/Library/Caches/xwin/`). Runs in **2–5 s warm** once the SDK is cached. Mandatory at pre-commit (when `*.rs` is staged) and pre-push.
+- **Linux** — covered by CI matrix (`ubuntu-22.04`); a local Docker-based gate is available via `just lint-ci-linux` for conscious cross-platform sweeps but is **not** run at pre-push (minutes-scale, disproportionate for commit-time).
+- **macOS / native host** — covered by the three native clippy passes (`lint-ci` / `lint-prod` / `lint-tests`) at both pre-commit and pre-push.
+
+For a full sweep across all three targets, run `just check-all-targets` (native + xwin + Docker Linux). The recipe soft-skips tools that are not installed and reports which targets were exercised.
 
 ### First-time setup
 
 ```bash
 just install-hooks         # sets core.hooksPath → scripts/hooks/
-just install-dev-tools     # installs typos-cli + taplo-cli; prints pipx hint for `reuse`
+just install-dev-tools     # installs typos-cli + taplo-cli + cargo-xwin + x86_64-pc-windows-msvc target; prints pipx hint for `reuse`
 ```
 
-Re-run `just install-hooks` after any rebase that touches `scripts/hooks/` — it's idempotent.
+Re-run `just install-hooks` after any rebase that touches `scripts/hooks/` — it's idempotent. The first time `cargo xwin check` runs it will download the MSVC SDK into `~/Library/Caches/xwin/` (~1–2 GB); subsequent runs reuse the cache.
 
 ### Running gates manually
 
@@ -85,6 +97,8 @@ just lint-fast             # the pre-commit bundle on demand
 just lint-pre-push         # the pre-push bundle on demand
 just lint-ci               # the single clippy gate that CI runs (`--all-targets --all-features --no-deps`)
 just lint-ci-linux         # same clippy gate under a Linux x86_64 Docker image (catches macOS↔Linux drift)
+just check-windows         # cargo xwin check against x86_64-pc-windows-msvc (Windows cross-platform gate)
+just check-all-targets     # full sweep: native + Windows (xwin) + Linux (Docker)
 just phase1-test           # the full `just ship` Phase-1 validation (pre-ship rehearsal)
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -92,9 +92,28 @@ rationale, and operational playbook.
 - **Dep-tree growth annotation** — every Dependabot PR is
   automatically annotated if `Cargo.lock` grows by more than a small
   threshold, surfacing unexpected transitive fan-out for human review.
+- **Software Bill of Materials (SBOM)** — every release ships a
+  CycloneDX 1.5 JSON SBOM per workspace crate
+  (`sbom-<crate>.cdx.json`), covered by the same SLSA
+  build-provenance attestation as the binaries.  Inspect with any
+  CycloneDX-aware tool:
+  ```bash
+  jq '.components[] | {name, version, purl}' sbom-uffs-cli.cdx.json
+  ```
+- **Semantic SAST** — `.github/workflows/codeql.yml` runs CodeQL's
+  Rust query pack on every PR plus a weekly baseline.  Rust is in
+  CodeQL's public preview (since CodeQL 2.22.1, July 2025); findings
+  are informational until we have a few weeks of clean baselines.
 - **Automated dependency updates** — Dependabot monitors Cargo and GitHub
-  Actions dependencies; PRs are **NOT** auto-merged — every bump
-  requires human review.
+  Actions dependencies.  **Patch-level bumps** are eligible for
+  auto-merge via `.github/workflows/dependabot-auto-merge.yml` — but
+  only if ALL required checks are green (`cargo-deny`, `cargo vet
+  check --locked`, clippy, tests, doc-tests, file-size policy) and
+  there is no active security advisory.  **Minor and major bumps**
+  continue to require human review and manual merge.  Auto-merge
+  never bypasses `main`'s branch protection rules (signed commits,
+  required reviews, required checks) — it just queues the merge for
+  when those conditions are met.
 
 ### CI / release pipeline
 
@@ -103,12 +122,21 @@ rationale, and operational playbook.
 - **Least-privilege CI** — Workflows use `permissions: contents: read`
   by default; `write` scopes are explicit and scoped to the minimum
   job that needs them.
+- **Concurrency hygiene** — Every workflow declares a `concurrency:`
+  group.  Superseded PR runs cancel cleanly; release and scheduled
+  runs queue instead of being cancelled mid-flight (important so a
+  half-signed release asset never ships).
+- **Windows regression check** — Tier 2 runs
+  `cargo check --workspace --all-features --all-targets` on
+  `windows-latest` weekly so Windows-only breakage surfaces before
+  the release pipeline discovers it.
 - **Branch protection** — `main` requires signed commits + passing
   Tier 1 checks (Clippy, tests, doc tests, security, build, file-size
   policy) before merge.
 - **Tag protection** — the `tag-protection-v-prefix` ruleset blocks
   deletion / force-update of any `v*` tag (release integrity).
-- **SLSA build-provenance** — every release asset is signed via
+- **SLSA build-provenance** — every release asset (binaries, ZIP
+  bundles, CHECKSUMS.txt, and SBOM JSON files) is signed via
   Sigstore OIDC by `actions/attest-build-provenance`.  Verify:
   ```bash
   gh attestation verify <file> --owner skyllc-ai
@@ -118,3 +146,7 @@ rationale, and operational playbook.
   blocking rollback attacks.
 - **SHA256 checksums** — `CHECKSUMS.txt` accompanies every release;
   the checksums file is itself covered by the SLSA attestation.
+- **Per-workflow failure triage** — CI failures open issues with
+  distinct labels (`ci-failure-tier-1`, `ci-failure-tier-2`,
+  `ci-failure-release`) so a release failure is never buried as a
+  comment on an older Tier 2 flake issue.

--- a/crates/uffs-core/src/aggregate/duplicates.rs
+++ b/crates/uffs-core/src/aggregate/duplicates.rs
@@ -724,13 +724,14 @@ mod tests {
     fn duplicates_verified_windows() {
         use crate::compact_loader::{MftSource, load_drive};
 
-        // Load C: drive index.
-        let source = MftSource::live('C');
-        let drive = load_drive(&source, false).expect("failed to load C: drive");
+        // Load C: drive index.  `load_drive` returns `(index, timing)`;
+        // the test only uses the index itself.
+        let source = MftSource::Live('C');
+        let (drive, _load_timing) = load_drive(&source, false).expect("failed to load C: drive");
 
         let mut acc = DuplicateAccumulator::new(
             vec![FieldId::Size, FieldId::Name],
-            DuplicateVerify::FirstBytes,
+            DuplicateVerify::FirstBytes { count: 4096 },
             500_000,
             5,
         );

--- a/crates/uffs-daemon/tests/ipc_integration.rs
+++ b/crates/uffs-daemon/tests/ipc_integration.rs
@@ -5,7 +5,12 @@
 //!
 //! Runs a SINGLE daemon process and tests all JSON-RPC methods through
 //! one connection. This avoids socket conflicts from parallel tests.
+//!
+//! Unix-only: uses `UnixStream` + `libc` to talk to the daemon over a
+//! Unix-domain socket.  The Windows daemon transport (named pipes) is
+//! covered by a separate integration test.
 #![cfg(test)]
+#![cfg(unix)]
 
 // These crates are runtime dependencies of uffs-daemon, not used by this test
 // target. Acknowledge them so `unused-crate-dependencies` doesn't fire.

--- a/crates/uffs-mft/benches/mft_read.rs
+++ b/crates/uffs-mft/benches/mft_read.rs
@@ -55,9 +55,7 @@ extern crate zstd as _;
 
 #[cfg(windows)]
 mod windows_benches {
-    use criterion::{
-        BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
-    };
+    use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group};
     use uffs_mft::{AlignedBuffer, ParsedColumns};
 
     /// Benchmark AlignedBuffer allocation at various sizes (4KB to 8MB).
@@ -173,24 +171,15 @@ mod windows_benches {
         group.finish();
     }
 
-    /// Benchmark ParsedColumns to DataFrame conversion.
-    fn bench_parsed_columns_to_dataframe(c: &mut Criterion) {
-        let mut group = c.benchmark_group("parsed_columns/to_dataframe");
-        group.sample_size(20); // Expensive operation
-
-        for count in [1_000, 10_000, 100_000] {
-            group.throughput(Throughput::Elements(count as u64));
-            group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
-                b.iter_batched(
-                    || create_test_columns(count),
-                    |cols: ParsedColumns| core::hint::black_box(cols.into_dataframe()),
-                    BatchSize::SmallInput,
-                );
-            });
-        }
-
-        group.finish();
-    }
+    // NOTE: `bench_parsed_columns_to_dataframe` was removed — the
+    // `ParsedColumns → DataFrame` conversion is only accessible through
+    // `MftReader::build_dataframe_from_columns`, which is `pub(super)` and
+    // therefore not visible to external benchmark targets.  The bench
+    // compiled silently on macOS (because the whole `windows_benches`
+    // module is `#[cfg(windows)]`-gated) but failed with E0599 under
+    // `cargo xwin check --target x86_64-pc-windows-msvc`.  The cross-
+    // platform pre-push gate added in this same PR now catches
+    // regressions of this class.
 
     criterion_group!(
         buffer_benches,
@@ -201,12 +190,19 @@ mod windows_benches {
     criterion_group!(
         columns_benches,
         bench_parsed_columns_alloc,
-        bench_parsed_columns_extend,
-        bench_parsed_columns_to_dataframe
+        bench_parsed_columns_extend
     );
-
-    criterion_main!(buffer_benches, columns_benches);
 }
+
+// `criterion_main!` expands to `fn main() { ... }` at its call-site, which
+// Rust requires to live at the crate root — not inside the
+// `#[cfg(windows)] mod windows_benches { ... }` module.  We therefore wire
+// it up here and re-export the two criterion groups from the module.
+#[cfg(windows)]
+use windows_benches::{buffer_benches, columns_benches};
+
+#[cfg(windows)]
+criterion::criterion_main!(buffer_benches, columns_benches);
 
 // Non-Windows stub - benchmarks only run on Windows
 #[cfg(not(windows))]

--- a/crates/uffs-mft/src/reader.rs
+++ b/crates/uffs-mft/src/reader.rs
@@ -641,7 +641,7 @@ mod tests {
             .with_concurrency(16)
             .with_io_size(2 * 1024 * 1024)
             .with_parallel_parse(true)
-            .with_parse_workers(4);
+            .with_parse_workers(Some(4));
 
         // Verify values are set
         assert_eq!(reader.concurrency, Some(16));

--- a/docs/architecture/security/supply-chain-posture.md
+++ b/docs/architecture/security/supply-chain-posture.md
@@ -18,6 +18,31 @@ Status as of **2026-04-22** · Maintainer: `@githubrobbi` · Review cadence: mon
   [Lockfile pinning](#lockfile-pinning-cargolock) below.
 - 2026-04-22 — Documented known softprops old-commit 403 limitation
   in the release flow (PR #33c).  See [Known limitations](#known-limitations-in-the-release-flow) below.
+- 2026-04-22 — Pipeline hardening batch:
+  - Added concurrency groups to `ci.yml` and `release.yml` so
+    superseded PR runs are cancelled and release dispatches queue
+    cleanly.
+  - Renamed `optimized-ci.yml` → `tier-2.yml` for clarity.
+  - Added **Tier 2 / Windows Compile Check** on `windows-latest` so
+    Windows regressions surface weekly, not 10-15 minutes into a
+    `just ship` release run.
+  - Added **CycloneDX 1.5 SBOMs** to every release: one
+    `sbom-<crate>.cdx.json` per workspace crate, covered by the
+    same SLSA build-provenance attestation as the binaries.
+  - Added **CodeQL (Rust SAST)** workflow on PR + weekly
+    schedule.  Rust support is in public preview (CodeQL ≥ 2.22.1)
+    so the check is not a required gate yet; promoted after a
+    few weeks of clean baselines.
+  - Split `notify-failure` labels per workflow
+    (`ci-failure-tier-1`, `ci-failure-tier-2`,
+    `ci-failure-release`) so a release failure is never buried as a
+    comment on a week-old Tier 2 flake issue.
+  - **Narrow Dependabot auto-merge** (`dependabot-auto-merge.yml`)
+    — patch-level bumps with no active security advisory queue for
+    auto-merge once all required checks + branch-protection rules
+    are satisfied.  Minor, major, and security-advisory bumps keep
+    the existing manual-review path.  Net effect: reviewer time
+    reclaimed for the bumps that actually carry review signal.
 
 This document captures UFFS's current supply-chain defences, the threat
 model they address, and the concrete gaps that are deferred (with
@@ -34,15 +59,20 @@ control lands or a deferred item is promoted.
 | License policy | `cargo-deny` `[licenses]` | Permitted list (MIT, Apache-2.0, MPL-2.0, …) | Every PR | **Yes** — same job |
 | Source whitelist | `cargo-deny` `[sources]` | crates.io + pinned polars git | Every PR | **Yes** — same job |
 | Workflow permissions | `permissions:` in every workflow | Minimal (`contents: read` default, `write` only where proven needed) | Reviewed per PR | N/A |
+| Concurrency hygiene | `concurrency:` groups on every workflow | Cancel superseded PR runs; queue (never cancel) release / scheduled runs | Every workflow | N/A |
 | Tag integrity | `main-protection` + `tag-protection-v-prefix` rulesets | Required reviews + signed commits on main; `v*` tag deletion/update blocked | Always | GitHub enforces |
 | Build-provenance | `actions/attest-build-provenance` | Every release asset signed with Sigstore OIDC | Every `v*` release | **Yes** — release.yml |
+| SBOM | `cargo-cyclonedx` → CycloneDX 1.5 JSON | One SBOM per workspace crate, shipped alongside binaries; covered by SLSA attestation | Every `v*` release | **Yes** — release.yml |
 | Commit ancestry check | Custom step in `release.yml` | `workflow_dispatch` `commit_sha` must be ancestor of main | Every release dispatch | **Yes** — release.yml |
 | Dep-tree growth | `dependabot-review.yml` | Cargo.lock crate-count delta on Dependabot PRs | Every Dependabot PR | Annotation only |
 | Lockfile pinning | Committed `Cargo.lock` | Every resolved crate-version frozen across devs / CI / releases | Always | **Yes** — `cargo vet check --locked` would fail any drift |
 | Audit trail | `cargo-vet check --locked` | Every resolved crate-version must have import / own audit / exemption | Every PR | **Yes** — `ci.yml` Security job |
 | Import refresh | `cargo-vet-refresh.yml` | Weekly `cargo vet regenerate imports` → PR | Mondays 08:00 UTC | GitHub schedules |
 | Structural audit | `cargo-geiger` via `just geiger` | unsafe / build.rs / proc-macro footprint | On-demand (monthly) | No |
-| Human review | Dependabot PRs are NOT auto-merged | Every dependency bump | Every Dependabot PR | GitHub enforces |
+| Semantic SAST | `codeql.yml` (Rust, public preview) | Dataflow-based bug patterns (path / SQL / regex injection, crypto misuse, unvalidated redirects) | PR + Tuesdays 06:30 UTC | Informational (not a required gate yet) |
+| Windows regression check | Tier 2 `windows-check` job | `cargo check --workspace --all-features --all-targets` on `windows-latest` | Weekly (Mondays 06:00 UTC) | GitHub schedules |
+| Human review for minor/major bumps | Dependabot PRs for minor + major + security advisories are NOT auto-merged | Minor / major / security-advisory bumps | Every Dependabot PR | GitHub enforces |
+| Gated auto-merge for patch bumps | `dependabot-auto-merge.yml` | Only `version-update:semver-patch` bumps with NO active security advisory, gated on all required checks (cargo-deny, cargo-vet, clippy, tests, doc-tests, file-size policy) + branch-protection rules (signed commits, required reviews) | Every Dependabot PR | Gates enforced via required checks + branch protection |
 
 ## Threat model and coverage matrix
 
@@ -51,9 +81,12 @@ control lands or a deferred item is promoted.
 | Known CVE in a dep | High | `cargo-deny` RustSec DB on every PR | Low — CI gates |
 | Unknown (zero-day) CVE | High | None specific; detection delayed | Medium — industry-wide |
 | Typo-squatted dep added via PR | Medium | `deny.toml` `[sources]` allow-list + `unknown-git = warn` | Low |
-| Maintainer-account compromise → silent minor-version malicious bump | **High** | `cargo-vet check` requires upstream or local audit for the new version; Dependabot-manual-merge + `dependabot-review.yml` tree-growth annotation + human review of diffs | **Low-medium** — cargo-vet covers most crates via Mozilla/Google imports; residual is the first N days after a malicious version lands until upstream audits it (or we audit locally) |
+| Maintainer-account compromise → silent minor-version malicious bump | **High** | `cargo-vet check` requires upstream or local audit for the new version; human review mandatory for minor+ / security-advisory bumps; `dependabot-review.yml` tree-growth annotation + human review of diffs.  Patch-level auto-merge is gated on cargo-vet + cargo-deny + the dep-tree-growth annotation, so a malicious patch still hits the same audit-trail wall as a manual-merge path | **Low-medium** — cargo-vet covers most crates via Mozilla/Google imports; residual is the first N days after a malicious version lands until upstream audits it (or we audit locally) |
 | Malicious `build.rs` / proc-macro executing in CI | **High** | Dependabot PRs run with **read-only `GITHUB_TOKEN`** + no repo secrets (GitHub default); `permissions:` block denies writes elsewhere; `cargo-vet` imports from Mozilla/Google are the primary vetting signal for new build-script crates | **Medium** — blast radius bounded (runner has no sensitive tokens); new unaudited crate bumps are caught by `cargo vet check`, forcing a conscious decision |
 | Release binary swapped on GitHub Release page | Medium | SHA256 `CHECKSUMS.txt` + SLSA build-provenance attestation via `gh attestation verify` | Low — requires attacker to also swap attestation, which is stored in GitHub Attestations API (separate audit trail) |
+| SBOM swapped on GitHub Release page (misleading component inventory) | Medium | `sbom-*.cdx.json` files are covered by the same SLSA attestation as the binaries — `gh attestation verify` on the SBOM matches only if the bytes match this workflow run | Low — inherits the binary-swap residual |
+| Windows-only build regression lands on main and only surfaces at release time | Low | Tier 2 `windows-check` job runs weekly on `windows-latest`; `cargo check --workspace --all-features --all-targets` catches type / link errors before `just ship` does | Low — up to a week of lag between merge and detection (acceptable given human-review gating on every merge) |
+| Semantic bug class (path / SQL / regex injection, crypto misuse) slipping past clippy | Medium | `codeql.yml` Rust SAST on every PR + weekly baseline | Medium — Rust support is in public preview; false-negative rate unknown |
 | Rollback attack (release an older vulnerable commit) | Medium | `commit_sha` ancestor-of-main guard in `release.yml` | Low |
 | Rogue `v*` tag push by write-access user | Low | `tag-protection-v-prefix` ruleset blocks deletion + update | **Medium on creation** — GitHub API does not support `Integration` bypass for user-owned repos, so `creation` rule not enforced (bot couldn't push tags if it were).  Partial protection only. |
 | Compromised runner (GitHub Actions infra itself) | Low | None — SLSA L2 attestation trusts the runner | Industry-wide; accept |
@@ -321,9 +354,12 @@ on `main` at branch-open time.
 - `supply-chain/config.toml` — `cargo-vet` imports + exemptions
 - `supply-chain/audits.toml` — our local audit records (starts empty)
 - `supply-chain/imports.lock` — pinned upstream audit snapshots
-- `.github/workflows/ci.yml` §Security — `cargo-deny` + `cargo-vet check` enforcement
-- `.github/workflows/release.yml` — SLSA attestation + ancestor check
+- `.github/workflows/ci.yml` §Security — `cargo-deny` + `cargo-vet check` enforcement (Tier 1)
+- `.github/workflows/tier-2.yml` — weekly coverage / udeps / Miri / Windows compile check
+- `.github/workflows/release.yml` — SLSA attestation + ancestor check + CycloneDX SBOM
+- `.github/workflows/codeql.yml` — Rust SAST (public preview)
 - `.github/workflows/dependabot-review.yml` — dep-tree growth annotation
+- `.github/workflows/dependabot-auto-merge.yml` — patch-level auto-merge gate
 - `.github/workflows/cargo-vet-refresh.yml` — weekly imports refresh
 - `.github/workflows/auto-tag-release.yml` — tagging bridge
 - `just/analysis.just` — `just geiger` / `just geiger-summary` recipes
@@ -335,3 +371,6 @@ on `main` at branch-open time.
 - cargo-vet [user guide](https://mozilla.github.io/cargo-vet/)
 - Mozilla's [supply-chain audits](https://github.com/mozilla/supply-chain)
 - Google's [supply-chain audits](https://github.com/google/supply-chain)
+- CycloneDX [1.5 specification](https://cyclonedx.org/specification/overview/)
+- [cargo-cyclonedx](https://github.com/CycloneDX/cyclonedx-rust-cargo)
+- CodeQL [Rust public preview changelog](https://github.blog/changelog/2025-07-02-codeql-2-22-1-bring-rust-support-to-public-preview/)

--- a/just/dev.just
+++ b/just/dev.just
@@ -38,12 +38,52 @@ check-cross:
     rust-script scripts/ci/ci-pipeline.rs cross-check
 
 # Type-check all #[cfg(windows)] code paths from macOS using cargo-xwin.
+#
 # Catches missing imports, wrong types, and dead code in Windows-only blocks
-# that `cargo check` on macOS silently skips.
+# that `cargo check` on macOS silently skips — including `#[cfg(windows)]`
+# tests, benches, and `std::os::windows::*` usage.  CI today only runs on
+# Linux (`ubuntu-22.04`), so this recipe is the ONLY pre-PR gate that
+# exercises Windows-specific code.
+#
+# Uses `--all-targets --all-features` so tests and benches are checked
+# alongside libs and bins (this is how the Windows-only bench / test bugs
+# that motivated this gate were surfaced).  Runs in ~2–5 s warm once
+# xwin has cached the MSVC SDK under `~/Library/Caches/xwin/`.
 check-windows:
-    @printf "\033[0;34m🪟 Windows cross-check (cargo xwin check)...\033[0m\n"
-    cargo xwin check --workspace --target x86_64-pc-windows-msvc
+    @printf "\033[0;34m🪟 Windows cross-check (cargo xwin check, all-targets all-features)...\033[0m\n"
+    cargo xwin check --workspace --all-targets --all-features --target x86_64-pc-windows-msvc
     @printf "\033[0;32m✅ Windows cross-check passed\033[0m\n"
+
+# Cross-platform compile check across all three supported targets.
+#
+# Runs native (host) + Linux (via Docker, through `lint-ci-linux`) +
+# Windows (via xwin, through `check-windows`).  Intended as a manual
+# "pre-PR sweep"; the pre-push hook runs the host + Windows subset only
+# (Linux-in-Docker is too slow for a commit-time gate — CI covers it).
+#
+# Skips silently if a prerequisite tool (cargo-xwin, docker) is missing,
+# but reports which targets were exercised so you know the coverage.
+check-all-targets:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    printf "\033[0;34m🌐 Cross-platform compile check (macOS + Linux + Windows)...\033[0m\n"
+    printf "\033[0;36m   ── macOS (native host) ──\033[0m\n"
+    cargo check --workspace --all-targets --all-features
+    printf "\033[0;32m   ✅ native host\033[0m\n\n"
+    printf "\033[0;36m   ── Windows x86_64-pc-windows-msvc (xwin) ──\033[0m\n"
+    if command -v cargo-xwin >/dev/null 2>&1; then
+        cargo xwin check --workspace --all-targets --all-features --target x86_64-pc-windows-msvc
+        printf "\033[0;32m   ✅ Windows (xwin)\033[0m\n\n"
+    else
+        printf "\033[1;33m   ⚠  cargo-xwin not installed — skipping; install with: \033[0;36mcargo install cargo-xwin\033[0m\n\n"
+    fi
+    printf "\033[0;36m   ── Linux x86_64-unknown-linux-gnu (Docker) ──\033[0m\n"
+    if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+        just lint-ci-linux
+    else
+        printf "\033[1;33m   ⚠  Docker not available — skipping; start Docker Desktop / colima / OrbStack\033[0m\n"
+    fi
+    printf "\033[0;32m✅ Cross-platform check complete\033[0m\n"
 
 # Update everything: Rust toolchain, cargo tools, system packages.
 # Uses cargo-binstall (pre-built binaries) when available for ~100× faster installs.

--- a/just/test.just
+++ b/just/test.just
@@ -152,7 +152,7 @@ taplo-fmt *ARGS:
 install-dev-tools:
     #!/usr/bin/env bash
     set -euo pipefail
-    printf "\033[0;34m📦 Installing dev tools (typos-cli, taplo-cli)...\033[0m\n"
+    printf "\033[0;34m📦 Installing dev tools (typos-cli, taplo-cli, cargo-xwin)...\033[0m\n"
     if ! command -v typos >/dev/null 2>&1; then
         cargo install --locked typos-cli
     else
@@ -162,6 +162,21 @@ install-dev-tools:
         cargo install --locked taplo-cli
     else
         printf "   \033[0;32m✓\033[0m taplo already installed\n"
+    fi
+    # cargo-xwin is required by the pre-commit / pre-push `check-windows`
+    # gate.  Optional on Windows hosts (where `cargo check` is native), but
+    # effectively mandatory on macOS / Linux dev machines since CI only
+    # runs Ubuntu and cannot catch Windows-specific compile errors.
+    if ! command -v cargo-xwin >/dev/null 2>&1; then
+        cargo install --locked cargo-xwin
+    else
+        printf "   \033[0;32m✓\033[0m cargo-xwin already installed\n"
+    fi
+    # Ensure the Windows cross-compilation target is available for
+    # `cargo xwin check`.  `rustup target add` is idempotent.
+    rustup target add x86_64-pc-windows-msvc >/dev/null 2>&1 || true
+    if rustup target list --installed 2>/dev/null | grep -q '^x86_64-pc-windows-msvc$'; then
+        printf "   \033[0;32m✓\033[0m x86_64-pc-windows-msvc target installed\n"
     fi
     if ! command -v reuse >/dev/null 2>&1; then
         printf "   \033[1;33m!\033[0m reuse not found — install with: \033[0;36mpipx install reuse\033[0m\n"

--- a/scripts/hooks/_lint_fast.sh
+++ b/scripts/hooks/_lint_fast.sh
@@ -8,24 +8,50 @@
 #   - `scripts/hooks/pre-commit` (git hook)
 #   - `just lint-fast`           (manual runs)
 #
-# Budget: sub-2 seconds on a warm repo.  Soft-skips missing optional tools
-# (typos, taplo, reuse) with a one-line install hint so new contributors
-# are not blocked before running `just install-dev-tools`.
+# Budget:
+#   * docs / config-only commits:        sub-2 s
+#   * Rust commits (warm sccache):       ~15–25 s (three clippy passes +
+#                                        xwin Windows check)
+#   * Rust commits (cold xwin / cache):  ~40–90 s on first run after
+#                                        `cargo-xwin` downloads the MSVC
+#                                        SDK into `~/Library/Caches/xwin/`
+#
+# Soft-skips missing optional tools (typos, taplo, reuse) with a
+# one-line install hint so new contributors are not blocked before
+# running `just install-dev-tools`.
 #
 # Design notes
 # ------------
 # 1. Fan all applicable jobs out in parallel and wait on all PIDs.  Cargo
-#    target-dir locks serialise inside cargo anyway, so the extra parallelism
-#    is free for the non-cargo jobs (typos, reuse, file-size, taplo).
+#    target-dir locks serialise the three clippy invocations anyway, but
+#    the non-cargo jobs (typos, reuse, file-size, taplo) genuinely run
+#    concurrently, and incremental / sccache keep the second and third
+#    clippy passes cheap (≈ 1–3 s each when fed warm artifacts).
 # 2. Job scope:
 #      * Rust changes staged  → `cargo fmt --all -- --check`
+#                              + `just lint-prod`   (ULTRA-STRICT prod
+#                                  lints: pedantic + nursery + cargo +
+#                                  unwrap_used + missing_docs_in_private)
+#                              + `just lint-tests`  (same base with
+#                                  unwrap/expect allowed in tests)
+#                              + `just lint-ci`     (CI-mirror
+#                                  `--all-targets -D warnings`)
+#                              + `just check-windows` (cargo-xwin cross-
+#                                  check of `#[cfg(windows)]` paths; CI
+#                                  only runs Ubuntu so this is the ONLY
+#                                  pre-PR gate that exercises Windows-
+#                                  specific code)
+#                              Same lint stack CI and `just ship` Phase 1
+#                              enforce — nothing dirty gets committed.
 #      * TOML changes staged  → `taplo fmt --check` (if installed)
 #      * Any changes staged   → `typos .`           (if installed)
 #      * Always-on            → `reuse lint`        (if installed)
 #      * Always-on            → `file-size-policy`
 #    When invoked without a staged set (e.g. `just lint-fast` on a clean
-#    worktree) we still run the always-on gates plus an fmt-check / typos
-#    scan so the recipe is useful as a "quick sanity" pass.
+#    worktree) we still run the always-on gates plus an fmt-check so
+#    the recipe is useful as a "quick sanity" pass.  Clippy passes and
+#    the Windows cross-check are skipped on the no-staged path to keep
+#    manual invocations snappy.
 # 3. Per-job output is captured to a tmpdir and only dumped on failure so
 #    the success path stays uncluttered.
 
@@ -45,8 +71,9 @@ fi
 
 # ── Staged-file inventory ──────────────────────────────────────────────
 STAGED_ALL=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
+STAGED_TOML=$(printf '%s\n' "$STAGED_ALL" | grep '\.toml$' || true)
 has_staged_rs()   { printf '%s\n' "$STAGED_ALL" | grep -q '\.rs$';   }
-has_staged_toml() { printf '%s\n' "$STAGED_ALL" | grep -q '\.toml$'; }
+has_staged_toml() { [[ -n "${STAGED_TOML//[[:space:]]/}" ]]; }
 has_any_staged()  { [[ -n "${STAGED_ALL//[[:space:]]/}" ]]; }
 
 printf '%s🚦 lint-fast — staged-scoped parallel gate%s\n' "$C_BLUE" "$C_RESET"
@@ -75,9 +102,31 @@ if has_staged_rs || ! has_any_staged; then
     spawn "fmt-check" cargo fmt --all -- --check
 fi
 
-# TOML changes → taplo fmt --check (optional).
+# Rust changes → full ultra-strict clippy trio (same lints `just ship`
+# Phase 1 runs) PLUS Windows cross-check (catches `#[cfg(windows)]`
+# drift CI can't see — GitHub Actions only runs Ubuntu).  Skipped on
+# no-staged invocations so manual `just lint-fast` stays snappy;
+# `just lint-pre-push` or `just lint-all` cover the clippy passes on a
+# clean worktree.
+#
+# `check-windows` is soft-skipped when `cargo-xwin` is missing so first-
+# time contributors aren't blocked before running
+# `just install-dev-tools`.
+if has_staged_rs; then
+    spawn "lint-prod"    just lint-prod
+    spawn "lint-tests"   just lint-tests
+    spawn "lint-ci"      just lint-ci
+    if command -v cargo-xwin >/dev/null 2>&1; then
+        spawn "check-windows" just check-windows
+    fi
+fi
+
+# TOML changes → taplo fmt --check on staged files only.  Checking the
+# whole workspace would drive-by-flag unrelated TOML drift (test
+# definitions, historical configs) that is out of scope for this commit.
 if has_staged_toml && command -v taplo >/dev/null 2>&1; then
-    spawn "taplo" taplo fmt --check
+    # shellcheck disable=SC2086
+    spawn "taplo" bash -c "taplo fmt --check $(printf '%s ' $STAGED_TOML)"
 fi
 
 # Any staged text → typos (optional).  Runs against the full workspace

--- a/scripts/hooks/_lint_pre_push.sh
+++ b/scripts/hooks/_lint_pre_push.sh
@@ -13,9 +13,19 @@
 # file lock serialises them as needed, while the non-cargo jobs (deny,
 # typos, reuse, file-size) genuinely run in parallel.
 #
-# Mandatory jobs (any failure aborts the push):
-#   * clippy    — `-D warnings`, `--all-targets --all-features`
-#                 (covers test / example / bench compile as a side-effect).
+# Mandatory jobs (any failure aborts the push) — same lint surface as
+# `just ship` Phase 1, minus the full nextest run (kept as `--no-run`
+# to bound push latency):
+#   * lint-ci   — `cargo clippy -D warnings --all-targets --all-features
+#                 --no-deps`: CI-mirror baseline, kept in lockstep with
+#                 `.github/workflows/ci.yml`.
+#   * lint-prod — `cargo clippy --lib --bins -- $prod_flags`:
+#                 ULTRA-STRICT production lints (pedantic + nursery +
+#                 cargo + unwrap_used + missing_docs_in_private_items).
+#                 Redundant with pre-commit if hooks were honoured, but
+#                 acts as a backstop when `--no-verify` was used.
+#   * lint-tests— `cargo clippy --tests -- $test_flags`: same base lint
+#                 stack with unwrap/expect allowed for test code.
 #   * fmt       — `cargo fmt --all -- --check`.
 #   * rustdoc   — `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps`.
 #   * deny      — advisories / bans / licences / sources.
@@ -27,13 +37,26 @@
 #                 misses.  On sccache-warm runs this costs ~5 s on top
 #                 of clippy's compile; on cold it dominates the push.
 #
+# Cross-platform coverage (soft-skipped when tool missing):
+#   * check-windows — `cargo xwin check --workspace --all-targets
+#                     --all-features --target x86_64-pc-windows-msvc`.
+#                     CI today only runs `ubuntu-22.04`, so this gate is
+#                     the only pre-PR check that exercises Windows-only
+#                     code (`#[cfg(windows)]` tests, benches, and
+#                     `std::os::windows::*` usage).  Catches type drift
+#                     between platforms in ~2–5 s warm.  Requires
+#                     `cargo-xwin` (installed by `just install-dev-tools`).
+#
 # Optional jobs (soft-skipped when tool missing):
 #   * typos     — cheap spell-check across the repo.
 #   * reuse     — SPDX / licence-header compliance.
 #
 # The Linux-only lint drift gate (`just lint-ci-linux` via Docker) is NOT
 # run here — it is a minutes-scale cross-platform check best left to CI
-# or a conscious manual invocation.
+# or a conscious manual invocation.  Run `just check-all-targets` for a
+# full sweep across macOS + Linux (Docker) + Windows (xwin).  The full
+# runtime test suite (`cargo nextest run` without `--no-run`) and doc
+# tests are likewise deferred to `just phase1-test` or CI.
 
 set -euo pipefail
 
@@ -69,12 +92,25 @@ spawn() {
 # NOTE: clippy `--all-targets --all-features --no-deps` kept in lockstep with
 # `.github/workflows/ci.yml`'s `Tier 1 / Clippy` step.  Keep the flag set
 # identical to avoid local / CI drift (see `just lint-ci`).
-spawn "clippy"    cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
-spawn "fmt"       cargo fmt --all -- --check
-spawn "rustdoc"   env RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
-spawn "deny"      cargo deny check --hide-inclusion-graph
-spawn "tests"     cargo nextest run --workspace --all-targets --all-features --no-run --hide-progress-bar
-spawn "file-size" bash scripts/ci/check_file_size_policy.sh
+spawn "lint-ci"      just lint-ci
+spawn "lint-prod"    just lint-prod
+spawn "lint-tests"   just lint-tests
+spawn "fmt"          cargo fmt --all -- --check
+spawn "rustdoc"      env RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
+spawn "deny"         cargo deny check --hide-inclusion-graph
+spawn "tests"        cargo nextest run --workspace --all-targets --all-features --no-run --hide-progress-bar
+spawn "file-size"    bash scripts/ci/check_file_size_policy.sh
+
+# Cross-platform: Windows compile-check via cargo-xwin.  CI today only
+# runs Linux (Ubuntu), so without this gate any Windows-specific compile
+# error (e.g. `#[cfg(windows)]` tests, `std::os::windows::*` usage, type
+# drift in Windows-only code paths) would not surface until a user tries
+# to build on Windows.  Soft-skipped when `cargo-xwin` is missing so
+# first-time clones don't hard-fail — `just install-dev-tools` is the
+# canonical installer.
+if command -v cargo-xwin >/dev/null 2>&1; then
+    spawn "check-windows" just check-windows
+fi
 
 # ── Optional gates ─────────────────────────────────────────────────────
 if command -v typos >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Two developer-experience / quality-gate batches merged together:

### 1. Pre-commit ultra-strict lints + Windows cross-check (commit `e09f6bed5`)

Shifts the ultra-strict clippy + Windows cross-check gates LEFT so
they run on `git commit` / `git push`, not just in CI.

### 2. CI / supply-chain pipeline hardening (commit `50a201e47`)

Closes the gaps + nits from the 2026-04-22 supply-chain review:

- **Concurrency groups** on `ci.yml` + `release.yml` — Tier 1
  cancels superseded PR runs (but queues on `main` pushes so
  branch-protection required checks stay stable); `release.yml`
  queues instead of cancelling so a half-signed release asset
  can never ship.
- **`optimized-ci.yml` → `tier-2.yml`** rename for clarity.
- **Tier 2 Windows Compile Check** —
  `cargo check --workspace --all-features --all-targets` natively
  on `windows-latest` weekly.  Previously Windows-only build
  regressions only surfaced 10-15 minutes into a `just ship`
  release.
- **CycloneDX 1.5 SBOMs on every release** via `cargo-cyclonedx`;
  `sbom-<crate>.cdx.json` files emitted into `final-release/`
  BEFORE `CHECKSUMS.txt` regeneration AND BEFORE the SLSA
  attestation step, so the SBOMs are in the checksum manifest AND
  covered by the Sigstore OIDC attestation.  Verify with the same
  `gh attestation verify` flow that already exists for binaries.
- **CodeQL (Rust SAST)** on every PR + weekly Tuesday baseline.
  Pinned to `github/codeql-action` v3.35.2
  (`ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a`, verified against
  the GitHub API).  Rust support is in CodeQL's public preview
  (since CodeQL 2.22.1, July 2025) — findings are informational
  until a clean baseline settles.  **NOT yet a required
  branch-protection gate.**
- **Narrow Dependabot auto-merge** (`dependabot-auto-merge.yml`) —
  only `version-update:semver-patch` bumps with no active
  security advisory queue for auto-merge, and only once every
  required check is green.  Branch protection (signed commits,
  required reviews) is **not** bypassed — this just saves the
  "merge when green" clickwork.  Minor / major / security-advisory
  bumps keep the existing manual-review flow.
- **Free-up-disk-space step on the clippy job** matching other
  heavy Tier 1 jobs.
- **Per-workflow `notify-failure` labels**
  (`ci-failure-tier-1`, `ci-failure-tier-2`,
  `ci-failure-release`).  Legacy `ci-failure` label kept as a
  secondary label for backwards-compat queries.
- **Tier 2 `file-size-policy` was dangling** — it ran but wasn't
  wired into `tier-2-summary` or `notify-failure`, so a failure
  would silently pass.  Now included in both.

## Verification

- YAML parses cleanly for all 8 workflows (`yq 'keys'`).
- Every `uses:` reference is pinned to a 40-char commit SHA.
- CodeQL v3.35.2 SHA + dependabot/fetch-metadata v3.1.0 SHA
  verified against the GitHub API.
- Concurrency groups on every workflow with appropriate
  `cancel-in-progress` semantics.
- Pre-commit hook passed (`file-size`, `typos`, `reuse` — 2s).
- Pre-push hook passed all 11 gates (`lint-ci`, `lint-prod`,
  `lint-tests`, `fmt`, `rustdoc`, `deny`, `tests`, `file-size`,
  `check-windows`, `typos`, `reuse` — 24s).

## Docs

- `SECURITY.md` — updated Dependabot bullet to describe the
  narrow patch-level auto-merge carve-out.
- `docs/architecture/security/supply-chain-posture.md` — split
  Dependabot row in Layered Defences table, refined
  maintainer-account-compromise residual-risk note, added new
  rows for SBOM / SAST / Windows regression check, added changelog
  entry for this batch.
- `CHANGELOG.md` — new `### Security` block under `[Unreleased]`.

## Policy change disclosure

This PR narrows (but does not abolish) the previous policy of
"every Dependabot PR is human-reviewed and human-merged."  Only
patch-level bumps with no active security advisory are eligible
for auto-merge, and only once every required check is green.
Documented in full in `SECURITY.md` and
`docs/architecture/security/supply-chain-posture.md`.