### PR TITLE
chore: release v0.5.76 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.75] - 2026-04-25
+## [0.5.76] - 2026-04-25
 
 ### Fixed
 - **macOS arm64 release binaries SIGKILLed at launch** under macOS 26+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,9 +1839,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "anyhow",
  "clap",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "chrono",
  "itoa",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "anyhow",
  "axum",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4533,14 +4533,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4553,14 +4553,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.75"
+version = "0.5.76"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.75"
+version = "0.5.76"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -607,7 +607,7 @@ version = "0.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
-version = "0.2.185"
+version = "0.2.186"
 criteria = "safe-to-deploy"
 
 [[exemptions.libm]]


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.76**.  This PR routes the version-bump commit through branch-protection rules (auto-merge squash).

Folded into the auto-commit: `supply-chain/config.toml` exemption bump for `libc 0.2.185 → 0.2.186` (crates.io patch update). `cargo vet` would otherwise have blocked the pre-push hook on `libc:0.2.186 missing ["safe-to-deploy"]`. Same criteria preserved.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

Local `main` had this commit with a different SHA before squash rewrote it onto main; recover with `git fetch origin && git reset --hard origin/main` (or `just sync`, available since v0.5.75).

`auto-tag-release.yml` will tag `v0.5.76` on push-to-main; `release.yml` then builds and publishes the cross-platform binaries.

## Release contents

- **fix(api-validation):** dot-gated extension extraction so `.bash_history` sorts as empty (`scripts/windows/api-validation.rs`). Closes the third copy of the bug — CLI / MCP / API lanes now share semantics. (#73)
- **chore(supply-chain):** bump `libc` exemption to 0.2.186.
