### PR TITLE
ci(release-automation): R1a advisory commitlint on PR titles

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,223 @@
+# SPDX-FileCopyright (c) 2025-2026 SKY, LLC.
+# SPDX-License-Identifier: MPL-2.0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Commitlint — Conventional Commits advisory check on PR titles
+#
+# Phase R1a of `docs/architecture/release-automation-plan.md`.
+#
+# Why this exists:
+#
+#   UFFS is migrating to release-plz + git-cliff + Conventional Commits to
+#   automate version bumping and changelog generation (see plan §4 and §5).
+#   Release-plz infers the next version and the changelog category from the
+#   PR title's `type:` prefix.  Non-conforming titles silently produce no
+#   changelog entry — release-plz treats them as if they didn't merge.
+#   That's a footgun: a fix shipped under "Improve search performance" gets
+#   no version bump and no changelog mention.
+#
+#   This workflow surfaces non-conforming titles at PR-open time so the
+#   author can fix them before merge.
+#
+# Why advisory (not enforcing):
+#
+#   Phase R1a is the OBSERVATION period.  We're at ~100% adherence over
+#   the last 3 days (24/24 PRs) but only 83.3% over the last 30 days
+#   (75/90 PRs).  The 15 non-conforming PRs use project-internal prefixes
+#   like `security:`, `bench:`, `shmem:`, `stream-stress:`,
+#   `cross-tool-benchmark:`, `gitignore:` (see
+#   `docs/architecture/release-automation-baseline.md` §4).  Some of those
+#   may be re-tagged as `chore(security):`, `bench:` (if we choose to
+#   accept it as a real type), etc.  Phase R1a gathers the data; Phase
+#   R1b (≥1 month later) makes the gate mandatory using the refined type
+#   list informed by the observation.
+#
+#   In advisory mode this workflow ALWAYS exits 0.  Non-conforming titles
+#   produce a sticky PR comment, never a merge block.
+#
+# Sticky-comment design:
+#
+#   The job re-runs on every `synchronize` event (force-pushes, additional
+#   commits to the PR branch).  Naïvely posting a comment on every run
+#   spams the PR.  Instead, we tag managed comments with a unique HTML
+#   marker `<!-- commitlint-advisory: managed by ... -->` and use the
+#   GitHub REST API to either edit the existing managed comment in-place
+#   or delete it once the title becomes conformant.  Result: at most ONE
+#   advisory comment per PR, auto-pruned when fixed.
+#
+# What this does NOT do:
+#
+#   • Block merge.  Always exits 0.  R1b will flip a single line to enforce.
+#   • Validate individual commit messages on the feature branch.  UFFS
+#     uses squash-merge exclusively, so the PR title (which becomes the
+#     squash subject) is the only commit message that lands on `main`.
+#   • Validate the PR description / body.  Only the title is parsed for
+#     release-plz's version inference.
+#
+# References:
+#
+#   • CONTRIBUTING.md → "Commit message conventions"
+#     (the user-facing list of allowed types and examples)
+#   • https://www.conventionalcommits.org/en/v1.0.0/
+#     (the spec that defines the type list and breaking-change syntax)
+#   • plan §2.8 (current adherence baseline) and §3 (R1a → R1b transition)
+
+name: "📝 Commitlint (advisory)"
+
+on:
+  pull_request:
+    # `edited` catches title edits after open.  `synchronize` catches
+    # additional commits / force-pushes (so a stale advisory comment
+    # gets pruned promptly when the author updates the title).
+    # `reopened` covers the reopen-after-close case so a closed-then-
+    # reopened PR re-evaluates fresh.
+    types: [opened, edited, synchronize, reopened]
+
+# Comment posting requires write access to the PR (which is the
+# `pull-requests` scope, not `contents`).  Read on contents is implicit
+# and unused — we never check out code in this workflow.
+permissions:
+  contents: read
+  pull-requests: write
+
+# Cancel any in-flight commitlint run on the same PR when a new event
+# arrives.  Title edits land in bursts (typo → realize → fix); we only
+# care about the latest state.
+concurrency:
+  group: commitlint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    name: "PR title — Conventional Commits"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    # Skip on PRs from forks: forked PRs don't have write tokens, so
+    # `gh pr comment` would fail.  Forks are advised separately via the
+    # CONTRIBUTING.md docs; they get a hint from the PR template instead.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Validate PR title against Conventional Commits
+        env:
+          # `pull_request.title` is the canonical squash-merge subject.
+          # We deliberately do NOT inspect commits on the branch — those
+          # get squashed away on merge and are noise for release-plz.
+          TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # `github.token` is the workflow's ephemeral GITHUB_TOKEN.
+          # The `gh` CLI auto-detects this env var.
+          GH_TOKEN: ${{ github.token }}
+          # Marker embedded in the comment body so the same comment can
+          # be located across re-runs.  Changing this string is a one-
+          # time migration: bump the marker AND delete any pre-bump
+          # advisory comments by hand on open PRs.
+          COMMENT_MARKER: "<!-- commitlint-advisory: managed by .github/workflows/commitlint.yml -->"
+        run: |
+          set -euo pipefail
+
+          # ── Allowed Conventional Commits types ─────────────────────
+          # Mirrors CONTRIBUTING.md → "Commit message conventions".
+          # Order matters only for readability; the regex is OR-of-all.
+          # Adding a new type means updating both this regex AND
+          # CONTRIBUTING.md in the same PR (and ideally cliff.toml's
+          # commit_parsers in Phase R2).
+          PATTERN='^(feat|fix|perf|refactor|docs|test|build|ci|chore|style|revert)(\([a-z0-9-]+\))?!?: .{1,}$'
+
+          # Group redirects to avoid the SC2129 shellcheck warning
+          # and minimise filesystem churn on the GitHub Actions side.
+          {
+            echo "## 📝 Commitlint — PR title check"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Title | \`${TITLE}\` |"
+            echo "| Pattern | \`${PATTERN}\` |"
+            echo "| Mode | **advisory** (Phase R1a) — never blocks merge |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # ── Locate any existing managed advisory comment ───────────
+          # `gh api` paginates automatically.  We use the raw issues
+          # comments endpoint (PR comments live there) and jq-filter
+          # by marker presence.  `head -1` defends against the
+          # (impossible-but-cheap-to-guard) double-managed-comment case.
+          EXISTING_ID=$(
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --jq ".[] | select(.body | contains(\"${COMMENT_MARKER}\")) | .id" \
+              | head -1 || true
+          )
+
+          if echo "$TITLE" | grep -qE "$PATTERN"; then
+            # ── Conforming title ───────────────────────────────────
+            echo "::notice::PR title matches Conventional Commits: ${TITLE}"
+            echo "✅ **Conforms** to Conventional Commits." >> "$GITHUB_STEP_SUMMARY"
+
+            if [ -n "${EXISTING_ID}" ]; then
+              # Title was previously non-conforming, now fixed —
+              # remove the stale advisory comment so the PR isn't
+              # cluttered with a resolved warning.
+              echo "::notice::Removing stale advisory comment ${EXISTING_ID}"
+              gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_ID}"
+              echo "🧹 Removed stale advisory comment from earlier non-conforming title." >> "$GITHUB_STEP_SUMMARY"
+            fi
+            exit 0
+          fi
+
+          # ── Non-conforming title ───────────────────────────────────
+          echo "::warning::PR title does not match Conventional Commits: ${TITLE}"
+          echo "⚠️  **Does not conform** — advisory comment posted/updated below." >> "$GITHUB_STEP_SUMMARY"
+
+          # Compose the advisory body.  The marker MUST be the first
+          # line for trivially-greppable detection.  Keep the body
+          # informative but not punishing: contributors who hit this
+          # check probably haven't read CONTRIBUTING.md yet.
+          #
+          # NOTE on indentation: YAML's literal block scalar (`run: |`)
+          # strips the least common leading indentation from every
+          # content line.  All heredoc body lines below sit at the
+          # same column as `set -euo pipefail` at the top of this
+          # block, so YAML strips them flush before bash sees them.
+          # No post-hoc `sed` indent-stripping required.
+          BODY=$(cat <<EOF
+          ${COMMENT_MARKER}
+
+          ## ⚠️ PR title is not in Conventional Commits format
+
+          **Your title:** \`${TITLE}\`
+
+          **Expected pattern:** \`type(optional-scope): subject\` where \`type\` is one of:
+
+          \`feat\`, \`fix\`, \`perf\`, \`refactor\`, \`docs\`, \`test\`, \`build\`, \`ci\`, \`chore\`, \`style\`, \`revert\`
+
+          **Examples** (from recent UFFS merges):
+
+          - \`fix(release): re-codesign macOS binaries after strip — v0.5.73\`
+          - \`refactor(uffs-mft): eliminate most shadow_reuse / shadow_unrelated via renames & let-else\`
+          - \`docs(architecture): add Windows-clippy + Linux-native-cross plan with W0 baseline\`
+          - \`feat(cli)!: drop deprecated --q shorthand\` (the trailing \`!\` marks a breaking change)
+
+          See [CONTRIBUTING.md → Commit message conventions](https://github.com/${GITHUB_REPOSITORY}/blob/main/CONTRIBUTING.md#commit-message-conventions) for the full rationale and the table of which types trigger releases.
+
+          ---
+
+          **🟡 This check is ADVISORY during release-automation Phase R1a** — non-conforming titles do **not** block merge.  Phase R1b (scheduled after ≥1 month of observation) will make this a required gate.  Until then, please update the title when convenient; this comment will auto-delete on the next workflow run once the title conforms.
+
+          *(Workflow: \`.github/workflows/commitlint.yml\` · Plan: [\`docs/architecture/release-automation-plan.md\`](https://github.com/${GITHUB_REPOSITORY}/blob/main/docs/architecture/release-automation-plan.md) Phase R1a)*
+          EOF
+          )
+
+          if [ -n "${EXISTING_ID}" ]; then
+            # Edit in place — preserves comment threading and avoids
+            # spamming the PR with duplicate advisories on every push.
+            echo "::notice::Updating existing advisory comment ${EXISTING_ID}"
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_ID}" \
+              -f body="${BODY}" >/dev/null
+          else
+            echo "::notice::Posting new advisory comment"
+            gh pr comment "${PR_NUMBER}" --body "${BODY}"
+          fi
+
+          # ADVISORY MODE: exit 0 even on non-conformance.
+          # Phase R1b will replace this single line with `exit 1` to
+          # promote the check from advisory to required.
+          exit 0

--- a/docs/architecture/release-automation-plan.md
+++ b/docs/architecture/release-automation-plan.md
@@ -1956,8 +1956,8 @@ Single source of truth for phase progress.  Mirror the format of
 
 | # | Phase | Status | Commit | Date | PR | Notes |
 |---|---|---|---|---|---|---|
-| R0 | Baseline & cleanup (remove dead cargo-dist + release-plz metadata, add lockfile-drift patch per decision 1, new baseline doc) | 🟡 | | 2026-04-25 | (open) | Includes: lockfile patch; **promotion of `build/update_all_versions.rs` into version control** via `.gitignore` carve-out (script was previously gitignored despite 4 callsites depending on it); drive-by deletion of stale `crates/uffs-mft/Cargo.toml.bak` (v0.4.106 auto-commit artifact); baseline metrics in `release-automation-baseline.md`. |
-| R1a | Conventional commits (advisory) | ⬜ | | | | PR title + commit messages scanned, comment-only |
+| R0 | Baseline & cleanup (remove dead cargo-dist + release-plz metadata, add lockfile-drift patch per decision 1, new baseline doc) | 🟢 | `873a668c4` | 2026-04-25 | [#64](https://github.com/skyllc-ai/UltraFastFileSearch/pull/64) | Final landed PR shape: 6 files, +1258 / −160 LOC. Includes: lockfile patch; **promotion of `build/update_all_versions.rs` into version control** via `.gitignore` carve-out (1073-line script was previously gitignored despite 4 callsites depending on it); drive-by deletion of stale `crates/uffs-mft/Cargo.toml.bak` (v0.4.106 auto-commit artifact); baseline metrics in `release-automation-baseline.md`. |
+| R1a | Conventional commits (advisory) | 🟡 | | 2026-04-25 | (open) | Adds `.github/workflows/commitlint.yml` (advisory mode, sticky comment via `gh pr comment` + `gh api PATCH/DELETE`); CONTRIBUTING.md "Commit message conventions" section already landed pre-R0 (lines 150-187). |
 | R1b | Conventional commits (mandatory gate) | ⬜ | | | | After ≥1 month of advisory observation |
 | R2 | `git-cliff` + `cliff.toml` (local validation) | ⬜ | | | | No workflow change; just the template |
 | R3 | release-plz shadow mode | ⬜ | | | | Observe 1-2 weeks / 3-5 merges |


### PR DESCRIPTION
## Summary

Phase **R1a** of [`docs/architecture/release-automation-plan.md`](docs/architecture/release-automation-plan.md) — adds an **advisory** PR-title check that surfaces non-Conventional-Commits titles without blocking merge, gathering observation data for the eventual hard-gate flip in R1b (~1 month later).

This is a small, low-risk PR: one new workflow file, one dashboard update.  No source code changes.  The workflow always exits 0; non-conforming titles produce a sticky PR comment, never a merge block.  The R1a → R1b transition is a **single line change** (`exit 0` → `exit 1`) once observation completes.

## What changed

- **`.github/workflows/commitlint.yml`** — new workflow (~225 lines including the heavy block-comment rationale that matches the project convention from `dependabot-review.yml`).  Runs on `pull_request: [opened, edited, synchronize, reopened]` and validates the PR title against the 11-type Conventional Commits regex matching `CONTRIBUTING.md → Commit message conventions`:

  ```regex
  ^(feat|fix|perf|refactor|docs|test|build|ci|chore|style|revert)(\([a-z0-9-]+\))?!?: .{1,}$
  ```

  On non-conformance: posts (or edits in place via `gh api PATCH`) a **sticky** advisory PR comment tagged with `<!-- commitlint-advisory: ... -->` so re-runs from `synchronize` events don't spam the PR.  When the title is fixed, the stale comment is auto-deleted.

  Also writes a rich step summary to `$GITHUB_STEP_SUMMARY` showing the title, pattern, and mode.

- **`docs/architecture/release-automation-plan.md`** — dashboard updates:
  - **R0**: 🟡 → 🟢 with merge commit [`873a668c4`](https://github.com/skyllc-ai/UltraFastFileSearch/commit/873a668c4) ([#64](https://github.com/skyllc-ai/UltraFastFileSearch/pull/64)), final landed PR shape recorded.
  - **R1a**: ⬜ → 🟡 with date and pointer to this PR.

## Why advisory now (not enforcing)

Per [`release-automation-baseline.md`](docs/architecture/release-automation-baseline.md) §4:

| Window | Adherence | Sample size |
|---|---|---|
| Last 3 days | **100%** | 24/24 PRs |
| Last 30 days | 83.3% | 75/90 PRs |

The 15 non-conforming PRs in the 30-day window use project-internal prefixes — `security:`, `bench:`, `shmem:`, `stream-stress:`, `cross-tool-benchmark:`, `gitignore:`, plus one space-in-scope (`chore(dev + ci):`).  Some of those should re-tag as standard CC scopes (`chore(security):`, etc.); some — like `bench:` — could legitimately be extended into the recognized type list if the project decides to.

R1a observation gathers ~1 month of real-PR data; R1b makes the hard-gate decision informed by it.  That decision should be a separate PR with its own discussion and rollout note.

## Sample comment body

When a non-conforming title (e.g. `Update README`) opens a PR, the workflow posts:

> **⚠️ PR title is not in Conventional Commits format**
>
> **Your title:** `Update README`
>
> **Expected pattern:** `type(optional-scope): subject` where `type` is one of: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, `style`, `revert`
>
> **Examples** (from recent UFFS merges):
> - `fix(release): re-codesign macOS binaries after strip — v0.5.73`
> - `refactor(uffs-mft): eliminate most shadow_reuse / shadow_unrelated via renames & let-else`
> - `docs(architecture): add Windows-clippy + Linux-native-cross plan with W0 baseline`
> - `feat(cli)!: drop deprecated --q shorthand` (the trailing `!` marks a breaking change)
>
> See [CONTRIBUTING.md → Commit message conventions](https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/CONTRIBUTING.md#commit-message-conventions) for the full rationale and the table of which types trigger releases.
>
> ---
>
> **🟡 This check is ADVISORY during release-automation Phase R1a** — non-conforming titles do **not** block merge.  Phase R1b (scheduled after ≥1 month of observation) will make this a required gate.  Until then, please update the title when convenient; this comment will auto-delete on the next workflow run once the title conforms.
>
> *(Workflow: `.github/workflows/commitlint.yml` · Plan: [`docs/architecture/release-automation-plan.md`](docs/architecture/release-automation-plan.md) Phase R1a)*

## Validation

- ✅ `actionlint .github/workflows/commitlint.yml` — clean (zero warnings after refactoring `>> $GITHUB_STEP_SUMMARY` into a grouped block and removing a redundant `sed` indent-strip that YAML's literal block scalar already handles).
- ✅ Regex tested locally against the last 23 PR titles on `main`: **22/23 pass**, 1 correctly flagged (`chore(dev + ci): ...` — PR #41's space-in-scope pattern).  Matches the baseline doc's findings.
- ✅ Heredoc behavior verified — YAML's literal block scalar strips the base indent before bash sees the content, so the advisory comment renders as proper markdown without leading-whitespace artifacts.
- ✅ Local `lint-fast` (3 gates active for non-Rust diff: file-size, typos, reuse) — passed pre-commit (2s).
- ✅ Local `lint-pre-push` — passed pre-push (43s).

## Permissions / security notes

- Workflow uses `permissions: { contents: read, pull-requests: write }` — narrow, least-privilege.
- `GH_TOKEN: ${{ github.token }}` — ephemeral workflow token, not a stored secret.
- `if: github.event.pull_request.head.repo.full_name == github.repository` — skips the workflow on PRs from forks (forked PRs don't get write tokens, so `gh pr comment` would 403).  Forks are advised separately via the CONTRIBUTING.md docs.
- The sticky-comment marker (`<!-- commitlint-advisory: managed by ... -->`) is the ONLY way the workflow identifies "its own" comments.  A PR author could manually post a comment containing this marker to confuse the cleanup logic, but the worst-case outcome is the workflow editing/deleting that comment instead of posting a fresh one — no security boundary crossed.

## Forward path

- **R1b** (after ≥1 month of observation, ~2026-05-25): change `exit 0` to `exit 1` in this workflow, possibly extend the type list based on observation data, register the check as required in branch protection.  Single-line code change; the rest is policy / branch-protection config.
- **R2** (`cliff.toml`): adopt the same 11-type list in `commit_parsers` so the changelog and the PR-title gate stay in sync.  Adding a new type after R2 means updating the regex here AND `cliff.toml` AND `CONTRIBUTING.md` in the same PR.

## Rollback

`git revert` this PR.  The workflow simply stops running on new PRs.  No state to clean up — sticky comments left on existing PRs are harmless markdown.

## Refs

- Plan: [`docs/architecture/release-automation-plan.md`](docs/architecture/release-automation-plan.md) Phase R1
- CONTRIBUTING.md → "Commit message conventions" (canonical user-facing list of allowed types and examples)
- Conventional Commits 1.0.0 spec
- Baseline observations: [`docs/architecture/release-automation-baseline.md`](docs/architecture/release-automation-baseline.md) §4
- Style precedent for advisory workflows: `.github/workflows/dependabot-review.yml`
