### PR TITLE
chore: release v0.5.80 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.79] - 2026-04-25
+## [0.5.80] - 2026-04-25
 
 ### Fixed
 - **macOS arm64 release binaries SIGKILLed at launch** under macOS 26+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "anyhow",
  "clap",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "chrono",
  "itoa",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "anyhow",
  "axum",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4537,14 +4537,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4559,14 +4559,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.79"
+version = "0.5.80"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.79"
+version = "0.5.80"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.80**.  Binaries + GitHub Release v0.5.80 are already live (step 09).  This PR routes the corresponding commit through branch-protection rules.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

Local `main` had this commit with a different SHA before squash rewrote it onto main; recover with `git fetch origin && git reset --hard origin/main`.