### PR TITLE
fix(api-validation): dot-gated extension extraction so .bash_history sorts as empty

### DIFF
--- a/scripts/windows/api-validation.rs
+++ b/scripts/windows/api-validation.rs
@@ -974,6 +974,29 @@ fn csv_col_to_json(col: &str) -> &str {
     }
 }
 
+/// Dot-gated extension extraction matching the sort engine's key
+/// (`extract_extension_after_dot` in
+/// `crates/uffs-core/src/search/filters/ext_match.rs`) and the CLI/MCP
+/// display helpers (`extension_from_name` in `uffs-format`/`uffs-core`).
+///
+/// Returns an empty string for:
+///   * dotless names           (`README`           -> `""`)
+///   * leading-dot "hidden"    (`.bash_history`   -> `""`)
+///   * trailing-dot names      (`foo.`             -> `""`)
+///
+/// Without this guard, `".bash_history".rsplit('.').next()` returns
+/// `"bash_history"`, which (a) breaks T62 `--sort extension asc` because
+/// `"bash_history" > "2008"` lexically, and (b) misclassifies dotless
+/// rows in the `type_*` allowlist validator (their full name becomes the
+/// purported extension).
+fn extract_ext_dot_gated(name: &str) -> String {
+    let Some(dot) = name.rfind('.') else { return String::new(); };
+    if dot == 0 || dot + 1 >= name.len() {
+        return String::new();
+    }
+    name.get(dot + 1..).unwrap_or("").to_ascii_lowercase()
+}
+
 /// Compute derived column values that don't exist directly in the
 /// JSON-RPC response but can be calculated from existing fields.
 fn rpc_field_computed(row: &Value, json_key: &str) -> Option<String> {
@@ -999,8 +1022,7 @@ fn rpc_field_computed(row: &Value, json_key: &str) -> Option<String> {
         }
         "_ext" => {
             let name = field_str(row, "name");
-            let ext = name.rsplit('.').next().unwrap_or("").to_lowercase();
-            Some(ext)
+            Some(extract_ext_dot_gated(&name))
         }
         "_path_only" => {
             // Directory path only (strip filename from full path).
@@ -1999,7 +2021,7 @@ fn run_rpc_custom_validator(name: &str, result: &Value) -> Result<String> {
                     // System files are $-prefixed OR have system extensions
                     if name.starts_with('$') { continue; }
                 }
-                let ext = name.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+                let ext = extract_ext_dot_gated(name);
                 if !allowed.contains(&ext.as_str()) {
                     bad.push(format!("row {i}: {name} (ext={ext})"));
                     if bad.len() >= 3 { break; }


### PR DESCRIPTION
## Symptom

T62 `--sort extension asc` fails on Windows live MFT with:

```
Error: Not asc: bash_history > 2008
RPC: search({"limit":10,"pattern":"*.*","sort":"extension"})
```

CLI lane (`uffs.exe "*.*" --sort extension --limit 10`) returns the **correct** order — `.bash_history` first with empty Extension `""`, then digit-prefixed `"2008"`, `"BIN"`, `"bin"`, `"csv"`, `"dat"`. MCP lane is also green (fixed in #69 / v0.5.74). Only the pure-RPC API validation lane fails.

## Root cause

`scripts/windows/api-validation.rs` derives the `Extension` column locally from the daemon's `name` JSON field via `rpc_field_computed("_ext")`:

```rust
"_ext" => {
    let name = field_str(row, "name");
    let ext = name.rsplit('.').next().unwrap_or("").to_lowercase();
    Some(ext)
}
```

`".bash_history".rsplit('.').next()` returns `"bash_history"` (post-dot suffix when the dot is at index 0), instead of the empty string the sort engine uses. Same naive extractor at line 2002 of the `type_*` allowlist validator: dotless names get their **full** lowercased name as a phantom extension.

This was the third copy of the bug. CLI/format and MCP lanes were fixed in v0.5.74 (#69) by routing through `extension_from_name` / `extract_extension_after_dot`. The API validation lane was missed because it has its own validator-side extraction (no shared helper with the workspace).

## Fix

Single helper, two call sites:

```rust
fn extract_ext_dot_gated(name: &str) -> String {
    let Some(dot) = name.rfind('.') else { return String::new(); };
    if dot == 0 || dot + 1 >= name.len() {
        return String::new();
    }
    name.get(dot + 1..).unwrap_or("").to_ascii_lowercase()
}
```

Mirrors `extract_extension_after_dot` in `crates/uffs-core/src/search/filters/ext_match.rs`. Returns `""` for: dotless names (`README`), leading-dot hidden files (`.bash_history`), trailing-dot names (`foo.`).

Used in:
- `_ext` computed column → fixes T62 sort + Extension column display in API validator.
- `type_*` allowlist (`type_code`, `type_document`, `type_executable`, `type_picture`, `type_system`) → no longer mis-classifies dotless rows by their full name.

## Verification

- `rust-script --package` + `cargo check` on the generated package: clean compile, no new warnings.
- `lint-fast` (file-size, fmt-check, lint-prod, lint-tests, lint-ci, typos, reuse): all green.
- `lint-pre-push` (incl. smoke + check-windows): all green.
- Equivalent dot-gated semantics already pinned by regression tests in `crates/uffs-format/src/writer.rs`, `crates/uffs-core/src/output/tests.rs`, and `crates/uffs-mcp/src/tools/search.rs` (#69).

## Out of scope

`scripts/windows/api-validation.rs` is a `rust-script` (not a workspace crate), so it is not gated by `just lint-ci`. Pre-existing clippy nits in unrelated parts of the file (`unnecessary_filter_map`, `unnecessary_map_or`, etc., lines 2689 / 2862 / …) are left untouched.

## Affects

- ✅ T62 `--sort extension asc` (the originally reported failure)
- ✅ `type_code` / `type_document` / `type_executable` / `type_picture` / `type_system` validators

Closes the third copy of the dot-gated extension bug; CLI / MCP / API lanes now share semantics.
