### PR TITLE
chore: release v0.5.75 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.74] - 2026-04-25
+## [0.5.75] - 2026-04-25
 
 ### Fixed
 - **macOS arm64 release binaries SIGKILLed at launch** under macOS 26+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "anyhow",
  "clap",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "chrono",
  "itoa",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "anyhow",
  "axum",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4533,14 +4533,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4553,14 +4553,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.74"
+version = "0.5.75"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.74"
+version = "0.5.75"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.75**.  Binaries + GitHub Release v0.5.75 are already live (step 09).  This PR routes the corresponding commit through branch-protection rules.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

Local `main` had this commit with a different SHA before squash rewrote it onto main; recover with `git fetch origin && git reset --hard origin/main`.