### PR TITLE
chore: release v0.5.71 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     packaging configuration lives under the tracked `packaging/`
     root (new top-level folder).  End-to-end verified on macOS:
     `dist/UFFS.app/Contents/MacOS/uffs --version` returns
-    `uffs 0.5.69` with the plist version fields templated correctly.
+    `uffs 0.5.71` with the plist version fields templated correctly.
   - **Linux `.desktop` + installer** (Phase 4 —
     `packaging/linux/uffs.desktop`,
     `packaging/linux/install.sh`, `just/packaging.just`).  New
@@ -546,7 +546,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   search"; `ensure_drives_loaded` as "tree metrics computation").
   Replaced with accurate per-function justifications.
 
-## [0.5.69] - 2026-04-19
+## [0.5.71] - 2026-04-19
 
 ### Added
 - **Phase 2 performance measurement series** (closed): 11 instrumented
@@ -704,8 +704,8 @@ thin clients over a unified `uffsd` process.
 ### Fixed
 - Various MFT parsing edge cases
 
-[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.5.69...HEAD
-[0.5.69]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.5.0...v0.5.69
+[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.5.71...HEAD
+[0.5.71]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.5.0...v0.5.71
 [0.5.0]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.2.208...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4310,7 +4310,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "anyhow",
  "clap",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "chrono",
  "itoa",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "anyhow",
  "axum",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4491,14 +4491,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4511,14 +4511,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.70"
+version = "0.5.71"
 
 [[package]]
 name = "unarray"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "percent-encoding"
@@ -3399,9 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
  "ring",
@@ -4310,7 +4310,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "anyhow",
  "clap",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "chrono",
  "itoa",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "anyhow",
  "axum",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4491,14 +4491,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4511,14 +4511,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.69"
+version = "0.5.70"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,31 +19,31 @@
 [workspace]
 resolver = "3"
 members = [
-    # ── Foundation ──
-    "crates/uffs-polars",   # 🚀 Polars facade (compilation isolation)
-    "crates/uffs-security", # 🔒 Crypto, key storage, secure FS ops
-    "crates/uffs-text",     # 📝 Unicode text processing, i18n foundation
-    "crates/uffs-time",     # ⏱️ NTFS FILETIME arithmetic (pure, zero deps)
-    "crates/uffs-mft",      # 📦 MFT reading → Polars DataFrame
-    "crates/uffs-format",   # 🧾 Shared CSV formatter (daemon + thin CLI)
-    "crates/uffs-core",     # 🎯 Query engine + compact search engine
-    # ── Daemon Architecture ──
-    "crates/uffs-daemon",   # 🛡️ Background service process
-    "crates/uffs-client",   # 📡 Thin client library
-    "crates/uffs-mcp",      # 🤖 MCP stdio adapter for AI agents
-    "crates/uffs-broker",   # 🔑 Windows elevated handle broker (optional)
-    # ── Surfaces ──
-    "crates/uffs-cli",      # 🖥️  Command-line interface
-    # NOTE: uffs-tui and uffs-gui have moved to the private uffs-products repo.
-    # ── Tools ──
-    "crates/uffs-diag",     # 🔬 Retained workspace-only diagnostic tools (not shipped in dist/)
+  # ── Foundation ──
+  "crates/uffs-polars",   # 🚀 Polars facade (compilation isolation)
+  "crates/uffs-security", # 🔒 Crypto, key storage, secure FS ops
+  "crates/uffs-text",     # 📝 Unicode text processing, i18n foundation
+  "crates/uffs-time",     # ⏱️ NTFS FILETIME arithmetic (pure, zero deps)
+  "crates/uffs-mft",      # 📦 MFT reading → Polars DataFrame
+  "crates/uffs-format",   # 🧾 Shared CSV formatter (daemon + thin CLI)
+  "crates/uffs-core",     # 🎯 Query engine + compact search engine
+  # ── Daemon Architecture ──
+  "crates/uffs-daemon", # 🛡️ Background service process
+  "crates/uffs-client", # 📡 Thin client library
+  "crates/uffs-mcp",    # 🤖 MCP stdio adapter for AI agents
+  "crates/uffs-broker", # 🔑 Windows elevated handle broker (optional)
+  # ── Surfaces ──
+  "crates/uffs-cli", # 🖥️  Command-line interface
+  # NOTE: uffs-tui and uffs-gui have moved to the private uffs-products repo.
+  # ── Tools ──
+  "crates/uffs-diag", # 🔬 Retained workspace-only diagnostic tools (not shipped in dist/)
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.69"
+version = "0.5.71"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires
@@ -63,14 +63,14 @@ categories = ["filesystem", "command-line-utilities"]
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.dependencies]
 # ───── Internal Crates ─────
-uffs-polars   = { path = "crates/uffs-polars" }
+uffs-polars = { path = "crates/uffs-polars" }
 uffs-security = { path = "crates/uffs-security" }
-uffs-text     = { path = "crates/uffs-text" }
-uffs-time     = { path = "crates/uffs-time" }
-uffs-mft      = { path = "crates/uffs-mft", features = ["zstd"] }
-uffs-format   = { path = "crates/uffs-format" }
-uffs-core     = { path = "crates/uffs-core" }
-uffs-client   = { path = "crates/uffs-client" }
+uffs-text = { path = "crates/uffs-text" }
+uffs-time = { path = "crates/uffs-time" }
+uffs-mft = { path = "crates/uffs-mft", features = ["zstd"] }
+uffs-format = { path = "crates/uffs-format" }
+uffs-core = { path = "crates/uffs-core" }
+uffs-client = { path = "crates/uffs-client" }
 # NOTE: no `uffs-diag` workspace dependency alias on purpose.
 # It is a top-level diagnostic/tool crate, not a shared runtime dependency.
 
@@ -84,36 +84,36 @@ uffs-client   = { path = "crates/uffs-client" }
 # uffs-mcp, and the `async` feature of uffs-client) re-enable `net`
 # explicitly in their own Cargo.toml via `features = ["net"]`.
 tokio = { version = "1.52.1", default-features = false, features = [
-    "io-util",
-    "macros",
-    "rt",
-    "rt-multi-thread",
-    "signal",
-    "sync",
-    "time",
-    "tracing",
+  "io-util",
+  "macros",
+  "rt",
+  "rt-multi-thread",
+  "signal",
+  "sync",
+  "time",
+  "tracing",
 ] }
 
 # ───── Windows APIs (Windows only) ─────
 windows = { version = "0.62.2", features = [
-    "Win32_Foundation",
-    "Win32_Security",
-    "Win32_Security_Authorization",
-    "Win32_Security_Cryptography",
-    "Win32_Storage",
-    "Win32_Storage_FileSystem",
-    "Win32_System_Com",
-    "Win32_System_Console",
-    "Win32_System_IO",
-    "Win32_System_Ioctl",
-    "Win32_System_Memory",
-    "Win32_System_Pipes",
-    "Win32_System_SystemInformation",
-    "Win32_System_Threading",
-    "Win32_System_Time",
-    "Win32_System_Wmi",
-    "Win32_UI_Shell",
-    "Win32_UI_WindowsAndMessaging",
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_Security_Authorization",
+  "Win32_Security_Cryptography",
+  "Win32_Storage",
+  "Win32_Storage_FileSystem",
+  "Win32_System_Com",
+  "Win32_System_Console",
+  "Win32_System_IO",
+  "Win32_System_Ioctl",
+  "Win32_System_Memory",
+  "Win32_System_Pipes",
+  "Win32_System_SystemInformation",
+  "Win32_System_Threading",
+  "Win32_System_Time",
+  "Win32_System_Wmi",
+  "Win32_UI_Shell",
+  "Win32_UI_WindowsAndMessaging",
 ] }
 
 # ───── Windows Build Tooling (build-dependency only) ─────
@@ -148,11 +148,20 @@ tower-service = "0.3.3"
 
 # ───── Logging & Tracing ─────
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.23", features = ["fmt", "time", "env-filter"] }
+tracing-subscriber = { version = "0.3.23", features = [
+  "fmt",
+  "time",
+  "env-filter",
+] }
 tracing-appender = "0.2.5"
 
 # ───── CLI ─────
-clap = { version = "4.6.1", features = ["derive", "env", "unicode", "wrap_help"] }
+clap = { version = "4.6.1", features = [
+  "derive",
+  "env",
+  "unicode",
+  "wrap_help",
+] }
 indicatif = "0.18.4"
 devicons = "0.6.12"
 
@@ -223,181 +232,181 @@ pedantic = { level = "deny", priority = -1 }
 
 # ───── DENY level lints (strictest possible - no exceptions) ─────
 wildcard_imports = "deny"
-unwrap_used = "deny"                    # Force proper error handling
-expect_used = "deny"                    # Force proper error handling
-panic = "deny"                          # No panics allowed
-todo = "deny"                           # No TODOs in production code
-unimplemented = "deny"                  # No unimplemented code
-unreachable = "deny"                    # No unreachable code
-missing_docs_in_private_items = "deny"  # Document everything
-undocumented_unsafe_blocks = "deny"     # Document all unsafe (if any)
-multiple_unsafe_ops_per_block = "deny"  # Limit unsafe operations
-unnecessary_safety_doc = "deny"         # Accurate safety docs
-unnecessary_safety_comment = "deny"     # Accurate safety comments
+unwrap_used = "deny"                   # Force proper error handling
+expect_used = "deny"                   # Force proper error handling
+panic = "deny"                         # No panics allowed
+todo = "deny"                          # No TODOs in production code
+unimplemented = "deny"                 # No unimplemented code
+unreachable = "deny"                   # No unreachable code
+missing_docs_in_private_items = "deny" # Document everything
+undocumented_unsafe_blocks = "deny"    # Document all unsafe (if any)
+multiple_unsafe_ops_per_block = "deny" # Limit unsafe operations
+unnecessary_safety_doc = "deny"        # Accurate safety docs
+unnecessary_safety_comment = "deny"    # Accurate safety comments
 
 # ───── DENY level lints — safety, correctness, discipline ─────
 # These MUST be clean in production code. clippy.toml relaxes test code
 # automatically via allow-*-in-tests settings.
-missing_errors_doc = "deny"             # Document error conditions
-missing_panics_doc = "deny"             # Document panic conditions
-missing_safety_doc = "deny"             # Document safety requirements
-cognitive_complexity = "deny"           # Keep functions simple (threshold=30 in clippy.toml)
-too_many_lines = "deny"                 # Keep functions short (threshold=150 in clippy.toml)
-type_complexity = "deny"                # Keep types simple (threshold=300 in clippy.toml)
-large_enum_variant = "deny"             # Optimize enum memory usage
-large_stack_arrays = "deny"             # Avoid large stack allocations
-large_types_passed_by_value = "deny"    # Pass large types by reference
-trivially_copy_pass_by_ref = "deny"     # Pass small types by value
-clone_on_ref_ptr = "deny"               # Avoid unnecessary clones
-redundant_clone = "deny"                # Remove redundant clones
-unnecessary_wraps = "deny"              # Remove unnecessary Result/Option wraps
-option_option = "deny"                  # Avoid Option<Option<T>>
-result_unit_err = "deny"                # Use better error types
-bool_to_int_with_if = "deny"            # Use more idiomatic conversions
-cast_lossless = "deny"                  # Use lossless casts
-cast_possible_truncation = "deny"       # Warn about truncating casts
-cast_possible_wrap = "deny"             # Warn about wrapping casts
-cast_precision_loss = "deny"            # Warn about precision loss
-cast_sign_loss = "deny"                 # Warn about sign loss
-float_cmp = "deny"                      # Proper float comparisons
-float_cmp_const = "deny"                # Proper float constant comparisons
-lossy_float_literal = "deny"            # Avoid lossy float literals
-imprecise_flops = "deny"                # Precise floating point operations
-suboptimal_flops = "deny"               # Optimal floating point operations
-fn_params_excessive_bools = "deny"      # Avoid too many boolean parameters
-struct_excessive_bools = "deny"         # Avoid too many boolean fields
-verbose_bit_mask = "deny"               # Use cleaner bit operations
-inefficient_to_string = "deny"          # Use efficient string conversions
-string_add = "deny"                     # Use format! instead of string addition
-string_add_assign = "deny"              # Use format! instead of +=
-string_slice = "deny"                   # Use proper string slicing
-str_to_string = "deny"                  # Use to_owned() instead of to_string()
-implicit_clone = "deny"                 # Make clones explicit
-cloned_instead_of_copied = "deny"       # Use copy when possible
-map_clone = "deny"                      # Use copied() instead of map(clone)
-filter_map_next = "deny"                # Use find_map instead
-flat_map_option = "deny"                # Use filter_map instead
-manual_filter_map = "deny"              # Use filter_map
-manual_find_map = "deny"                # Use find_map
-map_unwrap_or = "deny"                  # Use map_or instead
-unnecessary_unwrap = "deny"             # Remove unnecessary unwraps
-or_fun_call = "deny"                    # Use or_else for expensive operations
-single_match_else = "deny"              # Use if let instead of match
-match_bool = "deny"                     # Use if instead of match on bool
-indexing_slicing = "deny"               # Avoid indexing and slicing — use .get()
-match_same_arms = "deny"                # Combine identical match arms
-redundant_pattern_matching = "deny"     # Simplify pattern matching
-single_match = "deny"                   # Use if let instead of single match
-wildcard_enum_match_arm = "deny"        # Handle all enum variants explicitly
-enum_glob_use = "deny"                  # Avoid glob imports of enums
-use_self = "deny"                       # Use Self instead of type name
-needless_pass_by_value = "deny"         # Pass by reference when appropriate
-trivial_regex = "deny"                  # Use string methods instead of regex
-naive_bytecount = "deny"               # Use bytecount crate for counting
-manual_memcpy = "deny"                  # Use copy_from_slice
-manual_swap = "deny"                    # Use mem::swap
-ptr_as_ptr = "deny"                     # Use cast() instead of as
-ptr_cast_constness = "deny"             # Proper const pointer casts
-ref_as_ptr = "deny"                     # Proper reference to pointer conversion
-borrow_as_ptr = "deny"                  # Proper borrow to pointer conversion
-case_sensitive_file_extension_comparisons = "deny"  # Case-insensitive file extensions
-path_buf_push_overwrite = "deny"        # Avoid PathBuf overwrite bugs
-same_name_method = "deny"               # Avoid method name conflicts
-shadow_reuse = "deny"                   # Avoid variable shadowing
-shadow_same = "deny"                    # Avoid identical variable shadowing
-shadow_unrelated = "deny"               # Avoid unrelated variable shadowing
-similar_names = "deny"                  # Avoid confusingly similar names
-suspicious_else_formatting = "deny"     # Proper else formatting
-suspicious_unary_op_formatting = "deny" # Proper unary operator formatting
-tabs_in_doc_comments = "deny"           # Use spaces in doc comments
-trailing_empty_array = "deny"           # Remove trailing empty arrays
-unicode_not_nfc = "deny"                # Use NFC Unicode normalization
-unseparated_literal_suffix = "deny"     # Separate literal suffixes
-unused_self = "deny"                    # Remove unused self parameters
-used_underscore_binding = "deny"        # Don't use underscore bindings
-useless_let_if_seq = "deny"             # Simplify let-if sequences
-zero_sized_map_values = "deny"          # Avoid zero-sized map values
+missing_errors_doc = "deny"                        # Document error conditions
+missing_panics_doc = "deny"                        # Document panic conditions
+missing_safety_doc = "deny"                        # Document safety requirements
+cognitive_complexity = "deny"                      # Keep functions simple (threshold=30 in clippy.toml)
+too_many_lines = "deny"                            # Keep functions short (threshold=150 in clippy.toml)
+type_complexity = "deny"                           # Keep types simple (threshold=300 in clippy.toml)
+large_enum_variant = "deny"                        # Optimize enum memory usage
+large_stack_arrays = "deny"                        # Avoid large stack allocations
+large_types_passed_by_value = "deny"               # Pass large types by reference
+trivially_copy_pass_by_ref = "deny"                # Pass small types by value
+clone_on_ref_ptr = "deny"                          # Avoid unnecessary clones
+redundant_clone = "deny"                           # Remove redundant clones
+unnecessary_wraps = "deny"                         # Remove unnecessary Result/Option wraps
+option_option = "deny"                             # Avoid Option<Option<T>>
+result_unit_err = "deny"                           # Use better error types
+bool_to_int_with_if = "deny"                       # Use more idiomatic conversions
+cast_lossless = "deny"                             # Use lossless casts
+cast_possible_truncation = "deny"                  # Warn about truncating casts
+cast_possible_wrap = "deny"                        # Warn about wrapping casts
+cast_precision_loss = "deny"                       # Warn about precision loss
+cast_sign_loss = "deny"                            # Warn about sign loss
+float_cmp = "deny"                                 # Proper float comparisons
+float_cmp_const = "deny"                           # Proper float constant comparisons
+lossy_float_literal = "deny"                       # Avoid lossy float literals
+imprecise_flops = "deny"                           # Precise floating point operations
+suboptimal_flops = "deny"                          # Optimal floating point operations
+fn_params_excessive_bools = "deny"                 # Avoid too many boolean parameters
+struct_excessive_bools = "deny"                    # Avoid too many boolean fields
+verbose_bit_mask = "deny"                          # Use cleaner bit operations
+inefficient_to_string = "deny"                     # Use efficient string conversions
+string_add = "deny"                                # Use format! instead of string addition
+string_add_assign = "deny"                         # Use format! instead of +=
+string_slice = "deny"                              # Use proper string slicing
+str_to_string = "deny"                             # Use to_owned() instead of to_string()
+implicit_clone = "deny"                            # Make clones explicit
+cloned_instead_of_copied = "deny"                  # Use copy when possible
+map_clone = "deny"                                 # Use copied() instead of map(clone)
+filter_map_next = "deny"                           # Use find_map instead
+flat_map_option = "deny"                           # Use filter_map instead
+manual_filter_map = "deny"                         # Use filter_map
+manual_find_map = "deny"                           # Use find_map
+map_unwrap_or = "deny"                             # Use map_or instead
+unnecessary_unwrap = "deny"                        # Remove unnecessary unwraps
+or_fun_call = "deny"                               # Use or_else for expensive operations
+single_match_else = "deny"                         # Use if let instead of match
+match_bool = "deny"                                # Use if instead of match on bool
+indexing_slicing = "deny"                          # Avoid indexing and slicing — use .get()
+match_same_arms = "deny"                           # Combine identical match arms
+redundant_pattern_matching = "deny"                # Simplify pattern matching
+single_match = "deny"                              # Use if let instead of single match
+wildcard_enum_match_arm = "deny"                   # Handle all enum variants explicitly
+enum_glob_use = "deny"                             # Avoid glob imports of enums
+use_self = "deny"                                  # Use Self instead of type name
+needless_pass_by_value = "deny"                    # Pass by reference when appropriate
+trivial_regex = "deny"                             # Use string methods instead of regex
+naive_bytecount = "deny"                           # Use bytecount crate for counting
+manual_memcpy = "deny"                             # Use copy_from_slice
+manual_swap = "deny"                               # Use mem::swap
+ptr_as_ptr = "deny"                                # Use cast() instead of as
+ptr_cast_constness = "deny"                        # Proper const pointer casts
+ref_as_ptr = "deny"                                # Proper reference to pointer conversion
+borrow_as_ptr = "deny"                             # Proper borrow to pointer conversion
+case_sensitive_file_extension_comparisons = "deny" # Case-insensitive file extensions
+path_buf_push_overwrite = "deny"                   # Avoid PathBuf overwrite bugs
+same_name_method = "deny"                          # Avoid method name conflicts
+shadow_reuse = "deny"                              # Avoid variable shadowing
+shadow_same = "deny"                               # Avoid identical variable shadowing
+shadow_unrelated = "deny"                          # Avoid unrelated variable shadowing
+similar_names = "deny"                             # Avoid confusingly similar names
+suspicious_else_formatting = "deny"                # Proper else formatting
+suspicious_unary_op_formatting = "deny"            # Proper unary operator formatting
+tabs_in_doc_comments = "deny"                      # Use spaces in doc comments
+trailing_empty_array = "deny"                      # Remove trailing empty arrays
+unicode_not_nfc = "deny"                           # Use NFC Unicode normalization
+unseparated_literal_suffix = "deny"                # Separate literal suffixes
+unused_self = "deny"                               # Remove unused self parameters
+used_underscore_binding = "deny"                   # Don't use underscore bindings
+useless_let_if_seq = "deny"                        # Simplify let-if sequences
+zero_sized_map_values = "deny"                     # Avoid zero-sized map values
 
 # ───── Restriction lints (hand-picked — we do NOT enable the whole group) ─────
 # Best practice from rolldown, cargo, config-rs: cherry-pick high-value
 # restriction lints individually.
-allow_attributes = "deny"               # Force #[expect] over #[allow] — expect warns when suppression becomes stale
+allow_attributes = "deny"                # Force #[expect] over #[allow] — expect warns when suppression becomes stale
 allow_attributes_without_reason = "deny" # Force reason strings on all #[expect]/#[allow] attributes
-as_pointer_underscore = "deny"          # Dangerous pointer casts with inferred type
-as_underscore = "deny"                  # Catch `as _` with inferred type — lossy/dangerous casts
-cfg_not_test = "deny"                   # Catch cfg(not(test)) misuse
-dbg_macro = "deny"                      # No dbg! in production (clippy.toml allows in tests)
-deref_by_slicing = "deny"              # Use &* instead of &v[..]
-empty_line_after_doc_comments = "deny" # Clean doc comment style
-empty_line_after_outer_attr = "deny"   # Clean attribute style
-four_forward_slashes = "deny"          # Catch //// (typo for ///)
-iter_filter_is_ok = "deny"             # Use flatten() instead of filter + is_ok
-iter_filter_is_some = "deny"           # Use flatten() instead of filter + is_some
-manual_is_power_of_two = "deny"        # Use is_power_of_two()
-pathbuf_init_then_push = "deny"        # Use PathBuf::from directly
-pub_underscore_fields = "deny"         # Don't expose _prefixed fields
-renamed_function_params = "deny"       # Trait impls must match param names
-set_contains_or_insert = "deny"        # Use entry API for sets
-unnecessary_map_or = "deny"            # Simplify map_or calls
-unnecessary_result_map_or_else = "deny" # Simplify Result::map_or_else
+as_pointer_underscore = "deny"           # Dangerous pointer casts with inferred type
+as_underscore = "deny"                   # Catch `as _` with inferred type — lossy/dangerous casts
+cfg_not_test = "deny"                    # Catch cfg(not(test)) misuse
+dbg_macro = "deny"                       # No dbg! in production (clippy.toml allows in tests)
+deref_by_slicing = "deny"                # Use &* instead of &v[..]
+empty_line_after_doc_comments = "deny"   # Clean doc comment style
+empty_line_after_outer_attr = "deny"     # Clean attribute style
+four_forward_slashes = "deny"            # Catch //// (typo for ///)
+iter_filter_is_ok = "deny"               # Use flatten() instead of filter + is_ok
+iter_filter_is_some = "deny"             # Use flatten() instead of filter + is_some
+manual_is_power_of_two = "deny"          # Use is_power_of_two()
+pathbuf_init_then_push = "deny"          # Use PathBuf::from directly
+pub_underscore_fields = "deny"           # Don't expose _prefixed fields
+renamed_function_params = "deny"         # Trait impls must match param names
+set_contains_or_insert = "deny"          # Use entry API for sets
+unnecessary_map_or = "deny"              # Simplify map_or calls
+unnecessary_result_map_or_else = "deny"  # Simplify Result::map_or_else
 
 # ───── Error handling & safety ─────
-assertions_on_result_states = "deny"    # Use unwrap() over assert!(r.is_ok()) for clearer failures
-error_impl_error = "deny"               # Proper Error trait implementations
-exit = "deny"                           # No std::process::exit
-get_unwrap = "deny"                     # Use get().ok_or() instead
-let_underscore_must_use = "deny"        # Don't ignore must_use values
-map_err_ignore = "deny"                 # Don't ignore map_err values
-mem_forget = "deny"                     # Avoid mem::forget
-missing_assert_message = "deny"         # Add messages to assertions
-missing_asserts_for_indexing = "deny"   # Assert before indexing
-try_err = "deny"                        # Use ? instead of try!
-unwrap_in_result = "deny"              # No unwrap/expect inside Result-returning fns
+assertions_on_result_states = "deny"  # Use unwrap() over assert!(r.is_ok()) for clearer failures
+error_impl_error = "deny"             # Proper Error trait implementations
+exit = "deny"                         # No std::process::exit
+get_unwrap = "deny"                   # Use get().ok_or() instead
+let_underscore_must_use = "deny"      # Don't ignore must_use values
+map_err_ignore = "deny"               # Don't ignore map_err values
+mem_forget = "deny"                   # Avoid mem::forget
+missing_assert_message = "deny"       # Add messages to assertions
+missing_asserts_for_indexing = "deny" # Assert before indexing
+try_err = "deny"                      # Use ? instead of try!
+unwrap_in_result = "deny"             # No unwrap/expect inside Result-returning fns
 
 # ───── Memory & allocation ─────
-assigning_clones = "deny"               # Use clone_from instead of clone + assign
-rc_buffer = "deny"                      # Avoid Rc<String> or Rc<Vec>
-rc_mutex = "deny"                       # Avoid Rc<Mutex<T>>
-read_zero_byte_vec = "deny"             # Avoid reading into zero-capacity vec
-significant_drop_in_scrutinee = "deny"  # Avoid drops in match scrutinee
-significant_drop_tightening = "deny"    # Tighten significant drop scope
+assigning_clones = "deny"              # Use clone_from instead of clone + assign
+rc_buffer = "deny"                     # Avoid Rc<String> or Rc<Vec>
+rc_mutex = "deny"                      # Avoid Rc<Mutex<T>>
+read_zero_byte_vec = "deny"            # Avoid reading into zero-capacity vec
+significant_drop_in_scrutinee = "deny" # Avoid drops in match scrutinee
+significant_drop_tightening = "deny"   # Tighten significant drop scope
 
 # ───── Concurrency & performance ─────
-mutex_atomic = "deny"                   # Use atomics instead of mutex for simple types
-stable_sort_primitive = "deny"          # Use unstable_sort for primitives
-infinite_loop = "deny"                  # Detect infinite loops
+mutex_atomic = "deny"          # Use atomics instead of mutex for simple types
+stable_sort_primitive = "deny" # Use unstable_sort for primitives
+infinite_loop = "deny"         # Detect infinite loops
 
 # ───── Iterator patterns ─────
-collection_is_never_read = "deny"       # Detect unused collections
-iter_on_empty_collections = "deny"      # Avoid iterating empty collections
-iter_on_single_items = "deny"           # Use std::iter::once instead
-iter_over_hash_type = "deny"            # Non-deterministic iteration order
-needless_collect = "deny"               # Avoid unnecessary collect()
-needless_for_each = "deny"              # Use for loop instead of for_each
+collection_is_never_read = "deny"  # Detect unused collections
+iter_on_empty_collections = "deny" # Avoid iterating empty collections
+iter_on_single_items = "deny"      # Use std::iter::once instead
+iter_over_hash_type = "deny"       # Non-deterministic iteration order
+needless_collect = "deny"          # Avoid unnecessary collect()
+needless_for_each = "deny"         # Use for loop instead of for_each
 
 # ───── String & formatting ─────
-format_push_string = "deny"             # Use write! instead of format! + push
-manual_string_new = "deny"              # Use String::new()
-needless_raw_string_hashes = "deny"     # Minimize raw string hashes
-needless_raw_strings = "deny"           # Avoid unnecessary raw strings
-string_lit_chars_any = "deny"           # Use contains instead of chars().any()
+format_push_string = "deny"         # Use write! instead of format! + push
+manual_string_new = "deny"          # Use String::new()
+needless_raw_string_hashes = "deny" # Minimize raw string hashes
+needless_raw_strings = "deny"       # Avoid unnecessary raw strings
+string_lit_chars_any = "deny"       # Use contains instead of chars().any()
 
 # ───── Numeric & type precision ─────
-default_numeric_fallback = "deny"       # Explicit numeric types
-float_arithmetic = "deny"               # Be careful with float arithmetic (scoped #[expect] where needed)
-suspicious_xor_used_as_pow = "deny"     # Detect ^ used as power
-unreadable_literal = "deny"             # Use underscores in large literals
+default_numeric_fallback = "deny"   # Explicit numeric types
+float_arithmetic = "deny"           # Be careful with float arithmetic (scoped #[expect] where needed)
+suspicious_xor_used_as_pow = "deny" # Detect ^ used as power
+unreadable_literal = "deny"         # Use underscores in large literals
 
 # ───── Idiomatic patterns ─────
-equatable_if_let = "deny"               # Use == instead of if let for equality
-if_then_some_else_none = "deny"         # Use bool::then instead
-manual_assert = "deny"                  # Use assert! macro
-manual_instant_elapsed = "deny"         # Use Instant::elapsed()
-manual_is_ascii_check = "deny"          # Use is_ascii methods
-manual_let_else = "deny"                # Use let-else syntax
-manual_ok_or = "deny"                   # Use ok_or instead of match
-option_if_let_else = "deny"             # Use map_or_else instead
-verbose_file_reads = "deny"             # Use fs::read_to_string
+equatable_if_let = "deny"       # Use == instead of if let for equality
+if_then_some_else_none = "deny" # Use bool::then instead
+manual_assert = "deny"          # Use assert! macro
+manual_instant_elapsed = "deny" # Use Instant::elapsed()
+manual_is_ascii_check = "deny"  # Use is_ascii methods
+manual_let_else = "deny"        # Use let-else syntax
+manual_ok_or = "deny"           # Use ok_or instead of match
+option_if_let_else = "deny"     # Use map_or_else instead
+verbose_file_reads = "deny"     # Use fs::read_to_string
 
 # ───── Control flow & logic ─────
 debug_assert_with_mut_call = "deny"     # Avoid side effects in debug_assert
@@ -405,46 +414,46 @@ mixed_read_write_in_expression = "deny" # Avoid read+write in same expression
 same_functions_in_if_condition = "deny" # Avoid duplicate function calls
 
 # ───── Code style & structure ─────
-empty_drop = "deny"                     # Remove empty Drop implementations
-empty_structs_with_brackets = "deny"    # Use unit struct syntax
-impl_trait_in_params = "deny"           # Prefer generics over impl Trait in params
-let_underscore_untyped = "deny"         # Type underscore bindings
-min_ident_chars = "deny"                # Minimum identifier length
-no_effect_underscore_binding = "deny"   # Remove no-effect underscore bindings
-nonstandard_macro_braces = "deny"       # Consistent macro brace style
-partial_pub_fields = "deny"             # Consistent field visibility
-pub_without_shorthand = "deny"          # Use pub(crate) shorthand
-redundant_type_annotations = "deny"     # Remove redundant type annotations
-ref_patterns = "deny"                   # Avoid ref patterns
-rest_pat_in_fully_bound_structs = "deny" # Avoid .. in fully bound structs
-semicolon_inside_block = "deny"         # Consistent semicolon placement
-semicolon_outside_block = "deny"        # Consistent semicolon placement
-redundant_pub_crate = "allow"           # Conflicts with rustc::unreachable_pub — we prefer unreachable_pub
-single_call_fn = "allow"                # Intentional: helper functions improve readability even if called once
-unnecessary_self_imports = "deny"       # Remove unnecessary self imports
+empty_drop = "deny"                        # Remove empty Drop implementations
+empty_structs_with_brackets = "deny"       # Use unit struct syntax
+impl_trait_in_params = "deny"              # Prefer generics over impl Trait in params
+let_underscore_untyped = "deny"            # Type underscore bindings
+min_ident_chars = "deny"                   # Minimum identifier length
+no_effect_underscore_binding = "deny"      # Remove no-effect underscore bindings
+nonstandard_macro_braces = "deny"          # Consistent macro brace style
+partial_pub_fields = "deny"                # Consistent field visibility
+pub_without_shorthand = "deny"             # Use pub(crate) shorthand
+redundant_type_annotations = "deny"        # Remove redundant type annotations
+ref_patterns = "deny"                      # Avoid ref patterns
+rest_pat_in_fully_bound_structs = "deny"   # Avoid .. in fully bound structs
+semicolon_inside_block = "deny"            # Consistent semicolon placement
+semicolon_outside_block = "deny"           # Consistent semicolon placement
+redundant_pub_crate = "allow"              # Conflicts with rustc::unreachable_pub — we prefer unreachable_pub
+single_call_fn = "allow"                   # Intentional: helper functions improve readability even if called once
+unnecessary_self_imports = "deny"          # Remove unnecessary self imports
 unnecessary_struct_initialization = "deny" # Simplify struct initialization
-unneeded_field_pattern = "deny"         # Remove unneeded field patterns
+unneeded_field_pattern = "deny"            # Remove unneeded field patterns
 
 # ───── Filesystem ─────
-doc_include_without_cfg = "deny"        # Wrap doc includes in #[cfg(doc)] to avoid wasting compile time
-filetype_is_file = "deny"               # Detect is_file() misuse — returns false for symlinks
+doc_include_without_cfg = "deny" # Wrap doc includes in #[cfg(doc)] to avoid wasting compile time
+filetype_is_file = "deny"        # Detect is_file() misuse — returns false for symlinks
 
 # ───── Output discipline ─────
-print_stderr = "deny"                   # Use proper logging instead (clippy.toml allows in tests)
-print_stdout = "deny"                   # Use proper logging instead (clippy.toml allows in tests)
-use_debug = "deny"                      # Avoid Debug in production
+print_stderr = "deny" # Use proper logging instead (clippy.toml allows in tests)
+print_stdout = "deny" # Use proper logging instead (clippy.toml allows in tests)
+use_debug = "deny"    # Avoid Debug in production
 
 # ───── Portability ─────
-std_instead_of_alloc = "deny"           # Use alloc when std not needed
-std_instead_of_core = "deny"            # Use core when std not needed
+std_instead_of_alloc = "deny" # Use alloc when std not needed
+std_instead_of_core = "deny"  # Use core when std not needed
 
 # ───── Testing hygiene ─────
-tests_outside_test_module = "deny"      # Keep tests in test modules
+tests_outside_test_module = "deny" # Keep tests in test modules
 
 # ───── Unused / dead code ─────
-unused_async = "deny"                   # Remove unused async
-unused_peekable = "deny"                # Remove unused peekable
-unused_rounding = "deny"                # Remove unused rounding
+unused_async = "deny"    # Remove unused async
+unused_peekable = "deny" # Remove unused peekable
+unused_rounding = "deny" # Remove unused rounding
 
 # ───── Exceptions ─────
 # External deps (polars, tokio ecosystem) pull transitive version conflicts
@@ -453,20 +462,20 @@ multiple_crate_versions = "allow"
 
 [workspace.lints.rust]
 # ───── Rust compiler lints (strictest possible) ─────
-unsafe_code = "deny"                    # No unsafe code without explicit allow
-missing_docs = "deny"                   # Document all public items
-rust_2024_compatibility = { level = "warn", priority = -1 }  # Ensure 2024 edition compatibility
+unsafe_code = "deny"                                        # No unsafe code without explicit allow
+missing_docs = "deny"                                       # Document all public items
+rust_2024_compatibility = { level = "warn", priority = -1 } # Ensure 2024 edition compatibility
 # ───── Future-proofing lints ─────
-future_incompatible = { level = "deny", priority = -1 }  # Catch future breaking changes
-nonstandard_style = { level = "warn", priority = -1 }    # Consistent naming conventions
-unexpected_cfgs = "warn"                # Catch typos / stale cfg attributes
+future_incompatible = { level = "deny", priority = -1 } # Catch future breaking changes
+nonstandard_style = { level = "warn", priority = -1 }   # Consistent naming conventions
+unexpected_cfgs = "warn"                                # Catch typos / stale cfg attributes
 # ───── Additional safety lints ─────
-unsafe_op_in_unsafe_fn = "deny"         # Require unsafe blocks inside unsafe fn
-unused_crate_dependencies = "warn"      # Detect unused dependencies
-unused_import_braces = "deny"           # Clean import style — no tolerance
-unused_lifetimes = "deny"               # Remove unnecessary lifetimes — no tolerance
-unused_macro_rules = "deny"             # Remove unused macro rules — no tolerance
-unused_qualifications = "deny"          # Remove unnecessary path qualifications — no tolerance
+unsafe_op_in_unsafe_fn = "deny"    # Require unsafe blocks inside unsafe fn
+unused_crate_dependencies = "warn" # Detect unused dependencies
+unused_import_braces = "deny"      # Clean import style — no tolerance
+unused_lifetimes = "deny"          # Remove unnecessary lifetimes — no tolerance
+unused_macro_rules = "deny"        # Remove unused macro rules — no tolerance
+unused_qualifications = "deny"     # Remove unnecessary path qualifications — no tolerance
 # ───── Code hygiene ─────
 elided_lifetimes_in_paths = "warn"      # Make lifetime annotations explicit in type paths
 explicit_outlives_requirements = "warn" # Remove redundant where T: 'a bounds
@@ -475,13 +484,13 @@ variant_size_differences = "warn"       # Warn about enum variant size differenc
 
 [workspace.lints.rustdoc]
 # ───── Documentation quality lints ─────
-broken_intra_doc_links = "deny"         # No broken doc links
-private_intra_doc_links = "warn"        # Warn about private doc links
-missing_crate_level_docs = "warn"       # Require crate-level documentation
-invalid_codeblock_attributes = "warn"   # Valid code block attributes
-invalid_html_tags = "warn"              # Valid HTML in docs
-invalid_rust_codeblocks = "warn"        # Valid Rust in doc code blocks
-bare_urls = "warn"                      # Use proper markdown links
+broken_intra_doc_links = "deny"       # No broken doc links
+private_intra_doc_links = "warn"      # Warn about private doc links
+missing_crate_level_docs = "warn"     # Require crate-level documentation
+invalid_codeblock_attributes = "warn" # Valid code block attributes
+invalid_html_tags = "warn"            # Valid HTML in docs
+invalid_rust_codeblocks = "warn"      # Valid Rust in doc code blocks
+bare_urls = "warn"                    # Use proper markdown links
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Cargo Profiles
@@ -516,10 +525,10 @@ rpath = false
 
 [profile.profiling]
 inherits = "release"
-debug = true                            # Enable debug symbols for flamegraph
-strip = false                           # Don't strip symbols (needed for profiling)
-lto = false                             # Disable LTO for cleaner call stacks in profiles
-codegen-units = 16                      # Balance between compile time and consistent stacks
+debug = true         # Enable debug symbols for flamegraph
+strip = false        # Don't strip symbols (needed for profiling)
+lto = false          # Disable LTO for cleaner call stacks in profiles
+codegen-units = 16   # Balance between compile time and consistent stacks
 
 [profile.bench]
 inherits = "release"
@@ -544,11 +553,11 @@ inherits = "dev"
 # dramatically cuts peak RSS and link time. debug=1 gives stack traces
 # without full debuginfo cost. incremental=false is set via CARGO_INCREMENTAL=0
 # in CI (not here) so local `cargo test` still benefits from incrementals.
-debug = 1                               # Stack traces without full debuginfo cost
-codegen-units = 16                      # Sane for 4-core hosted runners (vs 256)
+debug = 1          # Stack traces without full debuginfo cost
+codegen-units = 16 # Sane for 4-core hosted runners (vs 256)
 
 [profile.dev.package.polars]
-opt-level = 2                           # Optimize Polars even in dev for usable performance
+opt-level = 2 # Optimize Polars even in dev for usable performance
 
 [profile.dev.package."*"]
 opt-level = 0
@@ -586,11 +595,11 @@ opt-level = "z"
 # ─────────────────────────────────────────────────────────────────────────────
 [profile.xwin-dev]
 inherits = "dev"
-debug = 2                               # Full debug for YOUR code
+debug = 2               # Full debug for YOUR code
 debug-assertions = true
 overflow-checks = true
-incremental = false                     # Required: incremental breaks xwin archives
-opt-level = 0                           # Fast compile for your code
+incremental = false     # Required: incremental breaks xwin archives
+opt-level = 0           # Fast compile for your code
 
 # Tame polars crates to keep .rlib under COFF limits
 # codegen-units=1 dramatically reduces archive member count
@@ -627,12 +636,11 @@ cargo-dist-version = "0.30.0"
 ci = ["github"]
 installers = ["shell", "powershell"]
 targets = [
-    "aarch64-apple-darwin",
-    "x86_64-apple-darwin",
-    "x86_64-unknown-linux-gnu",
-    "aarch64-unknown-linux-gnu",
-    "x86_64-pc-windows-msvc"
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-pc-windows-msvc",
 ]
 pr-run-mode = "plan"
 allow-dirty = ["ci"]
-

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@
 
 **A benchmark-driven NTFS search engine for Windows.** UFFS reads the Master File Table directly, builds a compact persisted index, and keeps large NTFS estates searchable through a background daemon.
 
-> Proven on a real 7-drive, 25.9M-record Windows system; scale-ceiling tested to **100.4M records** with offline MFT clones (v0.5.4 baseline; v0.5.69 current):
-> - **68.5 s COLD** — raw MFT read + compact index build (v0.5.69, flat ± 4 % vs v0.5.4)
-> - **5.7 s WARM CACHE** — restart from serialized cache (v0.5.62/v0.5.69, **−17 %** vs v0.5.4)
+> Proven on a real 7-drive, 25.9M-record Windows system; scale-ceiling tested to **100.4M records** with offline MFT clones (v0.5.4 baseline; v0.5.71 current):
+> - **68.5 s COLD** — raw MFT read + compact index build (v0.5.71, flat ± 4 % vs v0.5.4)
+> - **5.7 s WARM CACHE** — restart from serialized cache (v0.5.62/v0.5.71, **−17 %** vs v0.5.4)
 > - **0–3 ms daemon-side** for targeted queries — exact/prefix/ext/substring, unchanged from v0.5.4
-> - **29–32 ms CLI end-to-end** for targeted queries on v0.5.69 (v0.5.4 measured 9–13 ms e2e before the post-Phase-1 thin-client spawn floor settled at ~28 ms)
-> - **vs Everything on v0.5.69**: UFFS wins **12/12 head-to-head cells** at p50 on C+D, median ratio **0.51× (~1.96× faster)** — see the [**benchmark hub**](docs/benchmarks/) and the [full v0.5.69 report](docs/benchmarks/2026-04-v0.5.69-vs-everything-and-cpp.md)
+> - **29–32 ms CLI end-to-end** for targeted queries on v0.5.71 (v0.5.4 measured 9–13 ms e2e before the post-Phase-1 thin-client spawn floor settled at ~28 ms)
+> - **vs Everything on v0.5.71**: UFFS wins **12/12 head-to-head cells** at p50 on C+D, median ratio **0.51× (~1.96× faster)** — see the [**benchmark hub**](docs/benchmarks/) and the [full v0.5.71 report](docs/benchmarks/2026-04-v0.5.71-vs-everything-and-cpp.md)
 
 UFFS is built for **exact filename, path, and metadata search** at scales where directory walking, shell search, and some automation surfaces become the bottleneck. It is open source, written in Rust, and designed first for deterministic local search; CLI, TUI, API, and MCP are all interfaces on top of the same engine.
 
@@ -47,11 +47,11 @@ UFFS is built for **exact filename, path, and metadata search** at scales where 
 
 ---
 
-## Benchmark snapshot (v0.5.69)
+## Benchmark snapshot (v0.5.71)
 
 Measured on AMD Ryzen 9 3900XT, 64 GB RAM, Windows 11 Pro 24H2, 7 NTFS volumes totaling 26.1 M records; scaled to 100.4 M with offline MFT clones (v0.5.4 era). Full captures in [`docs/benchmarks/raw/2026-04-v0.5.66_cross-tool-vs-everything.txt`](docs/benchmarks/raw/2026-04-v0.5.66_cross-tool-vs-everything.txt) + [`docs/benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt`](docs/benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt). Publication-grade report: [**docs/benchmarks/**](docs/benchmarks/).
 
-| Phase | What happens | ALL 7 drives (v0.5.69) | Single NVMe (v0.5.4) |
+| Phase | What happens | ALL 7 drives (v0.5.71) | Single NVMe (v0.5.4) |
 |-------|--------------|-----------------------:|---------------------:|
 | **COLD** | Raw MFT read, parse, compact index build, cache write | 68.5 s | 7.7 s |
 | **WARM CACHE** | Daemon restart + serialized cache load | **5.7 s** | 6.4 s |
@@ -60,14 +60,14 @@ Measured on AMD Ryzen 9 3900XT, 64 GB RAM, Windows 11 Pro 24H2, 7 NTFS volumes t
 
 ¹ The `*` top-100 path regressed from the v0.5.4 163 ms figure after the Phase 2 sort rewrite ([`docs/benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt:657`](docs/benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt), n=30, StdDev 21 ms). Daemon-side is 1 081 ms — CLI tax is negligible here. Bounded-heap top-N fix is Phase 5 target #2 in the [cross-tool analysis](docs/benchmarks/2026-04-v0.5.66-vs-everything-and-cpp.md#known-regressions) doc.
 
-Hot-path context (v0.5.69, 30 rounds, p50):
+Hot-path context (v0.5.71, 30 rounds, p50):
 - **0–3 ms daemon-side** for targeted queries (exact, prefix, ext, substring, combined) — unchanged since v0.5.4
 - **29–32 ms CLI end-to-end** for targeted queries across all 7 drives (~28 ms post-Phase-1 cold-spawn floor + 0–3 ms daemon)
 - **UFFS wins 12/12 cells vs Everything** at p50 on C+D, median ratio **0.51×** — see the [benchmark hub](docs/benchmarks/)
 - **Direct stdout redirect crossover**: UFFS **0.27×–0.53×** vs ES across 4 size classes (34 K → 167 K rows)
 - **323 k rows/sec** bulk export throughput (CSV, `--out-dir`)
 - **Full-scan export** `*` → CSV at 26 M records: **13.6 s p50** (1.72 M rec/s through the full pipeline)
-- **100.4 M records** tested (v0.5.4 synthetic-clone data; not re-verified on v0.5.69): targeted queries stayed at 11–13 ms e2e
+- **100.4 M records** tested (v0.5.4 synthetic-clone data; not re-verified on v0.5.71): targeted queries stayed at 11–13 ms e2e
 
 > 📖 **[Benchmark hub](docs/benchmarks/)** — dated competitive-benchmark reports, fairness methodology, archive of prior versions, reproduction scripts.
 > 📖 **[Full benchmark data](docs/user-manual/performance.md)** — methodology, per-drive tables, interactive search percentiles, bulk retrieval, scale ceiling, and caveats.

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -41,8 +41,23 @@ _install 755 "$BIN"                        "$PREFIX/bin/uffs"
 _install 644 packaging/linux/uffs.desktop  "$PREFIX/share/applications/uffs.desktop"
 
 # Hicolor icon set — every size the assets/brand/ tree provides.
+#
+# The tree lives in two places depending on where install.sh is run from:
+#   • repo root      → assets/brand/icons/hicolor/…
+#   • extracted ZIP  → assets/hicolor/…   (release.yml flattens the path
+#                                          so the staged bundle is shallower)
+# Auto-detect so the same script works in both contexts.
+if   [[ -d "assets/brand/icons/hicolor" ]]; then
+    ICON_ROOT="assets/brand/icons/hicolor"
+elif [[ -d "assets/hicolor" ]]; then
+    ICON_ROOT="assets/hicolor"
+else
+    printf '\033[1;31merror:\033[0m hicolor icon tree not found under assets/\n' >&2
+    exit 1
+fi
+
 for size in 16 32 48 64 128 256 512; do
-    _install 644 "assets/brand/icons/hicolor/${size}x${size}/uffs.png" \
+    _install 644 "$ICON_ROOT/${size}x${size}/uffs.png" \
                  "$PREFIX/share/icons/hicolor/${size}x${size}/apps/uffs.png"
 done
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -30,27 +30,27 @@
 # CI pipeline will auto-refresh on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed — use that flag (or plain `just ship`) while the upstream regression
 # persists.
-channel = "nightly-2026-04-22"
+channel = "nightly-2026-04-23"
 
 # Specify components that should always be available
 components = [
-    "rustc",          # The Rust compiler
-    "cargo",          # Package manager and build tool
-    "rustfmt",        # Code formatter
-    "clippy",         # Linter for catching common mistakes
-    "rust-src",       # Source code for standard library (needed for IDE features)
-    "rust-analyzer",  # Language server for IDE support
-    "llvm-tools",     # LLVM tools for coverage and profiling
-    "miri",           # Interpreter for detecting undefined behavior
+  "rustc",         # The Rust compiler
+  "cargo",         # Package manager and build tool
+  "rustfmt",       # Code formatter
+  "clippy",        # Linter for catching common mistakes
+  "rust-src",      # Source code for standard library (needed for IDE features)
+  "rust-analyzer", # Language server for IDE support
+  "llvm-tools",    # LLVM tools for coverage and profiling
+  "miri",          # Interpreter for detecting undefined behavior
 ]
 
 # Specify targets for cross-compilation support
 targets = [
-    "x86_64-unknown-linux-gnu",    # Linux x64
-    "x86_64-pc-windows-msvc",      # Windows x64
-    "x86_64-apple-darwin",         # macOS Intel
-    "aarch64-apple-darwin",        # macOS Apple Silicon
-    "aarch64-unknown-linux-gnu",   # Linux ARM64
+  "x86_64-unknown-linux-gnu",  # Linux x64
+  "x86_64-pc-windows-msvc",    # Windows x64
+  "x86_64-apple-darwin",       # macOS Intel
+  "aarch64-apple-darwin",      # macOS Apple Silicon
+  "aarch64-unknown-linux-gnu", # Linux ARM64
 ]
 
 # Profile for development - optimized for fast compilation and good debugging

--- a/scripts/ci/ci-pipeline.rs
+++ b/scripts/ci/ci-pipeline.rs
@@ -538,6 +538,15 @@ impl PipelineContext {
         if sccache_available {
             global_env.push(("RUSTC_WRAPPER".into(), "sccache".into()));
             global_env.push(("CARGO_INCREMENTAL".into(), "0".into()));
+            // Diagnostic marker — presence of this line in the pipeline
+            // output proves the fresh binary (post-`fix(ci): pair
+            // CARGO_INCREMENTAL=0 with RUSTC_WRAPPER=sccache`) is the
+            // one being executed, not a stale rust-script cache entry.
+            if verbose {
+                eprintln!(
+                    "[ci-pipeline][sccache-fix] global_env: RUSTC_WRAPPER=sccache + CARGO_INCREMENTAL=0 paired"
+                );
+            }
         }
 
         // Create log file for non-verbose mode

--- a/scripts/ci/ci-pipeline.rs
+++ b/scripts/ci/ci-pipeline.rs
@@ -522,9 +522,22 @@ impl PipelineContext {
         ));
 
         // Optional sccache integration (massive win in CI and on developer machines).
+        //
+        // sccache refuses to wrap rustc when CARGO_INCREMENTAL=1 because
+        // incremental builds produce non-cacheable artifacts (sccache bails
+        // out at `sccache rustc -vV` with
+        // "incremental compilation is prohibited").  `just/shared.just`
+        // exports CARGO_INCREMENTAL=1 for local dev UX, so whenever we enable
+        // sccache for the pipeline we must pair it with CARGO_INCREMENTAL=0
+        // at the SAME scope.  Previously the unset lived in a per-command
+        // guard further down — which caught `cargo` and `rust-script` but
+        // not `git` (whose pre-push hook shells out to cargo internally and
+        // inherits this env).  Keeping the pair in the global env is the
+        // only scope that covers every subprocess the pipeline spawns.
         let sccache_available = !no_sccache && command_exists("sccache");
         if sccache_available {
             global_env.push(("RUSTC_WRAPPER".into(), "sccache".into()));
+            global_env.push(("CARGO_INCREMENTAL".into(), "0".into()));
         }
 
         // Create log file for non-verbose mode
@@ -613,12 +626,13 @@ async fn execute_command_with_env(
         command.env(key, value);
     }
 
-    // sccache prohibits incremental compilation - it conflicts with its caching model.
-    // Force CARGO_INCREMENTAL=0 for cargo and rust-script (which runs cargo internally).
-    // This overrides the `incremental = true` in profile.dev from Cargo.toml.
-    if ctx.sccache_enabled && (cmd == "cargo" || cmd == "rust-script") {
-        command.env("CARGO_INCREMENTAL", "0");
-    }
+    // NOTE: the sccache/`CARGO_INCREMENTAL=0` pairing is enforced in the
+    // global env at context-construction time (see `ContextBuilder`),
+    // which correctly covers every subprocess the pipeline spawns —
+    // including `git`, whose pre-push hook shells out to cargo.  A
+    // per-command guard here would only have caught `cargo` /
+    // `rust-script`, leaving hook-invoked cargo processes to fail with
+    // "incremental compilation is prohibited".
 
     // In verbose mode, inherit stdio; otherwise capture to log file
     if ctx.verbose {

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,4 +1,38 @@
 
 # cargo-vet audits file
 
-[audits]
+[[audits.pastey]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+version = "0.2.2"
+notes = """
+Audit rationale (Apr 2026, v0.5.71):
+- Transitive via rmcp → uffs-mcp (MCP framework proc-macro dependency).
+- Successor fork of dtolnay's 'paste'; David Tolnay (dtolnay) is listed as
+  co-author with the fork maintainer Aditya Kumar (as1100k).
+- Zero runtime dependencies. Pure proc-macro crate, 1649 LOC across 4 .rs files.
+- No 'unsafe' blocks anywhere in the source tree.
+- No filesystem, process, or network access.
+- Single ambient capability: std::env::var() in segment.rs:187, used for the
+  crate's advertised compile-time env-var interpolation in paste!() macros
+  (analogous to stdlib env!()). Bounded to compile time, returns a compile
+  error on missing var rather than silently succeeding.
+- License: MIT OR Apache-2.0 (inherited from paste)."""
+
+[[audits.rustls]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.23.38 -> 0.23.39"
+notes = """
+Delta audit (Apr 2026, v0.5.71):
+- Maintenance patch release. Total diff: 4 files changed, 10 insertions(+), 9 deletions(-).
+- Cargo.toml / Cargo.toml.orig: mechanical version bump 0.23.38 → 0.23.39.
+- src/client/hs.rs (ExpectServerHelloOrHelloRetryRequest::handle): the
+  ECH-acceptance check's 'if !ech_state.confirm_hrr_acceptance(...)' was
+  promoted from the match-arm body to a guard on the match-arm pattern.
+  Semantically identical: same arm, same predicate, same side effect
+  (EchStatus::Rejected). Error propagation via '?' preserved.
+- src/lib.rs: adds '#![cfg_attr(read_buf, feature(core_io))]'. Pure
+  nightly-only cfg-gated feature flag addition; inert on stable toolchains.
+  No runtime behavior change.
+- No unsafe additions, no API changes, no new ambient capabilities."""


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.71**.  Binaries + GitHub Release v0.5.71 are already live (step 09).  This PR routes the corresponding commit through branch-protection rules.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

Local `main` had this commit with a different SHA before squash rewrote it onto main; recover with `git fetch origin && git reset --hard origin/main`.