### PR TITLE
fix(daemon): emit version on `uffsd --version`

### DIFF
--- a/crates/uffs-daemon/src/main.rs
+++ b/crates/uffs-daemon/src/main.rs
@@ -59,7 +59,7 @@ use windows as _;
 
 /// UFFS background daemon — holds MFT index, serves queries via IPC.
 #[derive(Parser)]
-#[command(name = "uffs-daemon", about = "UFFS background search daemon")]
+#[command(name = "uffsd", version, about = "UFFS background search daemon")]
 struct Cli {
     /// MFT files to load (*.bin, *.raw, *.iocp, *.uffs).
     #[arg(long = "mft-file", value_name = "PATH")]

--- a/just/build.just
+++ b/just/build.just
@@ -347,6 +347,86 @@ use:
         }
     }
 
+# Reset local `main` to `origin/main`, discarding any uncommitted edits.
+#
+# Motivation: `cargo build` rewrites `Cargo.lock` whenever a transitive
+# dep resolves differently (mtime-driven re-resolution, polars git pin
+# updates, etc.).  After a `just ship` upstream the lockfile has moved,
+# so a plain `git pull` aborts with:
+#     "Your local changes to the following files would be overwritten
+#      by merge: Cargo.lock"
+# `just sync` is the explicit force-discard escape hatch.
+#
+# Safety: refuses to run on any branch other than `main`, so feature
+# branches with real WIP cannot be wiped by accident.  Use plain
+# `git pull --rebase` (or commit the WIP first) on those.
+[unix]
+sync:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [[ "$BRANCH" != "main" ]]; then
+        printf "\033[0;31m❌ just sync only runs on main (current: %s)\033[0m\n" "$BRANCH"
+        printf "   Use 'git pull --rebase' (or commit the WIP first) on feature branches.\n"
+        exit 1
+    fi
+    BEFORE=$(git rev-parse --short HEAD)
+    git fetch origin main
+    AFTER=$(git rev-parse --short FETCH_HEAD)
+    DIRTY=""
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        DIRTY="1"
+        printf "\033[1;33m⚠️  Discarding uncommitted edits to:\033[0m\n"
+        git diff --name-only HEAD | sed 's/^/   /'
+    fi
+    if [[ "$BEFORE" == "$AFTER" && -z "$DIRTY" ]]; then
+        printf "\033[0;32m✅ Already at origin/main (%s) — nothing to do\033[0m\n" "$BEFORE"
+    else
+        if [[ "$BEFORE" != "$AFTER" ]]; then
+            printf "\033[1;33m⚠️  Resetting %s -> %s\033[0m\n" "$BEFORE" "$AFTER"
+        fi
+        git reset --hard FETCH_HEAD
+        printf "\033[0;32m✅ Synced to %s\033[0m\n" "$(git rev-parse --short HEAD)"
+    fi
+
+# Reset local `main` to `origin/main`, discarding any uncommitted edits
+# (Windows / PowerShell variant — same semantics as the unix recipe).
+[windows]
+sync:
+    #!powershell
+    $ErrorActionPreference = 'Stop'
+    $branch = (git rev-parse --abbrev-ref HEAD).Trim()
+    if ($branch -ne 'main') {
+        Write-Host "❌ just sync only runs on main (current: $branch)" -ForegroundColor Red
+        Write-Host "   Use 'git pull --rebase' (or commit the WIP first) on feature branches."
+        exit 1
+    }
+    $before = (git rev-parse --short HEAD).Trim()
+    git fetch origin main
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    $after = (git rev-parse --short FETCH_HEAD).Trim()
+    $dirty = (git status --porcelain)
+    if ($dirty) {
+        Write-Host "⚠️  Discarding uncommitted edits to:" -ForegroundColor Yellow
+        (git diff --name-only HEAD) -split "`n" | Where-Object { $_ } | ForEach-Object { Write-Host "   $_" }
+    }
+    if ($before -eq $after -and -not $dirty) {
+        Write-Host "✅ Already at origin/main ($before) — nothing to do" -ForegroundColor Green
+    } else {
+        if ($before -ne $after) {
+            Write-Host "⚠️  Resetting $before -> $after" -ForegroundColor Yellow
+        }
+        git reset --hard FETCH_HEAD
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        $head = (git rev-parse --short HEAD).Trim()
+        Write-Host "✅ Synced to $head" -ForegroundColor Green
+    }
+
+# Force-pull main (discarding local edits) and reinstall release binaries
+# from `dist/` to `~/bin`.  Drop-in replacement for the `git pull; just use`
+# leg of the daily-driver oneliner — survives a dirty `Cargo.lock`.
+refresh: sync use
+
 # Git commit with auto-generated message.
 commit:
     @printf "\033[0;34m📝 Creating auto-generated commit...\033[0m\n"


### PR DESCRIPTION
## Why

`just use`'s install-time `--version` probe shows `uffsd` returning empty:

```
Installed versions:
  uffsmcp.exe  uffsmcp 0.5.74
  uffs.exe     uffs 0.5.74
  uffsd.exe                     ← empty
  uffs_mft.exe uffs_mft 0.5.74
```

Root cause: `uffsd`'s clap `#[command(...)]` attribute was missing `version`, so `clap` doesn't wire a `--version` handler at all and the binary exits silently.

Peer binaries already pull `CARGO_PKG_VERSION` via clap's auto-version:
- `uffs-mcp/src/main.rs` → `#[command(name = "uffsmcp", version, about)]`
- `uffs-mft/src/cli.rs` → `#[command(author, version, about, ...)]`
- `uffs-cli/src/args.rs` → custom `print_version()` handler

## What

**Daemon fix** (`crates/uffs-daemon/src/main.rs`):
- Add `version` to `#[command(...)]`.
- Align clap `name` from `"uffs-daemon"` → `"uffsd"`, matching the actual `[[bin]] name = "uffsd"` in `crates/uffs-daemon/Cargo.toml` (and the binary path users invoke).

Verified locally:

```bash
$ ./target/debug/uffsd --version
uffsd 0.5.74
$ ./target/debug/uffsd --help | head -1
UFFS background search daemon
```

**Bonus dev tooling** (`just/build.just`) — fixes a recurring friction in the daily-driver oneliner:

```
git pull; just use
    ↓
error: Your local changes to the following files would be overwritten
       by merge: Cargo.lock
```

`cargo build` rewrites `Cargo.lock` whenever a transitive dep re-resolves (mtime drift, polars git pin movement, etc.); after a `just ship` upstream the lockfile has moved, so a plain `git pull` aborts.

- **`just sync`** — `git fetch origin main && git reset --hard FETCH_HEAD`, **guarded against running on any branch other than `main`** so feature branches with real WIP cannot be wiped by accident. Prints what's being discarded. Both `[unix]` (bash) and `[windows]` (PowerShell) variants, matching the existing `use` / `use-local` split.
- **`just refresh`** — `refresh: sync use`. Drop-in replacement for the `git pull; just use` leg of the daily-driver oneliner.

New oneliner:

```powershell
clear; Remove-Item -Recurse -Force "$env:LOCALAPPDATA\uffs\cache" -ErrorAction SilentlyContinue; `
Remove-Item -Recurse -Force "$env:TEMP\uffs_index_cache" -ErrorAction SilentlyContinue; `
~\bin\uffs.exe mcp kill; ~\bin\uffs.exe daemon kill; `
just refresh; `
~\bin\uffs.exe daemon start; ~\bin\uffs.exe mcp start; ~\bin\uffs.exe status
```

Self-test on this branch (which is not `main`) confirms the safety guard:

```bash
$ just sync
❌ just sync only runs on main (current: fix/uffsd-version-and-sync-recipes)
   Use 'git pull --rebase' (or commit the WIP first) on feature branches.
```

## Scope

Single PR, type `fix` because the version-flag is the user-visible behavioral defect driving the patch-bump release. The recipe additions are dev-tooling-only and have no effect on shipped binaries.

## Tests / verification

- `cargo build -p uffs-daemon` — clean
- `./target/debug/uffsd --version` / `--help` — both produce the expected output
- `just lint-fast` — green (file-size, fmt-check, lint-prod, lint-tests, lint-ci, typos, reuse)
- `lint-pre-push` — green across all 13 gates including `tests`, `rustdoc`, `doc-tests`, `check-windows`, `smoke`
- `just --summary | grep` shows `sync`, `refresh`, `use`, `use-local` all parsed
- `just sync` on this branch correctly refuses with the helpful error

## Follow-up

After this lands I'll cut **v0.5.75** via `just ship` so `~/bin/uffsd.exe --version` actually shows `uffsd 0.5.75` next time you `just refresh`.
