### PR TITLE
fix(ci): CodeQL Rust extractor requires build-mode: none + bump to v4.35.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,9 +19,13 @@
 # Rust support status:
 #
 #   CodeQL 2.22.1 (July 2025) brought Rust to **public preview**; CodeQL
-#   2.23.3 / 2.23.7 / 2.23.8 added additional queries.  Treat failures as
-#   informational on first rollout — the query pack is still maturing.
-#   Not wired into branch protection for this reason.
+#   2.23.3 / 2.23.7 / 2.23.8 added additional queries; CodeQL 2.25.x
+#   (bundled with codeql-action v4.35.x) is the current baseline.  Rust
+#   support currently ONLY accepts `build-mode: none` — the CodeQL
+#   bundle includes its own Rust parser / analyzer and resolves crate
+#   metadata without invoking cargo.  Treat failures as informational
+#   on first rollout; the query pack is still maturing, and the check
+#   is NOT wired into branch protection for that reason.
 #
 # Triggers:
 #
@@ -31,15 +35,17 @@
 #     jobs don't share a runner queue.
 #   * `push: main` — capture the baseline on every merge.
 #   * `pull_request: main` — catches regressions before merge.  If the
-#     query pack gets noisy on a PR and blocks a human, the workflow can
-#     be re-run or temporarily disabled via `workflow_dispatch`; it is
-#     deliberately NOT added to required checks.
+#     query pack gets noisy on a PR and blocks a human, the workflow
+#     can be re-run or temporarily disabled via `workflow_dispatch`; it
+#     is deliberately NOT added to required checks.
 #
 # Cost:
 #
-#   ~15-25 min per run on ubuntu-22.04; builds the workspace once for
-#   CodeQL's extractor.  Re-uses the Swatinem rust-cache key namespace
-#   so subsequent runs warm in 5-8 min.
+#   ~5-10 min per run on ubuntu-22.04.  `build-mode: none` means no
+#   cargo build, no rust-cache, no debuginfo fetch — the Rust extractor
+#   parses source directly and emits a small DB (hundreds of MB rather
+#   than the multi-GB DB a compiled-extraction language like C++ would
+#   produce).
 
 name: "🔍 CodeQL (Rust SAST)"
 
@@ -88,7 +94,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -98,52 +104,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Free up disk space
-        # CodeQL's extractor materialises a large intermediate database on
-        # top of a full workspace build.  Reclaim the same ~20 GB that
-        # the other Tier 1 heavy jobs free, so we stay well clear of the
-        # ubuntu-22.04 14 GB default budget.
-        run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
-          sudo rm -rf /usr/local/share/boost /usr/local/graalvm
-          df -h /
-
-      - name: Install pinned nightly (from rust-toolchain.toml)
-        run: rustup show
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          # Dedicated cache namespace so CodeQL's full-debuginfo build
-          # doesn't evict the release-profile caches used by the Tier 1
-          # jobs (different fingerprint anyway, but be explicit).
-          shared-key: codeql
-
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
-          # `manual` build mode: we invoke cargo ourselves below so the
-          # extractor observes the real workspace graph, including all
-          # feature-gated code paths.
-          build-mode: manual
+          # Rust support (public preview) currently only accepts
+          # `build-mode: none`.  In this mode the extractor parses the
+          # source tree directly and resolves crate metadata via
+          # CodeQL's own bundled tooling — no cargo / rustc invocation,
+          # no build cache required.
+          build-mode: none
           # security-extended adds higher-recall queries at the cost of
           # more findings to triage; start with the default `security`
           # pack and upgrade once we've seen a few weeks of baseline.
           # queries: security-and-quality
 
-      - name: Build workspace for CodeQL extractor
-        # `--all-features --all-targets` so every gated module (live MFT,
-        # IOCP, USN journal, polars integration, etc.) is visible to the
-        # CodeQL dataflow analysis.
-        env:
-          # CodeQL benefits from full debuginfo.  The x86-64-v3 CPU
-          # baseline still applies (workflow-level default in ci.yml does
-          # NOT propagate here — this is a separate workflow).
-          RUSTFLAGS: "-C debuginfo=2 -C target-cpu=x86-64-v3"
-        run: cargo build --workspace --all-features --all-targets
-
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **CodeQL (Rust SAST)** workflow
     (`.github/workflows/codeql.yml`) on every PR and weekly
     Tuesday 06:30 UTC baseline.  Pinned to
-    `github/codeql-action` v3.35.2.  Rust is in CodeQL's public
+    `github/codeql-action` v4.35.2.  Uses `build-mode: none` (the
+    only mode Rust currently supports) so the extractor parses
+    source directly without a cargo build — run budget is ~5-10 min
+    rather than the 15-25 min a compiled-extraction pipeline would
+    need.  Rust is in CodeQL's public
     preview since CodeQL 2.22.1 (July 2025) — findings are
     informational until a clean baseline settles, so this is NOT
     yet a required branch-protection gate.


### PR DESCRIPTION
## Problem

PR #41 landed `codeql.yml` on `main` with `build-mode: manual`, which fails the first CodeQL run on any Rust repo:

```
A fatal error occurred: Rust does not support the manual build mode.
Please try using one of the following build modes instead: none.
```

The CodeQL Rust extractor (public preview since CodeQL 2.22.1, July 2025) currently **only** accepts `build-mode: none` — the CodeQL bundle ships its own Rust parser / analyzer and resolves crate metadata without invoking cargo.

## Fix

### 1. Switch to `build-mode: none`

Dropped the now-unnecessary scaffolding that `build-mode: manual` required:

- **Removed** `Free up disk space` step — no cargo build, no multi-GB DB
- **Removed** `rustup show` — extractor uses its own bundled Rust parser
- **Removed** `Swatinem/rust-cache` — nothing to cache without a cargo build
- **Removed** `cargo build --workspace --all-features --all-targets` step
- **Reduced** `timeout-minutes: 60` → `20` (build-less runs are 5-10 min typical)

### 2. Bump to CodeQL Action v4.35.2

Also upgrades `github/codeql-action` from `v3.35.2` (commit `ce64ddcb0…`) to `v4.35.2` (commit `95e58e9a2cdfd71adc6e0353d5c52f41a045d225`, verified against the GitHub API).

- v3 is slated for deprecation **December 2026** per [github.blog/changelog/2025-10-28](https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/).
- v4.35.2 ships CodeQL bundle 2.25.2 and addresses the deprecation warning that appeared in this PR's failed run.

## Verification

- YAML parses cleanly (`yq 'keys'` on the file).
- Action SHAs confirmed via `gh api repos/github/codeql-action/git/ref/tags/v4.35.2` → commit `95e58e9a2cdfd71adc6e0353d5c52f41a045d225`.
- Pre-commit hook passed (file-size, typos, reuse — 3s).
- Pre-push hook passed all 11 gates (lint-ci, lint-prod, lint-tests, fmt, rustdoc, deny, tests, file-size, check-windows, typos, reuse — 60s).
- Only 2 files change: `.github/workflows/codeql.yml` (−25 lines) and `CHANGELOG.md` (wording update on the v3 → v4 bullet).

## Docs

`CHANGELOG.md`'s `[Unreleased]` Security block now reads `v4.35.2 + build-mode: none` instead of `v3.35.2`.

## Why auto-merge slipped the broken config onto main

PR #41 enabled `--auto --squash`.  CodeQL is deliberately **not** a required branch-protection check (Rust is still in public preview), so when Tier 1 went green, GitHub merged the PR despite the CodeQL failure.  That's the intended policy — we don't want informational SAST findings to block merges yet.  The fix is a fast-follow PR, which is this one.