### PR TITLE
fix(ci): Windows release ZIP root no longer wraps in release-staging/ (closes #92)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,10 +405,17 @@ jobs:
           # `zip` on macOS/Linux.  The ZIP goes straight into
           # release-artifacts/ so the existing Upload step picks it up
           # alongside the raw binaries.
+          #
+          # Both branches `cd release-staging` first so the archive's
+          # root entry is `${{ matrix.artifact-name }}/`, not
+          # `release-staging/${{ matrix.artifact-name }}/` — fixes #92,
+          # where the Windows ZIP previously contained the staging
+          # directory as a wrapper folder.
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            7z a -tzip \
-              "release-artifacts/${{ matrix.artifact-name }}.zip" \
-              "$STAGE_DIR/*" > /dev/null
+            (cd release-staging && \
+             7z a -tzip \
+               "../release-artifacts/${{ matrix.artifact-name }}.zip" \
+               "${{ matrix.artifact-name }}" > /dev/null)
           else
             (cd release-staging && \
              zip -rq "../release-artifacts/${{ matrix.artifact-name }}.zip" \


### PR DESCRIPTION
Closes #92.

## Problem

`uffs-windows-x64.zip` produced by the release workflow contains a wrapper directory: extracting gives `release-staging/uffs-windows-x64/...` instead of just `uffs-windows-x64/...`. The non-Windows branch of the same workflow already produces the expected layout.

## Root cause

In `.github/workflows/release.yml::Stage release bundle`, the Windows branch ran:

```bash
STAGE_DIR="release-staging/${{ matrix.artifact-name }}"
...
7z a -tzip "release-artifacts/${{ matrix.artifact-name }}.zip" "$STAGE_DIR/*"
```

7z preserves the path prefix it's invoked with, so entries get stored as `release-staging/uffs-windows-x64/...`.

The non-Windows branch already side-stepped this by `cd release-staging`-ing first and archiving the bare `${{ matrix.artifact-name }}`.

## Fix

Mirror the non-Windows branch: `cd release-staging && 7z a -tzip ../release-artifacts/...zip uffs-windows-x64`.

Both branches are now symmetric.

## Verification

- `actionlint .github/workflows/release.yml` → clean on the changed region (exit 0; only pre-existing info-level shellcheck notes elsewhere in the file).
- `lint-pre-push` (full smoke + xwin check, 66 s) green.
- Cannot run the release workflow itself locally — actual ZIP layout will be verified on the next preview / release build via the existing CI.

## Risk

Tiny. The change is a one-step `cd` indirection in the bundling step. Failure mode (if any) would be archive-empty / archive-wrong-root, which is immediately visible from the workflow's own `ls -la "release-artifacts/...zip"` step. No code paths change; no end-user-visible binaries change.

