### PR TITLE
feat(daemon): Phase 0 memory tiering — surface RSS + mimalloc committed bytes

### DIFF
--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -224,9 +224,18 @@ fn daemon_status() -> Result<()> {
     }
     println!("Connections:   {}", status.connections);
 
-    // Memory info.
+    // Memory info.  Three numbers, in increasing order of "what the OS
+    // sees": logical heap (sum of per-drive `heap_size_bytes`), then
+    // mimalloc's committed pages, then the OS-reported RSS.  All three
+    // come from the same `status` payload so they are consistent.
     if let Some(heap) = status.index_heap_bytes {
         println!("Index heap:    {} MB", heap / (1024 * 1024));
+    }
+    if let Some(committed) = status.mimalloc_committed_bytes {
+        println!("Mimalloc:      {} MB (committed)", committed / (1024 * 1024));
+    }
+    if let Some(rss) = status.rss_bytes {
+        println!("RSS:           {} MB", rss / (1024 * 1024));
     }
 
     // Also show loaded drives.

--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -232,7 +232,10 @@ fn daemon_status() -> Result<()> {
         println!("Index heap:    {} MB", heap / (1024 * 1024));
     }
     if let Some(committed) = status.mimalloc_committed_bytes {
-        println!("Mimalloc:      {} MB (committed)", committed / (1024 * 1024));
+        println!(
+            "Mimalloc:      {} MB (committed)",
+            committed / (1024 * 1024)
+        );
     }
     if let Some(rss) = status.rss_bytes {
         println!("RSS:           {} MB", rss / (1024 * 1024));

--- a/crates/uffs-client/src/protocol/response.rs
+++ b/crates/uffs-client/src/protocol/response.rs
@@ -590,6 +590,16 @@ pub struct StatusResponse {
     /// Calculated heap footprint of all loaded indices (bytes).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub index_heap_bytes: Option<u64>,
+    /// Mimalloc allocator committed bytes (bytes paged in from the OS).
+    ///
+    /// Reported by `mi_process_info`; equals or exceeds `index_heap_bytes`
+    /// because the allocator carries page-level overhead and free-but-
+    /// not-yet-decommitted segments.  Comparing this to `rss_bytes` shows
+    /// how much of the daemon's RSS is allocator-managed.  Phase 0 of the
+    /// memory-tiering work surfaces this so subsequent phases can be
+    /// measured against a stable allocator-committed baseline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mimalloc_committed_bytes: Option<u64>,
     /// Per-drive memory breakdown (drive letter → heap bytes).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub drive_memory: Vec<DriveMemoryInfo>,

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -881,10 +881,10 @@ impl IndexManager {
         // allocator-committed bytes and the OS-reported RSS alongside
         // the per-drive logical heap.  Cross-platform via mimalloc's
         // `mi_process_info`; see `crate::telemetry::mem_snapshot`.
-        let (rss_bytes, mimalloc_committed_bytes) = crate::telemetry::mem_snapshot().map_or(
-            (None, None),
-            |mem| (Some(mem.rss_bytes), Some(mem.mimalloc_committed_bytes)),
-        );
+        let (rss_bytes, mimalloc_committed_bytes) = crate::telemetry::mem_snapshot()
+            .map_or((None, None), |mem| {
+                (Some(mem.rss_bytes), Some(mem.mimalloc_committed_bytes))
+            });
 
         StatusResponse {
             status: status.clone(),

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -877,15 +877,41 @@ impl IndexManager {
         }
         drop(snap);
 
+        // Phase 0 of the memory-tiering work: surface the live
+        // allocator-committed bytes and the OS-reported RSS alongside
+        // the per-drive logical heap.  Cross-platform via mimalloc's
+        // `mi_process_info`; see `crate::telemetry::mem_snapshot`.
+        let (rss_bytes, mimalloc_committed_bytes) = crate::telemetry::mem_snapshot().map_or(
+            (None, None),
+            |mem| (Some(mem.rss_bytes), Some(mem.mimalloc_committed_bytes)),
+        );
+
         StatusResponse {
             status: status.clone(),
             uptime_secs: self.start_time.elapsed().as_secs(),
             connections,
             pid: std::process::id(),
-            rss_bytes: None,
+            rss_bytes,
             index_heap_bytes: Some(total_index_heap),
+            mimalloc_committed_bytes,
             drive_memory,
         }
+    }
+
+    /// Sum of `DriveCompactIndex::heap_size_bytes()` across every
+    /// loaded drive.
+    ///
+    /// Used by [`crate::telemetry::spawn_mem_snapshot_task`] to emit
+    /// the `mem.snapshot` tracing event without going through the full
+    /// [`Self::status`] path (which builds a per-drive `Vec` we don't
+    /// need for the heartbeat).
+    pub(crate) async fn total_index_heap_bytes(&self) -> u64 {
+        let snap = self.snapshot().await;
+        let mut total: u64 = 0;
+        for dr in &snap.drives {
+            total = total.saturating_add(dr.heap_size_bytes().total as u64);
+        }
+        total
     }
 
     /// Refresh specific drives (or all if empty).

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -1137,3 +1137,70 @@ fn is_live_drive_marker_recognises_cached_volume_marker() {
         "./C_mft.iocp"
     )));
 }
+
+// ── Phase 0 telemetry: status() surfaces RSS + mimalloc committed ──
+
+/// `IndexManager::status` populates both `rss_bytes` and
+/// `mimalloc_committed_bytes` via [`crate::telemetry::mem_snapshot`]
+/// — the two new fields landed by Phase 0 of the memory-tiering
+/// work.  This pin guards against a future refactor accidentally
+/// dropping the wiring (which would silently zero the telemetry
+/// dataset the rest of the tiering work measures itself against).
+#[tokio::test]
+async fn status_populates_rss_and_mimalloc_committed() {
+    let mgr = test_manager_with_drive().await;
+    let status = mgr.status(0).await;
+
+    let rss = status
+        .rss_bytes
+        .expect("Phase 0: status must surface rss_bytes via mem_snapshot");
+    assert!(
+        rss > 0,
+        "rss_bytes must be positive in a live test process; got {rss}"
+    );
+
+    let committed = status
+        .mimalloc_committed_bytes
+        .expect("Phase 0: status must surface mimalloc_committed_bytes via mem_snapshot");
+    // Committed bytes can underflow into the high 64-bit range only
+    // through a sign-extension bug; this bound is a sanity guardrail.
+    assert!(
+        committed < u64::MAX / 2,
+        "mimalloc_committed_bytes looks like an underflow: {committed}"
+    );
+}
+
+/// `IndexManager::total_index_heap_bytes` returns 0 for a fresh
+/// manager (no drives loaded).  Pins the empty-state contract the
+/// `mem.snapshot` heartbeat relies on so the first event after
+/// startup carries a real number rather than a panic.
+#[tokio::test]
+async fn total_index_heap_bytes_zero_for_empty_manager() {
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    assert_eq!(mgr.total_index_heap_bytes().await, 0);
+}
+
+/// After [`IndexManager::add_drive`] the heap total is non-zero
+/// and matches the sum reported via the per-drive breakdown in
+/// `status().drive_memory`.  Pins the contract that the heartbeat
+/// path and the JSON-RPC `status` path agree on the same number.
+#[tokio::test]
+async fn total_index_heap_bytes_matches_status_breakdown() {
+    let mgr = test_manager_with_drive().await;
+    let total = mgr.total_index_heap_bytes().await;
+    assert!(total > 0, "loaded drive must report a positive heap; got {total}");
+
+    let status = mgr.status(0).await;
+    let summed: u64 = status.drive_memory.iter().map(|dm| dm.heap_bytes).sum();
+    assert_eq!(
+        total, summed,
+        "total_index_heap_bytes ({total}) must equal sum of \
+         drive_memory.heap_bytes ({summed})"
+    );
+    assert_eq!(
+        status.index_heap_bytes,
+        Some(total),
+        "status.index_heap_bytes must equal total_index_heap_bytes",
+    );
+}

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -1189,7 +1189,10 @@ async fn total_index_heap_bytes_zero_for_empty_manager() {
 async fn total_index_heap_bytes_matches_status_breakdown() {
     let mgr = test_manager_with_drive().await;
     let total = mgr.total_index_heap_bytes().await;
-    assert!(total > 0, "loaded drive must report a positive heap; got {total}");
+    assert!(
+        total > 0,
+        "loaded drive must report a positive heap; got {total}"
+    );
 
     let status = mgr.status(0).await;
     let summed: u64 = status.drive_memory.iter().map(|dm| dm.heap_bytes).sum();

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -41,6 +41,8 @@ mod ipc;
 mod lifecycle;
 /// JSON-RPC protocol types.
 mod protocol;
+/// Process-level memory and runtime telemetry.
+pub(crate) mod telemetry;
 
 /// Default log file location: `<data-local-dir>/uffs/uffsd.log`.
 ///
@@ -240,6 +242,10 @@ pub async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
 
     let ipc_task = spawn_ipc_servers(&idx, &lifecycle_mgr);
     let _stats_task = spawn_stats_heartbeat(Arc::clone(&idx), lifecycle_mgr.handle());
+    let _mem_snapshot_task = telemetry::spawn_mem_snapshot_task(
+        Arc::clone(&idx),
+        telemetry::DEFAULT_MEM_SNAPSHOT_INTERVAL,
+    );
 
     // Run idle timer (blocks until shutdown or timeout) then tear
     // everything down.  Returns `!` so `force_exit_with_watchdog`

--- a/crates/uffs-daemon/src/telemetry.rs
+++ b/crates/uffs-daemon/src/telemetry.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Process-level memory and runtime telemetry.
+//!
+//! Phase 0 of the memory-tiering work
+//! ([`docs/refactor/memory-tiering-implementation-plan.md`]).
+//!
+//! Provides:
+//!
+//! * [`mem_snapshot`] — a cross-platform helper that returns the
+//!   daemon's current resident-set size and mimalloc-committed bytes.
+//! * [`spawn_mem_snapshot_task`] — spawns a background tokio task that
+//!   logs that snapshot at a configurable interval as a `mem.snapshot`
+//!   tracing event so a long-running daemon produces the time-series
+//!   the tiering work needs to measure its impact.
+//!
+//! The numbers come from mimalloc's `mi_process_info`, which is
+//! implemented uniformly on Mac, Linux and Windows; this lets the
+//! daemon emit consistent telemetry without pulling in `sysinfo`,
+//! `psapi` or platform-specific `mach`/`procfs` crates.
+//!
+//! [`docs/refactor/memory-tiering-implementation-plan.md`]: https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/docs/refactor/memory-tiering-implementation-plan.md
+
+use alloc::sync::Arc;
+use core::time::Duration;
+
+use crate::index::IndexManager;
+
+/// Default cadence for the background `mem.snapshot` tracing event.
+///
+/// One hour is enough granularity for a 24 h soak run while staying
+/// well below any reasonable log-volume budget.
+pub(crate) const DEFAULT_MEM_SNAPSHOT_INTERVAL: Duration = Duration::from_hours(1);
+
+/// Process-level memory snapshot in bytes.
+///
+/// Snapshot is a single point-in-time read; no smoothing, no peak
+/// tracking.  Consumers that want trend lines layer EMA / max-window
+/// logic on top.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct MemSnapshot {
+    /// Process resident-set size (RSS) in bytes.
+    ///
+    /// What the OS reports as the process's committed-and-paged-in
+    /// memory.  Includes mimalloc's working pages, stack, executable
+    /// images and any non-allocator mappings.
+    pub(crate) rss_bytes: u64,
+    /// Mimalloc allocator committed bytes (`current_commit`).
+    ///
+    /// What the allocator has actually paged in from the OS.  After
+    /// `mi_collect(true)` this number drops as freed segments are
+    /// decommitted; comparing it to `rss_bytes` shows how much of the
+    /// daemon's RSS is allocator-managed versus everything else.
+    pub(crate) mimalloc_committed_bytes: u64,
+}
+
+/// Read the daemon's current memory snapshot.
+///
+/// Cross-platform via mimalloc's `mi_process_info` (enabled by the
+/// `extended` feature on `libmimalloc-sys`, already pinned in
+/// `crates/uffs-daemon/Cargo.toml`).
+///
+/// Returns `None` if `mi_process_info` reports zero for both RSS and
+/// committed bytes — that should not happen on Mac, Linux or Windows
+/// but it's the right "telemetry unavailable" signal if the function
+/// is ever stubbed out for a future platform.
+#[must_use]
+pub(crate) fn mem_snapshot() -> Option<MemSnapshot> {
+    // Eight `usize` slots, one per `mi_process_info` out-pointer.
+    // Only `current_rss` and `current_commit` are surfaced today; the
+    // rest are filled to satisfy the FFI contract and ignored.
+    let mut elapsed_msecs: usize = 0;
+    let mut user_msecs: usize = 0;
+    let mut system_msecs: usize = 0;
+    let mut current_rss: usize = 0;
+    let mut peak_rss: usize = 0;
+    let mut current_commit: usize = 0;
+    let mut peak_commit: usize = 0;
+    let mut page_faults: usize = 0;
+
+    // SAFETY: `mi_process_info` reads internal mimalloc counters and
+    // OS process info into the eight stack-local `usize` slots.  Each
+    // pointer is exclusive to a local binding (no aliasing); the
+    // function is documented as thread-safe; mimalloc is initialised
+    // because it is the global allocator (`crates/uffs-daemon/src/main.rs`).
+    #[expect(unsafe_code, reason = "FFI to libmimalloc-sys::mi_process_info")]
+    unsafe {
+        libmimalloc_sys::mi_process_info(
+            &raw mut elapsed_msecs,
+            &raw mut user_msecs,
+            &raw mut system_msecs,
+            &raw mut current_rss,
+            &raw mut peak_rss,
+            &raw mut current_commit,
+            &raw mut peak_commit,
+            &raw mut page_faults,
+        );
+    };
+
+    // `usize as u64` is loss-free on every platform UFFS supports
+    // (64-bit no-op; widening on hypothetical 32-bit) so no bound
+    // check is needed.
+    let snap = MemSnapshot {
+        rss_bytes: current_rss as u64,
+        mimalloc_committed_bytes: current_commit as u64,
+    };
+
+    if snap.rss_bytes == 0 && snap.mimalloc_committed_bytes == 0 {
+        None
+    } else {
+        Some(snap)
+    }
+}
+
+/// Spawn the background `mem.snapshot` emitter.
+///
+/// On every tick the task asks `IndexManager` for the logical heap
+/// total (sum of `DriveCompactIndex::heap_size_bytes()` across all
+/// loaded drives), reads `mem_snapshot()`, and emits a single
+/// `tracing::info!` event with target `mem.snapshot` carrying:
+///
+/// * `logical_heap_bytes` — sum of per-drive logical heap sizes
+/// * `mimalloc_committed_bytes` — what mimalloc has paged in
+/// * `rss_bytes` — process RSS
+///
+/// The tracing event taxonomy is documented in
+/// `docs/refactor/memory-tiering-implementation-plan.md` §4.2.
+///
+/// The returned `JoinHandle` is held by the caller for orderly
+/// cancellation; in the daemon it is dropped at process exit, the
+/// runtime tears the task down with everything else.
+pub(crate) fn spawn_mem_snapshot_task(
+    idx: Arc<IndexManager>,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        // The first tick fires immediately so we capture a baseline as
+        // soon as the daemon is up; subsequent ticks fire on the
+        // configured cadence.
+        loop {
+            ticker.tick().await;
+            let logical_heap = idx.total_index_heap_bytes().await;
+            if let Some(snap) = mem_snapshot() {
+                tracing::info!(
+                    target: "mem.snapshot",
+                    logical_heap_bytes = logical_heap,
+                    mimalloc_committed_bytes = snap.mimalloc_committed_bytes,
+                    rss_bytes = snap.rss_bytes,
+                    "memory snapshot",
+                );
+            } else {
+                // `mi_process_info` returned all zeros — log a debug
+                // line so the absence is visible without spamming
+                // info-level output.
+                tracing::debug!(
+                    target: "mem.snapshot",
+                    logical_heap_bytes = logical_heap,
+                    "memory snapshot (mimalloc reports zero)",
+                );
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `mem_snapshot()` returns `Some` with non-zero RSS when called
+    /// from a live process.  Covers Mac / Linux / Windows since
+    /// `mi_process_info` is implemented on all three.
+    #[test]
+    fn mem_snapshot_returns_some_with_nonzero_rss() {
+        let snap = mem_snapshot().expect("mimalloc returns a snapshot");
+        assert!(
+            snap.rss_bytes > 0,
+            "RSS must be positive in a live test process; got {}",
+            snap.rss_bytes
+        );
+        // committed_bytes is allowed to be zero on a very cold start,
+        // but the upper bound rules out an underflow / sign-bit bug.
+        assert!(
+            snap.mimalloc_committed_bytes < u64::MAX / 2,
+            "committed_bytes looks like an underflow: {}",
+            snap.mimalloc_committed_bytes
+        );
+    }
+
+    /// `MemSnapshot` defaults are zero on every field — used as the
+    /// "telemetry unavailable" sentinel value.
+    #[test]
+    fn mem_snapshot_default_is_zero() {
+        let zero = MemSnapshot::default();
+        assert_eq!(zero.rss_bytes, 0);
+        assert_eq!(zero.mimalloc_committed_bytes, 0);
+    }
+
+    /// `MemSnapshot` is `Copy`, so callers can hand it around without
+    /// thinking about ownership; locking that in regression-test form.
+    #[test]
+    fn mem_snapshot_is_copy() {
+        let original = MemSnapshot { rss_bytes: 1, mimalloc_committed_bytes: 2 };
+        let copied = original;
+        // Both reads are valid because of `Copy`.
+        assert_eq!(original.rss_bytes, 1);
+        assert_eq!(copied.rss_bytes, 1);
+    }
+}

--- a/crates/uffs-daemon/src/telemetry.rs
+++ b/crates/uffs-daemon/src/telemetry.rs
@@ -8,12 +8,12 @@
 //!
 //! Provides:
 //!
-//! * [`mem_snapshot`] — a cross-platform helper that returns the
-//!   daemon's current resident-set size and mimalloc-committed bytes.
-//! * [`spawn_mem_snapshot_task`] — spawns a background tokio task that
-//!   logs that snapshot at a configurable interval as a `mem.snapshot`
-//!   tracing event so a long-running daemon produces the time-series
-//!   the tiering work needs to measure its impact.
+//! * [`mem_snapshot`] — a cross-platform helper that returns the daemon's
+//!   current resident-set size and mimalloc-committed bytes.
+//! * [`spawn_mem_snapshot_task`] — spawns a background tokio task that logs
+//!   that snapshot at a configurable interval as a `mem.snapshot` tracing event
+//!   so a long-running daemon produces the time-series the tiering work needs
+//!   to measure its impact.
 //!
 //! The numbers come from mimalloc's `mi_process_info`, which is
 //! implemented uniformly on Mac, Linux and Windows; this lets the
@@ -201,7 +201,10 @@ mod tests {
     /// thinking about ownership; locking that in regression-test form.
     #[test]
     fn mem_snapshot_is_copy() {
-        let original = MemSnapshot { rss_bytes: 1, mimalloc_committed_bytes: 2 };
+        let original = MemSnapshot {
+            rss_bytes: 1,
+            mimalloc_committed_bytes: 2,
+        };
         let copied = original;
         // Both reads are valid because of `Copy`.
         assert_eq!(original.rss_bytes, 1);


### PR DESCRIPTION
## Phase 0 of the memory-tiering rollout

See `docs/refactor/memory-tiering-implementation-plan.md`. This PR
establishes the telemetry baseline every later phase measures itself
against — no behavioural change to query / load paths.

## What landed

- **New `uffs-daemon::telemetry` module** wraps mimalloc's
  `mi_process_info` (already pinned via `libmimalloc-sys` 0.1.44 with
  the `extended` feature) into a cross-platform `mem_snapshot()`
  returning `{ rss_bytes, mimalloc_committed_bytes }`.
- **`StatusResponse`** gains `mimalloc_committed_bytes`; the
  previously-stub `rss_bytes` is now populated from the snapshot.
- **New `IndexManager::total_index_heap_bytes()`** helper sums every
  drive's logical heap; reused by both the JSON-RPC `status` path and
  the new periodic `mem.snapshot` tracing emitter.
- **`spawn_mem_snapshot_task`** runs hourly inside `run_daemon`,
  emitting `tracing::info!(target = "mem.snapshot", …)` so a 24 h
  soak run produces the time-series the tiering work needs.
- **`uffs daemon status`** now prints both Mimalloc-committed and RSS
  alongside the existing index-heap line.
- **Five regression tests** pin the wiring (telemetry shape + Copy +
  default; status surfaces both fields; total agrees with per-drive
  breakdown).

## Validation (Mac-first per plan §4.1)

| Gate | Command | Status |
|---|---|---|
| T1 unit tests | `cargo nextest run` | 297 pass |
| T2 strict lint | `just lint-prod` | clean |
| T2b CI lint | `just lint-ci` | clean |
| T3 Windows xcompile | `just check-windows` | clean |

Windows live runtime gate (T6) will run via CI on this PR.

## Refs

- `docs/refactor/memory-tiering-plan.md` — architecture
- `docs/refactor/memory-budget-analysis.md` — sizing rationale
- `docs/refactor/memory-tiering-implementation-plan.md` — Phase 0 task list

## Release plan

After merge → `just ship` to bump 0.5.76 → 0.5.77 (patch bump per
the agreed cycle policy).