### PR TITLE
chore(daemon): post-v0.5.71 cleanup — warnings fixes, test diagnostics, hygiene, release-automation plan

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ UFFS uses a shift-left pipeline: cheap checks fire close to the keystroke, expen
 | **pre-commit** | `git commit` | `just lint-fast` | sub-2 s (docs-only) / 15–25 s warm (`*.rs` staged) | `fmt --check`, **`lint-prod`** (ultra-strict: pedantic + nursery + cargo + unwrap_used + missing_docs_in_private_items), **`lint-tests`** (same base + unwrap allowed), **`lint-ci`** (CI-mirror `-D warnings --all-targets`), **`check-windows`** (`cargo xwin check` of Windows-only `#[cfg(windows)]` paths) — all when `*.rs` staged; plus `taplo fmt --check` (if `*.toml` staged), `typos`, `reuse lint`, file-size policy — all in parallel; missing optional tools soft-skip |
 | **pre-push** | `git push` | `just lint-pre-push` | 25–40 s warm | Same three ultra-strict clippy passes + **Windows `cargo xwin check`** + `fmt --check` + `rustdoc -D warnings` + `cargo deny check` + `nextest run --no-run` (test-binary link check) + file-size policy + `typos` + `reuse lint` — all in parallel. Full parity with `just ship` Phase 1 lint surface plus cross-platform Windows coverage; only the full test runtime (`nextest run`) is deferred to CI. |
 | **PR CI** | on PR to `main` | `.github/workflows/pr-fast.yml` | minutes | PR-blocking matrix (classify → file-size, fmt, sanity, clippy, docs, test-build, tests, security, windows-check, required).  The `classify` job short-circuits docs-only / dep-only / infra-only PRs so heavy jobs only run when code actually changed.  Linux jobs run on `ubuntu-22.04`; `windows-check` runs natively on `windows-latest` (so `#[cfg(windows)]` compile errors now surface at PR time, not release time).  Tier 2 weekly workflow (`.github/workflows/tier-2.yml`) runs coverage + udeps + miri out of the critical path. |
-| **Release** | manual | `just ship` | minutes | version bump + `release/vX.Y.Z` PR + signed commit + auto-tag + binary build |
+| **Release** | manual today; automated after release-automation R4 | `just ship` today; release-plz release PR after R4 | minutes | today: version bump + `release/vX.Y.Z` PR + signed commit + auto-tag + binary build.  **Target state** (see [`docs/architecture/release-automation-plan.md`](docs/architecture/release-automation-plan.md)): release-plz opens `chore(release): prepare vX.Y.Z` PR automatically from conventional commits on `main`; merging that PR creates the tag; `release.yml` builds binaries as today. |
 
 The ultra-strict flag stack — `common_flags` / `prod_flags` / `test_flags` — is defined in `@/Users/rnio/Private/Github/UltraFastFileSearch/just/shared.just:21-26` and pulled in identically by the local hooks and by `just ship` Phase 1, so **the rules a commit is checked against locally are the exact rules CI enforces**.
 
@@ -121,6 +121,71 @@ The hooks are tuned for an sccache-warm workspace. If you notice cold-cache slow
 
 See `@scripts/hooks/_lint_fast.sh` and `@scripts/hooks/_lint_pre_push.sh` for the shared parallel runners both the hooks and the `just` recipes call into — edit there when adjusting the gate set, not in the hooks themselves.
 
+## Target-dir hygiene
+
+`just test` runs `cargo llvm-cov nextest` which writes source-instrumented artifacts into `$CARGO_TARGET_DIR/llvm-cov-target/` — a tree that is entirely separate from regular `cargo build`'s `target/debug/` and `target/release/`, and which can grow to **100 GB+** over a long session of coverage runs (each profile bump recompiles everything; every `.profraw` from a failed / killed run stays cached).  On a near-full disk (Dropbox sync volume, small SSD, external drive) this is the top cause of two otherwise-mysterious test failures:
+
+- `handler::paths_blob_tests::try_pack_paths_blob_offloads_large_blob_to_shmem`
+- `handler::csv_blob_tests::try_pack_csv_blob_offloads_large_blob_to_shmem`
+
+Both pin the daemon's **shmem-offload** transport for large search blobs.  When the underlying `write_paths_blob` hits `ENOSPC` / `ERROR_DISK_FULL` during shmem file creation the daemon correctly degrades to inline JSON (see `@/Users/rnio/Private/Github/UltraFastFileSearch/crates/uffs-daemon/src/handler_blob.rs:149-159`), which is exactly what the test asserts against — so the test panics with "*must be offloaded to SearchPayload::ShmemBlob; got InlineBlob(...)*".  This is working as designed: silently skipping under disk pressure would hide a real `write_paths_blob` regression on a healthy host.
+
+Run this on the host that surfaced the failure:
+
+```bash
+just clean-cov
+```
+
+The recipe (`@/Users/rnio/Private/Github/UltraFastFileSearch/just/cache.just`) prunes:
+
+- `$CARGO_TARGET_DIR/llvm-cov-target/` — the instrumented build tree
+- `$CARGO_TARGET_DIR/llvm-cov/` — the HTML coverage report directory
+- `$CARGO_TARGET_DIR/**/*.profraw` — leftover instrumentation output from killed / crashed runs
+- `$LOCALAPPDATA\uffs\shmem\` (Windows) / `$XDG_DATA_HOME/uffs/shmem/` (Linux) / `~/Library/Application Support/uffs/shmem/` (macOS) — orphan shmem files from aborted daemon sessions
+
+Leaves regular `cargo build` artifacts, the sccache wrapper cache, and the Cargo registry alone, so a subsequent `cargo build` stays incremental.  Empirically frees 5–30 GB on an active dev box and up to 100+ GB after a week of heavy coverage work.
+
+If `just clean-cov` finishes and `just test` still fails with the same shmem-offload assertion, the issue is in `write_paths_blob` itself (a real regression) — check the daemon's stderr for a `tracing::warn!` line beginning `paths_blob shmem write failed; falling back to inline JSON` and open an issue with that error message.
+
+## Commit message conventions
+
+UFFS is migrating to [Conventional Commits](https://www.conventionalcommits.org/) to drive automated versioning and changelog generation via `release-plz` + `git-cliff`.  The full migration plan lives in [`docs/architecture/release-automation-plan.md`](docs/architecture/release-automation-plan.md).
+
+**What matters for you today**:
+
+- The **PR title** (which becomes the squash-merge commit subject) should follow conventional commits.  Intermediate commits on a feature branch don't need to — only what lands on `main`.
+- During the **advisory phase** (release-automation Phase R1a, ongoing), non-conforming titles trigger a bot comment but do **not** block merge.  Treat the comment as a nudge, not a gate.
+- During the **mandatory phase** (release-automation Phase R1b, scheduled after ≥1 month of advisory observation), non-conforming titles will hard-fail the required PR Fast CI check.
+
+**Recognized types and their release impact**:
+
+| Type | Meaning | Triggers release? | Version bump |
+|---|---|---|---|
+| `feat:` | User-visible new feature | Yes | Minor (0.X.0) |
+| `fix:` | User-visible bug fix | Yes | Patch (0.0.X) |
+| `perf:` | Performance improvement | Yes | Patch |
+| `feat!:` / `fix!:` | Breaking change (note the `!`) | Yes | Major (X.0.0, or minor pre-1.0) |
+| `refactor:` | Code restructure, no behavior change | No | — |
+| `docs:` | Documentation only | No | — |
+| `test:` | Test additions / changes | No | — |
+| `chore:` | Tooling, config, catch-all | No | — |
+| `ci:` | CI / workflow change | No | — |
+| `build:` | Build system / dependency change | No | — |
+| `style:` | Formatting, whitespace | No | — |
+| `revert:` | Reverts a previous commit | Inherits reverted type | Inherits |
+
+**Examples**:
+
+- `feat(mft): add zstd-compressed MFT archive support` — minor bump, appears under "Features" in changelog
+- `fix(security): correct FNV-1a pipe hash for empty inputs` — patch bump, appears under "Bug Fixes"
+- `feat(cli)!: rename --query to --filter; drop deprecated --q shorthand` — major/minor bump (depending on current v0.x vs v1.x), appears under "BREAKING CHANGES"
+- `chore: bump dependabot grouping window to weekly` — no release
+- `docs(architecture): clarify pipeline stage naming` — no release
+
+**Scopes** (optional, in parentheses after type): prefer the crate name or a short area tag.  Examples: `mft`, `cli`, `core`, `security`, `polars`, `ci`, `build`, `architecture`.  Omit the scope if the change is workspace-wide.
+
+**If in doubt**, use `chore:` — it never triggers a release.  If a PR genuinely has both a fix and a feature, split it into two PRs.
+
 ## Architecture guardrails
 
 - Do not depend on `polars` directly; use `uffs-polars`.
@@ -134,5 +199,7 @@ See `@scripts/hooks/_lint_fast.sh` and `@scripts/hooks/_lint_pre_push.sh` for th
 - Documentation map: `docs/README.md`
 - Developer docs landing page: `docs/dev/README.md`
 - Architecture docs: `docs/architecture/README.md`
+- **CI / gate architecture**: `docs/architecture/dev-flow-implementation-plan.md`
+- **Release / versioning architecture**: `docs/architecture/release-automation-plan.md`
 
 If you are changing behavior that depends on raw NTFS access, call out the Windows/Admin requirement in the relevant docs and tests.

--- a/crates/uffs-daemon/src/broker_client.rs
+++ b/crates/uffs-daemon/src/broker_client.rs
@@ -14,12 +14,17 @@
 //! 5. Use the handle for MFT reading
 
 /// The broker pipe name (must match `uffs-broker/src/broker.rs`).
+///
+/// File-local: only consumed by `broker_available` and
+/// `request_volume_handle` below.  Kept private (not `pub(crate)`) to
+/// match the Windows-only scope of its consumers and avoid polluting
+/// the crate's internal namespace with a constant no other module uses.
 #[cfg(windows)]
-pub const BROKER_PIPE_NAME: &str = r"\\.\pipe\uffs-broker";
+const BROKER_PIPE_NAME: &str = r"\\.\pipe\uffs-broker";
 
 /// Check if the Access Broker is available (pipe exists).
 #[cfg(windows)]
-pub fn broker_available() -> bool {
+pub(crate) fn broker_available() -> bool {
     use std::os::windows::ffi::OsStrExt;
 
     use windows::Win32::Storage::FileSystem::GetFileAttributesW;
@@ -42,7 +47,7 @@ pub fn broker_available() -> bool {
 /// Returns the raw handle value (as a `u64`) that can be used for MFT reading.
 /// The handle is already duplicated into our process by the broker.
 #[cfg(windows)]
-pub fn request_volume_handle(drive_letter: char) -> anyhow::Result<u64> {
+pub(crate) fn request_volume_handle(drive_letter: char) -> anyhow::Result<u64> {
     use std::io::{Read, Write};
 
     // Connect to broker pipe

--- a/crates/uffs-daemon/src/handler_csv_blob_tests.rs
+++ b/crates/uffs-daemon/src/handler_csv_blob_tests.rs
@@ -616,9 +616,24 @@ fn try_pack_csv_blob_offloads_large_blob_to_shmem() {
 
     let SearchPayload::ShmemBlob(shmem_path_str) = &response.payload else {
         panic!(
-            "large multi-column blob must be offloaded to \
-             SearchPayload::ShmemBlob; got {:?} — regression of \
-             the csv_blob shmem branch",
+            "large multi-column CSV blob must be offloaded to \
+             SearchPayload::ShmemBlob; got {:?}.\n\n\
+             If the variant you see is SearchPayload::InlineBlob(...), \
+             the daemon's `package_csv_blob` correctly fell back from \
+             shmem to inline because `uffs_client::shmem::\
+             write_paths_blob` failed — check test stderr for a \
+             `tracing::warn!` line starting with `csv_blob shmem \
+             write failed; falling back to inline JSON`.  The single \
+             most common cause is `ENOSPC` / `ERROR_DISK_FULL` on \
+             the host's data-local dir (e.g. \
+             `$CARGO_TARGET_DIR/llvm-cov-target` has grown to 100+ GB \
+             or `%LOCALAPPDATA%\\uffs\\shmem` is out of space).  \
+             Run `just clean-cov` to prune the llvm-cov tree + \
+             orphan shmem files and re-run `just test` — see \
+             CONTRIBUTING.md §\"Target-dir hygiene\" for the full \
+             recovery procedure.  If the assertion still fails after \
+             `just clean-cov`, it is a genuine regression of the \
+             csv_blob shmem branch.",
             response.payload
         );
     };

--- a/crates/uffs-daemon/src/handler_paths_blob_tests.rs
+++ b/crates/uffs-daemon/src/handler_paths_blob_tests.rs
@@ -171,8 +171,23 @@ fn try_pack_paths_blob_offloads_large_blob_to_shmem() {
     let SearchPayload::ShmemBlob(shmem_path_str) = &response.payload else {
         panic!(
             "large path-only projection must be offloaded to \
-             SearchPayload::ShmemBlob; got {:?} — regression of \
-             the binary transport branch in try_pack_paths_blob",
+             SearchPayload::ShmemBlob; got {:?}.\n\n\
+             If the variant you see is SearchPayload::InlineBlob(...), \
+             the daemon's `try_pack_paths_blob` correctly fell back \
+             from shmem to inline because `uffs_client::shmem::\
+             write_paths_blob` failed — check test stderr for a \
+             `tracing::warn!` line starting with `paths_blob shmem \
+             write failed; falling back to inline JSON`.  The single \
+             most common cause is `ENOSPC` / `ERROR_DISK_FULL` on \
+             the host's data-local dir (e.g. \
+             `$CARGO_TARGET_DIR/llvm-cov-target` has grown to 100+ GB \
+             or `%LOCALAPPDATA%\\uffs\\shmem` is out of space).  \
+             Run `just clean-cov` to prune the llvm-cov tree + \
+             orphan shmem files and re-run `just test` — see \
+             CONTRIBUTING.md §\"Target-dir hygiene\" for the full \
+             recovery procedure.  If the assertion still fails after \
+             `just clean-cov`, it is a genuine regression of the \
+             binary transport branch in `try_pack_paths_blob`.",
             response.payload
         );
     };

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -417,7 +417,7 @@ impl IndexManager {
         clippy::use_debug,
         reason = "[diag] diagnostic tracing — remove after D: drive issue is resolved"
     )]
-    pub async fn load_live_drives(
+    pub(crate) async fn load_live_drives(
         &self,
         drives: &[char],
         no_cache: bool,
@@ -472,8 +472,15 @@ impl IndexManager {
                     // Abort the remaining stuck tasks (best-effort;
                     // kernel-mode I/O may not be interruptible, but
                     // process::exit at daemon shutdown will clean up).
+                    //
+                    // We intentionally do NOT update `loaded` here:
+                    // the surrounding loop is about to `break`, and
+                    // `set_ready()` (below the loop) transitions the
+                    // status out of `Loading` regardless — so any
+                    // write to `loaded` would be dead.  Stuck-drive
+                    // observability is carried by the `remaining`
+                    // count logged immediately above.
                     join_set.abort_all();
-                    loaded = total;
                     break;
                 }
             };

--- a/crates/uffs-daemon/src/ipc.rs
+++ b/crates/uffs-daemon/src/ipc.rs
@@ -581,7 +581,7 @@ fn create_pipe_server(
 /// Mirrors the Unix version: secure dir (icacls owner-only ACL), socket
 /// file permissions, max connections, peer verification via ACL.
 #[cfg(windows)]
-pub async fn run_ipc_server(
+pub(crate) async fn run_ipc_server(
     index: Arc<IndexManager>,
     lifecycle: LifecycleHandle,
 ) -> anyhow::Result<()> {

--- a/crates/uffs-daemon/src/lifecycle.rs
+++ b/crates/uffs-daemon/src/lifecycle.rs
@@ -108,7 +108,7 @@ impl LifecycleHandle {
     /// finishes loading.  Updates the heartbeat timestamp so the idle
     /// timer knows the load phase is still making progress.
     #[cfg(windows)]
-    pub fn record_load_progress(&self) {
+    pub(crate) fn record_load_progress(&self) {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |dur| dur.as_secs());

--- a/crates/uffs-daemon/src/main.rs
+++ b/crates/uffs-daemon/src/main.rs
@@ -15,9 +15,12 @@
 //! uffs-daemon --no-retire              # stay running indefinitely
 //! uffs-daemon --log-level debug        # verbose logging
 //! ```
-
-// Enable unstable Windows Unix domain socket support (Windows 10 1803+).
-#![cfg_attr(windows, feature(windows_unix_domain_sockets))]
+// Note: the `windows_unix_domain_sockets` nightly feature is declared in
+// `lib.rs` (where `std::os::windows::net::UnixListener` is actually used
+// by the `ipc` module).  The thin binary here only calls
+// `uffs_daemon::run_daemon()` and does not directly name any
+// feature-gated item, so declaring the feature here produces a
+// `unused_features` warning.
 
 use std::path::PathBuf;
 

--- a/crates/uffs-daemon/tests/ipc_integration.rs
+++ b/crates/uffs-daemon/tests/ipc_integration.rs
@@ -10,18 +10,21 @@
 //! Unix-domain socket.  The Windows daemon transport (named pipes) is
 //! covered by a separate integration test.
 #![cfg(test)]
-#![cfg(unix)]
 
-// These crates are runtime dependencies of uffs-daemon, not used by this test
-// target. Acknowledge them so `unused-crate-dependencies` doesn't fire.
-use core::time::Duration;
-use std::io::{BufRead, BufReader, Write};
-use std::os::unix::net::UnixStream;
-use std::path::PathBuf;
-use std::process::Command;
-
+// ─────────────────────────────────────────────────────────────────────
+// Crate-dependency acknowledgements — unconditional.
+//
+// `uffs-daemon`'s dev + lib deps are linked into this integration-test
+// binary on every platform, but every test body below is gated by
+// `#[cfg(unix)]` (the transport is a Unix domain socket).  Putting the
+// `use X as _;` suppressions at crate root keeps `unused-crate-
+// dependencies` quiet on Windows, where the inner `unix_tests` module
+// is compiled out entirely.
+// ─────────────────────────────────────────────────────────────────────
 use anyhow as _;
 use clap as _;
+use dirs_next as _;
+#[cfg(unix)]
 use libc as _;
 use libmimalloc_sys as _;
 use mimalloc as _;
@@ -39,451 +42,467 @@ use uffs_daemon as _;
 use uffs_format as _;
 use uffs_mft as _;
 use uffs_security as _;
+#[cfg(windows)]
+use windows as _;
 
-/// Find the daemon binary (`uffsd`).
-fn daemon_exe() -> PathBuf {
-    let current = std::env::current_exe().expect("current_exe");
+/// All actual test code is Unix-only because the transport is a Unix
+/// domain socket.  Tests are discovered by `cargo test` through this
+/// inner module just as they would be at crate root.
+#[cfg(unix)]
+mod unix_tests {
+    use core::time::Duration;
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixStream;
+    use std::path::PathBuf;
+    use std::process::Command;
 
-    // Try: pop binary name, pop deps/, look for uffsd
-    let mut candidate = current.clone();
-    candidate.pop(); // remove test binary
-    candidate.pop(); // remove deps/
-    candidate.push("uffsd");
-    if candidate.exists() {
-        return candidate;
-    }
+    /// Find the daemon binary (`uffsd`).
+    fn daemon_exe() -> PathBuf {
+        let current = std::env::current_exe().expect("current_exe");
 
-    // Try without deps/ (in case test isn't in deps/)
-    let mut alt = current;
-    alt.pop();
-    alt.push("uffsd");
-    if alt.exists() {
-        return alt;
-    }
-
-    // Fallback: assume it's in PATH
-    PathBuf::from("uffsd")
-}
-
-/// Get the platform socket path.
-fn socket_path() -> PathBuf {
-    let base = dirs_next::data_local_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-    #[cfg(target_os = "macos")]
-    {
-        base.join("uffs").join("daemon.sock")
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        base.join("uffs").join("daemon.sock")
-    }
-}
-
-/// PID file path.
-fn pid_path() -> PathBuf {
-    let base = dirs_next::data_local_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-    base.join("uffs").join("daemon.pid")
-}
-
-/// Send a request and read one response line.
-fn rpc(ws: &mut UnixStream, reader: &mut BufReader<UnixStream>, req: &str) -> String {
-    ws.write_all(req.as_bytes()).expect("write");
-    ws.write_all(b"\n").expect("newline");
-    ws.flush().expect("flush");
-    let mut line = String::new();
-    reader.read_line(&mut line).expect("read");
-    line
-}
-
-/// Start a daemon, wait for socket, return the child process.
-///
-/// Returns `None` if the daemon binary is missing or the socket doesn't appear.
-fn start_daemon(exe: &std::path::Path, extra_args: &[&str]) -> Option<std::process::Child> {
-    if !exe.exists() {
-        return None;
-    }
-    drop(std::fs::remove_file(socket_path()));
-    drop(std::fs::remove_file(pid_path()));
-
-    let mut args = vec!["--idle-timeout", "30", "--log-level", "warn"];
-    args.extend_from_slice(extra_args);
-
-    let mut daemon = Command::new(exe)
-        .args(&args)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .expect("spawn daemon");
-
-    let sock = socket_path();
-    for _tick in 0_i32..40_i32 {
-        std::thread::sleep(Duration::from_millis(100));
-        if sock.exists() {
-            return Some(daemon);
+        // Try: pop binary name, pop deps/, look for uffsd
+        let mut candidate = current.clone();
+        candidate.pop(); // remove test binary
+        candidate.pop(); // remove deps/
+        candidate.push("uffsd");
+        if candidate.exists() {
+            return candidate;
         }
-    }
-    drop(daemon.kill());
-    drop(daemon.wait());
-    None
-}
 
-/// Gracefully shut down a daemon using nonce-based shutdown, or kill it.
-fn shutdown_daemon(
-    daemon: &mut std::process::Child,
-    ws: &mut UnixStream,
-    reader: &mut BufReader<UnixStream>,
-) {
-    let nonce = std::fs::read_to_string(pid_path())
-        .ok()
-        .and_then(|pid_content| {
-            pid_content
-                .lines()
-                .nth(3)
-                .map(|line| line.trim().to_owned())
-        })
-        .unwrap_or_default();
-    if nonce.is_empty() {
-        drop(daemon.kill());
-    } else {
-        let _shutdown_resp = rpc(
-            ws,
-            reader,
-            &format!(
-                r#"{{"jsonrpc":"2.0","id":9999,"method":"shutdown","params":{{"nonce":"{nonce}"}}}}"#
-            ),
-        );
-    }
-    drop(daemon.wait());
-}
-
-/// D2/D3 integration tests — all run against one daemon instance.
-#[test]
-#[ignore = "requires pre-built daemon binary — run with --ignored"]
-fn test_daemon_ipc_all_methods() {
-    let exe = daemon_exe();
-    let Some(mut daemon) = start_daemon(&exe, &[]) else {
-        return;
-    };
-
-    let stream = UnixStream::connect(socket_path()).expect("connect");
-    stream
-        .set_read_timeout(Some(Duration::from_secs(5)))
-        .expect("timeout");
-    let mut ws = stream.try_clone().expect("clone");
-    let mut reader = BufReader::new(stream);
-
-    // Test 1: status
-    let status_resp = rpc(
-        &mut ws,
-        &mut reader,
-        r#"{"jsonrpc":"2.0","id":1,"method":"status"}"#,
-    );
-    assert!(
-        status_resp.contains("\"pid\""),
-        "status should have pid: {status_resp}"
-    );
-    assert!(
-        status_resp.contains("\"uptime_secs\""),
-        "status should have uptime: {status_resp}"
-    );
-
-    // Test 2: drives (empty)
-    let drives_resp = rpc(
-        &mut ws,
-        &mut reader,
-        r#"{"jsonrpc":"2.0","id":2,"method":"drives"}"#,
-    );
-    assert!(
-        drives_resp.contains("\"drives\":[]"),
-        "drives should be empty: {drives_resp}"
-    );
-
-    // Test 3: search (no data)
-    let search_resp = rpc(
-        &mut ws,
-        &mut reader,
-        r#"{"jsonrpc":"2.0","id":3,"method":"search","params":{"pattern":"*.rs"}}"#,
-    );
-    assert!(
-        search_resp.contains("\"rows\":[]"),
-        "search should be empty: {search_resp}"
-    );
-    assert!(
-        search_resp.contains("\"records_scanned\":0"),
-        "should scan 0: {search_resp}"
-    );
-
-    // Test 4: unknown method → -32601
-    let unknown_resp = rpc(
-        &mut ws,
-        &mut reader,
-        r#"{"jsonrpc":"2.0","id":4,"method":"nonexistent"}"#,
-    );
-    assert!(
-        unknown_resp.contains("-32601"),
-        "should be method not found: {unknown_resp}"
-    );
-
-    // Test 5: keepalive
-    let keepalive_resp = rpc(
-        &mut ws,
-        &mut reader,
-        r#"{"jsonrpc":"2.0","id":5,"method":"keepalive"}"#,
-    );
-    assert!(
-        keepalive_resp.contains("\"ok\":true"),
-        "keepalive should return ok: {keepalive_resp}"
-    );
-
-    // Test 6: invalid JSON → -32700
-    let parse_err_resp = rpc(&mut ws, &mut reader, "this is not json");
-    assert!(
-        parse_err_resp.contains("-32700"),
-        "should be parse error: {parse_err_resp}"
-    );
-
-    // Test 7: shutdown without nonce → rejected
-    let nonce_err_resp = rpc(
-        &mut ws,
-        &mut reader,
-        r#"{"jsonrpc":"2.0","id":7,"method":"shutdown","params":{}}"#,
-    );
-    assert!(
-        nonce_err_resp.contains("nonce"),
-        "should mention nonce: {nonce_err_resp}"
-    );
-
-    // Test 8: shutdown with correct nonce → accepted
-    shutdown_daemon(&mut daemon, &mut ws, &mut reader);
-}
-
-/// Real-data integration test: loads `G_mft.bin` fixture, verifies actual
-/// search.
-#[test]
-#[ignore = "requires pre-built daemon binary — run with --ignored"]
-fn test_real_data_search() {
-    let exe = daemon_exe();
-    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("tests/fixtures/drive_g/G_mft.bin");
-    if !fixture.exists() {
-        return;
-    }
-
-    let fixture_str = fixture.to_str().unwrap();
-    let Some(mut daemon) = start_daemon(&exe, &["--mft-file", fixture_str, "--no-cache"]) else {
-        return;
-    };
-
-    let stream = UnixStream::connect(socket_path()).expect("connect");
-    stream
-        .set_read_timeout(Some(Duration::from_secs(10)))
-        .expect("timeout");
-    let mut ws = stream.try_clone().expect("clone");
-    let mut reader = BufReader::new(stream);
-
-    // Poll until daemon finishes loading
-    let mut loaded = false;
-    for _poll in 0_i32..60_i32 {
-        let resp = rpc(
-            &mut ws,
-            &mut reader,
-            r#"{"jsonrpc":"2.0","id":0,"method":"drives"}"#,
-        );
-        if resp.contains("\"letter\":\"G\"") {
-            loaded = true;
-            break;
+        // Try without deps/ (in case test isn't in deps/)
+        let mut alt = current;
+        alt.pop();
+        alt.push("uffsd");
+        if alt.exists() {
+            return alt;
         }
-        std::thread::sleep(Duration::from_millis(500));
-    }
-    if !loaded {
-        drop(daemon.kill());
-        drop(daemon.wait());
-        return;
+
+        // Fallback: assume it's in PATH
+        PathBuf::from("uffsd")
     }
 
-    let drives_resp = rpc(
-        &mut ws,
-        &mut reader,
-        r#"{"jsonrpc":"2.0","id":1,"method":"drives"}"#,
-    );
-    assert!(
-        drives_resp.contains("\"letter\":\"G\""),
-        "should have drive G: {drives_resp}"
-    );
-
-    let search_all = rpc(
-        &mut ws,
-        &mut reader,
-        r#"{"jsonrpc":"2.0","id":2,"method":"search","params":{"pattern":"*","limit":10}}"#,
-    );
-    assert!(
-        search_all.contains("\"name\""),
-        "search * should return results with name: {search_all}"
-    );
-
-    let search_txt = rpc(
-        &mut ws,
-        &mut reader,
-        r#"{"jsonrpc":"2.0","id":3,"method":"search","params":{"pattern":"*.txt","limit":50}}"#,
-    );
-    assert!(
-        search_txt.contains("\"rows\""),
-        "search *.txt should have rows field: {search_txt}"
-    );
-
-    let status_resp = rpc(
-        &mut ws,
-        &mut reader,
-        r#"{"jsonrpc":"2.0","id":4,"method":"status"}"#,
-    );
-    assert!(
-        status_resp.contains("\"ready\"") || status_resp.contains("\"Ready\""),
-        "status should be ready: {status_resp}"
-    );
-
-    shutdown_daemon(&mut daemon, &mut ws, &mut reader);
-}
-
-/// D3.5.4: Benchmark — measure client round-trip latency (target <15ms).
-#[test]
-#[ignore = "requires pre-built daemon binary — run with --ignored"]
-fn test_benchmark_round_trip_latency() {
-    let exe = daemon_exe();
-    let Some(mut daemon) = start_daemon(&exe, &[]) else {
-        return;
-    };
-
-    let stream = UnixStream::connect(socket_path()).expect("connect");
-    stream
-        .set_read_timeout(Some(Duration::from_secs(5)))
-        .expect("timeout");
-    let mut ws = stream.try_clone().expect("clone");
-    let mut reader = BufReader::new(stream);
-
-    // Warm up
-    std::thread::sleep(Duration::from_millis(200));
-    for _warmup in 0_i32..10_i32 {
-        let resp = rpc(
-            &mut ws,
-            &mut reader,
-            r#"{"jsonrpc":"2.0","id":0,"method":"keepalive"}"#,
-        );
-        if resp.is_empty() {
-            drop(daemon.kill());
-            return;
+    /// Get the platform socket path.
+    fn socket_path() -> PathBuf {
+        let base = dirs_next::data_local_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+        #[cfg(target_os = "macos")]
+        {
+            base.join("uffs").join("daemon.sock")
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            base.join("uffs").join("daemon.sock")
         }
     }
 
-    // Benchmark: 100 keepalive requests
-    let iterations = 100_usize;
-    let mut latencies = Vec::with_capacity(iterations);
-    for i in 0_usize..iterations {
-        let start = std::time::Instant::now();
-        let resp = rpc(
-            &mut ws,
-            &mut reader,
-            &format!(
-                r#"{{"jsonrpc":"2.0","id":{},"method":"keepalive"}}"#,
-                i + 1000_usize
-            ),
-        );
-        let elapsed = start.elapsed();
-        if resp.contains("\"ok\"") {
-            latencies.push(elapsed);
-        }
+    /// PID file path.
+    fn pid_path() -> PathBuf {
+        let base = dirs_next::data_local_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+        base.join("uffs").join("daemon.pid")
     }
 
-    let total: Duration = latencies.iter().sum();
-    let count = u32::try_from(iterations).unwrap_or(100_u32);
-    let avg = total / count;
-
-    assert!(
-        avg.as_millis() < 15_u128,
-        "average latency {avg:?} exceeds 15ms target"
-    );
-
-    shutdown_daemon(&mut daemon, &mut ws, &mut reader);
-}
-
-/// D2.7.4: Concurrent clients — 3 connections, interleaved queries.
-#[test]
-#[ignore = "requires pre-built daemon binary — run with --ignored"]
-fn test_concurrent_clients() {
-    let exe = daemon_exe();
-    let Some(mut daemon) = start_daemon(&exe, &[]) else {
-        return;
-    };
-
-    let sock = socket_path();
-    let mut clients: Vec<(UnixStream, BufReader<UnixStream>)> = (0_i32..3_i32)
-        .filter_map(|_conn_idx| {
-            let stream = UnixStream::connect(&sock).ok()?;
-            stream.set_read_timeout(Some(Duration::from_secs(5))).ok()?;
-            let ws = stream.try_clone().ok()?;
-            let rdr = BufReader::new(stream);
-            Some((ws, rdr))
-        })
-        .collect();
-
-    assert_eq!(clients.len(), 3_usize, "should connect 3 clients");
-
-    let requests = [
-        r#"{"jsonrpc":"2.0","id":100,"method":"status"}"#,
-        r#"{"jsonrpc":"2.0","id":200,"method":"drives"}"#,
-        r#"{"jsonrpc":"2.0","id":300,"method":"keepalive"}"#,
-    ];
-    for (req_line, (ws, _)) in requests.iter().zip(clients.iter_mut()) {
-        ws.write_all(req_line.as_bytes()).expect("write");
+    /// Send a request and read one response line.
+    fn rpc(ws: &mut UnixStream, reader: &mut BufReader<UnixStream>, req: &str) -> String {
+        ws.write_all(req.as_bytes()).expect("write");
         ws.write_all(b"\n").expect("newline");
         ws.flush().expect("flush");
-    }
-
-    let mut responses = Vec::new();
-    for (_, rdr) in &mut clients {
         let mut line = String::new();
-        rdr.read_line(&mut line).expect("read response");
-        responses.push(line);
+        reader.read_line(&mut line).expect("read");
+        line
     }
 
-    #[expect(clippy::indexing_slicing, reason = "test with known 3-element vec")]
-    {
-        assert!(
-            responses[0].contains("\"id\":100"),
-            "client 0 should get id 100: {}",
-            responses[0]
-        );
-        assert!(
-            responses[0].contains("\"pid\""),
-            "client 0 should get status: {}",
-            responses[0]
-        );
-        assert!(
-            responses[1].contains("\"id\":200"),
-            "client 1 should get id 200: {}",
-            responses[1]
-        );
-        assert!(
-            responses[1].contains("\"drives\""),
-            "client 1 should get drives: {}",
-            responses[1]
-        );
-        assert!(
-            responses[2].contains("\"id\":300"),
-            "client 2 should get id 300: {}",
-            responses[2]
-        );
-        assert!(
-            responses[2].contains("\"ok\":true"),
-            "client 2 should get keepalive ok: {}",
-            responses[2]
-        );
-    };
+    /// Start a daemon, wait for socket, return the child process.
+    ///
+    /// Returns `None` if the daemon binary is missing or the socket doesn't
+    /// appear.
+    fn start_daemon(exe: &std::path::Path, extra_args: &[&str]) -> Option<std::process::Child> {
+        if !exe.exists() {
+            return None;
+        }
+        drop(std::fs::remove_file(socket_path()));
+        drop(std::fs::remove_file(pid_path()));
 
-    let Some(&mut (ref mut ws, ref mut rdr)) = clients.first_mut() else {
-        return;
-    };
-    shutdown_daemon(&mut daemon, ws, rdr);
+        let mut args = vec!["--idle-timeout", "30", "--log-level", "warn"];
+        args.extend_from_slice(extra_args);
+
+        let mut daemon = Command::new(exe)
+            .args(&args)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn daemon");
+
+        let sock = socket_path();
+        for _tick in 0_i32..40_i32 {
+            std::thread::sleep(Duration::from_millis(100));
+            if sock.exists() {
+                return Some(daemon);
+            }
+        }
+        drop(daemon.kill());
+        drop(daemon.wait());
+        None
+    }
+
+    /// Gracefully shut down a daemon using nonce-based shutdown, or kill it.
+    fn shutdown_daemon(
+        daemon: &mut std::process::Child,
+        ws: &mut UnixStream,
+        reader: &mut BufReader<UnixStream>,
+    ) {
+        let nonce = std::fs::read_to_string(pid_path())
+            .ok()
+            .and_then(|pid_content| {
+                pid_content
+                    .lines()
+                    .nth(3)
+                    .map(|line| line.trim().to_owned())
+            })
+            .unwrap_or_default();
+        if nonce.is_empty() {
+            drop(daemon.kill());
+        } else {
+            let _shutdown_resp = rpc(
+                ws,
+                reader,
+                &format!(
+                    r#"{{"jsonrpc":"2.0","id":9999,"method":"shutdown","params":{{"nonce":"{nonce}"}}}}"#
+                ),
+            );
+        }
+        drop(daemon.wait());
+    }
+
+    /// D2/D3 integration tests — all run against one daemon instance.
+    #[test]
+    #[ignore = "requires pre-built daemon binary — run with --ignored"]
+    fn test_daemon_ipc_all_methods() {
+        let exe = daemon_exe();
+        let Some(mut daemon) = start_daemon(&exe, &[]) else {
+            return;
+        };
+
+        let stream = UnixStream::connect(socket_path()).expect("connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("timeout");
+        let mut ws = stream.try_clone().expect("clone");
+        let mut reader = BufReader::new(stream);
+
+        // Test 1: status
+        let status_resp = rpc(
+            &mut ws,
+            &mut reader,
+            r#"{"jsonrpc":"2.0","id":1,"method":"status"}"#,
+        );
+        assert!(
+            status_resp.contains("\"pid\""),
+            "status should have pid: {status_resp}"
+        );
+        assert!(
+            status_resp.contains("\"uptime_secs\""),
+            "status should have uptime: {status_resp}"
+        );
+
+        // Test 2: drives (empty)
+        let drives_resp = rpc(
+            &mut ws,
+            &mut reader,
+            r#"{"jsonrpc":"2.0","id":2,"method":"drives"}"#,
+        );
+        assert!(
+            drives_resp.contains("\"drives\":[]"),
+            "drives should be empty: {drives_resp}"
+        );
+
+        // Test 3: search (no data)
+        let search_resp = rpc(
+            &mut ws,
+            &mut reader,
+            r#"{"jsonrpc":"2.0","id":3,"method":"search","params":{"pattern":"*.rs"}}"#,
+        );
+        assert!(
+            search_resp.contains("\"rows\":[]"),
+            "search should be empty: {search_resp}"
+        );
+        assert!(
+            search_resp.contains("\"records_scanned\":0"),
+            "should scan 0: {search_resp}"
+        );
+
+        // Test 4: unknown method → -32601
+        let unknown_resp = rpc(
+            &mut ws,
+            &mut reader,
+            r#"{"jsonrpc":"2.0","id":4,"method":"nonexistent"}"#,
+        );
+        assert!(
+            unknown_resp.contains("-32601"),
+            "should be method not found: {unknown_resp}"
+        );
+
+        // Test 5: keepalive
+        let keepalive_resp = rpc(
+            &mut ws,
+            &mut reader,
+            r#"{"jsonrpc":"2.0","id":5,"method":"keepalive"}"#,
+        );
+        assert!(
+            keepalive_resp.contains("\"ok\":true"),
+            "keepalive should return ok: {keepalive_resp}"
+        );
+
+        // Test 6: invalid JSON → -32700
+        let parse_err_resp = rpc(&mut ws, &mut reader, "this is not json");
+        assert!(
+            parse_err_resp.contains("-32700"),
+            "should be parse error: {parse_err_resp}"
+        );
+
+        // Test 7: shutdown without nonce → rejected
+        let nonce_err_resp = rpc(
+            &mut ws,
+            &mut reader,
+            r#"{"jsonrpc":"2.0","id":7,"method":"shutdown","params":{}}"#,
+        );
+        assert!(
+            nonce_err_resp.contains("nonce"),
+            "should mention nonce: {nonce_err_resp}"
+        );
+
+        // Test 8: shutdown with correct nonce → accepted
+        shutdown_daemon(&mut daemon, &mut ws, &mut reader);
+    }
+
+    /// Real-data integration test: loads `G_mft.bin` fixture, verifies actual
+    /// search.
+    #[test]
+    #[ignore = "requires pre-built daemon binary — run with --ignored"]
+    fn test_real_data_search() {
+        let exe = daemon_exe();
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("tests/fixtures/drive_g/G_mft.bin");
+        if !fixture.exists() {
+            return;
+        }
+
+        let fixture_str = fixture.to_str().unwrap();
+        let Some(mut daemon) = start_daemon(&exe, &["--mft-file", fixture_str, "--no-cache"])
+        else {
+            return;
+        };
+
+        let stream = UnixStream::connect(socket_path()).expect("connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .expect("timeout");
+        let mut ws = stream.try_clone().expect("clone");
+        let mut reader = BufReader::new(stream);
+
+        // Poll until daemon finishes loading
+        let mut loaded = false;
+        for _poll in 0_i32..60_i32 {
+            let resp = rpc(
+                &mut ws,
+                &mut reader,
+                r#"{"jsonrpc":"2.0","id":0,"method":"drives"}"#,
+            );
+            if resp.contains("\"letter\":\"G\"") {
+                loaded = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        if !loaded {
+            drop(daemon.kill());
+            drop(daemon.wait());
+            return;
+        }
+
+        let drives_resp = rpc(
+            &mut ws,
+            &mut reader,
+            r#"{"jsonrpc":"2.0","id":1,"method":"drives"}"#,
+        );
+        assert!(
+            drives_resp.contains("\"letter\":\"G\""),
+            "should have drive G: {drives_resp}"
+        );
+
+        let search_all = rpc(
+            &mut ws,
+            &mut reader,
+            r#"{"jsonrpc":"2.0","id":2,"method":"search","params":{"pattern":"*","limit":10}}"#,
+        );
+        assert!(
+            search_all.contains("\"name\""),
+            "search * should return results with name: {search_all}"
+        );
+
+        let search_txt = rpc(
+            &mut ws,
+            &mut reader,
+            r#"{"jsonrpc":"2.0","id":3,"method":"search","params":{"pattern":"*.txt","limit":50}}"#,
+        );
+        assert!(
+            search_txt.contains("\"rows\""),
+            "search *.txt should have rows field: {search_txt}"
+        );
+
+        let status_resp = rpc(
+            &mut ws,
+            &mut reader,
+            r#"{"jsonrpc":"2.0","id":4,"method":"status"}"#,
+        );
+        assert!(
+            status_resp.contains("\"ready\"") || status_resp.contains("\"Ready\""),
+            "status should be ready: {status_resp}"
+        );
+
+        shutdown_daemon(&mut daemon, &mut ws, &mut reader);
+    }
+
+    /// D3.5.4: Benchmark — measure client round-trip latency (target <15ms).
+    #[test]
+    #[ignore = "requires pre-built daemon binary — run with --ignored"]
+    fn test_benchmark_round_trip_latency() {
+        let exe = daemon_exe();
+        let Some(mut daemon) = start_daemon(&exe, &[]) else {
+            return;
+        };
+
+        let stream = UnixStream::connect(socket_path()).expect("connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("timeout");
+        let mut ws = stream.try_clone().expect("clone");
+        let mut reader = BufReader::new(stream);
+
+        // Warm up
+        std::thread::sleep(Duration::from_millis(200));
+        for _warmup in 0_i32..10_i32 {
+            let resp = rpc(
+                &mut ws,
+                &mut reader,
+                r#"{"jsonrpc":"2.0","id":0,"method":"keepalive"}"#,
+            );
+            if resp.is_empty() {
+                drop(daemon.kill());
+                return;
+            }
+        }
+
+        // Benchmark: 100 keepalive requests
+        let iterations = 100_usize;
+        let mut latencies = Vec::with_capacity(iterations);
+        for i in 0_usize..iterations {
+            let start = std::time::Instant::now();
+            let resp = rpc(
+                &mut ws,
+                &mut reader,
+                &format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"method":"keepalive"}}"#,
+                    i + 1000_usize
+                ),
+            );
+            let elapsed = start.elapsed();
+            if resp.contains("\"ok\"") {
+                latencies.push(elapsed);
+            }
+        }
+
+        let total: Duration = latencies.iter().sum();
+        let count = u32::try_from(iterations).unwrap_or(100_u32);
+        let avg = total / count;
+
+        assert!(
+            avg.as_millis() < 15_u128,
+            "average latency {avg:?} exceeds 15ms target"
+        );
+
+        shutdown_daemon(&mut daemon, &mut ws, &mut reader);
+    }
+
+    /// D2.7.4: Concurrent clients — 3 connections, interleaved queries.
+    #[test]
+    #[ignore = "requires pre-built daemon binary — run with --ignored"]
+    fn test_concurrent_clients() {
+        let exe = daemon_exe();
+        let Some(mut daemon) = start_daemon(&exe, &[]) else {
+            return;
+        };
+
+        let sock = socket_path();
+        let mut clients: Vec<(UnixStream, BufReader<UnixStream>)> = (0_i32..3_i32)
+            .filter_map(|_conn_idx| {
+                let stream = UnixStream::connect(&sock).ok()?;
+                stream.set_read_timeout(Some(Duration::from_secs(5))).ok()?;
+                let ws = stream.try_clone().ok()?;
+                let rdr = BufReader::new(stream);
+                Some((ws, rdr))
+            })
+            .collect();
+
+        assert_eq!(clients.len(), 3_usize, "should connect 3 clients");
+
+        let requests = [
+            r#"{"jsonrpc":"2.0","id":100,"method":"status"}"#,
+            r#"{"jsonrpc":"2.0","id":200,"method":"drives"}"#,
+            r#"{"jsonrpc":"2.0","id":300,"method":"keepalive"}"#,
+        ];
+        for (req_line, (ws, _)) in requests.iter().zip(clients.iter_mut()) {
+            ws.write_all(req_line.as_bytes()).expect("write");
+            ws.write_all(b"\n").expect("newline");
+            ws.flush().expect("flush");
+        }
+
+        let mut responses = Vec::new();
+        for (_, rdr) in &mut clients {
+            let mut line = String::new();
+            rdr.read_line(&mut line).expect("read response");
+            responses.push(line);
+        }
+
+        #[expect(clippy::indexing_slicing, reason = "test with known 3-element vec")]
+        {
+            assert!(
+                responses[0].contains("\"id\":100"),
+                "client 0 should get id 100: {}",
+                responses[0]
+            );
+            assert!(
+                responses[0].contains("\"pid\""),
+                "client 0 should get status: {}",
+                responses[0]
+            );
+            assert!(
+                responses[1].contains("\"id\":200"),
+                "client 1 should get id 200: {}",
+                responses[1]
+            );
+            assert!(
+                responses[1].contains("\"drives\""),
+                "client 1 should get drives: {}",
+                responses[1]
+            );
+            assert!(
+                responses[2].contains("\"id\":300"),
+                "client 2 should get id 300: {}",
+                responses[2]
+            );
+            assert!(
+                responses[2].contains("\"ok\":true"),
+                "client 2 should get keepalive ok: {}",
+                responses[2]
+            );
+        };
+
+        let Some(&mut (ref mut ws, ref mut rdr)) = clients.first_mut() else {
+            return;
+        };
+        shutdown_daemon(&mut daemon, ws, rdr);
+    }
 }

--- a/crates/uffs-mft/benches/mft_read.rs
+++ b/crates/uffs-mft/benches/mft_read.rs
@@ -44,6 +44,13 @@ use uffs_mft as _;
 use uffs_polars as _;
 use uffs_security as _;
 use uffs_text as _;
+// `windows` is linked via the `[target.'cfg(windows)'.dependencies]` section
+// of `uffs-mft`'s Cargo.toml.  The benchmark's Windows body only reaches the
+// crate transitively (through `uffs_mft::AlignedBuffer` / `ParsedColumns`),
+// so we acknowledge it here to keep `unused-crate-dependencies` quiet on
+// Windows without forcing a direct dependency on a platform-only crate.
+#[cfg(windows)]
+use windows as _;
 use zerocopy as _;
 
 #[cfg(feature = "zstd")]

--- a/docs/architecture/dev-flow-implementation-plan.md
+++ b/docs/architecture/dev-flow-implementation-plan.md
@@ -3,7 +3,17 @@
 <!-- SPDX-License-Identifier: MPL-2.0 -->
 <!-- Copyright (c) 2025-2026 SKY, LLC. -->
 
-Companion to `dev-flow.md`.  Incorporates external review (2026-04-23)
+Companion to `dev-flow.md`.  **Sibling plan**: see
+[`release-automation-plan.md`](release-automation-plan.md) for the
+release/versioning architecture (release-plz + git-cliff + eventual
+crates.io publishing).  This document owns **merge-time CI gates**;
+the release-automation plan owns **what happens after merge to main**
+— version bump, changelog generation, tag creation, binary + crate
+publishing.  Both plans share `release.yml` (binary distribution,
+left unchanged) and `scripts/ci-pipeline/src/version.rs` (whose
+version-bump functions are retired in release-automation Phase R5).
+
+Incorporates external review (2026-04-23)
 that correctly identified structural gaps in v1:
 
 - v1 still treated CI as **one long lane** instead of separating
@@ -1501,6 +1511,14 @@ Measured against current `v0.5.71` baseline:
 - **Does not adopt a pre-commit framework** (e.g. `pre-commit` the
   Python tool).  Bash + `just` stays; rationale: one less dependency
   for new contributors.
+- **Does not own release automation.**  Version bumping, changelog
+  generation, release PR cadence, tag creation semantics, and eventual
+  crates.io publishing are the concern of
+  [`release-automation-plan.md`](release-automation-plan.md).  Phases
+  in that plan (R0-R9) are sequenced independently of Phases 1-8 here;
+  they share only `release.yml` (unchanged by both) and the version-
+  bump bits of `scripts/ci-pipeline/src/version.rs` (retired in
+  release-automation R5).
 
 ---
 

--- a/docs/architecture/release-automation-plan.md
+++ b/docs/architecture/release-automation-plan.md
@@ -1,0 +1,2236 @@
+<!--
+SPDX-License-Identifier: MPL-2.0
+Copyright (c) 2025-2026 SKY, LLC.
+
+UFFS — Release Automation Implementation Plan
+-->
+
+# Release Automation Implementation Plan (v1)
+
+> Sibling document to
+> [`dev-flow-implementation-plan.md`](dev-flow-implementation-plan.md).
+> Where `dev-flow-implementation-plan.md` describes the **CI / gate**
+> architecture (what it takes to merge a PR safely), this document
+> describes the **release / versioning** architecture (what it takes
+> to ship a versioned release safely and, eventually, to publish
+> crates to `crates.io`).
+
+## 0. TL;DR
+
+| Aspect | Today | Target |
+|---|---|---|
+| Version source of truth | `[workspace.package].version` in root `Cargo.toml` (correct — all 12 crates inherit via `version.workspace = true`) | **Unchanged** |
+| Bumping mechanism | `build/update_all_versions.rs` (1028-line hand-rolled rust-script) invoked by `just ship` via `scripts/ci-pipeline/src/version.rs` | **`release-plz` GitHub Action** computing bumps from conventional commits |
+| Changelog | `CHANGELOG.md` `## [Unreleased]` section maintained **by hand** | **Generated** by `git-cliff` via `cliff.toml` template, assembled into `CHANGELOG.md` by release-plz |
+| Release PR | None — version bump lands directly on `main` via `just ship` → commit → push | **Release-plz PR**: `chore(release): prepare vX.Y.Z` opened automatically, human-reviewed, merged manually |
+| Tag creation | `auto-tag-release.yml` watches for `Cargo.toml` diff, dispatches `release.yml` | **release-plz** creates the tag directly after the release PR merges; `release.yml` keeps its tag-triggered path |
+| Binary distribution | `release.yml` (existing, ~780 lines, works well) | **Unchanged** — `release.yml` remains the binary-producing workflow |
+| crates.io publishing | `publish = true` accidentally set in `[workspace.metadata.release-plz]`, no workflow actually running | **Scaffolding only**: `publish = false` workspace-wide, dry-run validation in CI, docs.rs metadata per crate, trusted-publishing (OIDC) prep docs. **Actual publish: deferred to a separate plan.** |
+| Commit convention | Conventional commits used consistently by habit, not enforced | Advisory PR comment from day 1; mandatory gate after 1 month of observation |
+
+**Central mental shift**:
+
+> *"Stop bumping versions. Start describing changes. The version
+> computes itself."*
+
+## 1. Goals and non-goals
+
+### 1.1 Goals (in scope for this plan)
+
+1. **Eliminate bespoke version tooling.** Delete
+   `build/update_all_versions.rs` and the version-bump path of
+   `scripts/ci-pipeline/src/version.rs`.  Replace with
+   `release-plz` + `git-cliff` + conventional commits.
+2. **Automate changelog generation** so `CHANGELOG.md` is
+   derivable from commit history, not a hand-maintained artifact
+   that drifts.
+3. **Human-reviewable release cadence**: every release goes through
+   a PR (`chore(release): prepare vX.Y.Z`) that a human reviews
+   before merging.  No silent publish-on-push.
+4. **Preserve the existing `release.yml` binary pipeline** as-is.
+   Release-plz integrates **upstream** of it (opens the version PR
+   and eventually creates the tag); `release.yml` continues to do
+   what it does well: build signed binaries, emit SLSA attestations,
+   publish GitHub releases.
+5. **Scaffold crates.io publishing end-to-end** so that when the
+   project decides to publish, the switch is a **configuration
+   flip** (`publish = false` → `publish = true` per crate), not
+   weeks of setup:
+   - Per-crate metadata complete (`description`, `keywords`,
+     `categories`, `readme`, `license`)
+   - `[package.metadata.docs.rs]` per crate for docs.rs
+   - `cargo publish --dry-run` in CI catches metadata drift
+   - Trusted publishing (OIDC) path documented; secrets slots
+     named but empty
+   - Publish order (dependency DAG) documented
+   - First-publish checklist written
+6. **Formalize conventional commits** in `CONTRIBUTING.md` with
+   concrete examples, soft-enforced by a PR-level advisory bot
+   initially, hard-enforced once the discipline is proven stable.
+7. **Every step reversible.** No phase in this plan is committed
+   such that the next phase can't be rolled back to the previous
+   state with a single `git revert`.
+
+### 1.2 Non-goals (explicitly out of scope)
+
+1. **Actually publishing to crates.io.**  We're building the
+   ramp; taking off is a separate decision recorded in a separate
+   plan.  When that happens, the publish plan will reference this
+   plan's §5 ("crates.io scaffolding deep-dive") as its prerequisite
+   state.
+2. **`cargo-dist` adoption.**  The workspace already has
+   `[workspace.metadata.dist]` config (probably leftover from prior
+   exploration), but `release.yml` already does everything cargo-dist
+   would: builds for 5 targets, signs artifacts, emits SLSA
+   attestations, uploads to GitHub Releases.  Adding cargo-dist would
+   create a second, parallel binary pipeline.  **Explicitly declined.**
+   See §12 "Non-goals deep-dive" for the comparison and rationale.
+3. **Independent per-crate versioning.**  Today all 12 crates share
+   the workspace version `0.5.71`.  Independent versions (each crate
+   evolving on its own SemVer trajectory) is the pattern for mature
+   published libraries.  UFFS is currently a binary app; per-crate
+   versions don't add value.  Deferred to Phase R9, which is itself
+   deferred until approaching v1.0.
+4. **Breaking-change detection via API diffing** (`cargo-semver-checks`,
+   `public-api`).  Worth revisiting once publishing is live and the
+   stable-API contract becomes observable.  Not needed before then.
+5. **Automated pre-release / nightly publish to crates.io** (`-alpha`,
+   `-rc` channel tooling).  Stable releases only for the foreseeable
+   future; pre-release infrastructure added on-demand.
+6. **Signing the `Cargo.lock` / SBOM-driven release.**  The existing
+   `release.yml` already handles SLSA provenance attestation and
+   SHA256 manifests; this plan doesn't touch artifact signing.
+7. **Monorepo-style versioning tools from non-Rust ecosystems**
+   (changesets, semantic-release, standard-version).  Rust-native
+   tooling (release-plz + git-cliff) is purpose-built for Cargo
+   workspaces and integrates with crates.io semantics.  Cross-ecosystem
+   tools always miss Rust-specific concerns (workspace inheritance,
+   `cargo publish` ordering, cross-crate dependency version updates).
+
+### 1.3 Success criteria
+
+The plan is complete when **all** of the following hold
+simultaneously, without regression:
+
+- Opening a PR with a `feat:` commit and merging it causes release-plz
+  to open a release PR within 10 min of `main` landing the commit,
+  with:
+  - `Cargo.toml` workspace version bumped (minor increment)
+  - `CHANGELOG.md` updated with the new version header and the
+    commit's subject line categorized under "Features"
+  - `Cargo.lock` refreshed
+  - PR body containing the full changelog-style diff
+- Merging the release PR creates the `vX.Y.Z` tag on `main`, which
+  fires `release.yml` via its `push: tags: v*` trigger, producing
+  a GitHub Release with signed binaries within 45 min.
+- No step in the above flow touches `build/update_all_versions.rs`
+  (which is deleted) or `scripts/ci-pipeline/src/version.rs`'s
+  version-bump code path (which is deleted).
+- Running `cargo publish --dry-run --workspace` in CI succeeds on a
+  scheduled nightly job, proving per-crate metadata is valid for
+  crates.io.
+- `publish = false` explicitly set in every crate's `Cargo.toml`
+  and `[workspace.metadata.release-plz]`, preventing accidental
+  publish.
+- `CONTRIBUTING.md` has a "Commit convention" section citing
+  [Conventional Commits 1.0.0](https://www.conventionalcommits.org/)
+  with concrete UFFS examples, and a commit-msg CI check that posts
+  advisory comments on non-conforming PR title commits.
+- Reverting **any** of R0-R7 in isolation restores the project to a
+  functional state (versioning still works, releases still ship).
+
+## 2. Current state audit
+
+### 2.1 The version source of truth
+
+`@/Users/rnio/Private/Github/UltraFastFileSearch/Cargo.toml:46-47`
+
+```@/Users/rnio/Private/Github/UltraFastFileSearch/Cargo.toml:46-47
+[workspace.package]
+version = "0.5.71"
+```
+
+All 12 member crates inherit correctly:
+
+```toml
+# Pattern repeated across every crate/*/Cargo.toml:
+[package]
+name = "uffs-<name>"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+```
+
+Verified via grep on 2026-04-24: every crate in `crates/` plus
+`scripts/ci-pipeline/` uses workspace inheritance.  **The
+inheritance mechanism itself is correct and stays.**
+
+### 2.2 The bespoke bumper
+
+`@/Users/rnio/Private/Github/UltraFastFileSearch/build/update_all_versions.rs`
+is a **1028-line rust-script** (`#!/usr/bin/env rust-script`) that:
+
+1. Reads `[workspace.package].version` via hand-rolled TOML scanning
+2. Parses the SemVer triple (`MAJOR.MINOR.PATCH`)
+3. Increments patch / minor / major based on CLI arg (default: patch)
+4. Rewrites `Cargo.toml` using **4 spacing-variant patterns** to
+   match whatever formatting was on disk:
+
+```@/Users/rnio/Private/Github/UltraFastFileSearch/build/update_all_versions.rs:674-679
+    let patterns = [
+        format!("version = \"{}\"", current),           // Standard spacing (most common)
+        format!("version       = \"{}\"", current),     // Aligned spacing (formatted)
+        format!("version=\"{}\"", current),             // No spaces (compact)
+        format!("version\t= \"{}\"", current),          // Tab spacing (legacy)
+    ];
+```
+
+5. Updates `README.md` with **5 regex-like patterns** for version
+   badges, git tags, prose mentions, dependency declarations, and
+   TOML examples.
+6. Updates `CHANGELOG.md` version references.
+7. Updates `docs/*.md` files.
+
+The rust-script approach was pragmatic at inception (single file,
+no external deps, runnable directly) but has grown into a
+**maintenance liability**:
+
+- 4 variant patterns for a single Cargo.toml field — every patterns
+  list is a place for new Cargo.toml formatting styles to silently
+  not match.
+- 5 README patterns — a prose-heavy README makes it easy to forget
+  a reference; the script won't flag unmatched mentions.
+- No validation that the NEW version string is itself a valid
+  SemVer (it parses the OLD version then formats the new one, but
+  no round-trip check).
+- The script is duplicated in Rust in
+  `scripts/ci-pipeline/src/version.rs` (which shells out to the
+  rust-script rather than reimplementing — reasonable, but means
+  two files claim authority over versioning).
+
+**Observed bugs in the bespoke bumper** (informing the decision
+to retire rather than patch it):
+
+- **`Cargo.lock` drift after bump** — the script edits
+  `[workspace.package].version` in `Cargo.toml` but does NOT run
+  `cargo check` / `cargo generate-lockfile` afterwards, so
+  `Cargo.lock`'s `[[package]]` entries for the 12 internal crates
+  keep the OLD version string.  Observed on `origin/main` at
+  `v0.5.69`-era: workspace `Cargo.toml` = `0.5.69`, `Cargo.lock`
+  internal entries = `0.5.68`.  Self-heals intermittently (any
+  subsequent `cargo` invocation that touches the lockfile —
+  Dependabot dep bump, CI cold run, `just check` locally —
+  silently rewrites the internal versions), which is worse than a
+  hard failure because **the drift escapes notice for multiple
+  releases**.  Breaks the "tagged release is exactly reproducible
+  from its `Cargo.lock`" invariant for whichever releases shipped
+  before the self-heal fired.  The one-line fix on the bespoke
+  side is to run `cargo generate-lockfile --offline` (or a plain
+  `cargo check`) after the Cargo.toml edits; see R0 for the
+  interim-patch option.  **Phase R5 retires the entire script so
+  this bug disappears structurally**: release-plz's release PR
+  always includes the `Cargo.lock` diff alongside the `Cargo.toml`
+  diff because release-plz invokes `cargo update --workspace`
+  (via `dependencies_update = true`) as part of preparing the PR.
+- **Hardcoded patch-bump regardless of commit types** — see §2.3.
+  `feat:` commits silently become patch bumps, violating SemVer
+  expectations for any future library consumer.  Release-plz's
+  commit-driven bump computation fixes this structurally.
+- **No verification that the README / CHANGELOG / doc pattern
+  sweeps actually matched** — if one of the 5 README patterns
+  silently misses (because the README got reformatted), the
+  script exits 0 and the stale version string stays in prose.
+  Caught by eyeballing; not caught by CI.  Release-plz doesn't
+  touch prose files, so this failure mode disappears by
+  construction (README prose version references should be
+  removed in R6 README rewrites).
+
+### 2.3 The `just ship` flow
+
+```@/Users/rnio/Private/Github/UltraFastFileSearch/scripts/ci-pipeline/src/version.rs:88-101
+pub(crate) async fn increment_version() -> Result<()> {
+    println!("📈 Incrementing version...");
+    let output = Command::new("./build/update_all_versions.rs")
+        .arg("patch")
+        .output()
+        .await
+        .context("Failed to execute version update script")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Version bump failed: {stderr}");
+    }
+    println!("✅ Version incremented successfully");
+    Ok(())
+}
+```
+
+The `just ship` command (via the `ci-pipeline` binary) runs a
+**pipelined flow**: version bump → commit → push to a release
+branch → open PR.  The version bump is **hardcoded to `patch`**
+regardless of what the commits since the last release actually
+did — `feat:` commits silently become patch bumps, breaking SemVer
+expectations for any future consumer.
+
+### 2.4 The tag/release handoff
+
+`@/Users/rnio/Private/Github/UltraFastFileSearch/.github/workflows/auto-tag-release.yml`
+(169 lines) watches for `Cargo.toml` changes on `main` and, if
+`[workspace.package].version` differs from `HEAD~1`, dispatches
+`release.yml` via `gh workflow run` with the new version.  It does
+NOT push the tag itself — `release.yml` creates and pushes the tag
+after a successful build, making the tag a "release succeeded"
+marker rather than an intention.
+
+This two-workflow split is **actually well-designed**: the tag
+means "a release was built and published", nothing weaker.
+Release-plz can participate without disturbing this invariant —
+see §3 for how.
+
+### 2.5 The existing release-plz config hint
+
+`@/Users/rnio/Private/Github/UltraFastFileSearch/Cargo.toml:641-649`
+
+```@/Users/rnio/Private/Github/UltraFastFileSearch/Cargo.toml:641-649
+# Workspace-level release-plz configuration
+[workspace.metadata.release-plz]
+git_release_enable = true
+git_tag_enable = true
+changelog_update = true
+dependencies_update = true
+allow_dirty = false
+publish = true
+git_release_draft = false
+```
+
+This section is **dead code** (no release-plz workflow exists) but
+shows prior thinking about this migration.  The `publish = true`
+setting is the most dangerous residue: if release-plz were
+activated with the current config, it would attempt to publish all
+12 crates to crates.io immediately.  **Must be flipped to
+`publish = false` as the first scaffolding step.**
+
+### 2.6 The cargo-dist config hint
+
+`@/Users/rnio/Private/Github/UltraFastFileSearch/Cargo.toml:652-664`
+
+```@/Users/rnio/Private/Github/UltraFastFileSearch/Cargo.toml:652-664
+# Workspace-level cargo-dist configuration
+[workspace.metadata.dist]
+cargo-dist-version = "0.30.0"
+ci = ["github"]
+installers = ["shell", "powershell"]
+targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-pc-windows-msvc",
+]
+pr-run-mode = "plan"
+allow-dirty = ["ci"]
+```
+
+Another dead-code block.  `cargo-dist` competes directly with
+`release.yml` — both build cross-platform binaries and emit
+GitHub Releases.  `release.yml` is **already in production** and
+handles things cargo-dist does NOT natively do (SLSA provenance
+attestation, sccache integration, per-target rustflags baselines,
+Windows-specific cross-compile via xwin).  **Declined in §12.**
+Block will be deleted as part of Phase R0 pre-flight.
+
+### 2.7 The changelog
+
+`@/Users/rnio/Private/Github/UltraFastFileSearch/CHANGELOG.md` uses
+the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
+with a manually-edited `## [Unreleased]` section at the top.  789
+lines as of 2026-04-24, with high-quality prose but clearly
+maintained by hand — recent entries describe CI cutover work in
+fine-grained detail that came from the PR descriptions, not an
+automated harvest.
+
+**High information density per entry, but also high
+maintenance cost and drift risk**: if a PR merges without someone
+editing CHANGELOG.md, the change silently omits from the next
+release's notes.  Observed at least twice in the last 10 PRs
+(PR #51 and #52 landed without `## [Unreleased]` updates; caught
+only by tribal memory when compiling release notes later).
+
+### 2.8 Conventional commits adoption
+
+Scanning recent merges on `main`:
+
+```
+0e811d0bb fix(tests): correct stale expected values in Windows-gated unit tests (#55)
+ea65c5f84 docs(dev-flow): flip Phase 5 dashboard row 🟡 → ✅ + add sub-status (#56)
+2d3a7f5b3 fix(preview): complete Phase 5 re-bake — windows-latest move + RC_PATH fix (#52)
+b9a67f2dc docs(dev-flow): Phase 5 live bake ticks + preview-artifacts.yml robustness fixes (#51)
+294057973 chore(ci): retire stale ci.yml references across workspace (#50)
+1edf12ff1 docs(dev-flow): reconcile plan with post-cutover live state (v3.2) (#49)
+6f99b86aa feat(ci): cutover to pr-fast.yml + ruleset — retire ci.yml (#48)
+eef3359b2 chore(ci): actions hardening retrofit across workflows (#47)
+```
+
+**8/8 recent merges follow conventional-commit format** — `fix:`,
+`docs:`, `chore:`, `feat:`, all with appropriate scope.  The
+discipline is already there; the tooling just doesn't consume it.
+
+This is the single most important enabler for the entire plan:
+**release-plz works immediately** against a history like this.
+No backfill of commit messages needed.
+
+### 2.9 Per-crate metadata readiness for crates.io
+
+Cross-referencing crate Cargo.toml files against crates.io's
+publication requirements:
+
+| Field | Workspace source | Status |
+|---|---|---|
+| `name` | per-crate (unique) | ✅ all unique, all present |
+| `version` | `workspace.package` | ✅ inherited |
+| `edition` | `workspace.package` | ✅ inherited (edition = 2024) |
+| `rust-version` | `workspace.package` | ✅ inherited (1.91) |
+| `license` | `workspace.package` | ✅ MPL-2.0 (valid SPDX identifier, crates.io accepts) |
+| `repository` | `workspace.package` | ✅ `https://github.com/skyllc-ai/UltraFastFileSearch` |
+| `authors` | `workspace.package` | ✅ `Robert Nio <…@users.noreply.github.com>` |
+| `description` | `workspace.package` (has one) + per-crate override | ⚠️ per-crate has it; workspace-level description is for the CLI, may not fit library crates |
+| `documentation` | `workspace.package` | ⚠️ points at `https://docs.rs/uffs` which doesn't exist yet |
+| `readme` | `workspace.package` = `"README.md"` | ⚠️ per-crate READMEs missing; the root README is app-focused, not library-crate-focused |
+| `keywords` | `workspace.package` | ⚠️ workspace has 5; library crates each have max 5; may need per-crate overrides |
+| `categories` | `workspace.package` | ⚠️ same: per-crate overrides may differ (e.g. `uffs-text` is `text-processing`, not `filesystem`) |
+| `publish` | Cargo.toml workspace root has `publish = true` (in release-plz config), crates themselves have NO explicit `publish =` key | ⚠️ cargo defaults to `publish = true` — **AN ACCIDENTAL `git tag` + CI trigger today could publish!**  Must be addressed in R0. |
+
+`Cargo.toml:[workspace.package]`:
+
+```@/Users/rnio/Private/Github/UltraFastFileSearch/Cargo.toml:54-60
+repository = "https://github.com/skyllc-ai/UltraFastFileSearch"
+authors = ["Robert Nio <50460704+githubrobbi@users.noreply.github.com>"]
+description = "UFFS - Ultra Fast File Search using direct NTFS MFT reading and Polars DataFrames"
+documentation = "https://docs.rs/uffs"
+readme = "README.md"
+keywords = ["mft", "ntfs", "file-search", "windows", "polars"]
+categories = ["filesystem", "command-line-utilities"]
+```
+
+Library-crate metadata gaps will be filled in Phase R6.
+
+### 2.10 Licensing posture
+
+- `@/Users/rnio/Private/Github/UltraFastFileSearch/LICENSE` — MPL-2.0 full text at root.
+- `@/Users/rnio/Private/Github/UltraFastFileSearch/LICENSES/MPL-2.0.txt` — REUSE-compliant license file.
+- `@/Users/rnio/Private/Github/UltraFastFileSearch/LICENSES/LicenseRef-UFFS-Brand.txt` — custom trademark license for the UFFS brand (not software).
+- `@/Users/rnio/Private/Github/UltraFastFileSearch/TRADEMARK.md` — trademark policy.
+- All source files carry an MPL-2.0 SPDX license header (verified by `reuse lint` in PR Fast CI).
+
+**crates.io implications**:
+
+- MPL-2.0 is an [OSI-approved license](https://opensource.org/license/mpl-2-0/)
+  and accepted by crates.io without special handling.
+- The `LicenseRef-UFFS-Brand` applies only to the brand, not the
+  software — non-blocking for publishing.
+- The per-file SPDX headers satisfy the "source traceability"
+  expectation but are not required by crates.io.
+
+**Verdict**: licensing is clean.  No changes needed for crates.io
+readiness.
+
+## 3. Target architecture
+
+### 3.1 End-state flow diagram
+
+```
+Contributor                        main branch                GitHub Actions
+─────────────                      ──────────                ──────────────
+
+ writes feat: /                       ┌────────────┐
+ fix: commits                         │  commits   │         (PR Fast CI runs per-PR,
+      │                               │  on main   │          conventional-commit
+      ▼                               │            │          lint as advisory)
+ opens PR  ─── PR Fast CI ─────────▶  │            │
+      │    (required; blocks merge)   │            │
+      ▼                               │            │
+ PR merges                            │            │
+                                      └─────┬──────┘
+                                            │
+                                            ▼
+                                     release-plz workflow
+                                     (runs on every push to main)
+                                            │
+                                            ├── Reads conventional commits
+                                            │   since last vX.Y.Z tag
+                                            │
+                                            ├── Computes next version:
+                                            │     feat!: → MAJOR
+                                            │     feat:  → MINOR
+                                            │     fix:   → PATCH
+                                            │     other: no release
+                                            │
+                                            ├── git-cliff assembles
+                                            │   CHANGELOG.md sections
+                                            │   from cliff.toml template
+                                            │
+                                            ▼
+                              ┌──────────────────────────┐
+                              │  release PR opened:      │
+                              │  chore(release):         │
+                              │    prepare v0.5.72       │
+                              │                          │
+                              │  files changed:          │
+                              │    Cargo.toml (version)  │
+                              │    Cargo.lock (refresh)  │
+                              │    CHANGELOG.md (generated) │
+                              └──────────┬───────────────┘
+                                         │
+                 human reviews ◀─────────┤
+                 changelog, decides ──── ┤
+                 to merge / amend        │
+                                         ▼
+                              release PR merges into main
+                                         │
+                                         ▼
+                              release-plz workflow
+                              (triggered by merge of
+                               release PR)
+                                         │
+                                         ├── Creates + pushes tag
+                                         │   v0.5.72 on merge commit
+                                         │
+                                         ├── Creates GitHub Release
+                                         │   (draft or published)
+                                         │
+                                         ├── (if publish = true per crate)
+                                         │   cargo publish each crate
+                                         │   in dependency-DAG order
+                                         │
+                                         ▼
+                              release.yml workflow
+                              (triggered by push: tags: v*)
+                                         │
+                                         ├── Builds binaries for 5 targets
+                                         ├── Signs + attests (SLSA)
+                                         ├── Uploads to GitHub Release
+                                         └── Done.
+```
+
+### 3.2 Which workflows exist in the target state
+
+| Workflow | Purpose | Target status |
+|---|---|---|
+| `pr-fast.yml` | Per-PR gate (format, clippy, tests, etc.) | ✅ unchanged |
+| `preview-artifacts.yml` | Label-gated Windows preview binaries | ✅ unchanged |
+| `release.yml` | Tag-triggered binary build + GH Release | ✅ unchanged |
+| `tier-2.yml` | Weekly cron (coverage, miri, udeps) | ✅ unchanged |
+| `codeql.yml` | Security analysis | ✅ unchanged |
+| `dependabot-review.yml` | Dependabot PR validation | ✅ unchanged |
+| `dependabot-auto-merge.yml` | Auto-merge dependabot PRs | ✅ unchanged |
+| `cargo-vet-refresh.yml` | Cargo-vet upkeep | ✅ unchanged |
+| `auto-tag-release.yml` | **Version-diff → release.yml dispatcher** | ❌ **DELETED** in Phase R5 (release-plz creates the tag directly) |
+| `release-plz.yml` | **NEW** — release PR generator + release cutter | ➕ created in Phase R3 (shadow) → R4 (active) |
+| `commitlint.yml` | **NEW** — advisory conventional-commits check on PR titles | ➕ created in Phase R1 |
+| `crates-io-dry-run.yml` | **NEW** — scheduled `cargo publish --dry-run --workspace` | ➕ created in Phase R6 |
+
+### 3.3 Which config files exist in the target state
+
+| File | Purpose | Phase |
+|---|---|---|
+| `release-plz.toml` | Release-plz workspace config (supersedes `[workspace.metadata.release-plz]`) | R3 |
+| `cliff.toml` | git-cliff template for CHANGELOG.md sections | R2 |
+| `.github/workflows/release-plz.yml` | Release-plz action invocation | R3 / R4 |
+| `.github/workflows/commitlint.yml` | Commit convention check | R1 |
+| `.github/workflows/crates-io-dry-run.yml` | Metadata-drift detection | R6 |
+| `docs/publishing.md` | First-time crates.io publish runbook (dormant) | R6 |
+
+### 3.4 Which files get deleted
+
+| File | Lines | Reason |
+|---|---|---|
+| `build/update_all_versions.rs` | 1028 | Replaced by release-plz | R5 |
+| `scripts/ci-pipeline/src/version.rs` (bump-related functions) | ~140 | Replaced by release-plz | R5 |
+| `.github/workflows/auto-tag-release.yml` | 169 | Replaced by release-plz's tag step | R5 |
+| `[workspace.metadata.dist]` section in `Cargo.toml` | 13 | Unused cargo-dist config | R0 |
+
+Gross deletion: **~1350 lines of bespoke tooling removed.**
+
+## 4. Phase-by-phase plan
+
+Each phase is designed to be:
+
+- **Single-PR-merge-sized**: each phase is ONE PR that can be
+  reviewed in one sitting.
+- **Reversible**: `git revert` on the phase's merge commit
+  restores the prior state with no manual cleanup.
+- **Independently shippable**: subsequent phases depend on
+  earlier ones, but skipping or pausing the plan between phases
+  leaves the project functional (just partially modernized).
+- **Bake-in-on-main**: each phase lands on `main` and runs for
+  at least one real release cycle before the next phase
+  activates irreversible changes.
+
+### Phase R0 — Pre-flight audit and dangerous-config removal
+
+**Scope**: remove the two dead-code blocks in `Cargo.toml` that
+could bite us if release-plz or cargo-dist were ever accidentally
+activated, and record baseline metrics.
+
+**Steps**:
+
+1. Delete the `[workspace.metadata.release-plz]` block from
+   `Cargo.toml` — we'll reintroduce it in Phase R3 as a proper
+   standalone `release-plz.toml` with `publish = false`.  Keeping
+   it in place with `publish = true` is a footgun.
+2. Delete the `[workspace.metadata.dist]` block from `Cargo.toml`
+   — cargo-dist is explicitly non-goal (see §12).
+3. Capture baseline metrics into a new file
+   `docs/architecture/release-automation-baseline.md`:
+   - Current workspace version: `0.5.71`
+   - Number of merges since last release-worthy commit (for future
+     calibration of "release cadence")
+   - `auto-tag-release.yml` invocation count in last 30 days
+     (`gh run list --workflow auto-tag-release.yml --limit 30`)
+   - `release.yml` invocation count + success rate in last 30 days
+   - Average time from "version bump commit on main" to "release
+     assets visible in GitHub Releases UI"
+   - Hand-maintained `CHANGELOG.md` line count: **789** as of
+     2026-04-24.
+4. Add a `Phase R0` subsection to §10 of this plan's progress
+   dashboard (appended at the end of this file).
+5. **Optional interim lockfile-drift patch** — apply only if R5
+   is expected to be more than ~4 weeks out and at least one more
+   release will ship through `just ship` before R5.  In that
+   window, add a final `cargo generate-lockfile --offline` (or a
+   plain `cargo check --workspace --locked`) step to the bumper so
+   `Cargo.lock` tracks `Cargo.toml` on every bump.  See §2.2 for
+   the bug description.  Skip this if R5 is landing soon — the
+   one-line patch is throwaway work; R5's deletion subsumes it
+   and release-plz refreshes the lockfile natively.  One-line
+   change inside `build/update_all_versions.rs` (appended after
+   the Cargo.toml writes, before the script exits):
+   ```rust
+   // Ensure Cargo.lock tracks the new workspace version.  Without
+   // this, internal-crate `[[package]]` entries drift until some
+   // later `cargo` invocation self-heals.  See
+   // docs/architecture/release-automation-plan.md §2.2.
+   Command::new("cargo")
+       .args(["generate-lockfile", "--offline"])
+       .status()
+       .context("Failed to refresh Cargo.lock")?;
+   ```
+
+**Validation**:
+
+- `cargo check --workspace --all-features --locked` still passes
+  (the deleted TOML blocks are pure metadata, not consumed by
+  cargo itself).
+- `cargo publish --dry-run` run locally for any single crate to
+  confirm the `publish` default is still `true` at the Cargo level
+  (demonstrating that R0 reduced but did not eliminate the risk;
+  R6 will finish the job by adding explicit `publish = false`).
+- If the interim lockfile patch (step 5) was applied: run
+  `just ship` dry-run locally and verify `git diff Cargo.lock`
+  shows the internal-crate version bump alongside `Cargo.toml`.
+  Skip this validation step if step 5 was skipped.
+
+**PR shape**: 1 file changed (`Cargo.toml`), ~25 lines deleted.
+1 new file (`docs/architecture/release-automation-baseline.md`),
+~50 lines.  If the interim lockfile patch is included, +1 file
+touched (`build/update_all_versions.rs`), ~8 lines added.
+
+**Rollback**: `git revert` the merge commit.  No runtime behavior
+changes.
+
+### Phase R1 — Commit convention formalization (advisory)
+
+**Scope**: document the project's already-practiced conventional
+commits discipline in `CONTRIBUTING.md`, and add an **advisory**
+(non-blocking) PR check that comments when commit titles don't
+match the convention.
+
+**Rationale**: UFFS is already at ~100% adherence by habit (see
+§2.8), but new contributors will write `Update README` or
+`fix typo` etc. if we don't tell them the rule.  Release-plz's
+version inference fails silently on non-conforming commits
+(treats them as "no release" — they simply don't appear in the
+changelog).  Better to fail loudly at PR time.
+
+**Steps**:
+
+1. Add a "Commit message convention" section to `CONTRIBUTING.md`:
+   - Cite [Conventional Commits 1.0.0](https://www.conventionalcommits.org/)
+   - List the **allowed types** (chosen to match what UFFS already uses):
+     - `feat`: user-facing new feature → minor bump
+     - `fix`: user-facing bug fix → patch bump
+     - `perf`: performance improvement → patch bump
+     - `refactor`: code change without behavior change → no bump
+     - `docs`: documentation only → no bump
+     - `test`: test-only change → no bump
+     - `build`: build-system change (`Cargo.toml`, `Cargo.lock`, `rust-toolchain`) → no bump
+     - `ci`: CI/workflows change → no bump
+     - `chore`: everything else → no bump
+   - Explain **breaking changes**:
+     - `feat!: redesign IPC wire format` or
+     - a `BREAKING CHANGE: <description>` footer
+     - → major bump
+   - Give UFFS-specific examples drawn from recent real merges
+     (see §2.8 list).
+   - Explain that **only `feat`, `fix`, `perf` produce releases**;
+     all other types accumulate between releases but don't by
+     themselves trigger a release.
+2. Add `.github/workflows/commitlint.yml`:
+   - Runs on `pull_request: [opened, synchronize, edited]`
+   - Checks **only** the PR **title** (the squash-merge subject
+     line) since UFFS uses squash-merge exclusively, not individual
+     commit messages
+   - Uses a self-contained regex check (no external action needed —
+     the regex is ~200 bytes):
+     ```yaml
+     - name: Check PR title
+       run: |
+         TITLE="${{ github.event.pull_request.title }}"
+         if ! echo "$TITLE" | grep -qE '^(feat|fix|perf|refactor|docs|test|build|ci|chore)(\([a-z0-9-]+\))?!?: .{1,}$'; then
+           gh pr comment "${{ github.event.pull_request.number }}" \
+             --body "⚠️ PR title does not match the Conventional Commits convention.  Expected: \`type(scope): subject\`.  See [CONTRIBUTING.md](CONTRIBUTING.md#commit-message-conventions).  **This check is advisory — it will NOT block merge during Phase R1.**"
+           exit 0  # advisory: don't fail
+         fi
+     ```
+   - Logs `✓` or `⚠ non-conforming, advisory only` to the Actions
+     summary.  Exits 0 either way.
+3. Do **not** add commit-msg hook to `scripts/hooks/` yet — the PR
+   title is what gets squashed into `main`, not individual commit
+   messages, so local enforcement would be noise.
+
+**Validation**:
+
+- Open a test PR with title `Update CONTRIBUTING.md`.  Commitlint
+  posts the advisory comment; check does not block merge.
+- Open a test PR with title `docs: update CONTRIBUTING.md`.
+  Commitlint logs ✓ silently; no comment.
+- Merge both PRs as squashes; observe that the `main` log contains
+  properly-formatted subject lines for the conformant one and a
+  raw-subject line for the non-conformant one (the latter is what
+  we're preventing).
+
+**PR shape**: 2 files changed (`CONTRIBUTING.md`, new
+`.github/workflows/commitlint.yml`), ~100 lines added.
+
+**Rollback**: `git revert`.  The advisory check simply stops
+running.
+
+### Phase R2 — git-cliff standalone adoption
+
+**Scope**: introduce `git-cliff` with a `cliff.toml` template,
+generate a fresh `CHANGELOG.md` from commit history, compare against
+the hand-maintained one, and commit the result if quality is
+acceptable.
+
+**Rationale**: we want the commit → changelog pipeline working and
+proven **before** hooking it into release-plz.  If the generated
+changelog is worse than the hand-maintained one, we catch that here
+in isolation and iterate on `cliff.toml` until it's right.
+Release-plz delegates to `git-cliff` natively when `cliff.toml` is
+present, so getting it right here means release-plz inherits it.
+
+**Steps**:
+
+1. Add `cliff.toml` at workspace root with a template that produces
+   Keep-a-Changelog-compatible output matching the existing
+   `CHANGELOG.md` style.  Template outline:
+   - Header: unchanged from current
+   - Version section format: `## [X.Y.Z] - YYYY-MM-DD`
+   - Subsections by commit type:
+     - `feat:` → `### Added` (for new features) + `### Changed` (for behavior changes)
+     - `fix:` → `### Fixed`
+     - `perf:` → `### Performance`
+     - `BREAKING CHANGE:` → `### Breaking Changes`
+     - `docs:`, `test:`, `build:`, `ci:`, `chore:`, `refactor:` → suppressed (not shown in changelog)
+   - Commit formatting: `- **[scope]** subject (#PR)` where available
+   - Unreleased section preserved for WIP
+2. Install `git-cliff` locally for the initial generation:
+   - `cargo install git-cliff --locked`
+3. Generate the changelog to a scratch file first:
+   - `git cliff --config cliff.toml --unreleased -o /tmp/generated-CHANGELOG.md`
+   - Manually diff against current `CHANGELOG.md`
+   - Iterate on `cliff.toml` until the output captures all
+     release-worthy changes at acceptable prose quality.
+4. **Do not overwrite `CHANGELOG.md` yet** — that happens in
+   Phase R3/R4 when release-plz takes over changelog updates.
+   The goal of R2 is just to prove the template works.
+5. Document the verification in a short
+   `docs/architecture/release-automation-baseline.md` followup.
+
+**Validation**:
+
+- `git cliff --config cliff.toml --unreleased` runs cleanly with no
+  errors.
+- The generated output contains entries for every merge since the
+  last `v0.5.71` equivalent (which doesn't exist yet — so: since
+  the last `chore: release` commit, or since the initial commit,
+  whichever is shorter).
+- Categorization looks right: `feat:` → Added, `fix:` → Fixed, etc.
+
+**PR shape**: 1 file added (`cliff.toml`), ~80 lines.  1 file
+touched (`docs/architecture/release-automation-baseline.md` addendum),
+~30 lines.  `CHANGELOG.md` **not touched**.
+
+**Rollback**: `git revert`.  git-cliff installation is per-developer
+and orthogonal.
+
+### Phase R3 — release-plz in shadow (comment-only) mode
+
+**Scope**: install release-plz as a GitHub Action that runs on
+every push to `main` and **only posts a comment** saying what it
+WOULD do, without opening PRs or creating tags.  Observe for 1-2
+weeks / 3-5 merges.
+
+**Rationale**: release-plz's behavior depends on cliff.toml, the
+commit history, the workspace structure, and the `release-plz.toml`
+config.  Getting any of those wrong produces surprising output.
+Shadow mode lets us see the output on **real commits** without any
+blast radius.
+
+**Steps**:
+
+1. Add `release-plz.toml` at workspace root.  Minimum required
+   content:
+   ```toml
+   [workspace]
+   # Single version for the whole workspace (matches current layout).
+   # Can be flipped to per-crate later (Phase R9).
+   dependencies_update = true
+
+   # CRITICAL: dormant publishing.  Explicit and audited.
+   publish = false
+
+   # Git release created by release-plz; actual binary upload stays
+   # in release.yml (triggered by the tag push).
+   git_release_enable = true
+   git_tag_enable = true
+
+   # Changelog generation via git-cliff (cliff.toml at workspace root).
+   changelog_update = true
+
+   # Shadow mode: do not open PRs, do not create tags, do not release.
+   # This is a release-plz-specific flag set via the GitHub Action
+   # workflow below (release_always: false + dry_run semantics).
+   ```
+2. Add `.github/workflows/release-plz.yml`:
+   ```yaml
+   name: 🔮 Release-plz (shadow)
+   on:
+     push:
+       branches: [main]
+   permissions:
+     contents: read
+     pull-requests: read
+     issues: read
+   jobs:
+     dry-run:
+       name: Dry-run release plan
+       runs-on: ubuntu-latest
+       timeout-minutes: 10
+       steps:
+         - uses: actions/checkout@<pinned-sha>
+           with:
+             fetch-depth: 0
+         - uses: dtolnay/rust-toolchain@<pinned-sha>
+           with:
+             toolchain: stable
+         - name: release-plz plan
+           uses: release-plz/action@<pinned-sha>
+           with:
+             command: release-pr  # subcommand
+             config: release-plz.toml
+             # dry-run via NOT providing token write permissions above;
+             # the action will fail to open a PR but succeed at computing
+             # the plan, which it emits to the workflow summary.
+   ```
+   Note: release-plz's actual dry-run story evolved across versions;
+   if the above approach doesn't produce the desired output, pivot
+   to calling `release-plz release-pr --dry-run` via a raw step
+   (the CLI supports `--dry-run` since 0.3.x).
+3. Run on `main` naturally via subsequent merges — no synthetic
+   test PRs.
+4. After each run, record in
+   `docs/architecture/release-automation-baseline.md`:
+   - What release-plz proposed (version bump + changelog diff)
+   - What you would have proposed manually
+   - Discrepancies and their causes (e.g. "commit was `fix:` but
+     was actually a minor feature — upgrade to `feat:` in future")
+
+**Exit criteria** (all must hold before advancing to R4):
+
+- ≥3 consecutive release-plz runs where the proposed version bump
+  matches the manual judgement.
+- ≥1 run that includes a `feat:` commit, producing a minor bump
+  (validates the MINOR path, which is the commonest real-world
+  release driver).
+- ≥1 run that includes only `chore:` / `docs:` / `test:` commits,
+  producing **no release** (validates the suppression path).
+- The generated changelog entries are human-acceptable without
+  heavy editing — one-sentence edits are fine, multi-paragraph
+  rewrites are a signal that `cliff.toml` needs tuning.
+
+**PR shape**: 2 files added (`release-plz.toml`, new workflow),
+~80 lines total.
+
+**Rollback**: `git revert`.  The shadow workflow just stops
+running.
+
+### Phase R4 — release-plz active (release PR mode)
+
+**Scope**: flip release-plz from shadow to active.  It now opens
+release PRs on `main` pushes.  Humans review and merge.  Merging the
+release PR causes release-plz (on its next `main` run) to create the
+tag, which triggers `release.yml`.
+
+**Keep `auto-tag-release.yml` running in parallel during R4.**  Belt
+and suspenders: if release-plz's tag creation fails for any reason,
+`auto-tag-release.yml` still catches the Cargo.toml version change
+and dispatches `release.yml`.  The idempotency guard in
+`release.yml` (tag-exists check) prevents double-fire.
+
+**Steps**:
+
+1. Grant the release-plz workflow `contents: write` and
+   `pull-requests: write` permissions (needed to push the release
+   branch and open the PR).
+2. Flip the workflow to active mode:
+   ```yaml
+   permissions:
+     contents: write
+     pull-requests: write
+   # ...
+   - uses: release-plz/action@<pinned-sha>
+     with:
+       command: release-pr
+       config: release-plz.toml
+       token: ${{ secrets.GITHUB_TOKEN }}
+   ```
+3. Add a second job in the same workflow file for the **release
+   step** (creates tag after release PR merges):
+   ```yaml
+   release:
+     name: Cut release (after release PR merges)
+     needs: release-pr
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/checkout@<pinned-sha>
+         with: { fetch-depth: 0 }
+       - uses: release-plz/action@<pinned-sha>
+         with:
+           command: release
+           config: release-plz.toml
+           token: ${{ secrets.GITHUB_TOKEN }}
+   ```
+   This step only acts when the HEAD of main IS the merged release
+   PR (release-plz auto-detects this by seeing the "release commit"
+   pattern in the HEAD commit message).
+4. **Do NOT delete `auto-tag-release.yml` yet** — that's Phase R5.
+5. Do the first release through the new flow:
+   - Wait for a meaningful merge (not trivial docs churn)
+   - Observe release-plz's release PR
+   - Review the changelog, the version bump, the Cargo.toml diff
+   - Merge the release PR
+   - Observe both release-plz's tag-creation step AND
+     `auto-tag-release.yml`'s detection step — whichever fires first
+     dispatches `release.yml`; the other no-ops due to the
+     tag-exists guard.
+   - Wait for `release.yml` to complete and produce the GitHub
+     Release with binaries.
+6. Write a deviations-log entry in `dev-flow-implementation-plan.md`
+   §10.5-equivalent if anything unexpected happens.
+
+**Exit criteria** (all must hold before advancing to R5):
+
+- ≥1 complete release via release-plz flow succeeds end-to-end,
+  from merge-triggering-release-PR through tag-triggering-
+  `release.yml` through GitHub Release with signed binaries.
+- Both release-plz's tag step and `auto-tag-release.yml` fire on
+  the release PR merge, and the tag-exists guard correctly
+  deduplicates.
+- Generated `CHANGELOG.md` is in the `main` history, replacing the
+  hand-maintained `## [Unreleased]` workflow.
+
+**PR shape**: 1 file modified (`release-plz.yml` — permissions
+changed, release job added), ~30-line net diff.
+
+**Rollback**: `git revert` flips the workflow back to shadow mode.
+Any already-created tag from a shadow run stays (harmless; tags
+are idempotent).
+
+### Phase R5 — Retire bespoke tooling
+
+**Scope**: delete all the code and workflows that release-plz now
+replaces.
+
+**Prerequisites**:
+
+- ≥2 full releases successfully cut via release-plz (Phase R4).
+- `auto-tag-release.yml` has been observed to no-op after release-plz
+  creates the tag (confirming release-plz wins the race reliably and
+  the tag-exists guard is the correct invariant).
+
+**Steps**:
+
+1. Delete `build/update_all_versions.rs` (1028 lines).
+2. Delete version-bump functions from
+   `scripts/ci-pipeline/src/version.rs`:
+   - `increment_version()` — deleted
+   - `version_bump()` — deleted
+   - Keep `get_current_version()` and
+     `extract_version_from_cargo_toml()` — they're still useful
+     for `just ship`'s push step (constructing release branch
+     names).
+   - Keep `update_polars_git()` — unrelated to versioning,
+     updates the polars git dep pin.
+3. Remove the version-bump step from the `ship` pipeline in
+   `scripts/ci-pipeline/src/`.  `just ship` is now **only**:
+   check → lint → test → push.  Version bumping happens via
+   release-plz on `main`, not via local ship commands.
+4. Delete `.github/workflows/auto-tag-release.yml` (169 lines).
+5. Update `dev-flow-implementation-plan.md`:
+   - Remove references to the `auto-tag-release.yml` bridge
+     workflow.
+   - Add cross-reference to
+     `release-automation-plan.md` in §1 or §2 intro.
+6. Update `CONTRIBUTING.md`:
+   - Remove any mention of `./build/update_all_versions.rs`.
+   - Explain the new "just write conventional commits, releases
+     are automatic" flow.
+7. Update `justfile`:
+   - Remove the version-bump step from `just ship` (if present as a
+     distinct target).
+   - Keep any `just release` target that dispatches `release.yml`
+     manually, if such a target exists — it's a useful escape
+     hatch.
+
+**Validation**:
+
+- `just ship` runs cleanly end-to-end on a feature branch without
+  invoking any deleted script.
+- No workflow references `./build/update_all_versions.rs`.
+- `grep -r 'update_all_versions' .github/ scripts/ justfile` returns
+  zero matches.
+- `grep -r 'auto-tag-release' .github/ docs/ scripts/` returns zero
+  matches except historical entries in CHANGELOG.md and the
+  dev-flow plan's deviations log (retained as history).
+- Next release after Phase R5 lands cleanly — the release PR
+  opens, merges, tag creates, `release.yml` fires.
+
+**PR shape**: 3-4 files deleted (rust-script + workflow +
+CI-pipeline/src version bits), 2-3 files modified (doc + justfile +
+version.rs trim).  Net diff: **~1350 lines removed**, ~30 lines
+added.
+
+**Rollback**: `git revert` restores everything.  This is where the
+"reversibility" discipline earns its keep — reverting Phase R5 is
+the only way back to the bespoke-tooling world, and it works
+because nothing else was restructured simultaneously.
+
+### Phase R6 — Crates.io metadata audit + dry-run publish CI
+
+**Scope**: audit every `crates/*/Cargo.toml` for crates.io readiness
+and add a scheduled GitHub Action that runs `cargo publish --dry-run
+--workspace` to catch metadata drift early.  **No actual publishing
+happens; `publish = false` remains set workspace-wide.**
+
+**Rationale**: `cargo publish` has ~30 distinct failure modes
+(missing `description`, `license` mismatch, `readme` not found,
+path dependencies without `version =`, feature-flag typos, lockfile
+divergence, crate-size > 10 MB, disallowed registry, missing
+`repository` link, docs.rs build failures, ...).  You don't want
+to discover any of them during a real go-live release.  A nightly
+dry-run on the full workspace surfaces every failure class against
+the current `main` tip, so by the time Phase R9 flips publishing on,
+the `cargo publish` step is boring.
+
+This phase also sets up the **dependency ordering** discipline — the
+only publish order that works is a topological sort of the workspace
+internal-dependency DAG, and that order must be encoded in whatever
+invokes `cargo publish`.  Release-plz handles this automatically
+(it walks the DAG), but the dry-run workflow still needs to agree
+with release-plz's walk, or debugging becomes an archaeological
+expedition.
+
+**Steps**:
+
+1. **Audit each publishable crate** using the matrix in §5.1.  For
+   each crate, confirm:
+   - `name` is unique on crates.io (run
+     `cargo search <crate-name> --limit 1` for each; reserve names
+     NOW before someone else takes them — see §5.7).
+   - `description` exists and is ≤ 280 chars, ≥ 30 chars,
+     descriptive (not `"TODO"`, not the crate name echoed).
+   - `license` or `license-file` resolves.  The workspace sets
+     `license = "MPL-2.0"`; each crate inherits.  `MPL-2.0` is
+     an SPDX identifier crates.io accepts natively.
+   - `repository` URL is reachable (workspace-inherited).
+   - `homepage` set if a product landing page exists; otherwise
+     omit (do NOT repeat `repository`).
+   - `documentation` field — either omit (crates.io defaults to
+     `docs.rs/<crate-name>`) or set to a specific docs.rs URL per
+     crate.  **Recommend omitting** — simpler and always correct.
+   - `readme` field: each crate needs a `README.md` adjacent to
+     its `Cargo.toml` (or it inherits the workspace one, which is
+     generic and undesirable per-crate).  File an issue for each
+     missing per-crate README; don't block the phase on it but
+     track it.
+   - `keywords`: max 5, lowercase, hyphenated.  Workspace-inherited
+     value is reasonable starting point; individual crates may
+     override (e.g. `uffs-polars` might prefer `["polars", "facade",
+     "isolation"]`).
+   - `categories`: must match one of the ~50 crates.io
+     categories exactly.  See https://crates.io/category_slugs.
+     Workspace default `["filesystem", "command-line-utilities"]`
+     is correct for `uffs-cli`; library crates like `uffs-core`
+     should use `["filesystem", "data-structures"]` or similar.
+     Audit per crate.
+   - `rust-version` is honest — matches what CI actually tests.
+     Currently set to `1.91` workspace-wide.  Honest.
+2. **Explicitly set `publish = false`** at the workspace level in
+   `release-plz.toml` (already done in R3) **and** per-crate in
+   the `[package]` section of any crate that is a private
+   dev tool — specifically:
+   - `scripts/ci-pipeline` → `publish = false` (internal tool;
+     never goes on crates.io)
+   - `crates/uffs-diag` → `publish = false` (diagnostic tools;
+     not user-facing)
+   - `crates/uffs-broker` → **TBD** — it's the Windows elevated
+     handle broker, useful standalone?  Decide in Phase R8 dress
+     rehearsal.
+   This "publish = false at the crate level" is different from
+   "publish = false in release-plz.toml" — the former blocks
+   `cargo publish` locally too, the latter blocks just the
+   release-plz workflow.  Belt and suspenders.
+3. **Add docs.rs metadata** to each publishable crate's `Cargo.toml`:
+   ```toml
+   [package.metadata.docs.rs]
+   # Which feature flags to build with on docs.rs
+   all-features = true
+   # Target-specific build (docs.rs builds on Linux by default;
+   # this forces a specific target so platform-gated items render)
+   targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+   # Show cfg(docsrs) content (the `#[cfg_attr(docsrs, doc(cfg(...)))]`
+   # pattern that makes platform gating visible in docs)
+   rustdoc-args = ["--cfg", "docsrs"]
+   ```
+   For `uffs-mft`, `uffs-security`, `uffs-broker` (Windows-gated),
+   the `targets` list must include `x86_64-pc-windows-msvc` or
+   the Windows API surface disappears from docs.
+4. **Add `.github/workflows/crates-io-dry-run.yml`**:
+   ```yaml
+   name: 📦 crates.io dry-run
+   on:
+     schedule:
+       - cron: '0 6 * * 1'   # Mondays 06:00 UTC, weekly
+     workflow_dispatch:
+   permissions:
+     contents: read
+   jobs:
+     dry-run:
+       name: cargo publish --dry-run (workspace)
+       runs-on: ubuntu-latest
+       timeout-minutes: 30
+       steps:
+         - uses: actions/checkout@<pinned-sha>
+         - uses: dtolnay/rust-toolchain@<pinned-sha>
+           with:
+             toolchain: stable
+         - name: Dry-run publish every workspace member
+           run: |
+             # cargo publish refuses path-deps without version =
+             # (we already set version = in workspace.dependencies).
+             # --no-verify skips the expensive full build; we just
+             # want metadata + tarball assembly to succeed.
+             # For a richer signal, run without --no-verify but
+             # be prepared for ~20 min runtime.
+             for crate in $(cargo metadata --no-deps --format-version 1 \
+                 | jq -r '.packages[] | select(.publish != []) | .name'); do
+               echo "::group::dry-run $crate"
+               cargo publish --dry-run -p "$crate"
+               echo "::endgroup::"
+             done
+   ```
+   Notes on the `jq` filter: `.publish != []` picks crates whose
+   `publish` field is either absent (default: publishable) or a
+   registry list.  Crates with `publish = false` serialize to
+   `.publish == []` in cargo metadata and get filtered out.
+5. **Document first-publish runbook** at `docs/publishing.md` —
+   template in §5.7.  Marked clearly as "DORMANT — do not execute
+   without explicit release decision recorded in
+   release-automation-plan.md §9 status dashboard".
+6. **Reserve crate names on crates.io** (critical):
+   - Publish **empty stub 0.0.0 versions** of each crate name you
+     intend to own: `uffs`, `uffs-core`, `uffs-mft`, `uffs-polars`,
+     `uffs-security`, `uffs-text`, `uffs-time`, `uffs-format`,
+     `uffs-client`, `uffs-daemon`, `uffs-cli`, `uffs-mcp`,
+     `uffs-broker`.
+   - The stub is a single-file crate with `description = "Name
+     reservation for UFFS — see https://github.com/skyllc-ai/
+     UltraFastFileSearch"` and no code.
+   - **This is the one exception to "no actual publishing in
+     this plan"** — name squatting is a real risk and
+     reservations are irreversible (crates.io doesn't allow
+     name transfers except for abuse).
+   - Do the name reservations from a **throwaway dedicated
+     workspace** (not from the UFFS repo), so the actual project
+     still has `publish = false` everywhere.  The reserved 0.0.0
+     can be yanked later without side effects; the name stays
+     owned.
+   - Track reserved names in §5.1 audit matrix.
+
+**Exit criteria** (all must hold before advancing to R7):
+
+- Every publishable crate has complete, correct metadata per §5.1
+  matrix.
+- `crates-io-dry-run.yml` runs green for 2 consecutive weeks
+  (so we observe at least one post-release `main`).
+- All 13 intended crate names are reserved on crates.io under
+  the project owner's account.
+- `docs/publishing.md` exists and is reviewed by at least one
+  maintainer for accuracy.
+- `[package.metadata.docs.rs]` present in every publishable
+  crate.
+
+**PR shape**: ~13 files modified (per-crate Cargo.toml + metadata
+additions), 2 files added (workflow + docs/publishing.md),
+1 companion PR for name-reservation stubs (from the throwaway
+workspace, **not** in the UFFS repo).  Net diff in UFFS repo:
+~400 lines added.
+
+**Rollback**: `git revert` reverses metadata and deletes the
+workflow.  The crates.io name reservations stay (they're
+external state); the stubs can be `cargo yank`ed if the project
+is abandoned.
+
+### Phase R7 — Trusted publisher (OIDC) scaffolding
+
+**Scope**: configure GitHub's OIDC federation with crates.io's
+trusted-publisher feature.  This replaces the legacy pattern of
+"long-lived crates.io API token stored as a GitHub secret" with
+short-lived, audience-scoped OIDC tokens minted per workflow run.
+
+**Rationale**: crates.io trusted publishing shipped in mid-2024 and
+is now the recommended posture for CI publishing.  Benefits:
+- No long-lived secrets in GitHub repo settings (one less
+  rotation burden, one less exfiltration target)
+- Token audience restricted to a specific workflow + branch +
+  environment (narrow blast radius if compromised)
+- Server-side auditability: crates.io logs which GitHub Actions
+  run minted each publish
+- No human-in-the-loop credential handling during onboarding
+
+**Prerequisites**: Phase R6 complete (names reserved, dry-run
+green).
+
+**Steps**:
+
+1. **Create a GitHub Environment** in the repo settings:
+   - Name: `crates-io-production`
+   - Protection rule: required reviewers = 1 (maintainer list)
+   - Deployment branch rule: only `main` branch
+   - Environment secrets: **none** (trusted publishing doesn't
+     need a secret; the OIDC token is minted at runtime)
+2. **Register the trusted publisher on crates.io** for each
+   reserved crate:
+   - Log in to crates.io as the project owner.
+   - For each of the 13 reserved crate names, go to
+     Crate Settings → Trusted Publishers → Add.
+   - Form fields:
+     - Repository owner: `skyllc-ai`
+     - Repository name: `UltraFastFileSearch`
+     - Workflow filename: `release-plz.yml` (relative to
+       `.github/workflows/`)
+     - Environment: `crates-io-production`
+   - This binds the crate name to the exact GHA workflow that
+     is authorized to publish it.
+3. **Add the publish-eligible job to `release-plz.yml`** (but
+   leave it gated off via `if: false`):
+   ```yaml
+   publish:
+     name: Publish to crates.io (gated)
+     needs: release
+     if: false   # Gate flipped in Phase R9
+     runs-on: ubuntu-latest
+     environment: crates-io-production
+     permissions:
+       contents: read
+       id-token: write   # MANDATORY for OIDC
+     steps:
+       - uses: actions/checkout@<pinned-sha>
+       - uses: rust-lang/crates-io-auth-action@<pinned-sha>
+         id: auth
+       - uses: dtolnay/rust-toolchain@<pinned-sha>
+         with:
+           toolchain: stable
+       - name: cargo publish (workspace, OIDC)
+         env:
+           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+         run: |
+           # release-plz will eventually drive this; the shell
+           # loop is only for the pre-release-plz smoke test.
+           for crate in $(cargo metadata --no-deps --format-version 1 \
+               | jq -r '.packages[] | select(.publish != []) | .name'); do
+             cargo publish -p "$crate" --locked
+           done
+   ```
+   The `id-token: write` permission is what enables the workflow
+   to request an OIDC token.  Without it, the OIDC mint fails with
+   an opaque `"Unable to mint OIDC token"` error.
+4. **Document the trusted-publisher setup** in `docs/publishing.md`
+   with screenshots / exact form field values captured.  Rotation
+   and revocation instructions live here too: if trust breaks or
+   the repository is forked/renamed, the publisher registrations
+   need updating on crates.io.
+5. **Verify OIDC flow without publishing**: flip `if: false` to
+   `if: github.event_name == 'workflow_dispatch'` temporarily.
+   Trigger `workflow_dispatch` manually.  The auth step should
+   succeed and print a redacted token.  Keep the `cargo publish`
+   step dry-run only in this test (`--dry-run`).  Revert the `if`
+   gate after observation.
+6. **Do NOT flip `if: false` to `if: true` in this phase.**  That
+   cutover is Phase R9.
+
+**Exit criteria** (all must hold before advancing to R8):
+
+- Trusted-publisher registration done for all 13 reserved crate
+  names.
+- `crates-io-production` GitHub Environment exists with correct
+  protection rules.
+- OIDC dry-run via manual `workflow_dispatch` succeeds end-to-end
+  (token minted, cargo auth succeeds, `--dry-run` publish
+  succeeds) and result is documented in `docs/publishing.md`.
+- Regular `release-plz.yml` runs continue unaffected (the publish
+  job is `needs: release` + `if: false`, so it never runs on
+  scheduled or push-triggered invocations).
+
+**PR shape**: 1 file modified (`release-plz.yml` — publish job
+added), 1 file modified (`docs/publishing.md` — OIDC section),
+0 files deleted.  Net diff: ~80 lines added.  External state:
+13 crate registrations + 1 GitHub Environment (not in repo).
+
+**Rollback**: `git revert` removes the workflow job.  Trusted-
+publisher registrations on crates.io can be removed via crate
+settings; the GitHub Environment can be deleted.  No lingering
+tokens, no credential cleanup.
+
+### Phase R8 — First publish dress rehearsal
+
+**Scope**: execute **one** real publish against crates.io — for a
+**single, benign, low-surface crate** — to validate the entire
+chain end-to-end.  The publish target is intentionally the smallest,
+most leaf-like crate: `uffs-time` (pure NTFS FILETIME arithmetic,
+zero internal deps, no unsafe, no platform gating).
+
+**Rationale**: the dry-run workflow (R6) catches metadata errors but
+NOT:
+- Interaction with crates.io's actual registry backend
+- docs.rs rendering (only observable after a real publish)
+- The OIDC auth handshake with a real token
+- Network flakiness, registry throttling, 5xx errors
+- Post-publish verification (crate page renders, readme
+  displays, docs.rs build succeeds within its 2-hour window)
+
+A single-crate rehearsal against a real publishable surface
+shakes out everything the dry-run can't.  `uffs-time` is chosen
+because:
+- It has no internal dependencies → publish ordering irrelevant
+- It's pure compute with zero unsafe → minimal security surface
+- Its failure modes are purely "didn't render well on docs.rs",
+  not "accidentally shipped CVE"
+- If we decide to unpublish, yanking it affects nothing
+  downstream (it has no published users on day 1 by construction)
+
+**Prerequisites**:
+- Phase R7 complete (OIDC verified end-to-end in dry-run).
+- Workspace version has been bumped via release-plz at least
+  once (so we're publishing `uffs-time = "0.5.72"` or similar,
+  not `0.5.71`, which would collide with the reserved `0.0.0`
+  stub).
+
+**Steps**:
+
+1. **Temporarily gate the publish job to `uffs-time` only**:
+   ```yaml
+   - name: cargo publish (uffs-time only — R8 rehearsal)
+     env:
+       CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+     run: cargo publish -p uffs-time --locked
+   ```
+2. **Flip the `if: false` to `if: true`** on the publish job
+   (keeping it `needs: release`, so it only runs after the
+   release job succeeds, i.e. after a release tag is created).
+3. **Trigger a release** through the normal release-plz flow:
+   - Merge a `fix:` or `feat:` commit to `main`
+   - Wait for release PR
+   - Review, merge
+   - Observe release-plz → tag → `release.yml` (binaries) AND
+     the new publish job firing in parallel
+4. **Post-publish verification checklist**:
+   - `cargo search uffs-time --limit 1` shows the new version
+   - `crates.io/crates/uffs-time` page renders correctly
+   - `docs.rs/uffs-time` build starts within 5 min, succeeds
+     within 2 hours
+   - The published crate can be consumed from a throwaway
+     project: `cargo add uffs-time` in an empty `cargo new`
+     project, then `cargo build`.  This catches the "tarball
+     was missing a file" class of bugs that dry-run can't
+     detect.
+5. **Restore the publish job** to its full-workspace form after
+   rehearsal succeeds:
+   ```yaml
+   - name: cargo publish (workspace)
+     env:
+       CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+     run: |
+       for crate in $(cargo metadata --no-deps --format-version 1 \
+           | jq -r '.packages[] | select(.publish != []) | .name'); do
+         cargo publish -p "$crate" --locked
+       done
+   ```
+   But **flip `if: true` back to `if: false`** for the next
+   release cycle.  R8 is a one-off rehearsal; live publishing
+   is R9.
+
+**Exit criteria** (all must hold before advancing to R9):
+
+- `uffs-time` v0.5.72+ appears on crates.io via the GHA publish
+  path (not via manual `cargo publish`).
+- The crate builds green on docs.rs.
+- A throwaway downstream project can `cargo add uffs-time`
+  and build.
+- The publish job successfully authenticated via OIDC (the
+  crates.io publish log, accessible via crate settings, shows
+  the GitHub Actions run ID).
+- No cleanup actions pending (no accidentally-published
+  crates, no leaked tokens, no confused Dependabot).
+- Deviations log entry written in dev-flow-implementation-plan.md
+  §10.5 or release-automation-plan.md §9 for any surprises.
+
+**PR shape**: 1 file modified (`release-plz.yml` — gate flip +
+scope restrict + restore), 0 files deleted.  Net diff over the
+phase lifetime: ~10 lines (flip, restore).  External state:
+1 crate version published to crates.io (irreversible — can be
+yanked but not deleted).
+
+**Rollback**:
+- Flip `if: true` back to `if: false` (future releases won't
+  publish).
+- `cargo yank -p uffs-time --vers <published-version>` (crates.io
+  hides the version from new resolves; existing lockfiles still
+  work).
+- **Cannot unpublish** — crates.io's no-delete policy is
+  absolute except for the 72-hour grace window on accidental
+  pushes.  Within the grace window: `cargo owner --add` to give
+  the crates.io support team the ability to delete on your
+  behalf, then file a support ticket.
+- Document the yank rationale in `docs/publishing.md` "yank
+  decisions" log.
+
+### Phase R9 — Live publishing (deferred cutover)
+
+**Scope**: flip the publish job from `uffs-time`-only to
+full-workspace, and from `if: false` to `if: true`, on a
+maintainer's explicit go-ahead (recorded in the status dashboard,
+§8).  This is the "we are a published project now" milestone.
+
+**Explicit gate**: this phase is **not executed as part of the
+initial automation rollout**.  It is a separate decision gated
+on:
+
+1. API stability: the project has reached at least v0.6.0 or
+   v1.0.0, with a stated SemVer stability contract.
+2. Library API review: `cargo public-api` or
+   `cargo-semver-checks` integrated into PR Fast CI for at
+   least one release cycle.
+3. Documentation: every publishable crate has a usable
+   `README.md` adjacent to its `Cargo.toml` (not the
+   workspace-inherited one) and at least one working
+   `cargo add <crate> && use <crate>::...` example.
+4. Downstream readiness: a maintainer has written a short
+   "who is this crate for" blurb on each crate page.  Drive-by
+   adoption is a commitment; you don't get to unpublish when
+   it's inconvenient.
+5. Explicit maintainer approval recorded in this plan's §8
+   dashboard row R9, with date + maintainer handle + PR link.
+
+**Steps** (to be executed at go-live, not now):
+
+1. Flip the publish job's `if:` guard to `if: true`.
+2. Restore full-workspace scope (from R8 restore step).
+3. Add `[workspace.metadata.release-plz] publish = true` in
+   `release-plz.toml` (or per-crate via the release-plz config),
+   triggering release-plz's own publish step in addition to the
+   OIDC workflow job.  **Do not dual-path** — pick one:
+   - Option A: release-plz drives publishing (simpler, fewer
+     moving parts)
+   - Option B: dedicated `publish` workflow job drives
+     publishing, release-plz only does tag + GH Release
+   Recommend Option A for simplicity.  The workflow job from
+   R7/R8 then becomes a dry-run integration test, not the
+   publishing path.
+4. Lock the publishing workflow behind the `crates-io-production`
+   GitHub Environment with required reviewers.  Every published
+   version needs a human click.  The review should be "yes, the
+   release notes are accurate and the version bump is
+   appropriate", not "yes, this compiles" (CI already said it
+   compiles).
+5. Update `docs/publishing.md` from "DORMANT" to "LIVE" with
+   the cutover date.
+6. Update `release-automation-plan.md §8 dashboard` R9 row with
+   the cutover commit SHA, PR link, and first-live-published
+   crate version.
+
+**Exit criteria**: N/A — this is the terminal phase for the
+release automation plan.  Post-R9, the project is in a steady
+state and further evolution moves to operational docs rather
+than a migration plan.
+
+**PR shape**: ~3 lines modified in `release-plz.yml`, ~2 lines
+in `release-plz.toml`, ~20 lines in `docs/publishing.md`.
+
+**Rollback**: the nuclear option is flipping `publish` back to
+`false` everywhere and `cargo yank`ing whatever was published
+in the 24-48 hours before rollback.  Partial rollback (e.g.
+"publish these 3 crates but not those 10") is supported by
+setting `publish = false` per-crate in individual `Cargo.toml`
+files and tagging another release — release-plz respects the
+per-crate flag.
+
+## 5. Crates.io publishing scaffolding — deep-dive
+
+The phases R6-R9 above are the **execution steps**.  This section
+is the **reference** for the artifacts those phases produce.  Read
+this when you're:
+- Auditing a crate's metadata in R6 (§5.1)
+- Debugging publish ordering (§5.2)
+- Rendering docs.rs for the first time (§5.4)
+- Writing the runbook (§5.7)
+
+### 5.1 Per-crate metadata audit matrix
+
+Target state table.  Fill in the `Action` column during R6.
+
+| Crate | Publishable? | `publish` | `description` present | Per-crate `README.md`? | `keywords` override? | `categories` override? | `docs.rs` features | `[[bin]]`? | Action |
+|---|---|---|---|---|---|---|---|---|---|
+| `uffs-polars` | Yes (lib) | inherit (publishable) | Yes, tune | Missing — write | `["polars", "facade", "isolation"]` | `["rust-patterns", "caching"]` | `all-features` | No | write README, tune description |
+| `uffs-security` | Yes (lib) | inherit | Yes, tune | Missing — write | `["security", "filesystem", "crypto"]` | `["cryptography", "filesystem", "os::windows-apis"]` | `all-features` + Windows target | No | write README, tune description, add docs.rs Windows target |
+| `uffs-text` | Yes (lib) | inherit | Yes, tune | Missing — write | `["unicode", "text", "i18n"]` | `["text-processing", "internationalization"]` | `all-features` | No | write README |
+| `uffs-time` | Yes (lib) | inherit | Yes, tune | Missing — write | `["ntfs", "filetime", "windows", "time"]` | `["date-and-time", "os::windows-apis"]` | `all-features` | No | write README — **this is the R8 rehearsal crate, prioritize quality** |
+| `uffs-mft` | Yes (lib) | inherit | Yes, tune | Missing — write | `["ntfs", "mft", "polars", "filesystem"]` | `["filesystem", "os::windows-apis", "parser-implementations"]` | `all-features` + Windows target | No | write README, add docs.rs Windows target |
+| `uffs-format` | Yes (lib) | inherit | Yes, tune | Missing — write | `["csv", "format", "polars"]` | `["encoding", "filesystem"]` | `all-features` | No | write README |
+| `uffs-core` | Yes (lib) | inherit | Yes, tune | Missing — write | `["polars", "query", "search", "mft"]` | `["filesystem", "data-structures"]` | `all-features` | No | write README |
+| `uffs-client` | Yes (lib) | inherit | Yes, tune | Missing — write | `["uffs", "client", "ipc"]` | `["filesystem", "network-programming"]` | `all-features` | No | write README |
+| `uffs-daemon` | **Decide** — bin-only? | — | Yes, tune | Missing — write | — | — | — | Yes | **R8** decision: publishable (end-users install `cargo install uffs-daemon`) or private (`publish = false`) |
+| `uffs-mcp` | **Decide** — bin-only? | — | Yes, tune | Missing — write | — | — | — | Yes | **R8** decision: publishable (MCP stdio adapter has standalone value) or private |
+| `uffs-broker` | **Decide** — Windows-only bin? | — | Yes, tune | Missing — write | — | — | — | Yes | **R8** decision: Windows elevated handle broker — useful standalone? |
+| `uffs-cli` | Yes (bin) | inherit | Yes, tune | Missing — write | `["uffs", "cli", "search", "filesystem"]` | `["command-line-utilities", "filesystem"]` | `all-features` + Windows target | Yes | write README, add `[[bin]]` docs pattern |
+| `uffs-diag` | No | `publish = false` | N/A | N/A | N/A | N/A | N/A | Yes (internal) | Explicit `publish = false` — internal diagnostic tool |
+| `scripts/ci-pipeline` | No | `publish = false` | N/A | N/A | N/A | N/A | N/A | Yes (internal) | Explicit `publish = false` — CI driver |
+| (meta) `uffs` | **Decide** | — | — | — | — | — | — | No | **R6** decision: register a meta crate named `uffs` that re-exports the public API, similar to how `serde` works?  Or leave `uffs` as an unused reserved name?  See §5.8. |
+
+**Rust convention reminder**: crate names on crates.io are
+`kebab-case`; Rust identifiers are `snake_case`.  The mapping is
+automatic (`uffs-core` crate ↔ `uffs_core` module).  No aliasing
+needed.
+
+### 5.2 Dependency DAG and publish order
+
+The workspace internal dependency graph determines publish order.
+A crate can only publish when every crate it depends on is already
+published (or publishing in the same `cargo publish` invocation,
+which cargo handles for workspaces).
+
+From the 12 publishable crates (excluding `uffs-diag`,
+`scripts/ci-pipeline`):
+
+```
+Level 0 (leaves, no internal deps):
+  uffs-polars, uffs-text, uffs-time, uffs-security
+
+Level 1 (depends on level 0):
+  uffs-format     → uffs-polars, uffs-text
+  uffs-mft        → uffs-polars, uffs-security, uffs-time
+                    (re-exports some uffs-time types)
+
+Level 2 (depends on levels 0-1):
+  uffs-core       → uffs-polars, uffs-text, uffs-time,
+                    uffs-mft, uffs-format, uffs-security
+
+Level 3 (depends on levels 0-2):
+  uffs-client     → uffs-core
+  uffs-daemon     → uffs-core, uffs-client  (IPC server side)
+
+Level 4 (top-level):
+  uffs-cli        → uffs-core, uffs-client, uffs-daemon
+  uffs-mcp        → uffs-core, uffs-client
+  uffs-broker     → uffs-security (Windows-gated broker)
+```
+
+**Publish order for `cargo publish --workspace` (release-plz
+handles this automatically)**:
+
+1. `uffs-polars`, `uffs-text`, `uffs-time`, `uffs-security`  (parallel-eligible)
+2. `uffs-format`, `uffs-mft`  (parallel-eligible)
+3. `uffs-core`
+4. `uffs-client`, `uffs-broker`  (parallel-eligible)
+5. `uffs-daemon`
+6. `uffs-cli`, `uffs-mcp`  (parallel-eligible)
+
+crates.io **rate-limits** publishes to roughly 5/min per account
+(historically; check current quotas via the
+`https://crates.io/api/v1/crates/...` headers during R8 rehearsal).
+12 crates serialize conservatively at ~3 min total publish time.
+
+**DAG validation**: run `cargo metadata --no-deps --format-version
+1 | jq '.packages[] | {name, deps: .dependencies[] |
+select(.kind == null) | .name}'` and cross-check against the levels
+above.  Deviations indicate a dependency has been added/removed
+since this plan was written.
+
+### 5.3 Feature flag audit
+
+Each crate that has features needs those features documented for
+docs.rs and for downstream consumers.  The `[package.metadata.docs.rs]
+all-features = true` config makes docs.rs build with every feature
+on, which is the right default unless features conflict
+(mutually-exclusive features).
+
+Known feature flags in the workspace (as of this plan):
+
+| Crate | Feature | Purpose | Default? |
+|---|---|---|---|
+| `uffs-mft` | `zstd` | zstd compression for archived MFT records | Yes (per workspace dep in root `Cargo.toml`) |
+| `uffs-client` | `async` | Async client API (tokio) | No — sync path is default |
+
+For each feature flag, the crate should have a brief docs paragraph:
+
+```rust
+//! ## Feature flags
+//!
+//! - `zstd` (default): enables zstd compression of archived MFT
+//!   records.  Disabling reduces binary size by ~200KB but requires
+//!   external decompression for archives.
+```
+
+Audit once in R6.  Add rustdoc-level feature docs to each crate
+before R9.
+
+### 5.4 docs.rs rendering — what breaks, what to check
+
+docs.rs builds every published version on push.  Failures are
+**silent from crates.io's perspective** (the publish succeeds; only
+docs.rs shows a "build failed" badge).  Known failure modes:
+
+1. **Platform-gated items vanish**: docs.rs builds on
+   `x86_64-unknown-linux-gnu` by default.  Any `#[cfg(windows)]`
+   item gets dropped from the docs.  Fix: set
+   `[package.metadata.docs.rs] targets = ["x86_64-unknown-linux-gnu",
+   "x86_64-pc-windows-msvc"]` so docs.rs builds twice and the
+   Windows surface renders.
+2. **Unstable feature gates in docs.rs stable builds**: docs.rs
+   uses **nightly** by default, so `#![feature(...)]` works.  But
+   if a crate declares `rust-version = "1.91"`, docs.rs may still
+   complain.  Set the MSRV honestly; docs.rs handles it.
+3. **Missing `cfg(docsrs)` annotations** make feature-gated items
+   invisible.  Pattern:
+   ```rust
+   #[cfg(feature = "async")]
+   #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+   pub mod async_api { ... }
+   ```
+   The `doc(cfg(...))` line requires `#![feature(doc_cfg)]` at
+   crate root — but docs.rs enables this flag automatically
+   under the `docsrs` cfg.  On stable builds, the line is a
+   no-op.
+4. **README with relative image/link paths breaks** once rendered
+   on crates.io (which serves from a different domain).  Fix: use
+   absolute GitHub blob URLs for images, or embed them via the
+   `#![doc = include_str!("../README.md")]` pattern with relative
+   paths that work in both contexts.
+5. **Build timeout (2 hours on docs.rs)** is rarely hit, but
+   `uffs-mft` with polars features enabled is a risk.  Monitor
+   build times in R8 rehearsal; if polars-ops rebuild exceeds
+   90 min, reduce `docs.rs.features` to a minimal set for
+   documentation.
+
+### 5.5 Yanking and version deletion policy
+
+Crates.io follows an immutable-version policy except:
+- A version can be **yanked** (hidden from new resolves, kept for
+  existing lockfiles).  `cargo yank -p <crate> --vers X.Y.Z`.
+- A version can be **unyanked** (undo yank).  `cargo yank -p <crate>
+  --vers X.Y.Z --undo`.
+- A version **cannot be deleted** except via support request
+  within 72 hours of publish (for accidental pushes with
+  credentials in code, etc.).
+
+Project policy (target state post-R9):
+
+1. **Never delete.  Always yank.**  Deletion breaks downstream
+   lockfiles that reference the deleted version; yanking only
+   prevents new adoption.
+2. **Yank triggers**:
+   - Security vulnerability in the published version → yank + release
+     patched version same-day
+   - Accidentally-published debug/test content → yank within
+     24 hours
+   - License violation discovered post-publish → yank immediately,
+     rebuild and republish under correct license
+3. **Do not yank**:
+   - Because a later version is "better" — users need the ability
+     to pin to older stable versions
+   - Because of an API regression you want to hide — release a
+     new version with the API restored, don't erase history
+4. **Log yanks** in `docs/publishing.md` "yank decisions" section
+   with date, version, rationale, replacement version.
+
+### 5.6 Trusted publisher (OIDC) — step-by-step
+
+See §R7 for the phase-level steps.  This section is the reference
+for the exact crates.io UI form fields.
+
+crates.io Trusted Publisher form (as of 2026):
+
+| Field | Value | Notes |
+|---|---|---|
+| Repository owner | `skyllc-ai` | GitHub org or user |
+| Repository name | `UltraFastFileSearch` | Exact case |
+| Workflow filename | `release-plz.yml` | Relative to `.github/workflows/` |
+| Environment name | `crates-io-production` | Must match the GHA `environment:` value exactly |
+
+The workflow must request `id-token: write` in its permissions
+block to mint the OIDC token.  The OIDC audience crates.io expects
+is `crates.io` (not `api.crates.io` or anything else).  The
+`rust-lang/crates-io-auth-action` action handles the audience
+negotiation transparently; only break glass if building a custom
+auth step.
+
+**If the workflow filename changes**, ALL trusted-publisher
+registrations break and must be re-registered.  This is why
+`release-plz.yml` was chosen as the registered filename — it's
+the natural name, unlikely to be renamed.
+
+### 5.7 First-publish runbook (template for `docs/publishing.md`)
+
+```markdown
+# UFFS Publishing Runbook
+
+**STATUS**: DORMANT — publishing is not yet live.  See
+[release-automation-plan.md §8](architecture/release-automation-plan.md#8-status-dashboard)
+for the R9 go-live decision.
+
+## When do we publish?
+
+Never automatically.  Every publish is a maintainer decision made
+in the release PR review step.  Release-plz opens a release PR; a
+maintainer reviews the changelog, confirms the version bump, merges,
+and at that point the OIDC publish job fires (from R9 onward).
+
+## Pre-publish checklist (one-time, per go-live decision)
+
+- [ ] All 13 crate names reserved on crates.io under the project
+      account
+- [ ] Trusted-publisher registrations complete for all 13 names
+- [ ] `crates-io-production` GitHub Environment exists
+- [ ] `release-plz.yml` publish job has `if: true`
+- [ ] `release-plz.toml` has `publish = true` at workspace level
+- [ ] First-release communication drafted (blog post, release notes,
+      Twitter/Mastodon announcement)
+
+## Per-release checklist
+
+- [ ] Release-plz release PR opened
+- [ ] Changelog entries reviewed for accuracy
+- [ ] Version bump reviewed (feat → minor, fix → patch, feat! →
+      major — all consistent)
+- [ ] Breaking changes called out in changelog Migration section
+- [ ] Release PR merged → tag created → release.yml fires
+- [ ] Binaries visible on GitHub Release page
+- [ ] Publish job succeeds for all eligible crates (check run logs)
+- [ ] Each published crate appears on crates.io within 60 sec
+- [ ] docs.rs builds succeed for all published crates within 2 hours
+- [ ] Announcement posted (if major release)
+
+## Yank decisions log
+
+| Date | Crate | Version | Rationale | Replacement |
+|---|---|---|---|---|
+| (none yet) | | | | |
+
+## Post-publish checks
+
+- [ ] `cargo search <crate>` returns new version
+- [ ] Throwaway `cargo new test-pub && cargo add <crate> && cargo
+      build` succeeds
+- [ ] crates.io crate page renders readme correctly
+- [ ] docs.rs renders without errors (green build badge)
+```
+
+### 5.8 Meta-crate decision: `uffs` top-level crate
+
+Open question for Phase R6: publish a meta crate named `uffs` that
+re-exports the public API?
+
+**Pros**:
+- Users install ONE crate (`cargo add uffs`), get everything
+- Ergonomic for library consumers (`use uffs::query::...`)
+- Matches the pattern of `tokio`, `serde`, `clap` — which are
+  technically workspaces but expose a single public umbrella
+
+**Cons**:
+- Duplication of public API — the meta crate has to keep its
+  re-exports in sync with the underlying crates' APIs
+- Additional maintenance surface during refactoring
+- Potential confusion: is `uffs::mft::...` the same as
+  `uffs_mft::...`?  (Yes, via re-export; but users might not
+  know that.)
+
+**Recommendation**: defer to Phase R8 decision point.  If UFFS is
+primarily a binary app (users install `uffs-cli` via
+`cargo install uffs-cli`), the meta crate adds complexity without
+value.  If UFFS becomes a library for downstream embedding (MCP
+host, external tooling), the meta crate becomes the canonical
+API surface.  Today UFFS is 80% binary app, so the meta crate is
+likely unnecessary.  But reserve the name anyway — reservations
+are cheap, and owning `uffs` on crates.io prevents confusion.
+
+## 6. Risks and open questions
+
+### 6.1 Risks
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| 1 | **Release-plz misinterprets commit history**, producing wrong version bump on first active release | Medium | High (confusing user-facing version jump) | Phase R3 shadow mode observes ≥3 runs before activation; manual override always available via editing the release PR before merging |
+| 2 | **git-cliff template drift**: changelog sections categorize new commit prefixes incorrectly | Medium | Low (easy to fix in PR review) | R2 validation against last ~6 months of commits; PR review step catches drift |
+| 3 | **Concurrent tag creation** from release-plz + `auto-tag-release.yml` during R4 overlap period | Low | Medium (confused CI state) | Tag-exists idempotency guard in `release.yml`; one of the two no-ops cleanly |
+| 4 | **Merge conflicts in release PR** when main advances between PR creation and merge | High (for active projects) | Low (release-plz rebases automatically) | release-plz auto-updates the release PR on main advances; manual rebase available |
+| 5 | **Commit convention violations** by contributors who bypass commitlint | Medium | Low → High over time (version accuracy degrades) | Advisory phase (R1a) gathers data; mandatory gate (R1b) blocks violators |
+| 6 | **crates.io rate limits** hit during full-workspace publish in R9 | Low | Medium (partial publish, DAG disrupted) | Release-plz handles rate limit backoff; publish order (§5.2) respects DAG so partial publish fails closed, not open |
+| 7 | **OIDC misconfiguration** in R7 blocks publishing in R9 | Medium | Medium (blocks release) | R7 dry-run validation catches this; rollback is trivial (reset `if: false`, investigate offline) |
+| 8 | **Premature publishing** — someone flips `publish = true` before R9 gates are satisfied | Low | Very high (irreversible — cannot delete crates.io versions) | `if: false` gate + `crates-io-production` env required-reviewer + `publish = false` at workspace level + per-crate `publish = false` — **four independent locks**, all must be explicitly defeated |
+| 9 | **SemVer regression** — patch release accidentally breaks API, violating SemVer contract | Medium | High (ecosystem trust damage) | Pre-R9 gate: `cargo-semver-checks` in PR Fast CI for ≥1 release cycle |
+| 10 | **Orphaned meta-crate** (`uffs`) reserved but never maintained | Low | Low (name squatting for one's own project) | Reserve as stub 0.0.0 with clear pointer to canonical crates; yank if decision is "no meta crate" |
+| 11 | **Release-plz tooling breakage** (upstream bug, API change, action deprecation) | Low per cycle, High over 2 years | Medium (blocks releases until fixed) | Action SHA pinning; fall back to manual `cargo publish` via runbook (§5.7); monitor release-plz changelog |
+| 12 | **Fork PR poisoning release-plz**: malicious contributor opens a PR that manipulates commit messages to force an unexpected version bump | Low | Medium (wrong version, recoverable via amend) | release-plz only runs on `main`, not on PRs; PR commit messages are scanned but not acted upon until the PR merges; merge requires review |
+| 13 | **Interim `Cargo.lock` drift** between R0 and R5 — if the optional R0 step-5 patch is skipped, any releases cut via `just ship` during the R1-R4 window continue to ship with drifted lockfiles (see §2.2) | Medium (certain if step skipped) | Low (binaries still build; self-heals intermittently) | Either apply the R0 step-5 one-line patch, or accept that releases during the transition are not byte-reproducible from their `Cargo.lock`.  Fully resolved at R5 (release-plz refreshes lockfile natively via `dependencies_update = true`). |
+
+### 6.2 Open questions (resolve during phases)
+
+1. **`uffs-daemon`, `uffs-mcp`, `uffs-broker`: publishable or
+   private?**  Decide in R6/R8 dress rehearsal.  Default: publish
+   `uffs-mcp` (clear standalone value: MCP stdio adapter), keep
+   `uffs-daemon` and `uffs-broker` private unless there's
+   downstream demand.
+2. **Meta crate `uffs`: publish or reserve-only?**  See §5.8.
+   Default: reserve as 0.0.0 stub, decide on content after R8.
+3. **Release cadence: per-merge or batched?**  Release-plz defaults
+   to per-merge (every meaningful merge to main opens a release
+   PR).  Alternative: weekly batch via `release-plz.toml
+   release_pr_schedule`.  Default: per-merge; revisit if noise
+   becomes painful.
+4. **Pre-release channel (`-alpha.N`, `-rc.N`)?**  Not needed until
+   approaching v1.0.  Revisit as part of R9 go-live planning.
+5. **Changelog format**: Keep a Changelog (current) vs. commit-
+   subject list (git-cliff default).  Default: git-cliff default
+   with `cliff.toml` sections shaped to approximate Keep a
+   Changelog (Added, Changed, Fixed, Removed).  Decide in R2.
+6. **Advisory commitlint runner**: own workflow or step in
+   pr-fast.yml?  Default: separate `commitlint.yml` workflow —
+   easier to disable / toggle independently of PR Fast CI.
+7. **Per-crate versioning (R9-beta)**: when does the single-
+   workspace-version approach become painful?  Probably around
+   v1.0 when `uffs-polars` stabilizes ahead of `uffs-cli`.
+   Defer.
+
+## 7. Rollback playbook
+
+Per-phase rollback is documented in each phase's **Rollback**
+block.  This section is the cross-cutting playbook for
+"something went wrong across multiple phases."
+
+### 7.1 Rollback triggers
+
+Any of these conditions warrants rollback consideration:
+
+1. A release-plz run produces a changelog or version bump that
+   cannot be corrected by editing the release PR (i.e. the output
+   is structurally wrong, not cosmetically wrong)
+2. `release.yml` stops triggering on tags (tag/workflow trigger
+   divergence)
+3. A published crates.io version cannot be consumed
+4. OIDC authentication fails consistently, blocking releases
+5. Commitlint false-positive rate > 20% of PRs (hard-gate phase)
+
+### 7.2 Rollback order (latest phase first)
+
+Always roll back in **reverse execution order**.  Never "leap back"
+to an earlier phase skipping intermediate rollbacks.
+
+Example: if R7 breaks, roll back R7 first; do not roll back to
+R5 while R6 remains in the forward state.  This preserves the
+reversibility invariant.
+
+| Forward phase | Rollback command | Post-rollback state |
+|---|---|---|
+| R9 | Revert the `if: false` flip PR; `cargo yank` any versions published in the rollback window | Publishing disabled; historical versions remain on crates.io |
+| R8 | Revert the scope/flip PR; `cargo yank -p uffs-time --vers <rehearsal-version>` | OIDC scaffolding in place but dormant |
+| R7 | Revert the OIDC job PR; remove GitHub Environment | Dry-run CI still running; no OIDC trust registrations needed (but they stay on crates.io harmlessly) |
+| R6 | Revert per-crate metadata + `crates-io-dry-run.yml` | Back to R5 steady state; reserved names stay owned |
+| R5 | Revert the deletion PR → restores `build/update_all_versions.rs`, `auto-tag-release.yml`, and `scripts/ci-pipeline/src/version.rs` | Both the bespoke flow and release-plz flow present concurrently |
+| R4 | Revert the permissions/release-job PR | Release-plz back to shadow mode |
+| R3 | Revert the release-plz.toml + workflow PR | Release-plz not installed; git-cliff still present |
+| R2 | Revert the cliff.toml PR | `git-cliff` uninstalled-ish (the tool doesn't mind; the config just disappears) |
+| R1 | Revert the commitlint workflow PR | No commit convention checks; contributors continue by habit |
+| R0 | Revert the baseline / cleanup PR | Back to pre-plan state |
+
+### 7.3 Partial rollback patterns
+
+- **Rollback only the "active" bit of R4 without losing R3
+  shadow observability**: edit `release-plz.yml` to remove the
+  `release` job (keep `release-pr` in shadow mode).  Do not delete
+  the whole workflow.
+- **Rollback only R9's publishing without affecting R5's
+  deletion**: flip `if: false`, flip `publish = false` in
+  `release-plz.toml`, but do not un-delete `build/
+  update_all_versions.rs`.  The bespoke tooling stays deleted;
+  we just stop publishing new versions.
+- **Partial crate publishing after R9**: set `publish = false`
+  on individual `Cargo.toml` per crate, release-plz skips those.
+
+### 7.4 Communication plan for rollback
+
+If a rollback is executed after a public release has shipped:
+
+1. Open a GitHub issue with `rollback` label explaining which
+   phase was rolled back and why.
+2. Post an announcement in release notes or repo README if the
+   rollback affects user-facing behavior (binary distribution,
+   published crates).
+3. Update this plan's §8 status dashboard with the rollback
+   date and rationale.
+4. Write a deviations-log entry in `dev-flow-implementation-plan.md`
+   §10.5 if the rollback reveals a systemic issue.
+
+## 8. Status dashboard
+
+Single source of truth for phase progress.  Mirror the format of
+`dev-flow-implementation-plan.md §5 status dashboard`.
+
+| # | Phase | Status | Commit | Date | PR | Notes |
+|---|---|---|---|---|---|---|
+| R0 | Baseline & cleanup (remove dead cargo-dist config, rename commit-style doc) | ⬜ | | | | Cleanup before forward movement |
+| R1a | Conventional commits (advisory) | ⬜ | | | | PR title + commit messages scanned, comment-only |
+| R1b | Conventional commits (mandatory gate) | ⬜ | | | | After ≥1 month of advisory observation |
+| R2 | `git-cliff` + `cliff.toml` (local validation) | ⬜ | | | | No workflow change; just the template |
+| R3 | release-plz shadow mode | ⬜ | | | | Observe 1-2 weeks / 3-5 merges |
+| R4 | release-plz active (release PR mode) | ⬜ | | | | At least 1 full release cut through the new flow |
+| R5 | Retire bespoke tooling | ⬜ | | | | ~1350 lines deleted; point of no return for easy rollback |
+| R6 | crates.io metadata audit + dry-run CI | ⬜ | | | | Names reserved externally; per-crate metadata complete |
+| R7 | OIDC trusted publisher (dormant) | ⬜ | | | | Scaffolding, `if: false` gate |
+| R8 | First publish dress rehearsal (`uffs-time` only) | ⬜ | | | | **External state change** — one crate goes live on crates.io |
+| R9 | Live publishing (full workspace) | ⬜ | | | | **DEFERRED** — explicit maintainer decision, separate plan |
+
+Legend: ⬜ pending · 🟡 in progress · 🟢 complete · 🔴 blocked · ⏸️ paused
+
+### 8.1 Deviations log
+
+Mirror the format of
+`dev-flow-implementation-plan.md §10.5 deviations log`.  Empty
+until phases are executed.
+
+| Phase | Date | Anomaly | Root cause | Resolution | Plan impact |
+|---|---|---|---|---|---|
+| (none yet) | | | | | |
+
+## 9. Cross-references
+
+This plan is a sibling to
+[`dev-flow-implementation-plan.md`](dev-flow-implementation-plan.md);
+both depend on and complement each other.
+
+### 9.1 What this plan owns
+
+- Conventional commits policy
+- Version bumping mechanism (release-plz)
+- Changelog generation (git-cliff)
+- Release PR process
+- crates.io scaffolding and eventual publishing
+- Retirement of bespoke version tooling
+
+### 9.2 What `dev-flow-implementation-plan.md` owns
+
+- Per-PR CI gate composition (pr-fast.yml jobs)
+- Preview artifact workflow
+- Tier 1 vs Tier 2 split
+- `ci-pipeline` / `just ship` pipeline driver
+- Branch protection rulesets
+- `gates.toml` machine-readable manifest (Phase 8, deferred)
+
+### 9.3 Shared concerns (touched by both plans)
+
+- `scripts/ci-pipeline/src/version.rs` is touched by R5 in this
+  plan; its broader shape (check/lint/test pipeline) belongs to
+  dev-flow.
+- `release.yml` is referenced as "unchanged" in this plan; its
+  continued correctness is validated by tier-2 and preview flows
+  in dev-flow.
+- Branch protection: after R5, the `auto-tag-release` workflow is
+  deleted; any branch protection check referring to it must be
+  removed in the same PR.  Coordinate via dev-flow's branch-
+  protection ruleset tracking.
+
+### 9.4 Reading order for new maintainers
+
+1. `README.md` — what UFFS is
+2. `CONTRIBUTING.md` — how to contribute (includes commit
+   conventions from R1)
+3. `dev-flow-implementation-plan.md` §1-§4 — the CI architecture
+4. **This document §1-§3** — the release architecture
+5. Either plan's §5 onward — phase-by-phase detail, only if
+   executing the migration
+
+## 10. Non-goals deep-dive
+
+### 10.1 Why not `cargo-dist`?
+
+`cargo-dist` (now `dist`) is a strong tool for projects starting
+fresh.  It generates release.yml-equivalent workflows from
+declarative config and handles binary builds, signing, installer
+generation.  **Why decline for UFFS:**
+
+1. `release.yml` already does everything cargo-dist would:
+   5-target matrix build, SLSA provenance, sha256 manifests,
+   GitHub Release upload.  ~780 lines of tested workflow.
+2. cargo-dist's generated workflow would be ~1000 lines, much of
+   which would mirror `release.yml`'s existing logic.
+3. cargo-dist's install scripts (curl|sh) introduce a new
+   distribution surface that UFFS doesn't currently support.
+   Adding that is a product decision, not a tooling decision.
+4. The `[workspace.metadata.dist]` block in `Cargo.toml` (removed
+   in R0) was exploratory; adopting cargo-dist requires
+   regenerating `release.yml` from scratch, which would lose
+   hand-tuned behavior (specific winresource handling, cargo-xwin
+   invocation, polars-specific flags).
+
+**Re-evaluate if**: cargo-dist ships a migration tool that can
+import existing `release.yml` workflows.  Until then, cargo-dist
+adoption is a blank-slate rewrite of release infrastructure, which
+doesn't pencil.
+
+### 10.2 Why not non-Rust ecosystem tools?
+
+- **semantic-release** (Node.js): cross-ecosystem, but doesn't
+  understand Cargo workspaces, dependency DAG, or crates.io
+  publish semantics.  Would require ~500 lines of shell glue
+  to translate.
+- **changesets** (originally for npm): requires every contributor
+  to write a `.changeset/<random>.md` file per change — adds
+  friction.  Doesn't compute versions from commits.
+- **standard-version** / **release-it**: JS-centric, same DAG
+  and workspace blind spots.
+
+Rust-native tooling (release-plz + git-cliff) integrates with
+Cargo workspace inheritance, `[workspace.dependencies]` version
+updates, and the `cargo publish` DAG walk.  Using ecosystem-
+native tools is a strict win for correctness and maintenance
+cost.
+
+### 10.3 Why not single-PR mega-migration?
+
+Temptation: do R0-R5 in one big PR to minimize churn.  Decline
+because:
+
+1. Release infrastructure changes touch the critical path; one
+   broken piece breaks all releases.  Small reversible PRs limit
+   blast radius to a single phase.
+2. Shadow-observation phases (R3) require real commits flowing
+   through main to validate — impossible in a mega-PR.
+3. Rollback granularity: if R4 breaks, reverting R4 should not
+   also revert R0-R3.  Mega-PR rollback is all-or-nothing.
+4. Review burden: each phase is ~30-400 lines; reviewable in a
+   sitting.  A combined PR would be ~2000 lines of structural
+   change, review-fatigue-prone.
+
+## 11. FAQ
+
+**Q: Why not just adopt release-plz in one shot and delete the old
+tooling the same day?**
+A: Because release-plz's behavior depends on the commit history and
+`cliff.toml`.  Getting either wrong produces surprising versions.
+Phase R3 (shadow mode) observes that release-plz would produce the
+right output on real commits, without creating tags or PRs.  Same-
+day cutover would trade observability for speed, which is the wrong
+trade when the feedback loop is "did we ship the wrong version
+number to users".
+
+**Q: Do conventional commits mean every commit message has to be
+perfect?**
+A: No.  Only merge commit messages (the title of the squashed PR)
+need to follow the convention.  Intermediate commits on feature
+branches can be whatever the author prefers.  The squash-merge
+pattern (which UFFS already uses for most PRs) means the PR title
+becomes the merge commit subject — so "the PR title must follow
+conventional commits" is the effective rule.
+
+**Q: What if a PR genuinely doesn't fit any conventional commit
+type?**
+A: Use `chore:` as the catch-all.  `chore:` commits don't trigger
+a release.  If a PR is "`chore: refactor the whole world" that
+also fixes a user-visible bug, split the PR — one `chore:` for
+the refactor, one `fix:` for the bug.
+
+**Q: What about reverts and hotfixes — do they bump versions?**
+A: `revert:` commits follow the same semantics as the reverted
+commit.  Reverting a `feat:` bumps minor; reverting a `fix:` bumps
+patch.  Hotfixes are just `fix:` commits on main.  Urgent hotfix
+cadence (releases within hours) is supported because release-plz
+opens a release PR on every push to main — merge it ASAP for a
+fast release.
+
+**Q: Can we skip release-plz and use git-cliff + a hand-rolled
+version bump script?**
+A: Yes, but you'd be re-implementing release-plz.  The value of
+release-plz is the PR-review-based release cadence + tag creation
++ GitHub Release integration + dependency version walking, all in
+one tool.  Git-cliff alone gets you 30% of the way; release-plz
+adds the remaining 70%.
+
+**Q: What happens to the existing hand-maintained `## [Unreleased]`
+section of `CHANGELOG.md`?**
+A: In R2 we document the current format; in R3 we start letting
+git-cliff generate sections.  In R4 release-plz generates a new
+`## [0.5.72]` (or similar) header before the `## [Unreleased]`
+marker, and the `## [Unreleased]` block becomes vestigial.  R5
+deletes the vestigial block.  All historical `## [X.Y.Z]` entries
+stay — they're valuable.
+
+**Q: What if we later decide to publish cargo-dist's release
+format alongside our own?**
+A: Re-evaluated in the release-automation plan v2 (post-R9).  The
+current plan deliberately does not bind the project to one binary
+distribution path.
+
+## 12. Appendix A — Minimal `cliff.toml` reference
+
+```toml
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project are documented in this file.
+Format based on Keep a Changelog; versions follow SemVer.
+"""
+body = """
+{% if version %}\
+  ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+  ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+  ### {{ group | upper_first }}
+  {% for commit in commits %}
+    - {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+      {% if commit.breaking %} **BREAKING**{% endif %}
+  {% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+commit_parsers = [
+    { message = "^feat",     group = "Added"   },
+    { message = "^fix",      group = "Fixed"   },
+    { message = "^perf",     group = "Performance" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^docs",     group = "Docs"    },
+    { message = "^test",     group = "Tests"   },
+    { message = "^chore",    skip = true       },
+    { message = "^ci",       skip = true       },
+    { message = "^revert",   group = "Reverted" },
+    { body    = ".*BREAKING", group = "Breaking" },
+]
+protect_breaking_commits = true
+filter_commits = false
+tag_pattern = "v[0-9]*"
+skip_tags = "v0.1.0-beta.1"
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"
+```
+
+## 13. Appendix B — Minimal `release-plz.toml` reference
+
+```toml
+[workspace]
+# All crates share the same version (today's state).  Flip to
+# per-crate versioning (independent) post-R9 if needed.
+dependencies_update = true
+
+# Publishing gate: OFF at workspace level until R9.  Individual
+# crates also have `publish = false` in their Cargo.toml.
+publish = false
+
+# Release artifacts (GitHub Release + tag) driven by release-plz.
+# Actual binary upload still happens in release.yml (tag-triggered).
+git_release_enable = true
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
+
+# Changelog generation via git-cliff (cliff.toml).
+changelog_update = true
+changelog_path = "CHANGELOG.md"
+
+# PR title and body format.
+pr_name = "chore(release): prepare v{{ version }}"
+pr_body = """
+Automated release prepared by release-plz.
+
+Please review:
+- Version bump correctness
+- Changelog entries
+- Cargo.lock refresh
+
+Merging this PR triggers:
+1. Tag creation (v{{ version }})
+2. release.yml (binary builds + GitHub Release)
+3. crates.io publish (post-R9 only; gated today)
+"""
+
+# Semver-checks integration (once cargo-semver-checks is in PR Fast CI)
+# semver_check = true
+
+[[package]]
+name = "uffs-diag"
+publish = false
+release = false  # Never cut a release for this crate
+
+[[package]]
+name = "ci-pipeline"
+publish = false
+release = false
+```
+
+## 14. Execution order summary
+
+Read-through reminder:
+
+1. R0 (baseline cleanup) — ~30 LOC churn
+2. R1a (advisory commitlint) — ~60 LOC, new workflow
+3. R1b (mandatory commitlint) — 1-line change after observation window
+4. R2 (cliff.toml) — ~80 LOC, new config
+5. R3 (release-plz shadow) — ~80 LOC, new workflow + config
+6. R4 (release-plz active) — ~30 LOC change (permissions + release job)
+7. R5 (retire bespoke tooling) — ~1350 LOC deletion, ~30 LOC additions
+8. R6 (crates.io metadata + dry-run CI) — ~400 LOC additions
+9. R7 (OIDC scaffolding) — ~80 LOC additions
+10. R8 (publish rehearsal) — ~10 LOC, 1 crate published
+11. R9 (live publishing) — **deferred, separate decision**
+
+Total migration churn: **~2100 LOC added, ~1350 LOC removed**,
+spanning R0-R8.  Median PR size: ~100 LOC.  Max PR size: R5 (the
+deletion), which is net -1320 LOC.

--- a/docs/architecture/security/supply-chain-posture.md
+++ b/docs/architecture/security/supply-chain-posture.md
@@ -66,7 +66,7 @@ control lands or a deferred item is promoted.
 | Commit ancestry check | Custom step in `release.yml` | `workflow_dispatch` `commit_sha` must be ancestor of main | Every release dispatch | **Yes** — release.yml |
 | Dep-tree growth | `dependabot-review.yml` | Cargo.lock crate-count delta on Dependabot PRs | Every Dependabot PR | Annotation only |
 | Lockfile pinning | Committed `Cargo.lock` | Every resolved crate-version frozen across devs / CI / releases | Always | **Yes** — `cargo vet check --locked` would fail any drift |
-| Audit trail | `cargo-vet check --locked` | Every resolved crate-version must have import / own audit / exemption | Every PR | **Yes** — `ci.yml` Security job |
+| Audit trail | `cargo-vet check --locked` | Every resolved crate-version must have import / own audit / exemption | Every PR | **Yes** — `pr-fast.yml` security job |
 | Import refresh | `cargo-vet-refresh.yml` | Weekly `cargo vet regenerate imports` → PR | Mondays 08:00 UTC | GitHub schedules |
 | Structural audit | `cargo-geiger` via `just geiger` | unsafe / build.rs / proc-macro footprint | On-demand (monthly) | No |
 | Semantic SAST | `codeql.yml` (Rust, public preview) | Dataflow-based bug patterns (path / SQL / regex injection, crypto misuse, unvalidated redirects) | PR + Tuesdays 06:30 UTC | Informational (not a required gate yet) |
@@ -354,7 +354,7 @@ on `main` at branch-open time.
 - `supply-chain/config.toml` — `cargo-vet` imports + exemptions
 - `supply-chain/audits.toml` — our local audit records (starts empty)
 - `supply-chain/imports.lock` — pinned upstream audit snapshots
-- `.github/workflows/ci.yml` §Security — `cargo-deny` + `cargo-vet check` enforcement (Tier 1)
+- `.github/workflows/pr-fast.yml` — required per-PR gate (fmt, clippy, docs, tests, windows-check, `cargo-deny` + `cargo-vet check` in `security` job) (Tier 1)
 - `.github/workflows/tier-2.yml` — weekly coverage / udeps / Miri / Windows compile check
 - `.github/workflows/release.yml` — SLSA attestation + ancestor check + CycloneDX SBOM
 - `.github/workflows/codeql.yml` — Rust SAST (public preview)

--- a/just/cache.just
+++ b/just/cache.just
@@ -39,3 +39,99 @@ sccache-clear:
     mkdir -p "$HOME/.cache/sccache"
     printf "\033[0;32m✅ sccache cache cleared!\033[0m\n"
 
+# Prune the `cargo-llvm-cov` target tree + stale daemon shmem files.
+#
+# `just test` runs `cargo llvm-cov nextest` which writes an instrumented
+# build tree to `$CARGO_TARGET_DIR/llvm-cov-target/`.  That tree can
+# grow to 100+ GB over a long session — every profile bump, every
+# `.profraw` from a failed run, and every compiled test binary stays
+# cached there.  On a near-full disk (Dropbox / external drive / small
+# SSD) this is the top cause of ENOSPC that surfaces as:
+#
+#   handler::csv_blob_tests::try_pack_csv_blob_offloads_large_blob_to_shmem
+#     → panicked at 'large multi-column blob must be offloaded to ShmemBlob'
+#   handler::paths_blob_tests::try_pack_paths_blob_offloads_large_blob_to_shmem
+#     → panicked at 'large path-only projection must be offloaded to ShmemBlob'
+#
+# The daemon's `write_paths_blob` correctly falls back to
+# `SearchPayload::InlineBlob` on disk-full, but those two tests pin
+# the shmem branch specifically, so a disk-full environment makes
+# them loudly fail — which is exactly the design: silently skipping
+# would hide real `write_paths_blob` regressions on healthy hosts.
+#
+# What it prunes:
+#   - `$CARGO_TARGET_DIR/llvm-cov-target/` (instrumented build tree)
+#   - `$CARGO_TARGET_DIR/llvm-cov/`        (HTML coverage report)
+#   - `$CARGO_TARGET_DIR/**/*.profraw`     (instrumentation output)
+#   - `$LOCALAPPDATA/uffs/shmem/`            (Windows)
+#     `$XDG_DATA_HOME/uffs/shmem/`           (Linux)
+#     `~/Library/Application Support/uffs/shmem/` (macOS)
+#
+# Safe to re-run; leaves regular `cargo build` artifacts, sccache,
+# and the dependency cache untouched.  Reports total freed bytes.
+
+# Prune llvm-cov target tree + orphan daemon shmem files; fixes disk-full ENOSPC failures.
+clean-cov:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    printf "\033[0;34m🧹 Pruning cargo-llvm-cov target tree + stale shmem files...\033[0m\n"
+
+    TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+    printf "   target dir: %s\n" "$TARGET_DIR"
+
+    FREED_KB=0
+
+    # Phase 1 — llvm-cov instrumentation trees.
+    for sub in llvm-cov-target llvm-cov; do
+        if [ -d "$TARGET_DIR/$sub" ]; then
+            SIZE_KB=$(du -sk "$TARGET_DIR/$sub" 2>/dev/null | cut -f1 || echo 0)
+            printf "   \033[0;34m•\033[0m %s/%s — %s KB\n" "$TARGET_DIR" "$sub" "$SIZE_KB"
+            rm -rf "$TARGET_DIR/$sub"
+            FREED_KB=$((FREED_KB + SIZE_KB))
+        fi
+    done
+
+    # Phase 2 — stray .profraw instrumentation files.
+    if [ -d "$TARGET_DIR" ]; then
+        PROFRAW_COUNT=$(find "$TARGET_DIR" -name '*.profraw' -type f 2>/dev/null | wc -l | tr -d ' ')
+        if [ "${PROFRAW_COUNT:-0}" -gt 0 ]; then
+            PROFRAW_KB=$(find "$TARGET_DIR" -name '*.profraw' -type f -print0 2>/dev/null \
+                | du -sk --files0-from=- 2>/dev/null \
+                | awk '{sum += $1} END {print sum+0}')
+            find "$TARGET_DIR" -name '*.profraw' -type f -delete 2>/dev/null || true
+            printf "   \033[0;34m•\033[0m %s leftover *.profraw file(s) — %s KB\n" "$PROFRAW_COUNT" "${PROFRAW_KB:-0}"
+            FREED_KB=$((FREED_KB + ${PROFRAW_KB:-0}))
+        fi
+    fi
+
+    # Phase 3 — orphan daemon shmem files.
+    # Paths mirror `dirs_next::data_local_dir().join("uffs/shmem")` which
+    # is what the daemon writes through in `uffs_client::shmem`.
+    case "$(uname -s)" in
+        Darwin*)                     SHMEM_DIR="$HOME/Library/Application Support/uffs/shmem" ;;
+        Linux*)                      SHMEM_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/uffs/shmem" ;;
+        MINGW*|MSYS*|CYGWIN*|Windows_NT)
+                                     SHMEM_DIR="${LOCALAPPDATA:-$HOME/AppData/Local}/uffs/shmem" ;;
+        *)                           SHMEM_DIR="" ;;
+    esac
+    if [ -n "$SHMEM_DIR" ] && [ -d "$SHMEM_DIR" ]; then
+        SHMEM_COUNT=$(find "$SHMEM_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
+        if [ "${SHMEM_COUNT:-0}" -gt 0 ]; then
+            SHMEM_KB=$(du -sk "$SHMEM_DIR" 2>/dev/null | cut -f1 || echo 0)
+            rm -rf "$SHMEM_DIR"/*
+            printf "   \033[0;34m•\033[0m %s shmem file(s) in %s — %s KB\n" "$SHMEM_COUNT" "$SHMEM_DIR" "$SHMEM_KB"
+            FREED_KB=$((FREED_KB + SHMEM_KB))
+        fi
+    fi
+
+    # Summary — promote to MB / GB for readability.
+    if [ "$FREED_KB" -ge 1048576 ]; then
+        printf "\033[0;32m✅ Freed ~%s GB\033[0m\n" "$((FREED_KB / 1048576))"
+    elif [ "$FREED_KB" -ge 1024 ]; then
+        printf "\033[0;32m✅ Freed ~%s MB\033[0m\n" "$((FREED_KB / 1024))"
+    elif [ "$FREED_KB" -gt 0 ]; then
+        printf "\033[0;32m✅ Freed %s KB\033[0m\n" "$FREED_KB"
+    else
+        printf "\033[0;32m✅ Nothing to clean — llvm-cov tree and shmem dir already empty.\033[0m\n"
+    fi
+


### PR DESCRIPTION
## Summary

Post-v0.5.71 cleanup batching four related scopes into one PR so a single squash-merge
clears the working tree:

1. **Daemon compiler-warning cleanup** — 30+ warnings surfaced by `cargo xwin check`
   on Windows MSVC + nightly, now all green on macOS / Linux / Windows.
2. **Test diagnostics** — the two shmem-offload regression tests now self-document
   the most common failure cause (disk-full) and link to the one-command fix.
3. **`just clean-cov` recipe** — prunes the llvm-cov target tree + orphan shmem files
   that commonly pile up to 100+ GB during coverage sessions.
4. **Docs** — new `release-automation-plan.md` sibling plan, CONTRIBUTING.md
   "Target-dir hygiene" + "Commit message conventions" sections, and two stale
   `ci.yml` refs in `supply-chain-posture.md` corrected to `pr-fast.yml`.

## Commits

| # | Commit | Type | Scope |
|---|---|---|---|
| 1 | `fix(daemon): resolve compiler warnings on Windows MSVC + nightly` | fix | code |
| 2 | `test(daemon): enrich shmem-offload panic messages with disk-full hint` | test | test-diagnostics |
| 3 | ``chore(just): add `clean-cov` recipe for pruning llvm-cov artifacts`` | chore | tooling |
| 4 | `docs: target-dir hygiene, release-automation plan, workflow-rename cleanups` | docs | docs |

## Scope 1 — daemon warning fixes

Every `pub` → `pub(crate)` change is semantically correct (no cross-crate callers;
the compiler verified this).  No `#[allow]` / `#[expect]` added; no test weakened.

- `broker_client.rs` — `BROKER_PIPE_NAME` → file-local const; `broker_available` +
  `request_volume_handle` → `pub(crate)`
- `index/mod.rs` — `load_live_drives` → `pub(crate)`; drop dead `loaded = total;` write
- `ipc.rs` — `run_ipc_server` → `pub(crate)`
- `lifecycle.rs` — `record_load_progress` → `pub(crate)`
- `main.rs` — drop unused `#![cfg_attr(windows, feature(windows_unix_domain_sockets))]`
  (feature stays declared in `lib.rs:11` where `ipc.rs` actually uses it)
- `tests/ipc_integration.rs` — removed crate-level `#![cfg(unix)]` (was cfg-ing out the
  whole file and orphaning all `use X as _;` suppressions on Windows); hoisted
  suppressions to crate root with platform gating; wrapped tests in
  `#[cfg(unix)] mod unix_tests { ... }`
- `benches/mft_read.rs` — added `#[cfg(windows)] use windows as _;`

**Verification** (all green):

- `cargo check -p uffs-daemon -p uffs-mft --all-features --tests --locked` (macOS)
- `cargo xwin check --target x86_64-pc-windows-msvc --locked` (Windows MSVC)
- `just lint-prod` + `just lint-tests` + `just lint-ci`
- `cargo nextest run --workspace --all-targets --all-features --no-run --locked`
- `just lint-pre-push` (full 13-job parallel bundle, 50 s)

## Scope 2 — test diagnostics

Both `try_pack_{paths,csv}_blob_offloads_large_blob_to_shmem` tests are regression
guards for the shmem-offload branch.  Under disk-full (`ENOSPC` / `ERROR_DISK_FULL`)
the daemon's `write_paths_blob` correctly degrades to inline JSON (see
`handler_blob.rs:149-159`), so the tests' `let … else { panic!(…) }` fires.  That's
working as designed — silently skipping would hide real regressions on healthy hosts.

Enrich both panic messages to:

- Identify the fallback branch (InlineBlob vs ShmemBlob).
- Point to the `tracing::warn!` line the daemon emits.
- Call out `$CARGO_TARGET_DIR/llvm-cov-target` bloat as the top cause on Windows dev hosts.
- Direct the reader to `just clean-cov` + the CONTRIBUTING.md hygiene section.

Zero semantic change; happy-path tests still PASS in 22 ms.

## Scope 3 — `just clean-cov`

Cross-platform bash recipe added alongside `sccache-clear` in `just/cache.just`.
Prunes `llvm-cov-target/`, `llvm-cov/`, stray `*.profraw`, and the daemon's
per-platform shmem dir (`$LOCALAPPDATA\uffs\shmem\` / `$XDG_DATA_HOME/uffs/shmem/` /
`~/Library/Application Support/uffs/shmem/`).  Leaves regular build artifacts,
sccache, and the Cargo registry untouched.  Live-tested: freed 7 GB locally.

## Scope 4 — docs

- **CONTRIBUTING.md** — new "Target-dir hygiene" + "Commit message conventions"
  sections; Release row now references release-plz; Docs map links release-automation-plan.
- **`docs/architecture/release-automation-plan.md`** (new, 2236 lines) — sibling to
  `dev-flow-implementation-plan.md`, scoped to post-merge concerns.  Phases R0–R9.
  Thesis: *"Stop bumping versions.  Start describing changes.  The version computes itself."*
  Keeps `publish = false` workspace-wide; actual crates.io publishing deferred.
- **`docs/architecture/dev-flow-implementation-plan.md`** — cross-reference header +
  non-goals now point to release-automation-plan.
- **`docs/architecture/security/supply-chain-posture.md`** — fix two stale
  `.github/workflows/ci.yml` refs → `pr-fast.yml` (PR #48 / #50 retired `ci.yml`;
  these two references were missed in the original sweep).

## Discipline

- No `#[allow]` / `#[expect]` added.
- No test disabled, skipped, or relaxed.
- Public API untouched; every `pub` → `pub(crate)` is intra-crate and compiler-verified.
- Production code untouched (daemon's existing warn+degrade-on-ENOSPC behavior is
  correct; only the tests' explanatory text and the tooling around it changed).
