### PR TITLE
feat(daemon): Phase 3 — state machine + lazy body load (memory tiering)

### DIFF
--- a/crates/uffs-daemon/src/cache/body_loader.rs
+++ b/crates/uffs-daemon/src/cache/body_loader.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Body source for the Phase 3 demote / promote orchestrator.
+//!
+//! Phase 3 of the memory-tiering work
+//! (`docs/refactor/memory-tiering-implementation-plan.md`).
+//!
+//! [`IndexManager::ensure_warm_for_dispatch`] needs to materialise a
+//! `DriveCompactIndex` for any `Parked` / `Cold` shard the search
+//! hot path touches.  The production source is the encrypted compact
+//! cache on disk
+//! (`<cache_dir>/<letter>_compact.uffs`); tests inject deterministic
+//! fakes (fixed body, missing body, panicking loader) without
+//! touching the platform cache directory.
+//!
+//! Both flavours implement [`BodyLoader`].  The trait is **sync** —
+//! the caller in `IndexManager` wraps every call in
+//! `tokio::task::spawn_blocking` since the production loader does
+//! file I/O + decryption.  Test fakes are cheap and could be sync,
+//! but the same `spawn_blocking` wrapper applies uniformly to keep
+//! the call site simple.
+//!
+//! [`IndexManager::ensure_warm_for_dispatch`]:
+//!     crate::index::IndexManager::ensure_warm_for_dispatch
+
+use alloc::sync::Arc;
+
+use uffs_core::compact::DriveCompactIndex;
+
+/// Source for `Parked` / `Cold` shard bodies.
+///
+/// Implementations are held by [`crate::index::IndexManager`] as an
+/// `Arc<dyn BodyLoader>` so the manager can be constructed with the
+/// production [`DiskBodyLoader`] for normal daemon operation, or
+/// with a test fake for the Commit-E integration tests.
+///
+/// The single method is **synchronous** — the demote / promote
+/// orchestrator wraps every call in
+/// `tokio::task::spawn_blocking`, so implementations can do file
+/// I/O, decryption, allocation, or whatever they need without
+/// blocking the async runtime.  Async work inside the loader is
+/// not supported and would deadlock the spawn-blocking thread
+/// pool.
+///
+/// Returning `None` is a graceful failure: the orchestrator emits
+/// a `target: "shard.transition"` warning and leaves the shard in
+/// its current tier.  A panic is also recovered by the
+/// `JoinError` arm in the orchestrator and emits an error-level
+/// `shard.transition` event; the shard stays put.
+pub(crate) trait BodyLoader: Send + Sync + 'static {
+    /// Materialise the body for `letter`, or return `None` if the
+    /// underlying source is missing / stale / corrupted.
+    fn load(&self, letter: char) -> Option<Arc<DriveCompactIndex>>;
+}
+
+/// Production loader: reads
+/// `<cache_dir>/<letter>_compact.uffs`, validates the header,
+/// decrypts the encrypted body, and assembles a fresh
+/// `DriveCompactIndex` (heap or runtime-mmap variant per
+/// `compact_cache`'s own selection logic).
+///
+/// `ttl_seconds = u64::MAX` skips the freshness check — the
+/// demote / promote path doesn't care if the cache is "old", only
+/// that it is a valid serialisation of the drive that *was* loaded.
+/// Phase 4+ may add an explicit `mft_build_epoch` check to detect
+/// out-of-band MFT churn between demote and promote; for Phase 3
+/// the cache is trusted unconditionally.
+pub(crate) struct DiskBodyLoader;
+
+impl BodyLoader for DiskBodyLoader {
+    fn load(&self, letter: char) -> Option<Arc<DriveCompactIndex>> {
+        uffs_core::compact_cache::load_compact_cache(letter, u64::MAX, 0, true).map(Arc::new)
+    }
+}

--- a/crates/uffs-daemon/src/cache/mod.rs
+++ b/crates/uffs-daemon/src/cache/mod.rs
@@ -28,6 +28,7 @@
 //! [`ShardRegistry::active_index`] begins to diverge from the full
 //! shard list.
 
+pub(crate) mod body_loader;
 pub(crate) mod policy;
 pub(crate) mod registry;
 pub(crate) mod shard;

--- a/crates/uffs-daemon/src/cache/mod.rs
+++ b/crates/uffs-daemon/src/cache/mod.rs
@@ -28,6 +28,7 @@
 //! [`ShardRegistry::active_index`] begins to diverge from the full
 //! shard list.
 
+pub(crate) mod policy;
 pub(crate) mod registry;
 pub(crate) mod shard;
 
@@ -41,3 +42,23 @@ pub(crate) mod shard;
 // re-export list as more callers join.
 pub(crate) use registry::ShardRegistry;
 pub(crate) use shard::ShardState;
+
+/// Current Unix-millis timestamp for the cache subsystem's clocks.
+///
+/// Single canonical clock function shared by:
+///
+/// * [`crate::index::IndexManager::record_search_dispatch`] — stamps every
+///   Warm/Hot shard's `DriveStats::last_query_at_ms` on each dispatch.
+/// * The Phase-3 demote controller (Commit D, in
+///   [`registry::ShardRegistry::demote_idle_shards`]) — reads
+///   `last_query_at_ms` to compute `idle_secs`.
+///
+/// Returns `0` when the system clock is set before 1970-01-01 so the
+/// fallback matches the "never queried" sentinel
+/// `DriveStats::last_query_at_ms == 0` used by the demote controller.
+#[must_use]
+pub(crate) fn unix_now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |dur| u64::try_from(dur.as_millis()).unwrap_or(u64::MAX))
+}

--- a/crates/uffs-daemon/src/cache/mod.rs
+++ b/crates/uffs-daemon/src/cache/mod.rs
@@ -50,7 +50,7 @@ pub(crate) use shard::ShardState;
 /// * [`crate::index::IndexManager::record_search_dispatch`] — stamps every
 ///   Warm/Hot shard's `DriveStats::last_query_at_ms` on each dispatch.
 /// * The Phase-3 demote controller (Commit D, in
-///   [`registry::ShardRegistry::demote_idle_shards`]) — reads
+///   [`crate::index::IndexManager::demote_idle_shards`]) — reads
 ///   `last_query_at_ms` to compute `idle_secs`.
 ///
 /// Returns `0` when the system clock is set before 1970-01-01 so the

--- a/crates/uffs-daemon/src/cache/policy.rs
+++ b/crates/uffs-daemon/src/cache/policy.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Static-TTL placeholder policy for the Phase 3 demote/promote
+//! controller.
+//!
+//! Phase 3 of the memory-tiering work
+//! (`docs/refactor/memory-tiering-implementation-plan.md`).
+//!
+//! Adaptive TTL controllers live in Phase 6; for now every shard
+//! shares the same fixed thresholds:
+//!
+//! * **Hot → Warm** at [`HOT_TO_WARM_IDLE_SECS`] (5 min idle).
+//! * **Warm → Parked** at [`WARM_TO_PARKED_IDLE_SECS`] (30 min idle).
+//! * **Parked → Cold** at [`PARKED_TO_COLD_IDLE_SECS`] (24 h idle).
+//!
+//! [`next_state_for_idle`] is the single decision function consumed by
+//! `crate::cache::registry::ShardRegistry::demote_idle_shards`; it
+//! returns `None` when the shard is not yet idle past its current
+//! tier's TTL or when the tier is already at the bottom.
+
+use super::shard::ShardState;
+
+/// After this many seconds without a query a `Hot` shard demotes to
+/// `Warm`.  Phase 4+ extends "no query" to "no bloom-positive query"
+/// so cold drives don't re-warm just because their bloom got faulted
+/// in by a wildcard scan.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 3 Commit D consumer (`ShardRegistry::demote_idle_shards`); \
+                  Commit A lands the constant + the policy decision function \
+                  ahead of the controller that reads them."
+    )
+)]
+pub(crate) const HOT_TO_WARM_IDLE_SECS: u64 = 300;
+
+/// After this many seconds without a query a `Warm` shard demotes to
+/// `Parked`, dropping the runtime mmap (the records / names columns
+/// are released; bloom + trie persist in Phase 4+).
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 3 Commit D consumer; see HOT_TO_WARM_IDLE_SECS."
+    )
+)]
+pub(crate) const WARM_TO_PARKED_IDLE_SECS: u64 = 1800;
+
+/// After this many seconds without a query a `Parked` shard demotes
+/// to `Cold`, dropping bloom + trie too.  A `Cold` shard requires a
+/// full re-decrypt of the encrypted compact cache to re-promote, so
+/// the threshold is generous (24 h) — anything shorter risks
+/// thrashing under nightly batch processes that scan archives once
+/// per day.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 3 Commit D consumer; see HOT_TO_WARM_IDLE_SECS."
+    )
+)]
+pub(crate) const PARKED_TO_COLD_IDLE_SECS: u64 = 86_400;
+
+/// Decide whether a shard in `state` that has been idle for
+/// `idle_secs` seconds should demote to a colder tier.
+///
+/// Returns the target state on demote, or `None` when:
+///
+/// * the shard has not been idle long enough for its current tier, or
+/// * the shard is already at the bottom of the tier ladder
+///   ([`ShardState::Cold`], [`ShardState::Unknown`], [`ShardState::Evicting`])
+///   — only the controller produces those states, the policy never selects them
+///   as a *target*.
+///
+/// `Hot` skips straight to `Warm` rather than `Parked` so a brief
+/// idle window doesn't re-cost a runtime-mmap rebuild on the next
+/// query.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 3 Commit D consumer (`ShardRegistry::demote_idle_shards`); \
+                  Commit A lands the decision function ahead of the controller \
+                  that reads it."
+    )
+)]
+#[must_use]
+pub(crate) const fn next_state_for_idle(state: ShardState, idle_secs: u64) -> Option<ShardState> {
+    match state {
+        ShardState::Hot if idle_secs >= HOT_TO_WARM_IDLE_SECS => Some(ShardState::Warm),
+        ShardState::Warm if idle_secs >= WARM_TO_PARKED_IDLE_SECS => Some(ShardState::Parked),
+        ShardState::Parked if idle_secs >= PARKED_TO_COLD_IDLE_SECS => Some(ShardState::Cold),
+        // Two distinct cases collapsed into one arm because they
+        // share the same outcome:
+        //   * Hot / Warm / Parked: idle window not exceeded for the current tier (the guard above
+        //     this arm failed).
+        //   * Cold / Unknown / Evicting: floor + controller-only states; the policy never targets
+        //     these.
+        ShardState::Hot
+        | ShardState::Warm
+        | ShardState::Parked
+        | ShardState::Cold
+        | ShardState::Unknown
+        | ShardState::Evicting => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hot_demotes_to_warm_at_threshold() {
+        assert_eq!(
+            next_state_for_idle(ShardState::Hot, HOT_TO_WARM_IDLE_SECS),
+            Some(ShardState::Warm)
+        );
+        assert_eq!(
+            next_state_for_idle(ShardState::Hot, HOT_TO_WARM_IDLE_SECS + 1),
+            Some(ShardState::Warm)
+        );
+    }
+
+    #[test]
+    fn hot_does_not_demote_below_threshold() {
+        assert_eq!(next_state_for_idle(ShardState::Hot, 0), None);
+        assert_eq!(
+            next_state_for_idle(ShardState::Hot, HOT_TO_WARM_IDLE_SECS - 1),
+            None
+        );
+    }
+
+    #[test]
+    fn warm_demotes_to_parked_at_threshold() {
+        assert_eq!(
+            next_state_for_idle(ShardState::Warm, WARM_TO_PARKED_IDLE_SECS),
+            Some(ShardState::Parked)
+        );
+    }
+
+    #[test]
+    fn warm_does_not_demote_below_threshold() {
+        // Crucially below the warm-to-parked threshold even though
+        // it's already past the hot-to-warm one — `Warm` shards don't
+        // care about the hot threshold.
+        assert_eq!(
+            next_state_for_idle(ShardState::Warm, HOT_TO_WARM_IDLE_SECS),
+            None
+        );
+        assert_eq!(
+            next_state_for_idle(ShardState::Warm, WARM_TO_PARKED_IDLE_SECS - 1),
+            None
+        );
+    }
+
+    #[test]
+    fn parked_demotes_to_cold_at_threshold() {
+        assert_eq!(
+            next_state_for_idle(ShardState::Parked, PARKED_TO_COLD_IDLE_SECS),
+            Some(ShardState::Cold)
+        );
+    }
+
+    #[test]
+    fn parked_does_not_demote_below_threshold() {
+        assert_eq!(
+            next_state_for_idle(ShardState::Parked, WARM_TO_PARKED_IDLE_SECS),
+            None
+        );
+        assert_eq!(
+            next_state_for_idle(ShardState::Parked, PARKED_TO_COLD_IDLE_SECS - 1),
+            None
+        );
+    }
+
+    #[test]
+    fn floor_states_never_demote() {
+        for state in [ShardState::Cold, ShardState::Unknown, ShardState::Evicting] {
+            for idle_secs in [
+                0,
+                HOT_TO_WARM_IDLE_SECS,
+                WARM_TO_PARKED_IDLE_SECS,
+                PARKED_TO_COLD_IDLE_SECS,
+                u64::MAX,
+            ] {
+                assert_eq!(
+                    next_state_for_idle(state, idle_secs),
+                    None,
+                    "{state:?} at {idle_secs}s should never demote"
+                );
+            }
+        }
+    }
+
+    /// Pin the ladder so a future tweak can't accidentally make
+    /// `PARKED_TO_COLD_IDLE_SECS` shorter than
+    /// `WARM_TO_PARKED_IDLE_SECS`, which would mean a parked shard
+    /// could demote to Cold faster than a warm one demotes to
+    /// Parked.  Compile-time `const _: ()` so the invariant is
+    /// enforced at build time, not at test run.
+    const _: () = assert!(HOT_TO_WARM_IDLE_SECS < WARM_TO_PARKED_IDLE_SECS);
+    const _: () = assert!(WARM_TO_PARKED_IDLE_SECS < PARKED_TO_COLD_IDLE_SECS);
+}

--- a/crates/uffs-daemon/src/cache/policy.rs
+++ b/crates/uffs-daemon/src/cache/policy.rs
@@ -25,27 +25,14 @@ use super::shard::ShardState;
 /// `Warm`.  Phase 4+ extends "no query" to "no bloom-positive query"
 /// so cold drives don't re-warm just because their bloom got faulted
 /// in by a wildcard scan.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Phase 3 Commit D consumer (`ShardRegistry::demote_idle_shards`); \
-                  Commit A lands the constant + the policy decision function \
-                  ahead of the controller that reads them."
-    )
-)]
+///
+/// Consumed by [`crate::index::IndexManager::demote_idle_shards`]
+/// (Phase 3 Commit D) via [`next_state_for_idle`].
 pub(crate) const HOT_TO_WARM_IDLE_SECS: u64 = 300;
 
 /// After this many seconds without a query a `Warm` shard demotes to
 /// `Parked`, dropping the runtime mmap (the records / names columns
 /// are released; bloom + trie persist in Phase 4+).
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Phase 3 Commit D consumer; see HOT_TO_WARM_IDLE_SECS."
-    )
-)]
 pub(crate) const WARM_TO_PARKED_IDLE_SECS: u64 = 1800;
 
 /// After this many seconds without a query a `Parked` shard demotes
@@ -54,13 +41,6 @@ pub(crate) const WARM_TO_PARKED_IDLE_SECS: u64 = 1800;
 /// the threshold is generous (24 h) — anything shorter risks
 /// thrashing under nightly batch processes that scan archives once
 /// per day.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Phase 3 Commit D consumer; see HOT_TO_WARM_IDLE_SECS."
-    )
-)]
 pub(crate) const PARKED_TO_COLD_IDLE_SECS: u64 = 86_400;
 
 /// Decide whether a shard in `state` that has been idle for
@@ -77,15 +57,10 @@ pub(crate) const PARKED_TO_COLD_IDLE_SECS: u64 = 86_400;
 /// `Hot` skips straight to `Warm` rather than `Parked` so a brief
 /// idle window doesn't re-cost a runtime-mmap rebuild on the next
 /// query.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Phase 3 Commit D consumer (`ShardRegistry::demote_idle_shards`); \
-                  Commit A lands the decision function ahead of the controller \
-                  that reads it."
-    )
-)]
+///
+/// Wired into the production demote path by
+/// [`crate::index::IndexManager::demote_idle_shards`] (Phase 3
+/// Commit D).
 #[must_use]
 pub(crate) const fn next_state_for_idle(state: ShardState, idle_secs: u64) -> Option<ShardState> {
     match state {

--- a/crates/uffs-daemon/src/cache/registry.rs
+++ b/crates/uffs-daemon/src/cache/registry.rs
@@ -309,15 +309,10 @@ impl ShardRegistry {
     /// The per-drive `Arc<DriveStats>` from the demoted shard is
     /// shared with the new `Warm` entry so the round-trip
     /// demote-and-back preserves query counters.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "Phase 3 Commit C consumer (search-hot-path promote); \
-                      Commit B lands the helper so the promote logic + tracing \
-                      contract is reviewable independently of the wiring."
-        )
-    )]
+    ///
+    /// Wired into the search hot path by
+    /// [`crate::index::IndexManager::ensure_warm_for_dispatch`]
+    /// (Phase 3 Commit C).
     #[must_use]
     pub(crate) fn promote_letter(
         &self,

--- a/crates/uffs-daemon/src/cache/registry.rs
+++ b/crates/uffs-daemon/src/cache/registry.rs
@@ -26,15 +26,6 @@ use super::shard::{ShardEntry, ShardState};
 /// (`Parked → Parked`, `Cold → Cold`) are intentionally rejected so
 /// a buggy controller can't silently rebuild the registry on every
 /// idle tick for an already-demoted shard.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Phase 3 Commit B helper for `ShardRegistry::demote_letter`; \
-                  the demote_letter consumer is itself dead_code until \
-                  Commit D wires the idle-timer controller."
-    )
-)]
 const fn is_legal_demote_target(from: ShardState, target: ShardState) -> bool {
     // Single match arm so clippy's `match_same_arms` is satisfied:
     //
@@ -227,15 +218,10 @@ impl ShardRegistry {
     /// caller's old `Arc` keeps reading the old state forever, the
     /// new `Arc` reads the new state forever, and the registry's
     /// `Vec` swap is the linearisation point.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "Phase 3 Commit D consumer (per-registry idle timer); \
-                      Commit B lands the helper so the demote logic + tracing \
-                      contract is reviewable independently of the controller."
-        )
-    )]
+    ///
+    /// Wired into the production demote path by
+    /// [`crate::index::IndexManager::demote_idle_shards`] (Phase 3
+    /// Commit D).
     #[must_use]
     pub(crate) fn demote_letter(&self, letter: char, target: ShardState) -> Option<Self> {
         // Locate the matching shard by enumerating once: returns

--- a/crates/uffs-daemon/src/cache/registry.rs
+++ b/crates/uffs-daemon/src/cache/registry.rs
@@ -52,10 +52,18 @@ impl ShardRegistry {
     /// registry directly.
     #[must_use]
     pub(crate) fn from_shards(shards: Vec<Arc<ShardEntry>>) -> Self {
+        // Filter on tier first so the active subset matches the
+        // documented "Warm | Hot" contract; then filter_map on `body`
+        // because Phase-3 `ShardEntry::body()` returns `Option` —
+        // `Parked` / `Cold` shards lift the body and would yield
+        // `None` here.  The double filter is intentionally redundant
+        // (every `Warm` / `Hot` shard has `Some(body)` today) so a
+        // future "Warm with body in transit" state can't silently
+        // contribute an empty entry to the active index.
         let drives: Vec<Arc<DriveCompactIndex>> = shards
             .iter()
             .filter(|shard| matches!(shard.state(), ShardState::Warm | ShardState::Hot))
-            .map(|shard| shard.body())
+            .filter_map(|shard| shard.body())
             .collect();
         Self {
             shards,

--- a/crates/uffs-daemon/src/cache/registry.rs
+++ b/crates/uffs-daemon/src/cache/registry.rs
@@ -13,6 +13,46 @@ use uffs_core::search::backend::DriveIndex;
 
 use super::shard::{ShardEntry, ShardState};
 
+/// Predicate: can a shard in `from` legally demote to `target`?
+///
+/// Looser than [`ShardState::can_transition_to`] because the
+/// registry-level rebuild in
+/// [`ShardRegistry::demote_letter`] is the linearisation point — no
+/// stable `Arc<ShardEntry>` reader ever observes an in-place state
+/// mutation, so the strict per-`ShardEntry` graph used by the
+/// test-only `try_transition` CAS path doesn't apply.
+///
+/// Demote target must be `Parked` or `Cold`.  Self-demotes
+/// (`Parked → Parked`, `Cold → Cold`) are intentionally rejected so
+/// a buggy controller can't silently rebuild the registry on every
+/// idle tick for an already-demoted shard.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 3 Commit B helper for `ShardRegistry::demote_letter`; \
+                  the demote_letter consumer is itself dead_code until \
+                  Commit D wires the idle-timer controller."
+    )
+)]
+const fn is_legal_demote_target(from: ShardState, target: ShardState) -> bool {
+    // Single match arm so clippy's `match_same_arms` is satisfied:
+    //
+    //   * Hot / Warm: demote to Parked OR Cold.
+    //   * Parked: demote to Cold only (the bloom/trie drop step in Phase 4+; no
+    //     body to drop here).
+    //
+    // Everything else (Cold/Cold, Unknown/*, Evicting/*, all
+    // self-demotes) falls through to `false`.
+    matches!(
+        (from, target),
+        (
+            ShardState::Hot | ShardState::Warm,
+            ShardState::Parked | ShardState::Cold
+        ) | (ShardState::Parked, ShardState::Cold)
+    )
+}
+
 /// Registry of per-drive shards plus a cached `Arc<DriveIndex>` over
 /// the active subset (Warm/Hot tiers).
 ///
@@ -163,6 +203,161 @@ impl ShardRegistry {
     #[must_use]
     pub(crate) const fn len(&self) -> usize {
         self.shards.len()
+    }
+
+    /// Demote the shard for `letter` to `target` (`Parked` or
+    /// `Cold`), dropping the body and emitting a single
+    /// `shard.transition` tracing event.  Returns the rebuilt
+    /// registry, or `None` when:
+    ///
+    /// * `letter` is not registered;
+    /// * `target` is not a demote-legal tier (must be `Parked` or `Cold`);
+    /// * the existing shard's state is not a legal "from" for the requested
+    ///   demote (see [`is_legal_demote_target`]).
+    ///
+    /// The per-drive `Arc<DriveStats>` is shared with the
+    /// replacement shard so query counters survive the rebuild —
+    /// Commit C's idle-timer relies on `last_query_at_ms` staying
+    /// stable across demote/promote cycles.
+    ///
+    /// Registry-level rebuilds bypass the per-`ShardEntry`
+    /// `can_transition_to` graph (which guards the test-only
+    /// `try_transition` CAS path).  No stable `Arc<ShardEntry>`
+    /// reader ever observes an in-place state mutation here: the
+    /// caller's old `Arc` keeps reading the old state forever, the
+    /// new `Arc` reads the new state forever, and the registry's
+    /// `Vec` swap is the linearisation point.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 3 Commit D consumer (per-registry idle timer); \
+                      Commit B lands the helper so the demote logic + tracing \
+                      contract is reviewable independently of the controller."
+        )
+    )]
+    #[must_use]
+    pub(crate) fn demote_letter(&self, letter: char, target: ShardState) -> Option<Self> {
+        // Locate the matching shard by enumerating once: returns
+        // `(pos, &Arc<ShardEntry>)` so we never index into
+        // `self.shards` (clippy::indexing_slicing).
+        let (pos, old_arc) = self
+            .shards
+            .iter()
+            .enumerate()
+            .find(|(_, shard)| shard.drive.eq_ignore_ascii_case(&letter))?;
+        let from_state = old_arc.state();
+        if !is_legal_demote_target(from_state, target) {
+            return None;
+        }
+        // Compute the body heap we're about to release, for the
+        // tracing event.  Done before constructing the new entry so
+        // the read happens against the still-mounted body.
+        let freed_mb = old_arc.body().map_or(0_u64, |body| {
+            (body.heap_size_bytes().total / 1_048_576) as u64
+        });
+        let stats = Arc::clone(&old_arc.stats);
+        let drive = old_arc.drive;
+        let new_entry = match target {
+            ShardState::Parked => ShardEntry::new_parked(drive, stats),
+            ShardState::Cold => ShardEntry::new_cold(drive, stats),
+            // Filtered out by `is_legal_demote_target` above; this
+            // arm is unreachable in practice, exists only so the
+            // match is exhaustive without an `unreachable!`.
+            ShardState::Unknown | ShardState::Warm | ShardState::Hot | ShardState::Evicting => {
+                return None;
+            }
+        };
+        // Build the rebuilt shards Vec via enumerate-and-replace so
+        // the indexing-into-Vec is hidden inside `iter().map()` (no
+        // raw `vec[pos] = ...` site for clippy to flag).  The old
+        // entry's Arc is dropped by the closure when its branch isn't
+        // taken; the body Arc inside it follows.
+        let new_arc = Arc::new(new_entry);
+        let shards: Vec<Arc<ShardEntry>> = self
+            .shards
+            .iter()
+            .enumerate()
+            .map(|(i, existing)| {
+                if i == pos {
+                    Arc::clone(&new_arc)
+                } else {
+                    Arc::clone(existing)
+                }
+            })
+            .collect();
+        tracing::info!(
+            target: "shard.transition",
+            letter = %letter.to_ascii_uppercase(),
+            from = %from_state,
+            to = %target,
+            freed_mb,
+            reason = "demote",
+        );
+        Some(Self::from_shards(shards))
+    }
+
+    /// Promote the shard for `letter` from `Parked` / `Cold` back
+    /// to `Warm`, attaching `body` and emitting a single
+    /// `shard.transition` tracing event.  Returns the rebuilt
+    /// registry, or `None` when:
+    ///
+    /// * `letter` is not registered;
+    /// * the existing shard's state is not `Parked` / `Cold` (a request to
+    ///   promote an already-warm shard is a caller bug).
+    ///
+    /// The per-drive `Arc<DriveStats>` from the demoted shard is
+    /// shared with the new `Warm` entry so the round-trip
+    /// demote-and-back preserves query counters.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 3 Commit C consumer (search-hot-path promote); \
+                      Commit B lands the helper so the promote logic + tracing \
+                      contract is reviewable independently of the wiring."
+        )
+    )]
+    #[must_use]
+    pub(crate) fn promote_letter(
+        &self,
+        letter: char,
+        body: Arc<DriveCompactIndex>,
+    ) -> Option<Self> {
+        let (pos, old_arc) = self
+            .shards
+            .iter()
+            .enumerate()
+            .find(|(_, shard)| shard.drive.eq_ignore_ascii_case(&letter))?;
+        let from_state = old_arc.state();
+        if !matches!(from_state, ShardState::Parked | ShardState::Cold) {
+            return None;
+        }
+        let restored_mb = (body.heap_size_bytes().total / 1_048_576) as u64;
+        let stats = Arc::clone(&old_arc.stats);
+        let drive = old_arc.drive;
+        let new_arc = Arc::new(ShardEntry::new_warm_with_stats(drive, body, stats));
+        let shards: Vec<Arc<ShardEntry>> = self
+            .shards
+            .iter()
+            .enumerate()
+            .map(|(i, existing)| {
+                if i == pos {
+                    Arc::clone(&new_arc)
+                } else {
+                    Arc::clone(existing)
+                }
+            })
+            .collect();
+        tracing::info!(
+            target: "shard.transition",
+            letter = %letter.to_ascii_uppercase(),
+            from = %from_state,
+            to = %ShardState::Warm,
+            restored_mb,
+            reason = "promote",
+        );
+        Some(Self::from_shards(shards))
     }
 
     /// `true` iff the registry has no shards at all.

--- a/crates/uffs-daemon/src/cache/shard.rs
+++ b/crates/uffs-daemon/src/cache/shard.rs
@@ -242,20 +242,35 @@ impl DriveStats {
         self.last_query_at_ms.store(now_ms, Ordering::Relaxed);
     }
 
-    /// Read the last `mark_query_at` timestamp (Unix millis).
+    /// Set [`Self::last_query_at_ms`] to `now_ms` **without** bumping
+    /// the query counter.
     ///
-    /// Returns `0` when the shard has never been queried; the demote
-    /// controller short-circuits that case to use the daemon's
-    /// startup time as an approximation of "as old as we can know".
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "Phase 3 consumer (`ShardRegistry::demote_idle_shards` reads \
-                      this to compute idle_secs); exercised by the Commit-A \
-                      `mark_query_at_updates_last_query_at_ms` test."
-        )
-    )]
+    /// Phase 3 Commit D — called by `IndexManager::add_drive` and
+    /// `IndexManager::replace_drive` once per shard the moment the
+    /// drive is mounted, so the demote-controller's idle clock
+    /// starts ticking from the load time rather than from epoch zero.
+    /// Without this seed, a freshly loaded shard's
+    /// `last_query_at_ms == 0` would compute `idle_secs ≈ now_ms /
+    /// 1000` and trigger an immediate demote on the first 30 s tick.
+    ///
+    /// Distinct from `mark_query_at` so the per-shard `queries_total`
+    /// metric stays a clean count of actual searches dispatched, not
+    /// "searches plus one extra at load".
+    pub(crate) fn mark_loaded_at(&self, now_ms: u64) {
+        self.last_query_at_ms.store(now_ms, Ordering::Relaxed);
+    }
+
+    /// Read the last activity timestamp (Unix millis).
+    ///
+    /// Updated by [`Self::mark_query_at`] (search dispatch) and
+    /// [`Self::mark_loaded_at`] (drive load).  Returns `0` only on
+    /// the snapshot-deserialisation / test paths that go through
+    /// the legacy [`Self::new`] constructor without ever calling a
+    /// setter.
+    ///
+    /// Read by [`crate::index::IndexManager::demote_idle_shards`]
+    /// (Phase 3 Commit D) to compute `idle_secs` against the
+    /// per-tier TTL ladder.
     #[must_use]
     pub(crate) fn last_query_at_ms(&self) -> u64 {
         self.last_query_at_ms.load(Ordering::Relaxed)
@@ -459,15 +474,11 @@ impl ShardEntry {
     /// `Warm` / `Hot` `ShardEntry` for this drive during a tier
     /// transition rebuild).  No body — the runtime mmap has been
     /// released.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "Phase 3 Commit B consumer (`ShardRegistry::demote_letter`); \
-                      Commit A lands the constructor so the shape is reviewable \
-                      independently of the demote/promote logic."
-        )
-    )]
+    ///
+    /// Reached from production via
+    /// [`crate::index::IndexManager::demote_idle_shards`] →
+    /// [`crate::cache::ShardRegistry::demote_letter`] (Phase 3
+    /// Commit D).
     #[must_use]
     pub(crate) const fn new_parked(drive: char, stats: Arc<DriveStats>) -> Self {
         Self {
@@ -482,15 +493,12 @@ impl ShardEntry {
     /// `Arc<DriveStats>`.  No body, no bloom, no trie — a `Cold`
     /// shard is recovered only by re-decrypting the encrypted compact
     /// cache.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "Phase 3 Commit B consumer (`ShardRegistry::demote_letter`); \
-                      Commit A lands the constructor so the shape is reviewable \
-                      independently of the demote/promote logic."
-        )
-    )]
+    ///
+    /// Reached from production via
+    /// [`crate::index::IndexManager::demote_idle_shards`] →
+    /// [`crate::cache::ShardRegistry::demote_letter`] (Phase 3
+    /// Commit D, when a `Parked` shard's idle time exceeds
+    /// `PARKED_TO_COLD_IDLE_SECS`).
     #[must_use]
     pub(crate) const fn new_cold(drive: char, stats: Arc<DriveStats>) -> Self {
         Self {

--- a/crates/uffs-daemon/src/cache/shard.rs
+++ b/crates/uffs-daemon/src/cache/shard.rs
@@ -440,15 +440,6 @@ impl ShardEntry {
     /// the promote path: a `Parked` / `Cold` shard's `Arc<DriveStats>`
     /// is lifted into the new `Warm` `ShardEntry` so the per-drive
     /// query counters survive the round-trip through demote-and-back.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "Phase 3 Commit B consumer (`ShardRegistry::promote_letter`); \
-                      Commit A lands the constructor so the shape is reviewable \
-                      independently of the demote/promote logic."
-        )
-    )]
     #[must_use]
     pub(crate) const fn new_warm_with_stats(
         drive: char,

--- a/crates/uffs-daemon/src/cache/shard.rs
+++ b/crates/uffs-daemon/src/cache/shard.rs
@@ -435,6 +435,34 @@ impl ShardEntry {
         }
     }
 
+    /// Construct a `Warm` shard wrapping `body` and sharing an
+    /// existing `Arc<DriveStats>`.  Mirror of [`Self::new_warm`] for
+    /// the promote path: a `Parked` / `Cold` shard's `Arc<DriveStats>`
+    /// is lifted into the new `Warm` `ShardEntry` so the per-drive
+    /// query counters survive the round-trip through demote-and-back.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 3 Commit B consumer (`ShardRegistry::promote_letter`); \
+                      Commit A lands the constructor so the shape is reviewable \
+                      independently of the demote/promote logic."
+        )
+    )]
+    #[must_use]
+    pub(crate) const fn new_warm_with_stats(
+        drive: char,
+        body: Arc<DriveCompactIndex>,
+        stats: Arc<DriveStats>,
+    ) -> Self {
+        Self {
+            drive,
+            state: AtomicU8::new(ShardState::Warm as u8),
+            stats,
+            body: Some(body),
+        }
+    }
+
     /// Construct a `Parked` shard sharing an existing
     /// `Arc<DriveStats>` (typically lifted off the previous
     /// `Warm` / `Hot` `ShardEntry` for this drive during a tier

--- a/crates/uffs-daemon/src/cache/shard.rs
+++ b/crates/uffs-daemon/src/cache/shard.rs
@@ -165,13 +165,21 @@ impl StdError for IllegalTransition {}
 
 /// Per-drive query rate stats.
 ///
-/// Counters use atomics so [`Self::record_query`] stays lock-free on
-/// the search hot path.  [`Self::decay_ema`] reads + writes are not
-/// strictly atomic together, but the EMA tolerates skew (it is a rate
-/// estimator, not a hard counter).
+/// Counters use atomics so [`Self::record_query`] and
+/// [`Self::mark_query_at`] stay lock-free on the search hot path.
+/// [`Self::decay_ema`] reads + writes are not strictly atomic
+/// together, but the EMA tolerates skew (it is a rate estimator, not
+/// a hard counter).
 ///
 /// Half-life of the EMA is fixed at 60 s in Phase 1; Phase 6 makes it
 /// configurable via `daemon.toml`.
+///
+/// Phase 3 wraps the live `DriveStats` in `Arc<DriveStats>` on the
+/// owning [`ShardEntry`] so the per-drive counters survive intact
+/// when the registry rebuilds a `ShardEntry` for a tier transition
+/// — the new entry shares the same `Arc<DriveStats>` and concurrent
+/// `mark_query_at` writes from in-flight searches still land on the
+/// canonical counters.
 #[derive(Debug, Default)]
 pub(crate) struct DriveStats {
     /// Total queries served against this shard.
@@ -183,6 +191,12 @@ pub(crate) struct DriveStats {
     /// Zero means "never decayed" — first call short-circuits the
     /// decay arithmetic to avoid a huge-elapsed spike from epoch 0.
     last_decay_ms: AtomicU64,
+    /// Unix-millis timestamp of the last [`Self::mark_query_at`] call.
+    /// Zero means "never queried" — the Phase-3 demote controller in
+    /// `crate::cache::registry::ShardRegistry::demote_idle_shards`
+    /// treats a zero value as "as old as the daemon" so freshly-loaded
+    /// shards aren't immediately demoted on the first 30 s tick.
+    last_query_at_ms: AtomicU64,
 }
 
 impl DriveStats {
@@ -193,12 +207,58 @@ impl DriveStats {
             queries_total: AtomicU64::new(0),
             rate_ema_micro_per_s: AtomicU64::new(0),
             last_decay_ms: AtomicU64::new(0),
+            last_query_at_ms: AtomicU64::new(0),
         }
     }
 
     /// Lock-free increment of the total query counter.
+    ///
+    /// Phase 3 prefer [`Self::mark_query_at`] which also bumps
+    /// `last_query_at_ms` so the demote controller has a fresh idle
+    /// timestamp.  This bare counter remains for callers that have no
+    /// clock available (e.g. legacy tests).
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 3 migrated production `record_search_dispatch` to \
+                      `mark_query_at(now_ms)`; this clock-free entry point is \
+                      retained for tests that don't need timestamp wiring."
+        )
+    )]
     pub(crate) fn record_query(&self) {
         self.queries_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Lock-free increment of the total query counter that **also**
+    /// stores `now_ms` in [`Self::last_query_at_ms`].
+    ///
+    /// Two relaxed atomics; not synchronised together — the demote
+    /// controller tolerates a one-tick (30 s) lag on a shard whose
+    /// `last_query_at_ms` write was reordered after the
+    /// `queries_total` increment.
+    pub(crate) fn mark_query_at(&self, now_ms: u64) {
+        self.queries_total.fetch_add(1, Ordering::Relaxed);
+        self.last_query_at_ms.store(now_ms, Ordering::Relaxed);
+    }
+
+    /// Read the last `mark_query_at` timestamp (Unix millis).
+    ///
+    /// Returns `0` when the shard has never been queried; the demote
+    /// controller short-circuits that case to use the daemon's
+    /// startup time as an approximation of "as old as we can know".
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 3 consumer (`ShardRegistry::demote_idle_shards` reads \
+                      this to compute idle_secs); exercised by the Commit-A \
+                      `mark_query_at_updates_last_query_at_ms` test."
+        )
+    )]
+    #[must_use]
+    pub(crate) fn last_query_at_ms(&self) -> u64 {
+        self.last_query_at_ms.load(Ordering::Relaxed)
     }
 
     /// Total queries served against this shard since construction.
@@ -297,6 +357,11 @@ pub(crate) struct DriveStatsSnapshot {
     pub rate_ema_micro_per_s: u64,
     /// Last decay timestamp. See [`DriveStats::last_decay_ms`].
     pub last_decay_ms: u64,
+    /// Last query timestamp. See [`DriveStats::last_query_at_ms`].
+    /// Defaults to `0` so legacy snapshots without this field
+    /// deserialise as "never queried" rather than rejecting.
+    #[serde(default)]
+    pub last_query_at_ms: u64,
 }
 
 impl From<&DriveStats> for DriveStatsSnapshot {
@@ -305,6 +370,7 @@ impl From<&DriveStats> for DriveStatsSnapshot {
             queries_total: stats.queries_total.load(Ordering::Relaxed),
             rate_ema_micro_per_s: stats.rate_ema_micro_per_s.load(Ordering::Relaxed),
             last_decay_ms: stats.last_decay_ms.load(Ordering::Relaxed),
+            last_query_at_ms: stats.last_query_at_ms.load(Ordering::Relaxed),
         }
     }
 }
@@ -315,43 +381,104 @@ impl From<DriveStatsSnapshot> for DriveStats {
             queries_total: AtomicU64::new(snap.queries_total),
             rate_ema_micro_per_s: AtomicU64::new(snap.rate_ema_micro_per_s),
             last_decay_ms: AtomicU64::new(snap.last_decay_ms),
+            last_query_at_ms: AtomicU64::new(snap.last_query_at_ms),
         }
     }
 }
 
 /// One shard's runtime state + stats + body.
 ///
-/// Phase 1 holds the body unconditionally as `Arc<DriveCompactIndex>`.
-/// Phase 2 introduces an `Option`-wrapped variant for demoted shards;
-/// Phase-1 callers can rely on [`Self::body`] always returning the
-/// index.
+/// Phase 1 held the body unconditionally as `Arc<DriveCompactIndex>`.
+/// Phase 3 makes the body optional so demoted (`Parked` / `Cold`)
+/// shards can drop their runtime mmap and bloom/trie payload.
+///
+/// `stats` is wrapped in `Arc<DriveStats>` so a tier-transition rebuild
+/// (which replaces this `ShardEntry` with a fresh one inside the
+/// registry's `Vec<Arc<ShardEntry>>`) preserves the per-drive
+/// counters — the new entry shares the same `Arc<DriveStats>` so
+/// concurrent `mark_query_at` writes from in-flight searches still
+/// land on the canonical counters.
 pub(crate) struct ShardEntry {
     /// Drive letter (`'C'`, `'D'`, …). Capital ASCII per existing
     /// daemon convention.
     pub(crate) drive: char,
     /// Tier state. Read on every search via [`Self::state`]; mutated
-    /// only by tier-transition methods (`try_transition`).
+    /// only by [`Self::try_transition`] (test-only) or by the
+    /// registry's tier-transition rebuilds (production path).
     state: AtomicU8,
-    /// Per-drive query stats.
-    pub(crate) stats: DriveStats,
-    /// In-memory compact index. Cloned cheaply (Arc bump) into
-    /// [`crate::cache::ShardRegistry::active_index`] on rebuild.
-    body: Arc<DriveCompactIndex>,
+    /// Per-drive query stats.  Wrapped in `Arc` so tier transitions
+    /// preserve them across `ShardEntry` rebuilds.
+    pub(crate) stats: Arc<DriveStats>,
+    /// In-memory compact index, present only for `Warm` / `Hot`
+    /// tiers.  Cloned cheaply (Arc bump) into
+    /// [`crate::cache::ShardRegistry::active_index`] on rebuild for
+    /// shards in those states; absent (`None`) for `Parked` / `Cold`
+    /// where the runtime mmap has been released.
+    body: Option<Arc<DriveCompactIndex>>,
 }
 
 impl ShardEntry {
     /// Construct a shard wrapping `body` and pinning it in
-    /// [`ShardState::Warm`].
+    /// [`ShardState::Warm`] with a fresh, all-zero `DriveStats`.
     ///
-    /// Phase 1 only ever creates shards in this constructor; Phase 3
-    /// adds `new_cold` / `new_parked` for boot-time partial loads.
+    /// Used for the boot-time happy path — `IndexManager::add_drive`
+    /// and `IndexManager::replace_drive` both flow through this
+    /// constructor.  Phase 3 adds [`Self::new_parked`] /
+    /// [`Self::new_cold`] for tier-transition rebuilds.
     #[must_use]
-    pub(crate) const fn new_warm(drive: char, body: Arc<DriveCompactIndex>) -> Self {
+    pub(crate) fn new_warm(drive: char, body: Arc<DriveCompactIndex>) -> Self {
         Self {
             drive,
             state: AtomicU8::new(ShardState::Warm as u8),
-            stats: DriveStats::new(),
-            body,
+            stats: Arc::new(DriveStats::new()),
+            body: Some(body),
+        }
+    }
+
+    /// Construct a `Parked` shard sharing an existing
+    /// `Arc<DriveStats>` (typically lifted off the previous
+    /// `Warm` / `Hot` `ShardEntry` for this drive during a tier
+    /// transition rebuild).  No body — the runtime mmap has been
+    /// released.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 3 Commit B consumer (`ShardRegistry::demote_letter`); \
+                      Commit A lands the constructor so the shape is reviewable \
+                      independently of the demote/promote logic."
+        )
+    )]
+    #[must_use]
+    pub(crate) const fn new_parked(drive: char, stats: Arc<DriveStats>) -> Self {
+        Self {
+            drive,
+            state: AtomicU8::new(ShardState::Parked as u8),
+            stats,
+            body: None,
+        }
+    }
+
+    /// Construct a `Cold` shard sharing an existing
+    /// `Arc<DriveStats>`.  No body, no bloom, no trie — a `Cold`
+    /// shard is recovered only by re-decrypting the encrypted compact
+    /// cache.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 3 Commit B consumer (`ShardRegistry::demote_letter`); \
+                      Commit A lands the constructor so the shape is reviewable \
+                      independently of the demote/promote logic."
+        )
+    )]
+    #[must_use]
+    pub(crate) const fn new_cold(drive: char, stats: Arc<DriveStats>) -> Self {
+        Self {
+            drive,
+            state: AtomicU8::new(ShardState::Cold as u8),
+            stats,
+            body: None,
         }
     }
 
@@ -361,10 +488,12 @@ impl ShardEntry {
         ShardState::from_repr(self.state.load(Ordering::Acquire))
     }
 
-    /// Cheap clone of the in-memory body.
+    /// Cheap clone of the in-memory body, present only for
+    /// `Warm` / `Hot` shards.  Returns `None` for `Parked` / `Cold` /
+    /// `Unknown` / `Evicting`.
     #[must_use]
-    pub(crate) fn body(&self) -> Arc<DriveCompactIndex> {
-        Arc::clone(&self.body)
+    pub(crate) fn body(&self) -> Option<Arc<DriveCompactIndex>> {
+        self.body.as_ref().map(Arc::clone)
     }
 
     /// Attempt to transition the shard to `to`.
@@ -410,183 +539,9 @@ impl ShardEntry {
     }
 }
 
+// Test suite hosted in the sibling `shard/tests.rs` so this
+// production file stays under the workspace 800-LOC cap.  Module
+// path `crate::cache::shard::tests` is preserved for any downstream
+// consumer that imported individual helpers via that path.
 #[cfg(test)]
-mod tests {
-    #![expect(
-        clippy::min_ident_chars,
-        clippy::default_numeric_fallback,
-        clippy::doc_markdown,
-        reason = "test code — short loop counters and doc references like \
-                  `serde_json` are clearer without the pedantic ceremony."
-    )]
-
-    use proptest::prelude::*;
-
-    use super::*;
-
-    fn arb_state() -> impl Strategy<Value = ShardState> {
-        prop_oneof![
-            Just(ShardState::Unknown),
-            Just(ShardState::Cold),
-            Just(ShardState::Parked),
-            Just(ShardState::Warm),
-            Just(ShardState::Hot),
-            Just(ShardState::Evicting),
-        ]
-    }
-
-    proptest! {
-        /// Task 1.6: `decay_ema` is non-increasing between consecutive
-        /// calls without an intervening `record_query` (decay only
-        /// shrinks the EMA, never grows it).
-        #[test]
-        fn drivestats_decay_is_non_increasing(
-            seed_ema_micro in 0_u64..1_000_000_000_u64,
-            gap_ms in 1_u64..100_000_u64,
-        ) {
-            let stats = DriveStats::new();
-            stats.rate_ema_micro_per_s.store(seed_ema_micro, Ordering::Relaxed);
-            stats.last_decay_ms.store(1_000_000, Ordering::Relaxed);
-            let before = drive_stats_ema_value(&stats);
-            let after = stats.decay_ema(1_000_000_u64.saturating_add(gap_ms));
-            prop_assert!(
-                after <= before,
-                "after {} > before {}",
-                after,
-                before,
-            );
-            prop_assert!(after >= 0.0);
-        }
-
-        /// Task 1.7: every (from, to) pair outside the legal graph is
-        /// rejected by `can_transition_to`, and the inverse holds for
-        /// the listed legal pairs.
-        #[test]
-        fn shardstate_legal_graph_is_consistent(from in arb_state(), to in arb_state()) {
-            // The legal graph is hand-listed in `can_transition_to`;
-            // here we duplicate it as a set of pairs and check
-            // bidirectional agreement.
-            let legal: &[(ShardState, ShardState)] = &[
-                (ShardState::Unknown, ShardState::Cold),
-                (ShardState::Unknown, ShardState::Parked),
-                (ShardState::Unknown, ShardState::Warm),
-                (ShardState::Cold, ShardState::Parked),
-                (ShardState::Cold, ShardState::Warm),
-                (ShardState::Parked, ShardState::Cold),
-                (ShardState::Parked, ShardState::Warm),
-                (ShardState::Warm, ShardState::Hot),
-                (ShardState::Warm, ShardState::Evicting),
-                (ShardState::Hot, ShardState::Warm),
-                (ShardState::Hot, ShardState::Evicting),
-                (ShardState::Evicting, ShardState::Cold),
-                (ShardState::Evicting, ShardState::Parked),
-            ];
-            let in_graph = legal.iter().any(|&(a, b)| a == from && b == to);
-            let actual = from.can_transition_to(to);
-            prop_assert_eq!(
-                in_graph,
-                actual,
-                "{} -> {}: graph says {}, can_transition_to says {}",
-                from,
-                to,
-                in_graph,
-                actual,
-            );
-        }
-    }
-
-    /// Task 1.8: `DriveStatsSnapshot` round-trips through serde_json
-    /// and through the `From` conversions.
-    #[test]
-    fn drivestats_snapshot_round_trips() {
-        let stats = DriveStats::new();
-        for _ in 0..7 {
-            stats.record_query();
-        }
-        stats.rate_ema_micro_per_s.store(123_456, Ordering::Relaxed);
-        stats.last_decay_ms.store(987_654_321, Ordering::Relaxed);
-
-        let snap = DriveStatsSnapshot::from(&stats);
-        let json = serde_json::to_string(&snap).expect("serialize");
-        let restored: DriveStatsSnapshot = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(snap, restored);
-        assert_eq!(restored.queries_total, 7);
-        assert_eq!(restored.rate_ema_micro_per_s, 123_456);
-        assert_eq!(restored.last_decay_ms, 987_654_321);
-
-        let stats2 = DriveStats::from(restored);
-        assert_eq!(stats2.queries_total(), 7);
-    }
-
-    /// `record_query` is monotone — N increments yields total of N.
-    #[test]
-    fn record_query_is_monotone() {
-        let stats = DriveStats::new();
-        for _ in 0..10 {
-            stats.record_query();
-        }
-        assert_eq!(stats.queries_total(), 10);
-    }
-
-    /// First `decay_ema` call returns the stored value without decaying
-    /// (no elapsed signal yet).
-    #[test]
-    fn decay_ema_first_call_returns_stored_value() {
-        let stats = DriveStats::new();
-        stats
-            .rate_ema_micro_per_s
-            .store(5_000_000, Ordering::Relaxed);
-        // last_decay_ms == 0 means "never decayed".
-        let v = stats.decay_ema(1_000_000);
-        assert!((v - 5.0).abs() < 1e-9, "first call returned {v}");
-    }
-
-    /// `ShardState::FromStr` accepts every `Display` form and rejects
-    /// unknown input.
-    #[test]
-    fn shardstate_fromstr_round_trips() {
-        for state in [
-            ShardState::Unknown,
-            ShardState::Cold,
-            ShardState::Parked,
-            ShardState::Warm,
-            ShardState::Hot,
-            ShardState::Evicting,
-        ] {
-            let s = state.to_string();
-            let parsed: ShardState = s.parse().expect("parse round-trip");
-            assert_eq!(state, parsed, "{s} did not round-trip");
-        }
-        let err = "foobar".parse::<ShardState>().unwrap_err();
-        assert_eq!(err.0, "foobar");
-        assert!(format!("{err}").contains("unknown shard state"));
-    }
-
-    /// `ShardState` serializes through serde with lowercase names.
-    #[test]
-    fn shardstate_serde_lowercase() {
-        let json = serde_json::to_string(&ShardState::Warm).unwrap();
-        assert_eq!(json, r#""warm""#);
-        let back: ShardState = serde_json::from_str(r#""parked""#).unwrap();
-        assert_eq!(back, ShardState::Parked);
-    }
-
-    /// `ShardState::default()` is `Warm` (Phase-1 invariant).
-    #[test]
-    fn shardstate_default_is_warm() {
-        assert_eq!(ShardState::default(), ShardState::Warm);
-    }
-
-    /// `IllegalTransition` Display matches the documented format.
-    #[test]
-    fn illegal_transition_display() {
-        let err = IllegalTransition {
-            from: ShardState::Cold,
-            to: ShardState::Hot,
-        };
-        assert_eq!(
-            format!("{err}"),
-            "illegal shard state transition: cold -> hot"
-        );
-    }
-}
+mod tests;

--- a/crates/uffs-daemon/src/cache/shard/tests.rs
+++ b/crates/uffs-daemon/src/cache/shard/tests.rs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Test suite for [`super`] (`crate::cache::shard`).
+//!
+//! Hosted as a sibling submodule under `cache/shard/` so the
+//! production `cache/shard.rs` stays under the workspace 800-LOC
+//! file-size policy after Phase 3 Commit A added the
+//! `last_query_at_ms` + `mark_query_at` + `new_parked` / `new_cold`
+//! coverage.  Module path `crate::cache::shard::tests` is unchanged
+//! from the previous inline `#[cfg(test)] mod tests { ... }` block.
+
+#![expect(
+    clippy::min_ident_chars,
+    clippy::default_numeric_fallback,
+    clippy::doc_markdown,
+    reason = "test code — short loop counters and doc references like \
+              `serde_json` are clearer without the pedantic ceremony."
+)]
+
+use alloc::sync::Arc;
+use core::sync::atomic::Ordering;
+
+use proptest::prelude::*;
+
+use super::{
+    DriveStats, DriveStatsSnapshot, IllegalTransition, ShardEntry, ShardState,
+    drive_stats_ema_value,
+};
+
+fn arb_state() -> impl Strategy<Value = ShardState> {
+    prop_oneof![
+        Just(ShardState::Unknown),
+        Just(ShardState::Cold),
+        Just(ShardState::Parked),
+        Just(ShardState::Warm),
+        Just(ShardState::Hot),
+        Just(ShardState::Evicting),
+    ]
+}
+
+proptest! {
+    /// Task 1.6: `decay_ema` is non-increasing between consecutive
+    /// calls without an intervening `record_query` (decay only
+    /// shrinks the EMA, never grows it).
+    #[test]
+    fn drivestats_decay_is_non_increasing(
+        seed_ema_micro in 0_u64..1_000_000_000_u64,
+        gap_ms in 1_u64..100_000_u64,
+    ) {
+        let stats = DriveStats::new();
+        stats.rate_ema_micro_per_s.store(seed_ema_micro, Ordering::Relaxed);
+        stats.last_decay_ms.store(1_000_000, Ordering::Relaxed);
+        let before = drive_stats_ema_value(&stats);
+        let after = stats.decay_ema(1_000_000_u64.saturating_add(gap_ms));
+        prop_assert!(
+            after <= before,
+            "after {} > before {}",
+            after,
+            before,
+        );
+        prop_assert!(after >= 0.0);
+    }
+
+    /// Task 1.7: every (from, to) pair outside the legal graph is
+    /// rejected by `can_transition_to`, and the inverse holds for
+    /// the listed legal pairs.
+    #[test]
+    fn shardstate_legal_graph_is_consistent(from in arb_state(), to in arb_state()) {
+        // The legal graph is hand-listed in `can_transition_to`;
+        // here we duplicate it as a set of pairs and check
+        // bidirectional agreement.
+        let legal: &[(ShardState, ShardState)] = &[
+            (ShardState::Unknown, ShardState::Cold),
+            (ShardState::Unknown, ShardState::Parked),
+            (ShardState::Unknown, ShardState::Warm),
+            (ShardState::Cold, ShardState::Parked),
+            (ShardState::Cold, ShardState::Warm),
+            (ShardState::Parked, ShardState::Cold),
+            (ShardState::Parked, ShardState::Warm),
+            (ShardState::Warm, ShardState::Hot),
+            (ShardState::Warm, ShardState::Evicting),
+            (ShardState::Hot, ShardState::Warm),
+            (ShardState::Hot, ShardState::Evicting),
+            (ShardState::Evicting, ShardState::Cold),
+            (ShardState::Evicting, ShardState::Parked),
+        ];
+        let in_graph = legal.iter().any(|&(a, b)| a == from && b == to);
+        let actual = from.can_transition_to(to);
+        prop_assert_eq!(
+            in_graph,
+            actual,
+            "{} -> {}: graph says {}, can_transition_to says {}",
+            from,
+            to,
+            in_graph,
+            actual,
+        );
+    }
+}
+
+/// Task 1.8: `DriveStatsSnapshot` round-trips through serde_json
+/// and through the `From` conversions, including the Phase-3
+/// `last_query_at_ms` field.
+#[test]
+fn drivestats_snapshot_round_trips() {
+    let stats = DriveStats::new();
+    for _ in 0..7 {
+        stats.record_query();
+    }
+    stats.rate_ema_micro_per_s.store(123_456, Ordering::Relaxed);
+    stats.last_decay_ms.store(987_654_321, Ordering::Relaxed);
+    stats.last_query_at_ms.store(555_555_555, Ordering::Relaxed);
+
+    let snap = DriveStatsSnapshot::from(&stats);
+    let json = serde_json::to_string(&snap).expect("serialize");
+    let restored: DriveStatsSnapshot = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(snap, restored);
+    assert_eq!(restored.queries_total, 7);
+    assert_eq!(restored.rate_ema_micro_per_s, 123_456);
+    assert_eq!(restored.last_decay_ms, 987_654_321);
+    assert_eq!(restored.last_query_at_ms, 555_555_555);
+
+    let stats2 = DriveStats::from(restored);
+    assert_eq!(stats2.queries_total(), 7);
+    assert_eq!(stats2.last_query_at_ms(), 555_555_555);
+}
+
+/// Phase 3: `mark_query_at` increments `queries_total` and stores
+/// `now_ms` in `last_query_at_ms` in a single hot-path call.
+#[test]
+fn mark_query_at_updates_last_query_at_ms() {
+    let stats = DriveStats::new();
+    assert_eq!(stats.queries_total(), 0);
+    assert_eq!(stats.last_query_at_ms(), 0);
+
+    stats.mark_query_at(1_700_000_000_000);
+    assert_eq!(stats.queries_total(), 1);
+    assert_eq!(stats.last_query_at_ms(), 1_700_000_000_000);
+
+    stats.mark_query_at(1_700_000_000_500);
+    assert_eq!(stats.queries_total(), 2);
+    assert_eq!(stats.last_query_at_ms(), 1_700_000_000_500);
+}
+
+/// Phase 3: `mark_query_at` overwrites with whatever timestamp it
+/// receives — a non-monotonic clock (NTP rewind) doesn't trip an
+/// assertion, the demote controller just sees a small idle_secs
+/// or temporarily-negative-clamped-to-zero on the next tick.
+#[test]
+fn mark_query_at_overwrites_with_later_timestamp() {
+    let stats = DriveStats::new();
+    stats.mark_query_at(2_000);
+    assert_eq!(stats.last_query_at_ms(), 2_000);
+    // Earlier timestamp wins (caller's clock decision).
+    stats.mark_query_at(1_000);
+    assert_eq!(stats.last_query_at_ms(), 1_000);
+    assert_eq!(stats.queries_total(), 2);
+}
+
+/// Phase 3: a freshly-constructed `DriveStats` reports
+/// `last_query_at_ms() == 0` so the demote controller can use
+/// that as the "never queried" sentinel.
+#[test]
+fn last_query_at_ms_zero_after_construction() {
+    let stats = DriveStats::new();
+    assert_eq!(stats.last_query_at_ms(), 0);
+    // record_query (the legacy entry point that doesn't take a
+    // timestamp) must NOT touch last_query_at_ms; otherwise a
+    // legacy caller would synthesise a fake "queried at epoch"
+    // marker and the demote controller would compute a 50+ year
+    // idle window.
+    stats.record_query();
+    assert_eq!(stats.last_query_at_ms(), 0);
+    assert_eq!(stats.queries_total(), 1);
+}
+
+/// Phase 3: legacy `DriveStatsSnapshot` JSON without
+/// `last_query_at_ms` (e.g. v0.5.78 persisted state) deserialises
+/// with `last_query_at_ms == 0` instead of rejecting the input.
+/// Pins the `#[serde(default)]` fallback so the on-disk schema
+/// stays forward-compatible without a migration.
+#[test]
+fn drivestats_snapshot_legacy_json_back_compat() {
+    let legacy = r#"{"queries_total":42,"rate_ema_micro_per_s":12345,"last_decay_ms":67890}"#;
+    let snap: DriveStatsSnapshot = serde_json::from_str(legacy).expect("legacy parses");
+    assert_eq!(snap.queries_total, 42);
+    assert_eq!(snap.rate_ema_micro_per_s, 12345);
+    assert_eq!(snap.last_decay_ms, 67890);
+    assert_eq!(
+        snap.last_query_at_ms, 0,
+        "legacy omitted field defaults to 0"
+    );
+}
+
+/// `record_query` is monotone — N increments yields total of N.
+#[test]
+fn record_query_is_monotone() {
+    let stats = DriveStats::new();
+    for _ in 0..10 {
+        stats.record_query();
+    }
+    assert_eq!(stats.queries_total(), 10);
+}
+
+/// First `decay_ema` call returns the stored value without decaying
+/// (no elapsed signal yet).
+#[test]
+fn decay_ema_first_call_returns_stored_value() {
+    let stats = DriveStats::new();
+    stats
+        .rate_ema_micro_per_s
+        .store(5_000_000, Ordering::Relaxed);
+    // last_decay_ms == 0 means "never decayed".
+    let v = stats.decay_ema(1_000_000);
+    assert!((v - 5.0).abs() < 1e-9, "first call returned {v}");
+}
+
+/// `ShardState::FromStr` accepts every `Display` form and rejects
+/// unknown input.
+#[test]
+fn shardstate_fromstr_round_trips() {
+    for state in [
+        ShardState::Unknown,
+        ShardState::Cold,
+        ShardState::Parked,
+        ShardState::Warm,
+        ShardState::Hot,
+        ShardState::Evicting,
+    ] {
+        let s = state.to_string();
+        let parsed: ShardState = s.parse().expect("parse round-trip");
+        assert_eq!(state, parsed, "{s} did not round-trip");
+    }
+    let err = "foobar".parse::<ShardState>().unwrap_err();
+    assert_eq!(err.0, "foobar");
+    assert!(format!("{err}").contains("unknown shard state"));
+}
+
+/// `ShardState` serializes through serde with lowercase names.
+#[test]
+fn shardstate_serde_lowercase() {
+    let json = serde_json::to_string(&ShardState::Warm).unwrap();
+    assert_eq!(json, r#""warm""#);
+    let back: ShardState = serde_json::from_str(r#""parked""#).unwrap();
+    assert_eq!(back, ShardState::Parked);
+}
+
+/// `ShardState::default()` is `Warm` (Phase-1 invariant).
+#[test]
+fn shardstate_default_is_warm() {
+    assert_eq!(ShardState::default(), ShardState::Warm);
+}
+
+/// `IllegalTransition` Display matches the documented format.
+#[test]
+fn illegal_transition_display() {
+    let err = IllegalTransition {
+        from: ShardState::Cold,
+        to: ShardState::Hot,
+    };
+    assert_eq!(
+        format!("{err}"),
+        "illegal shard state transition: cold -> hot"
+    );
+}
+
+/// Phase 3: `ShardEntry::new_parked` produces a body-less shard
+/// in `ShardState::Parked` that shares the caller-provided
+/// `Arc<DriveStats>`.
+#[test]
+fn new_parked_has_no_body_and_shares_stats() {
+    let stats = Arc::new(DriveStats::new());
+    stats.record_query();
+    stats.record_query();
+
+    let shard = ShardEntry::new_parked('C', Arc::clone(&stats));
+    assert_eq!(shard.drive, 'C');
+    assert_eq!(shard.state(), ShardState::Parked);
+    assert!(shard.body().is_none());
+
+    // The shard's stats Arc points at the same DriveStats — a
+    // mutation via the external Arc shows up in the shard's
+    // counter, pinning the "shared not snapshotted" contract.
+    assert_eq!(shard.stats.queries_total(), 2);
+    stats.record_query();
+    assert_eq!(shard.stats.queries_total(), 3);
+}
+
+/// Phase 3: `ShardEntry::new_cold` produces the same body-less
+/// shape but in `ShardState::Cold`.
+#[test]
+fn new_cold_has_no_body_and_shares_stats() {
+    let stats = Arc::new(DriveStats::new());
+    let shard = ShardEntry::new_cold('D', Arc::clone(&stats));
+    assert_eq!(shard.drive, 'D');
+    assert_eq!(shard.state(), ShardState::Cold);
+    assert!(shard.body().is_none());
+
+    // Same Arc semantics as new_parked.
+    stats.mark_query_at(1_700_000_000_000);
+    assert_eq!(shard.stats.queries_total(), 1);
+    assert_eq!(shard.stats.last_query_at_ms(), 1_700_000_000_000);
+}

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -128,10 +128,17 @@ pub(crate) struct IndexManager {
     startup_duration_us: AtomicU64,
     /// Per-drive load timing for `--profile` reporting.
     drive_timings: RwLock<std::collections::HashMap<char, StoredDriveTiming>>,
+    /// Source for `Parked` / `Cold` shard bodies during
+    /// promote-on-search.  Production paths use
+    /// [`crate::cache::body_loader::DiskBodyLoader`]; the
+    /// Commit-E integration tests inject fakes via
+    /// [`Self::with_body_loader_for_test`].
+    body_loader: Arc<dyn crate::cache::body_loader::BodyLoader>,
 }
 
 impl IndexManager {
-    /// Create a new empty index manager.
+    /// Create a new empty index manager with the production
+    /// [`DiskBodyLoader`](crate::cache::body_loader::DiskBodyLoader).
     ///
     /// The search semaphore is initialised with `cpus` permits; this is
     /// retuned via [`Self::tune_concurrency`] (see
@@ -140,6 +147,25 @@ impl IndexManager {
     /// the initial value is not performance-critical.
     #[must_use]
     pub(crate) fn new(data_dir: Option<PathBuf>, events: EventSender) -> Self {
+        Self::new_with_body_loader(
+            data_dir,
+            events,
+            Arc::new(crate::cache::body_loader::DiskBodyLoader),
+        )
+    }
+
+    /// Inner constructor that also threads a custom body-loader.
+    ///
+    /// Production code calls [`Self::new`] which wires the
+    /// `DiskBodyLoader`; the Commit-E tests use this path through
+    /// [`Self::with_body_loader_for_test`] to inject fakes
+    /// (fixed body, missing body, panicking loader) without
+    /// touching the platform cache directory.
+    fn new_with_body_loader(
+        data_dir: Option<PathBuf>,
+        events: EventSender,
+        body_loader: Arc<dyn crate::cache::body_loader::BodyLoader>,
+    ) -> Self {
         let cpus = std::thread::available_parallelism().map_or(4, core::num::NonZeroUsize::get);
         Self {
             index: RwLock::new(Arc::new(ShardRegistry::new())),
@@ -158,7 +184,22 @@ impl IndexManager {
             queries_total_us: AtomicU64::new(0),
             startup_duration_us: AtomicU64::new(0),
             drive_timings: RwLock::new(std::collections::HashMap::new()),
+            body_loader,
         }
+    }
+
+    /// Test-only constructor that swaps in a custom body-loader.
+    ///
+    /// Used by the Commit-E integration tests to inject deterministic
+    /// fakes — no platform cache directory touched, no
+    /// process-global env-var override, no `tempfile`-juggling.
+    #[cfg(test)]
+    pub(crate) fn with_body_loader_for_test(
+        data_dir: Option<PathBuf>,
+        events: EventSender,
+        body_loader: Arc<dyn crate::cache::body_loader::BodyLoader>,
+    ) -> Self {
+        Self::new_with_body_loader(data_dir, events, body_loader)
     }
 
     /// Acquire an owned search-concurrency permit.
@@ -941,12 +982,10 @@ impl IndexManager {
         // contention from N parallel swaps would dwarf the
         // serialisation cost.
         for letter in needs_promote {
-            let load_result = tokio::task::spawn_blocking(move || {
-                uffs_core::compact_cache::load_compact_cache(letter, u64::MAX, 0, true)
-            })
-            .await;
+            let loader = Arc::clone(&self.body_loader);
+            let load_result = tokio::task::spawn_blocking(move || loader.load(letter)).await;
             let body = match load_result {
-                Ok(Some(loaded)) => Arc::new(loaded),
+                Ok(Some(body_arc)) => body_arc,
                 Ok(None) => {
                     tracing::warn!(
                         target: "shard.transition",

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -27,7 +27,7 @@ use uffs_client::protocol::response::{DaemonStatus, StatsResponse, StatusRespons
 use uffs_core::aggregate::AggregateCache;
 use uffs_core::search::backend::DriveIndex;
 
-use crate::cache::ShardRegistry;
+use crate::cache::{ShardRegistry, unix_now_ms};
 use crate::events::{DaemonEvent, EventSender};
 
 /// Per-drive load timing stored for profile reporting.
@@ -827,14 +827,22 @@ impl IndexManager {
     /// drive adaptive-TTL formulas.  Phase 4 will move the recording
     /// into the per-shard search-dispatch loop so bloom-skipped shards
     /// don't bump their counters.
+    ///
+    /// Phase 3 routes the increment through
+    /// [`crate::cache::shard::DriveStats::mark_query_at`] so the same
+    /// hot-path write also stores the dispatch timestamp in
+    /// `last_query_at_ms`; the demote controller in
+    /// `crate::cache::registry::ShardRegistry::demote_idle_shards`
+    /// reads that timestamp to compute `idle_secs`.
     async fn record_search_dispatch(&self) {
+        let now_ms = unix_now_ms();
         let guard = self.index.read().await;
         for shard in guard.iter() {
             if matches!(
                 shard.state(),
                 crate::cache::ShardState::Warm | crate::cache::ShardState::Hot
             ) {
-                shard.stats.record_query();
+                shard.stats.mark_query_at(now_ms);
             }
         }
     }

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -765,11 +765,24 @@ impl IndexManager {
     /// new one.
     async fn add_drive(&self, drive: uffs_core::compact::DriveCompactIndex) {
         let body = Arc::new(drive);
+        let letter = body.letter;
+        let now_ms = unix_now_ms();
         let mut guard = self.index.write().await;
         // ShardRegistry::add identifies the new shard by `body.letter`
         // (its canonical case from the index payload) — callers don't
         // thread the letter separately so it can't drift.
-        *guard = Arc::new(guard.add(body));
+        let new_registry = guard.add(body);
+        // Phase 3 Commit D — seed the load timestamp on the freshly
+        // mounted shard so the demote-controller's idle clock starts
+        // ticking from now, not from epoch zero.  See
+        // `DriveStats::mark_loaded_at` doc.
+        if let Some(shard) = new_registry
+            .iter()
+            .find(|shard| shard.drive.eq_ignore_ascii_case(&letter))
+        {
+            shard.stats.mark_loaded_at(now_ms);
+        }
+        *guard = Arc::new(new_registry);
         drop(guard);
         self.bump_index_version();
     }
@@ -782,10 +795,23 @@ impl IndexManager {
     /// computed against the pre-refresh snapshot.
     async fn replace_drive(&self, letter: char, new_drive: uffs_core::compact::DriveCompactIndex) {
         let body = Arc::new(new_drive);
+        let canonical = body.letter;
+        let now_ms = unix_now_ms();
         let mut guard = self.index.write().await;
         // `ShardRegistry::replace` matches case-insensitively, mirroring
         // the previous `eq_ignore_ascii_case` filter on `DriveIndex`.
-        *guard = Arc::new(guard.replace(letter, body));
+        let new_registry = guard.replace(letter, body);
+        // Phase 3 Commit D — same load-timestamp seeding as add_drive.
+        // The replaced shard gets a fresh `Arc<DriveStats>` (replace
+        // builds a new ShardEntry), so we don't need to preserve any
+        // older counters here.
+        if let Some(shard) = new_registry
+            .iter()
+            .find(|shard| shard.drive.eq_ignore_ascii_case(&canonical))
+        {
+            shard.stats.mark_loaded_at(now_ms);
+        }
+        *guard = Arc::new(new_registry);
         drop(guard);
         self.bump_index_version();
     }
@@ -957,6 +983,77 @@ impl IndexManager {
         }
     }
 
+    /// Demote any shards whose idle time exceeds the static-TTL
+    /// threshold for their current tier.
+    ///
+    /// Phase 3 Commit D — driven from a 30 s tick task in `lib.rs`
+    /// (see `spawn_idle_demote_controller`).  The tick cadence is
+    /// shorter than every TTL by design: a Hot shard idle for 5
+    /// minutes can race past the `HOT_TO_WARM_IDLE_SECS`
+    /// (300 s) boundary at most one tick (30 s) before the
+    /// controller observes it.  See `cache::policy` for the
+    /// per-tier thresholds.
+    ///
+    /// Three-phase orchestration:
+    ///
+    /// 1. **Read-lock detect.**  Single `self.index.read()` to enumerate
+    ///    `(letter, target)` pairs where the shard's `idle_secs = (now_ms -
+    ///    last_query_at_ms) / 1000` reaches its tier's TTL.  Common case (no
+    ///    shard past its TTL) exits with one read-lock acquisition.
+    /// 2. **Write-lock atomic batch.**  Apply every demote in a single
+    ///    write-lock window — N demotes → N registry rebuilds inside one lock
+    ///    acquisition, vs N separate write-lock acquisitions.  Each rebuild is
+    ///    O(shards) and sub-microsecond at the project's max ≤ 26 drives.
+    /// 3. **One `bump_index_version` for the batch.**  The aggregate cache only
+    ///    needs to invalidate once even when multiple shards moved.
+    ///
+    /// `now_ms` is threaded as a parameter so tests can pass
+    /// deterministic timestamps (no `tokio::time::pause`
+    /// dependency at this layer) and so the spawn task in
+    /// `lib.rs` controls when "now" is sampled (once per tick,
+    /// shared across every shard's idle computation).
+    ///
+    /// Race-resilient: if a search promoted the shard between our
+    /// detect and the corresponding swap, `demote_letter` returns
+    /// `None` for the now-Warm shard, that demote is skipped, the
+    /// rest of the batch proceeds, and the next idle-tick
+    /// re-evaluates.
+    pub(crate) async fn demote_idle_shards(&self, now_ms: u64) {
+        // ── Phase 1: read-lock detect ──────────────────────────────
+        let demotes: Vec<(char, crate::cache::ShardState)> = {
+            let guard = self.index.read().await;
+            guard
+                .iter()
+                .filter_map(|shard| {
+                    let last = shard.stats.last_query_at_ms();
+                    let idle_ms = now_ms.saturating_sub(last);
+                    let idle_secs = idle_ms / 1000;
+                    crate::cache::policy::next_state_for_idle(shard.state(), idle_secs)
+                        .map(|target| (shard.drive, target))
+                })
+                .collect()
+        };
+        if demotes.is_empty() {
+            return;
+        }
+
+        // ── Phase 2: write-lock atomic batch ───────────────────────
+        let mut guard = self.index.write().await;
+        let mut applied = 0_usize;
+        for (letter, target) in demotes {
+            if let Some(new_registry) = guard.demote_letter(letter, target) {
+                *guard = Arc::new(new_registry);
+                applied += 1;
+            }
+        }
+        drop(guard);
+
+        // ── Phase 3: single index-version bump for the batch ───────
+        if applied > 0 {
+            self.bump_index_version();
+        }
+    }
+
     /// Per-shard `(drive_letter, queries_total)` snapshot for tests.
     ///
     /// Test-only escape hatch so integration tests in `crate::index::tests`
@@ -994,6 +1091,35 @@ impl IndexManager {
                 *guard = Arc::new(new_registry);
                 drop(guard);
                 self.bump_index_version();
+                true
+            })
+    }
+
+    /// Backdate a shard's `last_query_at_ms` for tests.
+    ///
+    /// Sets the timestamp via [`crate::cache::DriveStats::mark_loaded_at`]
+    /// (no `queries_total` bump), so the per-shard query counter
+    /// stays a clean count of actual searches dispatched in tests
+    /// where that matters.  Returns `true` when the letter was
+    /// found, `false` otherwise.
+    ///
+    /// Used by the Commit-D virtual-time tests to simulate "shard
+    /// has been idle for N seconds" by writing a known-old
+    /// timestamp directly, then calling
+    /// [`Self::demote_idle_shards`] with `now_ms = old_ts + ttl +
+    /// epsilon` and asserting the demote happened.
+    #[cfg(test)]
+    pub(crate) async fn backdate_last_query_at_ms_for_test(
+        &self,
+        letter: char,
+        ts_ms: u64,
+    ) -> bool {
+        let guard = self.index.read().await;
+        guard
+            .iter()
+            .find(|shard| shard.drive.eq_ignore_ascii_case(&letter))
+            .is_some_and(|shard| {
+                shard.stats.mark_loaded_at(ts_ms);
                 true
             })
     }

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -847,6 +847,116 @@ impl IndexManager {
         }
     }
 
+    /// Phase 3 Commit C — promote any Parked/Cold shards that this
+    /// search will dispatch to, before
+    /// [`Self::snapshot`] reads the active subset.
+    ///
+    /// Three-phase orchestrator (read-detect → spawn-blocking
+    /// load → write-swap) — see implementation comments below.
+    ///
+    /// `params_drives` is the search's drive-letter filter
+    /// ([`uffs_client::protocol::SearchParams::drives`]).  An empty
+    /// slice means "no filter" — the touched set is every loaded
+    /// shard.  When non-empty, only shards whose drive letter
+    /// case-insensitively matches a filter entry are considered.
+    ///
+    /// **Conservative on under-promote, lenient on over-promote.**
+    /// If the search pattern itself implies a drive prefix
+    /// (e.g. `"C:*.txt"`) but `params_drives` is empty, we'll
+    /// over-promote (touching shards the search backend will then
+    /// skip) — wasted I/O, no correctness issue.  The opposite
+    /// (under-promote → search misses a Parked shard) is what we
+    /// can't afford, hence the empty-filter == all-loaded fallback.
+    ///
+    /// No-op if every touched shard is already Warm/Hot — common
+    /// case, single read-lock acquisition only.
+    async fn ensure_warm_for_dispatch(&self, params_drives: &[char]) {
+        // ── Phase 1: read-lock detection (fast path) ───────────
+        // Identify Parked/Cold shards in the touched set.  Single
+        // read-lock acquisition; the registry's `iter()` is a Vec
+        // walk, no allocation beyond the `needs_promote` Vec.
+        let needs_promote: Vec<char> = {
+            let guard = self.index.read().await;
+            guard
+                .iter()
+                .filter(|shard| {
+                    params_drives.is_empty()
+                        || params_drives
+                            .iter()
+                            .any(|filter| filter.eq_ignore_ascii_case(&shard.drive))
+                })
+                .filter(|shard| {
+                    matches!(
+                        shard.state(),
+                        crate::cache::ShardState::Parked | crate::cache::ShardState::Cold
+                    )
+                })
+                .map(|shard| shard.drive)
+                .collect()
+        };
+        if needs_promote.is_empty() {
+            return;
+        }
+
+        // ── Phase 2: spawn-blocking body load ──────────────────
+        // For each Parked/Cold letter, hop onto the blocking pool
+        // for the I/O + decrypt + decompress + runtime-mmap
+        // materialisation.  `load_compact_cache` returns `None` on
+        // any non-fatal failure (missing cache file, stale, decrypt
+        // error); we trace and skip — the shard stays in its
+        // current tier and the search will dispatch against the
+        // unchanged active subset.
+        //
+        // Phases 2 + 3 are interleaved per letter so a slow
+        // disk-read on letter A doesn't block the swap for letter
+        // B that's already loaded.  Serialised on purpose:
+        // promoting N drives in a single hot-path query is rare
+        // (idle-timer demote is per-drive) and the write-lock
+        // contention from N parallel swaps would dwarf the
+        // serialisation cost.
+        for letter in needs_promote {
+            let load_result = tokio::task::spawn_blocking(move || {
+                uffs_core::compact_cache::load_compact_cache(letter, u64::MAX, 0, true)
+            })
+            .await;
+            let body = match load_result {
+                Ok(Some(loaded)) => Arc::new(loaded),
+                Ok(None) => {
+                    tracing::warn!(
+                        target: "shard.transition",
+                        drive = %letter,
+                        reason = "promote-on-search",
+                        "compact-cache load returned None; shard stays in current tier",
+                    );
+                    continue;
+                }
+                Err(join_err) => {
+                    tracing::error!(
+                        target: "shard.transition",
+                        drive = %letter,
+                        error = %join_err,
+                        reason = "promote-on-search",
+                        "blocking-task panic during cache load; shard stays in current tier",
+                    );
+                    continue;
+                }
+            };
+
+            // ── Phase 3: write-lock atomic swap ────────────────
+            // `promote_letter` is `Option`-returning so a benign
+            // race (another task promoted between our read-detect
+            // and write-swap, or a demote landed on top of the
+            // Parked state we observed) drops the freshly-loaded
+            // body Arc and leaves the canonical registry alone.
+            let mut guard = self.index.write().await;
+            if let Some(new_registry) = guard.promote_letter(letter, body) {
+                *guard = Arc::new(new_registry);
+                drop(guard);
+                self.bump_index_version();
+            }
+        }
+    }
+
     /// Per-shard `(drive_letter, queries_total)` snapshot for tests.
     ///
     /// Test-only escape hatch so integration tests in `crate::index::tests`
@@ -858,6 +968,48 @@ impl IndexManager {
         guard
             .iter()
             .map(|shard| (shard.drive, shard.stats.queries_total()))
+            .collect()
+    }
+
+    /// Demote a single shard to `target` for tests.
+    ///
+    /// Test-only escape hatch used by Commit C tests to seed a
+    /// `Parked`/`Cold` shard so [`Self::ensure_warm_for_dispatch`]
+    /// has something to promote.  Production code never calls this
+    /// directly — the demote-on-idle controller in Commit D uses
+    /// `ShardRegistry::demote_letter` from a `tokio::task` instead.
+    ///
+    /// Returns `true` if the registry was rebuilt (demote was
+    /// legal), `false` otherwise (unknown letter or illegal target).
+    #[cfg(test)]
+    pub(crate) async fn demote_letter_for_test(
+        &self,
+        letter: char,
+        target: crate::cache::ShardState,
+    ) -> bool {
+        let mut guard = self.index.write().await;
+        guard
+            .demote_letter(letter, target)
+            .is_some_and(|new_registry| {
+                *guard = Arc::new(new_registry);
+                drop(guard);
+                self.bump_index_version();
+                true
+            })
+    }
+
+    /// Per-shard `(drive_letter, ShardState)` snapshot for tests.
+    ///
+    /// Test-only — the production code path observes shard state
+    /// only through [`Self::snapshot`] (which filters Warm/Hot).
+    /// Commit C tests need to assert the *full* tier distribution
+    /// (Parked/Cold) before and after `ensure_warm_for_dispatch`.
+    #[cfg(test)]
+    pub(crate) async fn shard_states_for_test(&self) -> Vec<(char, crate::cache::ShardState)> {
+        let guard = self.index.read().await;
+        guard
+            .iter()
+            .map(|shard| (shard.drive, shard.state()))
             .collect()
     }
 

--- a/crates/uffs-daemon/src/index/search.rs
+++ b/crates/uffs-daemon/src/index/search.rs
@@ -84,7 +84,14 @@ impl IndexManager {
         let requires_post_filter =
             Self::predicates_require_post_filter(&effective_params.predicates);
 
-        // Phase 3 Commit C — see `ensure_warm_for_dispatch` doc.
+        // Phase 3 Commit C — promote any Parked/Cold shards in the
+        // touched set before we snapshot the active subset.  Fast
+        // path (single read-lock acquisition, no work) when every
+        // touched shard is already Warm/Hot, which is the common
+        // case in steady state.  See
+        // `IndexManager::ensure_warm_for_dispatch` doc for the
+        // three-phase orchestration and the
+        // conservative-on-under-promote contract.
         self.ensure_warm_for_dispatch(&effective_params.drives)
             .await;
 
@@ -464,7 +471,7 @@ impl IndexManager {
 
         // ── Aggregation (if requested) ─────────────────────────────
         let (agg_results, agg_matched) = if !effective_params.aggregations.is_empty() {
-            let predicates = Self::build_query_predicates(&effective_params);
+            let predicates = build_query_predicates(&effective_params);
 
             // Pass the pattern if it's non-trivial (not just `*`).
             let agg_pattern =
@@ -646,64 +653,6 @@ impl IndexManager {
         }
     }
 
-    /// Convert search-request filters into drill-down predicates.
-    ///
-    /// These are prepended to each bucket's drill-down list so that a
-    /// follow-up query reproduces the original scope plus the bucket key.
-    fn build_query_predicates(
-        params: &SearchParams,
-    ) -> Vec<uffs_core::aggregate::finalize::DrilldownPredicate> {
-        use uffs_core::aggregate::finalize::{DrilldownPredicate, DrilldownValue};
-        let mut preds = Vec::new();
-
-        // Pattern
-        if !params.pattern.is_empty() && params.pattern != "*" {
-            preds.push(DrilldownPredicate {
-                field: "name".to_owned(),
-                op: "glob".to_owned(),
-                value: DrilldownValue::String(params.pattern.clone()),
-            });
-        }
-
-        // Filter mode (files / dirs)
-        if let Some(filter) = &params.filter
-            && filter != "all"
-        {
-            preds.push(DrilldownPredicate {
-                field: "type".to_owned(),
-                op: "eq".to_owned(),
-                value: DrilldownValue::String(filter.clone()),
-            });
-        }
-
-        // Size range
-        if let Some(min) = params.min_size {
-            preds.push(DrilldownPredicate {
-                field: "size".to_owned(),
-                op: "gte".to_owned(),
-                value: DrilldownValue::U64(min),
-            });
-        }
-        if let Some(max) = params.max_size {
-            preds.push(DrilldownPredicate {
-                field: "size".to_owned(),
-                op: "lte".to_owned(),
-                value: DrilldownValue::U64(max),
-            });
-        }
-
-        // Drives
-        for &drive in &params.drives {
-            preds.push(DrilldownPredicate {
-                field: "drive".to_owned(),
-                op: "eq".to_owned(),
-                value: DrilldownValue::String(drive.to_string()),
-            });
-        }
-
-        preds
-    }
-
     // ── Direct file output (OPT-4) ──────────────────────────────────
 
     /// Write `DisplayRow`s directly to a file, bypassing `SearchRow` and IPC.
@@ -787,6 +736,14 @@ impl IndexManager {
 #[path = "search_output_config.rs"]
 mod output_config;
 pub(crate) use output_config::build_output_config;
+
+// `build_query_predicates` lives in a sibling file to keep `search.rs`
+// under the 800-line policy ceiling.  Single call site (the
+// aggregation block in `search()` above), so the function stays
+// `pub(super)` — not re-exported beyond the `search` module.
+#[path = "search_predicates.rs"]
+mod predicates;
+use predicates::build_query_predicates;
 
 // The inline `tests` module lives in a sibling file to keep `search.rs`
 // under the 800-line policy ceiling.  `#[path]` keeps the test module

--- a/crates/uffs-daemon/src/index/search.rs
+++ b/crates/uffs-daemon/src/index/search.rs
@@ -84,6 +84,10 @@ impl IndexManager {
         let requires_post_filter =
             Self::predicates_require_post_filter(&effective_params.predicates);
 
+        // Phase 3 Commit C — see `ensure_warm_for_dispatch` doc.
+        self.ensure_warm_for_dispatch(&effective_params.drives)
+            .await;
+
         // ── Snapshot the index (< 1 μs) ────────────────────────────
         let t_lock = profiling.then(Instant::now);
         let snapshot = self.snapshot().await;

--- a/crates/uffs-daemon/src/index/search_predicates.rs
+++ b/crates/uffs-daemon/src/index/search_predicates.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Convert search-request filters into drill-down predicates.
+//!
+//! These predicates are prepended to each aggregation bucket's
+//! drill-down list so a follow-up query reproduces the original
+//! scope (pattern + filter mode + size range + drive selection)
+//! plus the bucket key.
+//!
+//! Lifted out of `search.rs` to keep that file under the 800-line
+//! policy ceiling.  Re-attached via
+//! `#[path = "search_predicates.rs"] mod predicates;` in
+//! `search.rs`, so `build_query_predicates` stays addressable as
+//! `crate::index::search::build_query_predicates(...)` at the
+//! single call site (the aggregation block in
+//! [`crate::index::IndexManager::search`]).
+
+use uffs_client::protocol::SearchParams;
+use uffs_core::aggregate::finalize::{DrilldownPredicate, DrilldownValue};
+
+/// Build the drill-down-predicate list that prefixes every
+/// aggregation bucket's follow-up query.
+///
+/// Pure function — no `IndexManager` state, no I/O.  Each predicate
+/// reproduces one filter from `params`:
+///
+/// * `pattern`: emitted as `name glob <pattern>` (skipped when the pattern is
+///   empty or the trivial `*`).
+/// * `filter` (`files` / `dirs`): emitted as `type eq <filter>` (skipped for
+///   `all` / unset).
+/// * `min_size` / `max_size`: emitted as `size gte <min>` and `size lte <max>`,
+///   independently.
+/// * `drives`: one `drive eq <letter>` per entry.
+///
+/// Returns an empty `Vec` when no filters are active — the
+/// aggregation engine treats that as the "match everything in the
+/// snapshot" baseline.
+pub(super) fn build_query_predicates(params: &SearchParams) -> Vec<DrilldownPredicate> {
+    let mut preds = Vec::new();
+
+    // Pattern
+    if !params.pattern.is_empty() && params.pattern != "*" {
+        preds.push(DrilldownPredicate {
+            field: "name".to_owned(),
+            op: "glob".to_owned(),
+            value: DrilldownValue::String(params.pattern.clone()),
+        });
+    }
+
+    // Filter mode (files / dirs)
+    if let Some(filter) = &params.filter
+        && filter != "all"
+    {
+        preds.push(DrilldownPredicate {
+            field: "type".to_owned(),
+            op: "eq".to_owned(),
+            value: DrilldownValue::String(filter.clone()),
+        });
+    }
+
+    // Size range
+    if let Some(min) = params.min_size {
+        preds.push(DrilldownPredicate {
+            field: "size".to_owned(),
+            op: "gte".to_owned(),
+            value: DrilldownValue::U64(min),
+        });
+    }
+    if let Some(max) = params.max_size {
+        preds.push(DrilldownPredicate {
+            field: "size".to_owned(),
+            op: "lte".to_owned(),
+            value: DrilldownValue::U64(max),
+        });
+    }
+
+    // Drives
+    for &drive in &params.drives {
+        preds.push(DrilldownPredicate {
+            field: "drive".to_owned(),
+            op: "eq".to_owned(),
+            value: DrilldownValue::String(drive.to_string()),
+        });
+    }
+
+    preds
+}

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -1401,3 +1401,232 @@ async fn search_records_query_on_every_active_shard() {
         );
     }
 }
+
+// ── Phase 3 Commit B — ShardRegistry demote_letter / promote_letter ────
+
+/// Demote a `Warm` shard to `Parked`: the new shard has no body,
+/// the active index drops the drive, and the per-drive
+/// `Arc<DriveStats>` is shared so query counters survive the
+/// rebuild.
+#[test]
+fn demote_letter_warm_to_parked_drops_body_and_preserves_stats() {
+    use crate::cache::{ShardRegistry, ShardState};
+
+    let body_c = Arc::new(build_test_drive());
+    let body_d = Arc::new(build_test_drive_d());
+    // Single mutable binding so we don't trip clippy::shadow_reuse
+    // on each rebuild — same pattern as
+    // `shard_registry_add_replace_remove_round_trip`.
+    let mut reg = ShardRegistry::new()
+        .add(Arc::clone(&body_c))
+        .add(Arc::clone(&body_d));
+    assert_eq!(reg.active_index().drives.len(), 2);
+
+    // Mark some queries on C so we can verify they survive the
+    // rebuild.
+    let c_shard_pre = reg
+        .iter()
+        .find(|s| s.drive == 'C')
+        .expect("C present pre-demote");
+    for _ in 0_u32..5_u32 {
+        c_shard_pre.stats.record_query();
+    }
+    assert_eq!(c_shard_pre.stats.queries_total(), 5);
+
+    reg = reg
+        .demote_letter('C', ShardState::Parked)
+        .expect("warm → parked is legal");
+
+    // Active index now only contains D.
+    assert_eq!(reg.active_index().drives.len(), 1);
+    assert_eq!(reg.active_index().drives[0].letter, 'D');
+
+    // Both shards are still loaded; C is Parked, body lifted.
+    let c_shard = reg
+        .iter()
+        .find(|s| s.drive == 'C')
+        .expect("C still loaded post-demote");
+    assert_eq!(c_shard.state(), ShardState::Parked);
+    assert!(c_shard.body().is_none());
+
+    // Query counter survives via the shared Arc<DriveStats>.
+    assert_eq!(
+        c_shard.stats.queries_total(),
+        5,
+        "demote rebuild must preserve query stats via shared Arc<DriveStats>",
+    );
+}
+
+/// Demote a `Warm` shard directly to `Cold` (skipping `Parked`).
+#[test]
+fn demote_letter_warm_to_cold_drops_body() {
+    use crate::cache::{ShardRegistry, ShardState};
+
+    let body_c = Arc::new(build_test_drive());
+    let mut reg = ShardRegistry::new().add(body_c);
+    reg = reg
+        .demote_letter('C', ShardState::Cold)
+        .expect("warm → cold is legal");
+
+    assert_eq!(reg.active_index().drives.len(), 0);
+    let c_shard = reg.iter().find(|s| s.drive == 'C').expect("C still loaded");
+    assert_eq!(c_shard.state(), ShardState::Cold);
+    assert!(c_shard.body().is_none());
+}
+
+/// Demoting an unknown letter is a `None` no-op.
+#[test]
+fn demote_letter_unknown_letter_returns_none() {
+    use crate::cache::{ShardRegistry, ShardState};
+
+    let body_c = Arc::new(build_test_drive());
+    let reg = ShardRegistry::new().add(body_c);
+    assert!(
+        reg.demote_letter('Z', ShardState::Parked).is_none(),
+        "demote on unknown letter must return None"
+    );
+}
+
+/// Demote target outside the legal demote set (e.g. `Warm`,
+/// `Hot`, `Unknown`) returns `None`.
+#[test]
+fn demote_letter_illegal_target_returns_none() {
+    use crate::cache::{ShardRegistry, ShardState};
+
+    let body_c = Arc::new(build_test_drive());
+    let reg = ShardRegistry::new().add(body_c);
+    for bad_target in [
+        ShardState::Warm,
+        ShardState::Hot,
+        ShardState::Unknown,
+        ShardState::Evicting,
+    ] {
+        assert!(
+            reg.demote_letter('C', bad_target).is_none(),
+            "demote target {bad_target} must be rejected"
+        );
+    }
+}
+
+/// Self-demote (`Parked → Parked`, `Cold → Cold`) is rejected so a
+/// buggy controller can't rebuild the registry on every idle tick
+/// for an already-demoted shard.
+#[test]
+fn demote_letter_self_demote_returns_none() {
+    use crate::cache::{ShardRegistry, ShardState};
+
+    let body_c = Arc::new(build_test_drive());
+    let mut reg = ShardRegistry::new().add(body_c);
+    reg = reg
+        .demote_letter('C', ShardState::Parked)
+        .expect("first demote");
+    assert!(
+        reg.demote_letter('C', ShardState::Parked).is_none(),
+        "Parked → Parked must be rejected"
+    );
+
+    reg = reg
+        .demote_letter('C', ShardState::Cold)
+        .expect("parked → cold");
+    assert!(
+        reg.demote_letter('C', ShardState::Cold).is_none(),
+        "Cold → Cold must be rejected"
+    );
+}
+
+/// Promote a `Parked` shard back to `Warm`: body restored, active
+/// index re-includes the letter, query stats preserved.
+#[test]
+fn promote_letter_parked_to_warm_restores_body_and_preserves_stats() {
+    use crate::cache::{ShardRegistry, ShardState};
+
+    let body_c = Arc::new(build_test_drive());
+    let mut reg = ShardRegistry::new().add(Arc::clone(&body_c));
+    // Bump a few queries before demote so we have something to
+    // verify across the round trip.
+    let pre = reg.iter().find(|s| s.drive == 'C').unwrap();
+    for _ in 0_u32..3_u32 {
+        pre.stats.record_query();
+    }
+    reg = reg.demote_letter('C', ShardState::Parked).expect("demote");
+
+    // Promote with a fresh body (Phase 4+ will fault the original
+    // back from disk; for this test we just hand it the same Arc).
+    reg = reg
+        .promote_letter('C', Arc::clone(&body_c))
+        .expect("promote");
+
+    assert_eq!(reg.active_index().drives.len(), 1);
+    let c = reg.iter().find(|s| s.drive == 'C').unwrap();
+    assert_eq!(c.state(), ShardState::Warm);
+    assert!(c.body().is_some());
+    assert_eq!(
+        c.stats.queries_total(),
+        3,
+        "round-trip demote+promote must preserve query stats",
+    );
+}
+
+/// Promoting an unknown letter is a `None` no-op.
+#[test]
+fn promote_letter_unknown_letter_returns_none() {
+    use crate::cache::ShardRegistry;
+
+    let body_c = Arc::new(build_test_drive());
+    let body_d = Arc::new(build_test_drive_d());
+    let reg = ShardRegistry::new().add(body_c);
+    assert!(
+        reg.promote_letter('Z', body_d).is_none(),
+        "promote on unknown letter must return None"
+    );
+}
+
+/// Promoting an already-`Warm` shard is a caller bug — `None`.
+#[test]
+fn promote_letter_already_warm_returns_none() {
+    use crate::cache::ShardRegistry;
+
+    let body_c = Arc::new(build_test_drive());
+    let reg = ShardRegistry::new().add(Arc::clone(&body_c));
+    assert!(
+        reg.promote_letter('C', body_c).is_none(),
+        "promote on already-Warm shard must return None"
+    );
+}
+
+/// End-to-end: demote → promote → demote → promote preserves
+/// query stats across every rebuild.  Pins the
+/// `Arc<DriveStats>`-sharing contract under repeated transitions.
+#[test]
+fn demote_then_promote_round_trips_query_stats() {
+    use crate::cache::{ShardRegistry, ShardState};
+
+    let body_c = Arc::new(build_test_drive());
+    let mut reg = ShardRegistry::new().add(Arc::clone(&body_c));
+
+    // Each transition adds queries to verify the canonical stats
+    // Arc is what the new shard's `.stats` points at.
+    for round in 0_u64..3_u64 {
+        reg.iter()
+            .find(|s| s.drive == 'C')
+            .unwrap()
+            .stats
+            .mark_query_at(1_000 + round);
+        reg = reg.demote_letter('C', ShardState::Parked).expect("demote");
+        reg.iter()
+            .find(|s| s.drive == 'C')
+            .unwrap()
+            .stats
+            .mark_query_at(2_000 + round);
+        reg = reg
+            .promote_letter('C', Arc::clone(&body_c))
+            .expect("promote");
+    }
+
+    let final_c = reg.iter().find(|s| s.drive == 'C').unwrap();
+    // 6 mark_query_at calls total across 3 rounds (3 pre-demote +
+    // 3 post-demote-pre-promote).
+    assert_eq!(final_c.stats.queries_total(), 6);
+    // Last mark_query_at was during round 2 with `now_ms = 2_002`.
+    assert_eq!(final_c.stats.last_query_at_ms(), 2_002);
+}

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -1594,6 +1594,87 @@ fn promote_letter_already_warm_returns_none() {
     );
 }
 
+// ── Phase 3 Commit C — IndexManager::ensure_warm_for_dispatch ──────
+
+/// Fast-path contract: when every loaded shard is already
+/// `Warm`/`Hot`, `ensure_warm_for_dispatch` is a single
+/// read-lock acquisition with no state mutation and no
+/// `index_version` bump.
+#[tokio::test]
+async fn ensure_warm_for_dispatch_no_op_when_all_warm() {
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+
+    let states_before = mgr.shard_states_for_test().await;
+    assert_eq!(states_before, vec![
+        ('C', ShardState::Warm),
+        ('D', ShardState::Warm)
+    ]);
+
+    // Empty filter → all touched.  Non-empty filter → subset.
+    // Either way, no shard is Parked/Cold so this is a no-op.
+    mgr.ensure_warm_for_dispatch(&[]).await;
+    mgr.ensure_warm_for_dispatch(&['C']).await;
+    mgr.ensure_warm_for_dispatch(&['c']).await; // case-insensitive
+    mgr.ensure_warm_for_dispatch(&['Z']).await; // unknown letter
+
+    let states_after = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states_after, states_before,
+        "all-Warm registry must survive ensure_warm_for_dispatch unchanged",
+    );
+}
+
+/// `ensure_warm_for_dispatch` honours the drive-letter filter:
+/// when the search targets only drive D and drive C is Parked,
+/// C must not be promoted.
+#[tokio::test]
+async fn ensure_warm_for_dispatch_skips_parked_shard_outside_filter() {
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+
+    // Demote C to Parked (test escape hatch).
+    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    let states_pre = mgr.shard_states_for_test().await;
+    assert!(states_pre.contains(&('C', ShardState::Parked)));
+
+    // Search targets only D — C must stay Parked.  The on-disk
+    // cache lookup for D would no-op because D is already Warm.
+    mgr.ensure_warm_for_dispatch(&['D']).await;
+
+    let states_post = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states_post, states_pre,
+        "filter excluded C — Parked state must survive",
+    );
+}
+
+// NOTE: The third Commit C contract — "missing cache file is
+// graceful: shard stays Parked, no panic" — is deferred to Commit E
+// (virtual-time integration tests) so it can land alongside the
+// `BodyLoader` trait that gives `IndexManager` a deterministic
+// per-test body source.  The current production code reads from
+// the platform cache dir (`~/Library/Caches/com.uffs/<letter>_compact.uffs`
+// on Mac), so a unit test for the missing-cache path would either
+// need a process-global `UFFS_CACHE_DIR_OVERRIDE` (which races with
+// parallel tests) or the BodyLoader scaffolding.  Commit E lands
+// the latter and gets the round-trip + graceful-failure tests for
+// free off the same fixture.
+//
+// In the meantime, the production graceful-failure path is exercised
+// indirectly by `ensure_warm_for_dispatch_no_op_when_all_warm` (no
+// load attempted) and
+// `ensure_warm_for_dispatch_skips_parked_shard_outside_filter` (load attempt
+// only on Parked shards, and the filter precludes any).
+
 /// End-to-end: demote → promote → demote → promote preserves
 /// query stats across every rebuild.  Pins the
 /// `Arc<DriveStats>`-sharing contract under repeated transitions.

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -1243,6 +1243,35 @@ fn build_test_drive_d() -> uffs_core::compact::DriveCompactIndex {
     drive
 }
 
+/// Build a synthetic drive with letter `'E'` — third drive for the
+/// Phase 3 Commit E virtual-time tests (plan tasks 3.7 + 3.8) that
+/// need to verify "queries on C only → D and E both demote, C
+/// stays Warm" and "advance past parked TTL → all three Cold".
+fn build_test_drive_e() -> uffs_core::compact::DriveCompactIndex {
+    let mut idx = MftIndex::new('E');
+    let root_off = idx.add_name(".");
+    let root = idx.get_or_create(ROOT_FRS);
+    root.stdinfo.set_directory(true);
+    root.first_name.name = IndexNameRef::new(root_off, 1, true, IndexNameRef::NO_EXTENSION);
+    root.first_name.parent_frs = ROOT_FRS;
+
+    let file = "beta.bin";
+    let off = idx.add_name(file);
+    let ext = idx.intern_extension(file);
+    let rec = idx.get_or_create(300);
+    rec.first_name.name = IndexNameRef::new(off, uffs_mft::len_to_u16(file.len()), true, ext);
+    rec.first_name.parent_frs = ROOT_FRS;
+    rec.first_stream.size = SizeInfo {
+        length: 84,
+        allocated: 1024,
+    };
+    rec.stdinfo.flags = 0x20;
+    rec.stdinfo.modified = 1_000_000;
+
+    let (drive, _, _) = build_compact_index('E', &idx);
+    drive
+}
+
 /// `ShardRegistry::{add, replace, remove}` round-trip with real
 /// `DriveCompactIndex` bodies.  Pins the case-insensitive contract on
 /// `replace` / `remove` that mirrors the pre-Phase-1
@@ -1657,23 +1686,150 @@ async fn ensure_warm_for_dispatch_skips_parked_shard_outside_filter() {
     );
 }
 
-// NOTE: The third Commit C contract — "missing cache file is
-// graceful: shard stays Parked, no panic" — is deferred to Commit E
-// (virtual-time integration tests) so it can land alongside the
-// `BodyLoader` trait that gives `IndexManager` a deterministic
-// per-test body source.  The current production code reads from
-// the platform cache dir (`~/Library/Caches/com.uffs/<letter>_compact.uffs`
-// on Mac), so a unit test for the missing-cache path would either
-// need a process-global `UFFS_CACHE_DIR_OVERRIDE` (which races with
-// parallel tests) or the BodyLoader scaffolding.  Commit E lands
-// the latter and gets the round-trip + graceful-failure tests for
-// free off the same fixture.
-//
-// In the meantime, the production graceful-failure path is exercised
-// indirectly by `ensure_warm_for_dispatch_no_op_when_all_warm` (no
-// load attempted) and
-// `ensure_warm_for_dispatch_skips_parked_shard_outside_filter` (load attempt
-// only on Parked shards, and the filter precludes any).
+// ── Phase 3 Commit E — BodyLoader injection ────────────────────────
+
+/// A `BodyLoader` that always returns `Some(self.body.clone())` —
+/// used to verify the success path of `ensure_warm_for_dispatch`
+/// without touching the platform cache directory.
+struct FixedBodyLoader {
+    body: Arc<uffs_core::compact::DriveCompactIndex>,
+}
+
+impl crate::cache::body_loader::BodyLoader for FixedBodyLoader {
+    fn load(&self, _letter: char) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
+        Some(Arc::clone(&self.body))
+    }
+}
+
+/// A `BodyLoader` that always returns `None` — simulates a missing
+/// or stale cache file between demote and promote.
+struct MissingBodyLoader;
+
+impl crate::cache::body_loader::BodyLoader for MissingBodyLoader {
+    fn load(&self, _letter: char) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
+        None
+    }
+}
+
+/// A `BodyLoader` whose `load` method panics — exercises the
+/// `Err(JoinError)` arm of the spawn-blocking match in
+/// `ensure_warm_for_dispatch`.  The panic is contained inside
+/// `tokio::task::spawn_blocking`'s thread; the daemon stays up and
+/// the shard stays in its current tier.
+struct PanickingBodyLoader;
+
+impl crate::cache::body_loader::BodyLoader for PanickingBodyLoader {
+    fn load(&self, _letter: char) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
+        panic!("PanickingBodyLoader::load — synthetic panic for the JoinError arm");
+    }
+}
+
+/// Pin the success path with an injected `FixedBodyLoader`:
+///
+/// 1. Add drive C, demote it to Parked (so the body Arc is dropped from the
+///    registry).
+/// 2. Configure the manager with a `FixedBodyLoader` carrying a fresh body for
+///    C.
+/// 3. Call `ensure_warm_for_dispatch(&['C'])`.
+/// 4. Assert C is now Warm AND the registry's view sees the body again (via
+///    `total_index_heap_bytes` — the Parked shard has `body == None` so its
+///    `heap_size_bytes()` is 0; the promoted shard reports the test-drive's
+///    heap size).
+#[tokio::test]
+async fn ensure_warm_for_dispatch_promotes_with_fixed_body_loader() {
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let body = Arc::new(build_test_drive());
+    let loader = Arc::new(FixedBodyLoader {
+        body: Arc::clone(&body),
+    });
+    let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
+    mgr.add_drive(build_test_drive()).await;
+
+    let warm_heap = mgr.total_index_heap_bytes().await;
+    assert!(warm_heap > 0, "Warm shard must report nonzero heap_bytes");
+
+    // Demote — the body Arc inside the registry is now None.
+    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+
+    // Promote via ensure_warm_for_dispatch.
+    mgr.ensure_warm_for_dispatch(&['C']).await;
+
+    // Shard is Warm again AND the heap-bytes metric is back to its
+    // pre-demote value (the FixedBodyLoader handed back a body
+    // identical in shape to the original).
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(states, vec![('C', ShardState::Warm)]);
+    let promoted_heap = mgr.total_index_heap_bytes().await;
+    assert_eq!(
+        promoted_heap, warm_heap,
+        "promoted shard's body must report the same heap size as the original Warm shard"
+    );
+}
+
+/// Pin the deferred Commit C contract (now possible thanks to the
+/// `BodyLoader` injection): when the loader returns `None`, the
+/// Parked shard stays Parked, no panic, no half-promoted state, no
+/// daemon crash.  The production code path that reads from the
+/// platform cache directory becomes `MissingBodyLoader` for the
+/// purposes of this test.
+#[tokio::test]
+async fn ensure_warm_for_dispatch_handles_missing_cache_gracefully() {
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::with_body_loader_for_test(None, tx, Arc::new(MissingBodyLoader));
+    mgr.add_drive(build_test_drive()).await;
+
+    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    let states_pre = mgr.shard_states_for_test().await;
+    assert_eq!(states_pre, vec![('C', ShardState::Parked)]);
+
+    // Loader returns None → graceful failure path.
+    mgr.ensure_warm_for_dispatch(&['C']).await;
+
+    let states_post = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states_post, states_pre,
+        "missing body → shard stays Parked, no panic, no half-promoted state"
+    );
+}
+
+/// Pin the panic-recovery path: a `BodyLoader::load` that panics
+/// surfaces as `Err(JoinError)` from `spawn_blocking`, gets logged
+/// at error-level, and leaves the shard untouched.  The daemon
+/// stays up and subsequent calls work normally.
+#[tokio::test]
+async fn ensure_warm_for_dispatch_handles_panicking_body_loader_gracefully() {
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::with_body_loader_for_test(None, tx, Arc::new(PanickingBodyLoader));
+    mgr.add_drive(build_test_drive()).await;
+
+    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+
+    // Loader panics → JoinError arm runs → shard stays Parked.
+    mgr.ensure_warm_for_dispatch(&['C']).await;
+
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states,
+        vec![('C', ShardState::Parked)],
+        "panicking loader → JoinError → shard stays Parked, no daemon crash"
+    );
+
+    // Subsequent ensure_warm_for_dispatch on the same manager
+    // still works (no global daemon state corruption).
+    mgr.ensure_warm_for_dispatch(&['C']).await;
+    let states_again = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states_again,
+        vec![('C', ShardState::Parked)],
+        "second call after a panicking-loader call must also be graceful"
+    );
+}
 
 // ── Phase 3 Commit D — IndexManager::demote_idle_shards ────────────
 
@@ -1913,4 +2069,320 @@ fn demote_then_promote_round_trips_query_stats() {
     assert_eq!(final_c.stats.queries_total(), 6);
     // Last mark_query_at was during round 2 with `now_ms = 2_002`.
     assert_eq!(final_c.stats.last_query_at_ms(), 2_002);
+}
+
+// ── Phase 3 Commit E — virtual-time multi-drive demote tests ───────
+
+/// Plan task 3.7 — three drives loaded; only C is queried; advance
+/// past `WARM_TO_PARKED_IDLE_SECS` and verify D + E demote to Parked
+/// while C stays Warm.
+///
+/// Models the steady-state pattern of a developer using their
+/// project drive (C) actively while archive drives (D, E) sit idle.
+/// Pins the per-shard idle-clock contract: each shard's
+/// `last_query_at_ms` is independent, so the demote controller
+/// only acts on the ones that have actually been idle.
+///
+/// `now_ms` threading lets the test simulate "31 minutes later"
+/// deterministically — no `tokio::time::pause` needed because
+/// `demote_idle_shards(now_ms)` reads the timestamp from its
+/// argument, not from a clock.
+#[tokio::test]
+async fn demote_idle_shards_warm_only_for_unqueried_drives() {
+    use crate::cache::ShardState;
+    use crate::cache::policy::WARM_TO_PARKED_IDLE_SECS;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+    mgr.add_drive(build_test_drive_e()).await;
+
+    let load_ts = 1_000_000_000_u64;
+    // Seed all three to the load timestamp.
+    for letter in ['C', 'D', 'E'] {
+        assert!(
+            mgr.backdate_last_query_at_ms_for_test(letter, load_ts)
+                .await
+        );
+    }
+
+    // C is queried 30 minutes after load (last query at
+    // load_ts + 30min).  D and E remain at load_ts.
+    let c_last_query_ms = load_ts + 30 * 60 * 1000;
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test('C', c_last_query_ms)
+            .await
+    );
+
+    // now_ms = load_ts + 31 minutes.
+    let now_ms = load_ts + 31 * 60 * 1000;
+
+    // Sanity: 31 min ≥ WARM_TO_PARKED_IDLE_SECS for D, E.
+    let d_e_idle_secs = (now_ms - load_ts) / 1000;
+    assert!(d_e_idle_secs >= WARM_TO_PARKED_IDLE_SECS);
+    // Sanity: 1 min < WARM_TO_PARKED_IDLE_SECS for C.
+    let c_idle_secs = (now_ms - c_last_query_ms) / 1000;
+    assert!(c_idle_secs < WARM_TO_PARKED_IDLE_SECS);
+
+    mgr.demote_idle_shards(now_ms).await;
+
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states,
+        vec![
+            ('C', ShardState::Warm),
+            ('D', ShardState::Parked),
+            ('E', ShardState::Parked),
+        ],
+        "C must stay Warm (recently queried); D and E must demote to Parked"
+    );
+}
+
+/// Plan task 3.8 — three Parked drives, advance past
+/// `PARKED_TO_COLD_IDLE_SECS`, verify all three demote to Cold.
+///
+/// Pins the bottom rung of the static-TTL ladder.  The Parked tier
+/// is the first that drops bloom + trie (Phase 4+); for Phase 3
+/// "Parked" already means "no body", so the only difference is the
+/// state label.  Cold means "needs a full re-decrypt to re-promote",
+/// captured by the policy via the longer 24 h threshold.
+#[tokio::test]
+async fn demote_idle_shards_parked_drives_demote_to_cold_past_threshold() {
+    use crate::cache::ShardState;
+    use crate::cache::policy::PARKED_TO_COLD_IDLE_SECS;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+    mgr.add_drive(build_test_drive_e()).await;
+
+    // Seed every drive's last_query to load_ts and demote each to
+    // Parked via the test escape hatch.  Order: backdate first so
+    // the demote controller doesn't trip on the seeding tick.
+    let load_ts = 1_000_000_000_u64;
+    for letter in ['C', 'D', 'E'] {
+        assert!(
+            mgr.backdate_last_query_at_ms_for_test(letter, load_ts)
+                .await
+        );
+        assert!(mgr.demote_letter_for_test(letter, ShardState::Parked).await);
+    }
+
+    let pre_states = mgr.shard_states_for_test().await;
+    assert_eq!(pre_states, vec![
+        ('C', ShardState::Parked),
+        ('D', ShardState::Parked),
+        ('E', ShardState::Parked),
+    ],);
+
+    // now_ms = load_ts + 25 hours (≥ PARKED_TO_COLD_IDLE_SECS = 24h).
+    let now_ms = load_ts + 25 * 60 * 60 * 1000;
+    let idle_secs = (now_ms - load_ts) / 1000;
+    assert!(idle_secs >= PARKED_TO_COLD_IDLE_SECS);
+
+    mgr.demote_idle_shards(now_ms).await;
+
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states,
+        vec![
+            ('C', ShardState::Cold),
+            ('D', ShardState::Cold),
+            ('E', ShardState::Cold),
+        ],
+        "all three Parked shards past the cold-tier TTL must demote to Cold"
+    );
+}
+
+// ── Phase 3 Commit E — tracing-event contract (plan task 3.9) ──────
+
+/// Plan task 3.9 — every demote / promote transition emits exactly
+/// one `tracing::event!(target: "shard.transition", ...)` event.
+///
+/// Pins the operator-facing observability contract: the tracing
+/// fields (`letter`, `from`, `to`, `reason`, `freed_mb` /
+/// `restored_mb`) are part of the public log surface, so a refactor
+/// that silently drops or renames them would break dashboards and
+/// alerting.  This test captures every event during a
+/// demote-then-promote round-trip and asserts on the field values.
+///
+/// `tokio::test` defaults to a `current_thread` runtime, so the
+/// thread-local `tracing::subscriber::set_default` we install at
+/// the top of the test captures every event emitted from inside
+/// the test future — including the events from `demote_letter` /
+/// `promote_letter` running on the same thread.
+#[tokio::test]
+async fn shard_transition_events_emitted_on_demote_and_promote() {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use crate::cache::ShardState;
+
+    let log = EventLog::default();
+    let subscriber = tracing_subscriber::registry().with(log.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let (tx, _rx) = crate::events::event_channel();
+    let body = Arc::new(build_test_drive());
+    let loader = Arc::new(FixedBodyLoader {
+        body: Arc::clone(&body),
+    });
+    let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
+    mgr.add_drive(build_test_drive()).await;
+
+    // Demote → expect one demote event.
+    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    // Promote via ensure_warm_for_dispatch → expect one promote event.
+    mgr.ensure_warm_for_dispatch(&['C']).await;
+
+    let events = log.events();
+    let transitions: Vec<&CapturedEvent> = events
+        .iter()
+        .filter(|event| event.target == "shard.transition")
+        .collect();
+
+    assert_eq!(
+        transitions.len(),
+        2,
+        "expected exactly two shard.transition events (one demote + one promote), got {}: {:#?}",
+        transitions.len(),
+        transitions
+    );
+
+    // `ShardState`'s `Display` impl emits lowercase variant names
+    // (`warm`, `parked`, `cold`, …) — that's the wire contract this
+    // test pins.  See `impl fmt::Display for ShardState` in
+    // `cache/shard.rs`.
+    let demote = transitions[0];
+    assert_eq!(demote.level, tracing::Level::INFO);
+    assert_eq!(demote.field("reason"), Some("demote"));
+    assert_eq!(demote.field("from"), Some("warm"));
+    assert_eq!(demote.field("to"), Some("parked"));
+    assert_eq!(demote.field("letter"), Some("C"));
+    assert!(
+        demote.has_field("freed_mb"),
+        "demote event must carry freed_mb field for resident-delta accounting"
+    );
+
+    let promote = transitions[1];
+    assert_eq!(promote.level, tracing::Level::INFO);
+    assert_eq!(promote.field("reason"), Some("promote"));
+    assert_eq!(promote.field("from"), Some("parked"));
+    assert_eq!(promote.field("to"), Some("warm"));
+    assert_eq!(promote.field("letter"), Some("C"));
+    assert!(
+        promote.has_field("restored_mb"),
+        "promote event must carry restored_mb field for resident-delta accounting"
+    );
+}
+
+// ── Tracing-event capture helpers ──────────────────────────────────
+//
+// Mini scaffold for the Commit E tracing contract test.  Implements
+// `tracing_subscriber::Layer` so a registry-based subscriber can
+// push every event into a thread-safe `Vec<CapturedEvent>`.  The
+// helpers are intentionally minimal — only the fields and methods
+// the contract test asserts on are surfaced.
+
+/// One captured tracing event.
+#[derive(Debug, Clone)]
+struct CapturedEvent {
+    target: String,
+    level: tracing::Level,
+    /// `(field_name, stringified_value)` pairs.
+    fields: Vec<(String, String)>,
+}
+
+impl CapturedEvent {
+    /// String value of `field_name`, or `None` when the field was
+    /// not present on this event.  Returns `&str` (not owned) so the
+    /// test's `assert_eq!` reads naturally.
+    fn field(&self, field_name: &str) -> Option<&str> {
+        self.fields
+            .iter()
+            .find(|(name, _)| name == field_name)
+            .map(|(_, value)| value.as_str())
+    }
+
+    /// `true` iff the event carries a field named `field_name`,
+    /// regardless of its value.  Used for fields whose value is
+    /// dynamic (e.g. `freed_mb` / `restored_mb`) and the test only
+    /// pins the *presence*, not the magnitude.
+    fn has_field(&self, field_name: &str) -> bool {
+        self.fields.iter().any(|(name, _)| name == field_name)
+    }
+}
+
+/// Thread-safe in-memory event log.  Cloned into the
+/// `tracing_subscriber::Layer` and the test asserts against the
+/// shared `Arc<Mutex<...>>`.
+#[derive(Default, Clone)]
+struct EventLog(Arc<std::sync::Mutex<Vec<CapturedEvent>>>);
+
+impl EventLog {
+    fn events(&self) -> Vec<CapturedEvent> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+impl<S> tracing_subscriber::Layer<S> for EventLog
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let metadata = event.metadata();
+        let mut visitor = FieldCapture::default();
+        event.record(&mut visitor);
+        self.0.lock().unwrap().push(CapturedEvent {
+            target: metadata.target().to_owned(),
+            level: *metadata.level(),
+            fields: visitor.fields,
+        });
+    }
+}
+
+/// `tracing::field::Visit` impl that converts every recorded field
+/// into a `(name, stringified_value)` pair.
+#[derive(Default)]
+struct FieldCapture {
+    fields: Vec<(String, String)>,
+}
+
+impl tracing::field::Visit for FieldCapture {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields
+            .push((field.name().to_owned(), value.to_owned()));
+    }
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn core::fmt::Debug) {
+        // The `tracing::info!(letter = %x.to_ascii_uppercase(), ...)`
+        // form goes through `record_debug` because `%` selects the
+        // `Display` adapter and the underlying `Field` is recorded
+        // via `Debug`.  We strip the surrounding quotes that
+        // `Debug` adds for strings so the test asserts read
+        // naturally.
+        let raw = format!("{value:?}");
+        let stripped = raw
+            .strip_prefix('"')
+            .and_then(|tail| tail.strip_suffix('"'))
+            .map(str::to_owned)
+            .unwrap_or(raw);
+        self.fields.push((field.name().to_owned(), stripped));
+    }
 }

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -1675,6 +1675,209 @@ async fn ensure_warm_for_dispatch_skips_parked_shard_outside_filter() {
 // `ensure_warm_for_dispatch_skips_parked_shard_outside_filter` (load attempt
 // only on Parked shards, and the filter precludes any).
 
+// ── Phase 3 Commit D — IndexManager::demote_idle_shards ────────────
+
+/// `add_drive` calls `DriveStats::mark_loaded_at(now_ms)` on the
+/// freshly mounted shard so the demote-controller's idle clock
+/// starts ticking from load time, not from epoch zero.  Without
+/// this seed, every freshly loaded shard would demote on the
+/// first idle tick because `last_query_at_ms == 0` would compute
+/// `idle_secs ≈ now_ms / 1000` (≈ billions of seconds since
+/// 1970-01-01).
+#[tokio::test]
+async fn mark_loaded_at_seeds_freshly_added_drive() {
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+
+    // Read the shard's last_query_at_ms via a search-ish path; we
+    // only have access from inside the manager, so drive a
+    // demote-controller call with `now_ms = load_ts + 0` and assert
+    // the shard didn't demote — that proves last_query_at_ms is
+    // recent (within `WARM_TO_PARKED_IDLE_SECS` of now).
+    //
+    // More directly: the timestamp must be non-zero.  We test that
+    // by attempting to demote at a now that's *exactly* the load
+    // time + 1 ms; an unseeded shard would have `idle_ms = now`
+    // (huge) and demote, but a seeded shard sees `idle_ms = 1` ms
+    // (basically 0 s) and stays Warm.
+    let states_before = mgr.shard_states_for_test().await;
+    assert_eq!(states_before, vec![('C', crate::cache::ShardState::Warm)]);
+
+    // Synthetic now_ms a billion ms in the future would catch
+    // unseeded `last_query_at_ms == 0`.  But a seeded shard has
+    // last_query_at_ms ≈ unix_now_ms() (when add_drive was just
+    // called), so calling demote_idle_shards with the same now
+    // gives idle_secs ≈ 0.
+    let now_ms = crate::cache::unix_now_ms();
+    mgr.demote_idle_shards(now_ms).await;
+
+    let states_after = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states_after, states_before,
+        "freshly loaded shard must NOT demote on the first tick — \
+         mark_loaded_at must have seeded last_query_at_ms",
+    );
+}
+
+/// Fast-path contract: `demote_idle_shards` on a registry where
+/// every shard has been queried recently must complete with no
+/// state mutation and no `index_version` bump.
+#[tokio::test]
+async fn demote_idle_shards_no_op_when_all_fresh() {
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+
+    // Pretend every shard was queried at t=10_000_000_000 ms.
+    let load_ts = 10_000_000_000_u64;
+    assert!(mgr.backdate_last_query_at_ms_for_test('C', load_ts).await);
+    assert!(mgr.backdate_last_query_at_ms_for_test('D', load_ts).await);
+
+    // `now_ms` only 1 ms after load → idle_secs = 0 → no demote.
+    mgr.demote_idle_shards(load_ts + 1).await;
+
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(states, vec![
+        ('C', ShardState::Warm),
+        ('D', ShardState::Warm)
+    ]);
+}
+
+/// Warm shard idle past `WARM_TO_PARKED_IDLE_SECS` demotes to
+/// Parked on the next `demote_idle_shards` call.
+#[tokio::test]
+async fn demote_idle_shards_warm_to_parked_at_ttl() {
+    use crate::cache::policy::WARM_TO_PARKED_IDLE_SECS;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+
+    // Backdate C's last_query_at_ms to t=1_000_000_000 ms.
+    let last_query_ms = 1_000_000_000_u64;
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test('C', last_query_ms)
+            .await
+    );
+
+    // now_ms = last_query + WARM_TO_PARKED_IDLE_SECS * 1000 (exact
+    // boundary; `next_state_for_idle` uses `>=`).
+    let now_ms = last_query_ms + WARM_TO_PARKED_IDLE_SECS * 1000;
+    mgr.demote_idle_shards(now_ms).await;
+
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(states, vec![('C', crate::cache::ShardState::Parked)]);
+}
+
+/// Warm shard idle just below `WARM_TO_PARKED_IDLE_SECS` stays
+/// Warm — pin the off-by-one that `>=` vs `>` would expose.
+#[tokio::test]
+async fn demote_idle_shards_below_ttl_keeps_warm() {
+    use crate::cache::policy::WARM_TO_PARKED_IDLE_SECS;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+
+    let last_query_ms = 1_000_000_000_u64;
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test('C', last_query_ms)
+            .await
+    );
+
+    // 1 ms before the boundary — idle_secs computed by
+    // `(now - last) / 1000` is `WARM_TO_PARKED_IDLE_SECS - 1`,
+    // strictly below the threshold.
+    let now_ms = last_query_ms + WARM_TO_PARKED_IDLE_SECS * 1000 - 1;
+    mgr.demote_idle_shards(now_ms).await;
+
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(states, vec![('C', crate::cache::ShardState::Warm)]);
+}
+
+/// Parked shard idle past `PARKED_TO_COLD_IDLE_SECS` demotes to
+/// Cold on the next `demote_idle_shards` call.
+///
+/// Pins the multi-step ladder: a single tick can see both
+/// `Warm → Parked` and `Parked → Cold` transitions if a Parked
+/// shard's `last_query_at_ms` is old enough, but the policy only
+/// returns one demote target per call so each tick advances each
+/// shard at most one tier.  This test seeds a Parked shard
+/// directly to keep the assertion focused.
+#[tokio::test]
+async fn demote_idle_shards_parked_to_cold_at_ttl() {
+    use crate::cache::ShardState;
+    use crate::cache::policy::PARKED_TO_COLD_IDLE_SECS;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+
+    // Seed C as Parked via the test escape hatch.
+    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+
+    // Backdate so the Parked shard has been idle past its TTL.
+    let last_query_ms = 1_000_000_000_u64;
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test('C', last_query_ms)
+            .await
+    );
+
+    let now_ms = last_query_ms + PARKED_TO_COLD_IDLE_SECS * 1000;
+    mgr.demote_idle_shards(now_ms).await;
+
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(states, vec![('C', ShardState::Cold)]);
+}
+
+/// `demote_idle_shards` batches multiple demotes inside a single
+/// write-lock window.  Pin the contract by demoting three shards
+/// in one call.
+#[tokio::test]
+async fn demote_idle_shards_batches_multiple_demotes() {
+    use crate::cache::ShardState;
+    use crate::cache::policy::WARM_TO_PARKED_IDLE_SECS;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+
+    let last_query_ms = 1_000_000_000_u64;
+    for letter in ['C', 'D'] {
+        assert!(
+            mgr.backdate_last_query_at_ms_for_test(letter, last_query_ms)
+                .await
+        );
+    }
+
+    let now_ms = last_query_ms + WARM_TO_PARKED_IDLE_SECS * 1000;
+    let version_before = mgr
+        .index_version
+        .load(core::sync::atomic::Ordering::Relaxed);
+    mgr.demote_idle_shards(now_ms).await;
+    let version_after = mgr
+        .index_version
+        .load(core::sync::atomic::Ordering::Relaxed);
+
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states,
+        vec![('C', ShardState::Parked), ('D', ShardState::Parked)],
+        "all backdated Warm shards must demote in a single batch call"
+    );
+    assert_eq!(
+        version_after - version_before,
+        1,
+        "batch must bump index_version exactly once for the whole batch, \
+         not once per demoted shard"
+    );
+}
+
 /// End-to-end: demote → promote → demote → promote preserves
 /// query stats across every rebuild.  Pins the
 /// `Arc<DriveStats>`-sharing contract under repeated transitions.

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -259,6 +259,8 @@ pub async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
         Arc::clone(&idx),
         telemetry::DEFAULT_MEM_SNAPSHOT_INTERVAL,
     );
+    // Phase 3 Commit D — periodic shard idle-demote sweep.
+    let _idle_demote_task = spawn_idle_demote_controller(Arc::clone(&idx));
 
     // Run idle timer (blocks until shutdown or timeout) then tear
     // everything down.  Returns `!` so `force_exit_with_watchdog`
@@ -617,6 +619,34 @@ fn spawn_stats_heartbeat(
                     total_records,
                     connections: stats_lifecycle.active_connections(),
                 });
+        }
+    })
+}
+
+/// Spawn the Phase 3 idle-demote controller — every 30 s, ask
+/// `IndexManager::demote_idle_shards` to walk the registry and
+/// demote any shard whose idle time exceeds its tier's TTL (see
+/// `cache::policy`).
+///
+/// The 30 s cadence is shorter than the shortest TTL (300 s
+/// Hot→Warm) by an order of magnitude, so a freshly idle Hot
+/// shard demotes within at most one tick of crossing its
+/// boundary.  Sampling `unix_now_ms()` once at the top of each
+/// tick (and threading it into the manager) keeps every shard's
+/// idle-secs computation referenced to the same baseline — a
+/// slow read-lock acquisition can't push later shards in the
+/// same batch over a TTL boundary mid-walk.
+fn spawn_idle_demote_controller(idx: Arc<index::IndexManager>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(core::time::Duration::from_secs(30));
+        // Skip the first tick (fires immediately at task spawn).
+        // We want the controller to take its first reading 30 s
+        // after startup, not at t=0 when no shard could possibly
+        // be idle yet.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            idx.demote_idle_shards(cache::unix_now_ms()).await;
         }
     })
 }


### PR DESCRIPTION
# Phase 3 — State machine + lazy body load

Closes the Phase 3 milestone of the memory-tiering work
(`docs/refactor/memory-tiering-implementation-plan.md` §3 Phase 3).
Wires `ShardState` transitions, demote-on-idle, promote-on-query, and the
`BodyLoader` injection point that makes the graceful-failure paths
testable.

Stacked PR — Phase 4 (`feat/memory-tiering-phase-4`) is already branched
off this HEAD and starts from Commit A (bloom filter scaffolding) on
top.

## What's in this PR

Six commits on `feat/memory-tiering-phase-3`:

| Commit | Subject | Plan tasks |
|---|---|---|
| `ed76eafb5` | **A**: optional body + `last_query_at_ms` + `cache::policy` | 3.1, 3.2, 3.3 (data shape) |
| `7e9917cf7` | **B**: `ShardRegistry::demote_letter` / `promote_letter` | 3.1, 3.2, 3.3 (logic) |
| `c05fb5ef8` | **C**: `IndexManager::ensure_warm_for_dispatch` wired into `search()` | 3.5 |
| `f56a48bea` | refactor: extract `build_query_predicates` to sibling module (file-size policy) | — |
| `c44a7ce4a` | **D**: `IndexManager::demote_idle_shards` + 30 s tick task | 3.4 |
| `1ee68c611` | **E**: `BodyLoader` trait + virtual-time + tracing tests | 3.7, 3.8, 3.9 |

## Plan acceptance

| Task | Status |
|---|---|
| 3.1 promote_to_warm | ✅ — `promote_letter` + `ensure_warm_for_dispatch` |
| 3.2 demote_to_parked | ✅ — `demote_letter(_, Parked)` |
| 3.3 demote_to_cold | ✅ — `demote_letter(_, Cold)` |
| 3.4 30 s tick task | ✅ — `spawn_idle_demote_controller` in `lib.rs` |
| 3.5 search calls promote | ✅ — wired into `IndexManager::search` |
| 3.6 LRU bookkeeping | **deferred to Phase 5** (pressure-driven eviction needs an ordering structure static-TTL doesn't) |
| 3.7 virtual-time test (queries on C only) | ✅ — `demote_idle_shards_warm_only_for_unqueried_drives` |
| 3.8 virtual-time test (past parked TTL) | ✅ — `demote_idle_shards_parked_drives_demote_to_cold_past_threshold` |
| 3.9 tracing-event contract | ✅ — `shard_transition_events_emitted_on_demote_and_promote` |

## Mac gate (PASS)

- `cargo nextest run --workspace` → **1425 / 1425** PASS, 11 skipped (was
  1419 / 1419 on `main` post-Phase-2b).
- 61 / 61 PASS in the targeted shard / registry / lifecycle / demote /
  promote / ensure_warm subset.
- `just lint-prod` clean.
- `just check-windows` clean (xwin cross-compile).
- `just check-all-targets` clean for macOS native + Windows-xwin (Linux
  Docker skipped — daemon not running).

## Architectural notes

### `BodyLoader` trait

`pub(crate) trait BodyLoader: Send + Sync + 'static` lives in
`crates/uffs-daemon/src/cache/body_loader.rs`.  Production impl
(`DiskBodyLoader`) wraps `uffs_core::compact_cache::load_compact_cache`;
test fakes (`FixedBodyLoader`, `MissingBodyLoader`,
`PanickingBodyLoader`) make the success / missing-cache /
panicking-loader paths deterministically testable without touching the
platform cache directory.

The trait is **synchronous** — the orchestrator wraps every call in
`tokio::task::spawn_blocking`, so impls can do file I/O, decryption,
allocation without blocking the async runtime.  Async work inside the
loader would deadlock the spawn-blocking thread pool and is documented
as unsupported.

### Tracing-event contract

Every demote / promote emits exactly one
`tracing::event!(target: "shard.transition", level=INFO, ...)` with
fields:

- `letter` — drive letter as a one-character string.
- `from` / `to` — `ShardState` `Display` form (lowercase: `warm`,
  `parked`, `cold`, …).
- `reason` — `"demote"` or `"promote"`.
- `freed_mb` (demote) or `restored_mb` (promote) — resident-delta
  accounting.

The `shard_transition_events_emitted_on_demote_and_promote` test pins
this surface via a custom `tracing_subscriber::Layer`.

### Per-shard idle clock

`add_drive` calls `DriveStats::mark_loaded_at(now_ms)` on the freshly
mounted shard so the demote-controller's idle clock starts ticking from
load time, not from epoch zero.  Without this seed, every freshly loaded
shard would demote on the first idle tick because
`last_query_at_ms == 0` would compute
`idle_secs ≈ now_ms / 1000` (≈ billions of seconds since 1970-01-01).

### File-size policy

The `f56a48bea` refactor extracts `build_query_predicates` to a sibling
module (`crates/uffs-daemon/src/index/search_predicates.rs`) so
`search.rs` stays under the 800-LOC soft cap after the
`ensure_warm_for_dispatch` call-site comment.  No behavioural change.

## Notes for the reviewer

- The `cache::body_loader::BodyLoader` trait is intentionally `pub(crate)`
  rather than `pub` — the abstraction exists to inject test fakes from
  the same crate, not to extend behaviour from outside.

- `IndexManager::with_body_loader_for_test` is `#[cfg(test)]`-only.

- The plan's 3.9 task wording said `resident_delta_mb`; the
  implementation uses per-direction `freed_mb` / `restored_mb` instead.
  The asymmetry is intentional (only demote frees memory; only promote
  restores it) and the per-direction names read more naturally on
  operator dashboards.  Plan doc updated locally to match.

## What's next (Phase 4 stacked PR)

Phase 4 is the **PRIMARY MILESTONE** that delivers the headline "≤ 50 MB
resident on a 7-drive idle box" target.  Branch
`feat/memory-tiering-phase-4` already has Commit A landed (bloom filter
scaffolding, `1d19470ca`); Commits B–G land:

- B — directory-only path-trie (`uffs-core/src/path_trie.rs`).
- C — `DriveCompactIndex::{build_bloom, build_path_trie}` insert-side
  wiring.
- D — cache format v9 (bloom + trie sections, bump `COMPACT_VERSION`
  to 9).
- E — PARKED partial-load (only bloom + trie, skip records / names /
  trigram / children).
- F — `search_dispatch` bloom pre-check + `IndexManager`
  promote-on-bloom-hit + multi-drive integration tests.
- G — perf + memory budgets.
