### PR TITLE
fix: clamp mimalloc_committed underflow on macOS + treat empty dist/ as cache miss in just use

### DIFF
--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -883,7 +883,7 @@ impl IndexManager {
         // `mi_process_info`; see `crate::telemetry::mem_snapshot`.
         let (rss_bytes, mimalloc_committed_bytes) = crate::telemetry::mem_snapshot()
             .map_or((None, None), |mem| {
-                (Some(mem.rss_bytes), Some(mem.mimalloc_committed_bytes))
+                (Some(mem.rss_bytes), mem.mimalloc_committed_bytes)
             });
 
         StatusResponse {

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -1159,15 +1159,19 @@ async fn status_populates_rss_and_mimalloc_committed() {
         "rss_bytes must be positive in a live test process; got {rss}"
     );
 
-    let committed = status
-        .mimalloc_committed_bytes
-        .expect("Phase 0: status must surface mimalloc_committed_bytes via mem_snapshot");
-    // Committed bytes can underflow into the high 64-bit range only
-    // through a sign-extension bug; this bound is a sanity guardrail.
-    assert!(
-        committed < u64::MAX / 2,
-        "mimalloc_committed_bytes looks like an underflow: {committed}"
-    );
+    // Committed bytes is `Option<u64>` on the wire because mimalloc's
+    // `current_commit` can underflow on macOS under heavy allocation
+    // churn (observed during v0.5.77 baseline capture); the daemon's
+    // `sanity_clamp_committed` rejects those readings, surfacing
+    // `None` instead of a `~u64::MAX` value.  Test asserts the bound
+    // only when `Some` is present so it stays meaningful on every
+    // platform without forcing macOS to lie.
+    if let Some(committed) = status.mimalloc_committed_bytes {
+        assert!(
+            committed < u64::MAX / 2,
+            "mimalloc_committed_bytes looks like an underflow: {committed}"
+        );
+    }
 }
 
 /// `IndexManager::total_index_heap_bytes` returns 0 for a fresh

--- a/crates/uffs-daemon/src/telemetry.rs
+++ b/crates/uffs-daemon/src/telemetry.rs
@@ -33,6 +33,41 @@ use crate::index::IndexManager;
 /// well below any reasonable log-volume budget.
 pub(crate) const DEFAULT_MEM_SNAPSHOT_INTERVAL: Duration = Duration::from_hours(1);
 
+/// Sanity cap for `current_commit`: any value above this is treated
+/// as evidence of a `usize` underflow in mimalloc's commit accounting.
+///
+/// Observed on macOS where `mi_process_info` reports values close to
+/// `u64::MAX` (`2^64 − small_number`) after heavy allocation churn.
+/// 1 TiB is well above any reasonable workstation total committed; a
+/// daemon that genuinely commits > 1 TiB wants its own dedicated
+/// telemetry pipeline anyway.
+const MAX_PLAUSIBLE_COMMIT_BYTES: u64 = 1 << 40;
+
+/// Drop implausible `current_commit` readings from `mi_process_info`.
+///
+/// Returns `None` when the raw value:
+/// * exceeds [`MAX_PLAUSIBLE_COMMIT_BYTES`] (absolute cap), or
+/// * exceeds 8× the reported RSS (relative cap, only applied when `rss_bytes >
+///   0`).
+///
+/// Otherwise returns `Some(raw_committed)`.  The 8× ratio is generous
+/// (mimalloc typically reports `committed ≈ 1.0–1.5× RSS`) so a
+/// legitimate large reservation is never clamped to `None`; in
+/// practice the underflow values observed are `≈ 2^64 / RSS` ≈ `10^9×`,
+/// many orders of magnitude above any plausible ratio.
+///
+/// Extracted as a free function so it can be unit-tested without the
+/// mimalloc FFI in the loop.
+const fn sanity_clamp_committed(rss_bytes: u64, raw_committed: u64) -> Option<u64> {
+    if raw_committed > MAX_PLAUSIBLE_COMMIT_BYTES {
+        return None;
+    }
+    if rss_bytes > 0 && raw_committed > rss_bytes.saturating_mul(8) {
+        return None;
+    }
+    Some(raw_committed)
+}
+
 /// Process-level memory snapshot in bytes.
 ///
 /// Snapshot is a single point-in-time read; no smoothing, no peak
@@ -46,13 +81,18 @@ pub(crate) struct MemSnapshot {
     /// memory.  Includes mimalloc's working pages, stack, executable
     /// images and any non-allocator mappings.
     pub(crate) rss_bytes: u64,
-    /// Mimalloc allocator committed bytes (`current_commit`).
+    /// Mimalloc allocator committed bytes (`current_commit`), if a
+    /// plausible reading is available.
     ///
     /// What the allocator has actually paged in from the OS.  After
     /// `mi_collect(true)` this number drops as freed segments are
     /// decommitted; comparing it to `rss_bytes` shows how much of the
     /// daemon's RSS is allocator-managed versus everything else.
-    pub(crate) mimalloc_committed_bytes: u64,
+    ///
+    /// `None` when [`sanity_clamp_committed`] rejects the raw FFI
+    /// reading — currently observed only on macOS where mimalloc's
+    /// commit accounting can underflow under heavy allocation churn.
+    pub(crate) mimalloc_committed_bytes: Option<u64>,
 }
 
 /// Read the daemon's current memory snapshot.
@@ -101,12 +141,13 @@ pub(crate) fn mem_snapshot() -> Option<MemSnapshot> {
     // `usize as u64` is loss-free on every platform UFFS supports
     // (64-bit no-op; widening on hypothetical 32-bit) so no bound
     // check is needed.
+    let rss = current_rss as u64;
     let snap = MemSnapshot {
-        rss_bytes: current_rss as u64,
-        mimalloc_committed_bytes: current_commit as u64,
+        rss_bytes: rss,
+        mimalloc_committed_bytes: sanity_clamp_committed(rss, current_commit as u64),
     };
 
-    if snap.rss_bytes == 0 && snap.mimalloc_committed_bytes == 0 {
+    if snap.rss_bytes == 0 && snap.mimalloc_committed_bytes.is_none() {
         None
     } else {
         Some(snap)
@@ -142,15 +183,7 @@ pub(crate) fn spawn_mem_snapshot_task(
         loop {
             ticker.tick().await;
             let logical_heap = idx.total_index_heap_bytes().await;
-            if let Some(snap) = mem_snapshot() {
-                tracing::info!(
-                    target: "mem.snapshot",
-                    logical_heap_bytes = logical_heap,
-                    mimalloc_committed_bytes = snap.mimalloc_committed_bytes,
-                    rss_bytes = snap.rss_bytes,
-                    "memory snapshot",
-                );
-            } else {
+            let Some(snap) = mem_snapshot() else {
                 // `mi_process_info` returned all zeros — log a debug
                 // line so the absence is visible without spamming
                 // info-level output.
@@ -158,6 +191,23 @@ pub(crate) fn spawn_mem_snapshot_task(
                     target: "mem.snapshot",
                     logical_heap_bytes = logical_heap,
                     "memory snapshot (mimalloc reports zero)",
+                );
+                continue;
+            };
+            if let Some(committed) = snap.mimalloc_committed_bytes {
+                tracing::info!(
+                    target: "mem.snapshot",
+                    logical_heap_bytes = logical_heap,
+                    mimalloc_committed_bytes = committed,
+                    rss_bytes = snap.rss_bytes,
+                    "memory snapshot",
+                );
+            } else {
+                tracing::info!(
+                    target: "mem.snapshot",
+                    logical_heap_bytes = logical_heap,
+                    rss_bytes = snap.rss_bytes,
+                    "memory snapshot (mimalloc committed unavailable)",
                 );
             }
         }
@@ -179,22 +229,25 @@ mod tests {
             "RSS must be positive in a live test process; got {}",
             snap.rss_bytes
         );
-        // committed_bytes is allowed to be zero on a very cold start,
-        // but the upper bound rules out an underflow / sign-bit bug.
-        assert!(
-            snap.mimalloc_committed_bytes < u64::MAX / 2,
-            "committed_bytes looks like an underflow: {}",
-            snap.mimalloc_committed_bytes
-        );
+        // committed may legitimately be `None` on macOS where the
+        // raw mimalloc reading underflows; if `Some`, the clamp has
+        // already vetted the upper bound, but reasserting documents
+        // the invariant for future readers.
+        if let Some(committed) = snap.mimalloc_committed_bytes {
+            assert!(
+                committed < u64::MAX / 2,
+                "committed_bytes looks like an underflow: {committed}"
+            );
+        }
     }
 
-    /// `MemSnapshot` defaults are zero on every field — used as the
+    /// `MemSnapshot` defaults are zero / `None` — used as the
     /// "telemetry unavailable" sentinel value.
     #[test]
     fn mem_snapshot_default_is_zero() {
         let zero = MemSnapshot::default();
         assert_eq!(zero.rss_bytes, 0);
-        assert_eq!(zero.mimalloc_committed_bytes, 0);
+        assert_eq!(zero.mimalloc_committed_bytes, None);
     }
 
     /// `MemSnapshot` is `Copy`, so callers can hand it around without
@@ -203,11 +256,67 @@ mod tests {
     fn mem_snapshot_is_copy() {
         let original = MemSnapshot {
             rss_bytes: 1,
-            mimalloc_committed_bytes: 2,
+            mimalloc_committed_bytes: Some(2),
         };
         let copied = original;
         // Both reads are valid because of `Copy`.
         assert_eq!(original.rss_bytes, 1);
         assert_eq!(copied.rss_bytes, 1);
+    }
+
+    /// `sanity_clamp_committed` drops the underflow value observed on
+    /// macOS during the v0.5.77 baseline capture (`Mimalloc:
+    /// 17592186035942 MB`).
+    #[test]
+    fn sanity_clamp_drops_macos_underflow() {
+        // Reproduce the exact byte value rendered as `17592186035942 MB`
+        // in the field report (`u64::MAX` minus a small offset — the
+        // signature of a `commit_inc − commit_dec` underflow).
+        let underflow = u64::MAX - 7_886_233_600;
+        let mac_rss = 12_005_u64 * 1024 * 1024;
+        assert_eq!(sanity_clamp_committed(mac_rss, underflow), None);
+    }
+
+    /// `sanity_clamp_committed` accepts the Windows v0.5.77 baseline
+    /// reading unchanged (committed > RSS but well under the 8× cap).
+    #[test]
+    fn sanity_clamp_accepts_windows_baseline() {
+        let rss = 5_110_u64 * 1024 * 1024;
+        let committed = 5_886_u64 * 1024 * 1024;
+        assert_eq!(sanity_clamp_committed(rss, committed), Some(committed));
+    }
+
+    /// `sanity_clamp_committed` enforces the absolute 1 TiB cap even
+    /// when RSS is zero (cold-start path with no live process info).
+    #[test]
+    fn sanity_clamp_enforces_absolute_cap() {
+        assert_eq!(
+            sanity_clamp_committed(0, MAX_PLAUSIBLE_COMMIT_BYTES + 1),
+            None
+        );
+        // Just under the cap with rss=0 still passes — lets the cold
+        // boot path through without over-clamping.
+        assert_eq!(
+            sanity_clamp_committed(0, MAX_PLAUSIBLE_COMMIT_BYTES - 1),
+            Some(MAX_PLAUSIBLE_COMMIT_BYTES - 1)
+        );
+    }
+
+    /// `sanity_clamp_committed` enforces the relative `8 × RSS` cap so
+    /// underflow values that happen to fall under 1 TiB are still
+    /// rejected when RSS is also abnormal.
+    #[test]
+    fn sanity_clamp_enforces_relative_cap() {
+        // 1 GiB RSS, 9 GiB committed — above the 8× ratio.
+        let rss = 1_u64 << 30_u32;
+        let committed = 9_u64 << 30_u32;
+        assert_eq!(sanity_clamp_committed(rss, committed), None);
+        // Same RSS, exactly 8 GiB — right at the boundary, still
+        // accepted (clamp uses strict greater-than).
+        let committed_at_boundary = 8_u64 << 30_u32;
+        assert_eq!(
+            sanity_clamp_committed(rss, committed_at_boundary),
+            Some(committed_at_boundary)
+        );
     }
 }

--- a/just/build.just
+++ b/just/build.just
@@ -153,14 +153,22 @@ use:
     # Read workspace version from Cargo.toml
     CARGO_VER=$(awk '/^\[workspace\.package\]/{flag=1; next} flag && /^version/{print "v"$3; exit}' Cargo.toml | tr -d '"')
 
-    # Find matching dist/ version (prefer workspace version)
+    # Find matching dist/ version (prefer workspace version).
+    # An empty `dist/$CARGO_VER` is treated as a cache miss — `just
+    # ship` (and prior failed `just use` runs) can leave the directory
+    # behind without any binaries, and accepting it here would skip
+    # the GH-release download fallback below.
     DIST_DIR=""
-    if [[ -n "$CARGO_VER" ]] && [[ -d "dist/$CARGO_VER" ]]; then
+    if [[ -n "$CARGO_VER" ]] \
+        && [[ -d "dist/$CARGO_VER" ]] \
+        && [[ -n "$(ls -A "dist/$CARGO_VER" 2>/dev/null)" ]]; then
         DIST_DIR="dist/$CARGO_VER"
         printf "\033[0;32m  Found dist/%s (matches workspace)\033[0m\n" "$CARGO_VER"
     elif [[ -d "dist" ]]; then
         LATEST=$(ls -d dist/v* 2>/dev/null | sort -V | tail -1 || true)
-        if [[ -n "$LATEST" ]] && [[ -d "$LATEST" ]]; then
+        if [[ -n "$LATEST" ]] \
+            && [[ -d "$LATEST" ]] \
+            && [[ -n "$(ls -A "$LATEST" 2>/dev/null)" ]]; then
             LATEST_VER=$(basename "$LATEST")
             if [[ -n "$CARGO_VER" ]] && [[ "$LATEST_VER" != "$CARGO_VER" ]]; then
                 printf "\033[1;33m⚠️  dist/ has %s but workspace is %s\033[0m\n" "$LATEST_VER" "$CARGO_VER"
@@ -257,14 +265,21 @@ use:
         if ($line -match '^\[' -and $inPkg) { break }
     }
 
-    # Try to find matching dist/ version (prefer workspace version)
+    # Try to find matching dist/ version (prefer workspace version).
+    # An empty `dist/$cargoVer` is treated as a cache miss — `just
+    # ship` (and prior failed `just use` runs) can leave the directory
+    # behind without any binaries, and accepting it here would skip
+    # the GH-release download fallback below.
     $distDir = $null
-    if ($cargoVer -and (Test-Path (Join-Path "dist" $cargoVer))) {
-        $distDir = (Join-Path "dist" $cargoVer)
+    $candidate = if ($cargoVer) { Join-Path "dist" $cargoVer } else { $null }
+    if ($candidate -and (Test-Path $candidate) -and `
+            (@(Get-ChildItem -Path $candidate -Force -ErrorAction SilentlyContinue)).Count -gt 0) {
+        $distDir = $candidate
         Write-Host "  Found dist/$cargoVer (matches workspace)" -ForegroundColor Green
     } elseif (Test-Path "dist") {
         $versions = Get-ChildItem -Path "dist" -Directory -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -match '^v\d+\.\d+\.\d+$' } |
+            Where-Object { (@(Get-ChildItem -Path $_.FullName -Force -ErrorAction SilentlyContinue)).Count -gt 0 } |
             Sort-Object { [version]($_.Name -replace '^v','') } -Descending
         if ($versions) {
             $distDir = $versions[0].FullName


### PR DESCRIPTION
## Why

Two bugs surfaced from the v0.5.77 Phase-0 baseline smoke-test on 2026-04-26.  Fixing together because both came from the same release-candidate flow.

## Bug 1 — macOS mimalloc `current_commit` underflow

### Symptom

On macOS, `uffs daemon status` rendered:

```
Mimalloc:      17592186035942 MB (committed)
```

`17592186035942 MB × (1024 × 1024) = 18446744065823318016 B ≈ 2^64 − 7.4 GB` — a textbook `usize` underflow.  Two consecutive snapshots both came back as `2^64 − small_number` with **different** `small_number`s, ruling out a constant misread and confirming live integer underflow.

Windows on the same workspace reports a clean reading:

```
Mimalloc:      5886 MB (committed)
RSS:           5110 MB
```

### Root cause

mimalloc's `current_commit` counter on macOS reflects `commit_inc − commit_dec` over a `usize` accumulator.  macOS uses `mmap` for segment commit (no Windows-style explicit commit/decommit semantics), so under heavy allocation churn the subtraction can wrap when the decommit accumulator overruns the commit one.

### Fix

`MemSnapshot.mimalloc_committed_bytes: u64` → `Option<u64>`, populated through a new `sanity_clamp_committed(rss, raw)` helper that returns `None` when:

- `raw > 1 TiB` (absolute cap, always applies), or
- `rss > 0 && raw > rss * 8` (relative cap, only when RSS is known).

The wire field on `StatusResponse` was already `Option<u64>` so the only ripple is that the CLI's `if let Some(committed) = ...` block silently skips the `Mimalloc:` line on macOS instead of printing garbage.  The hourly `mem.snapshot` tracing event splits into Some / None branches with a clear `"memory snapshot (mimalloc committed unavailable)"` message when clamped.

### Tests

Four new unit tests in `telemetry::tests` pin the clamp:

- `sanity_clamp_drops_macos_underflow` — uses the exact byte value observed in the field report.
- `sanity_clamp_accepts_windows_baseline` — uses the exact byte values from the Windows reading.
- `sanity_clamp_enforces_absolute_cap` — checks the 1 TiB hard cap.
- `sanity_clamp_enforces_relative_cap` — checks the `8 × RSS` ratio cap.

The existing `mem_snapshot_returns_some_with_nonzero_rss` and `status_populates_rss_and_mimalloc_committed` assertions now wrap their committed-bytes checks in `if let Some(...)` so they remain meaningful on every platform without forcing macOS to lie.

## Bug 2 — `just use` treats empty `dist/vX.Y.Z/` as cache hit

### Symptom

After `just ship` for v0.5.77, an empty `dist/v0.5.77/` directory was created.  The next `just use` printed:

```
  Found dist/v0.5.77 (matches workspace)
  → Using: dist/v0.5.77
📦 Installing to /Users/rnio/bin
  ⚠️  uffs-macos-arm64 (not found in dist/v0.5.77)
  ⚠️  uffsmcp-macos-arm64 (not found in dist/v0.5.77)
  ⚠️  uffsd-macos-arm64 (not found in dist/v0.5.77)
  ⚠️  uffs_mft-macos-arm64 (not found in dist/v0.5.77)
✅ Installed 0 binaries to ~/bin
⚠️  Skipped 4
```

…leaving `~/bin` on the prior v0.5.75 binaries because the GH-release download fallback only triggers when `DIST_DIR` is unset.

### Fix

Both the Unix and Windows recipes now also require the candidate directory to be **non-empty** before accepting it as a cache hit:

- Unix: `[[ -n "$(ls -A "dist/$CARGO_VER" 2>/dev/null)" ]]`
- Windows: `(@(Get-ChildItem ...)).Count -gt 0`

An empty directory falls through to the existing `gh release download` fallback path.

## Validation

| Gate | Result |
|---|---|
| `cargo nextest run -p uffs-daemon -p uffs-cli -p uffs-client` | **301 / 301 PASS** (4 new sanity-clamp tests) |
| `just lint-prod` | clean |
| `just lint-ci` | clean |
| `just check-windows` | clean (cargo-xwin compile-only) |
| `just lint-fast` (pre-commit) | all 7 sub-gates green |

## Refs

- Phase 0 baseline data + bug analysis: `docs/refactor/memory-tiering-implementation-plan.md` "Phase 0 known bug" subsection (gitignored — internal only).
- Released as v0.5.78 after merge.
