### PR TITLE
feat(core): Phase 4 memory tiering — bloom + path trie + parked-shard bloom skip

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -42,6 +42,8 @@ fo = "fo"
 ba = "ba"
 
 # ── Acronyms / identifier fragments found in docs & code ────────────
+FPR = "FPR"               # false-positive rate (probabilistic-DS / bloom-filter standard term)
+fpr = "fpr"               # lower-case form for identifier names like `target_fpr`
 anc = "anc"               # ancestry / ancestor abbreviations in MFT docs
 Ded = "Ded"               # acronym / identifier fragment
 Pn = "Pn"                 # pin / pinning abbreviations in trait bounds

--- a/crates/uffs-core/src/aggregate/rollup.rs
+++ b/crates/uffs-core/src/aggregate/rollup.rs
@@ -324,6 +324,8 @@ mod tests {
             ext_names: vec![],
             source: IndexSource::MftFile(PathBuf::from("C:")),
             source_epoch: 0,
+            bloom: None,
+            path_trie: None,
         }
     }
 

--- a/crates/uffs-core/src/bloom.rs
+++ b/crates/uffs-core/src/bloom.rs
@@ -259,6 +259,40 @@ impl Bloom {
         self.k_hashes
     }
 
+    /// Borrow the bit-packed storage as a slice of `u64` words.
+    ///
+    /// Used by the Phase 4 cache-format serialiser
+    /// (`compact_cache::filters_io::write_bloom_section`) to blit the
+    /// bloom contents in one `bytemuck::cast_slice` call.
+    #[must_use]
+    pub fn bits(&self) -> &[u64] {
+        &self.bits
+    }
+
+    /// Reconstruct a `Bloom` from raw `(nbits, k_hashes, bits)` parts.
+    ///
+    /// Validates that `bits.len() * 64 == nbits` and `nbits` is a
+    /// multiple of 64; returns `None` on either violation so the
+    /// cache-format deserialiser can reject corrupted files instead
+    /// of producing an inconsistent filter.  `k_hashes` is clamped
+    /// to `[1, 32]` (matching the [`Bloom::with_size_and_k`]
+    /// contract).
+    #[must_use]
+    pub fn from_raw_parts(nbits: u64, k_hashes: u8, bits: Vec<u64>) -> Option<Self> {
+        if nbits == 0 || !nbits.is_multiple_of(64) {
+            return None;
+        }
+        let expected_words = (nbits / 64) as usize;
+        if bits.len() != expected_words {
+            return None;
+        }
+        Some(Self {
+            bits,
+            nbits,
+            k_hashes: k_hashes.clamp(1, 32),
+        })
+    }
+
     /// Analytic false-positive rate estimate for `n_inserted` items.
     ///
     /// Formula: `(1 - exp(-k*n/m))^k`.  Useful for telemetry — the

--- a/crates/uffs-core/src/bloom.rs
+++ b/crates/uffs-core/src/bloom.rs
@@ -1,0 +1,541 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Bit-packed bloom filter for the Phase 4 memory-tiering tier-skip path.
+//!
+//! Phase 4's headline contract is **"Bloom miss ⇒ zero RAM touch, zero
+//! promotion."**  Each shard persists a bloom over its basenames /
+//! extensions / directory names; PARKED shards keep only bloom +
+//! path-trie resident (~5–15 MB) instead of the full records / names /
+//! trigram columns.  When a search dispatches to N drives, every drive's
+//! bloom is consulted first; misses skip the drive entirely so the
+//! kernel never has to fault its body back into RAM.  This is what
+//! unlocks the "≤ 50 MB resident on a 7-drive idle box" target
+//! documented at the headline of the
+//! `docs/refactor/memory-tiering-implementation-plan.md` §3 Phase 4.
+//!
+//! ## Design — k=7 hashes, double-hashing trick
+//!
+//! Per the tiering-plan §6.2 parameter table the filter targets a 1 %
+//! FPR at k=7 with `xxh3` as the underlying hash.  This implementation
+//! uses the workspace's existing `rustc_hash::FxHasher` (already a
+//! workspace dep, no new audit-surface), combined with the
+//! **double-hashing** technique of [Kirsch & Mitzenmacher 2006, "Less
+//! Hashing, Same Performance"][km06]:
+//!
+//! 1. Compute two independent base hashes `hash_a`, `hash_b` from the key by
+//!    feeding two different 64-bit prefix seeds into `FxHasher`.
+//! 2. The k bit positions are `(hash_a + i * hash_b) mod nbits` for `i ∈ 0..k`.
+//!
+//! This is provably equivalent (in expected FPR) to k independent
+//! hashes when `k ≪ √nbits`, which holds at our parameters (k=7,
+//! `nbits ≈ 10·n ≥ thousands`).  The benefit is two `FxHasher`
+//! invocations per query/insert instead of seven, and zero new
+//! dependencies.
+//!
+//! `FxHash` is non-cryptographic and has known bias on adversarial
+//! input distributions — but bloom filters in this codebase are
+//! populated from filesystem names that an attacker can't choose (the
+//! threat model is covered by the encrypted-cache layer, not the
+//! bloom).  For the standard "filesystem names → 1 % FPR target"
+//! workload `FxHash` is indistinguishable from `xxh3` in measured FPR.
+//!
+//! [km06]: https://www.eecs.harvard.edu/~michaelm/postscripts/rsa2008.pdf
+//!
+//! ## API surface
+//!
+//! - [`Bloom::with_capacity_and_fpr`] — sized for a target item count and
+//!   false-positive rate; computes optimal `(nbits, k)`.
+//! - [`Bloom::with_size_and_k`] — explicit size + hash count, for tests and
+//!   serialised-on-disk reconstruction.
+//! - [`Bloom::insert`] / [`Bloom::contains`] — the hot path.
+//! - [`Bloom::estimated_fpr`] — analytic FPR estimate for a given load factor;
+//!   used by tests and the `shard.bloom.decision` telemetry.
+
+use core::hash::Hasher;
+
+use rustc_hash::FxHasher;
+
+/// First seed for the double-hashing prefix.
+///
+/// Distinct from [`SEED_B`] to make `hash_a` and `hash_b` independent
+/// under `FxHasher`.  The exact bits don't matter — only that
+/// `(SEED_A, SEED_B)` aren't trivially related (e.g. one isn't a
+/// bit-shift of the other) so that prefix-then-`FxHash` produces
+/// statistically independent base hashes.
+const SEED_A: u64 = 0xA5A5_C3C3_F0F0_5A5A;
+
+/// Second seed for the double-hashing prefix.
+///
+/// Distinct from [`SEED_A`] (different high-byte pattern) so the two
+/// `FxHasher` streams diverge from the first byte.
+const SEED_B: u64 = 0x5A5A_3C3C_0F0F_A5A5;
+
+/// Number of hash functions for the workspace's standard 1 %-FPR
+/// target.
+///
+/// Per tiering-plan §6.2 this is fixed at 7.  Exposed via
+/// [`Bloom::k`] so callers can introspect.
+pub const DEFAULT_K: u8 = 7;
+
+/// Bit-packed bloom filter with double-hashing.
+///
+/// Memory layout: `bits` is a `Vec<u64>` where each `u64` packs 64
+/// bit-positions of the filter.  `nbits` is always a multiple of 64
+/// (constructors round up).  The total heap footprint is
+/// `nbits / 8` bytes plus 32 bytes of struct overhead — for the
+/// canonical 1 M-item / 1 % FPR sizing that's about 1.2 MB per shard.
+#[derive(Debug, Clone)]
+pub struct Bloom {
+    /// Bit-packed storage.  `bits[i]` holds bit positions
+    /// `64*i ..= 64*i + 63`.
+    bits: Vec<u64>,
+    /// Total bit count, always a multiple of 64.  Stored explicitly
+    /// so the modulo in [`Bloom::bit_index`] reads off a `u64`
+    /// rather than recomputing `bits.len() * 64` every probe.
+    nbits: u64,
+    /// Number of hash functions per insert / query.
+    ///
+    /// Stored as `u8` because the optimal value at any reasonable
+    /// load factor is well below 256 (~7 for 1 % FPR, ~10 for 0.1 %
+    /// FPR).
+    k_hashes: u8,
+}
+
+impl Bloom {
+    /// Construct a bloom sized for `n_items` distinct elements at the
+    /// given target false-positive rate.
+    ///
+    /// Uses the standard sizing formulas:
+    ///   - `m / n = -ln(p) / ln(2)^2`
+    ///   - `k = (m / n) * ln(2)`
+    ///
+    /// ## Panics
+    ///
+    /// - `n_items == 0`.
+    /// - `target_fpr` not in `(0.0, 1.0)`.
+    ///
+    /// Both conditions indicate caller bugs (a zero-element bloom or
+    /// a nonsense FPR target) rather than recoverable runtime states,
+    /// so panicking is the correct behaviour.
+    #[must_use]
+    #[expect(
+        clippy::float_arithmetic,
+        reason = "bloom sizing formulas are inherently floating-point; the workspace \
+                  ban exists to flag accidental float math in integer codepaths, not \
+                  to forbid math libraries that are *defined* over the reals"
+    )]
+    pub fn with_capacity_and_fpr(n_items: usize, target_fpr: f64) -> Self {
+        assert!(n_items > 0_usize, "bloom: n_items must be > 0");
+        assert!(
+            target_fpr > 0.0_f64 && target_fpr < 1.0_f64,
+            "bloom: target_fpr must be in (0.0, 1.0), got {target_fpr}",
+        );
+
+        // m / n = -ln(p) / ln(2)^2
+        let ln2 = core::f64::consts::LN_2;
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "n_items > 1<<53 would mean a multi-petabyte bloom; not a real \
+                      use case for filesystem-name filters"
+        )]
+        let n_as_float = n_items as f64;
+        let bits_per_element = -target_fpr.ln() / (ln2 * ln2);
+        let nbits_as_float = (n_as_float * bits_per_element).ceil();
+
+        // Round up to next multiple of 64 so the bit-packed Vec<u64>
+        // has whole-word alignment.  Saturate to u64::MAX on overflow
+        // (a 16-EB bloom is well outside any realistic call site).
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "nbits_as_float is non-negative and bounded by ceil(n * 30) for \
+                      reasonable inputs; the f64-to-u64 cast is the standard \
+                      conversion clippy permits via `#[expect]`"
+        )]
+        let nbits_raw = nbits_as_float as u64;
+        let aligned_nbits = nbits_raw.div_ceil(64).saturating_mul(64).max(64);
+
+        // k = (m / n) * ln(2), clamped to [1, 32].  The clamp protects
+        // the u8 cast and matches the tiering-plan §6.2 envelope.
+        let k_as_float = (bits_per_element * ln2).round();
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "k_as_float is in [1.0, 32.0] after clamp; the f64-to-u8 cast \
+                      is well-defined (the clamp bounds the value into u8 range)"
+        )]
+        let k_clamped = k_as_float.clamp(1.0_f64, 32.0_f64) as u8;
+
+        Self::with_size_and_k(aligned_nbits, k_clamped)
+    }
+
+    /// Construct a bloom with explicit `nbits` and `k_hashes`.
+    ///
+    /// `nbits` is rounded up to the next multiple of 64.  `k_hashes`
+    /// is clamped to `[1, 32]`.
+    ///
+    /// Used by [`Bloom::with_capacity_and_fpr`] internally and by the
+    /// cache-format deserialiser (Phase 4 Commit D), which
+    /// reconstructs the filter from the on-disk header.
+    #[must_use]
+    pub fn with_size_and_k(nbits: u64, k_hashes: u8) -> Self {
+        let aligned_nbits = nbits.div_ceil(64).saturating_mul(64).max(64);
+        let clamped_k = k_hashes.clamp(1, 32);
+        let nwords_u64 = aligned_nbits / 64;
+        // u64-to-usize is lossless on every 64-bit target the workspace
+        // supports.  On 32-bit targets the saturating_mul + Vec capacity
+        // limit would clip the bloom long before the cast became an issue.
+        let nwords = nwords_u64 as usize;
+        Self {
+            bits: vec![0_u64; nwords],
+            nbits: aligned_nbits,
+            k_hashes: clamped_k,
+        }
+    }
+
+    /// Insert `key` into the filter.
+    ///
+    /// Idempotent: re-inserting an existing key is a no-op (the bits
+    /// are already set).  O(k) time, O(1) extra memory.
+    pub fn insert(&mut self, key: &[u8]) {
+        let (hash_a, hash_b) = Self::base_hashes(key);
+        for probe_idx in 0..u64::from(self.k_hashes) {
+            let pos = self.bit_index(hash_a, hash_b, probe_idx);
+            self.set_bit(pos);
+        }
+    }
+
+    /// Test whether `key` is *possibly* in the filter.
+    ///
+    /// Returns `true` if every k-th bit is set (key may be present;
+    /// false-positive probability is bounded by
+    /// [`Bloom::estimated_fpr`]) or `false` if any bit is clear (key
+    /// is *definitely* not present).
+    ///
+    /// Short-circuits on the first clear bit so a miss is typically
+    /// `~k/2` probes on average.
+    #[must_use]
+    pub fn contains(&self, key: &[u8]) -> bool {
+        let (hash_a, hash_b) = Self::base_hashes(key);
+        for probe_idx in 0..u64::from(self.k_hashes) {
+            let pos = self.bit_index(hash_a, hash_b, probe_idx);
+            if !self.get_bit(pos) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Total bit count of the filter (always a multiple of 64).
+    #[must_use]
+    pub const fn nbits(&self) -> u64 {
+        self.nbits
+    }
+
+    /// Heap footprint in bytes (`nbits / 8`).
+    ///
+    /// Used by the Phase 4 memory-budget tests and by the
+    /// `shard.transition` event's `freed_mb` / `restored_mb`
+    /// accounting.
+    #[must_use]
+    pub const fn size_bytes(&self) -> usize {
+        // nbits is always a multiple of 64 and stored as u64; size in
+        // bytes is nbits / 8 which fits usize on every 32-bit-or-larger
+        // target the workspace supports.  The cast is safe because
+        // realistic blooms never exceed a few tens of MB.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "nbits / 8 ≤ a few tens of MB for any realistic bloom; \
+                      fits usize even on 32-bit targets"
+        )]
+        let bytes = self.nbits as usize / 8;
+        bytes
+    }
+
+    /// Number of hash functions per insert / query.
+    #[must_use]
+    pub const fn k(&self) -> u8 {
+        self.k_hashes
+    }
+
+    /// Analytic false-positive rate estimate for `n_inserted` items.
+    ///
+    /// Formula: `(1 - exp(-k*n/m))^k`.  Useful for telemetry — the
+    /// `shard.bloom.decision` event reports this so an operator can
+    /// see the live FPR converge on the design target as a shard
+    /// fills up.
+    #[must_use]
+    #[expect(
+        clippy::float_arithmetic,
+        reason = "FPR formula is inherently floating-point"
+    )]
+    pub fn estimated_fpr(&self, n_inserted: usize) -> f64 {
+        if n_inserted == 0 || self.nbits == 0 {
+            return 0.0_f64;
+        }
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "n_inserted up to 2^53 is representable exactly in f64; beyond \
+                      that the FPR estimate is already saturated near 1.0 anyway"
+        )]
+        let n_as_float = n_inserted as f64;
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "see above; nbits up to 2^53 is exact, beyond that the bloom is \
+                      petabyte-scale and FPR is dominated by k, not m"
+        )]
+        let m_as_float = self.nbits as f64;
+        let k_as_float = f64::from(self.k_hashes);
+        let inner = 1.0_f64 - (-k_as_float * n_as_float / m_as_float).exp();
+        inner.powf(k_as_float)
+    }
+
+    /// Compute the two base hashes used for double-hashing.
+    ///
+    /// Associated function (no `&self`) because the seeds are global
+    /// constants and the result is purely a function of the key.
+    fn base_hashes(key: &[u8]) -> (u64, u64) {
+        let mut hasher_a = FxHasher::default();
+        hasher_a.write_u64(SEED_A);
+        hasher_a.write(key);
+        let hash_a = hasher_a.finish();
+
+        let mut hasher_b = FxHasher::default();
+        hasher_b.write_u64(SEED_B);
+        hasher_b.write(key);
+        let hash_b = hasher_b.finish();
+
+        // Ensure hash_b is odd so `(hash_a + i*hash_b) mod nbits`
+        // walks every residue class as i increments.  An even hash_b
+        // would visit only half the bits when nbits is a power-of-two
+        // multiple of 64.  Setting the LSB is the standard fix and
+        // doesn't materially affect FPR (we just reflect the LSB into
+        // the seed space).
+        (hash_a, hash_b | 1)
+    }
+
+    /// Resolve the i-th bit position for a given key.
+    ///
+    /// `bit_index(hash_a, hash_b, probe_idx) =
+    /// (hash_a + probe_idx * hash_b) mod nbits`.  The `wrapping_*`
+    /// operators are correct here — modular arithmetic over `u64`
+    /// mod `nbits` is exactly what double-hashing needs.
+    const fn bit_index(&self, hash_a: u64, hash_b: u64, probe_idx: u64) -> u64 {
+        let raw = hash_a.wrapping_add(probe_idx.wrapping_mul(hash_b));
+        raw % self.nbits
+    }
+
+    /// Set bit `pos` in the bit-packed storage.
+    fn set_bit(&mut self, pos: u64) {
+        let word_idx = (pos / 64) as usize;
+        let bit_idx = pos & 63;
+        // SAFETY of the indexing: pos < self.nbits (caller invariant
+        // via `bit_index`), and self.nbits == self.bits.len() * 64
+        // (constructor invariant), so word_idx < self.bits.len().
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "pos < nbits ⇒ word_idx < bits.len() by constructor invariant"
+        )]
+        {
+            self.bits[word_idx] |= 1_u64 << bit_idx;
+        }
+    }
+
+    /// Read bit `pos` from the bit-packed storage.
+    fn get_bit(&self, pos: u64) -> bool {
+        let word_idx = (pos / 64) as usize;
+        let bit_idx = pos & 63;
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "pos < nbits ⇒ word_idx < bits.len() by constructor invariant"
+        )]
+        let word = self.bits[word_idx];
+        (word >> bit_idx) & 1 == 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke: an empty bloom returns `false` for every query.
+    #[test]
+    fn empty_bloom_contains_nothing() {
+        let bloom = Bloom::with_capacity_and_fpr(100, 0.01_f64);
+        for i in 0_u32..1000 {
+            assert!(!bloom.contains(&i.to_le_bytes()));
+        }
+    }
+
+    /// Insert determinism: every inserted key must report `contains
+    /// == true`.  This is the bloom's only hard guarantee (no false
+    /// negatives).
+    #[test]
+    fn no_false_negatives() {
+        let mut bloom = Bloom::with_capacity_and_fpr(10_000, 0.01_f64);
+        for i in 0_u32..10_000 {
+            bloom.insert(&i.to_le_bytes());
+        }
+        for i in 0_u32..10_000 {
+            assert!(
+                bloom.contains(&i.to_le_bytes()),
+                "key {i} reported as missing — bloom must never false-negative"
+            );
+        }
+    }
+
+    /// Sizing sanity: `with_capacity_and_fpr(1M, 1%)` lands on the
+    /// canonical ~10 bits/element envelope from tiering-plan §6.2.
+    #[test]
+    fn capacity_and_fpr_sizes_to_canonical_envelope() {
+        let bloom = Bloom::with_capacity_and_fpr(1_000_000, 0.01_f64);
+        // Optimal m/n for p=0.01 is ~9.585; rounded to multiple of 64
+        // and post-ceil() that lands in [9_500_000, 9_700_000].
+        assert!(
+            bloom.nbits() >= 9_500_000 && bloom.nbits() <= 9_700_000,
+            "nbits = {} outside canonical 1M-item / 1%-FPR envelope",
+            bloom.nbits(),
+        );
+        // k for 1 % FPR rounds to 7.
+        assert_eq!(bloom.k(), 7);
+        // Size in bytes is ~1.2 MB.
+        assert!(bloom.size_bytes() >= 1_180_000 && bloom.size_bytes() <= 1_220_000);
+    }
+
+    /// Plan task 4.2: 100 K random strings inserted into a **1.2
+    /// Mbit** bloom (k=7), 100 K *novel* strings queried,
+    /// FPR ≤ 1.5 %.
+    ///
+    /// Sizes the bloom via [`Bloom::with_size_and_k`] to match the
+    /// plan's explicit 1.2 Mbit / k=7 envelope rather than going
+    /// through [`Bloom::with_capacity_and_fpr`] (which would land on
+    /// the formula's optimum of ~960 kbit and trade off some FPR
+    /// margin for memory).  At m=1.2M / k=7 / n=100k the analytic
+    /// FPR is ≈ 0.5 %, leaving generous headroom under the 1.5 %
+    /// gate.
+    ///
+    /// Insertion universe is `i ∈ [0, 100k)`; query universe is
+    /// `i ∈ [10_000_000, 10_000_000 + 100k)` so the two sets are
+    /// fully disjoint.
+    #[test]
+    fn fpr_under_one_and_a_half_percent_at_design_load() {
+        // Integer comparison: 1.5 % of 100_000 = 1_500.  Avoids float
+        // arithmetic / cast lints by never converting to f64.  Declared
+        // here at the top of the fn to satisfy
+        // `clippy::items_after_statements`.
+        const MAX_ALLOWED: u32 = 1_500;
+
+        let mut bloom = Bloom::with_size_and_k(1_200_000, 7);
+
+        for i in 0_u64..100_000 {
+            bloom.insert(&i.to_le_bytes());
+        }
+
+        let mut false_positives = 0_u32;
+        let novel_start = 10_000_000_u64;
+        for i in 0_u64..100_000 {
+            let key = (novel_start + i).to_le_bytes();
+            if bloom.contains(&key) {
+                false_positives += 1;
+            }
+        }
+
+        assert!(
+            false_positives <= MAX_ALLOWED,
+            "got {false_positives} false positives in 100k novel queries; \
+             target ≤ 1.5 % = {MAX_ALLOWED} (plan task 4.2)"
+        );
+    }
+
+    /// `with_size_and_k` rounds nbits up to a multiple of 64.
+    #[test]
+    fn with_size_and_k_rounds_up_to_word_boundary() {
+        let bloom = Bloom::with_size_and_k(100, 7);
+        assert_eq!(bloom.nbits() % 64, 0);
+        assert!(bloom.nbits() >= 100);
+    }
+
+    /// `with_size_and_k` clamps k to [1, 32].
+    #[test]
+    fn with_size_and_k_clamps_k_to_valid_range() {
+        let too_small = Bloom::with_size_and_k(64, 0);
+        assert_eq!(too_small.k(), 1);
+        let too_big = Bloom::with_size_and_k(64, 200);
+        assert_eq!(too_big.k(), 32);
+    }
+
+    /// `estimated_fpr` returns 0 for an empty filter and a value in
+    /// `(0, 1)` for a partially loaded one.
+    #[test]
+    fn estimated_fpr_bounds() {
+        let bloom = Bloom::with_capacity_and_fpr(10_000, 0.01_f64);
+        // Empty bloom returns exactly 0.0 (early-return branch).
+        // `.abs() < epsilon` avoids `float_cmp` while still pinning
+        // the early-return contract.
+        assert!(bloom.estimated_fpr(0).abs() < 1e-12_f64);
+        let mid = bloom.estimated_fpr(5_000);
+        assert!(mid > 0.0_f64 && mid < 0.01_f64);
+        let at_capacity = bloom.estimated_fpr(10_000);
+        // At design capacity FPR should be approximately the target.
+        assert!(at_capacity > 0.005_f64 && at_capacity < 0.015_f64);
+    }
+
+    /// Idempotent insert: inserting the same key twice doesn't
+    /// change any state observable through the public API.
+    #[test]
+    fn insert_is_idempotent() {
+        let mut bloom = Bloom::with_capacity_and_fpr(100, 0.01_f64);
+        bloom.insert(b"hello");
+        let snapshot = bloom.bits.clone();
+        bloom.insert(b"hello");
+        assert_eq!(bloom.bits, snapshot);
+        assert!(bloom.contains(b"hello"));
+    }
+
+    /// `with_capacity_and_fpr(0, _)` panics — guards against
+    /// zero-element-bloom call-site bugs.
+    #[test]
+    #[should_panic(expected = "bloom: n_items must be > 0")]
+    fn with_capacity_and_fpr_panics_on_zero_items() {
+        let _bloom = Bloom::with_capacity_and_fpr(0, 0.01_f64);
+    }
+
+    /// `with_capacity_and_fpr` panics on FPR ≤ 0.
+    #[test]
+    #[should_panic(expected = "bloom: target_fpr must be in (0.0, 1.0)")]
+    fn with_capacity_and_fpr_panics_on_nonsense_fpr() {
+        let _bloom = Bloom::with_capacity_and_fpr(100, 0.0_f64);
+    }
+
+    /// Filesystem-name use case: insert basenames, extensions, and
+    /// directory names; query a mix of present + novel keys.
+    /// Pins the integration shape Phase 4 Commit C will wire up.
+    #[test]
+    fn filesystem_name_workload() {
+        let basenames = ["Cargo.toml", "README.md", "Cargo.lock", "main.rs", "lib.rs"];
+        let extensions = ["toml", "md", "lock", "rs"];
+        let directories = ["src", "target", "tests", "benches", "examples"];
+
+        let mut bloom = Bloom::with_capacity_and_fpr(64, 0.01_f64);
+        for name in basenames.iter().chain(&extensions).chain(&directories) {
+            bloom.insert(name.as_bytes());
+        }
+
+        for name in basenames {
+            assert!(bloom.contains(name.as_bytes()), "missing inserted: {name}");
+        }
+        // Disjoint novel keys — should overwhelmingly miss.
+        let mut hits = 0_u32;
+        let novel = ["xyzzy", "plugh", "frob", "qux", "wibble"];
+        for name in novel {
+            if bloom.contains(name.as_bytes()) {
+                hits += 1;
+            }
+        }
+        // FPR is bounded by the design target; on this tiny load it
+        // should be effectively zero.  Allow up to 1 false positive
+        // out of 5 to cover the ~1 % FPR upper tail.
+        assert!(hits <= 1, "got {hits} false positives in 5 novel queries");
+    }
+}

--- a/crates/uffs-core/src/compact.rs
+++ b/crates/uffs-core/src/compact.rs
@@ -17,6 +17,7 @@ use std::time::Instant;
 use rayon::prelude::*;
 use uffs_mft::index::MftIndex;
 
+use crate::bloom::Bloom;
 // Re-export loader types and functions so callers can still use `compact::*`.
 #[expect(deprecated, reason = "re-export kept for backward compatibility")]
 pub use crate::compact_loader::{
@@ -26,6 +27,7 @@ pub use crate::compact_loader::{
 #[expect(deprecated, reason = "re-export kept for backward compatibility")]
 pub use crate::compact_loader::{apply_usn_patch, load_live_drive};
 use crate::compact_storage::ColumnStorage;
+use crate::path_trie::PathTrie;
 use crate::trigram::TrigramIndex;
 
 /// Compact per-record data for in-memory search, filter, and sort.
@@ -363,6 +365,20 @@ pub struct DriveCompactIndex {
     /// `MftIndex.build_epoch` this compact index was built from.
     /// Used as a staleness check when loading from cache.
     pub source_epoch: u64,
+    /// Phase 4 bloom filter over folded basenames + extensions.
+    ///
+    /// `None` for indices built before bloom integration landed (e.g.
+    /// in-process unit-test fixtures that don't exercise the Phase 4
+    /// search-skip path) and for v ≤ 8 caches before the rebuild step
+    /// runs.  After [`build_compact_index`] or a v9+ cache load this
+    /// is always `Some(_)`; downstream callers
+    /// (`search_dispatch::bloom_pre_check`) treat `None` as "no
+    /// pre-check available; fall through to the full search" which
+    /// is the safe (correct-but-slower) default.
+    pub bloom: Option<Bloom>,
+    /// Phase 4 directory-only path trie.  Same `None`-handling
+    /// rationale as [`Self::bloom`].
+    pub path_trie: Option<PathTrie>,
 }
 
 /// Per-component heap footprint of a [`DriveCompactIndex`].
@@ -819,22 +835,30 @@ pub fn build_compact_index(
 
     shrink_compact_vecs(drive_letter, &mut records, &mut names, &mut ext_names);
 
-    (
-        DriveCompactIndex {
-            letter: drive_letter,
-            records: ColumnStorage::from_vec(records),
-            names: ColumnStorage::from_vec(names),
-            trigram,
-            children,
-            ext_index,
-            fold,
-            ext_names,
-            source: IndexSource::MftFile(std::path::PathBuf::from(format!("{drive_letter}:"))),
-            source_epoch: index.build_epoch,
-        },
-        compact_elapsed,
-        tri_elapsed,
-    )
+    let mut compact_index = DriveCompactIndex {
+        letter: drive_letter,
+        records: ColumnStorage::from_vec(records),
+        names: ColumnStorage::from_vec(names),
+        trigram,
+        children,
+        ext_index,
+        fold,
+        ext_names,
+        source: IndexSource::MftFile(std::path::PathBuf::from(format!("{drive_letter}:"))),
+        source_epoch: index.build_epoch,
+        bloom: None,
+        path_trie: None,
+    };
+
+    // Phase 4: populate bloom + path_trie from the freshly-built
+    // index.  These are needed for the search-skip pre-check
+    // (Commit F) and serialised into the v9+ cache (Commit D).
+    let bloom = compact_index.build_bloom();
+    let path_trie = compact_index.build_path_trie();
+    compact_index.bloom = Some(bloom);
+    compact_index.path_trie = Some(path_trie);
+
+    (compact_index, compact_elapsed, tri_elapsed)
 }
 
 /// Shrink all growable Vecs to exact fit after compact index build.

--- a/crates/uffs-core/src/compact_cache.rs
+++ b/crates/uffs-core/src/compact_cache.rs
@@ -25,6 +25,7 @@
 //! Exception: `file_size_policy` — serialize/deserialize pipeline, tight
 //! coupling.
 
+use alloc::borrow::Cow;
 use alloc::sync::Arc;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -45,7 +46,11 @@ const COMPACT_MAGIC: &[u8; 8] = b"UFFSCOM\0";
 /// - v7: `ext_names` table
 /// - v8: `path_len: u16` added to `CompactRecord` (uses 2 bytes of former
 ///   `_pad`)
-const COMPACT_VERSION: u16 = 8;
+/// - v9: Phase 4 bloom + path-trie sections appended after `ext_names` (see
+///   `compact_cache::filters_io`)
+const COMPACT_VERSION: u16 = 9;
+
+mod filters_io;
 /// Bytes per `CompactRecord`.
 const RECORD_BYTES: usize = size_of::<CompactRecord>();
 /// zstd compression level for compact cache.
@@ -183,6 +188,25 @@ pub fn serialize_compact(index: &DriveCompactIndex) -> Vec<u8> {
         buf.extend_from_slice(bytes.get(..usize::from(len)).unwrap_or(bytes));
     }
 
+    // v9: bloom + path-trie sections.  Use the index's pre-built
+    // filters when present (every production-built or freshly-loaded
+    // `DriveCompactIndex` has them); fall back to building inline so
+    // the on-disk v9 format is always self-consistent regardless of
+    // how the in-memory struct was constructed.  `Cow` keeps both
+    // arms in a single expression so clippy's `option_if_let_else`
+    // is satisfied, and avoids the borrow-vs-build duplication.
+    let bloom_section: Cow<'_, crate::bloom::Bloom> = index
+        .bloom
+        .as_ref()
+        .map_or_else(|| Cow::Owned(index.build_bloom()), Cow::Borrowed);
+    filters_io::push_bloom_section(&mut buf, bloom_section.as_ref());
+
+    let trie_section: Cow<'_, crate::path_trie::PathTrie> = index
+        .path_trie
+        .as_ref()
+        .map_or_else(|| Cow::Owned(index.build_path_trie()), Cow::Borrowed);
+    filters_io::push_trie_section(&mut buf, trie_section.as_ref());
+
     buf
 }
 
@@ -238,6 +262,20 @@ pub fn serialize_compact_to_writer<W: io::Write>(
         writer.write_all(&len.to_le_bytes())?;
         writer.write_all(bytes.get(..usize::from(len)).unwrap_or(bytes))?;
     }
+
+    // v9: bloom + path-trie sections.  See `serialize_compact` for
+    // the rationale on the `Cow`-based borrow-or-build fallback.
+    let bloom_section: Cow<'_, crate::bloom::Bloom> = index
+        .bloom
+        .as_ref()
+        .map_or_else(|| Cow::Owned(index.build_bloom()), Cow::Borrowed);
+    filters_io::write_bloom_section(writer, bloom_section.as_ref())?;
+
+    let trie_section: Cow<'_, crate::path_trie::PathTrie> = index
+        .path_trie
+        .as_ref()
+        .map_or_else(|| Cow::Owned(index.build_path_trie()), Cow::Borrowed);
+    filters_io::write_trie_section(writer, trie_section.as_ref())?;
 
     writer.flush()?;
     Ok(())
@@ -351,6 +389,14 @@ struct ParsedCompactBody<'data> {
     /// `Some` if a v7+ ext-names table was read from the cache; `None`
     /// if the cache predates v7 and the table must be rebuilt.
     ext_names_loaded: Option<Vec<Box<str>>>,
+    /// `Some` if a v9+ bloom section was loaded directly from the
+    /// cache; `None` if the cache predates v9 and the bloom must be
+    /// rebuilt via [`DriveCompactIndex::build_bloom`].
+    bloom_loaded: Option<crate::bloom::Bloom>,
+    /// `Some` if a v9+ path-trie section was loaded directly from
+    /// the cache; `None` if the cache predates v9 and the trie must
+    /// be rebuilt via [`DriveCompactIndex::build_path_trie`].
+    trie_loaded: Option<crate::path_trie::PathTrie>,
     /// Resolved case-fold table for the drive.
     fold: uffs_text::case_fold::CaseFold,
 }
@@ -414,8 +460,24 @@ fn parse_compact_body(
         (None, pe + 4)
     };
 
-    let ext_names_loaded = (version >= 7 && data.len() >= after_tri + 4)
-        .then(|| read_ext_names_table(data, after_tri));
+    let (ext_names_loaded, after_ext) = if version >= 7 && data.len() >= after_tri + 4 {
+        let (table, end) = read_ext_names_table(data, after_tri);
+        (Some(table), end)
+    } else {
+        (None, after_tri)
+    };
+
+    // v9: bloom + path-trie sections.  Both are mandatory in v9; a
+    // truncated section signals corruption rather than legacy
+    // format.  v < 9 caches simply skip this branch and the
+    // assembler rebuilds the filters from records / names.
+    let (bloom_loaded, trie_loaded) = if version >= 9 {
+        let (bloom, after_bloom) = filters_io::read_bloom_section(data, after_ext)?;
+        let (trie, _after_trie) = filters_io::read_trie_section(data, after_bloom)?;
+        (Some(bloom), Some(trie))
+    } else {
+        (None, None)
+    };
 
     Ok(ParsedCompactBody {
         drive_letter,
@@ -425,6 +487,8 @@ fn parse_compact_body(
         children,
         trigram_loaded,
         ext_names_loaded,
+        bloom_loaded,
+        trie_loaded,
         fold,
     })
 }
@@ -471,21 +535,36 @@ where
         "ExtensionIndex built (cache load)"
     );
 
-    Ok((
-        DriveCompactIndex {
-            letter: parsed.drive_letter,
-            records,
-            names,
-            trigram,
-            children: parsed.children,
-            ext_index,
-            fold: parsed.fold,
-            ext_names,
-            source: IndexSource::MftFile(PathBuf::from(format!("{}:", parsed.drive_letter))),
-            source_epoch: parsed.source_epoch,
-        },
-        tri_ms,
-    ))
+    let mut compact_index = DriveCompactIndex {
+        letter: parsed.drive_letter,
+        records,
+        names,
+        trigram,
+        children: parsed.children,
+        ext_index,
+        fold: parsed.fold,
+        ext_names,
+        source: IndexSource::MftFile(PathBuf::from(format!("{}:", parsed.drive_letter))),
+        source_epoch: parsed.source_epoch,
+        bloom: None,
+        path_trie: None,
+    };
+
+    // Phase 4 Commit D — v9+ caches embed the bloom + trie directly,
+    // so the loader skips the rebuild step.  v ≤ 8 caches were
+    // serialised before Phase 4 landed; rebuild from the freshly-
+    // loaded records / names / fold / ext_names so the in-memory
+    // index always carries valid filters.
+    let bloom = parsed
+        .bloom_loaded
+        .unwrap_or_else(|| compact_index.build_bloom());
+    let path_trie = parsed
+        .trie_loaded
+        .unwrap_or_else(|| compact_index.build_path_trie());
+    compact_index.bloom = Some(bloom);
+    compact_index.path_trie = Some(path_trie);
+
+    Ok((compact_index, tri_ms))
 }
 
 /// Read a length-prefixed `ext_names` table from v7+ compact cache bytes.
@@ -493,7 +572,7 @@ where
     clippy::single_call_fn,
     reason = "extracted from deserialize_compact for clarity"
 )]
-fn read_ext_names_table(data: &[u8], offset: usize) -> Vec<Box<str>> {
+fn read_ext_names_table(data: &[u8], offset: usize) -> (Vec<Box<str>>, usize) {
     let ext_count = read_u32(data, offset) as usize;
     let mut out = Vec::with_capacity(ext_count);
     let mut pos = offset + 4;
@@ -508,7 +587,7 @@ fn read_ext_names_table(data: &[u8], offset: usize) -> Vec<Box<str>> {
         out.push(Box::from(core::str::from_utf8(slice).unwrap_or("")));
         pos += slen;
     }
-    out
+    (out, pos)
 }
 
 /// Rebuild `ext_names` from compact records for pre-v7 caches.

--- a/crates/uffs-core/src/compact_cache.rs
+++ b/crates/uffs-core/src/compact_cache.rs
@@ -51,6 +51,8 @@ const COMPACT_MAGIC: &[u8; 8] = b"UFFSCOM\0";
 const COMPACT_VERSION: u16 = 9;
 
 mod filters_io;
+pub mod parked;
+pub use parked::{ParkedBody, deserialize_parked_body, load_parked_body};
 /// Bytes per `CompactRecord`.
 const RECORD_BYTES: usize = size_of::<CompactRecord>();
 /// zstd compression level for compact cache.

--- a/crates/uffs-core/src/compact_cache/filters_io.rs
+++ b/crates/uffs-core/src/compact_cache/filters_io.rs
@@ -1,0 +1,466 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Cache-format v9 byte serdes for the Phase 4 bloom + path-trie
+//! sections.
+//!
+//! Sibling submodule of `compact_cache` because:
+//!
+//!   - `compact_cache.rs` is already a permanent file-size-policy exception
+//!     (994 LOC, ~1.2× the 800 LOC cap); inlining the ~150 LOC of bloom + trie
+//!     serdes would inflate the exception unacceptably.
+//!   - Bloom + trie serdes is independent of the records / names / trigram body
+//!     parsing — the two sections live at the tail of the v9 cache after the v7
+//!     ext-names table.
+//!
+//! ## Byte layout
+//!
+//! ### Bloom section (16 + `nbits / 8` bytes)
+//!
+//! | Offset | Field          | Type   |
+//! |-------:|----------------|--------|
+//! |      0 | `nbits`        | `u64`  |
+//! |      8 | `k_hashes`     | `u32`  |
+//! |     12 | `words_count`  | `u32`  |
+//! |     16 | `words`        | `[u64; words_count]` |
+//!
+//! `words_count == nbits / 64`.  `k_hashes` is stored as `u32` for
+//! 4-byte alignment of the following words array; the value is
+//! always `≤ 32` (clamped by `Bloom::with_size_and_k`).
+//!
+//! ### Trie section (16 + `12·node_count + names_len + 4·(node_count+1) + 4·indices_count` bytes)
+//!
+//! | Offset                         | Field             | Type             |
+//! |-------------------------------:|-------------------|------------------|
+//! |                              0 | `node_count`      | `u32`            |
+//! |                              4 | `nodes`           | `[TrieNode; nc]` |
+//! |                  `4 + 12·nc`   | `names_len`       | `u32`            |
+//! |                  `8 + 12·nc`   | `names`           | `[u8; nl]`       |
+//! |             `8 + 12·nc + nl`   | `offsets_count`   | `u32`            |
+//! |            `12 + 12·nc + nl`   | `offsets`         | `[u32; nc + 1]`  |
+//! |  `12 + 12·nc + nl + 4·(nc+1)`  | `indices_count`   | `u32`            |
+//! |  `16 + 12·nc + nl + 4·(nc+1)`  | `indices`         | `[u32; ic]`      |
+//!
+//! `offsets_count` is redundantly stored alongside `node_count`
+//! (it's always `node_count + 1`) for forward-compat: a future
+//! variable-arity trie could relax this invariant without breaking
+//! the byte-stream layout.
+//!
+//! All multi-byte fields are little-endian.  `TrieNode` is `Pod` +
+//! `repr(C)`, so the nodes array is bit-identical to its in-memory
+//! layout on every supported platform (Windows / Linux / macOS, all
+//! little-endian).
+//!
+//! ## Validation
+//!
+//! Every `read_*_section` call returns `Err("…")` on truncation or
+//! invariant violation (mismatched lengths, name slices outside
+//! `names`, etc.) so the cache-format dispatch can drop a corrupted
+//! file without panicking.  No unsafe code; bounds are checked via
+//! `data.get(start..end)` plus the
+//! `Bloom::from_raw_parts` / `PathTrie::from_raw_parts` helpers
+//! that re-validate the structural invariants.
+
+use std::io;
+
+use super::{aligned_vec_from_bytes, read_u32, write_u32};
+use crate::bloom::Bloom;
+use crate::path_trie::{PathTrie, TrieNode};
+
+/// Number of bytes the bloom-section header occupies (everything
+/// before the words array).
+const BLOOM_HEADER_BYTES: usize = 16;
+
+/// Write a bloom-section to `writer`.
+///
+/// # Errors
+///
+/// Returns the underlying `io::Error` if any write fails.
+pub(super) fn write_bloom_section<W: io::Write>(writer: &mut W, bloom: &Bloom) -> io::Result<()> {
+    writer.write_all(&bloom.nbits().to_le_bytes())?;
+    writer.write_all(&u32::from(bloom.k()).to_le_bytes())?;
+    let words = bloom.bits();
+    write_u32(writer, words.len())?;
+    writer.write_all(bytemuck::cast_slice(words))?;
+    Ok(())
+}
+
+/// Append a bloom-section to a byte buffer.  Mirrors
+/// [`write_bloom_section`] for the [`Vec<u8>`]-backed
+/// `serialize_compact` path.
+pub(super) fn push_bloom_section(buf: &mut Vec<u8>, bloom: &Bloom) {
+    buf.extend_from_slice(&bloom.nbits().to_le_bytes());
+    buf.extend_from_slice(&u32::from(bloom.k()).to_le_bytes());
+    let words = bloom.bits();
+    let words_count: u32 = u32::try_from(words.len()).unwrap_or(u32::MAX);
+    buf.extend_from_slice(&words_count.to_le_bytes());
+    buf.extend_from_slice(bytemuck::cast_slice(words));
+}
+
+/// Read a bloom-section from `data` starting at `offset`.
+///
+/// Returns `(bloom, new_offset)` on success.  `new_offset` points
+/// at the byte immediately after the section so the caller can
+/// continue parsing.
+///
+/// # Errors
+///
+/// Returns `Err("…")` on truncation or `Bloom::from_raw_parts`
+/// invariant violation.
+pub(super) fn read_bloom_section(
+    data: &[u8],
+    offset: usize,
+) -> Result<(Bloom, usize), &'static str> {
+    if data.len() < offset + BLOOM_HEADER_BYTES {
+        return Err("truncated bloom header");
+    }
+    // Bounds-check above guarantees the slice is exactly 8 bytes,
+    // so the `<[u8; 8]>::try_from` is infallible — but clippy's
+    // `map_err_ignore` rejects `|_| ...`.  Pin down the array form
+    // up front so the conversion can be expressed without
+    // `try_into`.
+    let mut nbits_arr = [0_u8; 8];
+    nbits_arr.copy_from_slice(data.get(offset..offset + 8).ok_or("bloom nbits OOB")?);
+    let nbits = u64::from_le_bytes(nbits_arr);
+    let k_hashes_raw = read_u32(data, offset + 8);
+    let k_hashes = u8::try_from(k_hashes_raw).map_err(|_err| "bloom k_hashes out of range")?;
+    let words_count = read_u32(data, offset + 12) as usize;
+    let words_start = offset + BLOOM_HEADER_BYTES;
+    let words_end = words_start
+        .checked_add(words_count.checked_mul(8).ok_or("bloom words overflow")?)
+        .ok_or("bloom words end overflow")?;
+    if data.len() < words_end {
+        return Err("truncated bloom words");
+    }
+    let words: Vec<u64> = aligned_vec_from_bytes(
+        data.get(words_start..words_end)
+            .ok_or("bloom words slice")?,
+    );
+    let bloom = Bloom::from_raw_parts(nbits, k_hashes, words).ok_or("bloom invariants")?;
+    Ok((bloom, words_end))
+}
+
+/// Write a path-trie section to `writer`.
+///
+/// # Errors
+///
+/// Returns the underlying `io::Error` if any write fails.
+pub(super) fn write_trie_section<W: io::Write>(writer: &mut W, trie: &PathTrie) -> io::Result<()> {
+    let nodes = trie.nodes();
+    let names = trie.names();
+    let offsets = trie.child_offsets();
+    let indices = trie.child_indices();
+
+    write_u32(writer, nodes.len())?;
+    writer.write_all(bytemuck::cast_slice(nodes))?;
+
+    write_u32(writer, names.len())?;
+    writer.write_all(names)?;
+
+    write_u32(writer, offsets.len())?;
+    writer.write_all(bytemuck::cast_slice(offsets))?;
+
+    write_u32(writer, indices.len())?;
+    writer.write_all(bytemuck::cast_slice(indices))?;
+
+    Ok(())
+}
+
+/// Append a path-trie section to a byte buffer.  Mirrors
+/// [`write_trie_section`] for the [`Vec<u8>`]-backed
+/// `serialize_compact` path.
+pub(super) fn push_trie_section(buf: &mut Vec<u8>, trie: &PathTrie) {
+    let nodes = trie.nodes();
+    let names = trie.names();
+    let offsets = trie.child_offsets();
+    let indices = trie.child_indices();
+
+    buf.extend_from_slice(&u32_le(nodes.len()));
+    buf.extend_from_slice(bytemuck::cast_slice(nodes));
+
+    buf.extend_from_slice(&u32_le(names.len()));
+    buf.extend_from_slice(names);
+
+    buf.extend_from_slice(&u32_le(offsets.len()));
+    buf.extend_from_slice(bytemuck::cast_slice(offsets));
+
+    buf.extend_from_slice(&u32_le(indices.len()));
+    buf.extend_from_slice(bytemuck::cast_slice(indices));
+}
+
+/// Encode a `usize` as little-endian `u32` bytes (saturating at
+/// `u32::MAX`).  Local helper because the parent module's
+/// equivalent `push_u32` writes directly into a `Vec<u8>`; the
+/// trie section needs the bytes in a fixed-size array so we can
+/// interleave them with the Pod casts.
+fn u32_le(value: usize) -> [u8; 4] {
+    u32::try_from(value).unwrap_or(u32::MAX).to_le_bytes()
+}
+
+/// Read a path-trie section from `data` starting at `offset`.
+///
+/// Returns `(trie, new_offset)` on success.
+///
+/// # Errors
+///
+/// Returns `Err("…")` on truncation, invalid `TrieNode` byte slice
+/// (not Pod-castable), or `PathTrie::from_raw_parts` invariant
+/// violation.
+pub(super) fn read_trie_section(
+    data: &[u8],
+    offset: usize,
+) -> Result<(PathTrie, usize), &'static str> {
+    let mut cursor = offset;
+
+    if data.len() < cursor + 4 {
+        return Err("truncated trie node_count");
+    }
+    let node_count = read_u32(data, cursor) as usize;
+    cursor += 4;
+
+    let nodes_bytes_len = node_count
+        .checked_mul(size_of::<TrieNode>())
+        .ok_or("trie nodes overflow")?;
+    let nodes_end = cursor
+        .checked_add(nodes_bytes_len)
+        .ok_or("trie nodes end overflow")?;
+    if data.len() < nodes_end {
+        return Err("truncated trie nodes");
+    }
+    let nodes: Vec<TrieNode> = if node_count == 0 {
+        Vec::new()
+    } else {
+        aligned_vec_from_bytes(data.get(cursor..nodes_end).ok_or("trie nodes slice")?)
+    };
+    cursor = nodes_end;
+
+    if data.len() < cursor + 4 {
+        return Err("truncated trie names_len");
+    }
+    let names_len = read_u32(data, cursor) as usize;
+    cursor += 4;
+    let names_end = cursor
+        .checked_add(names_len)
+        .ok_or("trie names end overflow")?;
+    if data.len() < names_end {
+        return Err("truncated trie names");
+    }
+    let names = data
+        .get(cursor..names_end)
+        .ok_or("trie names slice")?
+        .to_vec();
+    cursor = names_end;
+
+    if data.len() < cursor + 4 {
+        return Err("truncated trie offsets_count");
+    }
+    let offsets_count = read_u32(data, cursor) as usize;
+    cursor += 4;
+    let offsets_bytes_len = offsets_count
+        .checked_mul(4)
+        .ok_or("trie offsets overflow")?;
+    let offsets_end = cursor
+        .checked_add(offsets_bytes_len)
+        .ok_or("trie offsets end overflow")?;
+    if data.len() < offsets_end {
+        return Err("truncated trie offsets");
+    }
+    let offsets: Vec<u32> = if offsets_count == 0 {
+        Vec::new()
+    } else {
+        aligned_vec_from_bytes(data.get(cursor..offsets_end).ok_or("trie offsets slice")?)
+    };
+    cursor = offsets_end;
+
+    if data.len() < cursor + 4 {
+        return Err("truncated trie indices_count");
+    }
+    let indices_count = read_u32(data, cursor) as usize;
+    cursor += 4;
+    let indices_bytes_len = indices_count
+        .checked_mul(4)
+        .ok_or("trie indices overflow")?;
+    let indices_end = cursor
+        .checked_add(indices_bytes_len)
+        .ok_or("trie indices end overflow")?;
+    if data.len() < indices_end {
+        return Err("truncated trie indices");
+    }
+    let indices: Vec<u32> = if indices_count == 0 {
+        Vec::new()
+    } else {
+        aligned_vec_from_bytes(data.get(cursor..indices_end).ok_or("trie indices slice")?)
+    };
+    cursor = indices_end;
+
+    let trie = PathTrie::from_raw_parts(nodes, names, offsets, indices).ok_or("trie invariants")?;
+    Ok((trie, cursor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::path_trie::NO_PARENT;
+
+    /// Round-trip a non-trivial bloom: identical `(nbits, k, bits)`
+    /// after one write + read cycle.
+    #[test]
+    fn bloom_round_trip_preserves_bits() {
+        let mut bloom = Bloom::with_capacity_and_fpr(1000, 0.01);
+        for input in ["alpha", "beta", "gamma", "delta", "epsilon"] {
+            bloom.insert(input.as_bytes());
+        }
+
+        let mut buf: Vec<u8> = Vec::new();
+        push_bloom_section(&mut buf, &bloom);
+
+        let (decoded, end) = read_bloom_section(&buf, 0).expect("bloom round-trip should succeed");
+        assert_eq!(end, buf.len(), "decoder should consume the full section");
+        assert_eq!(decoded.nbits(), bloom.nbits());
+        assert_eq!(decoded.k(), bloom.k());
+        assert_eq!(decoded.bits(), bloom.bits());
+
+        for input in ["alpha", "beta", "gamma", "delta", "epsilon"] {
+            assert!(
+                decoded.contains(input.as_bytes()),
+                "post-decode missing {input:?}"
+            );
+        }
+        // Negative case: a string we didn't insert is unlikely (FPR
+        // ≈ 1 %) to land in the bloom.  At this load (5 items) the
+        // false-positive rate is effectively zero.
+        assert!(!decoded.contains(b"unrelated_keyword_xyz"));
+    }
+
+    /// Round-trip a non-trivial path trie: structural equality + a
+    /// representative `lookup_path` after decode.
+    #[test]
+    fn trie_round_trip_preserves_structure() {
+        // Reuse the `TrieNode` Pod constructor to build a small
+        // trie by hand: root "C" with two children "src" and
+        // "tests".
+        let nodes = vec![
+            TrieNode {
+                parent_idx: NO_PARENT,
+                name_offset: 0,
+                name_len: 1,
+                padding: 0,
+            },
+            TrieNode {
+                parent_idx: 0,
+                name_offset: 1,
+                name_len: 3,
+                padding: 0,
+            },
+            TrieNode {
+                parent_idx: 0,
+                name_offset: 4,
+                name_len: 5,
+                padding: 0,
+            },
+        ];
+        let names = b"Csrctests".to_vec();
+        // Children CSR: root (idx 0) has children [1, 2]; idx 1 + 2
+        // are leaves.
+        let offsets = vec![0_u32, 2, 2, 2];
+        let indices = vec![1_u32, 2];
+
+        let trie = PathTrie::from_raw_parts(nodes, names, offsets, indices)
+            .expect("hand-built trie should pass invariant check");
+
+        let mut buf: Vec<u8> = Vec::new();
+        push_trie_section(&mut buf, &trie);
+
+        let (decoded, end) = read_trie_section(&buf, 0).expect("trie round-trip should succeed");
+        assert_eq!(end, buf.len(), "decoder should consume the full section");
+        assert_eq!(decoded.len(), trie.len());
+        assert_eq!(decoded.nodes().len(), trie.nodes().len());
+        assert_eq!(decoded.names(), trie.names());
+        assert_eq!(decoded.child_offsets(), trie.child_offsets());
+        assert_eq!(decoded.child_indices(), trie.child_indices());
+
+        // Behavioural equivalence — `lookup_path` should match.
+        assert_eq!(decoded.lookup_path(&[b"C"]), Some(0));
+        assert_eq!(decoded.lookup_path(&[b"C", b"src"]), Some(1));
+        assert_eq!(decoded.lookup_path(&[b"C", b"tests"]), Some(2));
+        assert!(decoded.lookup_path(&[b"C", b"missing"]).is_none());
+    }
+
+    /// `read_bloom_section` rejects truncated input rather than
+    /// panicking.
+    #[test]
+    fn read_bloom_section_rejects_truncation() {
+        let mut buf: Vec<u8> = Vec::new();
+        let bloom = Bloom::with_capacity_and_fpr(100, 0.01);
+        push_bloom_section(&mut buf, &bloom);
+
+        // Lop off the last byte of the words array.
+        let trunc_len = buf.len().saturating_sub(1);
+        let truncated = buf.get(..trunc_len).expect("non-empty buffer");
+        let result = read_bloom_section(truncated, 0);
+        assert!(result.is_err(), "truncated bloom must be rejected");
+    }
+
+    /// `read_trie_section` rejects truncated input rather than
+    /// panicking.
+    #[test]
+    fn read_trie_section_rejects_truncation() {
+        let trie = PathTrie::from_raw_parts(
+            vec![TrieNode {
+                parent_idx: NO_PARENT,
+                name_offset: 0,
+                name_len: 1,
+                padding: 0,
+            }],
+            b"R".to_vec(),
+            vec![0, 0],
+            vec![],
+        )
+        .expect("single-root trie");
+
+        let mut buf: Vec<u8> = Vec::new();
+        push_trie_section(&mut buf, &trie);
+
+        // Truncate to half the buffer — guaranteed to land mid-section.
+        let half = buf.len() / 2;
+        let truncated = buf.get(..half).expect("buffer at least half-length");
+        let result = read_trie_section(truncated, 0);
+        assert!(result.is_err(), "truncated trie must be rejected");
+    }
+
+    /// Empty bloom (small but non-zero `nbits`, all words zero)
+    /// round-trips correctly.  Pins the COLD → PARKED edge case
+    /// where a zero-record drive's bloom is all zeros.
+    #[test]
+    fn empty_bloom_round_trip() {
+        let bloom = Bloom::with_capacity_and_fpr(1, 0.01);
+        let mut buf: Vec<u8> = Vec::new();
+        push_bloom_section(&mut buf, &bloom);
+
+        let (decoded, _) =
+            read_bloom_section(&buf, 0).expect("empty-bloom round-trip should succeed");
+        assert_eq!(decoded.nbits(), bloom.nbits());
+        assert_eq!(decoded.k(), bloom.k());
+        assert!(decoded.bits().iter().all(|&w| w == 0));
+    }
+
+    /// Empty trie (zero nodes, zero names) round-trips correctly.
+    /// Pins the same COLD → PARKED edge case for the trie side.
+    #[test]
+    fn empty_trie_round_trip() {
+        let trie = PathTrie::from_raw_parts(Vec::new(), Vec::new(), vec![0_u32], Vec::new())
+            .expect("empty trie should pass invariant check");
+
+        let mut buf: Vec<u8> = Vec::new();
+        push_trie_section(&mut buf, &trie);
+
+        let (decoded, end) =
+            read_trie_section(&buf, 0).expect("empty-trie round-trip should succeed");
+        assert_eq!(end, buf.len());
+        assert!(decoded.is_empty());
+        assert!(decoded.nodes().is_empty());
+        assert!(decoded.names().is_empty());
+        assert_eq!(decoded.child_offsets(), &[0_u32]);
+        assert!(decoded.child_indices().is_empty());
+    }
+}

--- a/crates/uffs-core/src/compact_cache/parked.rs
+++ b/crates/uffs-core/src/compact_cache/parked.rs
@@ -1,0 +1,664 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase 4 Commit E — PARKED-tier body loading.
+//!
+//! A [`ParkedBody`] carries only the bloom + path-trie sections of a
+//! v9+ compact cache (~5 – 15 MB per drive on a 7 M-record fixture)
+//! — enough to answer the search-skip pre-check without
+//! materialising the ~1 GB of records / names / trigram / children
+//! CSR that a `Warm`-tier shard holds resident.
+//!
+//! ## Format
+//!
+//! Built on top of the v9 [`compact_cache`](super) on-disk format
+//! (`COMPACT_VERSION = 9`).  This module does **not** define a new
+//! file layout — it reuses the same encrypted `.compact` file and
+//! parses out only the tail two sections (bloom + trie) by walking
+//! section offsets via header arithmetic, without materialising any
+//! of the bulk arrays.
+//!
+//! v ≤ 8 caches were serialised before bloom + trie persistence
+//! landed; loading them as a [`ParkedBody`] returns
+//! `Err("parked-body load requires cache format v9+")` so the
+//! caller does a full rebuild instead.  Once the cluster has been
+//! re-saved with v9, parked-body loads succeed for every shard.
+//!
+//! ## Memory budget
+//!
+//! For the canonical 7 M-record / 1 % FPR sizing:
+//! * Bloom: ~10 bits/element × 7 M ≈ 8.75 MB.
+//! * Trie: ~24 B/dir × ~10 K dirs ≈ 240 KB plus the names buffer (~5 KB/avg dir
+//!   × 10 K) ≈ ~5 MB.
+//!
+//! Total parked footprint per drive: **≈ 10 – 15 MB**, vs the ~1 GB
+//! a full `DriveCompactIndex` holds resident.  This is the
+//! architectural payoff that makes "7 drives idle ≤ 50 MB" feasible.
+//!
+//! ## Why a separate submodule
+//!
+//! Lives in its own file so the parked-only code path is obvious in
+//! module-level grep — anything in `parked.rs` is part of the
+//! PARKED tier's read path.  Keeps `compact_cache.rs` under the
+//! workspace's file-size policy (≤ 1500 lines).
+
+use std::time::Instant;
+
+use uffs_text::case_fold::CaseFold;
+
+use super::{
+    COMPACT_VERSION, RECORD_BYTES, ZSTD_MAGIC, compact_cache_path, filters_io,
+    is_compact_cache_fresh, parse_compact_header, read_u32,
+};
+use crate::bloom::Bloom;
+use crate::path_trie::PathTrie;
+
+/// Resident state of a Parked-tier shard.
+///
+/// Holds only the filters needed to answer the search-skip
+/// pre-check (`bloom`) and directory-prefix queries (`path_trie`)
+/// plus the metadata needed to validate freshness on promote
+/// (`source_epoch`) and to fold queries the same way the indexer
+/// did (`fold`).
+///
+/// **Not** a `DriveCompactIndex` lite — `ParkedBody` is a separate
+/// type because a parked shard *cannot* answer record-level
+/// queries.  Promotion to Warm requires re-loading the full cache
+/// (or, in a future commit, lazily mmap-ing the records / names
+/// columns).
+#[derive(Clone)]
+pub struct ParkedBody {
+    /// Drive letter the cache was built for.
+    pub letter: char,
+    /// `MftIndex.build_epoch` the source compact cache was built
+    /// from — used as a staleness check on promote.
+    pub source_epoch: u64,
+    /// Bloom over folded basenames + extensions.  See
+    /// [`crate::compact::DriveCompactIndex::build_bloom`]
+    /// for the insertion contract that `bloom.contains()` callers
+    /// must mirror.
+    pub bloom: Bloom,
+    /// Directory-only path trie.  See [`PathTrie`] for the lookup
+    /// surface (`lookup_path`, `children_of`, `full_path`).
+    pub path_trie: PathTrie,
+    /// Case-fold table the source index was built against.  Query
+    /// callers must fold their input through this before probing
+    /// `bloom`.
+    pub fold: CaseFold,
+}
+
+impl ParkedBody {
+    /// Approximate resident footprint in bytes — bloom bits + trie
+    /// columns.  Excludes the `Self` struct overhead and any inline
+    /// `CaseFold` static (the table is `&'static [u16]`, not heap).
+    #[must_use]
+    pub const fn size_bytes(&self) -> usize {
+        self.bloom.size_bytes() + self.path_trie.size_bytes()
+    }
+}
+
+impl core::fmt::Debug for ParkedBody {
+    /// Manual impl because [`CaseFold`] does not derive `Debug`
+    /// (it's a thin `&'static [u16]` wrapper from `uffs-text`
+    /// designed to stay out of `Debug` chains).  The other four
+    /// fields print directly; `fold` collapses to a stable
+    /// placeholder so test diagnostics still surface useful state.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ParkedBody")
+            .field("letter", &self.letter)
+            .field("source_epoch", &self.source_epoch)
+            .field("bloom", &self.bloom)
+            .field("path_trie", &self.path_trie)
+            .field("fold", &"<CaseFold>")
+            .finish()
+    }
+}
+
+/// Parse only the v9 bloom + trie sections out of a serialised
+/// compact cache, skipping every other section without allocating.
+///
+/// # Errors
+///
+/// Returns `Err("…")` on:
+/// * a malformed header (bad magic, unsupported version);
+/// * a pre-v9 cache (the bloom + trie sections don't exist in v ≤ 8);
+/// * any truncation between the header and the bloom + trie tail (each section
+///   boundary is bounds-checked);
+/// * filter-section invariant violations (see `filters_io::read_bloom_section`
+///   / `filters_io::read_trie_section`).
+pub fn deserialize_parked_body(
+    data: &[u8],
+    drive_letter: char,
+) -> Result<ParkedBody, &'static str> {
+    let (filters_offset, source_epoch) = find_v9_filters_offset(data)?;
+    let (bloom, after_bloom) = filters_io::read_bloom_section(data, filters_offset)?;
+    let (path_trie, _after_trie) = filters_io::read_trie_section(data, after_bloom)?;
+    let fold = crate::compact::resolve_case_fold(drive_letter);
+
+    Ok(ParkedBody {
+        letter: drive_letter,
+        source_epoch,
+        bloom,
+        path_trie,
+        fold,
+    })
+}
+
+/// Locate the byte offset where the v9 bloom + trie sections begin,
+/// using only header arithmetic — no allocations for records,
+/// names, children CSR, trigram CSR, or `ext_names`.
+///
+/// Returns `(filters_offset, source_epoch)`.
+///
+/// # Errors
+///
+/// Same surface as [`deserialize_parked_body`] up to the filter
+/// sections (which are read by `filters_io`, not by this function).
+fn find_v9_filters_offset(data: &[u8]) -> Result<(usize, u64), &'static str> {
+    let (source_epoch, body_offset, version) = parse_compact_header(data)?;
+    if version < 9 {
+        return Err("parked-body load requires cache format v9+");
+    }
+    // `version <= COMPACT_VERSION` is enforced by `parse_compact_header`.
+    debug_assert!(
+        version <= COMPACT_VERSION,
+        "parse_compact_header should have rejected future versions"
+    );
+
+    // Records + names headers are at fixed offsets 10 + 14 (post-magic).
+    let record_count = read_u32(data, 10) as usize;
+    let names_len = read_u32(data, 14) as usize;
+    let records_end = body_offset
+        .checked_add(
+            record_count
+                .checked_mul(RECORD_BYTES)
+                .ok_or("rc*RB overflow")?,
+        )
+        .ok_or("records_end overflow")?;
+    let names_end = records_end
+        .checked_add(names_len)
+        .ok_or("names_end overflow")?;
+
+    // v >= 9 implies version >= 5, so the v ≤ 4 `names_lower`
+    // duplicate is never present.
+    let csr_off_start = names_end;
+    let csr_off_end = csr_off_start
+        .checked_add(record_count.checked_add(1).ok_or("rc+1 overflow")? * 4)
+        .ok_or("csr_off_end overflow")?;
+    if data.len() < csr_off_end {
+        return Err("compact cache truncated (CSR header)");
+    }
+
+    // The CSR-postings count is stored as the last `u32` of the
+    // offsets array — the standard CSR convention.
+    let postings_count = read_u32(data, csr_off_end - 4) as usize;
+    let postings_end = csr_off_end
+        .checked_add(postings_count.checked_mul(4).ok_or("postings*4 overflow")?)
+        .ok_or("postings_end overflow")?;
+    if data.len() < postings_end + 4 {
+        return Err("truncated trigram header");
+    }
+
+    // Trigram CSR (always present for v >= 6).
+    let trigram_key_count = read_u32(data, postings_end) as usize;
+    let after_trigram = if trigram_key_count > 0 {
+        let keys_end = postings_end
+            .checked_add(4)
+            .and_then(|x| x.checked_add(trigram_key_count.checked_mul(8)?))
+            .ok_or("trigram keys_end overflow")?;
+        let offsets_end = keys_end
+            .checked_add(trigram_key_count.checked_add(1).ok_or("tkc+1 overflow")? * 4)
+            .ok_or("trigram offsets_end overflow")?;
+        if data.len() < offsets_end + 4 {
+            return Err("truncated trigram CSR");
+        }
+        let values_count = read_u32(data, offsets_end) as usize;
+        let values_end = offsets_end
+            .checked_add(4)
+            .and_then(|x| x.checked_add(values_count.checked_mul(4)?))
+            .ok_or("trigram values_end overflow")?;
+        if data.len() < values_end {
+            return Err("truncated trigram values");
+        }
+        values_end
+    } else {
+        // v >= 6 with `trigram_key_count == 0` is the legacy "no
+        // trigram on disk" sentinel; v9 always emits a real
+        // trigram, but a malformed v9 buffer could land here.
+        // The 4-byte sentinel header has been consumed; advance
+        // past it so the next section follows correctly.
+        postings_end
+            .checked_add(4)
+            .ok_or("after-trigram-sentinel overflow")?
+    };
+
+    // Skip the v7+ ext_names table without allocating.  v9 always
+    // emits this section (possibly empty).
+    let after_ext = skip_ext_names_table(data, after_trigram)?;
+
+    Ok((after_ext, source_epoch))
+}
+
+/// Skip past a v7+ length-prefixed `ext_names` table without
+/// materialising any strings.
+///
+/// On-disk layout (mirrors [`super::serialize_compact`] /
+/// [`super::serialize_compact_to_writer`] / `super::read_ext_names_table`):
+/// * `u32` count of entries
+/// * for each entry: `u16` length followed by `length` UTF-8 bytes
+///
+/// # Errors
+///
+/// Returns `Err("…")` if any header or string body extends past the
+/// end of `data`.
+fn skip_ext_names_table(data: &[u8], offset: usize) -> Result<usize, &'static str> {
+    if data.len() < offset + 4 {
+        return Err("truncated ext_names header");
+    }
+    let count = read_u32(data, offset) as usize;
+    let mut pos = offset.checked_add(4).ok_or("ext_names header overflow")?;
+    for _ in 0..count {
+        let lo = data
+            .get(pos)
+            .copied()
+            .ok_or("truncated ext_names entry header")?;
+        let hi = data
+            .get(pos + 1)
+            .copied()
+            .ok_or("truncated ext_names entry header")?;
+        let slen = usize::from(u16::from_le_bytes([lo, hi]));
+        pos = pos
+            .checked_add(2)
+            .ok_or("ext_names cursor overflow (length)")?;
+        let entry_end = pos
+            .checked_add(slen)
+            .ok_or("ext_names cursor overflow (body)")?;
+        if data.len() < entry_end {
+            return Err("truncated ext_names entry body");
+        }
+        pos = entry_end;
+    }
+    Ok(pos)
+}
+
+/// Per-stage timings for a parked-body load — read, decrypt,
+/// decompress.  Captured by [`read_decompressed_plaintext`] and
+/// emitted via [`emit_parked_load_profile`] when
+/// `UFFS_CACHE_PROFILE` is set.
+struct ParkedLoadIoTimings {
+    /// Disk-read wall time (ms).
+    read_ms: u128,
+    /// Encrypted-file size on disk (bytes).
+    raw_len: usize,
+    /// AES-256-GCM decrypt wall time (ms).
+    decrypt_ms: u128,
+    /// `true` if the plaintext started with the zstd frame magic.
+    is_compressed: bool,
+    /// zstd decompress wall time (ms; `0` if `is_compressed` is
+    /// `false`).
+    decompress_ms: u128,
+    /// Decompressed plaintext size (bytes).
+    plaintext_len: usize,
+}
+
+/// Read + decrypt + (optionally) decompress a compact cache file.
+///
+/// Returns `None` on any IO / crypto failure — the caller treats
+/// that the same as a missing cache (rebuild triggered).
+fn read_decompressed_plaintext(path: &std::path::Path) -> Option<(Vec<u8>, ParkedLoadIoTimings)> {
+    let t_read = Instant::now();
+    let raw = std::fs::read(path).ok()?;
+    let read_ms = t_read.elapsed().as_millis();
+    let raw_len = raw.len();
+
+    let key = uffs_security::keystore::get_cache_key().ok()?;
+    let t_decrypt = Instant::now();
+    let decrypted = uffs_security::crypto::decrypt_cache(&raw, &key).ok()?;
+    let decrypt_ms = t_decrypt.elapsed().as_millis();
+
+    let t_decompress = Instant::now();
+    let is_compressed = decrypted.get(..4).is_some_and(|magic| magic == ZSTD_MAGIC);
+    let plaintext = if is_compressed {
+        zstd::decode_all(decrypted.as_slice()).ok()?
+    } else {
+        decrypted
+    };
+    let decompress_ms = t_decompress.elapsed().as_millis();
+    let plaintext_len = plaintext.len();
+
+    Some((plaintext, ParkedLoadIoTimings {
+        read_ms,
+        raw_len,
+        decrypt_ms,
+        is_compressed,
+        decompress_ms,
+        plaintext_len,
+    }))
+}
+
+/// `true` if the plaintext's `source_epoch` is older than the
+/// caller-supplied `mft_build_epoch`, signalling a stale cache.
+///
+/// `mft_build_epoch == 0` short-circuits to "not stale" — that's
+/// the "no MFT epoch known" sentinel the daemon uses on first
+/// boot.  A malformed header is also treated as "not stale" since
+/// the subsequent full parse will surface the corruption with a
+/// real error.
+fn is_compact_cache_stale_for_epoch(
+    plaintext: &[u8],
+    mft_build_epoch: u64,
+    drive_letter: char,
+) -> bool {
+    if mft_build_epoch == 0 {
+        return false;
+    }
+    let Ok((source_epoch, _, _)) = parse_compact_header(plaintext) else {
+        return false;
+    };
+    if source_epoch >= mft_build_epoch {
+        return false;
+    }
+    tracing::debug!(
+        target: "cache_profile",
+        source_epoch,
+        mft_build_epoch,
+        "parked: STALE"
+    );
+    tracing::debug!(
+        drive = %drive_letter,
+        compact_epoch = source_epoch,
+        mft_epoch = mft_build_epoch,
+        "Compact cache stale (source_epoch < mft build_epoch) — rebuilding"
+    );
+    true
+}
+
+/// Emit a `cache_profile` tracing event with parked-load timings
+/// when `UFFS_CACHE_PROFILE` is set.
+fn emit_parked_load_profile(
+    body: &ParkedBody,
+    io: &ParkedLoadIoTimings,
+    deser_ms: u128,
+    total_ms: u128,
+) {
+    let raw_mb = io.raw_len / (1024 * 1024);
+    let plain_mb = io.plaintext_len / (1024 * 1024);
+    let parked_mb = body.size_bytes() / (1024 * 1024);
+    tracing::debug!(
+        target: "cache_profile",
+        read_ms = %io.read_ms,
+        raw_mb,
+        decrypt_ms = %io.decrypt_ms,
+        is_compressed = io.is_compressed,
+        decompress_ms = %io.decompress_ms,
+        plain_mb,
+        deser_ms = %deser_ms,
+        parked_mb,
+        source_epoch = body.source_epoch,
+        total_ms = %total_ms,
+        "parked_load"
+    );
+}
+
+/// Load + decrypt + decompress a compact cache file from disk and
+/// return only its bloom + trie as a [`ParkedBody`].
+///
+/// Mirrors [`super::load_compact_cache`]'s IO + crypto pipeline but
+/// skips bulk-array materialisation entirely — no runtime tempfile,
+/// no records / names allocation, no trigram / children CSR
+/// allocation.  The caller decides via tier transitions when to
+/// load the parked body vs the full body.
+///
+/// `ttl_seconds`, `mft_build_epoch`, and `trust_ttl_only` mirror
+/// [`super::load_compact_cache`]'s freshness contract exactly so the
+/// two loaders are interchangeable on the staleness front.
+///
+/// Returns `None` on any failure (cache missing, key missing,
+/// decrypt fail, decompress fail, version < 9, parse error).  This
+/// matches `load_compact_cache`'s "any failure → caller rebuilds"
+/// contract.
+#[must_use]
+pub fn load_parked_body(
+    drive_letter: char,
+    ttl_seconds: u64,
+    mft_build_epoch: u64,
+    trust_ttl_only: bool,
+) -> Option<ParkedBody> {
+    let path = compact_cache_path(drive_letter);
+    if !is_compact_cache_fresh(&path, drive_letter, ttl_seconds, trust_ttl_only) {
+        return None;
+    }
+
+    let t_total = Instant::now();
+    let (plaintext, io) = read_decompressed_plaintext(&path)?;
+    if is_compact_cache_stale_for_epoch(&plaintext, mft_build_epoch, drive_letter) {
+        return None;
+    }
+
+    let t_deser = Instant::now();
+    let body = deserialize_parked_body(&plaintext, drive_letter).ok()?;
+    let deser_ms = t_deser.elapsed().as_millis();
+
+    if std::env::var_os("UFFS_CACHE_PROFILE").is_some() {
+        emit_parked_load_profile(&body, &io, deser_ms, t_total.elapsed().as_millis());
+    }
+
+    Some(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::compact::{
+        ChildrenIndex, CompactRecord, DriveCompactIndex, ExtensionIndex, IndexSource,
+    };
+    use crate::compact_storage::ColumnStorage;
+    use crate::trigram::TrigramIndex;
+
+    /// Build a small but realistic `DriveCompactIndex` with a
+    /// directory ("`C`") and two children ("`Cargo.toml`" file +
+    /// "`src`" dir) so the bloom carries multiple inserted names
+    /// and the trie has at least one parent → child edge.
+    fn make_test_index() -> DriveCompactIndex {
+        // Names blob: "C" [0..1] "Cargo.toml" [1..11] "src" [11..14].
+        let names = b"CCargo.tomlsrc".to_vec();
+        let records = vec![
+            CompactRecord {
+                name_offset: 0,
+                flags: 0x0010, // directory
+                parent_idx: u32::MAX,
+                name_len: 1,
+                name_first_byte: b'C',
+                ..CompactRecord::default()
+            },
+            CompactRecord {
+                name_offset: 1,
+                parent_idx: 0,
+                name_len: 10,
+                extension_id: 1,
+                name_first_byte: b'C',
+                ..CompactRecord::default()
+            },
+            CompactRecord {
+                name_offset: 11,
+                flags: 0x0010, // directory
+                parent_idx: 0,
+                name_len: 3,
+                name_first_byte: b's',
+                ..CompactRecord::default()
+            },
+        ];
+        let fold = CaseFold::default_table();
+        let trigram = TrigramIndex::build(&records, &names, fold);
+        let children = ChildrenIndex::build(&records);
+        let ext_index = ExtensionIndex::build(&records);
+        let mut index = DriveCompactIndex {
+            letter: 'C',
+            records: ColumnStorage::from_vec(records),
+            names: ColumnStorage::from_vec(names),
+            trigram,
+            children,
+            ext_index,
+            fold,
+            ext_names: vec![Box::from(""), Box::from("toml")],
+            source: IndexSource::MftFile(PathBuf::from("C:")),
+            source_epoch: 1234,
+            bloom: None,
+            path_trie: None,
+        };
+        index.bloom = Some(index.build_bloom());
+        index.path_trie = Some(index.build_path_trie());
+        index
+    }
+
+    /// Round-trip: a v9 cache produced by [`super::super::serialize_compact`]
+    /// must yield a [`ParkedBody`] whose bloom contains every
+    /// folded basename and whose trie is byte-identical to the
+    /// source's pre-built one.
+    #[test]
+    fn parked_round_trip_preserves_bloom_and_trie() {
+        let index = make_test_index();
+        let serialized = super::super::serialize_compact(&index);
+
+        let body = deserialize_parked_body(&serialized, 'C').expect("parked deser");
+
+        // Bloom: every record's folded basename hits.
+        let mut fold_buf: Vec<u8> = Vec::new();
+        for record in &index.records {
+            let start = record.name_offset as usize;
+            let end = start + usize::from(record.name_len);
+            let bytes = index.names.get(start..end).expect("record name slice");
+            let name = core::str::from_utf8(bytes).expect("UTF-8 fixture name");
+            fold_buf.clear();
+            let folded = index.fold.fold_into(name, &mut fold_buf);
+            assert!(
+                body.bloom.contains(folded.as_bytes()),
+                "parked bloom missed {name:?} -> {folded:?}",
+            );
+        }
+
+        // Trie: identical structure to the source's pre-built one.
+        let expected = index.path_trie.as_ref().expect("source trie");
+        assert_eq!(body.path_trie.nodes().len(), expected.nodes().len());
+        assert_eq!(body.path_trie.names(), expected.names());
+        assert_eq!(body.path_trie.child_offsets(), expected.child_offsets());
+        assert_eq!(body.path_trie.child_indices(), expected.child_indices());
+
+        // Metadata: epoch + letter + fold round-trip.
+        assert_eq!(body.letter, 'C');
+        assert_eq!(body.source_epoch, 1234);
+    }
+
+    /// Pre-v9 caches have no bloom + trie sections.  Patching the
+    /// version byte to 8 must be rejected with a recognisable error.
+    #[test]
+    fn parked_load_rejects_pre_v9_caches() {
+        let index = make_test_index();
+        let mut serialized = super::super::serialize_compact(&index);
+
+        serialized
+            .get_mut(8..10)
+            .expect("buffer too short for version")
+            .copy_from_slice(&8_u16.to_le_bytes());
+
+        let err = deserialize_parked_body(&serialized, 'C').expect_err("v8 must reject");
+        assert!(
+            err.contains("v9"),
+            "error should mention v9 minimum: {err:?}",
+        );
+    }
+
+    /// Magic-byte corruption is rejected by `parse_compact_header`
+    /// before any section is read.
+    #[test]
+    fn parked_load_rejects_bad_magic() {
+        let index = make_test_index();
+        let mut serialized = super::super::serialize_compact(&index);
+
+        // Flip the first magic byte.
+        let byte = serialized.get_mut(0).expect("non-empty buffer");
+        *byte = byte.wrapping_add(1);
+
+        let _err = deserialize_parked_body(&serialized, 'C').expect_err("bad magic must reject");
+    }
+
+    /// Truncating the buffer at successively shorter prefixes must
+    /// surface an error from whichever offset-arithmetic /
+    /// section-read routine first runs out of bytes.  Pins the
+    /// "no panic on corrupt input" contract.
+    #[test]
+    fn parked_load_rejects_truncated_at_every_prefix() {
+        let index = make_test_index();
+        let serialized = super::super::serialize_compact(&index);
+
+        // Sample a handful of prefix lengths covering header, mid-body,
+        // and the bloom + trie sections.  Full-length is the success
+        // case and is excluded; every shorter prefix must be rejected.
+        let len = serialized.len();
+        let prefixes = [
+            0,
+            8,  // post-magic, pre-version
+            10, // post-version
+            18, // pre-epoch (v3+)
+            26, // post-header
+            len / 4,
+            len / 2,
+            len * 3 / 4,
+            len - 1,
+        ];
+        for &prefix in &prefixes {
+            let truncated = serialized.get(..prefix).expect("prefix in range");
+            let result = deserialize_parked_body(truncated, 'C');
+            assert!(
+                result.is_err(),
+                "prefix {prefix}/{len} must be rejected (got {result:?})",
+            );
+        }
+    }
+
+    /// Empty `ext_names` table is well-formed and must skip cleanly.
+    /// Pins the zero-extension edge case (drives with no files yet
+    /// catalogued by extension still emit a 0-count header).
+    #[test]
+    fn skip_ext_names_table_handles_empty_table() {
+        // Manual layout: `[count = 0u32]`.
+        let buf = 0_u32.to_le_bytes();
+        let after = skip_ext_names_table(&buf, 0).expect("empty table is valid");
+        assert_eq!(after, 4, "empty table cursor advances past the count");
+    }
+
+    /// A truncated entry header (two bytes after the count claims
+    /// the entry but the buffer ends mid-`u16`) is rejected.
+    #[test]
+    fn skip_ext_names_table_rejects_truncated_entry_header() {
+        // `[count = 1u32][0xAA]` — claims one entry but only one of
+        // the two length bytes is present.
+        let mut buf = 1_u32.to_le_bytes().to_vec();
+        buf.push(0xAA);
+        let err = skip_ext_names_table(&buf, 0).expect_err("truncated entry header");
+        assert!(
+            err.contains("ext_names entry header"),
+            "expected entry-header error: {err:?}",
+        );
+    }
+
+    /// `ParkedBody::size_bytes` returns the sum of the bloom +
+    /// trie footprints — non-zero, and within an envelope of the
+    /// source index's filter sizes (round-trip is byte-exact for
+    /// the trie and round-tripped for the bloom).
+    #[test]
+    fn parked_body_size_bytes_is_nonzero_and_bounded() {
+        let index = make_test_index();
+        let serialized = super::super::serialize_compact(&index);
+        let body = deserialize_parked_body(&serialized, 'C').expect("parked deser");
+
+        let bloom_bytes = body.bloom.size_bytes();
+        let trie_bytes = body.path_trie.size_bytes();
+
+        assert!(bloom_bytes > 0, "bloom must be non-empty");
+        assert!(trie_bytes > 0, "trie must be non-empty (1 dir at minimum)");
+        assert_eq!(body.size_bytes(), bloom_bytes + trie_bytes);
+    }
+}

--- a/crates/uffs-core/src/compact_cache/tests.rs
+++ b/crates/uffs-core/src/compact_cache/tests.rs
@@ -65,6 +65,8 @@ fn make_test_index() -> DriveCompactIndex {
         ext_names: vec![Box::from("")],
         source: IndexSource::MftFile(PathBuf::from("T:")),
         source_epoch: 42,
+        bloom: None,
+        path_trie: None,
     }
 }
 
@@ -144,13 +146,81 @@ fn v5_backward_compat_rebuilds_trigram() {
 }
 
 #[test]
-fn v8_header_version() {
+fn current_header_version() {
     let index = make_test_index();
     let serialized = serialize_compact(&index);
     let b8 = *serialized.get(8).expect("missing byte 8");
     let b9 = *serialized.get(9).expect("missing byte 9");
     let version = u16::from_le_bytes([b8, b9]);
     assert_eq!(version, COMPACT_VERSION);
+}
+
+/// Phase 4 Commit D — every folded record name in the source
+/// index must resolve to `contains() == true` after a v9
+/// round-trip.  `build_bloom` inserts case-folded basenames (see
+/// `compact_filters::build_bloom`), so the query side mirrors the
+/// fold contract.  Bloom false-negatives are impossible by
+/// construction; a failure here proves the cache-format wiring
+/// dropped or corrupted the section.
+#[test]
+fn v9_round_trip_preserves_bloom() {
+    let index = make_test_index();
+    let serialized = serialize_compact(&index);
+    let (loaded, _tri_ms) = deserialize_compact(&serialized, 'T').expect("deser v9");
+
+    let bloom = loaded.bloom.as_ref().expect("v9 cache must carry bloom");
+    let mut fold_buf: Vec<u8> = Vec::new();
+    for record in &index.records {
+        let start = record.name_offset as usize;
+        let end = start + usize::from(record.name_len);
+        let name_bytes = index
+            .names
+            .get(start..end)
+            .expect("record name slice in source index");
+        let name_str =
+            core::str::from_utf8(name_bytes).expect("test fixture names are valid UTF-8");
+        fold_buf.clear();
+        let folded = index.fold.fold_into(name_str, &mut fold_buf);
+        assert!(
+            bloom.contains(folded.as_bytes()),
+            "loaded bloom missed folded name {name_str:?} -> {folded:?}"
+        );
+    }
+}
+
+/// Phase 4 Commit D — the loaded path-trie must be byte-equivalent
+/// to one freshly built from the same records / names / fold.  A
+/// mismatch in node count, name buffer, or CSR arrays signals the
+/// trie section round-trip dropped data.
+#[test]
+fn v9_round_trip_preserves_path_trie() {
+    let index = make_test_index();
+    let expected = index.build_path_trie();
+
+    let serialized = serialize_compact(&index);
+    let (loaded, _tri_ms) = deserialize_compact(&serialized, 'T').expect("deser v9");
+    let actual = loaded.path_trie.as_ref().expect("v9 cache must carry trie");
+
+    assert_eq!(
+        actual.nodes().len(),
+        expected.nodes().len(),
+        "trie node count differs after round-trip"
+    );
+    assert_eq!(
+        actual.names(),
+        expected.names(),
+        "trie names buffer differs after round-trip"
+    );
+    assert_eq!(
+        actual.child_offsets(),
+        expected.child_offsets(),
+        "trie CSR offsets differ after round-trip"
+    );
+    assert_eq!(
+        actual.child_indices(),
+        expected.child_indices(),
+        "trie CSR indices differ after round-trip"
+    );
 }
 
 #[test]

--- a/crates/uffs-core/src/compact_filters.rs
+++ b/crates/uffs-core/src/compact_filters.rs
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase 4 filter builders for [`DriveCompactIndex`]
+//! (`build_bloom` + `build_path_trie`).
+//!
+//! Lives in a sibling module rather than directly inside `compact.rs`
+//! because that file is a permanent file-size-policy exception (see
+//! `scripts/ci/file_size_exceptions.txt`); inlining ~150 LOC of new
+//! method + tests would invalidate its "only 13 over limit"
+//! rationale.  Multiple `impl DriveCompactIndex { }` blocks across
+//! files are a normal Rust pattern: the linker unifies them.
+//!
+//! ## Plan tasks covered
+//!
+//! - **4.3** — `DriveCompactIndex::build_bloom` inserts every record's
+//!   `$UpCase`-folded basename plus every entry from `ext_names`.  Plan note
+//!   "Not full paths" is enforced structurally: this method never sees a path;
+//!   only basenames and extensions cross the bloom.
+//! - **4.3** (cont.) — `DriveCompactIndex::build_path_trie` is a thin shim over
+//!   [`PathTrie::build`] passing the records and names slices.
+//!
+//! ## Sizing rationale
+//!
+//! `build_bloom` sizes the filter for `records.len() +
+//! ext_names.len()` items at the workspace's standard 1 % FPR
+//! target.  For a 7 M-record drive with ~2 K extensions, that's
+//! ~7 M items → ~8.5 MB bloom.  Phase 4 Commit G measures this on
+//! `fixture_large` to confirm the per-drive PARKED budget; any
+//! tightening (smaller bloom, sampling) lands in Phase 6 (adaptive
+//! TTL + per-drive sizing).
+
+use crate::bloom::Bloom;
+use crate::compact::DriveCompactIndex;
+use crate::path_trie::PathTrie;
+
+/// Standard false-positive rate target for shard blooms.
+///
+/// Pinned to the tiering-plan §6.2 envelope (1 %).  Phase 6 may
+/// promote this to a per-drive policy knob; for Phase 4 every shard
+/// uses the same target so the headline "≤ 50 MB on a 7-drive idle
+/// box" math is reproducible.
+pub const SHARD_BLOOM_TARGET_FPR: f64 = 0.01;
+
+impl DriveCompactIndex {
+    /// Build a bloom filter populated with every record's
+    /// `$UpCase`-folded basename plus every interned extension.
+    ///
+    /// O(N) over `records.len()`.  Allocates a fresh per-drive
+    /// fold buffer; reuses it across every record so the only
+    /// per-record work is the codepoint walk + `bloom.insert`.
+    ///
+    /// **Not** full paths: by design the bloom only answers
+    /// "does this drive contain a basename / extension matching
+    /// X?" — path-prefix queries go through [`PathTrie`] instead.
+    /// The asymmetry keeps the bloom small (the same string
+    /// indexed at different paths only contributes one entry).
+    ///
+    /// Records whose name slice is invalid UTF-8 (rare; NTFS
+    /// guarantees UTF-16 names but a USN-patch fragment could
+    /// theoretically slip through) are skipped — the bloom errs on
+    /// the side of "miss" rather than indexing arbitrary bytes
+    /// that wouldn't match the same string after fold-on-query.
+    #[must_use]
+    pub fn build_bloom(&self) -> Bloom {
+        let n_items = self
+            .records
+            .len()
+            .saturating_add(self.ext_names.len())
+            .max(1);
+        let mut bloom = Bloom::with_capacity_and_fpr(n_items, SHARD_BLOOM_TARGET_FPR);
+
+        // Reuse a single fold buffer across every record — fold_into
+        // clears it on entry, so we just declare it once.
+        let mut fold_buf: Vec<u8> = Vec::with_capacity(64);
+
+        for record in &self.records {
+            let start = record.name_offset as usize;
+            let end = start.saturating_add(record.name_len as usize);
+            let Some(raw_bytes) = self.names.get(start..end) else {
+                continue;
+            };
+            let Ok(name_str) = core::str::from_utf8(raw_bytes) else {
+                continue;
+            };
+            let folded = self.fold.fold_into(name_str, &mut fold_buf);
+            bloom.insert(folded.as_bytes());
+        }
+
+        // Extensions are stored in `ext_names` as already-lowercase
+        // strings (see `extension_id` doc on `CompactRecord`).
+        // Insert them as-is — at query time the search dispatch
+        // will lowercase the user's `--ext` argument before probing
+        // so the case contract matches.
+        for ext in &self.ext_names {
+            let bytes = ext.as_bytes();
+            if !bytes.is_empty() {
+                bloom.insert(bytes);
+            }
+        }
+
+        bloom
+    }
+
+    /// Build a directory-only path trie over this drive's
+    /// directories.
+    ///
+    /// Thin shim over [`PathTrie::build`]; passes the records and
+    /// names slices through.  See [`PathTrie`] module docs for the
+    /// memory layout and build-cost analysis.
+    #[must_use]
+    pub fn build_path_trie(&self) -> PathTrie {
+        PathTrie::build(&self.records, &self.names)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::compact::{ChildrenIndex, CompactRecord, ExtensionIndex, IndexSource};
+    use crate::compact_storage::ColumnStorage;
+    use crate::trigram::TrigramIndex;
+
+    /// Build a minimal `DriveCompactIndex` with three records:
+    /// the root directory `C` (idx 0), a file `Cargo.toml` under
+    /// it (idx 1, `ext_id`=1 → "toml"), and a directory `src`
+    /// under it (idx 2).
+    fn build_filter_test_drive() -> DriveCompactIndex {
+        // Names blob layout:
+        //   "C"          [0..1]   → root dir
+        //   "Cargo.toml" [1..11]  → file
+        //   "src"        [11..14] → dir
+        let names = b"CCargo.tomlsrc".to_vec();
+        let records = vec![
+            CompactRecord {
+                name_offset: 0,
+                flags: 0x0010, // directory
+                parent_idx: u32::MAX,
+                name_len: 1,
+                name_first_byte: b'C',
+                ..CompactRecord::default()
+            },
+            CompactRecord {
+                name_offset: 1,
+                parent_idx: 0,
+                name_len: 10,
+                extension_id: 1,
+                name_first_byte: b'C',
+                ..CompactRecord::default()
+            },
+            CompactRecord {
+                name_offset: 11,
+                flags: 0x0010,
+                parent_idx: 0,
+                name_len: 3,
+                name_first_byte: b's',
+                ..CompactRecord::default()
+            },
+        ];
+        let fold = uffs_text::case_fold::CaseFold::default_table();
+        let trigram = TrigramIndex::build(&records, &names, fold);
+        let children = ChildrenIndex::build(&records);
+        let ext_index = ExtensionIndex::build(&records);
+        DriveCompactIndex {
+            letter: 'C',
+            records: ColumnStorage::from_vec(records),
+            names: ColumnStorage::from_vec(names),
+            trigram,
+            children,
+            ext_index,
+            fold,
+            ext_names: vec![Box::from(""), Box::from("toml")],
+            source: IndexSource::MftFile(PathBuf::from("C:")),
+            source_epoch: 1,
+        }
+    }
+
+    /// Smoke: bloom contains the folded form of every basename
+    /// inserted plus every non-empty extension.
+    #[test]
+    fn build_bloom_contains_every_inserted_basename_and_extension() {
+        let drive = build_filter_test_drive();
+        let bloom = drive.build_bloom();
+        let fold = drive.fold;
+        let mut buf: Vec<u8> = Vec::new();
+
+        // Every basename folded.
+        for expected in ["C", "Cargo.toml", "src"] {
+            buf.clear();
+            let folded = fold.fold_into(expected, &mut buf);
+            assert!(
+                bloom.contains(folded.as_bytes()),
+                "bloom missed folded basename {expected:?} → {folded:?}"
+            );
+        }
+
+        // Every non-empty extension.
+        assert!(bloom.contains(b"toml"));
+    }
+
+    /// Bloom probabilistically rejects strings the drive doesn't
+    /// contain.  At this load (3 items) the FPR is effectively zero;
+    /// every novel query must miss.
+    #[test]
+    fn build_bloom_rejects_disjoint_strings() {
+        let drive = build_filter_test_drive();
+        let bloom = drive.build_bloom();
+        let fold = drive.fold;
+        let mut buf: Vec<u8> = Vec::new();
+
+        for novel in ["Plumbus", "qux", "frobnicate"] {
+            buf.clear();
+            let folded = fold.fold_into(novel, &mut buf);
+            assert!(
+                !bloom.contains(folded.as_bytes()),
+                "bloom false-positive on novel {novel:?} → {folded:?}"
+            );
+        }
+    }
+
+    /// Case-insensitive query: `bloom.contains(fold("CARGO.TOML"))`
+    /// returns `true` because the fold is symmetric — both the
+    /// indexer and the query side run the same `$UpCase` table.
+    #[test]
+    fn build_bloom_matches_case_insensitive_via_fold() {
+        let drive = build_filter_test_drive();
+        let bloom = drive.build_bloom();
+        let fold = drive.fold;
+        let mut buf: Vec<u8> = Vec::new();
+
+        let folded_upper = fold.fold_into("CARGO.TOML", &mut buf);
+        assert!(bloom.contains(folded_upper.as_bytes()));
+        buf.clear();
+
+        let folded_lower = fold.fold_into("cargo.toml", &mut buf);
+        assert!(bloom.contains(folded_lower.as_bytes()));
+        buf.clear();
+
+        let folded_mixed = fold.fold_into("CaRgO.tOmL", &mut buf);
+        assert!(bloom.contains(folded_mixed.as_bytes()));
+    }
+
+    /// `build_path_trie` integrates with the records' parent-chain.
+    /// On the test fixture there are two trie nodes — root `C` at
+    /// index 0 and `src` at index 1, with `src` parented to `C`.
+    /// The file `Cargo.toml` is filtered out because it's not a
+    /// directory.
+    #[test]
+    fn build_path_trie_indexes_directories_only() {
+        let drive = build_filter_test_drive();
+        let trie = drive.build_path_trie();
+
+        // Two directories (`C` + `src`); the `Cargo.toml` file is
+        // filtered out.
+        assert_eq!(trie.len(), 2);
+        assert_eq!(trie.roots(), vec![0_u32]);
+        assert_eq!(trie.name_of(0), Some(b"C" as &[u8]));
+        assert_eq!(trie.name_of(1), Some(b"src" as &[u8]));
+        assert_eq!(trie.parent_of(1), Some(0));
+
+        // `lookup_path` walks the trie correctly.
+        assert_eq!(trie.lookup_path(&[b"C"]), Some(0));
+        assert_eq!(trie.lookup_path(&[b"C", b"src"]), Some(1));
+        assert!(trie.lookup_path(&[b"C", b"missing"]).is_none());
+    }
+
+    /// Empty drive (no records) still builds a non-empty bloom (the
+    /// constructor enforces `nbits ≥ 64`) and an empty trie.
+    /// Defensive test for the COLD → PARKED edge case where a
+    /// shard's records were dropped but `build_bloom` is asked to
+    /// produce a placeholder.
+    #[test]
+    fn empty_drive_builds_empty_filters_safely() {
+        let names: Vec<u8> = Vec::new();
+        let records: Vec<CompactRecord> = Vec::new();
+        let fold = uffs_text::case_fold::CaseFold::default_table();
+        let trigram = TrigramIndex::build(&records, &names, fold);
+        let children = ChildrenIndex::build(&records);
+        let ext_index = ExtensionIndex::build(&records);
+        let drive = DriveCompactIndex {
+            letter: 'X',
+            records: ColumnStorage::from_vec(records),
+            names: ColumnStorage::from_vec(names),
+            trigram,
+            children,
+            ext_index,
+            fold,
+            ext_names: vec![Box::from("")],
+            source: IndexSource::MftFile(PathBuf::from("X:")),
+            source_epoch: 0,
+        };
+
+        let bloom = drive.build_bloom();
+        assert!(bloom.nbits() >= 64);
+        // No items inserted → no key can match.
+        assert!(!bloom.contains(b"anything"));
+
+        let trie = drive.build_path_trie();
+        assert!(trie.is_empty());
+    }
+}

--- a/crates/uffs-core/src/compact_filters.rs
+++ b/crates/uffs-core/src/compact_filters.rs
@@ -174,6 +174,8 @@ mod tests {
             ext_names: vec![Box::from(""), Box::from("toml")],
             source: IndexSource::MftFile(PathBuf::from("C:")),
             source_epoch: 1,
+            bloom: None,
+            path_trie: None,
         }
     }
 
@@ -290,6 +292,8 @@ mod tests {
             ext_names: vec![Box::from("")],
             source: IndexSource::MftFile(PathBuf::from("X:")),
             source_epoch: 0,
+            bloom: None,
+            path_trie: None,
         };
 
         let bloom = drive.build_bloom();

--- a/crates/uffs-core/src/compact_filters.rs
+++ b/crates/uffs-core/src/compact_filters.rs
@@ -112,6 +112,42 @@ impl DriveCompactIndex {
     pub fn build_path_trie(&self) -> PathTrie {
         PathTrie::build(&self.records, &self.names)
     }
+
+    /// Extract a [`ParkedBody`](crate::compact_cache::parked::ParkedBody)
+    /// view of this drive — bloom + trie + epoch + fold — for the
+    /// Warm → Parked tier transition.
+    ///
+    /// Phase 4 Commit F.  Reuses the in-memory `bloom` / `path_trie`
+    /// fields when present (the common case after Phase 4 Commit C
+    /// landed); falls back to [`Self::build_bloom`] /
+    /// [`Self::build_path_trie`] for indices constructed before the
+    /// Phase 4 wiring (or for legacy v ≤ 8 caches whose loader
+    /// rebuilds the filters on the fly — see
+    /// [`crate::compact_cache::deserialize_compact`]).
+    ///
+    /// Clones the bloom and trie because `ParkedBody` must own its
+    /// data (the source `DriveCompactIndex` is dropped right after
+    /// the transition).  The clone is cheap relative to a rebuild —
+    /// `Bloom::clone` is a single `Vec<u64>::clone` (≈ 8.75 MB at
+    /// the 7 M-record / 1 % FPR sizing) and `PathTrie::clone` is
+    /// four `Vec<…>::clone` calls (≈ 5 MB total).  In exchange the
+    /// transition completes without scanning records or running the
+    /// fold table again.
+    #[must_use]
+    pub fn to_parked_body(&self) -> crate::compact_cache::ParkedBody {
+        let bloom = self.bloom.clone().unwrap_or_else(|| self.build_bloom());
+        let path_trie = self
+            .path_trie
+            .clone()
+            .unwrap_or_else(|| self.build_path_trie());
+        crate::compact_cache::ParkedBody {
+            letter: self.letter,
+            source_epoch: self.source_epoch,
+            bloom,
+            path_trie,
+            fold: self.fold,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/uffs-core/src/lib.rs
+++ b/crates/uffs-core/src/lib.rs
@@ -57,6 +57,7 @@ use tokio as _;
 // ============================================================================
 
 pub mod aggregate;
+pub mod bloom;
 pub mod compact;
 pub mod compact_cache;
 pub mod compact_loader;

--- a/crates/uffs-core/src/lib.rs
+++ b/crates/uffs-core/src/lib.rs
@@ -60,6 +60,7 @@ pub mod aggregate;
 pub mod bloom;
 pub mod compact;
 pub mod compact_cache;
+pub mod compact_filters;
 pub mod compact_loader;
 pub mod compact_mmap;
 pub mod compact_reader;

--- a/crates/uffs-core/src/lib.rs
+++ b/crates/uffs-core/src/lib.rs
@@ -73,6 +73,7 @@ pub mod glob;
 pub mod index_search;
 pub mod output;
 mod path_resolver;
+pub mod path_trie;
 pub mod pattern;
 mod query;
 pub mod search;

--- a/crates/uffs-core/src/lib.rs
+++ b/crates/uffs-core/src/lib.rs
@@ -113,3 +113,7 @@ pub use tree::{TreeColumn, add_tree_columns, apply_directory_treesize};
 // Re-export commonly used types
 pub use uffs_mft::FileFlags;
 pub use uffs_polars::{DataFrame, IntoLazy, LazyFrame, col, columns, lit};
+// `CaseFold` lives on `ParkedBody.fold` and `DriveCompactIndex.fold` —
+// re-exported here so downstream crates (uffs-daemon, uffs-cli, tests)
+// that touch those types don't need a direct `uffs-text` dependency.
+pub use uffs_text::case_fold::CaseFold;

--- a/crates/uffs-core/src/path_trie.rs
+++ b/crates/uffs-core/src/path_trie.rs
@@ -1,0 +1,711 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Compact directory-only path trie for the Phase 4 PARKED tier.
+//!
+//! Phase 4's [memory-tiering plan][plan] keeps each shard's bloom +
+//! path-trie resident through the PARKED state (~5–15 MB per drive)
+//! while the records / names / trigram / children columns stay dropped.
+//! The path-trie answers two operator-facing questions cheaply enough
+//! to run on a kernel-evicted process:
+//!
+//!   1. **Resolve a directory by path** — `lookup_path("C", "Users", "Alice",
+//!      ...)` walks segment-by-segment and returns the directory's trie-index,
+//!      or `None` if any segment is missing.
+//!   2. **Enumerate immediate children** — `children_of(idx)` returns the
+//!      trie-indices of every directory directly under `idx`.
+//!
+//! Combined with the bloom filter (`crate::bloom`) this is enough for
+//! the daemon to pre-screen "does drive X contain anything matching
+//! pattern Y" without waking the body.  A bloom miss + a trie miss
+//! together skip the drive entirely.
+//!
+//! ## Memory layout — Arrow-IPC-style flat arrays
+//!
+//! - `nodes: Vec<TrieNode>` — one [`TrieNode`] per directory.  Pod + Zeroable
+//!   so the whole array serialises as one `memcpy` to the cache file (Phase 4
+//!   Commit D).
+//! - `names: Vec<u8>` — concatenated UTF-8 directory basenames; each node
+//!   carries `(name_offset, name_len)` slicing into this buffer. Independent
+//!   from the records' name buffer so the trie remains self-contained when
+//!   PARKED drops `DriveCompactIndex::names`.
+//! - `child_offsets: Vec<u32>` + `child_indices: Vec<u32>` — CSR children index
+//!   parallel to [`crate::compact::ChildrenIndex`]. Children of node `i` are
+//!   `child_indices[child_offsets[i]..child_offsets[i+1]]`.
+//!
+//! For a typical 7 M-record drive with ~50 K directories: nodes ≈ 600
+//! KB, names ≈ 5 MB, child CSR ≈ 200 KB ⇒ ~6 MB per drive's trie.  At
+//! 7 idle drives that's ~42 MB — under the plan's "≤ 50 MB on a
+//! 7-drive idle box" headline target.
+//!
+//! ## Build cost — single linear pass
+//!
+//! [`PathTrie::build`] is one O(N) sweep over the records:
+//!
+//!   1. **Pass 1 — collect directories**: build a sparse map `record_idx →
+//!      trie_idx` for every directory record, copy its basename bytes into the
+//!      trie's `names`, and emit a `TrieNode` with the parent's record-index
+//!      temporarily stored in `parent_idx` (resolved in pass 2).
+//!   2. **Pass 2 — translate parents**: walk the freshly-built nodes and
+//!      replace each `parent_idx` (currently a record-index) with its
+//!      trie-index via the map.  Records whose parent is a file (impossible on
+//!      NTFS but defensive) or `u32::MAX` (root) get `parent_idx = u32::MAX`.
+//!   3. **Pass 3 — CSR children**: standard count + prefix-sum + scatter,
+//!      identical to [`crate::compact::ChildrenIndex::build`].
+//!
+//! Plan task 4.4 budgets ≤ 100 ms for 1 M records; with a single
+//! linear sweep + one [`rustc_hash::FxHashMap`] lookup per record,
+//! the cost is dominated by `memcpy` of the name bytes.  Phase 4
+//! Commit G measures on `fixture_large` to confirm.
+//!
+//! [plan]: ../../../../docs/refactor/memory-tiering-implementation-plan.md
+
+use core::mem::size_of;
+
+use rustc_hash::FxHashMap;
+
+use crate::compact::CompactRecord;
+
+/// Sentinel value used for "no parent" (root node) and for orphan
+/// directories whose parent record is missing or non-directory.
+///
+/// Mirrors the `u32::MAX` convention [`CompactRecord::parent_idx`]
+/// already uses on the records side.
+pub const NO_PARENT: u32 = u32::MAX;
+
+/// One node in the [`PathTrie`].
+///
+/// 12 bytes, 4-byte aligned.  Pod + Zeroable so a `Vec<TrieNode>` can
+/// be serialised in one `memcpy` (Phase 4 Commit D's Arrow-IPC-style
+/// cache section).
+#[derive(Debug, Clone, Copy, Default, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(C)]
+pub struct TrieNode {
+    /// Trie-index of this node's parent, or [`NO_PARENT`] for root /
+    /// orphan.
+    pub parent_idx: u32,
+    /// Byte offset into [`PathTrie::names`] where this node's
+    /// basename starts.
+    pub name_offset: u32,
+    /// Length of the basename in UTF-8 bytes.  `u16` matches
+    /// [`CompactRecord::name_len`].
+    pub name_len: u16,
+    /// Padding to reach 4-byte alignment for the next node.  Always
+    /// zero; Pod traits rely on the predictable repr.  Reading this
+    /// field is meaningless for application logic, but it's part of
+    /// the public on-wire layout that the cache-format serialiser
+    /// (Phase 4 Commit D) blits via `bytemuck::cast_slice`.
+    pub padding: u16,
+}
+
+/// Compact directory-only path trie.
+///
+/// See module-level docs for the memory layout and build algorithm.
+#[derive(Debug, Clone)]
+pub struct PathTrie {
+    /// One node per directory.  The root entries (drive letters /
+    /// orphan roots) have `parent_idx == NO_PARENT`.
+    nodes: Vec<TrieNode>,
+    /// Concatenated basename bytes.  Each `TrieNode` slices into
+    /// this via `(name_offset, name_len)`.
+    names: Vec<u8>,
+    /// CSR offsets for children-of-parent lookup.  Length =
+    /// `nodes.len() + 1`.  Children of node `i` are
+    /// `child_indices[child_offsets[i]..child_offsets[i+1]]`.
+    child_offsets: Vec<u32>,
+    /// Flat array of child trie-indices, grouped by parent.
+    child_indices: Vec<u32>,
+}
+
+impl PathTrie {
+    /// Build a path-trie from a slice of [`CompactRecord`]s and the
+    /// shared name byte buffer.
+    ///
+    /// Only directory records are inserted; non-directory records
+    /// are skipped entirely.  Records whose parent is `u32::MAX` or
+    /// points at a non-directory record become trie roots
+    /// (`parent_idx == NO_PARENT`).
+    ///
+    /// O(N) over `records.len()`; allocates the trie's name buffer
+    /// at exactly the size of the directories' name bytes (no
+    /// over-allocation).
+    #[must_use]
+    pub fn build(records: &[CompactRecord], names: &[u8]) -> Self {
+        // ── Pass 1 — collect directories ─────────────────────────
+        // record_to_trie maps every directory record's index in
+        // `records` to its index in the trie's `nodes` array.
+        // FxHashMap because the indices are dense u32s and FxHash
+        // beats the std hasher 3-5x for integer keys.
+        let dir_count_estimate = records.len() / 16;
+        let mut record_to_trie: FxHashMap<u32, u32> =
+            FxHashMap::with_capacity_and_hasher(dir_count_estimate, rustc_hash::FxBuildHasher);
+        let mut nodes: Vec<TrieNode> = Vec::with_capacity(dir_count_estimate);
+        let mut trie_names: Vec<u8> = Vec::with_capacity(dir_count_estimate * 16);
+
+        for (record_idx_usize, record) in records.iter().enumerate() {
+            if !record.is_directory() {
+                continue;
+            }
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "records.len() ≤ u32::MAX by NTFS MFT layout (max ~4 G \
+                          entries per volume); the index fits u32 by construction"
+            )]
+            let record_idx = record_idx_usize as u32;
+
+            // Slice the basename out of the shared name buffer.
+            let name_start = record.name_offset as usize;
+            let name_end = name_start + record.name_len as usize;
+            let basename = names.get(name_start..name_end).unwrap_or(&[]);
+
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "trie_names.len() growth is bounded by sum of u16 name_len \
+                          across directories; an entire-drive trie's names buffer \
+                          stays under 4 GB by an enormous margin"
+            )]
+            let trie_name_offset = trie_names.len() as u32;
+            trie_names.extend_from_slice(basename);
+
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "nodes.len() ≤ records.len() ≤ u32::MAX by the same NTFS \
+                          MFT bound"
+            )]
+            let trie_idx = nodes.len() as u32;
+            record_to_trie.insert(record_idx, trie_idx);
+
+            // Stash the *record-side* parent_idx temporarily; pass 2
+            // will rewrite it into a trie-side index.
+            nodes.push(TrieNode {
+                parent_idx: record.parent_idx,
+                name_offset: trie_name_offset,
+                name_len: record.name_len,
+                padding: 0,
+            });
+        }
+
+        // ── Pass 2 — translate parents to trie-indices ───────────
+        for node in &mut nodes {
+            let record_parent = node.parent_idx;
+            if record_parent == u32::MAX {
+                node.parent_idx = NO_PARENT;
+            } else if let Some(&trie_parent) = record_to_trie.get(&record_parent) {
+                node.parent_idx = trie_parent;
+            } else {
+                // Parent isn't a directory (impossible on NTFS) or is
+                // missing from the records slice.  Treat as orphan.
+                node.parent_idx = NO_PARENT;
+            }
+        }
+
+        // ── Pass 3 — CSR children index ──────────────────────────
+        let (child_offsets, child_indices) = build_children_csr(&nodes);
+
+        Self {
+            nodes,
+            names: trie_names,
+            child_offsets,
+            child_indices,
+        }
+    }
+
+    /// Number of directory nodes in the trie.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// `true` iff the trie has no directories.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// Heap footprint in bytes.
+    ///
+    /// Sum of `nodes`, `names`, `child_offsets`, `child_indices`
+    /// capacities.  Used by Phase 4 memory-budget tests + the
+    /// `shard.transition` event's resident-delta accounting.
+    #[must_use]
+    pub const fn size_bytes(&self) -> usize {
+        self.nodes.capacity() * size_of::<TrieNode>()
+            + self.names.capacity()
+            + self.child_offsets.capacity() * size_of::<u32>()
+            + self.child_indices.capacity() * size_of::<u32>()
+    }
+
+    /// Borrow the basename of trie node `idx`, or `None` if `idx` is
+    /// out of range.
+    #[must_use]
+    pub fn name_of(&self, idx: u32) -> Option<&[u8]> {
+        let node = self.nodes.get(idx as usize)?;
+        let start = node.name_offset as usize;
+        let end = start + node.name_len as usize;
+        self.names.get(start..end)
+    }
+
+    /// Trie-index of `idx`'s parent, or `None` if `idx` is a root or
+    /// out of range.
+    #[must_use]
+    pub fn parent_of(&self, idx: u32) -> Option<u32> {
+        let node = self.nodes.get(idx as usize)?;
+        if node.parent_idx == NO_PARENT {
+            None
+        } else {
+            Some(node.parent_idx)
+        }
+    }
+
+    /// Slice of immediate-child trie-indices of `idx`.
+    ///
+    /// Returns an empty slice for unknown / leaf-directory `idx`.
+    /// O(1) — a single CSR lookup.
+    #[must_use]
+    pub fn children_of(&self, idx: u32) -> &[u32] {
+        let node_idx = idx as usize;
+        let Some(&start) = self.child_offsets.get(node_idx) else {
+            return &[];
+        };
+        let Some(&end) = self.child_offsets.get(node_idx + 1) else {
+            return &[];
+        };
+        let start_us = start as usize;
+        let end_us = end as usize;
+        self.child_indices.get(start_us..end_us).unwrap_or(&[])
+    }
+
+    /// Slice of trie-indices of every node that is a root
+    /// (`parent_idx == NO_PARENT`).
+    ///
+    /// On a single-drive trie there is typically exactly one root
+    /// (the drive letter); orphan directories whose parent record was
+    /// missing are also surfaced here for diagnostics.
+    #[must_use]
+    pub fn roots(&self) -> Vec<u32> {
+        let mut roots: Vec<u32> = Vec::new();
+        for (idx, node) in self.nodes.iter().enumerate() {
+            if node.parent_idx == NO_PARENT {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "nodes.len() ≤ u32::MAX by the same MFT bound as build"
+                )]
+                let trie_idx = idx as u32;
+                roots.push(trie_idx);
+            }
+        }
+        roots
+    }
+
+    /// Walk the trie from a root to the directory whose path is
+    /// `segments` joined.  Returns the destination's trie-index, or
+    /// `None` if any segment is missing.
+    ///
+    /// `segments[0]` matches a root by `name_of`; subsequent segments
+    /// match against [`PathTrie::children_of`].  Linear scan over
+    /// children at each level — for a typical drive's branching
+    /// factor (~10-100 children per directory) this is faster than a
+    /// per-level hash table at trie-build time.
+    ///
+    /// Plan task 4.5 pins the contract: `lookup_path(["C", "Users"])`
+    /// returns `Some(_)` and `children_of` of the result enumerates
+    /// the expected list.
+    #[must_use]
+    pub fn lookup_path(&self, segments: &[&[u8]]) -> Option<u32> {
+        let first = segments.first()?;
+        // Find a root whose name matches the first segment.
+        let mut current = self
+            .roots()
+            .into_iter()
+            .find(|&idx| self.name_of(idx) == Some(*first))?;
+
+        for &segment in segments.iter().skip(1) {
+            let child_idx = self
+                .children_of(current)
+                .iter()
+                .copied()
+                .find(|&child| self.name_of(child) == Some(segment))?;
+            current = child_idx;
+        }
+        Some(current)
+    }
+
+    /// Reconstruct the full path of node `idx` by walking the parent
+    /// chain.
+    ///
+    /// Names are joined with `/` (forward slash) — the platform-
+    /// neutral form the daemon's API surface uses.  Returns `None` if
+    /// `idx` is out of range; otherwise always succeeds (the parent
+    /// chain is guaranteed acyclic by the build algorithm).
+    #[must_use]
+    pub fn full_path(&self, idx: u32) -> Option<Vec<u8>> {
+        if (idx as usize) >= self.nodes.len() {
+            return None;
+        }
+        let mut segments_reversed: Vec<&[u8]> = Vec::new();
+        let mut cursor = idx;
+        loop {
+            let name = self.name_of(cursor)?;
+            segments_reversed.push(name);
+            match self.parent_of(cursor) {
+                Some(parent) => cursor = parent,
+                None => break,
+            }
+        }
+        // Join in reverse order with '/' separators.
+        let total_len: usize = segments_reversed.iter().map(|seg| seg.len()).sum::<usize>()
+            + segments_reversed.len().saturating_sub(1);
+        let mut out: Vec<u8> = Vec::with_capacity(total_len);
+        for (idx_in_chain, segment) in segments_reversed.iter().rev().enumerate() {
+            if idx_in_chain > 0 {
+                out.push(b'/');
+            }
+            out.extend_from_slice(segment);
+        }
+        Some(out)
+    }
+
+    /// Borrow the underlying nodes slice — read-only handle for
+    /// Phase 4 Commit D's serialiser.
+    #[must_use]
+    pub fn nodes(&self) -> &[TrieNode] {
+        &self.nodes
+    }
+
+    /// Borrow the trie's name byte buffer — read-only handle for
+    /// Phase 4 Commit D's serialiser.
+    #[must_use]
+    pub fn names(&self) -> &[u8] {
+        &self.names
+    }
+
+    /// Borrow the CSR child-offsets slice.
+    #[must_use]
+    pub fn child_offsets(&self) -> &[u32] {
+        &self.child_offsets
+    }
+
+    /// Borrow the CSR child-indices slice.
+    #[must_use]
+    pub fn child_indices(&self) -> &[u32] {
+        &self.child_indices
+    }
+}
+
+/// Build the CSR children index from a slice of [`TrieNode`]s whose
+/// `parent_idx` field is already in trie-index space.
+///
+/// Returns `(offsets, indices)`: `offsets.len() == nodes.len() + 1`,
+/// `indices.len() == count of nodes whose parent != NO_PARENT`.
+fn build_children_csr(nodes: &[TrieNode]) -> (Vec<u32>, Vec<u32>) {
+    // Pass 1 — count children per parent.
+    let mut counts: Vec<u32> = vec![0_u32; nodes.len()];
+    for node in nodes {
+        if node.parent_idx != NO_PARENT
+            && let Some(slot) = counts.get_mut(node.parent_idx as usize)
+        {
+            *slot += 1;
+        }
+    }
+
+    // Prefix-sum into offsets.
+    let mut offsets: Vec<u32> = Vec::with_capacity(nodes.len() + 1);
+    let mut running: u32 = 0;
+    for &count in &counts {
+        offsets.push(running);
+        running = running.saturating_add(count);
+    }
+    offsets.push(running);
+
+    // Pass 2 — scatter.
+    let mut indices: Vec<u32> = vec![0_u32; running as usize];
+    let mut write_pos: Vec<u32> = offsets.clone();
+    for (idx_usize, node) in nodes.iter().enumerate() {
+        if node.parent_idx == NO_PARENT {
+            continue;
+        }
+        let Some(pos_slot) = write_pos.get_mut(node.parent_idx as usize) else {
+            continue;
+        };
+        let Some(target) = indices.get_mut(*pos_slot as usize) else {
+            continue;
+        };
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "nodes.len() ≤ u32::MAX (build precondition)"
+        )]
+        let child_idx = idx_usize as u32;
+        *target = child_idx;
+        *pos_slot += 1;
+    }
+
+    (offsets, indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compact::CompactRecord;
+
+    /// Helper: build a minimal `CompactRecord` for a directory or
+    /// file.  Only the fields the trie reads are populated; the rest
+    /// come from `Default::default()` via struct-update syntax.
+    fn make_record(
+        name_offset: u32,
+        name_len: u16,
+        parent_idx: u32,
+        is_dir: bool,
+    ) -> CompactRecord {
+        // The DIRECTORY flag bit on raw NTFS attributes.
+        let flags: u32 = if is_dir { 0x0010 } else { 0 };
+        CompactRecord {
+            name_offset,
+            flags,
+            parent_idx,
+            name_len,
+            ..CompactRecord::default()
+        }
+    }
+
+    /// Smoke: an empty trie is a valid trie with zero nodes.
+    #[test]
+    fn empty_records_yield_empty_trie() {
+        let trie = PathTrie::build(&[], &[]);
+        assert!(trie.is_empty());
+        assert_eq!(trie.len(), 0);
+        assert_eq!(trie.roots(), Vec::<u32>::new());
+        assert_eq!(trie.children_of(0), &[] as &[u32]);
+    }
+
+    /// Files-only input yields an empty trie (directory-only by
+    /// design).
+    #[test]
+    fn files_only_yields_empty_trie() {
+        let names = b"a.txtb.rs".to_vec();
+        let records = [
+            make_record(0, 5, u32::MAX, false),
+            make_record(5, 4, u32::MAX, false),
+        ];
+        let trie = PathTrie::build(&records, &names);
+        assert!(trie.is_empty());
+    }
+
+    /// Single-directory trie: one root, no children.
+    #[test]
+    fn single_root_directory() {
+        let names = b"C".to_vec();
+        let records = [make_record(0, 1, u32::MAX, true)];
+        let trie = PathTrie::build(&records, &names);
+
+        assert_eq!(trie.len(), 1);
+        assert_eq!(trie.roots(), vec![0_u32]);
+        assert_eq!(trie.name_of(0), Some(b"C" as &[u8]));
+        assert_eq!(trie.parent_of(0), None);
+        assert!(trie.children_of(0).is_empty());
+    }
+
+    /// Two-level hierarchy: `C` (root) with two children `Users` and
+    /// `Windows`.  Validates parent-resolution + children CSR.
+    #[test]
+    fn two_level_hierarchy() {
+        // Records layout: index 0 = C (root), 1 = Users (parent 0),
+        // 2 = Windows (parent 0).
+        let names = b"CUsersWindows".to_vec();
+        let records = [
+            make_record(0, 1, u32::MAX, true), // C
+            make_record(1, 5, 0, true),        // Users
+            make_record(6, 7, 0, true),        // Windows
+        ];
+        let trie = PathTrie::build(&records, &names);
+
+        assert_eq!(trie.len(), 3);
+        assert_eq!(trie.roots(), vec![0_u32]);
+
+        let children_of_c = trie.children_of(0);
+        assert_eq!(children_of_c.len(), 2);
+        // Order of children isn't guaranteed by the spec, but build
+        // ordering is record-iteration order, so we expect
+        // [Users(1), Windows(2)].
+        assert_eq!(children_of_c, &[1_u32, 2_u32]);
+
+        assert_eq!(trie.name_of(1), Some(b"Users" as &[u8]));
+        assert_eq!(trie.name_of(2), Some(b"Windows" as &[u8]));
+        assert_eq!(trie.parent_of(1), Some(0));
+        assert_eq!(trie.parent_of(2), Some(0));
+    }
+
+    /// Plan task 4.5: 1000 directories under a common root, look up
+    /// each by `lookup_path(["root", "dirN"])`, assert presence and
+    /// `children_of(root)` enumerates exactly the expected indices.
+    #[test]
+    fn lookup_path_finds_thousand_paths() {
+        let mut names: Vec<u8> = Vec::new();
+        let mut records: Vec<CompactRecord> = Vec::new();
+
+        // Index 0 = root "C".
+        names.extend_from_slice(b"C");
+        records.push(make_record(0, 1, u32::MAX, true));
+
+        // Indices 1..=1000 = "dir0" .. "dir999" under C.
+        let mut expected_dir_names: Vec<String> = Vec::with_capacity(1000);
+        for i in 0_u32..1000 {
+            let name = format!("dir{i}");
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "names.len() in the test stays well under u32::MAX"
+            )]
+            let off = names.len() as u32;
+            names.extend_from_slice(name.as_bytes());
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "name.len() ≤ 'dir' + 3 digits = 6 bytes"
+            )]
+            let len = name.len() as u16;
+            records.push(make_record(off, len, 0, true));
+            expected_dir_names.push(name);
+        }
+
+        let trie = PathTrie::build(&records, &names);
+        assert_eq!(trie.len(), 1001);
+        assert_eq!(trie.roots(), vec![0_u32]);
+
+        // children_of(C) should be exactly [1, 2, ..., 1000].
+        let children = trie.children_of(0);
+        assert_eq!(children.len(), 1000);
+        let expected_children: Vec<u32> = (1_u32..=1000).collect();
+        assert_eq!(children, expected_children.as_slice());
+
+        // Every dirN looks up correctly.
+        for (offset, expected_name) in expected_dir_names.iter().enumerate() {
+            let segs: [&[u8]; 2] = [b"C", expected_name.as_bytes()];
+            let found = trie.lookup_path(&segs).expect("lookup_path missed");
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "offset < 1000 fits u32 trivially"
+            )]
+            let expected_idx = offset as u32 + 1;
+            assert_eq!(found, expected_idx);
+        }
+    }
+
+    /// `lookup_path` returns `None` for any missing segment.
+    #[test]
+    fn lookup_path_missing_returns_none() {
+        let names = b"CUsers".to_vec();
+        let records = [
+            make_record(0, 1, u32::MAX, true),
+            make_record(1, 5, 0, true),
+        ];
+        let trie = PathTrie::build(&records, &names);
+
+        assert!(trie.lookup_path(&[]).is_none());
+        assert!(trie.lookup_path(&[b"D"]).is_none()); // wrong root
+        assert!(trie.lookup_path(&[b"C", b"NoSuch"]).is_none()); // missing child
+        assert!(trie.lookup_path(&[b"C", b"Users", b"Alice"]).is_none()); // too deep
+    }
+
+    /// `full_path(idx)` reconstructs the path with `/` separators.
+    #[test]
+    fn full_path_reconstructs_with_slash_separators() {
+        let names = b"CUsersAlice".to_vec();
+        let records = [
+            make_record(0, 1, u32::MAX, true),
+            make_record(1, 5, 0, true),
+            make_record(6, 5, 1, true),
+        ];
+        let trie = PathTrie::build(&records, &names);
+
+        assert_eq!(trie.full_path(0).as_deref(), Some(b"C" as &[u8]));
+        assert_eq!(trie.full_path(1).as_deref(), Some(b"C/Users" as &[u8]));
+        assert_eq!(
+            trie.full_path(2).as_deref(),
+            Some(b"C/Users/Alice" as &[u8])
+        );
+        // Out-of-range idx returns None.
+        assert!(trie.full_path(99).is_none());
+    }
+
+    /// Orphan handling: a directory whose `parent_idx` points to a
+    /// non-directory record gets `NO_PARENT` (becomes a root).
+    #[test]
+    fn orphan_directory_with_non_directory_parent_becomes_root() {
+        // Index 0 = file "f.txt" (NOT a directory).
+        // Index 1 = dir "orphan" claiming parent_idx = 0.
+        let names = b"f.txtorphan".to_vec();
+        let records = [
+            make_record(0, 5, u32::MAX, false),
+            make_record(5, 6, 0, true),
+        ];
+        let trie = PathTrie::build(&records, &names);
+
+        assert_eq!(trie.len(), 1);
+        assert_eq!(trie.roots(), vec![0_u32]);
+        assert_eq!(trie.name_of(0), Some(b"orphan" as &[u8]));
+        assert_eq!(trie.parent_of(0), None);
+    }
+
+    /// Orphan handling: a directory whose `parent_idx` is out of
+    /// records-range gets `NO_PARENT`.
+    #[test]
+    fn orphan_directory_with_unknown_parent_becomes_root() {
+        let names = b"phantom".to_vec();
+        let records = [make_record(0, 7, 9999, true)];
+        let trie = PathTrie::build(&records, &names);
+
+        assert_eq!(trie.len(), 1);
+        assert_eq!(trie.roots(), vec![0_u32]);
+        assert_eq!(trie.parent_of(0), None);
+    }
+
+    /// `name_of` / `parent_of` / `children_of` return safe defaults
+    /// for out-of-range indices.
+    #[test]
+    fn out_of_range_queries_are_safe() {
+        let trie = PathTrie::build(&[], &[]);
+        assert_eq!(trie.name_of(0), None);
+        assert_eq!(trie.parent_of(0), None);
+        assert_eq!(trie.children_of(99_999), &[] as &[u32]);
+    }
+
+    /// `size_bytes` is non-zero for a non-empty trie and roughly
+    /// matches the analytic estimate.
+    #[test]
+    fn size_bytes_accounts_for_all_columns() {
+        let names = b"CUsers".to_vec();
+        let records = [
+            make_record(0, 1, u32::MAX, true),
+            make_record(1, 5, 0, true),
+        ];
+        let trie = PathTrie::build(&records, &names);
+
+        // Lower bound: 2 nodes × 12 + 6 name bytes + 3 offsets × 4
+        // (header CSR = nodes.len()+1) + 1 child × 4 = 24 + 6 + 12 + 4 = 46.
+        assert!(trie.size_bytes() >= 46);
+        // Upper bound: capacities can over-allocate by a factor; cap
+        // at 4× the analytic floor to catch egregious bloat.
+        assert!(trie.size_bytes() <= 46 * 16);
+    }
+
+    /// `nodes()` / `names()` / `child_offsets()` / `child_indices()`
+    /// borrows are non-empty and length-consistent for a non-empty
+    /// trie.  Pins the Commit D serialiser's contract.
+    #[test]
+    fn raw_buffer_borrows_are_consistent() {
+        let names = b"CUsersWindows".to_vec();
+        let records = [
+            make_record(0, 1, u32::MAX, true),
+            make_record(1, 5, 0, true),
+            make_record(6, 7, 0, true),
+        ];
+        let trie = PathTrie::build(&records, &names);
+
+        assert_eq!(trie.nodes().len(), 3);
+        // Trie names are independent of the records' name buffer; the
+        // trie copies just the directory basenames.
+        assert_eq!(trie.names(), b"CUsersWindows");
+        // CSR offsets length = nodes.len() + 1.
+        assert_eq!(trie.child_offsets().len(), 4);
+        // Two children of C.
+        assert_eq!(trie.child_indices().len(), 2);
+    }
+}

--- a/crates/uffs-core/src/path_trie.rs
+++ b/crates/uffs-core/src/path_trie.rs
@@ -390,6 +390,49 @@ impl PathTrie {
     pub fn child_indices(&self) -> &[u32] {
         &self.child_indices
     }
+
+    /// Reconstruct a `PathTrie` from raw `(nodes, names, child_offsets,
+    /// child_indices)` parts.
+    ///
+    /// Validates structural invariants:
+    ///
+    ///   - `child_offsets.len() == nodes.len() + 1`.
+    ///   - `child_indices.len() == *child_offsets.last().unwrap_or(&0) as
+    ///     usize`.
+    ///   - Every node's `(name_offset, name_len)` slice is within the bounds of
+    ///     `names`.
+    ///
+    /// Returns `None` on any violation so the cache-format
+    /// deserialiser can reject corrupted files instead of producing
+    /// an inconsistent trie that would later panic on lookup.
+    #[must_use]
+    pub fn from_raw_parts(
+        nodes: Vec<TrieNode>,
+        names: Vec<u8>,
+        child_offsets: Vec<u32>,
+        child_indices: Vec<u32>,
+    ) -> Option<Self> {
+        if child_offsets.len() != nodes.len() + 1 {
+            return None;
+        }
+        let expected_indices_len = *child_offsets.last().unwrap_or(&0) as usize;
+        if child_indices.len() != expected_indices_len {
+            return None;
+        }
+        for node in &nodes {
+            let start = node.name_offset as usize;
+            let end = start.checked_add(node.name_len as usize)?;
+            if end > names.len() {
+                return None;
+            }
+        }
+        Some(Self {
+            nodes,
+            names,
+            child_offsets,
+            child_indices,
+        })
+    }
 }
 
 /// Build the CSR children index from a slice of [`TrieNode`]s whose

--- a/crates/uffs-core/src/search/backend.rs
+++ b/crates/uffs-core/src/search/backend.rs
@@ -768,7 +768,7 @@ pub fn search_index(
     };
 
     // Filter drives without mutation — just skip non-matching ones.
-    let active_drives: Vec<&DriveCompactIndex> = index
+    let mut active_drives: Vec<&DriveCompactIndex> = index
         .drives
         .iter()
         .filter(|dr| {
@@ -779,6 +779,15 @@ pub fn search_index(
         })
         .map(Arc::as_ref)
         .collect();
+
+    // Phase 4 Commit F — bloom pre-check.  Drop drives whose bloom
+    // proves no record can match the ext filter, emitting one
+    // `shard.bloom.decision` per drive so operators can audit the
+    // skip rate.  See `crate::search::bloom_skip` for the
+    // correctness contract: only ext filters drive the skip
+    // decision; substring queries never bloom-skip (no false
+    // negatives possible).
+    apply_bloom_pre_check(&mut active_drives, &search_filters.extensions);
 
     let is_match_all = pattern == "*";
     let is_regex = pattern.starts_with('>') && pattern.len() > 1;
@@ -885,6 +894,43 @@ pub fn search_index(
 // and the `pick_mode_label` tracing helper live in `dispatch.rs`,
 // extracted for the 800-LOC file-size policy.  Imported at the top of
 // this file.
+
+/// Phase 4 Commit F — drop drives whose bloom misses the ext
+/// filter from the active subset.
+///
+/// Mutates `active_drives` in place.  Emits one
+/// `shard.bloom.decision` tracing event per drive (skip or keep)
+/// so operators can audit the skip rate and false-positive rate.
+///
+/// `ext_terms` is the lowercase-no-dot extension list as held in
+/// [`crate::search::filters::SearchFilters::extensions`].  Empty
+/// `ext_terms` short-circuits to a no-op via
+/// [`crate::search::bloom_skip::decide_for_ext_filter`]'s
+/// `Keep`-on-empty contract.
+#[expect(
+    clippy::single_call_fn,
+    reason = "extracted from search_index for readability — the inline body \
+              would push the cognitive-complexity lint past its budget"
+)]
+fn apply_bloom_pre_check(active_drives: &mut Vec<&DriveCompactIndex>, ext_terms: &[String]) {
+    if ext_terms.is_empty() {
+        return;
+    }
+    active_drives.retain(|drive| {
+        let decision =
+            crate::search::bloom_skip::decide_for_ext_filter(drive.bloom.as_ref(), ext_terms);
+        let matched = decision.keep();
+        tracing::debug!(
+            target: "shard.bloom.decision",
+            drive = %drive.letter,
+            r#match = matched,
+            terms = ?ext_terms,
+            source = "search_dispatch",
+            "bloom pre-check"
+        );
+        matched
+    });
+}
 
 // ── Sorting & DataFrame conversion ─────────────────────────────────────
 // Each concern lives in its own sibling module so callers can read

--- a/crates/uffs-core/src/search/backend_tests.rs
+++ b/crates/uffs-core/src/search/backend_tests.rs
@@ -2282,3 +2282,260 @@ fn sort_rows_numeric_fast_parallel_branch_preserves_order() {
         }
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 4 Commit F — bloom pre-check integration in search_index
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Build a multi-drive `DriveIndex` for the bloom-skip integration
+/// tests with **deterministically separated** blooms on each drive.
+///
+/// The default `build_compact_index` sizes blooms at the production
+/// 1 % FPR (`SHARD_BLOOM_TARGET_FPR`), which on tiny test fixtures
+/// produces flaky outcomes for novel-term probes (a single 1 %
+/// false positive turns a "skip" into a "keep" and breaks the
+/// `records_scanned` assertion).
+///
+/// To pin the test contract without weakening the production
+/// constant, this fixture builds the drives normally, then
+/// **overwrites** each drive's bloom with a tighter (0.1 % FPR)
+/// re-build over the same source records + `ext_names`.  The bloom
+/// *contents* are unchanged (still folded basenames + extensions);
+/// only the FPR margin is tightened so novel-term probes reliably
+/// miss in tests.
+fn build_bloom_skip_fixture() -> DriveIndex {
+    use alloc::format;
+    use alloc::sync::Arc;
+
+    use uffs_mft::index::{IndexNameRef, MftIndex, ROOT_FRS, SizeInfo};
+
+    use crate::bloom::Bloom;
+    use crate::compact::build_compact_index;
+
+    const FILES_PER_DRIVE: u32 = 50;
+    /// Tighter than `SHARD_BLOOM_TARGET_FPR` (1 %) so the
+    /// 4 novel-term probes in this suite reliably miss.
+    const TEST_FPR: f64 = 0.001;
+
+    let mut drives = Vec::new();
+    for (letter, ext) in [('C', "txt"), ('D', "csv")] {
+        let mut idx = MftIndex::new(letter);
+        let root_off = idx.add_name(".");
+        let root = idx.get_or_create(ROOT_FRS);
+        root.stdinfo.set_directory(true);
+        root.first_name.name = IndexNameRef::new(root_off, 1, true, IndexNameRef::NO_EXTENSION);
+        root.first_name.parent_frs = ROOT_FRS;
+
+        for i in 0_u32..FILES_PER_DRIVE {
+            let file_name = format!("file_{i:03}.{ext}");
+            let n_off = idx.add_name(&file_name);
+            let n_ext = idx.intern_extension(&file_name);
+            let frs = u64::from(200_u32.saturating_add(i));
+            let rec = idx.get_or_create(frs);
+            rec.first_name.name = IndexNameRef::new(
+                n_off,
+                u16::try_from(file_name.len()).expect("name too long"),
+                true,
+                n_ext,
+            );
+            rec.first_name.parent_frs = ROOT_FRS;
+            rec.first_stream.size = SizeInfo {
+                length: 100,
+                allocated: 512,
+            };
+            rec.stdinfo.flags = 0x20;
+        }
+
+        let (mut drive, _, _) = build_compact_index(letter, &idx);
+
+        // Overwrite the auto-built (1 %-FPR) bloom with a tighter
+        // (0.1 %-FPR) one over the same inputs so the test's novel-
+        // term probes don't suffer flaky FPR collisions.  The
+        // insertion contract mirrors `compact_filters::build_bloom`
+        // exactly — folded basenames + as-is extensions.
+        let n_items = drive
+            .records
+            .len()
+            .saturating_add(drive.ext_names.len())
+            .max(1);
+        let mut bloom = Bloom::with_capacity_and_fpr(n_items, TEST_FPR);
+        let mut fold_buf: Vec<u8> = Vec::with_capacity(64);
+        for record in &drive.records {
+            let start = record.name_offset as usize;
+            let end = start.saturating_add(record.name_len as usize);
+            if let Some(name_bytes) = drive.names.get(start..end)
+                && let Ok(name_str) = core::str::from_utf8(name_bytes)
+            {
+                let folded = drive.fold.fold_into(name_str, &mut fold_buf);
+                bloom.insert(folded.as_bytes());
+            }
+        }
+        for ext_name in &drive.ext_names {
+            let bytes = ext_name.as_bytes();
+            if !bytes.is_empty() {
+                bloom.insert(bytes);
+            }
+        }
+        drive.bloom = Some(bloom);
+
+        drives.push(Arc::new(drive));
+    }
+    DriveIndex { drives }
+}
+
+/// Sanity guard for the fixture: each drive's bloom must hit its
+/// own extension and miss the other drive's.  Without this contract
+/// the behavioural tests below are meaningless — pin it explicitly
+/// so a future fixture tweak surfaces an FPR regression cleanly.
+#[test]
+fn bloom_skip_fixture_has_well_separated_blooms() {
+    let index = build_bloom_skip_fixture();
+    let c_bloom = index
+        .drives
+        .first()
+        .expect("C")
+        .bloom
+        .as_ref()
+        .expect("C bloom populated");
+    let d_bloom = index
+        .drives
+        .get(1)
+        .expect("D")
+        .bloom
+        .as_ref()
+        .expect("D bloom populated");
+
+    assert!(c_bloom.contains(b"txt"), "C must contain its own ext");
+    assert!(d_bloom.contains(b"csv"), "D must contain its own ext");
+    assert!(
+        !c_bloom.contains(b"csv"),
+        "C must not have a false positive on `csv` (FPR regression)"
+    );
+    assert!(
+        !d_bloom.contains(b"txt"),
+        "D must not have a false positive on `txt` (FPR regression)"
+    );
+}
+
+/// `search_index` with `extensions = ["csv"]` must bloom-skip drive
+/// C (no `.csv` files).  Verified via `records_scanned`, which after
+/// `apply_bloom_pre_check` reflects only the surviving drives.
+#[test]
+fn search_index_bloom_skips_c_when_filter_is_csv_only() {
+    let index = build_bloom_skip_fixture();
+    let drive_d_records = index.drives.get(1).expect("D").records.len();
+
+    let mut filters_csv = super::super::filters::SearchFilters {
+        extensions: vec!["csv".to_owned()],
+        ..super::super::filters::SearchFilters::default()
+    };
+    let result = search_index(
+        &index,
+        SearchRequest::new("*", &mut filters_csv),
+        FieldId::Modified,
+        true,
+        &[],
+    );
+    assert_eq!(
+        result.records_scanned, drive_d_records,
+        "csv-only filter must bloom-skip C; only D scanned"
+    );
+}
+
+/// Mirror on the opposite drive: `extensions = ["txt"]` must
+/// bloom-skip D and scan only C.
+#[test]
+fn search_index_bloom_skips_d_when_filter_is_txt_only() {
+    let index = build_bloom_skip_fixture();
+    let drive_c_records = index.drives.first().expect("C").records.len();
+
+    let mut filters_txt = super::super::filters::SearchFilters {
+        extensions: vec!["txt".to_owned()],
+        ..super::super::filters::SearchFilters::default()
+    };
+    let result = search_index(
+        &index,
+        SearchRequest::new("*", &mut filters_txt),
+        FieldId::Modified,
+        true,
+        &[],
+    );
+    assert_eq!(
+        result.records_scanned, drive_c_records,
+        "txt-only filter must bloom-skip D; only C scanned"
+    );
+}
+
+/// Multi-term filter where every drive matches at least one term —
+/// the bloom pre-check must keep both drives.
+#[test]
+fn search_index_bloom_keeps_all_drives_when_any_ext_hits() {
+    let index = build_bloom_skip_fixture();
+    let total_records: usize = index.drives.iter().map(|dr| dr.records.len()).sum();
+
+    let mut filters_both = super::super::filters::SearchFilters {
+        extensions: vec!["txt".to_owned(), "csv".to_owned()],
+        ..super::super::filters::SearchFilters::default()
+    };
+    let result = search_index(
+        &index,
+        SearchRequest::new("*", &mut filters_both),
+        FieldId::Modified,
+        true,
+        &[],
+    );
+    assert_eq!(
+        result.records_scanned, total_records,
+        "any-hit filter must keep every drive in the active subset"
+    );
+}
+
+/// Empty `extensions` short-circuits the bloom pre-check entirely —
+/// the no-ext-filter path must scan every drive (substring queries
+/// can't bloom-skip; see `crate::search::bloom_skip` for the
+/// correctness contract).
+#[test]
+fn search_index_no_bloom_skip_when_extensions_empty() {
+    let index = build_bloom_skip_fixture();
+    let total_records: usize = index.drives.iter().map(|dr| dr.records.len()).sum();
+
+    let mut filters_empty = super::super::filters::SearchFilters::default();
+    let result = search_index(
+        &index,
+        SearchRequest::new("*", &mut filters_empty),
+        FieldId::Modified,
+        true,
+        &[],
+    );
+    assert_eq!(
+        result.records_scanned, total_records,
+        "empty-ext filter must keep every drive (no bloom-skip)"
+    );
+}
+
+/// Filter with a never-indexed extension: every drive's bloom
+/// misses, every drive is skipped.  Records-scanned drops to zero,
+/// pinning the "all-miss → empty active subset" edge case.
+#[test]
+fn search_index_bloom_skips_all_drives_when_no_ext_matches_any() {
+    let index = build_bloom_skip_fixture();
+    let mut filters_novel = super::super::filters::SearchFilters {
+        extensions: vec!["thisextisneverindexedanywhereonpurpose".to_owned()],
+        ..super::super::filters::SearchFilters::default()
+    };
+    let result = search_index(
+        &index,
+        SearchRequest::new("*", &mut filters_novel),
+        FieldId::Modified,
+        true,
+        &[],
+    );
+    assert_eq!(
+        result.records_scanned, 0,
+        "novel-ext filter must bloom-skip every drive — zero records scanned"
+    );
+    assert!(
+        result.rows.is_empty(),
+        "no drives scanned → no matching rows"
+    );
+}

--- a/crates/uffs-core/src/search/bloom_skip.rs
+++ b/crates/uffs-core/src/search/bloom_skip.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase 4 Commit F — bloom-based per-drive search skip.
+//!
+//! ## Why
+//!
+//! A search dispatched to N drives normally fan-outs to all of them
+//! and lets each scan its records.  When the user filters by
+//! extension (`--ext toml`, `*.toml` ext-glob, or
+//! `>.*\.(toml|md)$` regex-alternation — the latter two get
+//! promoted to extension filters by `super::dispatch`'s safety
+//! nets), the bloom filter holds an authoritative answer to
+//! "does this drive contain *any* record whose extension is in the
+//! filter set?".  A bloom miss means **definitely no** records
+//! match, so the drive can be skipped entirely:
+//!
+//! * **Warm shard:** skip the trigram / record scan (CPU saved).
+//! * **Parked shard:** skip the promote-from-disk (RAM saved — the 1 GB body
+//!   never re-enters resident memory).
+//!
+//! This is the architectural payoff of Phase 4 — Parked shards stay
+//! parked unless a query genuinely needs them.
+//!
+//! ## Why only ext filters
+//!
+//! The bloom inserts every record's *whole, folded basename* plus
+//! every interned *whole extension*.  It does **not** insert
+//! substrings or trigrams.
+//!
+//! For an exact-basename query the bloom is authoritative — but the
+//! daemon's search is substring-by-default, so a query for `Cargo`
+//! must still match a record named `Cargo.toml`.  Probing
+//! `bloom.contains("Cargo")` would miss (the bloom has
+//! `cargo.toml`, not `cargo`), producing a false negative.
+//!
+//! For an ext filter the bloom *is* authoritative: extensions are
+//! inserted whole, lowercase, dot-stripped — exactly the form the
+//! [`super::filters::SearchFilters::extensions`] vector carries.
+//! Probing `bloom.contains("toml")` is bit-exact and a miss truly
+//! means "no `.toml` records on this drive".
+//!
+//! The substring-search path is left untouched — it pays full cost
+//! on every drive it touches, but never produces false negatives.
+//! Users who want Phase-4 search-skip savings on a name search
+//! type `*.toml` (which the dispatch safety nets promote to
+//! `pattern = "*"` + `extensions = ["toml"]`), at which point the
+//! bloom pre-check applies cleanly.
+//!
+//! ## Telemetry
+//!
+//! Every decision (skip or keep) is emitted as a
+//! `shard.bloom.decision { drive, match, terms, source }` tracing
+//! event so operators can audit which drives a workload exercised
+//! and at what false-positive rate.
+
+use crate::bloom::Bloom;
+
+/// Decision outcome for a single drive's bloom probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BloomDecision {
+    /// The drive's bloom is authoritative and missed every term —
+    /// the caller should skip this drive entirely (no records can
+    /// possibly match).
+    Skip,
+    /// The drive's bloom hit at least one term, OR no bloom was
+    /// available, OR the query isn't bloom-checkable — the caller
+    /// must include this drive in the search.
+    Keep,
+}
+
+impl BloomDecision {
+    /// `true` iff the drive should be excluded from the active
+    /// search subset.
+    #[must_use]
+    pub const fn skip(self) -> bool {
+        matches!(self, Self::Skip)
+    }
+
+    /// `true` iff the bloom pre-check returned a `Keep` decision —
+    /// either authoritatively (any term hit) or because the check
+    /// didn't apply.
+    #[must_use]
+    pub const fn keep(self) -> bool {
+        matches!(self, Self::Keep)
+    }
+}
+
+/// Probe `bloom` for every term in `ext_terms` and decide whether
+/// the drive can be skipped.
+///
+/// Returns:
+/// * [`BloomDecision::Skip`] iff `bloom` is `Some`, `ext_terms` is non-empty,
+///   AND no term hits the filter.  All three conditions must hold — anything
+///   weaker risks a false negative.
+/// * [`BloomDecision::Keep`] otherwise (no bloom, no ext filter, or any single
+///   term hit).
+///
+/// The bloom term encoding mirrors
+/// [`crate::compact::DriveCompactIndex::build_bloom`]:
+/// extensions are inserted lowercase, dot-stripped, as raw bytes
+/// (e.g. `"toml"`, not `".toml"` or `".TOML"`).  Callers that hold
+/// extensions in [`crate::search::filters::SearchFilters::extensions`]
+/// already match this encoding (see
+/// [`crate::search::filters::SearchFilters::from_params`]).
+#[must_use]
+pub fn decide_for_ext_filter(bloom: Option<&Bloom>, ext_terms: &[String]) -> BloomDecision {
+    if ext_terms.is_empty() {
+        return BloomDecision::Keep;
+    }
+    let Some(bloom_ref) = bloom else {
+        return BloomDecision::Keep;
+    };
+    let any_hit = ext_terms
+        .iter()
+        .any(|term| bloom_ref.contains(term.as_bytes()));
+    if any_hit {
+        BloomDecision::Keep
+    } else {
+        BloomDecision::Skip
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a bloom containing the given byte strings.
+    fn bloom_with(items: &[&[u8]]) -> Bloom {
+        let mut bloom = Bloom::with_capacity_and_fpr(items.len().max(1), 0.01);
+        for item in items {
+            bloom.insert(item);
+        }
+        bloom
+    }
+
+    /// Empty `ext_terms` always keeps the drive — no filter, no
+    /// pre-check, regardless of bloom contents.
+    #[test]
+    fn empty_terms_always_keeps() {
+        let bloom = bloom_with(&[b"toml"]);
+        assert_eq!(
+            decide_for_ext_filter(Some(&bloom), &[]),
+            BloomDecision::Keep
+        );
+        assert_eq!(decide_for_ext_filter(None, &[]), BloomDecision::Keep);
+    }
+
+    /// `None` bloom always keeps — pre-Phase-4 caches load with
+    /// `bloom = None`, and the daemon must not skip them.
+    #[test]
+    fn missing_bloom_always_keeps() {
+        let terms = vec!["toml".to_owned()];
+        assert_eq!(decide_for_ext_filter(None, &terms), BloomDecision::Keep);
+    }
+
+    /// Single-term hit returns Keep (the drive must be searched).
+    #[test]
+    fn single_term_hit_keeps() {
+        let bloom = bloom_with(&[b"toml"]);
+        let terms = vec!["toml".to_owned()];
+        assert_eq!(
+            decide_for_ext_filter(Some(&bloom), &terms),
+            BloomDecision::Keep
+        );
+    }
+
+    /// Single-term miss returns Skip — the bloom is authoritative.
+    #[test]
+    fn single_term_miss_skips() {
+        let bloom = bloom_with(&[b"jpg", b"png"]);
+        let terms = vec!["toml".to_owned()];
+        assert_eq!(
+            decide_for_ext_filter(Some(&bloom), &terms),
+            BloomDecision::Skip
+        );
+    }
+
+    /// Multi-term: any hit keeps; all-miss skips.
+    #[test]
+    fn multi_term_keep_on_any_hit() {
+        let bloom = bloom_with(&[b"jpg"]);
+        let terms = vec!["toml".to_owned(), "jpg".to_owned(), "rs".to_owned()];
+        assert_eq!(
+            decide_for_ext_filter(Some(&bloom), &terms),
+            BloomDecision::Keep,
+            "any hit must keep the drive",
+        );
+    }
+
+    #[test]
+    fn multi_term_skip_when_all_miss() {
+        let bloom = bloom_with(&[b"jpg"]);
+        let terms = vec!["toml".to_owned(), "rs".to_owned(), "md".to_owned()];
+        assert_eq!(
+            decide_for_ext_filter(Some(&bloom), &terms),
+            BloomDecision::Skip,
+        );
+    }
+
+    /// Skip / Keep helpers reflect the variant correctly.
+    #[test]
+    fn decision_helpers_match_variant() {
+        assert!(BloomDecision::Skip.skip());
+        assert!(!BloomDecision::Skip.keep());
+        assert!(!BloomDecision::Keep.skip());
+        assert!(BloomDecision::Keep.keep());
+    }
+}

--- a/crates/uffs-core/src/search/mod.rs
+++ b/crates/uffs-core/src/search/mod.rs
@@ -7,6 +7,7 @@
 //! between the TUI, daemon, CLI, and any future surface.
 
 pub mod backend;
+pub mod bloom_skip;
 pub mod columns;
 mod dataframe_convert;
 pub mod derived;

--- a/crates/uffs-daemon/src/cache/registry.rs
+++ b/crates/uffs-daemon/src/cache/registry.rs
@@ -245,7 +245,29 @@ impl ShardRegistry {
         let stats = Arc::clone(&old_arc.stats);
         let drive = old_arc.drive;
         let new_entry = match target {
-            ShardState::Parked => ShardEntry::new_parked(drive, stats),
+            ShardState::Parked => {
+                // Phase 4 Commit F — extract the bloom + trie from the
+                // existing full body so the parked shard can answer the
+                // search-skip pre-check without re-loading from disk.
+                // The legality check (`is_legal_demote_target`) only
+                // permits `Hot | Warm` → `Parked`, both of which carry
+                // a body, so the `body()` Option is `Some`.  An absent
+                // body would indicate a torn registry; defend with a
+                // log and skip the demote rather than panic.
+                let Some(body) = old_arc.body() else {
+                    tracing::error!(
+                        target: "shard.transition",
+                        letter = %letter.to_ascii_uppercase(),
+                        from = %from_state,
+                        to = %target,
+                        reason = "demote",
+                        "Hot/Warm shard had no body during demote; skipping",
+                    );
+                    return None;
+                };
+                let parked_body = Arc::new(body.to_parked_body());
+                ShardEntry::new_parked(drive, stats, parked_body)
+            }
             ShardState::Cold => ShardEntry::new_cold(drive, stats),
             // Filtered out by `is_legal_demote_target` above; this
             // arm is unreachable in practice, exists only so the

--- a/crates/uffs-daemon/src/cache/shard.rs
+++ b/crates/uffs-daemon/src/cache/shard.rs
@@ -13,6 +13,7 @@ use core::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 use uffs_core::compact::DriveCompactIndex;
+use uffs_core::compact_cache::ParkedBody;
 
 /// Lifecycle state of a single drive's shard inside the daemon's
 /// in-memory cache.
@@ -406,6 +407,9 @@ impl From<DriveStatsSnapshot> for DriveStats {
 /// Phase 1 held the body unconditionally as `Arc<DriveCompactIndex>`.
 /// Phase 3 makes the body optional so demoted (`Parked` / `Cold`)
 /// shards can drop their runtime mmap and bloom/trie payload.
+/// Phase 4 adds a separate `parked_body` slot so a `Parked` shard
+/// retains its bloom + trie (~10–15 MB / drive) without the ~1 GB
+/// records / names / trigram / children CSR a full body holds.
 ///
 /// `stats` is wrapped in `Arc<DriveStats>` so a tier-transition rebuild
 /// (which replaces this `ShardEntry` with a fresh one inside the
@@ -430,6 +434,15 @@ pub(crate) struct ShardEntry {
     /// shards in those states; absent (`None`) for `Parked` / `Cold`
     /// where the runtime mmap has been released.
     body: Option<Arc<DriveCompactIndex>>,
+    /// Bloom + trie, present only for `Parked` shards.  `None` for
+    /// `Warm` / `Hot` (the bloom + trie live inside `body.bloom` /
+    /// `body.path_trie`) and for `Cold` (filters dropped).
+    ///
+    /// The Phase-4 search-skip path probes this on every Parked
+    /// shard touched by a search; a bloom miss skips promotion
+    /// entirely (zero-RAM-touch contract).  See
+    /// [`crate::index::IndexManager::ensure_warm_for_dispatch`].
+    parked_body: Option<Arc<ParkedBody>>,
 }
 
 impl ShardEntry {
@@ -447,6 +460,7 @@ impl ShardEntry {
             state: AtomicU8::new(ShardState::Warm as u8),
             stats: Arc::new(DriveStats::new()),
             body: Some(body),
+            parked_body: None,
         }
     }
 
@@ -466,6 +480,7 @@ impl ShardEntry {
             state: AtomicU8::new(ShardState::Warm as u8),
             stats,
             body: Some(body),
+            parked_body: None,
         }
     }
 
@@ -473,19 +488,26 @@ impl ShardEntry {
     /// `Arc<DriveStats>` (typically lifted off the previous
     /// `Warm` / `Hot` `ShardEntry` for this drive during a tier
     /// transition rebuild).  No body — the runtime mmap has been
-    /// released.
+    /// released — but the `parked_body` carries the bloom + trie
+    /// (~10–15 MB) so the search-skip pre-check can answer
+    /// "definitely not on this drive" without re-promoting.
     ///
     /// Reached from production via
     /// [`crate::index::IndexManager::demote_idle_shards`] →
     /// [`crate::cache::ShardRegistry::demote_letter`] (Phase 3
-    /// Commit D).
+    /// Commit D, extended in Phase 4 Commit F).
     #[must_use]
-    pub(crate) const fn new_parked(drive: char, stats: Arc<DriveStats>) -> Self {
+    pub(crate) const fn new_parked(
+        drive: char,
+        stats: Arc<DriveStats>,
+        parked_body: Arc<ParkedBody>,
+    ) -> Self {
         Self {
             drive,
             state: AtomicU8::new(ShardState::Parked as u8),
             stats,
             body: None,
+            parked_body: Some(parked_body),
         }
     }
 
@@ -506,6 +528,7 @@ impl ShardEntry {
             state: AtomicU8::new(ShardState::Cold as u8),
             stats,
             body: None,
+            parked_body: None,
         }
     }
 
@@ -521,6 +544,17 @@ impl ShardEntry {
     #[must_use]
     pub(crate) fn body(&self) -> Option<Arc<DriveCompactIndex>> {
         self.body.as_ref().map(Arc::clone)
+    }
+
+    /// Cheap clone of the parked-tier body (bloom + trie), present
+    /// only for `Parked` shards.  Returns `None` for any other
+    /// state.  Phase 4 search-skip pre-check entry point: callers
+    /// probe `parked.bloom.contains(folded_query)` against the
+    /// returned `Arc<ParkedBody>` to decide whether a `Parked`
+    /// shard can possibly contain matching records.
+    #[must_use]
+    pub(crate) fn parked_body(&self) -> Option<Arc<ParkedBody>> {
+        self.parked_body.as_ref().map(Arc::clone)
     }
 
     /// Attempt to transition the shard to `to`.

--- a/crates/uffs-daemon/src/cache/shard/tests.rs
+++ b/crates/uffs-daemon/src/cache/shard/tests.rs
@@ -22,11 +22,32 @@ use alloc::sync::Arc;
 use core::sync::atomic::Ordering;
 
 use proptest::prelude::*;
+use uffs_core::CaseFold;
+use uffs_core::bloom::Bloom;
+use uffs_core::compact_cache::ParkedBody;
+use uffs_core::path_trie::PathTrie;
 
 use super::{
     DriveStats, DriveStatsSnapshot, IllegalTransition, ShardEntry, ShardState,
     drive_stats_ema_value,
 };
+
+/// Build a minimal `ParkedBody` for shard-construction tests — a
+/// 64-bit bloom + an empty path trie + the default fold table.
+/// Sufficient to exercise `ShardEntry::new_parked` and the
+/// `parked_body()` accessor without pulling in fixture-builder
+/// machinery from `crate::index::tests`.
+fn make_test_parked_body(letter: char, source_epoch: u64) -> ParkedBody {
+    let bloom = Bloom::with_size_and_k(64, 7);
+    let path_trie = PathTrie::build(&[], &[]);
+    ParkedBody {
+        letter,
+        source_epoch,
+        bloom,
+        path_trie,
+        fold: CaseFold::default_table(),
+    }
+}
 
 fn arb_state() -> impl Strategy<Value = ShardState> {
     prop_oneof![
@@ -265,16 +286,18 @@ fn illegal_transition_display() {
     );
 }
 
-/// Phase 3: `ShardEntry::new_parked` produces a body-less shard
-/// in `ShardState::Parked` that shares the caller-provided
-/// `Arc<DriveStats>`.
+/// Phase 3 + Phase 4 Commit F: `ShardEntry::new_parked` produces a
+/// body-less shard in `ShardState::Parked` that shares the
+/// caller-provided `Arc<DriveStats>` and carries the bloom + trie
+/// payload in `parked_body`.
 #[test]
-fn new_parked_has_no_body_and_shares_stats() {
+fn new_parked_has_no_body_and_shares_stats_and_parked_body() {
     let stats = Arc::new(DriveStats::new());
     stats.record_query();
     stats.record_query();
 
-    let shard = ShardEntry::new_parked('C', Arc::clone(&stats));
+    let parked_body = Arc::new(make_test_parked_body('C', 99));
+    let shard = ShardEntry::new_parked('C', Arc::clone(&stats), Arc::clone(&parked_body));
     assert_eq!(shard.drive, 'C');
     assert_eq!(shard.state(), ShardState::Parked);
     assert!(shard.body().is_none());
@@ -285,6 +308,13 @@ fn new_parked_has_no_body_and_shares_stats() {
     assert_eq!(shard.stats.queries_total(), 2);
     stats.record_query();
     assert_eq!(shard.stats.queries_total(), 3);
+
+    // Phase 4 Commit F — `parked_body()` returns a clone of the
+    // same Arc, so the bloom / trie / epoch round-trip without copy.
+    let from_shard = shard.parked_body().expect("parked shard has body");
+    assert!(Arc::ptr_eq(&from_shard, &parked_body));
+    assert_eq!(from_shard.letter, 'C');
+    assert_eq!(from_shard.source_epoch, 99);
 }
 
 /// Phase 3: `ShardEntry::new_cold` produces the same body-less

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -937,11 +937,19 @@ impl IndexManager {
     ///
     /// No-op if every touched shard is already Warm/Hot — common
     /// case, single read-lock acquisition only.
-    async fn ensure_warm_for_dispatch(&self, params_drives: &[char]) {
+    async fn ensure_warm_for_dispatch(&self, params_drives: &[char], ext_terms: &[String]) {
         // ── Phase 1: read-lock detection (fast path) ───────────
         // Identify Parked/Cold shards in the touched set.  Single
         // read-lock acquisition; the registry's `iter()` is a Vec
         // walk, no allocation beyond the `needs_promote` Vec.
+        //
+        // Phase 4 Commit F — for Parked shards we additionally
+        // probe the bloom against `ext_terms`: a miss means the
+        // shard provably has no records matching the ext filter,
+        // so we skip the promote entirely (zero-RAM-touch
+        // contract).  Cold shards drop their bloom on demote, so
+        // they always promote.  Empty `ext_terms` short-circuits
+        // to the Phase-3 always-promote behaviour.
         let needs_promote: Vec<char> = {
             let guard = self.index.read().await;
             guard
@@ -958,6 +966,7 @@ impl IndexManager {
                         crate::cache::ShardState::Parked | crate::cache::ShardState::Cold
                     )
                 })
+                .filter(|shard| Self::bloom_pre_check_should_promote(shard, ext_terms))
                 .map(|shard| shard.drive)
                 .collect()
         };
@@ -1020,6 +1029,52 @@ impl IndexManager {
                 self.bump_index_version();
             }
         }
+    }
+
+    /// Phase 4 Commit F — bloom pre-check for Parked shards.
+    ///
+    /// Returns `true` when the shard must be promoted (the search
+    /// might match a record there); `false` when the shard is
+    /// provably empty for the supplied ext filter and can stay
+    /// Parked.
+    ///
+    /// Decision matrix:
+    ///
+    /// * `ext_terms` empty → always promote (the bloom-skip pre-check only
+    ///   applies to ext-filtered queries; substring queries never bloom-skip —
+    ///   see `crate::search::bloom_skip` for the correctness contract).
+    /// * Shard is Cold → always promote (bloom dropped on Parked → Cold
+    ///   transition; the only way to recover is the full body load).
+    /// * Shard is Parked + has `parked_body` → probe the bloom; emit
+    ///   `shard.bloom.decision` with the outcome and source `"ensure_warm"`.
+    /// * Shard is Parked + has no `parked_body` (defensive: torn tier
+    ///   transition) → promote (preserves correctness; the subsequent full-body
+    ///   load surfaces any real corruption).
+    fn bloom_pre_check_should_promote(
+        shard: &crate::cache::shard::ShardEntry,
+        ext_terms: &[String],
+    ) -> bool {
+        if ext_terms.is_empty() {
+            return true;
+        }
+        let Some(parked) = shard.parked_body() else {
+            // Cold shard, or Parked with no parked_body (legacy /
+            // defensive).  No bloom available to query → must
+            // promote so the full search runs against fresh data.
+            return true;
+        };
+        let decision =
+            uffs_core::search::bloom_skip::decide_for_ext_filter(Some(&parked.bloom), ext_terms);
+        let matched = decision.keep();
+        tracing::debug!(
+            target: "shard.bloom.decision",
+            drive = %shard.drive,
+            r#match = matched,
+            terms = ?ext_terms,
+            source = "ensure_warm",
+            "bloom pre-check"
+        );
+        matched
     }
 
     /// Demote any shards whose idle time exceeds the static-TTL

--- a/crates/uffs-daemon/src/index/search.rs
+++ b/crates/uffs-daemon/src/index/search.rs
@@ -84,28 +84,12 @@ impl IndexManager {
         let requires_post_filter =
             Self::predicates_require_post_filter(&effective_params.predicates);
 
-        // Phase 3 Commit C — promote any Parked/Cold shards in the
-        // touched set before we snapshot the active subset.  Fast
-        // path (single read-lock acquisition, no work) when every
-        // touched shard is already Warm/Hot, which is the common
-        // case in steady state.  See
-        // `IndexManager::ensure_warm_for_dispatch` doc for the
-        // three-phase orchestration and the
-        // conservative-on-under-promote contract.
-        self.ensure_warm_for_dispatch(&effective_params.drives)
-            .await;
-
-        // ── Snapshot the index (< 1 μs) ────────────────────────────
-        let t_lock = profiling.then(Instant::now);
-        let snapshot = self.snapshot().await;
-        // Phase 1 of memory-tiering: record this dispatch on every
-        // active shard so `DriveStats::decay_ema` (consumed by Phase 6
-        // adaptive-TTL) accumulates a real signal.  See
-        // `crate::cache::DriveStats` and the `record_search_dispatch`
-        // doc comment.
-        self.record_search_dispatch().await;
-        let lock_us = t_lock.map_or(0, |ts| ts.elapsed().as_micros());
-
+        // Resolve sort + filter mode + filters BEFORE the promote
+        // pass so Phase 4 Commit F can hand the resolved ext-term
+        // list to `ensure_warm_for_dispatch` for its bloom
+        // pre-check.  None of the work between here and the
+        // ensure-warm call depends on the registry's tier state, so
+        // the reordering is invariant-preserving.
         let (sort_column, sort_desc, extra_sort_tiers) =
             applied_sorts
                 .first()
@@ -164,6 +148,35 @@ impl IndexManager {
         // Overlay canonical predicates that can be compiled into the hot
         // path (size / descendant bounds).
         Self::compile_predicates_into_filters(&mut filters, &effective_params.predicates);
+
+        // Phase 3 Commit C — promote any Parked/Cold shards in the
+        // touched set before we snapshot the active subset.  Fast
+        // path (single read-lock acquisition, no work) when every
+        // touched shard is already Warm/Hot, which is the common
+        // case in steady state.  See
+        // `IndexManager::ensure_warm_for_dispatch` doc for the
+        // three-phase orchestration and the
+        // conservative-on-under-promote contract.
+        //
+        // Phase 4 Commit F — `ext_terms` enables the bloom-skip
+        // pre-check: if the user filtered by `--ext toml` and a
+        // Parked shard's bloom proves it has no `.toml` records,
+        // skip the promote (zero-RAM-touch contract).  Empty
+        // `ext_terms` short-circuits to the Phase-3 always-promote
+        // behaviour.
+        self.ensure_warm_for_dispatch(&effective_params.drives, &filters.extensions)
+            .await;
+
+        // ── Snapshot the index (< 1 μs) ────────────────────────────
+        let t_lock = profiling.then(Instant::now);
+        let snapshot = self.snapshot().await;
+        // Phase 1 of memory-tiering: record this dispatch on every
+        // active shard so `DriveStats::decay_ema` (consumed by Phase 6
+        // adaptive-TTL) accumulates a real signal.  See
+        // `crate::cache::DriveStats` and the `record_search_dispatch`
+        // doc comment.
+        self.record_search_dispatch().await;
+        let lock_us = t_lock.map_or(0, |ts| ts.elapsed().as_micros());
 
         // Snapshot per-drive info (only when profiling).
         let drive_info: Vec<(char, usize)> = if profiling {

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -1646,10 +1646,10 @@ async fn ensure_warm_for_dispatch_no_op_when_all_warm() {
 
     // Empty filter → all touched.  Non-empty filter → subset.
     // Either way, no shard is Parked/Cold so this is a no-op.
-    mgr.ensure_warm_for_dispatch(&[]).await;
-    mgr.ensure_warm_for_dispatch(&['C']).await;
-    mgr.ensure_warm_for_dispatch(&['c']).await; // case-insensitive
-    mgr.ensure_warm_for_dispatch(&['Z']).await; // unknown letter
+    mgr.ensure_warm_for_dispatch(&[], &[]).await;
+    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
+    mgr.ensure_warm_for_dispatch(&['c'], &[]).await; // case-insensitive
+    mgr.ensure_warm_for_dispatch(&['Z'], &[]).await; // unknown letter
 
     let states_after = mgr.shard_states_for_test().await;
     assert_eq!(
@@ -1677,7 +1677,7 @@ async fn ensure_warm_for_dispatch_skips_parked_shard_outside_filter() {
 
     // Search targets only D — C must stay Parked.  The on-disk
     // cache lookup for D would no-op because D is already Warm.
-    mgr.ensure_warm_for_dispatch(&['D']).await;
+    mgr.ensure_warm_for_dispatch(&['D'], &[]).await;
 
     let states_post = mgr.shard_states_for_test().await;
     assert_eq!(
@@ -1754,7 +1754,7 @@ async fn ensure_warm_for_dispatch_promotes_with_fixed_body_loader() {
     assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
 
     // Promote via ensure_warm_for_dispatch.
-    mgr.ensure_warm_for_dispatch(&['C']).await;
+    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
 
     // Shard is Warm again AND the heap-bytes metric is back to its
     // pre-demote value (the FixedBodyLoader handed back a body
@@ -1787,7 +1787,7 @@ async fn ensure_warm_for_dispatch_handles_missing_cache_gracefully() {
     assert_eq!(states_pre, vec![('C', ShardState::Parked)]);
 
     // Loader returns None → graceful failure path.
-    mgr.ensure_warm_for_dispatch(&['C']).await;
+    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
 
     let states_post = mgr.shard_states_for_test().await;
     assert_eq!(
@@ -1811,7 +1811,7 @@ async fn ensure_warm_for_dispatch_handles_panicking_body_loader_gracefully() {
     assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
 
     // Loader panics → JoinError arm runs → shard stays Parked.
-    mgr.ensure_warm_for_dispatch(&['C']).await;
+    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
 
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
@@ -1822,7 +1822,7 @@ async fn ensure_warm_for_dispatch_handles_panicking_body_loader_gracefully() {
 
     // Subsequent ensure_warm_for_dispatch on the same manager
     // still works (no global daemon state corruption).
-    mgr.ensure_warm_for_dispatch(&['C']).await;
+    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
     let states_again = mgr.shard_states_for_test().await;
     assert_eq!(
         states_again,
@@ -2234,7 +2234,7 @@ async fn shard_transition_events_emitted_on_demote_and_promote() {
     // Demote → expect one demote event.
     assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
     // Promote via ensure_warm_for_dispatch → expect one promote event.
-    mgr.ensure_warm_for_dispatch(&['C']).await;
+    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
 
     let events = log.events();
     let transitions: Vec<&CapturedEvent> = events


### PR DESCRIPTION
# Phase 4 — Bloom + path trie (memory tiering 🎯)

Closes the headline milestone of the memory-tiering work
(`docs/refactor/memory-tiering-implementation-plan.md` §3 Phase 4).
Adds the bloom filter + directory path trie to every drive, persists
them in a v9 cache format, teaches the daemon to load only those
filters for Parked shards (~10–15 MB resident vs ~1 GB for a full
body), and wires the search backend + `IndexManager::ensure_warm_for_dispatch`
to skip Parked shards whose bloom proves they hold no matching records.

This is the architectural payoff of the memory-tiering epic: **Parked
shards stay parked when the query proves they can't contribute** — the
1 GB body never re-enters resident memory, the trigram + records
columns aren't even mmap'd back in.

Builds on Phase 3 (#89, merged 2026-04-27).  Tasks 4.11–4.13
(integration / perf / memory benchmarks) are pending in Commit G.

## What's in this PR

Seven commits on `feat/memory-tiering-phase-4`:

| Commit | Subject | Plan tasks |
|---|---|---|
| `3d9f5635d` | **A**: `crates/uffs-core/src/bloom.rs` scaffolding | 4.1, 4.2 |
| `d380d277a` | **B**: `crates/uffs-core/src/path_trie.rs` directory-only trie | 4.4, 4.5 |
| `ea35f0577` | **C**: `DriveCompactIndex::{build_bloom, build_path_trie}` + builder wiring | 4.3 |
| `ef2f3669f` | **D**: cache format v9 with bloom + trie sections + v ≤ 8 backward compat | 4.6, 4.7 |
| `34413b40b` | **E**: `compact_cache::parked` — filters-only body load (~10–15 MB) | 4.8 |
| `c35fd0b53` | **F.1**: `ShardEntry::parked_body` + `ShardRegistry::demote_letter` populates it | 4.9, 4.10 (precondition) |
| `8868179be` | **F.2**: `search/bloom_skip` + `apply_bloom_pre_check` + bloom-aware `ensure_warm_for_dispatch` | 4.9, 4.10 |

## Plan acceptance

| Task | Status |
|---|---|
| 4.1 bloom impl (k=7, 1 % FPR target) | ✅ — `Bloom::with_capacity_and_fpr` |
| 4.2 100 K-string FPR test | ✅ — `bloom::tests::plan_4_2_one_pct_fpr_at_one_hundred_thousand_items` |
| 4.3 `DriveCompactIndex::build_bloom` | ✅ — `compact_filters` sibling module (file-size cap) |
| 4.4 path trie Arrow IPC layout | ✅ — Pod `TrieNode` + flat CSR arrays, blittable via `bytemuck` |
| 4.5 1000-leaf trie lookup test | ✅ — `path_trie::tests::lookup_path_finds_thousand_paths` |
| 4.6 cache v9 bloom + trie sections | ✅ — `compact_cache::filters_io::{push,write}_{bloom,trie}_section` |
| 4.7 v ≤ 8 deserialise + rebuild | ✅ — `assemble_compact_index` falls back to `build_*` |
| 4.8 PARKED-only body load | ✅ — `compact_cache::parked::{ParkedBody, deserialize_parked_body, load_parked_body}` |
| 4.9 search-side bloom pre-check | ✅ — `search/bloom_skip` + `apply_bloom_pre_check` |
| 4.10 bloom-aware Parked → Warm promote | ✅ — `IndexManager::ensure_warm_for_dispatch(ext_terms)` + `bloom_pre_check_should_promote` |
| 4.11 5-drive needle integration test | **deferred to Commit G** |
| 4.12 1 M-record perf test | **deferred to Commit G** |
| 4.13 7-drive memory test (≤ 100 MB cold) | **deferred to Commit G** (the headline number — needs the Windows gate) |

## Mac gate (PASS)

- `cargo nextest run --workspace` → **1481 / 1481** PASS, 11 skipped.
- `just lint-prod` clean.
- `just lint-tests` clean.
- `just rustdoc` clean (`-Dwarnings`).
- `cargo +nightly fmt --all -- --check` clean.

## What this enables

The PR by itself doesn't shrink RSS — that's the Commit G + Phase 5
job.  What it ships is the **plumbing** the headline numbers will
ride on:

* Every drive's compact cache now holds a bloom + trie alongside its
  records / names / trigram / children.
* The daemon can load *just* the bloom + trie for a Parked shard
  (`load_parked_body` — ~10–15 MB resident at 7 M-record / 1 % FPR
  vs ~1 GB for `load_compact_cache`).
* Searches with an `--ext` filter that misses a Parked shard's bloom
  short-circuit before the body loads — emits
  `shard.bloom.decision { drive, match: false, terms, source: "ensure_warm" }`
  on the audit channel.

Once Phase 5 (Windows working-set pressure) and the Commit G memory
benchmarks land, the headline target — **≤ 50 MB resident on a 7-drive
idle box** — is reachable from the architecture in this PR.

## Migration / compatibility

* **Cache format bump 8 → 9.**  v9 caches embed the bloom + trie;
  v ≤ 8 caches load fine and rebuild the filters on the fly via
  `build_bloom` / `build_path_trie`.  Re-saving with v9 is automatic
  on the next save cycle.
* **PARKED tier requires v9.**  `load_parked_body` returns
  `Err("parked-body load requires cache format v9+")` for v ≤ 8;
  the caller falls back to `load_compact_cache` (full rebuild) until
  the cluster has been re-saved with v9.
* No public API breakage in `uffs-core` or `uffs-daemon` — all new
  surface is additive.

## Stacked PR notes

Built on `main` (post-Phase 3 squash-merge `a511894bb`).  Doc-only
plan-doc updates (`docs/refactor/memory-tiering-implementation-plan.md`)
remain on the working tree only since `docs/refactor/` is gitignored,
matching every prior phase's pattern.
