### PR TITLE
chore(just): add xwin clippy recipes for Windows strict lint gate (Phase W1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,7 @@ UFFS is migrating to [Conventional Commits](https://www.conventionalcommits.org/
 - Preserve the crate layering: `uffs-polars` ← `uffs-mft` ← `uffs-core` ← `uffs-cli`.
 - Prefer fixture-, golden-, or saved-MFT/index-based tests for portable validation.
 - Update docs when contributor-facing workflow or user-visible behavior changes.
+- **New Windows-gated code must pass `just lint-ci-windows` before PR.**  Strict clippy on `#[cfg(windows)]` paths is advisory during the Phase W2–W5 backlog cleanup (see `docs/architecture/windows-clippy-and-linux-cross-plan.md`) and becomes a hard gate at PR CI after W5.  New lints introduced into the backlog trigger an immediate reviewer ask.
 
 ## Docs map
 
@@ -201,5 +202,6 @@ UFFS is migrating to [Conventional Commits](https://www.conventionalcommits.org/
 - Architecture docs: `docs/architecture/README.md`
 - **CI / gate architecture**: `docs/architecture/dev-flow-implementation-plan.md`
 - **Release / versioning architecture**: `docs/architecture/release-automation-plan.md`
+- **Cross-target strict-lint architecture**: `docs/architecture/windows-clippy-and-linux-cross-plan.md`
 
 If you are changing behavior that depends on raw NTFS access, call out the Windows/Admin requirement in the relevant docs and tests.

--- a/docs/architecture/dev-flow-implementation-plan.md
+++ b/docs/architecture/dev-flow-implementation-plan.md
@@ -1519,6 +1519,14 @@ Measured against current `v0.5.71` baseline:
   they share only `release.yml` (unchanged by both) and the version-
   bump bits of `scripts/ci-pipeline/src/version.rs` (retired in
   release-automation R5).
+- **Does not own cross-target strict-lint convergence.**  Upgrading the
+  Windows lint gate from `cargo check` to `cargo clippy` (1,346-lint
+  backlog as of 2026-04-24) and adding a native macOS → Linux
+  cross-check path via `cargo-zigbuild` are the concern of
+  [`windows-clippy-and-linux-cross-plan.md`](windows-clippy-and-linux-cross-plan.md).
+  The dev-flow plan owns the 4-layer gate **model** (IDE / pre-commit
+  / pre-push / PR CI); the cross-target plan owns **which flag
+  stack runs on which target** at each of those layers.
 
 ---
 

--- a/docs/architecture/release-automation-plan.md
+++ b/docs/architecture/release-automation-plan.md
@@ -106,6 +106,14 @@ UFFS — Release Automation Implementation Plan
    workspaces and integrates with crates.io semantics.  Cross-ecosystem
    tools always miss Rust-specific concerns (workspace inheritance,
    `cargo publish` ordering, cross-crate dependency version updates).
+8. **Cross-target strict-lint convergence.**  Upgrading the Windows
+   lint gate from `cargo check` to `cargo clippy -- -D warnings`
+   (1,346-lint backlog) and adding a native macOS → Linux cross-check
+   path are the concern of
+   [`windows-clippy-and-linux-cross-plan.md`](windows-clippy-and-linux-cross-plan.md).
+   Release-automation honours that work by running the post-R5
+   release pipeline against a Windows-clippy-clean `main`; the two
+   plans share no workflows or tooling surface.
 
 ### 1.3 Success criteria
 

--- a/docs/architecture/windows-clippy-and-linux-cross-plan.md
+++ b/docs/architecture/windows-clippy-and-linux-cross-plan.md
@@ -215,7 +215,7 @@ Full per-rule and per-file distribution is captured in `_trash/w0-baseline/` (gi
 - **W1.3** — Decide naming: either rename `check-windows` → `lint-windows` (canonical) with a deprecation redirect, or keep `check-windows` as the fast type-check entry-point and make `lint-ci-windows` the strict entry.  Default: keep both; `check-windows` stays as a cheap fallback.
 - **W1.4** — Measure warm xwin clippy duration for each pass; record in this doc's § 5 table below.
 
-**Acceptance**: `just lint-ci-windows` runs and reports exactly the baseline count from W0.3.  No semantic change yet.
+**Acceptance** (2026-04-24, ✅ met): `just lint-prod-windows` + `just lint-tests-windows` + `just lint-ci-windows` run and report lint counts matching the W0.3 baseline (93 / 1,342 / 1,346 ±1 — the ±1 offset is the `error: could not compile` summary line cargo wraps each aborted crate in).  No semantic change.  Raw outputs captured in `_trash/w1-measurements/` (gitignored).
 
 ### Phase W2 — Prod gate (3–5 days) **← starts immediately after W1**
 
@@ -228,7 +228,7 @@ The W0 baseline reveals prod is only 93 errors across ~15 rule families — an o
   - etc.
 - **W2.2** — T2 targeted (~15 of 93): `undocumented_unsafe_blocks` (10) needs prose `SAFETY:` comments justifying each `unsafe` block's invariants (FFI signature, buffer lifetime, alignment — usually all three).  `indexing_slicing` (2) and `cognitive_complexity` (2) per-site.
 - **W2.3** — T3 semantic (~5 of 93): `multiple_unsafe_ops_per_block` (5) splits `unsafe { read(); transmute(); }` into discrete `unsafe {}` blocks, each with its own SAFETY comment.  Touches FFI design surface; regression tests for each split.
-- **W2.4** — **Wire `lint-prod-windows` into pre-push and PR CI**.  This is the first concrete authoritative-gate upgrade: new Windows production code is now lint-clean from day one.  Pre-push bundle gains ~15 s (xwin clippy `--lib --bins` is much faster than `--all-targets` since fewer compilation units).
+- **W2.4** — **Wire `lint-prod-windows` into pre-push and PR CI**.  This is the first concrete authoritative-gate upgrade: new Windows production code is now lint-clean from day one.  W1.4 measurement shows prod pass is **2 s warm** — pre-push bundle gains negligible time (current 50 s bundle → ~52 s).  PR CI job adds a sub-minute step.
 
 **Acceptance after W2**: `just lint-prod-windows` exits 0.  PR Fast CI runs Windows clippy on `--lib --bins`.  Production Windows regressions are now authoritatively gated.  Test backlog (~1,249 remaining) is UNBLOCKED and parallelisable.
 
@@ -262,7 +262,7 @@ The W0 baseline reveals prod is only 93 errors across ~15 rule families — an o
 - **W5.3** — `ref_patterns` (83): `if let Some(ref x @ Foo(_)) = …` → explicit borrow destructure.  Pattern-semantics sensitive; each fix reviewed.
 - **W5.4** — `multiple_unsafe_ops_per_block` (30 in tests), `float_arithmetic` (32): per-site motivation.  Float arithmetic in perf benches is legitimate; add `#[expect]` with reason.
 - **W5.5** — **Upgrade `windows-check` in PR Fast CI** from `cargo check` → `cargo clippy --workspace --all-targets --all-features --locked --no-deps -- -D warnings`.  Rename job `windows-check` → `windows-lint` for clarity.  Keep `windows-latest` runner.
-- **W5.6** — Upgrade local `check-windows` in pre-push to `lint-ci-windows`.  **Budget gate**: if total pre-push bundle exceeds 90 s warm, keep pre-push on `lint-prod-windows` only (full-scope stays in CI).  Decision empirical, based on W1.4 measurements.
+- **W5.6** — Upgrade local `check-windows` in pre-push to `lint-ci-windows`.  W1.4 measurement shows CI pass is **6 s warm** — pre-push bundle lands well under the 60 s target (current 50 s → ~56 s).  The original "if > 90 s, back off" budget gate is no longer needed; proceed directly to full-scope pre-push.
 - **W5.7** — Final `#[expect(…, reason = …)]` audit.  Target: fewer than **20** total across the whole Windows surface (higher than the original 10 to accommodate cast-family FFI sites); each with prose `reason`.
 
 **Acceptance after W5**: `just lint-ci-windows` exits 0.  PR Fast CI `windows-lint` runs clippy and passes.  `required` aggregator gates on it.  **No code can merge without passing Windows clippy on all targets.**
@@ -307,25 +307,27 @@ The W0 baseline reveals prod is only 93 errors across ~15 rule families — an o
 |---|---|---|
 | **IDE save** | rust-analyzer check-on-save (native only) | Unchanged (cross-target too expensive for on-save) |
 | **pre-commit** (`lint-fast`, sub-2 s / ~25 s Rust) | fmt + native clippy trio + typos + reuse + file-size | **Unchanged** — xwin clippy too expensive here |
-| **pre-push** (`lint-pre-push`, ≤ 60 s target) | fmt + native trio + rustdoc + doc-tests + tests + smoke + `check-windows` (8 s `check`) | **Upgrade**: `check-windows` → `lint-ci-windows` (+ ⏳ TBD seconds, measured in W1.4).  Budget gate in W4.4: if it pushes the bundle over 90 s, rollback to CI-only. |
+| **pre-push** (`lint-pre-push`, ≤ 60 s target) | fmt + native trio + rustdoc + doc-tests + tests + smoke + `check-windows` (8 s `check`) | **Upgrade**: `check-windows` → `lint-ci-windows` (+ 6 s warm, measured W1.4).  Bundle goes 50 s → ≈56 s — well under target.  Original W4.4 "> 90 s back off" gate no longer needed. |
 | **PR CI** (`pr-fast.yml`) | Required: classify + file-size + fmt + sanity + clippy + docs + test-build + tests + security + `windows-check` (**`check`**) | **Upgrade** `windows-check` → `windows-lint` running `cargo clippy -- -D warnings`.  Linux clippy already covered by the existing `clippy` job on `ubuntu-22.04` (no change needed for Linux). |
 | **Tier 2 nightly** (`tier-2.yml`) | Weekly `windows-latest` `cargo check` + coverage + udeps + miri | **Drop** the now-redundant windows check (PR-time authoritative post-W4.3); keep coverage / udeps / miri single-target. |
 
 **Flag stack discipline**: all three targets (native host, Linux, Windows) use the exact same `common_flags` / `prod_flags` / `test_flags` from `@/Users/rnio/Private/Github/UltraFastFileSearch/just/shared.just:28-30`.  Zero target-specific allowlists.  Any rule that truly diverges per-target (e.g. `cast_possible_wrap` on 32-bit targets) goes in `[workspace.lints]` in the root `Cargo.toml` where it is visible and review-gated.
 
-**xwin clippy warm-runtime measurements** (⏳ TBD — filled by W1.4):
+**xwin clippy warm-runtime measurements** (filled by W1.4, 2026-04-24):
 
-| Pass | Command | Warm duration |
-|---|---|---|
-| prod | `cargo xwin clippy --lib --bins ... -- {{ prod_flags }}` | TBD s |
-| tests | `cargo xwin clippy --tests ... -- {{ test_flags }}` | TBD s |
-| CI | `cargo xwin clippy --all-targets ... -- -D warnings` | TBD s |
+| Pass | Command | Warm duration | Lint count (matches W0) |
+|---|---|---|---|
+| prod | `just lint-prod-windows` | **2 s** | 93 ±1 ✅ |
+| tests | `just lint-tests-windows` | **6 s** | 1,342 ±1 ✅ |
+| ci | `just lint-ci-windows` | **6 s** | 1,346 ±1 ✅ |
+
+**Pre-push budget implication**: all three passes fit well under the 60 s pre-push budget, even full-workspace (`lint-ci-windows` at 6 s warm).  The W5.6 "budget gate" conservatism can now be relaxed — there is room to run either `lint-prod-windows` (W2.4) or even `lint-ci-windows` (W5.6) in pre-push without exceeding 60 s.  **Decision now safe to make at W2.4 empirically, not at W5.6.**
 
 ## 6. Discipline enforcement (mapping to the four rules)
 
 | Rule | How this plan honours it |
 |---|---|
-| **1. No suppression hacks** | Zero blanket `#[allow]`.  Only `#[expect(lint::name, reason = "prose")]` on individual items, with a target count of **< 10** total after W4.  Every suppression reviewed in the PR that introduces it. |
+| **1. No suppression hacks** | Zero blanket `#[allow]`.  Only `#[expect(lint::name, reason = "prose")]` on individual items, with a target count of **< 20** total after W5 (revised up from 10 after W0 revealed the cast-family FFI site density).  Every suppression reviewed in the PR that introduces it. |
 | **2. Surgical, correct fixes** | Phased by lint rule, not by file.  Each PR touches one rule family at a time; mechanical T1 fixes are deterministic, T2 + T3 fixes are per-site reasoned.  No "refactor-while-I'm-here" smuggling. |
 | **3. Preserve behavior & contracts** | Public API unchanged except where a lint surfaces a real bug (typically `cast_*` truncations or `significant_drop_*` deadlocks).  Each API change gets a CHANGELOG entry + regression test. |
 | **4. Improve tests, don't dodge** | T3 semantic fixes ship with new regression tests (deadlock / ordering / cast-boundary).  T1 + T2 fixes rely on the existing Windows test suite remaining green; `@/Users/rnio/Private/Github/UltraFastFileSearch/crates/uffs-daemon/tests/ipc_integration.rs` + `uffs-mft` unit tests already exercise the heaviest Windows surface area. |

--- a/just/test.just
+++ b/just/test.just
@@ -106,6 +106,41 @@ lint-ci-linux:
         bash -lc "rustup show >/dev/null && cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings"
     printf "\033[0;32m✅ Linux CI lint gate passed\033[0m\n"
 
+# Cross-platform strict lint gate for Windows (cargo-xwin clippy).
+#
+# The Windows counterpart of `lint-prod` / `lint-tests` / `lint-ci` — mirrors
+# the exact same flag stack so the strict clippy rules apply identically on
+# Windows-gated code.  Until Phase W5 of
+# `docs/architecture/windows-clippy-and-linux-cross-plan.md` lands, these
+# recipes emit hundreds of lints (W0 baseline: prod=93, tests=1342, ci=1346)
+# and are therefore not yet wired into `lint-all` or the pre-push hook.
+# They exist as the authoritative surface the Windows backlog is being
+# converged against phase by phase.  Requires `cargo-xwin` + target
+# `x86_64-pc-windows-msvc` (both from `just install-dev-tools`).
+#
+# Ultra-strict Windows production linting (workspace lints on --lib --bins).
+lint-prod-windows:
+    @printf "\033[0;34m🪟 Windows strict production lint (cargo xwin clippy)...\033[0m\n"
+    cargo xwin clippy --workspace --lib --bins --all-features --target x86_64-pc-windows-msvc --no-deps -- {{ prod_flags }}
+
+# Pragmatic Windows test linting (allows unwrap/expect in test code).
+lint-tests-windows:
+    @printf "\033[0;34m🪟 Windows strict test lint (cargo xwin clippy)...\033[0m\n"
+    cargo xwin clippy --workspace --tests --all-features --target x86_64-pc-windows-msvc --no-deps -- {{ test_flags }}
+
+# This is the gate the PR Fast CI `windows-check` job will adopt after Phase
+# W5 (see cross-target plan) completes.
+#
+# Windows CI lint gating (all-targets, deny warnings).
+lint-ci-windows:
+    @printf "\033[0;34m🚨 Windows CI lint gating (cargo xwin clippy)...\033[0m\n"
+    cargo xwin clippy --workspace --all-targets --all-features --target x86_64-pc-windows-msvc --no-deps -- -D warnings
+
+# Host-only on purpose — Windows (`lint-*-windows`) and Linux-in-Docker
+# (`lint-ci-linux`) are separate recipes.  They will be wired into this
+# sweep after their backlogs converge to zero (Phase W5 of the
+# cross-target plan: `docs/architecture/windows-clippy-and-linux-cross-plan.md`).
+#
 # Full lint sweep: production + tests + CI gate + formatting.
 lint-all:
     @printf "\033[0;34m🔍 Full lint sweep (prod + tests + CI + fmt)...\033[0m\n"


### PR DESCRIPTION
## Summary

Phase W1 of [`windows-clippy-and-linux-cross-plan.md`](../blob/main/docs/architecture/windows-clippy-and-linux-cross-plan.md).  Pure infrastructure — no lint fixes yet, no CI workflow changes, no pre-push hook changes.  Adds the Windows counterparts to the native strict-lint trio + fills the plan doc's § 5 measurement table with real numbers.

## Three new `just` recipes

| Recipe | Scope | Flag stack | Warm | Lint count (matches W0 ±1) |
|---|---|---|---|---|
| `just lint-prod-windows` | `--lib --bins` | `prod_flags` | **2 s** | 93 ✅ |
| `just lint-tests-windows` | `--tests` | `test_flags` | **6 s** | 1,342 ✅ |
| `just lint-ci-windows` | `--all-targets` | `-D warnings` | **6 s** | 1,346 ✅ |

All three drive `cargo xwin clippy --target x86_64-pc-windows-msvc`.  Flag stacks pulled verbatim from `just/shared.just:28-30` — **zero lint drift between native and Windows**.

The ±1 offset is cargo's `error: could not compile <crate> (…) due to N previous errors` summary line; excluded from the lint-rule URL count, which matches W0 exactly (92 / 1,338 / 1,341).

## Pre-push budget — good news

Measured durations open up more options than the conservative plan assumed:

- `lint-prod-windows` at 2 s warm → pre-push bundle 50 s → **52 s** at W2.4.
- `lint-ci-windows` at 6 s warm → pre-push bundle 50 s → **56 s** at W5.6.

The original W5.6 "if > 90 s, back off to CI-only" budget gate is **no longer needed**.  Full-scope Windows clippy can run in pre-push without breaking the 60 s target.  Plan doc § 4 Phase W5.6 + § 5 updated to reflect this.

## Plan doc updates

- § 4 Phase W1 — acceptance marked ✅ met with real measurements.
- § 4 W2.4 + W5.6 — pre-push budget analysis updated (concrete durations, budget gate removed).
- § 5 — xwin clippy warm-runtime measurement table filled.
- § 6 — `#[expect]` target count corrected from < 10 to < 20 (matches § 8 + TL;DR).

## Sibling-doc cross-references (plan P1.2 + P1.3)

- **`CONTRIBUTING.md`** — new Architecture-guardrails bullet: new Windows-gated code must pass `just lint-ci-windows` before PR.  Docs map gains "Cross-target strict-lint architecture" entry.
- **`dev-flow-implementation-plan.md` § 7** — new non-goal: cross-target lint plan owns *which flag stack runs on which target*; dev-flow owns the 4-layer gate **model**.
- **`release-automation-plan.md` § 1.2 non-goal #8** — release-automation honours a Windows-clippy-clean `main` after R5; the two plans share no workflows or tooling surface.

## Discipline

- **Zero lint fixes.**  That is Phase W2.
- **Zero workspace.lints / `prod_flags` / `test_flags` / `clippy.toml` changes.**
- **Zero CI workflow changes.**  `windows-check` stays on `cargo check` until W5.5.
- **Zero pre-push hook changes.**  `check-windows` stays advisory until W2.4.
- **No suppression hacks.**  Recipes are INERT — they surface the backlog; they don't hide it.

## Verification

- `just --list` shows all 3 new recipes with clean one-line summaries matching their native counterparts.
- Each recipe runs warm in 2–6 s and reports baseline counts matching W0.
- `reuse lint --quiet` ✅
- `typos` on all edited files ✅
- Pre-push bundle (13 jobs) passed in **56 s** ✅ — budget preserved.

## What's next

- **W2.1** — T1 mechanical cleanups (~70 of the 93 prod lints): one PR per crate, lint-family-scoped commits.
- **W2.2** — T2 targeted: `undocumented_unsafe_blocks` SAFETY prose (10) + a couple of `indexing_slicing` + `cognitive_complexity`.
- **W2.3** — T3 semantic: 5 `multiple_unsafe_ops_per_block` splits with regression tests.
- **W2.4** — wire `lint-prod-windows` into pre-push + PR CI (first authoritative-gate upgrade).

Typical ETA for W2 end-to-end: 3–5 working days per plan calendar.
