### PR TITLE
docs(release-automation): one-page contributor cheatsheet for current flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ If `just clean-cov` finishes and `just test` still fails with the same shmem-off
 
 ## Commit message conventions
 
-UFFS is migrating to [Conventional Commits](https://www.conventionalcommits.org/) to drive automated versioning and changelog generation via `release-plz` + `git-cliff`.  The full migration plan lives in [`docs/architecture/release-automation-plan.md`](docs/architecture/release-automation-plan.md).
+UFFS is migrating to [Conventional Commits](https://www.conventionalcommits.org/) to drive automated versioning and changelog generation via `release-plz` + `git-cliff`.  For a one-page **"what to do this week"** cheatsheet (PR conventions, what's automatic, FAQs), see [`docs/architecture/release-automation-current-flow.md`](docs/architecture/release-automation-current-flow.md).  The full multi-phase migration plan lives in [`docs/architecture/release-automation-plan.md`](docs/architecture/release-automation-plan.md).
 
 **What matters for you today**:
 

--- a/docs/architecture/release-automation-current-flow.md
+++ b/docs/architecture/release-automation-current-flow.md
@@ -1,0 +1,164 @@
+<!--
+SPDX-License-Identifier: MPL-2.0
+Copyright (c) 2025-2026 SKY, LLC.
+
+UFFS — Release Automation: Current Flow Cheatsheet
+-->
+
+# Release Automation — Current Flow
+
+> **Last updated**: 2026-04-25
+> **Current phase**: **R3 — release-plz shadow mode** (observation only)
+> **Authoritative release mechanism**: still `just ship` + `auto-tag-release.yml` + `release.yml` (unchanged from pre-R3)
+
+> _One-page contributor cheatsheet. For the full multi-phase migration plan see [`release-automation-plan.md`](release-automation-plan.md). For metrics and per-phase validation results see [`release-automation-baseline.md`](release-automation-baseline.md)._
+
+## What you do — vs — what's automatic
+
+| You | Automation |
+|---|---|
+| Open PR with **conventional-commit title** (`type(scope): subject`) | Commitlint posts an advisory comment if the title is non-conforming; never blocks merge today (Phase R1a). |
+| Squash-merge as usual | `release-plz.yml` shadow workflow runs; posts the **proposed release plan** to the run summary. Does not push, tag, PR, or publish. |
+| Cut releases the OLD way: run `just ship` locally | `auto-tag-release.yml` detects the version bump, creates the `vX.Y.Z` tag. `release.yml` builds binaries, signs, uploads, creates the GitHub Release. |
+| Periodically check the shadow workflow runs at [`Actions → 🔮 Release-plz (shadow)`](https://github.com/skyllc-ai/UltraFastFileSearch/actions/workflows/release-plz.yml) and compare to your gut "what should this release have bumped" | — |
+
+## PR title format (the only thing you have to remember)
+
+```
+type(scope): subject
+```
+
+| Type | Triggers release? | Version bump |
+|---|---|---|
+| `feat` | yes | minor (0.X.0) |
+| `fix` | yes | patch (0.0.X) |
+| `perf` | yes | patch |
+| `feat!` / `fix!` | yes | major (or minor pre-1.0) |
+| `refactor`, `docs`, `test`, `chore`, `ci`, `build`, `style`, `revert` | no | — |
+
+**Scope** (optional): a crate name or short area tag — `mft`, `cli`, `core`, `security`, `polars`, `ci`, `architecture`, etc.  Omit if the change is workspace-wide.
+
+**If unsure**: use `chore:` — it never triggers a release.
+
+Full reference (with examples): [`CONTRIBUTING.md` → "Commit message conventions"](../../CONTRIBUTING.md#commit-message-conventions).
+
+## Step-by-step for a typical change
+
+```bash
+# 1. Branch
+git checkout -b feat/my-change
+
+# 2. Code
+# (... your edits ...)
+
+# 3. Local validation (cheap layer, ~seconds)
+just lint-fast
+
+# 4. Commit (intermediate commits don't need conventional format —
+#    only the squash subject does)
+git commit -m "WIP: trying X"
+git push --set-upstream origin feat/my-change
+
+# 5. Open PR with a CONVENTIONAL TITLE
+gh pr create --title "feat(mft): add zstd-compressed MFT archive support" \
+             --body "..."
+
+# 6. CI runs:
+#    - PR Fast (sanity, security, build, test, windows, ...)
+#    - Commitlint advisory on title
+#    - Other auto-checks
+
+# 7. Address review feedback, push more commits
+# 8. Squash-merge.  PR title becomes the squash subject on `main`.
+
+# 9. Watch:
+#    - Shadow `release-plz.yml` runs and posts proposed plan to run summary.
+#    - No release happens — that requires `just ship`.
+```
+
+## Step-by-step for cutting a release (still the OLD way)
+
+Until R4 lands, releases are still cut manually exactly as they were before R0:
+
+```bash
+# On main, after merging the PRs you want in this release:
+git checkout main && git pull
+just ship           # runs the full pipeline:
+                    #   - bumps versions in Cargo.toml + Cargo.lock
+                    #   - regenerates lockfile (R0 fix)
+                    #   - commits the version bump
+                    #   - pushes to main
+# auto-tag-release.yml then:
+#   - sees the version diff in Cargo.toml
+#   - creates tag `vX.Y.Z`
+# release.yml then:
+#   - builds binaries on Linux/macOS/Windows
+#   - signs (codesign on macOS)
+#   - publishes the GitHub Release with binaries attached
+```
+
+## What changes at each upcoming phase
+
+(Each row only describes the **delta** from the previous phase.  See [`release-automation-plan.md`](release-automation-plan.md) for full detail.)
+
+| Phase | What flips | What you'll do differently |
+|---|---|---|
+| **R3 (now)** | Shadow workflow active | Watch the run summary on each merge.  No flow change. |
+| **R1b** (≥1 month after R1a) | Commitlint becomes mandatory | A non-conforming title hard-fails PR Fast.  Edit the title; the bot re-checks automatically. |
+| **R4** | release-plz flips to active mode (`release-pr` + `release` commands, write permissions, `RELEASE_PLZ_TOKEN` secret) | After merging release-worthy PRs, release-plz opens a "Release PR" automatically.  You **review and merge it**.  Tag + GitHub Release happen automatically.  `just ship` is no longer needed for releases. |
+| **R5** | Bespoke tooling retired (`build/update_all_versions.rs`, `auto-tag-release.yml`, `scripts/ci-pipeline/src/version.rs`) | `just ship` becomes a thin local sanity-check wrapper or is deleted entirely.  Releases happen exclusively via release-plz PRs. |
+| **R6** | Per-crate `[[package]]` config + `cargo-semver-checks` | API breaking changes get caught at PR time, not at release time.  No flow change. |
+| **R7** | OIDC trusted publisher scaffolded (still dormant) | No change in your day-to-day. |
+| **R8** | First crates.io publish dress rehearsal — `uffs-time` only | One crate becomes available on `crates.io`.  No change to your flow. |
+| **R9** | Live publishing for the full publishable workspace (deferred — explicit decision) | Deferred indefinitely; documented separately when scheduled. |
+
+The whole multi-phase rollout is designed so each transition is **a single small PR** that you review like any other.  No "big bang".
+
+## FAQ
+
+**Q: I forgot the conventional title and merged a PR with `Improve search performance`. Did I just break the release pipeline?**
+A: No.  In R1a (today) commitlint is advisory — your PR merged fine.  In R3 the shadow workflow's release-plz proposal will quietly skip that commit (treated as if the merge had no release-worthy content), and you'll see no entry for it in the proposed changelog.  Going forward, just use `perf: improve search performance` on the next PR.  In R1b (≥1 month from now) the gate becomes mandatory and you'd be asked to edit the title before merge.
+
+**Q: The shadow workflow turned red. Should I worry?**
+A: Probably not.  The shadow workflow is advisory — it has no required-checks dependents and cannot block any other workflow or PR.  If it's red, click into the run, look at the error, and either fix it (`release-plz.toml` / `cliff.toml` regression) or open an issue if it's a release-plz upstream bug.  In the meantime everything else keeps working.
+
+**Q: I want to test the shadow workflow without waiting for a merge. Can I?**
+A: Yes — go to [`Actions → 🔮 Release-plz (shadow) → Run workflow`](https://github.com/skyllc-ai/UltraFastFileSearch/actions/workflows/release-plz.yml) (the `workflow_dispatch` trigger).  This runs against the current `main` HEAD with no side effects.
+
+**Q: Can I run release-plz locally to preview?**
+A: Yes.  `cargo install release-plz --locked` then `release-plz update --config release-plz.toml` from the workspace root.  This edits files in your working tree but never pushes — it's the same command CI runs.  Discard the changes with `git checkout .` when done.  Note: requires a clean working tree (`release-plz` aborts if there are uncommitted changes; pass `--allow-dirty` to override locally).
+
+**Q: I need to ship a fix RIGHT NOW. Does the R3 work block me?**
+A: No.  Run `just ship` exactly as you would have pre-R3.  R3 added a parallel observation workflow; it didn't change the live release path.
+
+**Q: What's the merge order if multiple release-worthy PRs land in a single day?**
+A: For now (R3): each merge triggers an independent shadow run; the latest one is the most relevant.  For R4+: release-plz coalesces them into a single Release PR, which auto-updates as new release-worthy commits land.  You merge it when you're ready to cut the release.
+
+**Q: I see `release-plz update` created `crates/uffs-*/CHANGELOG.md` files in my local tree. Do I commit them?**
+A: No.  Per-crate vs workspace-root changelog structure is an open R4-blocking decision (see [`release-automation-baseline.md` §9](release-automation-baseline.md#9-r3-addendum--release-plz-shadow-mode-validation-2026-04-25)).  Discard them with `rm crates/*/CHANGELOG.md` until R4 settles the structure.
+
+## Where things live
+
+| Concern | File |
+|---|---|
+| PR-title convention reference | [`CONTRIBUTING.md`](../../CONTRIBUTING.md) → "Commit message conventions" |
+| Commitlint workflow | [`.github/workflows/commitlint.yml`](../../.github/workflows/commitlint.yml) |
+| git-cliff template (changelog format) | [`cliff.toml`](../../cliff.toml) (workspace root) |
+| release-plz config | [`release-plz.toml`](../../release-plz.toml) (workspace root) |
+| Shadow workflow (R3) | [`.github/workflows/release-plz.yml`](../../.github/workflows/release-plz.yml) |
+| Live release workflow (current) | [`.github/workflows/release.yml`](../../.github/workflows/release.yml) |
+| Live tag-creation workflow (current) | [`.github/workflows/auto-tag-release.yml`](../../.github/workflows/auto-tag-release.yml) |
+| Bespoke version bumper (will be retired in R5) | [`build/update_all_versions.rs`](../../build/update_all_versions.rs) |
+| Multi-phase migration plan | [`release-automation-plan.md`](release-automation-plan.md) |
+| Per-phase validation evidence | [`release-automation-baseline.md`](release-automation-baseline.md) |
+
+## Maintenance of this document
+
+This file is a **living reference** — its `Current phase` header at top is updated at each phase transition.  When you open a phase-N PR, also update:
+
+- The `Current phase:` line at top.
+- The "Last updated" line.
+- The "What changes at each upcoming phase" table — strikethrough or remove the row that just landed; verify the next row is still accurate.
+- Any FAQ that's been overtaken by reality.
+
+If you're reading this and the `Last updated` line is stale by more than a phase transition, ping the maintainer.


### PR DESCRIPTION
## One-page contributor cheatsheet for the release-automation flow

Companion to [#67](https://github.com/skyllc-ai/UltraFastFileSearch/pull/67) (R3 shadow mode).  Adds a short living reference at `docs/architecture/release-automation-current-flow.md` so collaborators have a clear "what to do this week" doc during the 1-2 week R3 → R4 observation window.

Two files, +165 / −1 LOC.  No automation, config, or workflow changes — pure documentation.

### Why this exists

R0 added the multi-phase plan ([`release-automation-plan.md`](https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/docs/architecture/release-automation-plan.md), 2000+ lines).  R1a added the PR-title convention reference (`CONTRIBUTING.md` → "Commit message conventions").  R0 also added the metrics doc ([`release-automation-baseline.md`](https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/docs/architecture/release-automation-baseline.md)).

Missing: a one-page **action-oriented** doc that answers "what do I, as a contributor, do today, given that we're in phase X of the rollout?".  This PR fills that gap.

### What the doc covers

- **Current phase indicator** at top.  Updated at each phase transition.
- **"What you do" vs "what's automatic"** two-column table.
- **PR title format** with the type → version-bump table (mirrors `CONTRIBUTING.md` → "Commit message conventions" so the two stay in sync).
- **Step-by-step for a typical PR** (`git checkout -b feat/x` → ... → squash-merge → watch shadow run).
- **Step-by-step for cutting a release** — still the OLD `just ship` path until R4 lands.  Explicitly called out so nobody assumes R3 changed the live release mechanism.
- **What changes at each upcoming phase** — one row per phase (R1b, R4, R5, R6, R7, R8, R9), describing only the **delta** from the previous phase.  Keeps the doc short.
- **FAQ** covering the most likely contributor worries during the R3 → R4 window:
  - "I forgot the conventional title — did I break the pipeline?"
  - "The shadow workflow turned red — should I worry?"
  - "Can I run release-plz locally?"
  - "I see `crates/uffs-*/CHANGELOG.md` files in my tree — do I commit them?"
  - "I need to ship a fix RIGHT NOW — does the R3 work block me?"
- **Where things live** — table mapping concerns to specific files (commitlint, cliff.toml, release-plz.toml, the workflows, the bumper, etc.).
- **Maintenance contract** — explicit: the `Current phase` line at top is part of every phase-N PR.

### Cross-reference policy

`CONTRIBUTING.md` → "Commit message conventions" links to the cheatsheet at the top of the section.  The cheatsheet links back to `CONTRIBUTING.md` for the convention reference, to `release-automation-plan.md` for full detail, and to `release-automation-baseline.md` for per-phase validation evidence.

This makes the four release-automation docs a tight web:

```
CONTRIBUTING.md ─────► release-automation-current-flow.md  (what to do today)
                              │   │  │
                              ▼   │  ▼
            release-automation-plan.md (the multi-phase plan)
                                  ▼
            release-automation-baseline.md (per-phase metrics + validation)
```

### Risk

Zero — docs only, no behavior changes.

### Tests / CI

- File size policy passes.
- Commitlint will validate the PR title (`docs(release-automation): one-page contributor cheatsheet for current flow` matches the configured pattern).
- No Rust workflows triggered (classify-changes will mark Rust steps as skipping).

### Order of merge

Independent of #67.  Either order works:

- **Merge #67 first, then this**: cheatsheet's "Current phase: R3" line is accurate at merge time.  (Slightly preferred.)
- **Merge this first, then #67**: cheatsheet is forward-looking by a few hours.  Equally fine since both PRs land in the same observation window.
