### PR TITLE
fix(mcp): dot-gated extension extraction so .bash_history sorts as empty

### DIFF
--- a/crates/uffs-core/src/output/display_rows.rs
+++ b/crates/uffs-core/src/output/display_rows.rs
@@ -25,6 +25,7 @@ use rayon::prelude::*;
 use super::{BASELINE_COLUMN_ORDER, OutputColumn, OutputConfig};
 use crate::error::Result;
 use crate::search::backend::DisplayRow;
+use crate::search::derived::extension_from_name;
 
 /// Row count above which [`write_display_rows`] parallelises row
 /// formatting via rayon chunks.
@@ -330,8 +331,13 @@ pub fn write_display_row_columns(
             }
             OutputColumn::Extension => {
                 buf.push_str(&cfg.quote);
-                if let Some(dot) = row.name().rfind('.') {
-                    buf.push_str(row.name().get(dot + 1..).unwrap_or(""));
+                // Dot-gated: dotfiles (`.bash_history`), dotless names
+                // (`README`), and trailing-dot names (`foo.`) emit an
+                // empty extension so the displayed value matches the
+                // sort engine's key (`search::sorting::build_row_sort_key`)
+                // and the indexer's `intern_extension` semantics.
+                if let Some(ext) = extension_from_name(row.name()) {
+                    buf.push_str(ext);
                 }
                 buf.push_str(&cfg.quote);
             }

--- a/crates/uffs-core/src/output/tests.rs
+++ b/crates/uffs-core/src/output/tests.rs
@@ -699,3 +699,73 @@ fn test_write_datetime_column_zero_filetime_is_empty() {
         "FILETIME 0 must NOT render as 1601-01-01 (got: {csv})"
     );
 }
+
+/// Regression: the `Extension` column must use dot-gated extraction so the
+/// displayed value matches the sort engine's key
+/// (`crate::search::sorting::build_row_sort_key`, which calls
+/// `extract_extension_after_dot`) and the indexer's `intern_extension`
+/// semantics.  Pre-fix, naive `rfind('.')` extraction produced
+/// `ext = "bash_history"` for `.bash_history`, while the sort key was `""`,
+/// causing `--sort extension` ascending to place `.bash_history` at row 1
+/// with a displayed `ext` value that violated the asc invariant against
+/// every following row.  Caught by Windows MCP T62 (`scripts/tests/
+/// definitions/03-sort.toml`).
+#[test]
+fn extension_column_dot_gated_for_dotfiles_dotless_and_trailing_dot() {
+    use crate::search::backend::DisplayRow;
+
+    // Build one DisplayRow per case: dotfile, dotless, trailing-dot,
+    // multi-dot directory name, and a normal file (positive control).
+    fn row(path: &str) -> DisplayRow {
+        DisplayRow::new(0, 'C', path.to_owned(), 0, false, 0, 0, 0, 0, 0, 0, 0, 0)
+    }
+
+    let rows = [
+        row("F:\\Ch\\.bash_history"),
+        row("C:\\Users\\rnio\\.gitignore"),
+        row("C:\\tmp\\README"),
+        row("C:\\tmp\\foo."),
+        row(
+            "C:\\Windows\\WinSxS\\amd64_microsoft-windows-mdmappinstaller_31bf3856ad364e35_10.0.26100.8115_none_3591783d4bfd6e96",
+        ),
+        row("C:\\Projects\\report.txt"),
+    ];
+
+    let config = OutputConfig::new()
+        .with_columns("name,ext")
+        .with_header(false)
+        .with_quote("\"");
+
+    let mut out = Vec::new();
+    config
+        .write_display_rows(&rows, &mut out)
+        .expect("write should succeed");
+    let csv = String::from_utf8(out).expect("UTF-8");
+    assert_eq!(
+        csv.lines().count(),
+        rows.len(),
+        "one output line per row (no header), got: {csv}"
+    );
+
+    // Each expected line covers a distinct extension-extraction edge case.
+    let expected_lines = [
+        // Dotfiles → empty ext.
+        "\".bash_history\",\"\"",
+        "\".gitignore\",\"\"",
+        // Dotless name → empty ext.
+        "\"README\",\"\"",
+        // Trailing-dot name → empty ext.
+        "\"foo.\",\"\"",
+        // Multi-dot directory name → segment after the last dot
+        // (matches the sort key produced by `extract_extension_after_dot`).
+        "\"amd64_microsoft-windows-mdmappinstaller_31bf3856ad364e35_10.0.26100.8115_none_3591783d4bfd6e96\",\"8115_none_3591783d4bfd6e96\"",
+        // Normal file → ext after the last dot.
+        "\"report.txt\",\"txt\"",
+    ];
+    for expected in expected_lines {
+        assert!(
+            csv.contains(expected),
+            "Extension column output missing expected line {expected:?}; full CSV:\n{csv}"
+        );
+    }
+}

--- a/crates/uffs-format/src/derived.rs
+++ b/crates/uffs-format/src/derived.rs
@@ -109,8 +109,15 @@ const CODE: &[&str] = &[
     "cs", "vb", "fs", "ml", "hs", "clj", "dart", "zig", "nim", "cr", "jl",
 ];
 
-/// Return the lowercase extension (no leading dot) of a filename.
-fn extension_from_name(name: &str) -> Option<&str> {
+/// Return the extension (no leading dot) of a filename.
+///
+/// Dot-gated: dotfiles (`.bash_history`), dotless names (`README`), and
+/// trailing-dot names (`foo.`) all return `None`.  Visible to the rest
+/// of the crate so [`writer::write_display_row_columns`] can format the
+/// `Extension` column with the same rule as the sort key (regression:
+/// T62 `--sort extension` MCP failure where `.bash_history`'s displayed
+/// `ext` disagreed with its sort position).
+pub(crate) fn extension_from_name(name: &str) -> Option<&str> {
     let dot = name.rfind('.')?;
     if dot == 0 || dot + 1 >= name.len() {
         return None;

--- a/crates/uffs-format/src/writer.rs
+++ b/crates/uffs-format/src/writer.rs
@@ -17,7 +17,7 @@ use crate::attr;
 use crate::column::{BASELINE_COLUMN_ORDER, OutputColumn};
 use crate::config::OutputConfig;
 use crate::datetime::append_datetime_native;
-use crate::derived::{bulkiness_for_row, semantic_type_for_row};
+use crate::derived::{bulkiness_for_row, extension_from_name, semantic_type_for_row};
 use crate::row::FormatRow;
 
 /// Row-count cutover between the sequential writer and the rayon
@@ -233,8 +233,14 @@ pub fn write_row<R: FormatRow>(
             }
             OutputColumn::Extension => {
                 buf.push_str(&cfg.quote);
-                if let Some(dot) = row.name().rfind('.') {
-                    buf.push_str(row.name().get(dot + 1..).unwrap_or(""));
+                // Dot-gated: dotfiles (`.bash_history`), dotless names
+                // (`README`), and trailing-dot names (`foo.`) emit an
+                // empty extension so the displayed value matches the
+                // sort engine's key
+                // (`uffs_core::search::sorting::build_row_sort_key`)
+                // and the indexer's `intern_extension` semantics.
+                if let Some(ext) = extension_from_name(row.name()) {
+                    buf.push_str(ext);
                 }
                 buf.push_str(&cfg.quote);
             }
@@ -395,5 +401,51 @@ mod tests {
         write_rows(&cfg, &rows, &mut out).expect("write");
         let text = String::from_utf8(out).expect("utf8");
         assert_eq!(text, "+,-\n");
+    }
+
+    /// Regression: the `Extension` column must use dot-gated extraction so
+    /// the displayed value matches the sort engine's key
+    /// (`uffs_core::search::sorting::build_row_sort_key` →
+    /// `extract_extension_after_dot`) and the indexer's `intern_extension`
+    /// semantics.  Pre-fix, naive `rfind('.')` produced
+    /// `ext = "bash_history"` for `.bash_history`, while the sort key was
+    /// `""`.  Caught by Windows MCP T62
+    /// (`scripts/tests/definitions/03-sort.toml`).
+    #[test]
+    fn extension_column_dot_gated_for_dotfiles_dotless_and_trailing_dot() {
+        let cfg = OutputConfig::new()
+            .with_columns("name,ext")
+            .with_header(false)
+            .with_quote("\"");
+
+        let cases = [
+            // (path,                                     name,             expected_ext)
+            ("F:\\Ch\\.bash_history", ".bash_history", ""),
+            ("C:\\Users\\rnio\\.gitignore", ".gitignore", ""),
+            ("C:\\tmp\\README", "README", ""),
+            ("C:\\tmp\\foo.", "foo.", ""),
+            (
+                "C:\\Win\\amd64_x_10.0.26100.8115_none_xyz",
+                "amd64_x_10.0.26100.8115_none_xyz",
+                "8115_none_xyz",
+            ),
+            ("C:\\Projects\\report.txt", "report.txt", "txt"),
+        ];
+
+        for (path, name, expected_ext) in cases {
+            let row = TestRow {
+                path: path.to_owned(),
+                name: name.to_owned(),
+                ..sample()
+            };
+            let mut out = Vec::new();
+            write_rows(&cfg, &[row], &mut out).expect("write");
+            let text = String::from_utf8(out).expect("utf8");
+            let expected = format!("\"{name}\",\"{expected_ext}\"\n");
+            assert_eq!(
+                text, expected,
+                "Extension column mismatch for name {name:?}: got {text:?}"
+            );
+        }
     }
 }

--- a/crates/uffs-mcp/src/tools/search.rs
+++ b/crates/uffs-mcp/src/tools/search.rs
@@ -214,11 +214,24 @@ fn default_filter() -> String {
 }
 
 /// Derive the file extension from a filename (lowercase, no leading dot).
+///
+/// Dot-gated to match the MFT indexer's `intern_extension` and the search
+/// engine's `extract_extension_after_dot`: dotless names (`README`),
+/// hidden dotfiles (`.bash_history`, `.gitignore`), and trailing-dot
+/// names (`foo.`) all return the empty string.  Keeping the displayed
+/// `ext` aligned with the sort key prevents `--sort extension` from
+/// emitting rows whose `ext` field disagrees with their position
+/// (regression: T62 on Windows where `.bash_history` placed at row 1
+/// reported `ext = "bash_history"` and broke the ascending invariant).
 fn extract_ext(name: &str) -> String {
-    match name.rsplit_once('.') {
-        Some((_, ext)) if !ext.is_empty() => ext.to_ascii_lowercase(),
-        _ => String::new(),
+    let Some(dot_pos) = name.rfind('.') else {
+        return String::new();
+    };
+    if dot_pos == 0 || dot_pos + 1 >= name.len() {
+        return String::new();
     }
+    name.get(dot_pos + 1..)
+        .map_or_else(String::new, str::to_ascii_lowercase)
 }
 
 /// Decode a cursor string into an offset.  Returns 0 for invalid cursors.
@@ -428,10 +441,7 @@ pub async fn run(
         rows: page_rows
             .iter()
             .map(|row| {
-                let ext = match row.name.rsplit_once('.') {
-                    Some((_, ext)) if !ext.is_empty() => ext.to_ascii_lowercase(),
-                    _ => String::new(),
-                };
+                let ext = extract_ext(&row.name);
                 let r#type = if row.is_directory { "dir" } else { "file" }.to_owned();
                 SearchRowOutput {
                     drive: row.drive,
@@ -629,4 +639,52 @@ pub fn percent_encode_path(path: &str) -> String {
         }
     }
     encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_ext;
+
+    /// Regression: dot-gated extraction so the MCP-emitted `ext` field
+    /// (in both the markdown table and `structuredContent.rows[*].ext`)
+    /// matches the daemon's sort key
+    /// (`uffs_core::search::sorting::build_row_sort_key` →
+    /// `extract_extension_after_dot`).  Pre-fix, naive `rsplit_once('.')`
+    /// produced `ext = "bash_history"` for `.bash_history`, but the sort
+    /// engine placed the row in the empty-extension bucket — the
+    /// resulting disagreement broke Windows MCP T62 `--sort extension`
+    /// (`scripts/tests/definitions/03-sort.toml`) because the validator
+    /// reads `ext` and finds it non-monotonic.
+    #[test]
+    fn extract_ext_returns_empty_for_dotfiles() {
+        assert_eq!(extract_ext(".bash_history"), "");
+        assert_eq!(extract_ext(".gitignore"), "");
+        assert_eq!(extract_ext(".env"), "");
+    }
+
+    #[test]
+    fn extract_ext_returns_empty_for_dotless_names() {
+        assert_eq!(extract_ext("README"), "");
+        assert_eq!(extract_ext("Makefile"), "");
+        assert_eq!(extract_ext(""), "");
+    }
+
+    #[test]
+    fn extract_ext_returns_empty_for_trailing_dot() {
+        assert_eq!(extract_ext("foo."), "");
+        assert_eq!(extract_ext("archive.tar."), "");
+    }
+
+    #[test]
+    fn extract_ext_returns_lowercase_segment_after_last_dot() {
+        assert_eq!(extract_ext("report.txt"), "txt");
+        assert_eq!(extract_ext("archive.tar.gz"), "gz");
+        assert_eq!(extract_ext("$RECYCLE.BIN"), "bin");
+        assert_eq!(
+            extract_ext(
+                "amd64_microsoft-windows-mdmappinstaller_31bf3856ad364e35_10.0.26100.8115_none_3591783d4bfd6e96"
+            ),
+            "8115_none_3591783d4bfd6e96"
+        );
+    }
 }


### PR DESCRIPTION
## Why

Windows MCP T62 (`scripts/tests/definitions/03-sort.toml`, `--sort extension` ascending) failed at row 1:

```
Not ascending: bash_history > 8115_none_3591783d4bfd6e96
```

Root cause: the **display-side** extension extraction disagrees with the **sort engine's** key for dotfiles, dotless names, and trailing-dot names.

- The sort key uses `extract_extension_after_dot` (dot-gated): `.bash_history` → `""`, so the daemon correctly places it in the empty-extension bucket at row 1.
- But the MCP layer (and two display formatters) used naive `rsplit_once('.')` / `rfind('.')`, so `.bash_history`'s **displayed** `ext` came out as `"bash_history"` — non-monotonic against `"8115_none_..."` on row 2.

CLI / API tests historically passed for T62 by accident: `Extension` is not in the CLI default column set (`Drive, Name, Size, Modified, Path` per `uffs-core/src/search/columns.rs:15-21`), so the validator's `col_val` returned `""` for every row and the asc check passed vacuously (false negative). MCP exposes the bug because its default projection includes `ext`.

## What

Aligned all four display-side extension extractors with dot-gated semantics so the displayed `Extension` column / MCP `ext` field agrees with the sort key for **every** edge case the indexer recognizes.

| File | Change |
|------|--------|
| `crates/uffs-mcp/src/tools/search.rs` | Fix `extract_ext`; replace inline duplicate in `structuredContent.rows[*].ext` builder. |
| `crates/uffs-core/src/output/display_rows.rs` | Import + use `crate::search::derived::extension_from_name` (the existing dot-gated helper) for the `Extension` column. |
| `crates/uffs-format/src/derived.rs` | Promote `extension_from_name` to `pub(crate)`. |
| `crates/uffs-format/src/writer.rs` | Use `extension_from_name` for the `Extension` column. |

Sort engine, indexer, and filter logic are unchanged — only the display path is brought into agreement with the canonical sort key.

## Edge cases now consistent across MCP / CLI / format-writer

- `.bash_history` → `""`
- `.gitignore` → `""`
- `README` (no dot) → `""`
- `foo.` (trailing dot) → `""`
- `amd64_..._10.0.26100.8115_none_3591783d4bfd6e96` → `"8115_none_3591783d4bfd6e96"`
- `report.txt` → `"txt"`

## Tests

- **`uffs-mcp`** — 4 unit tests on `extract_ext` covering dotfiles, dotless, trailing-dot, and the multi-dot WinSxS string.
- **`uffs-core/src/output/tests.rs`** — end-to-end `write_display_rows` test driving five `DisplayRow`s through the native formatter and asserting the CSV output for the `name,ext` projection.
- **`uffs-format/src/writer.rs`** — end-to-end `write_rows` test pinning the same six edge cases on the format-crate writer (CLI thin-client path after `SearchPayload::InlineRows`).

```bash
cargo test -p uffs-format -p uffs-mcp -p uffs-core --lib extension_column extract_ext
```

All targeted tests + 714 `uffs-core`, 15 `uffs-format`, 12 `uffs-mcp` lib tests pass. `cargo clippy --all-targets` clean across the touched crates. `just lint-fast` and `lint-pre-push` both green.

## Out of scope

The CLI/API false-negative (T62 vacuous pass via missing `Extension` column) is left as a separate follow-up: either add `--columns name,ext,…` to the test definition or harden `col_val` to fail loudly when a referenced column is absent. Filed mentally; happy to open a tiny follow-up PR if requested.
