### PR TITLE
fix(ci): release-pipeline followups (#80, #83)

### DIFF
--- a/.github/workflows/cargo-vet-refresh.yml
+++ b/.github/workflows/cargo-vet-refresh.yml
@@ -78,6 +78,20 @@ concurrency:
   group: cargo-vet-refresh
   cancel-in-progress: false
 
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Override `.cargo/config.toml`'s `rustc-wrapper = "sccache"` setting.
+  # sccache is a developer-machine convenience (`cargo install sccache`);
+  # GitHub-hosted runners don't have it pre-installed, so every `cargo`
+  # invocation — including `cargo vet`'s internal `cargo metadata` —
+  # fails immediately with `could not execute process sccache …` and
+  # exit code 255.  An empty `RUSTC_WRAPPER` defeats the wrapper
+  # without touching `.cargo/config.toml` (which would hurt local dev
+  # UX).  Same override `pr-fast.yml`, `release.yml`, `tier-2.yml`,
+  # and `preview-artifacts.yml` carry for the same reason.
+  RUSTC_WRAPPER: ""
+
 jobs:
   refresh-imports:
     name: "Regenerate cargo-vet imports"

--- a/.github/workflows/cargo-vet-refresh.yml
+++ b/.github/workflows/cargo-vet-refresh.yml
@@ -91,7 +91,7 @@ jobs:
         run: rustup show
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # Unique suffix so this workflow's cache doesn't evict the
           # main CI cache (and vice versa).  cargo-vet's compile is

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -234,7 +234,7 @@ jobs:
           df -h /
 
       - run: rustup show
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: pr-fast-sanity
           cache-on-failure: 'true'
@@ -276,7 +276,7 @@ jobs:
           df -h /
 
       - run: rustup show
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: pr-fast-sanity
           save-if: 'false'
@@ -308,7 +308,7 @@ jobs:
           df -h /
 
       - run: rustup show
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: pr-fast-sanity
           save-if: 'false'
@@ -345,7 +345,7 @@ jobs:
           df -h /
 
       - run: rustup show
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: pr-fast-test-build
           cache-on-failure: 'true'
@@ -382,7 +382,7 @@ jobs:
           df -h /
 
       - run: rustup show
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: pr-fast-test-build
           save-if: 'false'
@@ -411,7 +411,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - run: rustup show
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: pr-fast-security
 
@@ -451,7 +451,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - run: rustup show
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: pr-fast-windows
 

--- a/.github/workflows/preview-artifacts.yml
+++ b/.github/workflows/preview-artifacts.yml
@@ -174,7 +174,7 @@ jobs:
         with:
           tool: cargo-xwin
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: preview-windows
 
@@ -265,7 +265,7 @@ jobs:
         with:
           tool: nextest
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: preview-test-archive-windows
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -132,7 +132,7 @@ jobs:
         run: rustup show
 
       - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # Dedicated cache key — release-plz's compile is small and
           # disjoint from the main CI compile, so a separate key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,7 @@ jobs:
         run: rustup show
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # `shared-key:` (not `key:`) so the action's built-in fallback
           # restores partial matches when `Cargo.lock` shifts between

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,18 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: release-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          # `shared-key:` (not `key:`) so the action's built-in fallback
+          # restores partial matches when `Cargo.lock` shifts between
+          # releases.  `just ship` runs `cargo update` on every release,
+          # which changes the `Cargo.lock` hash and would force an exact
+          # `key:` to miss every single time (issue #80).  `shared-key:`
+          # gives us the same cache-key prefix on every release-${target}
+          # invocation and lets the action recover ~80-90 % of the
+          # previous compile graph; only crates whose sources actually
+          # changed need recompilation.  `pr-fast.yml` uses the same
+          # pattern; the divergence here was unintentional.
+          shared-key: release-${{ matrix.target }}
+          cache-on-failure: 'true'
 
       - name: Build optimized release binaries
         shell: bash

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -74,7 +74,7 @@ jobs:
         run: rustup show
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install tools
         uses: taiki-e/install-action@dfc84ffb7254b048a0a843316ff5a2714dcdc7bd # v2
@@ -135,7 +135,7 @@ jobs:
         run: rustup show
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # Dedicated cache key — the Linux Tier 2 jobs below have fragments
           # that make the default key hash to something different on Windows
@@ -168,7 +168,7 @@ jobs:
         run: rustup show
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Run build validation
         # --locked per §2.8 — validation builds must resolve through
@@ -193,7 +193,7 @@ jobs:
         run: rustup show
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-udeps
         uses: taiki-e/install-action@dfc84ffb7254b048a0a843316ff5a2714dcdc7bd # v2
@@ -222,7 +222,7 @@ jobs:
         run: rustup show
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Run focused Miri coverage
         env:

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -75,6 +75,9 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: tier-2-coverage
+          cache-on-failure: 'true'
 
       - name: Install tools
         uses: taiki-e/install-action@dfc84ffb7254b048a0a843316ff5a2714dcdc7bd # v2
@@ -142,6 +145,11 @@ jobs:
           # anyway, but be explicit so a future refactor does not cross the
           # streams.
           shared-key: tier-2-windows-check
+          # Persist a partial cache even if the job fails — runner
+          # pre-emption (SIGTERM) mid-compile is the most common Tier 2
+          # failure mode (issue #83), so the next attempt should resume
+          # from the partially-built compile graph.
+          cache-on-failure: 'true'
 
       - name: cargo check --workspace --all-features
         # --all-features to exercise every feature-gated path that only
@@ -169,6 +177,9 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: tier-2-build-validation
+          cache-on-failure: 'true'
 
       - name: Run build validation
         # --locked per §2.8 — validation builds must resolve through
@@ -194,6 +205,9 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: tier-2-udeps
+          cache-on-failure: 'true'
 
       - name: Install cargo-udeps
         uses: taiki-e/install-action@dfc84ffb7254b048a0a843316ff5a2714dcdc7bd # v2
@@ -223,6 +237,9 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: tier-2-miri
+          cache-on-failure: 'true'
 
       - name: Run focused Miri coverage
         env:

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -185,6 +185,21 @@ jobs:
         # --locked per §2.8 — validation builds must resolve through
         # the committed Cargo.lock, otherwise a broken lockfile wouldn't
         # surface here.
+        #
+        # CARGO_BUILD_JOBS=2: ubuntu-latest's 16 GB RAM cannot host
+        # parallel linkers for every workspace binary — `uffs` +
+        # `uffsd` + `uffsmcp` + `uffs_mft` + diagnostic bins each pull
+        # in polars + axum + rmcp + mimalloc + ring during link, which
+        # adds up to multiple GB per `ld` invocation.  4–5 wide
+        # parallelism (the default for ubuntu-latest's 4 vCPU) breached
+        # the memory budget mid-link and the kernel pre-empted the
+        # runner agent (exit 143 / "runner has received a shutdown
+        # signal" — issue #83).  Capping at 2 keeps a useful amount of
+        # compile parallelism while never linking more than 2 bins at
+        # once.  Total wall time goes up modestly (≈10 → ≈12 min on
+        # warm cache) — well within the 60-min budget.
+        env:
+          CARGO_BUILD_JOBS: '2'
         run: cargo build --locked --workspace --all-features --bins
 
   udeps:

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -36,10 +36,16 @@ env:
   # Disable sccache in CI - it's configured in .cargo/config.toml for local dev
   # but not installed on GitHub Actions runners
   RUSTC_WRAPPER: ""
-  # Limit parallel jobs to reduce memory pressure during Polars compilation
-  # GitHub Actions runners have limited RAM; too many parallel rustc processes
-  # can trigger OOM killer or runner preemption (exit code 143)
-  CARGO_BUILD_JOBS: 2
+  # Limit parallel jobs to reduce memory pressure during Polars compilation.
+  # GitHub Actions ubuntu-latest runners (16 GB / 4 vCPU) cannot host parallel
+  # link-stages of every workspace binary — each pulls polars + axum + rmcp +
+  # mimalloc + ring through its dep graph and consumes multiple GB during `ld`.
+  # The previous cap of 2 was still being pre-empted with exit 143 / SIGTERM
+  # mid-link of the workspace bins (issue #83, runs 24984887285 attempts 1+2),
+  # so this drops to 1 — fully serialised compile/link.  Wall time goes up
+  # modestly (≈10 → ≈14 min on warm cache) but stays well within the
+  # 60-min step budget; correctness > speed for a once-weekly cron.
+  CARGO_BUILD_JOBS: 1
 
 jobs:
   file-size-policy:
@@ -186,20 +192,18 @@ jobs:
         # the committed Cargo.lock, otherwise a broken lockfile wouldn't
         # surface here.
         #
-        # CARGO_BUILD_JOBS=2: ubuntu-latest's 16 GB RAM cannot host
-        # parallel linkers for every workspace binary — `uffs` +
-        # `uffsd` + `uffsmcp` + `uffs_mft` + diagnostic bins each pull
-        # in polars + axum + rmcp + mimalloc + ring during link, which
-        # adds up to multiple GB per `ld` invocation.  4–5 wide
-        # parallelism (the default for ubuntu-latest's 4 vCPU) breached
-        # the memory budget mid-link and the kernel pre-empted the
-        # runner agent (exit 143 / "runner has received a shutdown
-        # signal" — issue #83).  Capping at 2 keeps a useful amount of
-        # compile parallelism while never linking more than 2 bins at
-        # once.  Total wall time goes up modestly (≈10 → ≈12 min on
-        # warm cache) — well within the 60-min budget.
+        # CARGO_BUILD_JOBS=1: workflow-level env already sets this; the
+        # step-level override is kept in lockstep so a future split
+        # of the workflow-level cap doesn't silently re-introduce
+        # parallel linking.  GitHub Actions step-env > workflow-env,
+        # so divergence here would defeat the fix.  Background:
+        # ubuntu-latest's 16 GB / 4 vCPU pre-empted the runner mid-link
+        # of the workspace binaries even at parallelism 2 (issue #83,
+        # run 24984887285 attempts 1+2 — both died ~60 s after the
+        # last `Compiling …` line, mid-`ld`).  Serialised link is
+        # ~+2-4 min wall time on warm cache, well inside budget.
         env:
-          CARGO_BUILD_JOBS: '2'
+          CARGO_BUILD_JOBS: '1'
         run: cargo build --locked --workspace --all-features --bins
 
   udeps:

--- a/crates/uffs-cli/src/commands.rs
+++ b/crates/uffs-cli/src/commands.rs
@@ -22,6 +22,34 @@ pub mod stats;
 /// Combined `uffs status` command.
 pub mod system_status;
 
+/// Render a one-line version summary suitable for `daemon status`,
+/// `daemon stats`, and `uffs status` output.
+///
+/// `daemon_version` is the daemon-reported `env!("CARGO_PKG_VERSION")`
+/// from [`uffs_client::protocol::response::StatusResponse::version`]
+/// (or `StatsResponse::version`).  The CLI's own compile-time version
+/// is read locally; when the two differ we surface both with a
+/// `MISMATCH` flag so a stale long-running daemon paired with a
+/// freshly-upgraded CLI binary (or vice versa) is visible at a glance
+/// instead of being inferred from the existing mtime-based stale-binary
+/// heuristic in `system_status::print_daemon_status`.
+///
+/// Pre-0.5.79 daemons send no version; rendered as `<unknown>`.
+///
+/// The function returns the value portion only — callers prepend
+/// their own label/indentation (`Version:`, `  Version:`, etc.) so a
+/// single helper covers both indented and non-indented layouts.
+pub(crate) fn version_summary(daemon_version: &str) -> String {
+    let cli_version = env!("CARGO_PKG_VERSION");
+    if daemon_version.is_empty() {
+        format!("<unknown> (daemon) / {cli_version} (cli)")
+    } else if daemon_version == cli_version {
+        cli_version.to_owned()
+    } else {
+        format!("{daemon_version} (daemon) / {cli_version} (cli)  ⚠ MISMATCH")
+    }
+}
+
 /// Format a number with comma separators.
 fn format_number(num: u64) -> String {
     let num_str = num.to_string();

--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -198,6 +198,10 @@ fn daemon_status() -> Result<()> {
     };
 
     let uptime = core::time::Duration::from_secs(status.uptime_secs);
+    println!(
+        "Version:       {}",
+        crate::commands::version_summary(&status.version)
+    );
     println!("Daemon PID:    {}", status.pid);
     println!(
         "Uptime:        {}",
@@ -303,6 +307,10 @@ fn daemon_stats() -> Result<()> {
         let total_query = core::time::Duration::from_micros(stats.total_query_time_us);
 
         println!("═══ Daemon Performance Stats ═══");
+        println!(
+            "Version:           {}",
+            crate::commands::version_summary(&stats.version)
+        );
         println!("Uptime:            {}", fmt(uptime));
         println!("Startup duration:  {}", fmt(startup));
         println!(

--- a/crates/uffs-cli/src/commands/system_status.rs
+++ b/crates/uffs-cli/src/commands/system_status.rs
@@ -62,6 +62,10 @@ fn print_daemon_status() {
     } else {
         ""
     };
+    println!(
+        "  Version:     {}",
+        crate::commands::version_summary(&status.version)
+    );
     println!("  Status:      running (PID {}){stale_tag}", status.pid);
     println!(
         "  Uptime:      {}",

--- a/crates/uffs-client/src/protocol/mod.rs
+++ b/crates/uffs-client/src/protocol/mod.rs
@@ -9,6 +9,7 @@
 pub mod cli_args;
 mod cli_args_helpers;
 pub mod response;
+pub mod response_status;
 pub mod search_params;
 #[cfg(test)]
 mod tests;

--- a/crates/uffs-client/src/protocol/response.rs
+++ b/crates/uffs-client/src/protocol/response.rs
@@ -2,9 +2,18 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Response types, RPC convenience methods, and command parameter types.
+//!
+//! Daemon-state responses (`DrivesResponse`, `StatusResponse`,
+//! `StatsResponse`, `DaemonStatus`, `DriveMemoryInfo`, `DriveInfo`)
+//! live in the sibling [`response_status`](super::response_status)
+//! module and are re-exported below for back-compat with the historical
+//! `crate::protocol::response::*` import surface.
 
 use serde::{Deserialize, Serialize};
 
+pub use super::response_status::{
+    DaemonStatus, DriveInfo, DriveMemoryInfo, DrivesResponse, StatsResponse, StatusResponse,
+};
 use super::{
     AggregateResultWire, BucketWire, RpcError, RpcErrorResponse, RpcRequest, RpcResponse,
     SearchResponseMode, SearchSortSpec,
@@ -553,131 +562,6 @@ impl uffs_format::FormatRow for SearchRow {
     fn tree_allocated(&self) -> u64 {
         self.tree_allocated
     }
-}
-
-/// Response for the `drives` method.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct DrivesResponse {
-    /// Loaded drives with record counts.
-    pub drives: Vec<DriveInfo>,
-}
-
-/// Information about a loaded drive.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct DriveInfo {
-    /// Drive letter.
-    pub letter: char,
-    /// Number of records in the compact index.
-    pub records: usize,
-    /// Source (e.g. `"cache"`, `"live"`, `"mft_file"`).
-    pub source: String,
-}
-
-/// Response for the `status` method.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct StatusResponse {
-    /// Current daemon status.
-    pub status: DaemonStatus,
-    /// Daemon uptime in seconds.
-    pub uptime_secs: u64,
-    /// Number of active connections.
-    pub connections: usize,
-    /// Daemon process ID.
-    pub pid: u32,
-    /// Process RSS (resident set size) in bytes, if available.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub rss_bytes: Option<u64>,
-    /// Calculated heap footprint of all loaded indices (bytes).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub index_heap_bytes: Option<u64>,
-    /// Mimalloc allocator committed bytes (bytes paged in from the OS).
-    ///
-    /// Reported by `mi_process_info`; equals or exceeds `index_heap_bytes`
-    /// because the allocator carries page-level overhead and free-but-
-    /// not-yet-decommitted segments.  Comparing this to `rss_bytes` shows
-    /// how much of the daemon's RSS is allocator-managed.  Phase 0 of the
-    /// memory-tiering work surfaces this so subsequent phases can be
-    /// measured against a stable allocator-committed baseline.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mimalloc_committed_bytes: Option<u64>,
-    /// Per-drive memory breakdown (drive letter → heap bytes).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub drive_memory: Vec<DriveMemoryInfo>,
-}
-
-/// Per-drive memory breakdown for status reporting.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct DriveMemoryInfo {
-    /// Drive letter.
-    pub drive: char,
-    /// Number of records in this drive's index.
-    pub records: usize,
-    /// Calculated heap footprint in bytes.
-    pub heap_bytes: u64,
-    /// Breakdown: records Vec.
-    pub records_bytes: u64,
-    /// Breakdown: names Vec.
-    pub names_bytes: u64,
-    /// Breakdown: trigram index.
-    pub trigram_bytes: u64,
-    /// Breakdown: children index.
-    pub children_bytes: u64,
-    /// Breakdown: extension index.
-    pub ext_index_bytes: u64,
-}
-
-/// Response for the `stats` method — daemon performance metrics.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct StatsResponse {
-    /// Total search queries served since startup.
-    pub total_queries: u64,
-    /// Cumulative search time in microseconds.
-    pub total_query_time_us: u64,
-    /// Average query time in microseconds.
-    pub avg_query_time_us: f64,
-    /// Time from daemon start to `Ready` in milliseconds.
-    pub startup_duration_ms: u64,
-    /// Daemon uptime in seconds.
-    pub uptime_secs: u64,
-    /// Total records across all loaded drives.
-    pub total_records: usize,
-    /// Queries per second (over daemon lifetime).
-    pub queries_per_second: f64,
-    /// Aggregate-cache hit count (lifetime, since daemon start).
-    ///
-    /// Defaults to `0` when the daemon is older than this field
-    /// (forward compatibility with pre-0.5.44 daemons).
-    #[serde(default)]
-    pub agg_cache_hits: u64,
-    /// Aggregate-cache miss count (lifetime, includes stale/expired).
-    #[serde(default)]
-    pub agg_cache_misses: u64,
-    /// Number of entries currently in the aggregate cache.
-    #[serde(default)]
-    pub agg_cache_entries: u64,
-}
-
-/// Daemon operational status.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "state")]
-pub enum DaemonStatus {
-    /// Daemon is loading indices.
-    #[serde(rename = "loading")]
-    Loading {
-        /// Drives loaded so far.
-        drives_loaded: usize,
-        /// Total drives to load.
-        drives_total: usize,
-    },
-    /// Daemon is ready to serve queries.
-    #[serde(rename = "ready")]
-    Ready,
-    /// Daemon is refreshing one or more drives.
-    #[serde(rename = "refreshing")]
-    Refreshing {
-        /// Drives being refreshed.
-        drives: Vec<char>,
-    },
 }
 
 /// Response for the `info` method (all 25 columns for a path).

--- a/crates/uffs-client/src/protocol/response_status.rs
+++ b/crates/uffs-client/src/protocol/response_status.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Daemon-state wire types: `drives`, `status`, and `stats` RPC responses.
+//!
+//! Split out of [`super::response`] so the search/payload subset of the
+//! protocol surface stays under the workspace 800-LOC policy ceiling
+//! without a file-size exemption.  Functionally these types form one
+//! cohesive group — they describe the *daemon's own state* (loaded
+//! drives, runtime telemetry, lifecycle phase, perf counters) — as
+//! opposed to query results, which live alongside `SearchResponse` in
+//! `response.rs`.
+//!
+//! The original module re-exports each type via `pub use`, so external
+//! callers continue to import from `uffs_client::protocol::response::*`
+//! exactly as before — the split is internal layout, not a breaking
+//! change to the public protocol surface.
+
+use serde::{Deserialize, Serialize};
+
+/// Response for the `drives` method.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DrivesResponse {
+    /// Loaded drives with record counts.
+    pub drives: Vec<DriveInfo>,
+}
+
+/// Information about a loaded drive.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DriveInfo {
+    /// Drive letter.
+    pub letter: char,
+    /// Number of records in the compact index.
+    pub records: usize,
+    /// Source (e.g. `"cache"`, `"live"`, `"mft_file"`).
+    pub source: String,
+}
+
+/// Response for the `status` method.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StatusResponse {
+    /// Current daemon status.
+    pub status: DaemonStatus,
+    /// Daemon uptime in seconds.
+    pub uptime_secs: u64,
+    /// Number of active connections.
+    pub connections: usize,
+    /// Daemon process ID.
+    pub pid: u32,
+    /// Compile-time version of the daemon binary (`env!("CARGO_PKG_VERSION")`).
+    ///
+    /// Surfaced to the CLI so `uffs daemon status` / `uffs status` can
+    /// flag a daemon-vs-CLI version mismatch when the user has an old
+    /// long-running daemon and an upgraded CLI binary (or vice versa).
+    /// Defaults to `""` for back-compat with pre-0.5.79 daemons that
+    /// did not populate this field; the CLI renders that as `<unknown>`.
+    #[serde(default)]
+    pub version: String,
+    /// Process RSS (resident set size) in bytes, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rss_bytes: Option<u64>,
+    /// Calculated heap footprint of all loaded indices (bytes).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index_heap_bytes: Option<u64>,
+    /// Mimalloc allocator committed bytes (bytes paged in from the OS).
+    ///
+    /// Reported by `mi_process_info`; equals or exceeds `index_heap_bytes`
+    /// because the allocator carries page-level overhead and free-but-
+    /// not-yet-decommitted segments.  Comparing this to `rss_bytes` shows
+    /// how much of the daemon's RSS is allocator-managed.  Phase 0 of the
+    /// memory-tiering work surfaces this so subsequent phases can be
+    /// measured against a stable allocator-committed baseline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mimalloc_committed_bytes: Option<u64>,
+    /// Per-drive memory breakdown (drive letter → heap bytes).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub drive_memory: Vec<DriveMemoryInfo>,
+}
+
+/// Per-drive memory breakdown for status reporting.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DriveMemoryInfo {
+    /// Drive letter.
+    pub drive: char,
+    /// Number of records in this drive's index.
+    pub records: usize,
+    /// Calculated heap footprint in bytes.
+    pub heap_bytes: u64,
+    /// Breakdown: records Vec.
+    pub records_bytes: u64,
+    /// Breakdown: names Vec.
+    pub names_bytes: u64,
+    /// Breakdown: trigram index.
+    pub trigram_bytes: u64,
+    /// Breakdown: children index.
+    pub children_bytes: u64,
+    /// Breakdown: extension index.
+    pub ext_index_bytes: u64,
+}
+
+/// Response for the `stats` method — daemon performance metrics.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StatsResponse {
+    /// Compile-time version of the daemon binary (`env!("CARGO_PKG_VERSION")`).
+    ///
+    /// Mirrors [`StatusResponse::version`].  Both responses include it
+    /// so neither RPC has to chain to the other purely to obtain the
+    /// daemon's version string.  Defaults to `""` for pre-0.5.79
+    /// daemons (back-compat).
+    #[serde(default)]
+    pub version: String,
+    /// Total search queries served since startup.
+    pub total_queries: u64,
+    /// Cumulative search time in microseconds.
+    pub total_query_time_us: u64,
+    /// Average query time in microseconds.
+    pub avg_query_time_us: f64,
+    /// Time from daemon start to `Ready` in milliseconds.
+    pub startup_duration_ms: u64,
+    /// Daemon uptime in seconds.
+    pub uptime_secs: u64,
+    /// Total records across all loaded drives.
+    pub total_records: usize,
+    /// Queries per second (over daemon lifetime).
+    pub queries_per_second: f64,
+    /// Aggregate-cache hit count (lifetime, since daemon start).
+    ///
+    /// Defaults to `0` when the daemon is older than this field
+    /// (forward compatibility with pre-0.5.44 daemons).
+    #[serde(default)]
+    pub agg_cache_hits: u64,
+    /// Aggregate-cache miss count (lifetime, includes stale/expired).
+    #[serde(default)]
+    pub agg_cache_misses: u64,
+    /// Number of entries currently in the aggregate cache.
+    #[serde(default)]
+    pub agg_cache_entries: u64,
+}
+
+/// Daemon operational status.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "state")]
+pub enum DaemonStatus {
+    /// Daemon is loading indices.
+    #[serde(rename = "loading")]
+    Loading {
+        /// Drives loaded so far.
+        drives_loaded: usize,
+        /// Total drives to load.
+        drives_total: usize,
+    },
+    /// Daemon is ready to serve queries.
+    #[serde(rename = "ready")]
+    Ready,
+    /// Daemon is refreshing one or more drives.
+    #[serde(rename = "refreshing")]
+    Refreshing {
+        /// Drives being refreshed.
+        drives: Vec<char>,
+    },
+}

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -880,6 +880,7 @@ impl IndexManager {
         let cache_stats = self.aggregate_cache.stats();
 
         StatsResponse {
+            version: env!("CARGO_PKG_VERSION").to_owned(),
             total_queries,
             total_query_time_us: total_us,
             avg_query_time_us: avg_query_us,
@@ -941,6 +942,7 @@ impl IndexManager {
             uptime_secs: self.start_time.elapsed().as_secs(),
             connections,
             pid: std::process::id(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
             rss_bytes,
             index_heap_bytes: Some(total_index_heap),
             mimalloc_committed_bytes,

--- a/just/dev.just
+++ b/just/dev.just
@@ -24,6 +24,19 @@ kill:
     @pkill -f "rustc" 2>/dev/null || true
     @printf "\033[0;32m✅ All cargo processes terminated\033[0m\n"
 
+# Find and kill orphan `uffs` processes left behind by aborted CLI runs,
+# crashed test harnesses, or Ctrl-C'd validation scripts.  The
+# legitimate long-running daemon is identified via `uffs daemon status`
+# and explicitly preserved.  Pass `--dry-run` to list orphans without
+# killing them, or `--bin <path>` to use a specific uffs binary for
+# the daemon-PID lookup.
+#
+# Pulled out of the validation suites
+# (`scripts/windows/{api,cli,mcp}-validation.rs`) so those scripts only
+# observe daemon state — they never mutate the host process table.
+orphan *ARGS:
+    @rust-script scripts/dev/orphan-cleanup.rs {{ ARGS }}
+
 # Install cross-compilation targets for GitHub Actions compatibility.
 setup-cross:
     @printf "\033[0;34m Installing cross-compilation targets...\033[0m\n"

--- a/scripts/dev/orphan-cleanup.rs
+++ b/scripts/dev/orphan-cleanup.rs
@@ -1,0 +1,267 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [dependencies]
+//! anyhow = "1"
+//! colored = "2"
+//! ```
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+//!
+//! orphan-cleanup.rs — find and kill stale `uffs` / `uffs.exe` processes
+//! that were left behind by an aborted CLI invocation, a crashed test
+//! harness, or a Ctrl-C'd validation script, while leaving the
+//! legitimate long-running daemon (and its parent shell) untouched.
+//!
+//! The validation suites (`scripts/windows/{api,cli,mcp}-validation.rs`)
+//! used to perform this cleanup as their final step.  That coupled
+//! "did the test pass?" with "is the host process table tidy?" — two
+//! orthogonal concerns — so the cleanup logic now lives here and is
+//! invoked by `just orphan` (or directly via `rust-script`) only when
+//! the operator asks for it.
+//!
+//! Usage:
+//!   rust-script scripts/dev/orphan-cleanup.rs
+//!   rust-script scripts/dev/orphan-cleanup.rs --bin target/release/uffs
+//!   rust-script scripts/dev/orphan-cleanup.rs --dry-run
+//!
+//! How "orphan" is decided:
+//!   1. Run `<bin> daemon status` to learn the legitimate daemon PID.
+//!   2. Enumerate every running `uffs[.exe]` process on the host.
+//!   3. Anything that is **not** the daemon, and **not** this script
+//!      itself, is an orphan.
+//!
+//! Cross-platform:
+//!   * Unix : `ps -eo pid,command`              + `kill -9 <pid>`
+//!   * Windows : `wmic process ... CommandLine` + `taskkill /F /PID`
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::Result;
+use colored::Colorize;
+
+fn main() -> Result<()> {
+    let mut args_iter = std::env::args().skip(1);
+    let mut bin_override: Option<String> = None;
+    let mut dry_run = false;
+    while let Some(arg) = args_iter.next() {
+        match arg.as_str() {
+            "--bin" | "-b" | "--binary" => bin_override = args_iter.next(),
+            "--dry-run" | "-n" => dry_run = true,
+            "--help" | "-h" => {
+                eprintln!("Usage: rust-script scripts/dev/orphan-cleanup.rs [--bin <path>] [--dry-run]");
+                eprintln!();
+                eprintln!("  --bin <path>   Override the uffs binary used to query daemon PID.");
+                eprintln!("                 Default: $HOME/bin/uffs[.exe], target/release/uffs[.exe], or PATH.");
+                eprintln!("  --dry-run      List orphan processes without killing them.");
+                return Ok(());
+            }
+            other => {
+                eprintln!("Unknown argument: {other}");
+                eprintln!("Run with --help for usage.");
+                std::process::exit(2);
+            }
+        }
+    }
+
+    let bin = bin_override.unwrap_or_else(default_binary);
+
+    eprintln!();
+    eprintln!("┌───────────────────────────────────────────────────────────────┐");
+    eprintln!("│  Orphan uffs-process cleanup                                 │");
+    eprintln!("└───────────────────────────────────────────────────────────────┘");
+    eprintln!("  Binary:  {}", bin.cyan());
+    if dry_run {
+        eprintln!("  Mode:    {} (no processes will be killed)", "dry-run".yellow().bold());
+    }
+
+    // 1. Ask the daemon for its PID via `daemon status` so we always
+    //    have the authoritative current PID — even if the on-disk PID
+    //    file went stale (different binary, restart race, etc.).
+    let daemon_pid = read_daemon_pid_via_status(&bin);
+    match daemon_pid {
+        Some(pid) => eprintln!("  {} Daemon verified (PID {pid})", "✅".green()),
+        None      => eprintln!("  {} Daemon not reachable — every uffs process is an orphan candidate", "⚠️".yellow()),
+    }
+
+    // 2. Enumerate every uffs[.exe] process on the host.
+    let bin_name = std::path::Path::new(&bin)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("uffs");
+    let all_procs = find_uffs_processes(bin_name);
+
+    // 3. Filter: skip self, skip the legitimate daemon.
+    let my_pid = std::process::id();
+    let orphans: Vec<&(u32, String)> = all_procs
+        .iter()
+        .filter(|(pid, _)| {
+            *pid != my_pid && daemon_pid.map_or(true, |dp| *pid != dp)
+        })
+        .collect();
+
+    if orphans.is_empty() {
+        eprintln!("  {} No orphan uffs processes found.", "✅".green());
+        return Ok(());
+    }
+
+    eprintln!(
+        "  {} {} orphan uffs process(es){}:",
+        "⚠️".yellow(),
+        orphans.len(),
+        if dry_run { "" } else { " — killing" },
+    );
+    let mut killed = 0_usize;
+    for (pid, cmdline) in &orphans {
+        eprintln!("    PID {pid}: {cmdline}");
+        if !dry_run && kill_process(*pid) {
+            killed += 1;
+        }
+    }
+    if dry_run {
+        eprintln!("  {} Re-run without --dry-run to actually kill them.", "ℹ".cyan());
+    } else {
+        eprintln!("  🔪 Killed {killed}/{} orphan process(es).", orphans.len());
+    }
+    Ok(())
+}
+
+/// Locate an existing uffs binary; do **not** auto-build.
+///
+/// Mirrors `scripts/windows/{api,cli,mcp}-validation.rs::default_binary`
+/// — same search order so the cleanup runs against whatever artifact
+/// the validation suites would also use.
+///
+/// Search order (cross-platform):
+///   1. `$HOME/bin/uffs[.exe]`           — `just use` install location
+///   2. `target/release/uffs[.exe]`      — `cargo build --release` output
+///   3. Bare `uffs[.exe]`                — falls through to PATH lookup
+fn default_binary() -> String {
+    let bin_name = if cfg!(windows) { "uffs.exe" } else { "uffs" };
+    let home_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    let home = std::env::var(home_var).unwrap_or_else(|_| ".".to_string());
+    let candidates = [
+        PathBuf::from(&home).join("bin").join(bin_name),
+        PathBuf::from("target").join("release").join(bin_name),
+    ];
+    for candidate in &candidates {
+        if candidate.exists() {
+            return candidate.to_string_lossy().into_owned();
+        }
+    }
+    bin_name.to_string()
+}
+
+/// Run `<bin> daemon status` and extract the `Daemon PID:` value.
+///
+/// Returns `None` when the daemon is unreachable (no socket, no
+/// listener, no `Daemon PID:` line in the output).  Same parser
+/// pattern as the validation scripts' `capture_daemon_version`,
+/// targeting a different label.
+fn read_daemon_pid_via_status(bin: &str) -> Option<u32> {
+    let out = Command::new(bin).args(["daemon", "status"]).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("Daemon PID:") {
+            return rest.trim().parse::<u32>().ok();
+        }
+    }
+    None
+}
+
+/// Returns `Vec<(pid, command line)>` for every running `<bin_name>`
+/// process visible to the current user.
+fn find_uffs_processes(bin_name: &str) -> Vec<(u32, String)> {
+    let my_pid = std::process::id();
+
+    #[cfg(unix)]
+    {
+        // `ps -eo pid,command` lists all visible processes with their
+        // full command line.  Filter for our binary name, skip
+        // helper processes like `ps`, `grep`, and `rust-script`.
+        let output = Command::new("ps").args(["-eo", "pid,command"]).output().ok();
+        let stdout = output
+            .as_ref()
+            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+            .unwrap_or_default();
+        stdout
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                if !line.contains(bin_name) {
+                    return None;
+                }
+                if line.contains("ps -eo") || line.contains("grep") || line.contains("rust-script") {
+                    return None;
+                }
+                let mut parts = line.splitn(2, char::is_whitespace);
+                let pid: u32 = parts.next()?.trim().parse().ok()?;
+                let cmd = parts.next().unwrap_or("").trim().to_string();
+                if pid == my_pid {
+                    return None;
+                }
+                Some((pid, cmd))
+            })
+            .collect()
+    }
+
+    #[cfg(windows)]
+    {
+        // WMIC carries the full command line; `tasklist` does not.
+        let output = Command::new("wmic")
+            .args([
+                "process",
+                "where",
+                &format!("name like '%{bin_name}%'"),
+                "get",
+                "ProcessId,CommandLine",
+                "/format:csv",
+            ])
+            .output()
+            .ok();
+        let stdout = output
+            .as_ref()
+            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+            .unwrap_or_default();
+        stdout
+            .lines()
+            .skip(1) // CSV header
+            .filter_map(|line| {
+                let fields: Vec<&str> = line.split(',').collect();
+                if fields.len() < 3 {
+                    return None;
+                }
+                let cmd = fields[1].trim().to_string();
+                let pid: u32 = fields[2].trim().parse().ok()?;
+                if pid == my_pid || cmd.is_empty() {
+                    return None;
+                }
+                Some((pid, cmd))
+            })
+            .collect()
+    }
+}
+
+/// Send SIGKILL (Unix) or `taskkill /F` (Windows) to the given PID.
+fn kill_process(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        Command::new("kill")
+            .args(["-9", &pid.to_string()])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(windows)]
+    {
+        Command::new("taskkill")
+            .args(["/F", "/PID", &pid.to_string()])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+}

--- a/scripts/windows/api-validation.rs
+++ b/scripts/windows/api-validation.rs
@@ -196,59 +196,61 @@ fn find_workspace_root() -> PathBuf {
     cwd
 }
 
-/// Build a fresh release binary and return the path to it (macOS/Linux).
-fn ensure_fresh_release_build() -> String {
-    let workspace = find_workspace_root();
-    let binary_path = workspace.join("target").join("release").join("uffs");
-
-    eprintln!("╔══════════════════════════════════════════════════════════════════╗");
-    eprintln!("║  Building fresh release binary...                                ║");
-    eprintln!("╚══════════════════════════════════════════════════════════════════╝");
-    eprintln!("  Workspace: {}", workspace.display());
-
-    let start = Instant::now();
-    let status = Command::new("cargo")
-        .args(["build", "--release", "-p", "uffs-cli"])
-        .current_dir(&workspace)
-        .status();
-
-    match status {
-        Ok(s) if s.success() => {
-            eprintln!("  ✅ Build completed in {:.1}s", start.elapsed().as_secs_f64());
-            eprintln!("  Binary: {}", binary_path.display());
-            eprintln!();
-        }
-        Ok(s) => {
-            eprintln!("  ❌ cargo build --release failed (exit {s})");
-            std::process::exit(1);
-        }
-        Err(e) => {
-            eprintln!("  ❌ Failed to run cargo: {e}");
-            std::process::exit(1);
-        }
-    }
-
-    binary_path.to_string_lossy().into_owned()
-}
-
-/// Locate the uffs binary.
+/// Locate an existing uffs binary; do **not** auto-build.
 ///
-/// On non-Windows: build a fresh release binary.
-/// On Windows: check ~/bin, target/release, then PATH.
+/// Validation scripts run against whatever artifact is on disk so the
+/// user can control which build is being exercised (release tag,
+/// local `cargo build --release`, or installed `just use` payload).
+/// Auto-rebuilding from inside the script masks the very mismatch
+/// these suites are meant to detect.
+///
+/// Search order (cross-platform):
+///   1. `$HOME/bin/uffs[.exe]`           — `just use` install location
+///   2. `target/release/uffs[.exe]`      — `cargo build --release` output
+///   3. Bare `uffs[.exe]`                — falls through to PATH lookup
+///
+/// If none exists, the first `Command::new(bin).output()` call surfaces
+/// the OS's "executable not found" error with the path-search
+/// diagnostic — clearer than a fabricated panic from this layer.
 fn default_binary() -> String {
-    if !cfg!(windows) {
-        return ensure_fresh_release_build();
-    }
-    let bin_name = "uffs.exe";
-    let home = std::env::var("USERPROFILE").unwrap_or_else(|_| ".".to_string());
+    let bin_name = if cfg!(windows) { "uffs.exe" } else { "uffs" };
+    let home_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    let home = std::env::var(home_var).unwrap_or_else(|_| ".".to_string());
     let candidates = [
-        format!("{home}\\bin\\{bin_name}"),
-        format!("target\\release\\{bin_name}"),
+        PathBuf::from(&home).join("bin").join(bin_name),
+        PathBuf::from("target").join("release").join(bin_name),
     ];
-    for c in &candidates {
-        if std::path::Path::new(c).exists() { return c.clone(); }
+    for candidate in &candidates {
+        if candidate.exists() {
+            return candidate.to_string_lossy().into_owned();
+        }
     }
     bin_name.to_string()
+}
+
+/// Run `<bin> daemon status` and extract the daemon's reported
+/// version string for inclusion in the validation-summary block.
+///
+/// Returns the trimmed value of the `Version:` line printed by
+/// `uffs daemon status` on uffs ≥ 0.5.79.  Pre-0.5.79 daemons emit
+/// `<unknown> (daemon) / X.Y.Z (cli)` via the CLI's back-compat
+/// renderer; pre-this-feature daemons (no `Version:` line at all)
+/// surface as `<line not found>`.  When the daemon is unreachable
+/// the helper reports `<not running>` instead of erroring — the
+/// version line is informational, not load-bearing.
+fn capture_daemon_version(bin: &str) -> String {
+    match Command::new(bin).args(["daemon", "status"]).output() {
+        Ok(out) if out.status.success() => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            for line in text.lines() {
+                if let Some(rest) = line.strip_prefix("Version:") {
+                    return rest.trim().to_owned();
+                }
+            }
+            "<line not found>".to_owned()
+        }
+        _ => "<not running>".to_owned(),
+    }
 }
 
 /// Detect whether the user passed a file or directory and return the
@@ -2595,6 +2597,39 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> bool {
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
+/// Extract the test ID (e.g. `"T04"`) from a test name like
+/// `"T04 search foo bar"`.
+///
+/// The validation suites use space-prefixed test names where the first
+/// whitespace-separated token is the canonical ID.  Mirrors
+/// `cli-validation.rs::test_id` so the three suites stay in lock-step
+/// on retest-command shape.
+fn test_id(name: &str) -> String {
+    name.split_whitespace()
+        .next()
+        .unwrap_or(name)
+        .to_uppercase()
+}
+
+/// Find the longest common prefix of a set of strings.
+///
+/// Used by the failure-summary block to suggest a single
+/// `--tests <prefix>` re-run command when every failed test ID shares
+/// a common stem.  Mirrors `mcp-validation.rs::common_prefix` and
+/// `cli-validation.rs::common_prefix` byte-for-byte.
+fn common_prefix(strings: &[&str]) -> String {
+    if strings.is_empty() { return String::new(); }
+    let first = strings[0];
+    let mut len = first.len();
+    for s in &strings[1..] {
+        len = len.min(s.len());
+        for (i, (a, b)) in first.bytes().zip(s.bytes()).enumerate() {
+            if a != b { len = len.min(i); break; }
+        }
+    }
+    first[..len].to_string()
+}
+
 fn main() {
     let script_start = Instant::now();
     let _lock = ValidationLock::acquire();
@@ -2797,10 +2832,12 @@ fn main() {
     }
 
     let script_total_ms = script_start.elapsed().as_millis();
+    let daemon_version = capture_daemon_version(&args.bin);
     eprintln!();
     eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     eprintln!("  {} Timing Breakdown", "⏱".dimmed());
     eprintln!("  ─────────────────────────────────────────────────────");
+    eprintln!("  Daemon version:       {daemon_version}");
     eprintln!("  Daemon ready:         {:>7}ms  (status check + start + drive load)", daemon_ms);
     eprintln!("  ─────────────────────────────────────────────────────");
     eprintln!("  Tests wall time:      {:>7}ms  ({test_count} tests, parallelism: {max_par})", test_wall_ms);
@@ -2816,115 +2853,71 @@ fn main() {
     eprintln!("  Script total:         {:>7}ms", script_total_ms);
     eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
 
-    // ═══ Cleanup: verify daemon, kill orphan uffs processes ═════════════
-    cleanup_orphan_processes(&sock, &args.bin);
+    // ═══ Daemon STATUS + STATS — observe-only post-run snapshot ═════════
+    //
+    // The validation suite is a strict observer: it does not kill orphan
+    // processes or mutate the host in any way.  Those concerns live in
+    // `scripts/dev/orphan-cleanup.rs` (callable via `just orphan`).
+    print_uffs_command_block(&args.bin, &["daemon", "status"], "═══ Daemon STATUS ═══");
+    print_uffs_command_block(&args.bin, &["daemon", "stats"],  "═══ Daemon STATS ═══");
 
     if failed > 0 {
+        // Build retest command with failed test IDs.  Same shape as
+        // `mcp-validation.rs` and `cli-validation.rs` so the three
+        // validation suites give the operator a one-line copy-pasteable
+        // replay regardless of which suite produced the failure.
+        let failed_ids: Vec<String> = results.iter()
+            .filter(|r| !r.passed)
+            .map(|r| test_id(&r.name))
+            .collect();
+        eprintln!();
+        eprintln!("  Retest failed using:");
+        let joined = failed_ids.join(",");
+        eprintln!("    rust-script scripts/windows/api-validation.rs --tests {joined}");
+        if failed_ids.len() > 1 {
+            // Suggest a prefix shortcut when every failed ID shares one
+            // (e.g. RPC.4 / RPC.7 → RPC.).
+            let id_refs: Vec<&str> = failed_ids.iter().map(String::as_str).collect();
+            let prefix = common_prefix(&id_refs);
+            if !prefix.is_empty() && prefix.len() >= 2 {
+                eprintln!();
+                eprintln!("  Or by prefix:");
+                eprintln!("    rust-script scripts/windows/api-validation.rs --tests {prefix}");
+            }
+        }
         std::process::exit(1);
     }
 }
 
-// ── Orphan Process Cleanup ──────────────────────────────────────────────────
+// ── Post-run STATUS / STATS rendering ───────────────────────────────────────
 
-/// Query the daemon for its PID, find all running uffs processes, and kill
-/// only the orphans.  The legitimate daemon is left running so other clients
-/// (TUI, MCP, etc.) are not disrupted.
-fn cleanup_orphan_processes(sock: &str, bin: &str) {
+/// Run `<bin> <args...>` and render its stdout under a 2-space-indented
+/// `<header>` so the validation summary embeds the daemon's own
+/// `daemon status` / `daemon stats` output verbatim.
+///
+/// The CLI already formats these views nicely (Index heap, RSS, mimalloc,
+/// per-drive breakdown, agg-cache hit-rate, etc.), so re-formatting here
+/// would just diverge them over time.  Failures are surfaced inline
+/// rather than aborting — the STATUS block is observability, not a gate.
+fn print_uffs_command_block(bin: &str, args: &[&str], header: &str) {
     eprintln!();
-    eprintln!("┌───────────────────────────────────────────────────────────────┐");
-    eprintln!("│  Cleanup: verifying daemon & checking for orphan processes   │");
-    eprintln!("└───────────────────────────────────────────────────────────────┘");
-
-    // 1. Ask the daemon for its PID via the status RPC.
-    let daemon_pid = rpc_call(sock, "status", None)
-        .ok()
-        .and_then(|resp| resp.pointer("/result/pid").and_then(|v| v.as_u64()))
-        .map(|p| p as u32);
-
-    if let Some(pid) = daemon_pid {
-        eprintln!("  {} Daemon verified (PID {pid})", "✅".green());
-    } else {
-        eprintln!("  {} Could not query daemon PID — it may have stopped", "⚠️".yellow());
-    }
-
-    // 2. Find all uffs processes.
-    let bin_name = std::path::Path::new(bin)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("uffs");
-    let all_procs = find_uffs_processes(bin_name);
-
-    // 3. Separate daemon from orphans.
-    let my_pid = std::process::id();
-    let orphans: Vec<_> = all_procs
-        .iter()
-        .filter(|(pid, _)| {
-            *pid != my_pid && daemon_pid.map_or(true, |dp| *pid != dp)
-        })
-        .collect();
-
-    if orphans.is_empty() {
-        eprintln!("  {} No orphan uffs processes found.", "✅".green());
-        return;
-    }
-
-    eprintln!(
-        "  {} {} orphan uffs process(es) — killing:",
-        "⚠️".yellow(),
-        orphans.len()
-    );
-    let mut killed = 0;
-    for (pid, cmdline) in &orphans {
-        eprintln!("    PID {pid}: {cmdline}");
-        if kill_process(*pid) {
-            killed += 1;
+    eprintln!("  {header}");
+    match Command::new(bin).args(args).output() {
+        Ok(out) if out.status.success() => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            for line in text.lines() {
+                eprintln!("    {line}");
+            }
+        }
+        Ok(out) => {
+            eprintln!("    (command failed: exit {})", out.status.code().unwrap_or(-1));
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            for line in stderr.lines() {
+                eprintln!("    {line}");
+            }
+        }
+        Err(e) => {
+            eprintln!("    (failed to run: {e})");
         }
     }
-    eprintln!("  🔪 Killed {killed}/{} orphan process(es).", orphans.len());
-}
-
-/// Returns Vec of (pid, command line) for running uffs processes.
-fn find_uffs_processes(bin_name: &str) -> Vec<(u32, String)> {
-    let my_pid = std::process::id();
-    let output = Command::new("ps")
-        .args(["-eo", "pid,command"])
-        .output()
-        .ok();
-    let stdout = output
-        .as_ref()
-        .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
-        .unwrap_or_default();
-
-    stdout
-        .lines()
-        .filter_map(|line| {
-            let line = line.trim();
-            if !line.contains(bin_name) {
-                return None;
-            }
-            // Skip ps/grep/rust-script themselves.
-            if line.contains("ps -eo")
-                || line.contains("grep")
-                || line.contains("rust-script")
-            {
-                return None;
-            }
-            let mut parts = line.splitn(2, char::is_whitespace);
-            let pid: u32 = parts.next()?.trim().parse().ok()?;
-            let cmd = parts.next().unwrap_or("").trim().to_string();
-            if pid == my_pid {
-                return None;
-            }
-            Some((pid, cmd))
-        })
-        .collect()
-}
-
-/// Kill a process by PID.  Returns true if the kill signal was sent.
-fn kill_process(pid: u32) -> bool {
-    Command::new("kill")
-        .args(["-9", &pid.to_string()])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
 }

--- a/scripts/windows/cli-validation.rs
+++ b/scripts/windows/cli-validation.rs
@@ -221,21 +221,7 @@ fn parse_script_args() -> ScriptArgs {
         }
     };
 
-    let bin = bin_override.unwrap_or_else(|| {
-        if cfg!(windows) {
-            let home = std::env::var("USERPROFILE").unwrap_or_else(|_| ".".to_string());
-            let candidates = [
-                format!("{home}\\bin\\uffs.exe"),
-                "target\\release\\uffs.exe".to_string(),
-            ];
-            for c in &candidates {
-                if std::path::Path::new(c).exists() { return c.clone(); }
-            }
-            "uffs".to_string()
-        } else {
-            ensure_fresh_release_build()
-        }
-    });
+    let bin = bin_override.unwrap_or_else(default_binary);
 
     ScriptArgs { bin, source_flag, source_path, test_filter }
 }
@@ -256,39 +242,61 @@ fn find_workspace_root() -> std::path::PathBuf {
     cwd
 }
 
-/// Build a fresh release binary and return the path to it (macOS/Linux).
-fn ensure_fresh_release_build() -> String {
-    let workspace = find_workspace_root();
-    let binary_path = workspace.join("target").join("release").join("uffs");
-
-    eprintln!("╔══════════════════════════════════════════════════════════════════╗");
-    eprintln!("║  Building fresh release binary...                                ║");
-    eprintln!("╚══════════════════════════════════════════════════════════════════╝");
-    eprintln!("  Workspace: {}", workspace.display());
-
-    let start = Instant::now();
-    let status = Command::new("cargo")
-        .args(["build", "--release", "-p", "uffs-cli"])
-        .current_dir(&workspace)
-        .status();
-
-    match status {
-        Ok(s) if s.success() => {
-            eprintln!("  ✅ Build completed in {:.1}s", start.elapsed().as_secs_f64());
-            eprintln!("  Binary: {}", binary_path.display());
-            eprintln!();
-        }
-        Ok(s) => {
-            eprintln!("  ❌ cargo build --release failed (exit {s})");
-            std::process::exit(1);
-        }
-        Err(e) => {
-            eprintln!("  ❌ Failed to run cargo: {e}");
-            std::process::exit(1);
+/// Locate an existing uffs binary; do **not** auto-build.
+///
+/// Validation scripts run against whatever artifact is on disk so the
+/// user can control which build is being exercised (release tag,
+/// local `cargo build --release`, or installed `just use` payload).
+/// Auto-rebuilding from inside the script masks the very mismatch
+/// these suites are meant to detect.
+///
+/// Search order (cross-platform):
+///   1. `$HOME/bin/uffs[.exe]`           — `just use` install location
+///   2. `target/release/uffs[.exe]`      — `cargo build --release` output
+///   3. Bare `uffs[.exe]`                — falls through to PATH lookup
+///
+/// If none exists, the first `Command::new(bin).output()` call surfaces
+/// the OS's "executable not found" error with the path-search
+/// diagnostic — clearer than a fabricated panic from this layer.
+fn default_binary() -> String {
+    let bin_name = if cfg!(windows) { "uffs.exe" } else { "uffs" };
+    let home_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    let home = std::env::var(home_var).unwrap_or_else(|_| ".".to_string());
+    let candidates = [
+        std::path::PathBuf::from(&home).join("bin").join(bin_name),
+        std::path::PathBuf::from("target").join("release").join(bin_name),
+    ];
+    for candidate in &candidates {
+        if candidate.exists() {
+            return candidate.to_string_lossy().into_owned();
         }
     }
+    bin_name.to_string()
+}
 
-    binary_path.to_string_lossy().into_owned()
+/// Run `<bin> daemon status` and extract the daemon's reported
+/// version string for inclusion in the validation-summary block.
+///
+/// Returns the trimmed value of the `Version:` line printed by
+/// `uffs daemon status` on uffs ≥ 0.5.79.  Pre-0.5.79 daemons emit
+/// `<unknown> (daemon) / X.Y.Z (cli)` via the CLI's back-compat
+/// renderer; pre-this-feature daemons (no `Version:` line at all)
+/// surface as `<line not found>`.  When the daemon is unreachable
+/// the helper reports `<not running>` instead of erroring — the
+/// version line is informational, not load-bearing.
+fn capture_daemon_version(bin: &str) -> String {
+    match Command::new(bin).args(["daemon", "status"]).output() {
+        Ok(out) if out.status.success() => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            for line in text.lines() {
+                if let Some(rest) = line.strip_prefix("Version:") {
+                    return rest.trim().to_owned();
+                }
+            }
+            "<line not found>".to_owned()
+        }
+        _ => "<not running>".to_owned(),
+    }
 }
 
 // ── Validation Helpers ───────────────────────────────────────────────────────
@@ -2087,6 +2095,26 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> u128 {
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
+/// Find the longest common prefix of a set of strings.
+///
+/// Used by the failure-summary block to suggest a single `--tests <prefix>`
+/// re-run command when every failed test ID shares a common stem (e.g.
+/// all `T88a`, `T88b`, `T88c` failures collapse to `T88`).  Mirrors
+/// `mcp-validation.rs::common_prefix` byte-for-byte so the three
+/// validation suites behave identically on this output.
+fn common_prefix(strings: &[&str]) -> String {
+    if strings.is_empty() { return String::new(); }
+    let first = strings[0];
+    let mut len = first.len();
+    for s in &strings[1..] {
+        len = len.min(s.len());
+        for (i, (a, b)) in first.bytes().zip(s.bytes()).enumerate() {
+            if a != b { len = len.min(i); break; }
+        }
+    }
+    first[..len].to_string()
+}
+
 /// Extract the test ID (e.g. "T88H") from a test name like "T88h --in-path + pattern".
 fn test_id(name: &str) -> String {
     // Take everything up to the first space.
@@ -2110,7 +2138,6 @@ fn main() {
     let _lock = ValidationLock::acquire();
     let script_start = Instant::now();
     let args = parse_script_args();
-    let build_ms = script_start.elapsed().as_millis();
     eprintln!();
     eprintln!("╔═══════════════════════════════════════════════════════════════╗");
     eprintln!("║  UFFS CLI Flag Validation Suite                              ║");
@@ -2185,11 +2212,12 @@ fn main() {
     let slowest = results.iter().max_by_key(|r| r.duration_ms);
     let fastest = results.iter().filter(|r| r.duration_ms > 0).min_by_key(|r| r.duration_ms);
 
+    let daemon_version = capture_daemon_version(&args.bin);
     eprintln!();
     eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     eprintln!("  {} Timing Breakdown", "⏱".dimmed());
     eprintln!("  ─────────────────────────────────────────────────────");
-    eprintln!("  Build binary:         {:>7}ms", build_ms);
+    eprintln!("  Daemon version:       {daemon_version}");
     eprintln!("  Daemon ready:         {:>7}ms  (status check + start + drive load)", daemon_ms);
     eprintln!("  ─────────────────────────────────────────────────────");
     eprintln!("  Tests wall time:      {:>7}ms  ({test_count} tests, parallelism: {max_par})", test_wall_ms);
@@ -2205,164 +2233,72 @@ fn main() {
     eprintln!("  Script total:         {:>7}ms", script_total_ms);
     eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
 
-    // ═══ Cleanup: find and kill orphan uffs processes ═══════════════════
-    cleanup_orphan_processes(&args.bin);
+    // ═══ Daemon STATUS + STATS — observe-only post-run snapshot ═════════
+    //
+    // The validation suite is a strict observer: it does not kill orphan
+    // processes or mutate the host in any way.  Those concerns live in
+    // `scripts/dev/orphan-cleanup.rs` (callable via `just orphan`).
+    print_uffs_command_block(&args.bin, &["daemon", "status"], "═══ Daemon STATUS ═══");
+    print_uffs_command_block(&args.bin, &["daemon", "stats"],  "═══ Daemon STATS ═══");
+
+    if failed > 0 {
+        // Build retest command with failed test IDs.  Same shape as
+        // `mcp-validation.rs` so the three validation suites give the
+        // operator a one-line copy-pasteable replay.
+        let failed_ids: Vec<String> = results.iter()
+            .filter(|r| !r.passed)
+            .map(|r| test_id(&r.name))
+            .collect();
+        eprintln!();
+        eprintln!("  Retest failed using:");
+        let joined = failed_ids.join(",");
+        eprintln!("    rust-script scripts/windows/cli-validation.rs --tests {joined}");
+        if failed_ids.len() > 1 {
+            // Suggest a prefix shortcut when every failed ID shares one
+            // (e.g. T88a / T88b / T88c → T88).
+            let id_refs: Vec<&str> = failed_ids.iter().map(String::as_str).collect();
+            let prefix = common_prefix(&id_refs);
+            if !prefix.is_empty() && prefix.len() >= 2 {
+                eprintln!();
+                eprintln!("  Or by prefix:");
+                eprintln!("    rust-script scripts/windows/cli-validation.rs --tests {prefix}");
+            }
+        }
+    }
 
     // Exit code: fail if any test failed.
     std::process::exit(if failed == 0 { 0 } else { 1 });
 }
 
-// ── Orphan Process Cleanup ──────────────────────────────────────────────────
+// ── Post-run STATUS / STATS rendering ───────────────────────────────────────
 
-/// Query the daemon for its PID (via PID file), find all running uffs
-/// processes, and kill only the orphans.  The legitimate daemon is left
-/// running so other clients (TUI, MCP, etc.) are not disrupted.
-fn cleanup_orphan_processes(bin: &str) {
-    eprintln!();
-    eprintln!("┌───────────────────────────────────────────────────────────────┐");
-    eprintln!("│  Cleanup: verifying daemon & checking for orphan processes   │");
-    eprintln!("└───────────────────────────────────────────────────────────────┘");
-
-    // 1. Read daemon PID from the PID file.
-    let daemon_pid = read_daemon_pid();
-    if let Some(pid) = daemon_pid {
-        eprintln!("  {} Daemon verified (PID {pid})", "✅".green());
-    } else {
-        eprintln!("  {} Could not read daemon PID file — daemon may not be running", "⚠️".yellow());
-    }
-
-    // 2. Find all uffs processes.
-    let bin_name = std::path::Path::new(bin)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("uffs");
-    let all_procs = find_uffs_processes(bin_name);
-
-    // 3. Separate daemon from orphans.
-    let my_pid = std::process::id();
-    let orphans: Vec<_> = all_procs
-        .iter()
-        .filter(|(pid, _)| {
-            *pid != my_pid && daemon_pid.map_or(true, |dp| *pid != dp)
-        })
-        .collect();
-
-    if orphans.is_empty() {
-        eprintln!("  {} No orphan uffs processes found.", "✅".green());
-        return;
-    }
-
-    eprintln!(
-        "  {} {} orphan uffs process(es) — killing:",
-        "⚠️".yellow(),
-        orphans.len()
-    );
-    let mut killed = 0;
-    for (pid, cmdline) in &orphans {
-        eprintln!("    PID {pid}: {cmdline}");
-        if kill_process(*pid) {
-            killed += 1;
-        }
-    }
-    eprintln!("  🔪 Killed {killed}/{} orphan process(es).", orphans.len());
-}
-
-/// Read the daemon PID from the standard PID file location.
+/// Run `<bin> <args...>` and render its stdout under a 2-space-indented
+/// `<header>` so the validation summary embeds the daemon's own
+/// `daemon status` / `daemon stats` output verbatim.
 ///
-/// PID file format: `{pid}\n{timestamp}\n{exe_hash}\n{nonce}\n`
-fn read_daemon_pid() -> Option<u32> {
-    let base = dirs_next::data_local_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-    let pid_path = base.join("uffs").join("daemon.pid");
-    let content = std::fs::read_to_string(&pid_path).ok()?;
-    let pid: u32 = content.lines().next()?.parse().ok()?;
-    if pid == 0 { return None; }
-    Some(pid)
-}
-
-/// Returns Vec of (pid, command line) for running uffs processes.
-fn find_uffs_processes(bin_name: &str) -> Vec<(u32, String)> {
-    let my_pid = std::process::id();
-
-    #[cfg(unix)]
-    {
-        // `ps -eo pid,command` lists all processes.
-        let output = Command::new("ps")
-            .args(["-eo", "pid,command"])
-            .output()
-            .ok();
-        let stdout = output
-            .as_ref()
-            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
-            .unwrap_or_default();
-
-        stdout
-            .lines()
-            .filter_map(|line| {
-                let line = line.trim();
-                // Match lines containing our binary name but skip ourselves.
-                if !line.contains(bin_name) {
-                    return None;
-                }
-                // Skip ps/grep/rust-script themselves.
-                if line.contains("ps -eo") || line.contains("grep") || line.contains("rust-script") {
-                    return None;
-                }
-                let mut parts = line.splitn(2, char::is_whitespace);
-                let pid: u32 = parts.next()?.trim().parse().ok()?;
-                let cmd = parts.next().unwrap_or("").trim().to_string();
-                if pid == my_pid {
-                    return None;
-                }
-                Some((pid, cmd))
-            })
-            .collect()
-    }
-
-    #[cfg(windows)]
-    {
-        // Use WMIC for process info (more reliable than tasklist for full command lines).
-        let output = Command::new("wmic")
-            .args(["process", "where", &format!("name like '%{bin_name}%'"),
-                   "get", "ProcessId,CommandLine", "/format:csv"])
-            .output()
-            .ok();
-        let stdout = output
-            .as_ref()
-            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
-            .unwrap_or_default();
-
-        stdout
-            .lines()
-            .skip(1) // header
-            .filter_map(|line| {
-                let fields: Vec<&str> = line.split(',').collect();
-                if fields.len() < 3 { return None; }
-                let cmd = fields[1].trim().to_string();
-                let pid: u32 = fields[2].trim().parse().ok()?;
-                if pid == my_pid || cmd.is_empty() { return None; }
-                Some((pid, cmd))
-            })
-            .collect()
-    }
-}
-
-/// Kill a process by PID.  Returns true if the kill signal was sent.
-fn kill_process(pid: u32) -> bool {
-    #[cfg(unix)]
-    {
-        Command::new("kill")
-            .args(["-9", &pid.to_string()])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
-    }
-
-    #[cfg(windows)]
-    {
-        Command::new("taskkill")
-            .args(["/F", "/PID", &pid.to_string()])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+/// The CLI already formats these views nicely (Index heap, RSS, mimalloc,
+/// per-drive breakdown, agg-cache hit-rate, etc.), so re-formatting here
+/// would just diverge them over time.  Failures are surfaced inline
+/// rather than aborting — the STATUS block is observability, not a gate.
+fn print_uffs_command_block(bin: &str, args: &[&str], header: &str) {
+    eprintln!();
+    eprintln!("  {header}");
+    match Command::new(bin).args(args).output() {
+        Ok(out) if out.status.success() => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            for line in text.lines() {
+                eprintln!("    {line}");
+            }
+        }
+        Ok(out) => {
+            eprintln!("    (command failed: exit {})", out.status.code().unwrap_or(-1));
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            for line in stderr.lines() {
+                eprintln!("    {line}");
+            }
+        }
+        Err(e) => {
+            eprintln!("    (failed to run: {e})");
+        }
     }
 }

--- a/scripts/windows/mcp-validation.rs
+++ b/scripts/windows/mcp-validation.rs
@@ -6,7 +6,6 @@
 //! toml = "0.8"
 //! anyhow = "1"
 //! colored = "2"
-//! dirs-next = "2"
 //! ```
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
@@ -61,38 +60,60 @@ fn find_workspace_root() -> PathBuf {
     cwd
 }
 
-fn ensure_fresh_release_build() -> String {
-    let ws = find_workspace_root();
-    let bin = ws.join("target").join("release").join("uffs");
-    eprintln!("╔══════════════════════════════════════════════════════════════════╗");
-    eprintln!("║  Building fresh release binary...                                ║");
-    eprintln!("╚══════════════════════════════════════════════════════════════════╝");
-    eprintln!("  Workspace: {}", ws.display());
-    let start = Instant::now();
-    let status = Command::new("cargo")
-        .args(["build", "--release", "-p", "uffs-cli"])
-        .current_dir(&ws).status();
-    match status {
-        Ok(s) if s.success() => {
-            eprintln!("  ✅ Build completed in {:.1}s", start.elapsed().as_secs_f64());
-            eprintln!("  Binary: {}", bin.display());
-            eprintln!();
+/// Locate an existing uffs binary; do **not** auto-build.
+///
+/// Validation scripts run against whatever artifact is on disk so the
+/// user can control which build is being exercised (release tag,
+/// local `cargo build --release`, or installed `just use` payload).
+/// Auto-rebuilding from inside the script masks the very mismatch
+/// these suites are meant to detect.
+///
+/// Search order (cross-platform):
+///   1. `$HOME/bin/uffs[.exe]`           — `just use` install location
+///   2. `target/release/uffs[.exe]`      — `cargo build --release` output
+///   3. Bare `uffs[.exe]`                — falls through to PATH lookup
+///
+/// If none exists, the first `Command::new(bin).output()` call surfaces
+/// the OS's "executable not found" error with the path-search
+/// diagnostic — clearer than a fabricated panic from this layer.
+fn default_binary() -> String {
+    let bin_name = if cfg!(windows) { "uffs.exe" } else { "uffs" };
+    let home_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    let home = std::env::var(home_var).unwrap_or_else(|_| ".".to_string());
+    let candidates = [
+        PathBuf::from(&home).join("bin").join(bin_name),
+        PathBuf::from("target").join("release").join(bin_name),
+    ];
+    for candidate in &candidates {
+        if candidate.exists() {
+            return candidate.to_string_lossy().into_owned();
         }
-        Ok(s) => { eprintln!("  ❌ Build failed ({s})"); std::process::exit(1); }
-        Err(e) => { eprintln!("  ❌ cargo: {e}"); std::process::exit(1); }
     }
-    bin.to_string_lossy().into_owned()
+    bin_name.to_string()
 }
 
-fn default_binary() -> String {
-    if cfg!(windows) {
-        if let Ok(h) = std::env::var("USERPROFILE") {
-            let d = PathBuf::from(&h).join("bin").join("uffs.exe");
-            if d.exists() { return d.to_string_lossy().into_owned(); }
+/// Run `<bin> daemon status` and extract the daemon's reported
+/// version string for inclusion in the validation-summary block.
+///
+/// Returns the trimmed value of the `Version:` line printed by
+/// `uffs daemon status` on uffs ≥ 0.5.79.  Pre-0.5.79 daemons emit
+/// `<unknown> (daemon) / X.Y.Z (cli)` via the CLI's back-compat
+/// renderer; pre-this-feature daemons (no `Version:` line at all)
+/// surface as `<line not found>`.  When the daemon is unreachable
+/// the helper reports `<not running>` instead of erroring — the
+/// version line is informational, not load-bearing.
+fn capture_daemon_version(bin: &str) -> String {
+    match Command::new(bin).args(["daemon", "status"]).output() {
+        Ok(out) if out.status.success() => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            for line in text.lines() {
+                if let Some(rest) = line.strip_prefix("Version:") {
+                    return rest.trim().to_owned();
+                }
+            }
+            "<line not found>".to_owned()
         }
-        "target\\release\\uffs.exe".to_string()
-    } else {
-        ensure_fresh_release_build()
+        _ => "<not running>".to_owned(),
     }
 }
 
@@ -1683,7 +1704,6 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> u128 {
 fn main() -> Result<()> {
     let script_start = Instant::now();
     let args = parse_args();
-    let build_ms = script_start.elapsed().as_millis();
 
     eprintln!("╔═══════════════════════════════════════════════════════════════╗");
     eprintln!("║  UFFS MCP Capability & Conformance Validation               ║");
@@ -1943,11 +1963,12 @@ fn main() -> Result<()> {
     let slowest = results.iter().max_by_key(|r| r.elapsed_ms);
     let fastest = results.iter().filter(|r| r.passed).min_by_key(|r| r.elapsed_ms);
 
+    let daemon_version = capture_daemon_version(&args.bin);
     eprintln!();
     eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     eprintln!("  {} Timing Breakdown", "⏱".dimmed());
     eprintln!("  ─────────────────────────────────────────────────────");
-    eprintln!("  Build binary:         {:>7}ms", build_ms);
+    eprintln!("  Daemon version:       {daemon_version}");
     eprintln!("  Daemon ready:         {:>7}ms  (status check + start + drive load)", daemon_ms);
     eprintln!("  ─────────────────────────────────────────────────────");
     eprintln!("  Tests wall time:      {:>7}ms  ({total} tests, parallelism: {n_workers})", test_wall_ms);
@@ -1963,8 +1984,22 @@ fn main() -> Result<()> {
     eprintln!("  Script total:         {:>7}ms", script_total_ms);
     eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
 
-    // ═══ Cleanup: verify daemon, kill orphan uffs processes ═════════════
-    cleanup_orphan_processes(&args.bin);
+    // ═══ Daemon + MCP STATUS + STATS — observe-only post-run snapshot ═══
+    //
+    // The validation suite is a strict observer: it does not kill orphan
+    // processes or mutate the host in any way.  Those concerns live in
+    // `scripts/dev/orphan-cleanup.rs` (callable via `just orphan`).
+    //
+    // Three blocks:
+    //   * `daemon status` — Index heap, RSS, mimalloc, per-drive
+    //   * `daemon stats`  — queries served, agg-cache hit-rate
+    //   * `status`        — combined system view incl. MCP gateway +
+    //                       MCP stdio sessions (this suite specifically
+    //                       exercises the MCP surface, so the gateway
+    //                       telemetry belongs in the summary).
+    print_uffs_command_block(&args.bin, &["daemon", "status"], "═══ Daemon STATUS ═══");
+    print_uffs_command_block(&args.bin, &["daemon", "stats"],  "═══ Daemon STATS ═══");
+    print_uffs_command_block(&args.bin, &["status"],           "═══ MCP STATUS (system-wide) ═══");
 
     if failed > 0 {
         // Build retest command with failed test IDs.
@@ -1994,110 +2029,36 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-// ── Orphan Process Cleanup ──────────────────────────────────────────────────
+// ── Post-run STATUS / STATS rendering ───────────────────────────────────────
 
-/// Find all running uffs processes via `ps`.
-fn find_uffs_processes(bin_name: &str) -> Vec<(u32, String)> {
-    let my_pid = std::process::id();
-    let output = Command::new("ps")
-        .args(["-eo", "pid,command"])
-        .output()
-        .ok();
-    let stdout = output
-        .as_ref()
-        .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
-        .unwrap_or_default();
-
-    stdout
-        .lines()
-        .filter_map(|line| {
-            let line = line.trim();
-            if !line.contains(bin_name) { return None; }
-            // Skip ps/grep/rust-script themselves.
-            if line.contains("ps -eo") || line.contains("grep") || line.contains("rust-script") {
-                return None;
-            }
-            let mut parts = line.splitn(2, char::is_whitespace);
-            let pid: u32 = parts.next()?.trim().parse().ok()?;
-            let cmd = parts.next().unwrap_or("").trim().to_string();
-            if pid == my_pid { return None; }
-            Some((pid, cmd))
-        })
-        .collect()
-}
-
-/// Read the daemon PID from the PID file.
-/// File format: `{pid}\n{timestamp}\n{exe_hash}\n{nonce}\n` — we read line 1.
-fn read_daemon_pid() -> Option<u32> {
-    let base = dirs_next::data_local_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-    let pid_path = base.join("uffs").join("daemon.pid");
-    let content = std::fs::read_to_string(&pid_path).ok()?;
-    content.lines().next()?.trim().parse().ok()
-}
-
-/// Query the daemon for its PID, find all running uffs processes, and kill
-/// only the orphans.  The legitimate daemon is left running.
-fn cleanup_orphan_processes(bin: &str) {
+/// Run `<bin> <args...>` and render its stdout under a 2-space-indented
+/// `<header>` so the validation summary embeds the daemon's own
+/// `daemon status` / `daemon stats` / `status` output verbatim.
+///
+/// The CLI already formats these views nicely (Index heap, RSS, mimalloc,
+/// per-drive breakdown, agg-cache hit-rate, MCP gateway state, MCP stdio
+/// sessions, etc.), so re-formatting here would just diverge them over
+/// time.  Failures are surfaced inline rather than aborting — the STATUS
+/// blocks are observability, not gates.
+fn print_uffs_command_block(bin: &str, args: &[&str], header: &str) {
     eprintln!();
-    eprintln!("┌───────────────────────────────────────────────────────────────┐");
-    eprintln!("│  Cleanup: verifying daemon & checking for orphan processes   │");
-    eprintln!("└───────────────────────────────────────────────────────────────┘");
-
-    let daemon_pid = read_daemon_pid();
-    if let Some(pid) = daemon_pid {
-        eprintln!("  {} Daemon verified (PID {pid})", "✅".green());
-    } else {
-        eprintln!("  {} Could not read daemon PID file — daemon may not be running", "⚠️".yellow());
-    }
-
-    let bin_name = std::path::Path::new(bin)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("uffs");
-    let all_procs = find_uffs_processes(bin_name);
-
-    // Protect: our own PID, the daemon PID, and any `daemon run` or `mcp run`
-    // processes (those are the legitimate daemon and MCP server).
-    let my_pid = std::process::id();
-    let orphans: Vec<_> = all_procs
-        .iter()
-        .filter(|(pid, cmd)| {
-            if *pid == my_pid { return false; }
-            if daemon_pid.map_or(false, |dp| *pid == dp) { return false; }
-            // Keep daemon and MCP server processes alive.
-            let cmd_lower = cmd.to_lowercase();
-            if cmd_lower.contains("daemon run") || cmd_lower.contains("mcp run") {
-                return false;
+    eprintln!("  {header}");
+    match Command::new(bin).args(args).output() {
+        Ok(out) if out.status.success() => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            for line in text.lines() {
+                eprintln!("    {line}");
             }
-            true
-        })
-        .collect();
-
-    if orphans.is_empty() {
-        eprintln!("  {} No orphan uffs processes found.", "✅".green());
-        return;
-    }
-
-    eprintln!("  {} {} orphan uffs process(es) — killing:",
-        "⚠️".yellow(), orphans.len());
-
-    let mut killed = 0;
-    for (pid, cmd) in &orphans {
-        eprintln!("    PID {pid}: {cmd}");
-        #[cfg(unix)]
-        {
-            use std::process::Command as Cmd;
-            let ok = Cmd::new("kill").arg("-9").arg(pid.to_string())
-                .output().map(|o| o.status.success()).unwrap_or(false);
-            if ok { killed += 1; }
         }
-        #[cfg(windows)]
-        {
-            use std::process::Command as Cmd;
-            let ok = Cmd::new("taskkill").args(["/F", "/PID", &pid.to_string()])
-                .output().map(|o| o.status.success()).unwrap_or(false);
-            if ok { killed += 1; }
+        Ok(out) => {
+            eprintln!("    (command failed: exit {})", out.status.code().unwrap_or(-1));
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            for line in stderr.lines() {
+                eprintln!("    {line}");
+            }
+        }
+        Err(e) => {
+            eprintln!("    (failed to run: {e})");
         }
     }
-    eprintln!("  🔪 Killed {killed}/{} orphan process(es).", orphans.len());
 }


### PR DESCRIPTION
Consolidated fix-it batch for two infra issues (#80, #83) plus a UX/observability layer that surfaced during cross-platform smoke testing of v0.5.78.

Validates green on local Mac through the full lint-fast hook on every commit; CI green pending here.

## Changes by commit

| | Commit | Layer | Summary |
|-|---|---|---|
| 1 | `cac4ea502` | ci | `release.yml` cache uses `shared-key` for partial restore on Cargo.lock churn (#80) |
| 2 | `aac7512a4` | ci | Pin Swatinem/rust-cache to v2.9.1 release SHA across all 17 workflow sites (#80) |
| 3 | `5cf00e0cc` | feat (cli + daemon) | Show daemon+cli version in `daemon status` / `daemon stats` / `uffs status` |
| 4 | `2f9f14657` | refactor (scripts) | Validation suites are observe-only; STATUS+STATS summary; `just orphan` |
| 5 | `b639eac58` | ci | tier-2.yml — add `cache-on-failure` + per-job shared-keys (#83) |
| 6 | `1369b1d98` | ci | Step-level `CARGO_BUILD_JOBS=2` on tier-2 build-validation (#83 — turned out redundant; kept for explicit-intent at the step site) |
| 7 | `de82cde94` | ci | cargo-vet-refresh — disable sccache wrapper on hosted runners |
| 8 | `7a0553517` | ci | tier-2 — drop `CARGO_BUILD_JOBS` from 2 to 1 (#83) |

## Closes / mitigates

- **Closes #80** — \"UFFS Release Pipeline - Swatinem/rust-cache - not found\". Two-layer fix (cache-key strategy + SHA repin to v2.9.1); already commented + closed on the issue.
- **Mitigates #83** — \"Tier 2 Nightly CI — 459bfae\". Build Validation hit `exit 143` (SIGTERM mid-link) twice on the same run with `CARGO_BUILD_JOBS=2` already in scope. Drops to 1 (fully serialised compile/link), plus `cache-on-failure: 'true'` so future pre-emption is cheap to recover from. Validation requires a `workflow_dispatch` after this PR merges.

## Wire-protocol additions (back-compat)

`StatusResponse.version: String` and `StatsResponse.version: String`, both `#[serde(default)]` so a new CLI talking to a pre-this-PR daemon decodes a missing field as `\"\"` and renders `<unknown> (daemon) / <cli> (cli)`. Daemon-state types extracted to a new sibling `crates/uffs-client/src/protocol/response_status.rs` (with `pub use` re-exports) so `response.rs` stays under the 800-LOC policy without requiring a file-size exception.

## Validation script changes

`scripts/windows/{api,cli,mcp}-validation.rs`:

- No more in-script `cargo build --release` — suites run against whatever artifact is on disk (`\$HOME/bin/uffs`, `target/release/uffs`, or `PATH`).
- No more `cleanup_orphan_processes` — that logic moved to the new `scripts/dev/orphan-cleanup.rs` (cross-platform, dry-run support), invokable via `just orphan`.
- New `Daemon STATUS` + `Daemon STATS` blocks (and an `MCP STATUS (system-wide)` block in `mcp-validation.rs`) embedded in the post-run summary.
- `Retest failed using:` block + `common_prefix` helper added to api/cli suites; mcp had it already.

## Local validation

Every commit ran the lint-fast hook on commit:

- file-size  ✓
- typos  ✓
- reuse  ✓
- fmt-check  ✓ (where applicable)
- lint-prod / lint-tests / lint-ci  ✓ (where applicable)

Plus targeted runs:

- `cargo nextest run -p uffs-client --lib`  →  158/158 pass
- `cargo nextest run -p {client,daemon,cli} --lib`  →  271/271 pass
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p {client,daemon,cli} --no-deps`  →  clean
- `bash scripts/ci/check_file_size_policy.sh`  →  ALLOW (response.rs back under cap)
- `actionlint .github/workflows/{tier-2,cargo-vet-refresh,release}.yml`  →  clean on changed lines
- `rust-script --package` on each refactored validation script  →  clean
- `just orphan --dry-run`  →  correctly identifies daemon PID 94874, reports zero orphans
- Live `./target/release/uffs daemon status` against the user's pre-this-PR daemon prints `Version:       <unknown> (daemon) / 0.5.78 (cli)` — confirming the back-compat path

## Outstanding post-merge verifications

- **Tier 2** (#83): `gh workflow run tier-2.yml --ref main` after merge — confirm Build Validation is green with `CARGO_BUILD_JOBS=1`.
- **cargo-vet-refresh**: `gh workflow run cargo-vet-refresh.yml --ref main` after merge — confirm `cargo vet regenerate imports` runs without the sccache spawn error.