### PR TITLE
feat(daemon): Phase 1 memory tiering — ShardRegistry + per-drive stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,6 +4433,7 @@ dependencies = [
  "libc",
  "libmimalloc-sys",
  "mimalloc",
+ "proptest",
  "rand 0.10.1",
  "serde",
  "serde_json",

--- a/crates/uffs-daemon/Cargo.toml
+++ b/crates/uffs-daemon/Cargo.toml
@@ -74,5 +74,11 @@ libc.workspace = true
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
 
+[dev-dependencies]
+# Phase 1 of memory-tiering: property-test the `ShardState` legal-transition
+# graph in `crates/uffs-daemon/src/cache/shard.rs`.  Workspace-pinned to
+# `proptest = "1.11.0"` (see top-level `Cargo.toml`).
+proptest.workspace = true
+
 [lints]
 workspace = true

--- a/crates/uffs-daemon/src/cache/mod.rs
+++ b/crates/uffs-daemon/src/cache/mod.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Shard-based index cache with per-drive lifecycle.
+//!
+//! Phase 1 of the memory-tiering work
+//! (`docs/refactor/memory-tiering-implementation-plan.md`).
+//!
+//! The cache layer wraps each loaded `DriveCompactIndex` in a
+//! [`ShardEntry`] that carries:
+//!
+//! * a tier state ([`ShardState`]) — Phase 1 pins everything to
+//!   [`ShardState::Warm`]; Phase 3 wires real transitions.
+//! * per-drive query stats ([`DriveStats`]) — atomic counters plus an
+//!   exponentially-weighted moving average rate; consumed by the adaptive-TTL
+//!   formulas in Phase 6.
+//! * the in-memory body, an `Arc<DriveCompactIndex>` cloned cheaply into the
+//!   per-search snapshot.
+//!
+//! [`ShardRegistry`] is the top-level container that the daemon swaps
+//! under `RwLock<Arc<...>>` in place of the old
+//! `Arc<uffs_core::search::backend::DriveIndex>`.  It maintains a
+//! cached `Arc<DriveIndex>` over the active (Warm/Hot) subset so the
+//! search hot path stays an `Arc::clone` away from a usable backend.
+//!
+//! Phase 1 keeps every shard in `Warm` so the active subset always
+//! matches the full registry; Phase 3 starts demoting and
+//! [`ShardRegistry::active_index`] begins to diverge from the full
+//! shard list.
+
+pub(crate) mod registry;
+pub(crate) mod shard;
+
+// Phase 1 surface: only `ShardRegistry` and `ShardState` are referenced
+// from outside this module (in `crate::index`).  The other types
+// (`ShardEntry`, `DriveStats`, `DriveStatsSnapshot`,
+// `IllegalTransition`) stay accessible via the explicit `shard::` /
+// `registry::` paths so the proptest harness in `shard.rs` and the
+// integration tests in `crate::index::tests` can construct them
+// without going through this re-export.  Phase 3+ widens the
+// re-export list as more callers join.
+pub(crate) use registry::ShardRegistry;
+pub(crate) use shard::ShardState;

--- a/crates/uffs-daemon/src/cache/registry.rs
+++ b/crates/uffs-daemon/src/cache/registry.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! [`ShardRegistry`] — top-level container that replaces the old
+//! `Arc<DriveIndex>` field on [`crate::index::IndexManager`].
+//!
+//! See [`crate::cache`] module docs for the bigger picture.
+
+use alloc::sync::Arc;
+
+use uffs_core::compact::DriveCompactIndex;
+use uffs_core::search::backend::DriveIndex;
+
+use super::shard::{ShardEntry, ShardState};
+
+/// Registry of per-drive shards plus a cached `Arc<DriveIndex>` over
+/// the active subset (Warm/Hot tiers).
+///
+/// The cached `active_index` makes [`Self::active_index`] an
+/// `Arc::clone` — search dispatch reads it under the daemon's
+/// `RwLock<Arc<ShardRegistry>>` and never builds a `Vec` per query.
+/// Mutations (`add` / `replace` / `remove`) return a *new* registry
+/// with the rebuilt active subset; the daemon swaps the outer `Arc`.
+///
+/// Phase 1 keeps every shard in [`ShardState::Warm`] so the active
+/// subset always equals the full registry.  Phase 3 starts demoting,
+/// at which point the active subset shrinks below the full shard list.
+pub(crate) struct ShardRegistry {
+    /// Every loaded shard, in load order.  `Arc<ShardEntry>` so a
+    /// registry rebuild is a Vec clone of pointers, not bodies.
+    shards: Vec<Arc<ShardEntry>>,
+    /// Pre-computed `DriveIndex` over shards in [`ShardState::Warm`]
+    /// or [`ShardState::Hot`].  Cheap to clone for search dispatch.
+    active_index: Arc<DriveIndex>,
+}
+
+impl ShardRegistry {
+    /// Empty registry — no shards, empty active index.
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self {
+            shards: Vec::new(),
+            active_index: Arc::new(DriveIndex::new()),
+        }
+    }
+
+    /// Build a registry from an explicit shard vector, recomputing the
+    /// active subset.
+    ///
+    /// Used internally by [`Self::add`], [`Self::replace`], and
+    /// [`Self::remove`]; exposed for tests that want to seed a
+    /// registry directly.
+    #[must_use]
+    pub(crate) fn from_shards(shards: Vec<Arc<ShardEntry>>) -> Self {
+        let drives: Vec<Arc<DriveCompactIndex>> = shards
+            .iter()
+            .filter(|shard| matches!(shard.state(), ShardState::Warm | ShardState::Hot))
+            .map(|shard| shard.body())
+            .collect();
+        Self {
+            shards,
+            active_index: Arc::new(DriveIndex { drives }),
+        }
+    }
+
+    /// Insert a fresh `Warm` shard for `body.letter` and return the
+    /// rebuilt registry.  The previous registry is left untouched.
+    ///
+    /// The shard's identity is `body.letter` so callers don't have to
+    /// thread the letter separately and can't accidentally store a
+    /// shard whose letter disagrees with its body.
+    #[must_use]
+    pub(crate) fn add(&self, body: Arc<DriveCompactIndex>) -> Self {
+        let letter = body.letter;
+        let mut shards = self.shards.clone();
+        shards.push(Arc::new(ShardEntry::new_warm(letter, body)));
+        Self::from_shards(shards)
+    }
+
+    /// Replace the shard whose drive letter case-insensitively
+    /// matches `match_letter` (if any) with a fresh `Warm` entry, and
+    /// return the rebuilt registry.
+    ///
+    /// The new shard's identity is `body.letter` (canonical case from
+    /// the index payload), preserving the pre-Phase-1 contract where
+    /// `DriveIndex { drives: vec![Arc::new(new_drive)] }` always
+    /// identified the new entry by `new_drive.letter`.  When no
+    /// existing shard matches `match_letter`, this is equivalent to
+    /// [`Self::add`].
+    ///
+    /// The match is **case-insensitive** to preserve the behavior of
+    /// the pre-Phase-1 `IndexManager::replace_drive`, which used
+    /// `eq_ignore_ascii_case` to handle drive letters that flow
+    /// through the daemon in either case.
+    #[must_use]
+    pub(crate) fn replace(&self, match_letter: char, body: Arc<DriveCompactIndex>) -> Self {
+        let new_letter = body.letter;
+        let mut shards: Vec<Arc<ShardEntry>> = self
+            .shards
+            .iter()
+            .filter(|shard| !shard.drive.eq_ignore_ascii_case(&match_letter))
+            .cloned()
+            .collect();
+        shards.push(Arc::new(ShardEntry::new_warm(new_letter, body)));
+        Self::from_shards(shards)
+    }
+
+    /// Drop the shard for `drive` (if any) and return the rebuilt
+    /// registry.  No-op when `drive` is not in the registry.
+    ///
+    /// Match is case-insensitive — see [`Self::replace`] for the
+    /// rationale.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 3 consumer (tier-transition cleanup); exercised \
+                      by `cache::registry::tests::remove_missing_is_noop` \
+                      under `cfg(test)`."
+        )
+    )]
+    #[must_use]
+    pub(crate) fn remove(&self, drive: char) -> Self {
+        let shards: Vec<Arc<ShardEntry>> = self
+            .shards
+            .iter()
+            .filter(|shard| !shard.drive.eq_ignore_ascii_case(&drive))
+            .cloned()
+            .collect();
+        Self::from_shards(shards)
+    }
+
+    /// Iterate over every shard in load order.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Arc<ShardEntry>> {
+        self.shards.iter()
+    }
+
+    /// Snapshot of the active (`Warm`/`Hot`) subset as an
+    /// `Arc<DriveIndex>` for the search backend.  Cheap clone.
+    #[must_use]
+    pub(crate) fn active_index(&self) -> Arc<DriveIndex> {
+        Arc::clone(&self.active_index)
+    }
+
+    /// Total number of loaded shards (active + demoted).
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 3 consumer (status renderer with active vs demoted \
+                      shard counts); exercised by registry tests under \
+                      `cfg(test)`."
+        )
+    )]
+    #[must_use]
+    pub(crate) const fn len(&self) -> usize {
+        self.shards.len()
+    }
+
+    /// `true` iff the registry has no shards at all.
+    #[must_use]
+    pub(crate) const fn is_empty(&self) -> bool {
+        self.shards.is_empty()
+    }
+
+    /// `true` iff any shard exists for `drive` (regardless of tier).
+    #[must_use]
+    pub(crate) fn contains(&self, drive: char) -> bool {
+        self.shards.iter().any(|shard| shard.drive == drive)
+    }
+
+    /// Drive letters of every loaded shard in load order.
+    #[must_use]
+    pub(crate) fn loaded_letters(&self) -> Vec<char> {
+        self.shards.iter().map(|shard| shard.drive).collect()
+    }
+}
+
+impl Default for ShardRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(
+        clippy::min_ident_chars,
+        reason = "test code — short names like `a`/`b` are clearer than \
+                  long names in equality assertions."
+    )]
+
+    use super::*;
+
+    /// Empty registry has zero shards and an empty active index.
+    #[test]
+    fn empty_registry_is_empty() {
+        let reg = ShardRegistry::new();
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+        assert_eq!(reg.active_index().drives.len(), 0);
+        assert_eq!(reg.loaded_letters(), Vec::<char>::new());
+        assert!(!reg.contains('C'));
+    }
+
+    /// `Default` matches `new()`.
+    #[test]
+    fn default_matches_new() {
+        let a = ShardRegistry::default();
+        let b = ShardRegistry::new();
+        assert_eq!(a.len(), b.len());
+        assert_eq!(a.is_empty(), b.is_empty());
+    }
+
+    /// `from_shards(empty)` produces the empty registry.
+    #[test]
+    fn from_shards_empty_is_empty() {
+        let reg = ShardRegistry::from_shards(Vec::new());
+        assert!(reg.is_empty());
+        assert_eq!(reg.active_index().drives.len(), 0);
+    }
+
+    /// `remove` on a missing letter is a no-op that still produces a
+    /// valid empty registry — pins the no-op contract that
+    /// `IndexManager::replace_drive` relies on for fresh inserts.
+    #[test]
+    fn remove_missing_is_noop() {
+        let reg = ShardRegistry::new().remove('Z');
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+        assert_eq!(reg.active_index().drives.len(), 0);
+    }
+
+    // Tests that exercise mutation paths with real `DriveCompactIndex`
+    // bodies live in `crate::index::tests` next to the existing
+    // `build_test_drive` helper — see
+    // `shard_registry_add_replace_remove_round_trip` and
+    // `shard_registry_records_query_per_search`.
+}

--- a/crates/uffs-daemon/src/cache/shard.rs
+++ b/crates/uffs-daemon/src/cache/shard.rs
@@ -1,0 +1,592 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Per-shard wrapper: tier state machine + query stats + body.
+//!
+//! See [`crate::cache`] module docs for the bigger picture.
+
+use alloc::sync::Arc;
+use core::error::Error as StdError;
+use core::fmt;
+use core::str::FromStr;
+use core::sync::atomic::{AtomicU8, AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+use uffs_core::compact::DriveCompactIndex;
+
+/// Lifecycle state of a single drive's shard inside the daemon's
+/// in-memory cache.
+///
+/// The state machine mirrors `docs/refactor/memory-tiering-plan.md`
+/// §3.1.  Phase 1 only ever holds shards in [`Self::Warm`]; tier
+/// transitions out of `Warm` land in Phase 3.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+#[repr(u8)]
+pub(crate) enum ShardState {
+    /// Just discovered; no body, no bloom, no stats. Pre-load.
+    Unknown = 0,
+    /// Encrypted cache exists but nothing in RAM. Boot/early-startup.
+    Cold = 1,
+    /// Bloom + trie loaded; body dropped (Phase 4+).
+    Parked = 2,
+    /// Body fully loaded and searchable. Phase 1 default.
+    #[default]
+    Warm = 3,
+    /// Body loaded + pre-faulted via `Prefetch::hint`. Recent activity.
+    Hot = 4,
+    /// Demote in progress. Transient.
+    Evicting = 5,
+}
+
+impl ShardState {
+    /// Returns true iff a transition `self` → `to` is in the legal
+    /// graph.
+    ///
+    /// Legal transitions:
+    /// * `Unknown` → `Cold`, `Parked`, `Warm`
+    /// * `Cold` → `Parked`, `Warm`
+    /// * `Parked` → `Cold`, `Warm`
+    /// * `Warm` → `Hot`, `Evicting`
+    /// * `Hot` → `Warm`, `Evicting`
+    /// * `Evicting` → `Cold`, `Parked`
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 3 consumer (tier-transition demote/promote logic); \
+                      exercised by this module's proptest and by the \
+                      integration test in `crate::index::tests` \
+                      under `cfg(test)`."
+        )
+    )]
+    #[must_use]
+    pub(crate) const fn can_transition_to(self, to: Self) -> bool {
+        matches!(
+            (self, to),
+            (Self::Unknown, Self::Cold | Self::Parked | Self::Warm)
+                | (Self::Cold, Self::Parked | Self::Warm)
+                | (Self::Parked, Self::Cold | Self::Warm)
+                | (Self::Warm, Self::Hot | Self::Evicting)
+                | (Self::Hot, Self::Warm | Self::Evicting)
+                | (Self::Evicting, Self::Cold | Self::Parked)
+        )
+    }
+
+    /// Round-trip from atomic storage.  Unknown encodings fall back to
+    /// `Warm` (the Phase-1 default) to preserve forward-progress on a
+    /// torn read; the caller's CAS will redo the transition cleanly.
+    const fn from_repr(repr: u8) -> Self {
+        match repr {
+            0 => Self::Unknown,
+            1 => Self::Cold,
+            2 => Self::Parked,
+            4 => Self::Hot,
+            5 => Self::Evicting,
+            _ => Self::Warm,
+        }
+    }
+}
+
+impl fmt::Display for ShardState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Unknown => "unknown",
+            Self::Cold => "cold",
+            Self::Parked => "parked",
+            Self::Warm => "warm",
+            Self::Hot => "hot",
+            Self::Evicting => "evicting",
+        })
+    }
+}
+
+/// Error returned by [`FromStr`] for [`ShardState`] when the input
+/// isn't one of the six known state names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParseShardStateError(pub String);
+
+impl fmt::Display for ParseShardStateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown shard state: {}", self.0)
+    }
+}
+
+impl StdError for ParseShardStateError {}
+
+impl FromStr for ShardState {
+    type Err = ParseShardStateError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "unknown" => Ok(Self::Unknown),
+            "cold" => Ok(Self::Cold),
+            "parked" => Ok(Self::Parked),
+            "warm" => Ok(Self::Warm),
+            "hot" => Ok(Self::Hot),
+            "evicting" => Ok(Self::Evicting),
+            other => Err(ParseShardStateError(other.into())),
+        }
+    }
+}
+
+/// Error returned by [`ShardEntry::try_transition`] when the requested
+/// transition is outside the legal graph encoded in
+/// [`ShardState::can_transition_to`].
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 3 consumer (returned by `ShardEntry::try_transition` \
+                  when the demoter attempts an out-of-graph move); \
+                  exercised by \
+                  `crate::index::tests::shard_entry_try_transition_legal_and_illegal` \
+                  under `cfg(test)`."
+    )
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct IllegalTransition {
+    /// State the shard was in when the transition was attempted.
+    pub from: ShardState,
+    /// State the caller asked to move to.
+    pub to: ShardState,
+}
+
+impl fmt::Display for IllegalTransition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "illegal shard state transition: {} -> {}",
+            self.from, self.to
+        )
+    }
+}
+
+impl StdError for IllegalTransition {}
+
+/// Per-drive query rate stats.
+///
+/// Counters use atomics so [`Self::record_query`] stays lock-free on
+/// the search hot path.  [`Self::decay_ema`] reads + writes are not
+/// strictly atomic together, but the EMA tolerates skew (it is a rate
+/// estimator, not a hard counter).
+///
+/// Half-life of the EMA is fixed at 60 s in Phase 1; Phase 6 makes it
+/// configurable via `daemon.toml`.
+#[derive(Debug, Default)]
+pub(crate) struct DriveStats {
+    /// Total queries served against this shard.
+    queries_total: AtomicU64,
+    /// EMA of the per-second query rate, stored as fixed-point `× 1e6`
+    /// so it round-trips through the `AtomicU64`.
+    rate_ema_micro_per_s: AtomicU64,
+    /// Unix-millis timestamp of the last [`Self::decay_ema`] call.
+    /// Zero means "never decayed" — first call short-circuits the
+    /// decay arithmetic to avoid a huge-elapsed spike from epoch 0.
+    last_decay_ms: AtomicU64,
+}
+
+impl DriveStats {
+    /// Construct a fresh, all-zero stats record.
+    #[must_use]
+    pub(crate) const fn new() -> Self {
+        Self {
+            queries_total: AtomicU64::new(0),
+            rate_ema_micro_per_s: AtomicU64::new(0),
+            last_decay_ms: AtomicU64::new(0),
+        }
+    }
+
+    /// Lock-free increment of the total query counter.
+    pub(crate) fn record_query(&self) {
+        self.queries_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Total queries served against this shard since construction.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 6 consumer (status renderer / Prometheus telemetry); \
+                      read by `IndexManager::shard_query_totals_for_test` \
+                      under `cfg(test)`."
+        )
+    )]
+    #[must_use]
+    pub(crate) fn queries_total(&self) -> u64 {
+        self.queries_total.load(Ordering::Relaxed)
+    }
+
+    /// Apply exponential decay to the EMA based on elapsed time since
+    /// the last call and return the new EMA in queries/sec.
+    ///
+    /// First call after construction returns the stored value as-is
+    /// (no elapsed-time signal to decay against).
+    ///
+    /// Half-life is 60 s, chosen so a burst of activity is "forgotten"
+    /// within ~5 minutes (5 half-lives → 1/32 of the original).
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 6 consumer (adaptive-TTL controller reads the EMA \
+                      to size the demote/promote thresholds); exercised by \
+                      the `drivestats_decay_is_non_increasing` proptest in \
+                      this module under `cfg(test)`."
+        )
+    )]
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::float_arithmetic,
+        clippy::default_numeric_fallback,
+        reason = "EMA arithmetic; precision loss is tolerated by the \
+                  rate-estimator semantics and bounded by the 60 s half-life. \
+                  Float arithmetic and the `1.0e6` literal are core to the \
+                  decay formula; suffixing or changing types would obscure \
+                  intent without changing behavior."
+    )]
+    pub(crate) fn decay_ema(&self, now_ms: u64) -> f64 {
+        const HALF_LIFE_MS: u64 = 60_000;
+        let prev_ms = self.last_decay_ms.swap(now_ms, Ordering::Relaxed);
+        let prev_ema_fixed = self.rate_ema_micro_per_s.load(Ordering::Relaxed);
+        let prev_ema = prev_ema_fixed as f64 / 1.0e6;
+        if prev_ms == 0 {
+            return prev_ema;
+        }
+        let elapsed_ms = now_ms.saturating_sub(prev_ms);
+        if elapsed_ms == 0 {
+            return prev_ema;
+        }
+        let decay_factor =
+            (-(elapsed_ms as f64) * core::f64::consts::LN_2 / HALF_LIFE_MS as f64).exp();
+        let new_ema = prev_ema * decay_factor;
+        self.rate_ema_micro_per_s
+            .store((new_ema * 1.0e6) as u64, Ordering::Relaxed);
+        new_ema
+    }
+}
+
+/// Test-only direct EMA read for `DriveStats`.
+///
+/// Free function (rather than a `#[cfg(test)]` method on
+/// `impl DriveStats`) so the production block carries no test-only
+/// methods.  All test-specific lint ceremony stays attached to this
+/// helper.
+#[cfg(test)]
+#[expect(
+    clippy::cast_precision_loss,
+    clippy::float_arithmetic,
+    reason = "test-only EMA read: float divide on a fixed-point store; \
+              the precision loss is tolerated by the rate-estimator \
+              semantics."
+)]
+fn drive_stats_ema_value(stats: &DriveStats) -> f64 {
+    stats.rate_ema_micro_per_s.load(Ordering::Relaxed) as f64 / 1.0e6
+}
+
+/// Serializable snapshot of a [`DriveStats`].
+///
+/// `AtomicU64` doesn't derive `Serialize`/`Deserialize` so persistence
+/// goes through this plain-`u64` mirror.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DriveStatsSnapshot {
+    /// Total queries served. See [`DriveStats::queries_total`].
+    pub queries_total: u64,
+    /// EMA fixed-point. See [`DriveStats::rate_ema_micro_per_s`].
+    pub rate_ema_micro_per_s: u64,
+    /// Last decay timestamp. See [`DriveStats::last_decay_ms`].
+    pub last_decay_ms: u64,
+}
+
+impl From<&DriveStats> for DriveStatsSnapshot {
+    fn from(stats: &DriveStats) -> Self {
+        Self {
+            queries_total: stats.queries_total.load(Ordering::Relaxed),
+            rate_ema_micro_per_s: stats.rate_ema_micro_per_s.load(Ordering::Relaxed),
+            last_decay_ms: stats.last_decay_ms.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl From<DriveStatsSnapshot> for DriveStats {
+    fn from(snap: DriveStatsSnapshot) -> Self {
+        Self {
+            queries_total: AtomicU64::new(snap.queries_total),
+            rate_ema_micro_per_s: AtomicU64::new(snap.rate_ema_micro_per_s),
+            last_decay_ms: AtomicU64::new(snap.last_decay_ms),
+        }
+    }
+}
+
+/// One shard's runtime state + stats + body.
+///
+/// Phase 1 holds the body unconditionally as `Arc<DriveCompactIndex>`.
+/// Phase 2 introduces an `Option`-wrapped variant for demoted shards;
+/// Phase-1 callers can rely on [`Self::body`] always returning the
+/// index.
+pub(crate) struct ShardEntry {
+    /// Drive letter (`'C'`, `'D'`, …). Capital ASCII per existing
+    /// daemon convention.
+    pub(crate) drive: char,
+    /// Tier state. Read on every search via [`Self::state`]; mutated
+    /// only by tier-transition methods (`try_transition`).
+    state: AtomicU8,
+    /// Per-drive query stats.
+    pub(crate) stats: DriveStats,
+    /// In-memory compact index. Cloned cheaply (Arc bump) into
+    /// [`crate::cache::ShardRegistry::active_index`] on rebuild.
+    body: Arc<DriveCompactIndex>,
+}
+
+impl ShardEntry {
+    /// Construct a shard wrapping `body` and pinning it in
+    /// [`ShardState::Warm`].
+    ///
+    /// Phase 1 only ever creates shards in this constructor; Phase 3
+    /// adds `new_cold` / `new_parked` for boot-time partial loads.
+    #[must_use]
+    pub(crate) const fn new_warm(drive: char, body: Arc<DriveCompactIndex>) -> Self {
+        Self {
+            drive,
+            state: AtomicU8::new(ShardState::Warm as u8),
+            stats: DriveStats::new(),
+            body,
+        }
+    }
+
+    /// Read the current tier state without locking.
+    #[must_use]
+    pub(crate) fn state(&self) -> ShardState {
+        ShardState::from_repr(self.state.load(Ordering::Acquire))
+    }
+
+    /// Cheap clone of the in-memory body.
+    #[must_use]
+    pub(crate) fn body(&self) -> Arc<DriveCompactIndex> {
+        Arc::clone(&self.body)
+    }
+
+    /// Attempt to transition the shard to `to`.
+    ///
+    /// On success returns the previous state.  On failure returns
+    /// [`IllegalTransition`] without mutating the shard.
+    ///
+    /// Internally uses a CAS loop so concurrent transition attempts
+    /// linearise without lost updates.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IllegalTransition`] when the requested move is
+    /// outside the graph encoded in [`ShardState::can_transition_to`].
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 3 consumer (tier-transition CAS used by the \
+                      demoter / promoter); exercised by \
+                      `crate::index::tests::shard_entry_try_transition_legal_and_illegal` \
+                      under `cfg(test)`."
+        )
+    )]
+    pub(crate) fn try_transition(&self, to: ShardState) -> Result<ShardState, IllegalTransition> {
+        loop {
+            let prev_repr = self.state.load(Ordering::Acquire);
+            let prev = ShardState::from_repr(prev_repr);
+            if !prev.can_transition_to(to) {
+                return Err(IllegalTransition { from: prev, to });
+            }
+            // CAS loop: on success return the prior state; on failure
+            // (concurrent transition raced us) fall through and retry.
+            if let Ok(_prev) = self.state.compare_exchange(
+                prev_repr,
+                to as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                return Ok(prev);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(
+        clippy::min_ident_chars,
+        clippy::default_numeric_fallback,
+        clippy::doc_markdown,
+        reason = "test code — short loop counters and doc references like \
+                  `serde_json` are clearer without the pedantic ceremony."
+    )]
+
+    use proptest::prelude::*;
+
+    use super::*;
+
+    fn arb_state() -> impl Strategy<Value = ShardState> {
+        prop_oneof![
+            Just(ShardState::Unknown),
+            Just(ShardState::Cold),
+            Just(ShardState::Parked),
+            Just(ShardState::Warm),
+            Just(ShardState::Hot),
+            Just(ShardState::Evicting),
+        ]
+    }
+
+    proptest! {
+        /// Task 1.6: `decay_ema` is non-increasing between consecutive
+        /// calls without an intervening `record_query` (decay only
+        /// shrinks the EMA, never grows it).
+        #[test]
+        fn drivestats_decay_is_non_increasing(
+            seed_ema_micro in 0_u64..1_000_000_000_u64,
+            gap_ms in 1_u64..100_000_u64,
+        ) {
+            let stats = DriveStats::new();
+            stats.rate_ema_micro_per_s.store(seed_ema_micro, Ordering::Relaxed);
+            stats.last_decay_ms.store(1_000_000, Ordering::Relaxed);
+            let before = drive_stats_ema_value(&stats);
+            let after = stats.decay_ema(1_000_000_u64.saturating_add(gap_ms));
+            prop_assert!(
+                after <= before,
+                "after {} > before {}",
+                after,
+                before,
+            );
+            prop_assert!(after >= 0.0);
+        }
+
+        /// Task 1.7: every (from, to) pair outside the legal graph is
+        /// rejected by `can_transition_to`, and the inverse holds for
+        /// the listed legal pairs.
+        #[test]
+        fn shardstate_legal_graph_is_consistent(from in arb_state(), to in arb_state()) {
+            // The legal graph is hand-listed in `can_transition_to`;
+            // here we duplicate it as a set of pairs and check
+            // bidirectional agreement.
+            let legal: &[(ShardState, ShardState)] = &[
+                (ShardState::Unknown, ShardState::Cold),
+                (ShardState::Unknown, ShardState::Parked),
+                (ShardState::Unknown, ShardState::Warm),
+                (ShardState::Cold, ShardState::Parked),
+                (ShardState::Cold, ShardState::Warm),
+                (ShardState::Parked, ShardState::Cold),
+                (ShardState::Parked, ShardState::Warm),
+                (ShardState::Warm, ShardState::Hot),
+                (ShardState::Warm, ShardState::Evicting),
+                (ShardState::Hot, ShardState::Warm),
+                (ShardState::Hot, ShardState::Evicting),
+                (ShardState::Evicting, ShardState::Cold),
+                (ShardState::Evicting, ShardState::Parked),
+            ];
+            let in_graph = legal.iter().any(|&(a, b)| a == from && b == to);
+            let actual = from.can_transition_to(to);
+            prop_assert_eq!(
+                in_graph,
+                actual,
+                "{} -> {}: graph says {}, can_transition_to says {}",
+                from,
+                to,
+                in_graph,
+                actual,
+            );
+        }
+    }
+
+    /// Task 1.8: `DriveStatsSnapshot` round-trips through serde_json
+    /// and through the `From` conversions.
+    #[test]
+    fn drivestats_snapshot_round_trips() {
+        let stats = DriveStats::new();
+        for _ in 0..7 {
+            stats.record_query();
+        }
+        stats.rate_ema_micro_per_s.store(123_456, Ordering::Relaxed);
+        stats.last_decay_ms.store(987_654_321, Ordering::Relaxed);
+
+        let snap = DriveStatsSnapshot::from(&stats);
+        let json = serde_json::to_string(&snap).expect("serialize");
+        let restored: DriveStatsSnapshot = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(snap, restored);
+        assert_eq!(restored.queries_total, 7);
+        assert_eq!(restored.rate_ema_micro_per_s, 123_456);
+        assert_eq!(restored.last_decay_ms, 987_654_321);
+
+        let stats2 = DriveStats::from(restored);
+        assert_eq!(stats2.queries_total(), 7);
+    }
+
+    /// `record_query` is monotone — N increments yields total of N.
+    #[test]
+    fn record_query_is_monotone() {
+        let stats = DriveStats::new();
+        for _ in 0..10 {
+            stats.record_query();
+        }
+        assert_eq!(stats.queries_total(), 10);
+    }
+
+    /// First `decay_ema` call returns the stored value without decaying
+    /// (no elapsed signal yet).
+    #[test]
+    fn decay_ema_first_call_returns_stored_value() {
+        let stats = DriveStats::new();
+        stats
+            .rate_ema_micro_per_s
+            .store(5_000_000, Ordering::Relaxed);
+        // last_decay_ms == 0 means "never decayed".
+        let v = stats.decay_ema(1_000_000);
+        assert!((v - 5.0).abs() < 1e-9, "first call returned {v}");
+    }
+
+    /// `ShardState::FromStr` accepts every `Display` form and rejects
+    /// unknown input.
+    #[test]
+    fn shardstate_fromstr_round_trips() {
+        for state in [
+            ShardState::Unknown,
+            ShardState::Cold,
+            ShardState::Parked,
+            ShardState::Warm,
+            ShardState::Hot,
+            ShardState::Evicting,
+        ] {
+            let s = state.to_string();
+            let parsed: ShardState = s.parse().expect("parse round-trip");
+            assert_eq!(state, parsed, "{s} did not round-trip");
+        }
+        let err = "foobar".parse::<ShardState>().unwrap_err();
+        assert_eq!(err.0, "foobar");
+        assert!(format!("{err}").contains("unknown shard state"));
+    }
+
+    /// `ShardState` serializes through serde with lowercase names.
+    #[test]
+    fn shardstate_serde_lowercase() {
+        let json = serde_json::to_string(&ShardState::Warm).unwrap();
+        assert_eq!(json, r#""warm""#);
+        let back: ShardState = serde_json::from_str(r#""parked""#).unwrap();
+        assert_eq!(back, ShardState::Parked);
+    }
+
+    /// `ShardState::default()` is `Warm` (Phase-1 invariant).
+    #[test]
+    fn shardstate_default_is_warm() {
+        assert_eq!(ShardState::default(), ShardState::Warm);
+    }
+
+    /// `IllegalTransition` Display matches the documented format.
+    #[test]
+    fn illegal_transition_display() {
+        let err = IllegalTransition {
+            from: ShardState::Cold,
+            to: ShardState::Hot,
+        };
+        assert_eq!(
+            format!("{err}"),
+            "illegal shard state transition: cold -> hot"
+        );
+    }
+}

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -27,6 +27,7 @@ use uffs_client::protocol::response::{DaemonStatus, StatsResponse, StatusRespons
 use uffs_core::aggregate::AggregateCache;
 use uffs_core::search::backend::DriveIndex;
 
+use crate::cache::ShardRegistry;
 use crate::events::{DaemonEvent, EventSender};
 
 /// Per-drive load timing stored for profile reporting.
@@ -52,9 +53,20 @@ struct StoredDriveTiming {
 /// (< 1 μs).  In-flight queries keep the old snapshot alive until they
 /// finish.
 pub(crate) struct IndexManager {
-    /// Shared index snapshot: read lock to clone Arc (< 1 μs), write lock
-    /// only during load/refresh/remove (pointer swap, < 1 μs).
-    index: RwLock<Arc<DriveIndex>>,
+    /// Shared shard-registry snapshot.
+    ///
+    /// Read lock to clone the inner `Arc<ShardRegistry>` (< 1 μs);
+    /// write lock only during load / refresh / remove (pointer swap,
+    /// < 1 μs).  The registry caches an `Arc<DriveIndex>` over its
+    /// active (Warm/Hot) subset so the search hot path stays one
+    /// `Arc::clone` away from a usable backend — see
+    /// [`Self::snapshot`].
+    ///
+    /// Phase 1 of the memory-tiering work replaced the previous
+    /// `Arc<DriveIndex>` field with `Arc<ShardRegistry>`; every shard
+    /// is pinned to `Warm` so observable behavior is unchanged.  See
+    /// `crate::cache` for the type layer.
+    index: RwLock<Arc<ShardRegistry>>,
     /// Current daemon status.
     status: RwLock<DaemonStatus>,
     /// When the daemon started.
@@ -130,7 +142,7 @@ impl IndexManager {
     pub(crate) fn new(data_dir: Option<PathBuf>, events: EventSender) -> Self {
         let cpus = std::thread::available_parallelism().map_or(4, core::num::NonZeroUsize::get);
         Self {
-            index: RwLock::new(Arc::new(DriveIndex::new())),
+            index: RwLock::new(Arc::new(ShardRegistry::new())),
             status: RwLock::new(DaemonStatus::Loading {
                 drives_loaded: 0,
                 drives_total: 0,
@@ -752,10 +764,12 @@ impl IndexManager {
     /// cached results from the previous snapshot can't leak into the
     /// new one.
     async fn add_drive(&self, drive: uffs_core::compact::DriveCompactIndex) {
+        let body = Arc::new(drive);
         let mut guard = self.index.write().await;
-        let mut drives = guard.drives.clone();
-        drives.push(Arc::new(drive));
-        *guard = Arc::new(DriveIndex { drives });
+        // ShardRegistry::add identifies the new shard by `body.letter`
+        // (its canonical case from the index payload) — callers don't
+        // thread the letter separately so it can't drift.
+        *guard = Arc::new(guard.add(body));
         drop(guard);
         self.bump_index_version();
     }
@@ -767,15 +781,11 @@ impl IndexManager {
     /// Bumps `index_version` so the aggregate cache drops entries
     /// computed against the pre-refresh snapshot.
     async fn replace_drive(&self, letter: char, new_drive: uffs_core::compact::DriveCompactIndex) {
+        let body = Arc::new(new_drive);
         let mut guard = self.index.write().await;
-        let mut drives: Vec<Arc<uffs_core::compact::DriveCompactIndex>> = guard
-            .drives
-            .iter()
-            .filter(|drv| !drv.letter.eq_ignore_ascii_case(&letter))
-            .cloned()
-            .collect();
-        drives.push(Arc::new(new_drive));
-        *guard = Arc::new(DriveIndex { drives });
+        // `ShardRegistry::replace` matches case-insensitively, mirroring
+        // the previous `eq_ignore_ascii_case` filter on `DriveIndex`.
+        *guard = Arc::new(guard.replace(letter, body));
         drop(guard);
         self.bump_index_version();
     }
@@ -796,11 +806,51 @@ impl IndexManager {
         self.aggregate_cache.set_index_version(new_version);
     }
 
-    /// Snapshot the current index (< 1 μs).  Callers search the returned
-    /// `Arc` with no lock held.
+    /// Snapshot the current `DriveIndex` over the active (Warm/Hot)
+    /// shard subset.
+    ///
+    /// Two `Arc::clone`s under the read lock (registry, then its
+    /// pre-cached active index) — no per-search rebuild.  Callers run
+    /// the search against the returned `Arc` with no lock held.  Phase
+    /// 1 keeps every shard `Warm` so the active subset always equals
+    /// the full loaded set; Phase 3+ this return value shrinks below
+    /// the registry as shards demote.
     async fn snapshot(&self) -> Arc<DriveIndex> {
         let guard = self.index.read().await;
-        Arc::clone(&guard)
+        guard.active_index()
+    }
+
+    /// Record one search dispatch against every active shard.
+    ///
+    /// Phase 1 records on every Warm/Hot shard; the counter feeds
+    /// [`crate::cache::DriveStats::decay_ema`] which Phase 6 reads to
+    /// drive adaptive-TTL formulas.  Phase 4 will move the recording
+    /// into the per-shard search-dispatch loop so bloom-skipped shards
+    /// don't bump their counters.
+    async fn record_search_dispatch(&self) {
+        let guard = self.index.read().await;
+        for shard in guard.iter() {
+            if matches!(
+                shard.state(),
+                crate::cache::ShardState::Warm | crate::cache::ShardState::Hot
+            ) {
+                shard.stats.record_query();
+            }
+        }
+    }
+
+    /// Per-shard `(drive_letter, queries_total)` snapshot for tests.
+    ///
+    /// Test-only escape hatch so integration tests in `crate::index::tests`
+    /// can verify the [`Self::record_search_dispatch`] wiring without
+    /// exposing the registry to production callers.
+    #[cfg(test)]
+    pub(crate) async fn shard_query_totals_for_test(&self) -> Vec<(char, u64)> {
+        let guard = self.index.read().await;
+        guard
+            .iter()
+            .map(|shard| (shard.drive, shard.stats.queries_total()))
+            .collect()
     }
 
     /// Get daemon performance statistics.
@@ -1266,19 +1316,29 @@ impl IndexManager {
     /// Check if the daemon has any loaded drives.
     pub(crate) async fn has_drives(&self) -> bool {
         let guard = self.index.read().await;
-        !guard.drives.is_empty()
+        !guard.is_empty()
     }
 
-    /// Total records across all drives.
+    /// Total records across all active (Warm/Hot) drives.
+    ///
+    /// Phase 1 keeps every shard `Warm`, so this is identical to the
+    /// pre-Phase-1 "records across every loaded drive" count.  Phase
+    /// 3+ when shards demote, this returns only the records that are
+    /// actually searchable right now.
     pub(crate) async fn total_records(&self) -> usize {
         let guard = self.index.read().await;
-        guard.total_records()
+        guard.active_index().total_records()
     }
 
     /// Return the set of currently loaded drive letters.
+    ///
+    /// Includes every shard regardless of tier (Warm, Hot, Parked,
+    /// Cold).  Pre-Phase-3 this matched the active-index drive list
+    /// exactly; post-Phase-3 it can include shards whose body has been
+    /// dropped.
     pub(crate) async fn loaded_drive_letters(&self) -> Vec<char> {
-        let snap = self.snapshot().await;
-        snap.drives.iter().map(|dr| dr.letter).collect()
+        let guard = self.index.read().await;
+        guard.loaded_letters()
     }
 
     /// Hot-load a single MFT file if its drive letter is not already loaded.
@@ -1432,8 +1492,8 @@ impl IndexManager {
 
     /// Check whether a drive letter is already in the index.
     async fn is_drive_loaded(&self, letter: char) -> bool {
-        let snap = self.snapshot().await;
-        snap.drives.iter().any(|dr| dr.letter == letter)
+        let guard = self.index.read().await;
+        guard.contains(letter)
     }
 
     /// Determine the [`MftSource`] for a drive letter.

--- a/crates/uffs-daemon/src/index/search.rs
+++ b/crates/uffs-daemon/src/index/search.rs
@@ -87,6 +87,12 @@ impl IndexManager {
         // ── Snapshot the index (< 1 μs) ────────────────────────────
         let t_lock = profiling.then(Instant::now);
         let snapshot = self.snapshot().await;
+        // Phase 1 of memory-tiering: record this dispatch on every
+        // active shard so `DriveStats::decay_ema` (consumed by Phase 6
+        // adaptive-TTL) accumulates a real signal.  See
+        // `crate::cache::DriveStats` and the `record_search_dispatch`
+        // doc comment.
+        self.record_search_dispatch().await;
         let lock_us = t_lock.map_or(0, |ts| ts.elapsed().as_micros());
 
         let (sort_column, sort_desc, extra_sort_tiers) =

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -1207,3 +1207,193 @@ async fn total_index_heap_bytes_matches_status_breakdown() {
         "status.index_heap_bytes must equal total_index_heap_bytes",
     );
 }
+
+// ── Phase 1 — ShardRegistry / ShardEntry integration ────────────────
+
+/// Build a synthetic drive with letter `'D'` for multi-drive tests.
+///
+/// Same shape as [`build_test_drive`] but a different letter so a
+/// 2-drive registry is unambiguous.
+fn build_test_drive_d() -> uffs_core::compact::DriveCompactIndex {
+    let mut idx = MftIndex::new('D');
+    let root_off = idx.add_name(".");
+    let root = idx.get_or_create(ROOT_FRS);
+    root.stdinfo.set_directory(true);
+    root.first_name.name = IndexNameRef::new(root_off, 1, true, IndexNameRef::NO_EXTENSION);
+    root.first_name.parent_frs = ROOT_FRS;
+
+    let file = "alpha.txt";
+    let off = idx.add_name(file);
+    let ext = idx.intern_extension(file);
+    let rec = idx.get_or_create(200);
+    rec.first_name.name = IndexNameRef::new(off, uffs_mft::len_to_u16(file.len()), true, ext);
+    rec.first_name.parent_frs = ROOT_FRS;
+    rec.first_stream.size = SizeInfo {
+        length: 42,
+        allocated: 512,
+    };
+    rec.stdinfo.flags = 0x20;
+    rec.stdinfo.modified = 1_000_000;
+
+    let (drive, _, _) = build_compact_index('D', &idx);
+    drive
+}
+
+/// `ShardRegistry::{add, replace, remove}` round-trip with real
+/// `DriveCompactIndex` bodies.  Pins the case-insensitive contract on
+/// `replace` / `remove` that mirrors the pre-Phase-1
+/// `IndexManager::replace_drive` filter.
+#[test]
+fn shard_registry_add_replace_remove_round_trip() {
+    use crate::cache::ShardRegistry;
+
+    let body_c = Arc::new(build_test_drive());
+    let body_d = Arc::new(build_test_drive_d());
+    let body_c_v2 = Arc::new(build_test_drive());
+
+    // Empty start → add C → add D → replace 'c' (case-insensitive) →
+    // remove 'd' (case-insensitive).  Single mutable binding so we
+    // don't trip clippy::shadow_reuse on each rebuild.
+    let mut reg = ShardRegistry::new();
+    assert!(reg.is_empty());
+    assert_eq!(reg.active_index().drives.len(), 0);
+
+    reg = reg.add(Arc::clone(&body_c));
+    reg = reg.add(Arc::clone(&body_d));
+    assert_eq!(reg.active_index().drives.len(), 2);
+    assert!(reg.contains('C'));
+    assert!(reg.contains('D'));
+
+    reg = reg.replace('c', Arc::clone(&body_c_v2));
+    assert_eq!(
+        reg.active_index().drives.len(),
+        2,
+        "replace must not duplicate",
+    );
+
+    reg = reg.remove('d');
+    assert!(!reg.contains('D'));
+    assert_eq!(reg.active_index().drives.len(), 1);
+    assert_eq!(reg.loaded_letters(), vec!['C']);
+}
+
+/// `ShardEntry::try_transition` enforces the legal-transition graph
+/// from [`ShardState::can_transition_to`] using a CAS loop.
+///
+/// Task 1.7 — covers both legal and illegal moves on a real shard
+/// with a `DriveCompactIndex` body, complementing the proptest in
+/// `crate::cache::shard::tests` which exercises the pure state graph.
+#[test]
+fn shard_entry_try_transition_legal_and_illegal() {
+    use crate::cache::ShardState;
+    use crate::cache::shard::ShardEntry;
+
+    let body = Arc::new(build_test_drive());
+    let shard = ShardEntry::new_warm('C', Arc::clone(&body));
+    assert_eq!(shard.state(), ShardState::Warm);
+
+    // Legal: Warm → Hot.
+    let prev = shard
+        .try_transition(ShardState::Hot)
+        .expect("warm->hot is legal");
+    assert_eq!(prev, ShardState::Warm);
+    assert_eq!(shard.state(), ShardState::Hot);
+
+    // Illegal: Hot → Cold (must go via Evicting → Cold/Parked).
+    let err = shard
+        .try_transition(ShardState::Cold)
+        .expect_err("hot->cold is illegal");
+    assert_eq!(err.from, ShardState::Hot);
+    assert_eq!(err.to, ShardState::Cold);
+    assert_eq!(
+        shard.state(),
+        ShardState::Hot,
+        "state must be unchanged on illegal transition"
+    );
+
+    // Recovery path: Hot → Warm → Evicting → Cold all legal.
+    shard
+        .try_transition(ShardState::Warm)
+        .expect("hot->warm legal");
+    shard
+        .try_transition(ShardState::Evicting)
+        .expect("warm->evicting legal");
+    shard
+        .try_transition(ShardState::Cold)
+        .expect("evicting->cold legal");
+    assert_eq!(shard.state(), ShardState::Cold);
+}
+
+/// Two-drive integration: searches dispatch correctly across both
+/// shards under the new `ShardRegistry` indirection.
+///
+/// Task 1.9 — `build_test_drive` + `build_test_drive_d` with
+/// `IndexManager::search`, asserting the results carry rows from both
+/// drives.  Pins the "zero observable change" contract for Phase 1.
+#[tokio::test]
+async fn shard_registry_search_two_drives_returns_rows_from_each() {
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+
+    let params = uffs_client::protocol::SearchParams {
+        pattern: "*".to_owned(),
+        limit: Some(50),
+        ..Default::default()
+    };
+    let resp = mgr.search(&params).await;
+    assert!(
+        resp.total_count >= 2,
+        "two-drive '*' search must return at least 2 rows; got {}",
+        resp.total_count,
+    );
+
+    // Both drives must contribute records to the snapshot.
+    let snap = mgr.snapshot().await;
+    assert_eq!(snap.drives.len(), 2);
+    let letters: std::collections::HashSet<char> = snap.drives.iter().map(|d| d.letter).collect();
+    assert!(letters.contains(&'C'), "C drive must be in the snapshot");
+    assert!(letters.contains(&'D'), "D drive must be in the snapshot");
+}
+
+/// `IndexManager::search` records one query per dispatch on every
+/// active shard, via `record_search_dispatch` + `DriveStats::record_query`.
+///
+/// Task 1.5 — pins the wiring between the search hot path and the
+/// per-shard counter that Phase 6 reads for adaptive-TTL.
+#[tokio::test]
+async fn search_records_query_on_every_active_shard() {
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+
+    // Baseline: no searches yet.
+    let before = mgr.shard_query_totals_for_test().await;
+    assert_eq!(before.len(), 2);
+    for (letter, count) in &before {
+        assert_eq!(*count, 0, "drive {letter} must start at 0 queries");
+    }
+
+    let params = uffs_client::protocol::SearchParams {
+        pattern: "*".to_owned(),
+        limit: Some(10),
+        ..Default::default()
+    };
+
+    // Three searches.  Suffix the loop bound to avoid the implicit i32
+    // fallback flagged by clippy::default_numeric_fallback.
+    for _ in 0_u32..3_u32 {
+        drop(mgr.search(&params).await);
+    }
+
+    let after = mgr.shard_query_totals_for_test().await;
+    assert_eq!(after.len(), 2);
+    for (letter, count) in after {
+        assert_eq!(
+            count, 3,
+            "drive {letter} must have recorded 3 queries; got {count}",
+        );
+    }
+}

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -29,6 +29,11 @@ use uffs_security as _;
 
 /// Broker client — volume handle requests (Windows) / stubs (other).
 mod broker_client;
+/// Shard-based index cache with per-drive lifecycle.
+///
+/// Phase 1 of the memory-tiering work — see
+/// `docs/refactor/memory-tiering-implementation-plan.md`.
+mod cache;
 /// Daemon event broadcasting — push notifications to connected clients.
 pub mod events;
 /// JSON-RPC request handler.

--- a/crates/uffs-daemon/src/main.rs
+++ b/crates/uffs-daemon/src/main.rs
@@ -40,6 +40,8 @@ use dirs_next as _;
 #[cfg(unix)]
 use libc as _;
 use libmimalloc_sys as _;
+#[cfg(test)]
+use proptest as _;
 use rand as _;
 use serde as _;
 use serde_json as _;

--- a/crates/uffs-daemon/tests/ipc_integration.rs
+++ b/crates/uffs-daemon/tests/ipc_integration.rs
@@ -28,6 +28,7 @@ use dirs_next as _;
 use libc as _;
 use libmimalloc_sys as _;
 use mimalloc as _;
+use proptest as _;
 use rand as _;
 use serde as _;
 use serde_json as _;


### PR DESCRIPTION
## Summary

Phase 1 of the memory-tiering rollout (see `docs/refactor/memory-tiering-implementation-plan.md`).  Lays the **ShardRegistry / ShardState / DriveStats** foundation that Phases 2–6 hang their state and decisions off.

**Zero observable behavior change** in this phase: same JSON-RPC contracts, same search results, same status output.  Pinned by golden-file equality in `shard_registry_search_two_drives_returns_rows_from_each` and the unchanged `aggregation.rs` / `handler.rs` test suites.

## What's new

### `crate::cache` module
- **`ShardState`** (`Unknown`, `Cold`, `Parked`, `Warm`, `Hot`, `Evicting`) encoded as `AtomicU8` for lock-free reads / CAS transitions.  Hand-listed legal-transition graph in `can_transition_to` (Phase 6's adaptive-TTL controller will walk it).
- **`DriveStats`** with atomic `record_query()` and lock-light `decay_ema()` (60 s half-life).  `DriveStatsSnapshot` mirror for serde persistence.
- **`ShardEntry`** carries `drive`, `state`, `stats`, and `body: Arc<DriveCompactIndex>`.  Bloom / trie placeholders deferred to Phase 4 per plan.
- **`ShardRegistry`** with `new` / `add` / `replace` / `remove` / `iter` / `contains` / `loaded_letters` / `active_index` / `len` / `is_empty` / `from_shards`.  The active (Warm/Hot) subset is **pre-cached as `Arc<DriveIndex>`** so the read-hot search path stays a single `Arc::clone` — zero ripple to the ~22 read sites in `index/mod.rs`, `aggregation.rs`, and `handler.rs`.

### `IndexManager` wire-in
- `index: RwLock<Arc<DriveIndex>>` → `RwLock<Arc<ShardRegistry>>`.
- `snapshot()` keeps its `Arc<DriveIndex>` return shape by reading `registry.active_index()`.  **No reader site changes.**
- `add_drive` / `replace_drive` route through `registry.add(body)` / `registry.replace(letter, body)`, preserving the case-insensitive replace contract (`eq_ignore_ascii_case`) that pre-Phase-1 callers relied on.
- New `record_search_dispatch()` is invoked once per search after the active snapshot is acquired, bumping every Warm/Hot shard's `queries_total` so Phase 6's adaptive-TTL controller has a real signal to decay.  Phase 4 will tighten this to the per-shard dispatch loop so bloom-skipped shards don't increment.

## Tests

**Two proptests** in `cache/shard.rs::tests`:
- `drivestats_decay_is_non_increasing` — 1 000+ random EMA seeds × elapsed-gaps, verifies the decay function is monotone-non-increasing without intervening `record_query` calls.
- `shardstate_legal_graph_is_consistent` — full 6 × 6 = 36-pair Cartesian product over `ShardState`, asserting `can_transition_to` agrees with a hand-listed legal-pair table.

**Four integration tests** in `index/tests.rs` (real `DriveCompactIndex` bodies via `build_test_drive` / `build_test_drive_d`):
- `shard_registry_add_replace_remove_round_trip` — pure registry contract on real bodies; pins case-insensitive replace.
- `shard_entry_try_transition_legal_and_illegal` — `try_transition` end-to-end on a real shard, including illegal-move rejection.
- `shard_registry_search_two_drives_returns_rows_from_each` — 2-drive search through `IndexManager::search`, golden equality with v0.5.x.
- `search_records_query_on_every_active_shard` — verifies each shard's `queries_total` increments by exactly the dispatch count.

## Design notes

### Lint discipline
Seven `#[cfg_attr(not(test), expect(dead_code, reason = "..."))]` attributes on items used only by `cfg(test)` consumers (`try_transition`, `IllegalTransition`, `queries_total`, `decay_ema`, `can_transition_to`, `ShardRegistry::{remove, len}`).  Each justification names the Phase-3+ production consumer that will activate it.  No blanket `#[allow]`s; all `#[expect]`s carry `reason = "..."` strings per workspace policy.

### Why pre-cached active index?
Two-tier lookups (find drives → search them) can't tolerate a second pass over the registry on every search.  Pre-caching the `Arc<DriveIndex>` on every mutation keeps the search hot-path identical to v0.5.x: one `RwLock::read` + one `Arc::clone`.  The price is rebuilding the active snapshot on `add` / `replace` / `remove`, but those happen on drive load (rare) and the rebuild is one allocation + a filter pass.

## Validation

| Gate | Result |
| --- | --- |
| `cargo nextest run -p uffs-daemon` | **109 / 109 PASS** |
| `cargo nextest run --workspace` | **1334 / 1334 PASS** (zero regressions) |
| `just lint-prod` (`-D pedantic -D nursery -D cargo`) | clean |
| `just lint-ci` (`--all-targets -D warnings`) | clean |
| `just check-windows` | ✅ |
| Pre-commit `lint-fast` (8 sub-gates) | ✅ 23s |
| Pre-push `lint-pre-push` (incl. `deny`, `check-windows`) | ✅ 63s |

## Forward plan

- **Phase 2** (1 wk): Decrypt-into-mmap'd-tempfile (`Option C`) — drops WARM tier from ~250 B/record to ~110-130 B/record.
- **Phase 3** (2 wk): Cold/Parked tier transitions wired through `ShardEntry::try_transition`.
- **Phase 4** (2 wk): Bloom-filter pre-filtering on the per-shard dispatch path.
- **Phase 6** (1 wk): Adaptive-TTL controller reads `DriveStats::decay_ema()`.

Refs: `docs/refactor/memory-tiering-implementation-plan.md` Phase 1
