### PR TITLE
docs(readme): tokio-style hero trim — wordmark + 4 badges, drop H1, shields.io CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <p align="center">
-  <img src="assets/brand/uffs-hero-1024.png" alt="UFFS — Ultra Fast File Search" width="480">
+  <img src="assets/brand/uffs-wordmark.png" alt="UFFS — Ultra Fast File Search">
 </p>
-
-<h1 align="center">UFFS — Ultra Fast File Search</h1>
 
 <p align="center">
   <b>Wire-speed search across your NTFS drives. No indexing. No waiting.</b><br>
@@ -10,11 +8,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/skyllc-ai/UltraFastFileSearch/actions/workflows/pr-fast.yml"><img src="https://github.com/skyllc-ai/UltraFastFileSearch/actions/workflows/pr-fast.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/skyllc-ai/UltraFastFileSearch/actions/workflows/pr-fast.yml"><img src="https://img.shields.io/github/actions/workflow/status/skyllc-ai/UltraFastFileSearch/pr-fast.yml?branch=main&label=CI" alt="CI"></a>
   <a href="https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest"><img src="https://img.shields.io/github/v/release/skyllc-ai/UltraFastFileSearch?label=release" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg" alt="License: MPL 2.0"></a>
   <a href="https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest"><img src="https://img.shields.io/badge/platform-Windows-blue.svg" alt="Platform: Windows"></a>
-  <a href="TRADEMARK.md"><img src="https://img.shields.io/badge/brand-TRADEMARK.md-ce422b.svg" alt="Brand policy"></a>
 </p>
 
 **A benchmark-driven NTFS search engine for Windows.** UFFS reads the Master File Table directly, builds a compact persisted index, and keeps large NTFS estates searchable through a background daemon.


### PR DESCRIPTION
## Summary

Trims the README hero to land more content above the fold on first paint.

### Hero changes
- **Logo**: 480×480 square hero (`uffs-hero-1024.png`) → 4:1 wordmark (`uffs-wordmark.png`). Renders at GitHub's container width (~880×220) so the wordmark is bigger AND the README content climbs higher on the page.
- **H1**: dropped — the wordmark image carries the title via alt text + visual identity. Matches `tokio`/`uv`/`fd` hero pattern.
- **Brand policy badge**: dropped — no top-tier repo carries one in the hero. Trademark info still surfaces in the License & Trademarks section below.

### CI badge
- Was: GitHub-native `pr-fast.yml/badge.svg` which displays the workflow's `name:` field ("PR Fast CI") regardless of `alt` text.
- Now: shields.io `?label=CI` so the visible text reads just "CI".
- The workflow keeps `name: PR Fast CI` so the branch-protection check `PR Fast CI / required` continues to match.

## Discoverability checks

- Zero internal anchor links to `#uffs--ultra-fast-file-search` (verified with grep across `*.md`, `*.rs`, `*.toml`, `*.yml`).
- No markdownlint config in the workspace requires a top-level H1.
- GitHub's `<title>` tag already contains repo name + description — that's what search engines index.
- Wordmark `alt="UFFS — Ultra Fast File Search"` preserves accessibility for screen readers.

## Net change

`README.md`: +2/-5 lines, content body untouched. Hero collapses from ~600px tall to ~280px.

## Auto-merge

`--auto --squash` queued. Will auto-tag v0.5.77 on merge if the auto-tag-release.yml fires (no Cargo.toml changes here, so it may skip — that's fine, this is a docs-only ride-along).