### PR TITLE
ci(actions): phase 4b actions-hardening retrofit across 7 workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -103,6 +103,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # §2.8: pin checkout to the PR head SHA (not the synthetic
+          # merge commit that `actions/checkout` defaults to for PR
+          # events).  For `push` / `schedule` / `workflow_dispatch`,
+          # `pull_request.head.sha` is undefined and we fall back to
+          # `github.sha` — which is already the correct commit for
+          # those triggers.  Net effect: CodeQL always analyses the
+          # exact bytes pushed / proposed, never a synthetic merge.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.github/workflows/dependabot-review.yml
+++ b/.github/workflows/dependabot-review.yml
@@ -81,9 +81,16 @@ jobs:
         # resolved dependency graph between the pre-bump state and the
         # post-bump state.  Dependabot PRs are single-commit by
         # default, so HEAD~1 is always main's tip at branch-open time.
+        #
+        # §2.8: pin `ref:` to the PR head SHA (Dependabot's actual
+        # bump commit) instead of the synthetic merge commit that
+        # `actions/checkout` defaults to for `pull_request` events.
+        # That way `HEAD~1:Cargo.lock` is deterministically the
+        # pre-bump lockfile, not a merge-specific artifact.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Count Cargo.lock crate-count delta
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,13 @@ jobs:
           # The previous `CARGO_PROFILE_RELEASE_LTO=false` override silently
           # disabled LTO in release artifacts; removed so users get the
           # perf the profile was designed for.
-          cargo build --release --target ${{ matrix.target }} --workspace --bins
+          #
+          # --locked per §2.8 policy.  Release builds MUST resolve
+          # through the committed Cargo.lock or the binaries we ship
+          # may differ from what the tests validated — worst-case a
+          # silent dep drift ships to end-users.  CI fails loudly
+          # instead.
+          cargo build --locked --release --target ${{ matrix.target }} --workspace --bins
 
           echo "✅ Build completed for ${{ matrix.target }}"
 

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -12,9 +12,13 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+# Workflow-level permissions follow least-privilege (§2.8):
+# every job that doesn't declare its own `permissions:` block
+# inherits `contents: read` only.  `notify-failure` re-declares
+# `issues: write` on its own block so that scope is scoped to the
+# one job that actually opens issues.
 permissions:
   contents: read
-  issues: write
 
 # Tier 2 runs on a weekly cron; a manual `workflow_dispatch` landing
 # on top of a cron run should queue, not cancel — we want the full
@@ -78,7 +82,11 @@ jobs:
           tool: cargo-llvm-cov,cargo-nextest
 
       - name: Generate coverage report
-        run: cargo llvm-cov nextest --workspace --all-features --lcov --output-path lcov.info
+        # --locked per §2.8 policy; the release-profile cargo also
+        # resolves through the committed Cargo.lock, so coverage
+        # reports reflect exactly the versions that CI / local
+        # development use.
+        run: cargo llvm-cov nextest --locked --workspace --all-features --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
@@ -138,8 +146,10 @@ jobs:
       - name: cargo check --workspace --all-features
         # --all-features to exercise every feature-gated path that only
         # compiles on Windows (e.g. live MFT / USN / IOCP code paths).
-        # --tests so test-only Windows code is also type-checked.
-        run: cargo check --workspace --all-features --all-targets
+        # --all-targets so test-only Windows code is also type-checked.
+        # --locked per §2.8 so lockfile drift surfaces as a CI failure
+        # rather than silently pulling in a newer patch version.
+        run: cargo check --locked --workspace --all-features --all-targets
 
   build-validation:
     name: Tier 2 / Build Validation
@@ -161,7 +171,10 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run build validation
-        run: cargo build --workspace --all-features --bins
+        # --locked per §2.8 — validation builds must resolve through
+        # the committed Cargo.lock, otherwise a broken lockfile wouldn't
+        # surface here.
+        run: cargo build --locked --workspace --all-features --bins
 
   udeps:
     name: Tier 2 / cargo-udeps
@@ -188,7 +201,9 @@ jobs:
           tool: cargo-udeps
 
       - name: Run cargo-udeps
-        run: cargo udeps --workspace --all-targets --all-features
+        # --locked per §2.8; cargo-udeps resolves through the same
+        # lockfile as the rest of the workspace.
+        run: cargo udeps --locked --workspace --all-targets --all-features
 
   miri:
     name: Tier 2 / Miri
@@ -216,10 +231,12 @@ jobs:
           # These raw persistence tests use temp files, so Miri needs isolation disabled.
           # Keep coverage focused on the subset that runs under Miri today; the zstd-backed
           # compressed raw test uses foreign-function calls that Miri does not support.
-          cargo miri test -p uffs-mft raw::tests::test_header_roundtrip -- --exact
-          cargo miri test -p uffs-mft raw::tests::test_load_header_only -- --exact
-          cargo miri test -p uffs-mft raw::tests::test_save_load_uncompressed -- --exact
-          cargo miri test -p uffs-mft raw::tests::test_raw_compat_mode -- --exact
+          # --locked per §2.8 so miri evaluates the same resolved crate
+          # graph as the rest of the workspace.
+          cargo miri test --locked -p uffs-mft raw::tests::test_header_roundtrip -- --exact
+          cargo miri test --locked -p uffs-mft raw::tests::test_load_header_only -- --exact
+          cargo miri test --locked -p uffs-mft raw::tests::test_save_load_uncompressed -- --exact
+          cargo miri test --locked -p uffs-mft raw::tests::test_raw_compat_mode -- --exact
 
   tier-2-summary:
     name: Tier 2 / Summary
@@ -265,6 +282,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [file-size-policy, coverage, build-validation, udeps, miri, windows-check]
     if: failure()
+    # §2.8: every job caps its runtime.  Cheap notifier — 2 min is
+    # generous for a single API call round-trip + JSON formatting.
+    timeout-minutes: 2
     permissions:
       issues: write
     steps:

--- a/docs/architecture/dev-flow-implementation-plan.md
+++ b/docs/architecture/dev-flow-implementation-plan.md
@@ -1520,7 +1520,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🔵 blocked (see notes)
 | 3 | Cache policy single source (`.cargo/config.toml` owns `incremental`) | ✅ | 2026-04-23 | 2026-04-23 | `780c1dbb1` (squash) | [#45](https://github.com/skyllc-ai/UltraFastFileSearch/pull/45) |
 | 6 | Resumable-push fix in `ci-pipeline.rs` | ✅ | 2026-04-23 | 2026-04-23 | `780c1dbb1` (squash) | [#45](https://github.com/skyllc-ai/UltraFastFileSearch/pull/45) |
 | 4 | Split `ci.yml` → `pr-fast.yml` + `preview-artifacts.yml` | 🟡 | 2026-04-23 | — | `780c1dbb1` (squash) | [#45](https://github.com/skyllc-ai/UltraFastFileSearch/pull/45) |
-| 4b | Actions hardening retrofit across existing workflows | ⬜ | | | | |
+| 4b | Actions hardening retrofit across existing workflows | 🟡 | 2026-04-23 | — | (pending PR) | — |
 | 5 | Preview lane fleshed out (smoke runner + manifest) | 🟡 | 2026-04-23 | — | `780c1dbb1` (squash) | [#45](https://github.com/skyllc-ai/UltraFastFileSearch/pull/45) |
 | 7 | `ci-pipeline.rs` promoted to workspace binary | ✅ | 2026-04-23 | 2026-04-23 | `780c1dbb1` (squash) | [#45](https://github.com/skyllc-ai/UltraFastFileSearch/pull/45) |
 | 8 | (stretch) `gates.toml` machine-readable manifest | ⬜ | | | | |
@@ -1738,15 +1738,79 @@ the `uffs-client` package.  Runtime remains within budget.
 
 Audit each existing workflow against §2.8 policy:
 
-- [ ] `tier-2.yml` — permissions, SHA pinning, timeouts, merge_group.
-- [ ] `codeql.yml` — same.
-- [ ] `release.yml` — same.
-- [ ] `auto-tag-release.yml` — same.
-- [ ] `cargo-vet-refresh.yml` — same.
-- [ ] `dependabot-review.yml` — same.
-- [ ] `dependabot-auto-merge.yml` — same.
+- [x] `tier-2.yml` — narrowed workflow-level `permissions` from
+      `contents: read, issues: write` to just `contents: read`
+      (notify-failure re-declares `issues: write` on its own block,
+      so the broader scope was over-privileged for the other 7 jobs);
+      added `timeout-minutes: 2` to notify-failure (only job that
+      was missing one); added `--locked` to all 5 cargo invocations
+      (coverage / windows-check / build-validation / udeps / miri).
+- [x] `codeql.yml` — added explicit
+      `ref: github.event.pull_request.head.sha || github.sha` on the
+      checkout so CodeQL analyses the exact bytes pushed / proposed
+      instead of the synthetic merge commit that `actions/checkout`
+      defaults to on `pull_request` events.
+- [x] `release.yml` — added `--locked` to the matrix
+      `cargo build --release` step.  Deliberately did NOT refactor
+      the workflow-level permissions block (sophisticated
+      `contents/actions/id-token/attestations/issues` grants are all
+      commented + justified; tightening is a distinct change best
+      kept out of a housekeeping retrofit commit).
+- [x] `auto-tag-release.yml` — already conformant; verified (1) no
+      PR trigger so `merge_group:` N/A, (2) minimum-privilege
+      `contents: read, actions: write` with comments, (3) single job
+      with `timeout-minutes: 5`, (4) no cargo commands (pure git +
+      gh CLI).  Zero changes.
+- [x] `cargo-vet-refresh.yml` — already conformant; verified (1) no
+      PR trigger, (2) minimum-privilege `contents: write,
+      pull-requests: write` (both needed for refresh-PR creation,
+      both justified with comments), (3) `timeout-minutes: 10`,
+      (4) `cargo vet check --locked` already present, (5) `cargo vet
+      regenerate imports` / `cargo vet prune` deliberately run
+      unlocked (they mutate the lockfile by design).  Zero changes.
+- [x] `dependabot-review.yml` — added explicit
+      `ref: github.event.pull_request.head.sha || github.sha` on
+      checkout so `git show HEAD~1:Cargo.lock` is deterministically
+      the pre-bump lockfile, not whatever the synthetic merge commit
+      resolves to.  Other §2.8 properties already conformant
+      (contents:read + pull-requests:read, actor-gated to Dependabot
+      only, `timeout-minutes: 3`, full-SHA action pins).
+- [x] `dependabot-auto-merge.yml` — already conformant; verified
+      (1) PR trigger but actor-gated so `merge_group:` wouldn't fire
+      anyway, (2) minimum-privilege `contents: write,
+      pull-requests: write` for `gh pr merge --auto`, (3)
+      `timeout-minutes: 5`, (4) no checkout step (uses dependabot/
+      fetch-metadata + gh CLI), (5) full-SHA action pins.  Zero
+      changes.
 
 **Notes**:
+- `merge_group:` triggers were NOT added retroactively because
+  §2.8's requirement is scoped to "workflows that report required
+  checks".  Today that's only `pr-fast.yml` (and the soon-to-be-
+  deleted `ci.yml`).  The 7 workflows audited here don't report
+  required checks, so merge-queue compatibility is moot until that
+  changes.
+- The permissions refactor in `release.yml` (workflow-level
+  `contents: write` → workflow-level `contents: read` +
+  per-job write grants on `create-github-release`) was deliberately
+  scoped out of this pass.  Release infra is critical path; a
+  per-job permissions restructure deserves its own focused PR with
+  a full release dry-run.
+- Pre-existing shellcheck `style` / `warning` notes in unmodified
+  shell blocks (tier-2-summary, release-preparation summary,
+  dependabot-review summary) are explicitly out of scope — cleaning
+  them up would balloon the diff and obscure the actual hardening.
+  Track them separately if ever desired.
+
+Post-retrofit verification (2026-04-23):
+- `actionlint` exits 0 on all 4 modified files (remaining warnings
+  are pre-existing style-level SC2129 / SC2010 in unmodified
+  blocks).
+- `ruby -ryaml -e 'YAML.load_file(...)'` passes on all 4 files.
+- Diff touches only the 4 files listed above; zero behavioural
+  changes on already-conformant workflows.
+
+**Original notes**:
 
 #### Phase 5 — Preview lane
 


### PR DESCRIPTION
Closes the open Phase 4b box from `docs/architecture/dev-flow-implementation-plan.md` \u00a710.3. Applies the \u00a72.8 GitHub Actions hardening policy retroactively to each of the 7 pre-existing workflows the policy names.

Four needed concrete changes; three were already conformant.

## Modified workflows

### `tier-2.yml`
- Narrowed workflow-level `permissions` from `contents: read, issues: write` \u2192 just `contents: read`. `notify-failure` already has its own `issues: write` block, so the broader scope was over-privileging 7 other jobs.
- Added `timeout-minutes: 2` to `notify-failure` (only job missing one).
- Added `--locked` to all 5 cargo invocations (coverage, windows-check, build-validation, udeps, miri).

### `codeql.yml`
- Pinned `actions/checkout` `ref: ${{ github.event.pull_request.head.sha || github.sha }}` so CodeQL analyses the exact bytes pushed / proposed, not the synthetic merge commit GitHub generates on `pull_request` events.

### `release.yml`
- Added `--locked` to the matrix `cargo build --release ...` step. **Release builds MUST resolve through the committed `Cargo.lock`** or the binaries we ship can silently drift from what CI validates.
- **Deliberately NOT touched**: the sophisticated workflow-level `permissions` block. A per-job permissions refactor on the release-critical workflow deserves its own focused PR with a full release dry-run.

### `dependabot-review.yml`
- Pinned `actions/checkout` `ref: ${{ github.event.pull_request.head.sha || github.sha }}` so `git show HEAD~1:Cargo.lock` is deterministically the pre-bump lockfile.

## Audited, already conformant (zero changes)

- `auto-tag-release.yml` \u2014 push-only trigger, tight `contents:read + actions:write` perms, 5 min timeout, no cargo.
- `cargo-vet-refresh.yml` \u2014 cron-only trigger, tight `contents:write + pull-requests:write`, 10 min timeout, `cargo vet check --locked` already present.
- `dependabot-auto-merge.yml` \u2014 actor-gated, tight `contents:write + pull-requests:write`, 5 min timeout, no checkout step.

## Explicitly out of scope

- `merge_group:` retrofits \u2014 \u00a72.8 scopes that requirement to workflows reporting required checks. Today only `pr-fast.yml` (and soon-to-be-deleted `ci.yml`) does. None of the 7 retrofit targets report required checks, so adding `merge_group:` would be a no-op.
- Pre-existing shellcheck style notes in unmodified shell blocks (SC2129 in tier-2-summary / release / dependabot-review; SC2010 in the release-assets loop). Would balloon the diff and obscure the hardening.
- Any behaviour-changing refactor. Pure housekeeping: add `--locked`, narrow `permissions`, pin checkout refs, add one timeout. No job added, removed, reordered, or renamed.

## Verification

- `actionlint --oneline` exits 0 on all 4 modified files.
- `ruby -ryaml -e 'YAML.load_file(...)'` passes on all 4 files.
- Diff scope: `git diff --stat` shows exactly 5 files (4 workflows + plan doc).
- Local pre-push gate passed all 13 parallel job checks in 48s.

## Expected CI behaviour on this PR

Touches `.github/workflows/` \u2192 `infra_changed=true` \u2192 `code=true` \u2192 full PR Fast CI matrix runs (fmt, sanity, clippy, docs, test-build, tests, security, windows-check). Tier 1 lane also runs because `**/*.rs` path filter in `ci.yml` would normally skip this, but the `.github/workflows/ci.yml` path IS in the filter so Tier 1 triggers on workflow edits too. Both should go green; if PR Fast CI / required flips red, investigate the specific job that failed (likely a --locked incompatibility somewhere I missed).

## Merge ordering with PR #46

PR #46 (docs reconciliation) and this PR are non-overlapping on the plan-doc table rows:
- PR #46 edits dashboard rows 1, 2, 3, 4, 5, 6, 7.
- This PR edits dashboard row 4b only.
- The two \u00a710.3 checklist sections (Phase 4 and Phase 4b) are distinct subsections.

GitHub should merge both without conflict regardless of order. If merged first, PR #46 just rebases cleanly on top of this; if merged second, same story in reverse.