### PR TITLE
feat(daemon): Phase 5 — parallel re-promote + USN replay on warm load + background refresh timer (closes #93, #94, #95, #96)

### DIFF
--- a/crates/uffs-core/src/compact_cache.rs
+++ b/crates/uffs-core/src/compact_cache.rs
@@ -40,6 +40,89 @@ use crate::compact_mmap;
 use crate::compact_storage::ColumnStorage;
 use crate::trigram::TrigramIndex;
 
+/// Structured error variants for [`load_compact_cache`].
+///
+/// Phase 5 (#96): each failure path that previously collapsed into
+/// `Option::None` now surfaces a typed variant.  Callers that only
+/// care about success vs failure can still pattern-match on `Ok(_)`
+/// vs `Err(_)`, but production logs and the daemon's stale-cache
+/// detection logic can now distinguish "cache file missing" from
+/// "decryption failed" from "stale by epoch" — the previous silent-
+/// `None` return collapsed all eight failure modes into one log line.
+#[derive(Debug, thiserror::Error)]
+pub enum LoadCacheError {
+    /// Cache file does not exist on disk yet (typical on first boot
+    /// or after a `cache clear`).  Caller should rebuild.
+    #[error("compact cache file missing")]
+    Missing,
+
+    /// Cache file age exceeds the supplied TTL.  Caller should
+    /// rebuild.
+    #[error("compact cache stale by TTL: age={age_secs}s, ttl={ttl_secs}s")]
+    StaleByTtl {
+        /// Cache file age in seconds (computed from mtime).
+        age_secs: u64,
+        /// Caller-supplied TTL ceiling in seconds.
+        ttl_secs: u64,
+    },
+
+    /// Cache file mtime is older than the underlying MFT cache
+    /// (`.uffs`).  The MFT cache was rebuilt between the compact
+    /// cache being saved and now, so the compact must be rebuilt.
+    #[error("compact cache older than MFT cache — rebuild required")]
+    StaleVsMft,
+
+    /// `source_epoch` in the cache header is older than the live
+    /// MFT `build_epoch`.  Caller should rebuild.
+    #[error("compact cache stale by epoch: cached={cached_epoch}, current={current_epoch}")]
+    StaleByEpoch {
+        /// `source_epoch` value embedded in the cache header.
+        cached_epoch: u64,
+        /// `build_epoch` of the live `MftIndex` the caller passed in.
+        current_epoch: u64,
+    },
+
+    /// Filesystem I/O error reading the cache file (disk gone, perms,
+    /// path traversal blocked, etc.).
+    #[error("compact cache I/O failed: {0}")]
+    Io(#[from] io::Error),
+
+    /// Cache encryption key unavailable (Keychain access denied,
+    /// dev-mode file missing or unreadable, etc.).
+    #[error("cache encryption key unavailable: {0}")]
+    KeyUnavailable(String),
+
+    /// AES-256-GCM decryption failed (wrong key, MAC mismatch,
+    /// truncated ciphertext, unsupported header version).
+    #[error("compact cache decryption failed: {0}")]
+    DecryptFailed(String),
+
+    /// zstd decompression failed (ciphertext was decrypted but the
+    /// inner frame is corrupt).
+    #[error("compact cache decompression failed: {0}")]
+    DecompressFailed(String),
+
+    /// Header / body parse error (bad magic, version mismatch,
+    /// truncated body).  See `parse_compact_header` /
+    /// `parse_compact_body` for the canonical messages.
+    #[error("compact cache parse error: {0}")]
+    ParseError(&'static str),
+
+    /// Runtime tempfile setup failed (path collision, perms, parent
+    /// directory missing).  See `compact_runtime_tempfile_path`.
+    #[error("runtime tempfile setup failed: {0}")]
+    RuntimeTempfile(String),
+
+    /// Final deserialise + mmap step failed (alignment, bounds,
+    /// `write_runtime_layout` invariant violation).
+    #[error("compact cache deserialise failed: {0}")]
+    Deserialize(String),
+}
+
+/// Convenience alias — [`LoadCacheError`] is the canonical failure
+/// type for compact-cache loads.
+pub type LoadCacheResult<T> = Result<T, LoadCacheError>;
+
 /// Magic bytes for compact cache files.
 const COMPACT_MAGIC: &[u8; 8] = b"UFFSCOM\0";
 /// Current compact cache format version.
@@ -772,32 +855,40 @@ fn encrypt_and_write(
 /// load, based on TTL and (optionally) mtime comparison against the
 /// `MftIndex` `.uffs` file.
 ///
-/// Returns `true` when the cache passes both checks and should be read.
-/// Returns `false` when the file is missing, older than `ttl_seconds`,
-/// or older than the `MftIndex` source (cross-process staleness — the
-/// daemon rebuilt the MFT after this compact cache was written).
-/// When `trust_ttl_only` is true the mtime comparison is skipped — the
-/// caller vouches that the TTL alone is sufficient freshness evidence.
-fn is_compact_cache_fresh(
+/// Returns `Ok(())` when the cache passes both checks and should be
+/// read.  Returns the matching [`LoadCacheError`] variant when the
+/// file is missing, older than `ttl_seconds`, or older than the
+/// `MftIndex` source.  When `trust_ttl_only` is true the mtime
+/// comparison is skipped — the caller vouches that the TTL alone is
+/// sufficient freshness evidence.
+///
+/// Phase 5 (#96): replaces the previous `bool` return so the caller
+/// can distinguish "file missing" from "stale by TTL" from
+/// "stale vs MFT" without re-reading the metadata.
+fn check_compact_cache_freshness(
     path: &Path,
     drive_letter: char,
     ttl_seconds: u64,
     trust_ttl_only: bool,
-) -> bool {
-    let Ok(meta) = std::fs::metadata(path) else {
-        return false;
+) -> LoadCacheResult<()> {
+    let meta = match std::fs::metadata(path) {
+        Ok(meta) => meta,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            return Err(LoadCacheError::Missing);
+        }
+        Err(err) => return Err(LoadCacheError::Io(err)),
     };
-    let Ok(compact_mtime) = meta.modified() else {
-        return false;
-    };
-    let Ok(age) = compact_mtime.elapsed() else {
-        return false;
-    };
-    if age.as_secs() > ttl_seconds {
-        return false;
+    let compact_mtime = meta.modified()?;
+    let age = compact_mtime.elapsed().unwrap_or_default();
+    let age_secs = age.as_secs();
+    if age_secs > ttl_seconds {
+        return Err(LoadCacheError::StaleByTtl {
+            age_secs,
+            ttl_secs: ttl_seconds,
+        });
     }
     if trust_ttl_only {
-        return true;
+        return Ok(());
     }
     let mft_path = uffs_mft::cache::cache_file_path(drive_letter);
     if let Ok(mft_meta) = std::fs::metadata(&mft_path)
@@ -808,51 +899,60 @@ fn is_compact_cache_fresh(
             drive = %drive_letter,
             "Compact cache older than MftIndex cache — rebuilding"
         );
-        return false;
+        return Err(LoadCacheError::StaleVsMft);
     }
-    true
+    Ok(())
 }
 
-/// Loads a compact index from its cache file if fresh. Returns `None` if
-/// cache is missing, stale, corrupt, or built from an older `MftIndex`.
+/// Loads a compact index from its cache file if fresh.
 ///
 /// `mft_build_epoch` is the `build_epoch` of the current `MftIndex`.
-/// If the compact cache was built from an older epoch it is considered stale
-/// and `None` is returned so the caller rebuilds.
+/// If the compact cache was built from an older epoch it is considered
+/// stale and the matching [`LoadCacheError::StaleByEpoch`] is returned
+/// so the caller rebuilds.
 ///
 /// When `trust_ttl_only` is `true`, the mtime comparison against the
 /// `MftIndex` `.uffs` file is skipped — only the TTL age check is used.
-/// This is useful for hot-path searches where the caller knows the compact
-/// cache was just built or the `MftIndex` hasn't changed.
-#[must_use]
+/// This is useful for hot-path searches where the caller knows the
+/// compact cache was just built or the `MftIndex` hasn't changed.
+///
+/// # Errors
+///
+/// Returns the matching [`LoadCacheError`] variant on any failure.
+/// Phase 5 (#96): the previous `Option<DriveCompactIndex>` API
+/// collapsed eight distinct failure modes into a single silent-`None`
+/// return; callers can now distinguish e.g. "cache file missing"
+/// (cold-boot rebuild) from "decryption failed" (key rotated;
+/// rebuild + alert) from "stale by epoch" (incremental refresh).
 pub fn load_compact_cache(
     drive_letter: char,
     ttl_seconds: u64,
     mft_build_epoch: u64,
     trust_ttl_only: bool,
-) -> Option<DriveCompactIndex> {
+) -> LoadCacheResult<DriveCompactIndex> {
     let path = compact_cache_path(drive_letter);
-    if !is_compact_cache_fresh(&path, drive_letter, ttl_seconds, trust_ttl_only) {
-        return None;
-    }
+    check_compact_cache_freshness(&path, drive_letter, ttl_seconds, trust_ttl_only)?;
 
     let profile = std::env::var_os("UFFS_CACHE_PROFILE").is_some();
     let t_total = Instant::now();
 
     let t_read = Instant::now();
-    let raw = std::fs::read(&path).ok()?;
+    let raw = std::fs::read(&path)?;
     let read_ms = t_read.elapsed().as_millis();
     let raw_len = raw.len();
 
-    let key = uffs_security::keystore::get_cache_key().ok()?;
+    let key = uffs_security::keystore::get_cache_key()
+        .map_err(|err| LoadCacheError::KeyUnavailable(err.to_string()))?;
     let t_decrypt = Instant::now();
-    let decrypted = uffs_security::crypto::decrypt_cache(&raw, &key).ok()?;
+    let decrypted = uffs_security::crypto::decrypt_cache(&raw, &key)
+        .map_err(|err| LoadCacheError::DecryptFailed(err.to_string()))?;
     let decrypt_ms = t_decrypt.elapsed().as_millis();
 
     let t_decompress = Instant::now();
     let is_compressed = decrypted.get(..4).is_some_and(|magic| magic == ZSTD_MAGIC);
     let plaintext = if is_compressed {
-        zstd::decode_all(decrypted.as_slice()).ok()?
+        zstd::decode_all(decrypted.as_slice())
+            .map_err(|err| LoadCacheError::DecompressFailed(err.to_string()))?
     } else {
         decrypted
     };
@@ -860,23 +960,21 @@ pub fn load_compact_cache(
     let plaintext_len = plaintext.len();
 
     // Early staleness check — inspect header before full deserialization.
-    if mft_build_epoch > 0
-        && let Ok((source_epoch, _, _)) = parse_compact_header(&plaintext)
-        && source_epoch < mft_build_epoch
-    {
-        tracing::debug!(
-            target: "cache_profile",
-            source_epoch,
-            mft_build_epoch,
-            "compact: STALE"
-        );
-        tracing::debug!(
-            drive = %drive_letter,
-            compact_epoch = source_epoch,
-            mft_epoch = mft_build_epoch,
-            "Compact cache stale (source_epoch < mft build_epoch) — rebuilding"
-        );
-        return None;
+    if mft_build_epoch > 0 {
+        let (source_epoch, _, _) =
+            parse_compact_header(&plaintext).map_err(LoadCacheError::ParseError)?;
+        if source_epoch < mft_build_epoch {
+            tracing::debug!(
+                target: "cache_profile",
+                source_epoch,
+                mft_build_epoch,
+                "compact: STALE"
+            );
+            return Err(LoadCacheError::StaleByEpoch {
+                cached_epoch: source_epoch,
+                current_epoch: mft_build_epoch,
+            });
+        }
     }
 
     // Phase 2b: materialise records + names through a daemon-private
@@ -884,14 +982,13 @@ pub fn load_compact_cache(
     // the resident set for the two largest columns.  Path is unique
     // per call (atomic sequence) so re-loading the same drive in the
     // same process never hits an `O_EXCL` / `CREATE_NEW` collision.
-    // `.ok()?` mirrors the previous heap path: any failure
-    // (path-collision, mmap, parse) falls back to a cold rebuild.
-    let runtime_path = compact_runtime_tempfile_path(drive_letter).ok()?;
+    let runtime_path = compact_runtime_tempfile_path(drive_letter)
+        .map_err(|err| LoadCacheError::RuntimeTempfile(err.to_string()))?;
     let runtime_dir = uffs_security::runtime_dir::DefaultRuntimeDir::default();
     let t_deser = Instant::now();
     let (index, tri_ms) =
         deserialize_compact_into_runtime(&plaintext, drive_letter, &runtime_dir, &runtime_path)
-            .ok()?;
+            .map_err(|err| LoadCacheError::Deserialize(err.to_string()))?;
     let deser_ms = t_deser.elapsed().as_millis();
 
     if profile {
@@ -907,7 +1004,7 @@ pub fn load_compact_cache(
             total_ms: t_total.elapsed().as_millis(),
         });
     }
-    Some(index)
+    Ok(index)
 }
 
 /// Timing profile for compact-cache loading stages.
@@ -961,6 +1058,38 @@ fn log_compact_load_profile(index: &DriveCompactIndex, profile: &CompactLoadProf
 
 // ─── Build-or-load + save ────────────────────────────────────────────────────
 
+/// `ensure_compact_cached` cache-load helper.
+///
+/// Extracted from [`ensure_compact_cached`] to keep that function's
+/// cognitive complexity below clippy's strict-gate ceiling (Phase 5
+/// added an extra match arm for #96 structured errors).
+fn try_load_for_ensure(drive_letter: char, build_epoch: u64) -> Option<DriveCompactIndex> {
+    match load_compact_cache(
+        drive_letter,
+        super::compact::INDEX_TTL_SECONDS,
+        build_epoch,
+        false,
+    ) {
+        Ok(cached) => {
+            tracing::debug!(
+                target: "cache_profile",
+                records = cached.records.len(),
+                "compact: loaded from cache"
+            );
+            Some(cached)
+        }
+        Err(err) => {
+            tracing::debug!(
+                target: "cache_profile",
+                drive = %drive_letter,
+                error = %err,
+                "compact: cache miss/stale; building from MftIndex",
+            );
+            None
+        }
+    }
+}
+
 /// Ensures the compact cache is up-to-date for a given drive.
 ///
 /// - If a fresh compact cache exists on disk → loads and returns it.
@@ -974,17 +1103,7 @@ pub fn ensure_compact_cached(
 ) -> DriveCompactIndex {
     // Try loading existing compact cache (epoch check catches stale caches).
     // Not TTL-only: we have the MftIndex, so mtime validation is cheap & correct.
-    if let Some(cached) = load_compact_cache(
-        drive_letter,
-        super::compact::INDEX_TTL_SECONDS,
-        mft_index.build_epoch,
-        false,
-    ) {
-        tracing::debug!(
-            target: "cache_profile",
-            records = cached.records.len(),
-            "compact: loaded from cache"
-        );
+    if let Some(cached) = try_load_for_ensure(drive_letter, mft_index.build_epoch) {
         return cached;
     }
 

--- a/crates/uffs-core/src/compact_cache/parked.rs
+++ b/crates/uffs-core/src/compact_cache/parked.rs
@@ -47,8 +47,8 @@ use std::time::Instant;
 use uffs_text::case_fold::CaseFold;
 
 use super::{
-    COMPACT_VERSION, RECORD_BYTES, ZSTD_MAGIC, compact_cache_path, filters_io,
-    is_compact_cache_fresh, parse_compact_header, read_u32,
+    COMPACT_VERSION, RECORD_BYTES, ZSTD_MAGIC, check_compact_cache_freshness, compact_cache_path,
+    filters_io, parse_compact_header, read_u32,
 };
 use crate::bloom::Bloom;
 use crate::path_trie::PathTrie;
@@ -425,7 +425,17 @@ pub fn load_parked_body(
     trust_ttl_only: bool,
 ) -> Option<ParkedBody> {
     let path = compact_cache_path(drive_letter);
-    if !is_compact_cache_fresh(&path, drive_letter, ttl_seconds, trust_ttl_only) {
+    // `load_parked_body` keeps its `Option` return for now (#96 scope
+    // limited the Result conversion to `load_compact_cache`); fold any
+    // structured `LoadCacheError` into a debug-logged `None`.
+    if let Err(err) =
+        check_compact_cache_freshness(&path, drive_letter, ttl_seconds, trust_ttl_only)
+    {
+        tracing::debug!(
+            drive = %drive_letter,
+            error = %err,
+            "parked-body load: freshness check failed",
+        );
         return None;
     }
 

--- a/crates/uffs-core/src/compact_loader.rs
+++ b/crates/uffs-core/src/compact_loader.rs
@@ -95,12 +95,25 @@ pub fn load_drive(
         MftSource::Live(ch) => *ch,
     };
 
-    // ── Fast path: compact cache hit ───────────────────────────────
-    if !no_cache && let Some(result) = try_compact_cache_hit(drive_letter, source) {
-        return Ok(result);
-    }
-
-    // ── Load MftIndex (cache or cold) ──────────────────────────────
+    // ── Load MftIndex (cache + USN replay, or cold) ────────────────
+    //
+    // Phase 5 (#94): the previous `try_compact_cache_hit` fast path
+    // returned the on-disk compact cache directly without applying
+    // USN deltas, so cold-boot WARM load served stale data for any
+    // drive whose compact cache was older than the live filesystem
+    // (5/7 drives at the v0.5.80 reference run).  We now always go
+    // through the MftIndex path: on Windows this triggers
+    // `read_index_cached` → `apply_usn_updates_to_fresh_index`, so
+    // the rebuilt compact reflects the live USN journal state.  On
+    // non-Windows / offline-file sources the MFT itself is the
+    // source of truth and USN replay is a no-op.
+    //
+    // Cost: ~1.5 s per drive for the compact rebuild + trigram
+    // step; at N=7 drives in parallel the cold-boot WARM total
+    // moves from ~5.7 s to ~7–10 s (one-time per daemon start).
+    // The Phase 4 re-promote path uses
+    // [`load_drive_with_usn_refresh`] for the same correctness
+    // guarantee.
     let mft_start = Instant::now();
     let mft_index = match source {
         MftSource::File(path, _) => load_mft_index_from_file(path, drive_letter, no_cache)?,
@@ -144,37 +157,113 @@ pub fn load_drive(
     }))
 }
 
-/// Attempt to load a compact index from cache (TTL-only, no mtime validation).
+/// Timing breakdown for [`load_drive_with_usn_refresh`].
 ///
-/// Returns `Some((index, timing))` on cache hit, `None` on miss.
-#[expect(
-    clippy::single_call_fn,
-    reason = "extracted for readability from load_drive"
-)]
-fn try_compact_cache_hit(
-    drive_letter: char,
-    source: &MftSource,
-) -> Option<(DriveCompactIndex, LoadTiming)> {
-    let cache_start = Instant::now();
-    let mut compact =
-        crate::compact_cache::load_compact_cache(drive_letter, INDEX_TTL_SECONDS, 0, true)?;
-    let cache_ms = cache_start.elapsed().as_millis();
+/// Mirrors [`LoadTiming`] but with names that match the USN-refresh
+/// flow (no "cache hit" arm — that path was removed in #94).  Field
+/// names follow [`LoadTiming`]'s `_ms`-free convention.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RefreshTiming {
+    /// `MftIndex` load wall-clock in milliseconds (cache hit + USN
+    /// replay).
+    pub mft: u128,
+    /// Compact rebuild from the refreshed `MftIndex` in
+    /// milliseconds.
+    pub compact: u128,
+    /// Trigram CSR rebuild in milliseconds.
+    pub trigram: u128,
+    /// Total wall-clock in milliseconds, including the
+    /// background-save submission.
+    pub total: u128,
+}
 
-    if let Some(path) = source.file_path() {
-        compact.source = IndexSource::MftFile(path.to_path_buf());
+/// Phase 5 (#94) re-promote helper: load the per-drive `MftIndex`
+/// from cache, apply USN journal deltas, rebuild the
+/// `DriveCompactIndex` from the refreshed MFT, and submit a
+/// background compact-cache save so the next call is faster.
+///
+/// Used by the daemon's `DiskBodyLoader::load` and (eventually) the
+/// background USN refresh timer (#95).  On Windows the call goes
+/// through `MftReader::read_index_cached` →
+/// `apply_usn_updates_to_fresh_index` which is the canonical USN
+/// replay path the cold-boot fall-through has been using all along.
+/// On non-Windows the live-volume reader is unavailable and the
+/// function returns an error so the caller can fall back to a bare
+/// [`crate::compact_cache::load_compact_cache`].
+///
+/// # Errors
+///
+/// Returns an error if the live MFT cannot be opened, the cached
+/// `MftIndex` cannot be loaded, or the USN journal apply step fails.
+/// The compact-cache save is best-effort (warn-logged on failure)
+/// and never propagates an error to the caller.
+#[cfg(windows)]
+pub fn load_drive_with_usn_refresh(
+    drive_letter: char,
+) -> anyhow::Result<(DriveCompactIndex, RefreshTiming)> {
+    let total_start = Instant::now();
+    let mft_start = Instant::now();
+    let mft_index = load_mft_index_live(drive_letter, /* no_cache = */ false)?;
+    let mft = mft_start.elapsed().as_millis();
+
+    let (mut compact, compact_ms_inner, trigram_ms_inner) =
+        build_compact_index(drive_letter, &mft_index);
+    drop(mft_index);
+
+    // Persist the USN-refreshed compact so the next promote on this
+    // letter (or the next cold-boot) starts from a fresher snapshot.
+    // Best-effort — warn on failure but don't fail the caller; the
+    // returned in-memory body is still correct.
+    if let Err(err) = crate::compact_cache::save_compact_cache_background(&compact) {
+        tracing::warn!(
+            drive = %drive_letter,
+            error = %err,
+            "Failed to start USN-refreshed compact cache save (best-effort)",
+        );
     }
+
+    let total = total_start.elapsed().as_millis();
     tracing::info!(
+        target: "shard.transition",
         drive = %drive_letter,
+        mft_ms = %mft,
+        compact_ms = %compact_ms_inner,
+        trigram_ms = %trigram_ms_inner,
+        total_ms = %total,
         records = compact.records.len(),
-        cache_ms,
-        "📦 Cache hit — loaded compact cache"
+        "♻️ USN-refreshed body ready (load_drive_with_usn_refresh)",
     );
-    Some((compact, LoadTiming {
-        cache: cache_ms,
-        mft: 0,
-        compact: 0,
-        trigram: 0,
+    compact.source = IndexSource::MftFile(PathBuf::from(format!("{drive_letter}:")));
+    Ok((compact, RefreshTiming {
+        mft,
+        compact: compact_ms_inner,
+        trigram: trigram_ms_inner,
+        total,
     }))
+}
+
+/// Non-Windows stub for [`load_drive_with_usn_refresh`].
+///
+/// USN journals are NTFS-only.  On macOS / Linux the daemon's only
+/// cache source is the offline-file path (`MftSource::File`), which
+/// does not need USN replay because the underlying `.iocp` /
+/// `.uffs` snapshot is the source of truth.  This stub returns an
+/// error so callers (notably `DiskBodyLoader::load`) fall back to
+/// [`crate::compact_cache::load_compact_cache`] without a Windows
+/// `cfg` gate at the call site.
+///
+/// # Errors
+///
+/// Always returns an `anyhow` error noting USN replay is unsupported
+/// on this platform.  The caller is expected to handle this by
+/// falling back to the bare compact-cache load.
+#[cfg(not(windows))]
+pub fn load_drive_with_usn_refresh(
+    drive_letter: char,
+) -> anyhow::Result<(DriveCompactIndex, RefreshTiming)> {
+    anyhow::bail!(
+        "USN refresh not supported on this platform (drive {drive_letter}); caller should fall back to load_compact_cache"
+    )
 }
 
 /// Parse a `.uffs` MFT file into `MftIndex`, choosing the parser that

--- a/crates/uffs-daemon/src/cache/body_loader.rs
+++ b/crates/uffs-daemon/src/cache/body_loader.rs
@@ -63,13 +63,61 @@ pub(crate) trait BodyLoader: Send + Sync + 'static {
 /// `ttl_seconds = u64::MAX` skips the freshness check — the
 /// demote / promote path doesn't care if the cache is "old", only
 /// that it is a valid serialisation of the drive that *was* loaded.
-/// Phase 4+ may add an explicit `mft_build_epoch` check to detect
-/// out-of-band MFT churn between demote and promote; for Phase 3
-/// the cache is trusted unconditionally.
+///
+/// Phase 5 (#94) wires this loader to `load_drive_with_usn_refresh`
+/// so re-promote on Windows applies USN deltas before the body
+/// reaches the search hot path.  This struct stays as the
+/// "trust-the-on-disk-cache" fallback: if MFT cache is missing or
+/// the USN journal is unavailable (e.g. drive G `error 1179`), the
+/// daemon logs the failure and serves the un-refreshed body so the
+/// shard still becomes usable.
+///
+/// Phase 5 (#96) updates the failure path to log the structured
+/// [`uffs_core::compact_cache::LoadCacheError`] variant so the
+/// daemon's tracing output distinguishes "cache file missing"
+/// (cold-boot first-touch) from "decryption failed" (key rotated;
+/// alert) from "stale by TTL" (idle-timer rebuild trigger).
 pub(crate) struct DiskBodyLoader;
 
 impl BodyLoader for DiskBodyLoader {
     fn load(&self, letter: char) -> Option<Arc<DriveCompactIndex>> {
-        uffs_core::compact_cache::load_compact_cache(letter, u64::MAX, 0, true).map(Arc::new)
+        // Phase 5 (#94): primary path — USN-refreshed re-promote.
+        // On Windows this applies USN deltas to the cached MftIndex
+        // and rebuilds the compact index, so the body served to the
+        // search hot path reflects the live filesystem state since
+        // the daemon's last MFT refresh.  On non-Windows the helper
+        // errors out by design and we fall through to the bare
+        // compact-cache load below.
+        match uffs_core::compact_loader::load_drive_with_usn_refresh(letter) {
+            Ok((body, _timing)) => return Some(Arc::new(body)),
+            Err(err) => {
+                tracing::warn!(
+                    target: "shard.transition",
+                    drive = %letter,
+                    error = %err,
+                    reason = "promote-on-search",
+                    "USN-refresh failed; falling back to bare compact-cache load",
+                );
+            }
+        }
+
+        // Phase 5 (#94) fallback: the USN-refresh path failed (cache
+        // missing, journal unavailable, drive G `error 1179`, etc.).
+        // Serve the un-refreshed compact cache so the shard is still
+        // usable, with a structured `LoadCacheError` (#96) surfaced
+        // on failure.
+        match uffs_core::compact_cache::load_compact_cache(letter, u64::MAX, 0, true) {
+            Ok(body) => Some(Arc::new(body)),
+            Err(err) => {
+                tracing::warn!(
+                    target: "shard.transition",
+                    drive = %letter,
+                    error = %err,
+                    reason = "promote-on-search",
+                    "compact-cache fallback also failed; shard stays in current tier",
+                );
+                None
+            }
+        }
     }
 }

--- a/crates/uffs-daemon/src/cache/policy.rs
+++ b/crates/uffs-daemon/src/cache/policy.rs
@@ -63,6 +63,21 @@ pub(crate) const WARM_TO_PARKED_IDLE_SECS: u64 = 1800;
 /// under nightly batch processes that scan archives once per day.
 pub(crate) const PARKED_TO_COLD_IDLE_SECS: u64 = 86_400;
 
+/// Default cadence for the Phase 5 (#95) background USN refresh
+/// controller.  Every `USN_REFRESH_INTERVAL_SECS` (default 5 min)
+/// the daemon walks all `Warm` / `Hot` shards and folds live USN
+/// journal deltas into their in-memory body so search results
+/// reflect the live filesystem state without waiting for the next
+/// idle-tier transition.
+///
+/// 5 min is a deliberate trade-off: short enough that `Warm` shards
+/// don't drift more than `WARM_TO_PARKED_IDLE_SECS / 6` between
+/// refreshes (so nothing demotes mid-refresh), long enough that the
+/// USN journal accumulates a meaningful batch (per-drive replay
+/// dominated by fixed setup, not by record count).  Override at
+/// daemon startup via [`USN_REFRESH_INTERVAL_ENV`].
+pub(crate) const USN_REFRESH_INTERVAL_SECS: u64 = 300;
+
 /// Env var that overrides [`HOT_TO_WARM_IDLE_SECS`].
 pub(crate) const HOT_TO_WARM_IDLE_ENV: &str = "UFFS_HOT_TO_WARM_IDLE_SECS";
 
@@ -71,6 +86,9 @@ pub(crate) const WARM_TO_PARKED_IDLE_ENV: &str = "UFFS_WARM_TO_PARKED_IDLE_SECS"
 
 /// Env var that overrides [`PARKED_TO_COLD_IDLE_SECS`].
 pub(crate) const PARKED_TO_COLD_IDLE_ENV: &str = "UFFS_PARKED_TO_COLD_IDLE_SECS";
+
+/// Env var that overrides [`USN_REFRESH_INTERVAL_SECS`].
+pub(crate) const USN_REFRESH_INTERVAL_ENV: &str = "UFFS_USN_REFRESH_INTERVAL_SECS";
 
 /// Read a positive `u64` seconds value from `env_name`, falling back
 /// to `default` on any parse error or non-positive value.  Logs a
@@ -121,6 +139,15 @@ pub(crate) fn warm_to_parked_idle_secs() -> u64 {
 pub(crate) fn parked_to_cold_idle_secs() -> u64 {
     static CACHED: OnceLock<u64> = OnceLock::new();
     *CACHED.get_or_init(|| read_env_secs(PARKED_TO_COLD_IDLE_ENV, PARKED_TO_COLD_IDLE_SECS))
+}
+
+/// Effective USN refresh interval (env override or default), in
+/// seconds.  Consumed by the Phase 5 (#95) background USN refresh
+/// controller spawned from `crate::lib::run_daemon`.
+#[must_use]
+pub(crate) fn usn_refresh_interval_secs() -> u64 {
+    static CACHED: OnceLock<u64> = OnceLock::new();
+    *CACHED.get_or_init(|| read_env_secs(USN_REFRESH_INTERVAL_ENV, USN_REFRESH_INTERVAL_SECS))
 }
 
 /// Decide whether a shard in `state` that has been idle for

--- a/crates/uffs-daemon/src/cache/policy.rs
+++ b/crates/uffs-daemon/src/cache/policy.rs
@@ -10,41 +10,127 @@
 //! Adaptive TTL controllers live in Phase 6; for now every shard
 //! shares the same fixed thresholds:
 //!
-//! * **Hot → Warm** at [`HOT_TO_WARM_IDLE_SECS`] (5 min idle).
-//! * **Warm → Parked** at [`WARM_TO_PARKED_IDLE_SECS`] (30 min idle).
-//! * **Parked → Cold** at [`PARKED_TO_COLD_IDLE_SECS`] (24 h idle).
+//! * **Hot → Warm** at [`HOT_TO_WARM_IDLE_SECS`] (5 min idle, default).
+//! * **Warm → Parked** at [`WARM_TO_PARKED_IDLE_SECS`] (30 min idle, default).
+//! * **Parked → Cold** at [`PARKED_TO_COLD_IDLE_SECS`] (24 h idle, default).
+//!
+//! Each default is overridable at daemon startup via env var so
+//! Phase 5 testing flows can compress the 30 min Warm → Parked
+//! idle into a 6 min cycle (or any other duration) without
+//! shipping a non-default policy to end users.  The override is
+//! read once and cached; restart the daemon to pick up a change.
+//!
+//! ```text
+//! UFFS_HOT_TO_WARM_IDLE_SECS=60      \
+//! UFFS_WARM_TO_PARKED_IDLE_SECS=360  \
+//! UFFS_PARKED_TO_COLD_IDLE_SECS=900  \
+//!     uffs daemon start --drive C,D,E,F,G,M,S
+//! ```
 //!
 //! [`next_state_for_idle`] is the single decision function consumed by
 //! `crate::cache::registry::ShardRegistry::demote_idle_shards`; it
 //! returns `None` when the shard is not yet idle past its current
 //! tier's TTL or when the tier is already at the bottom.
 
+use std::sync::OnceLock;
+
 use super::shard::ShardState;
 
-/// After this many seconds without a query a `Hot` shard demotes to
-/// `Warm`.  Phase 4+ extends "no query" to "no bloom-positive query"
-/// so cold drives don't re-warm just because their bloom got faulted
-/// in by a wildcard scan.
+/// Default for the `Hot` → `Warm` idle threshold.
+///
+/// Overridable at daemon startup via [`HOT_TO_WARM_IDLE_ENV`].
+/// Phase 4+ extends "no query" to "no bloom-positive query" so cold
+/// drives don't re-warm just because their bloom got faulted in by
+/// a wildcard scan.
 ///
 /// Consumed by [`crate::index::IndexManager::demote_idle_shards`]
 /// (Phase 3 Commit D) via [`next_state_for_idle`].
 pub(crate) const HOT_TO_WARM_IDLE_SECS: u64 = 300;
 
-/// After this many seconds without a query a `Warm` shard demotes to
-/// `Parked`, dropping the runtime mmap (the records / names columns
-/// are released; bloom + trie persist in Phase 4+).
+/// Default for the `Warm` → `Parked` idle threshold.
+///
+/// Overridable at daemon startup via [`WARM_TO_PARKED_IDLE_ENV`].
+/// `Parked` drops the runtime mmap (the records / names columns
+/// are released; bloom + trie persist for Phase 4+ search-skip).
 pub(crate) const WARM_TO_PARKED_IDLE_SECS: u64 = 1800;
 
-/// After this many seconds without a query a `Parked` shard demotes
-/// to `Cold`, dropping bloom + trie too.  A `Cold` shard requires a
-/// full re-decrypt of the encrypted compact cache to re-promote, so
-/// the threshold is generous (24 h) — anything shorter risks
-/// thrashing under nightly batch processes that scan archives once
-/// per day.
+/// Default for the `Parked` → `Cold` idle threshold.
+///
+/// Overridable at daemon startup via [`PARKED_TO_COLD_IDLE_ENV`].
+/// `Cold` drops bloom + trie too — re-promotion requires a full
+/// re-decrypt of the encrypted compact cache, so the threshold is
+/// generous (24 h) by default.  Anything shorter risks thrashing
+/// under nightly batch processes that scan archives once per day.
 pub(crate) const PARKED_TO_COLD_IDLE_SECS: u64 = 86_400;
+
+/// Env var that overrides [`HOT_TO_WARM_IDLE_SECS`].
+pub(crate) const HOT_TO_WARM_IDLE_ENV: &str = "UFFS_HOT_TO_WARM_IDLE_SECS";
+
+/// Env var that overrides [`WARM_TO_PARKED_IDLE_SECS`].
+pub(crate) const WARM_TO_PARKED_IDLE_ENV: &str = "UFFS_WARM_TO_PARKED_IDLE_SECS";
+
+/// Env var that overrides [`PARKED_TO_COLD_IDLE_SECS`].
+pub(crate) const PARKED_TO_COLD_IDLE_ENV: &str = "UFFS_PARKED_TO_COLD_IDLE_SECS";
+
+/// Read a positive `u64` seconds value from `env_name`, falling back
+/// to `default` on any parse error or non-positive value.  Logs a
+/// single startup line per override so the effective policy is
+/// observable in production.
+fn read_env_secs(env_name: &str, default: u64) -> u64 {
+    let Ok(raw) = std::env::var(env_name) else {
+        return default;
+    };
+    let parsed: Option<u64> = raw.trim().parse::<u64>().ok().filter(|&n| n > 0);
+    let effective = parsed.unwrap_or(default);
+    if parsed.is_some() {
+        tracing::info!(
+            target: "shard.policy",
+            env_var = env_name,
+            override_secs = effective,
+            default_secs = default,
+            "idle-threshold override active",
+        );
+    } else {
+        tracing::warn!(
+            target: "shard.policy",
+            env_var = env_name,
+            raw = %raw,
+            default_secs = default,
+            "idle-threshold env var unparseable; using default",
+        );
+    }
+    effective
+}
+
+/// Effective `Hot` → `Warm` idle threshold (env override or default).
+#[must_use]
+pub(crate) fn hot_to_warm_idle_secs() -> u64 {
+    static CACHED: OnceLock<u64> = OnceLock::new();
+    *CACHED.get_or_init(|| read_env_secs(HOT_TO_WARM_IDLE_ENV, HOT_TO_WARM_IDLE_SECS))
+}
+
+/// Effective `Warm` → `Parked` idle threshold (env override or default).
+#[must_use]
+pub(crate) fn warm_to_parked_idle_secs() -> u64 {
+    static CACHED: OnceLock<u64> = OnceLock::new();
+    *CACHED.get_or_init(|| read_env_secs(WARM_TO_PARKED_IDLE_ENV, WARM_TO_PARKED_IDLE_SECS))
+}
+
+/// Effective `Parked` → `Cold` idle threshold (env override or default).
+#[must_use]
+pub(crate) fn parked_to_cold_idle_secs() -> u64 {
+    static CACHED: OnceLock<u64> = OnceLock::new();
+    *CACHED.get_or_init(|| read_env_secs(PARKED_TO_COLD_IDLE_ENV, PARKED_TO_COLD_IDLE_SECS))
+}
 
 /// Decide whether a shard in `state` that has been idle for
 /// `idle_secs` seconds should demote to a colder tier.
+///
+/// Reads the effective tier thresholds via the
+/// [`hot_to_warm_idle_secs`] / [`warm_to_parked_idle_secs`] /
+/// [`parked_to_cold_idle_secs`] getters, so any
+/// `UFFS_*_IDLE_SECS` env-var override set before daemon startup is
+/// honoured here too.
 ///
 /// Returns the target state on demote, or `None` when:
 ///
@@ -62,11 +148,11 @@ pub(crate) const PARKED_TO_COLD_IDLE_SECS: u64 = 86_400;
 /// [`crate::index::IndexManager::demote_idle_shards`] (Phase 3
 /// Commit D).
 #[must_use]
-pub(crate) const fn next_state_for_idle(state: ShardState, idle_secs: u64) -> Option<ShardState> {
+pub(crate) fn next_state_for_idle(state: ShardState, idle_secs: u64) -> Option<ShardState> {
     match state {
-        ShardState::Hot if idle_secs >= HOT_TO_WARM_IDLE_SECS => Some(ShardState::Warm),
-        ShardState::Warm if idle_secs >= WARM_TO_PARKED_IDLE_SECS => Some(ShardState::Parked),
-        ShardState::Parked if idle_secs >= PARKED_TO_COLD_IDLE_SECS => Some(ShardState::Cold),
+        ShardState::Hot if idle_secs >= hot_to_warm_idle_secs() => Some(ShardState::Warm),
+        ShardState::Warm if idle_secs >= warm_to_parked_idle_secs() => Some(ShardState::Parked),
+        ShardState::Parked if idle_secs >= parked_to_cold_idle_secs() => Some(ShardState::Cold),
         // Two distinct cases collapsed into one arm because they
         // share the same outcome:
         //   * Hot / Warm / Parked: idle window not exceeded for the current tier (the guard above
@@ -177,4 +263,16 @@ mod tests {
     /// enforced at build time, not at test run.
     const _: () = assert!(HOT_TO_WARM_IDLE_SECS < WARM_TO_PARKED_IDLE_SECS);
     const _: () = assert!(WARM_TO_PARKED_IDLE_SECS < PARKED_TO_COLD_IDLE_SECS);
+
+    /// `read_env_secs` falls back to the supplied default when the
+    /// env var is unset.  Pins the contract that a non-overridden
+    /// daemon uses the in-source thresholds.  Uses a deliberately
+    /// unique env-var name (`UFFS_TEST_ENV_NEVER_SET`) so the test
+    /// is independent of any `UFFS_*_IDLE_SECS` value the developer
+    /// happens to have exported in their shell.
+    #[test]
+    fn read_env_secs_falls_back_when_env_unset() {
+        let val = read_env_secs("UFFS_TEST_ENV_NEVER_SET_12345", 42);
+        assert_eq!(val, 42, "unset env var → default");
+    }
 }

--- a/crates/uffs-daemon/src/cache/registry.rs
+++ b/crates/uffs-daemon/src/cache/registry.rs
@@ -363,6 +363,69 @@ impl ShardRegistry {
         Some(Self::from_shards(shards))
     }
 
+    /// Phase 5 (#95) — replace the body of a `Warm` / `Hot` shard
+    /// with a fresher one (typically the output of
+    /// [`uffs_core::compact_loader::load_drive_with_usn_refresh`]).
+    /// Returns the rebuilt registry on success, or `None` when:
+    ///
+    /// * `letter` is not registered;
+    /// * the existing shard's state is `Parked` / `Cold` / `Unknown` /
+    ///   `Evicting` — these tiers don't have an in-memory body to refresh.  A
+    ///   `Parked` shard gets a USN-refreshed body via the normal
+    ///   `promote_letter` path on its next search-hot-path touch.
+    ///
+    /// The per-drive [`Arc<DriveStats>`] is preserved so query
+    /// counters / `last_query_at_ms` survive the swap.  The new
+    /// shard always lands in `Warm`; if the previous state was
+    /// `Hot`, the next search query will re-promote it via the
+    /// natural state-machine — the brief Hot → Warm → Hot bounce is
+    /// invisible in production telemetry (sub-millisecond gap on
+    /// the next dispatch).
+    ///
+    /// Wired into the production refresh path by
+    /// [`crate::index::IndexManager::refresh_usn_for_warm_shards`].
+    #[must_use]
+    pub(crate) fn replace_warm_body(
+        &self,
+        letter: char,
+        body: Arc<DriveCompactIndex>,
+    ) -> Option<Self> {
+        let (pos, old_arc) = self
+            .shards
+            .iter()
+            .enumerate()
+            .find(|(_, shard)| shard.drive.eq_ignore_ascii_case(&letter))?;
+        let from_state = old_arc.state();
+        if !matches!(from_state, ShardState::Warm | ShardState::Hot) {
+            return None;
+        }
+        let refreshed_mb = (body.heap_size_bytes().total / 1_048_576) as u64;
+        let stats = Arc::clone(&old_arc.stats);
+        let drive = old_arc.drive;
+        let new_arc = Arc::new(ShardEntry::new_warm_with_stats(drive, body, stats));
+        let shards: Vec<Arc<ShardEntry>> = self
+            .shards
+            .iter()
+            .enumerate()
+            .map(|(i, existing)| {
+                if i == pos {
+                    Arc::clone(&new_arc)
+                } else {
+                    Arc::clone(existing)
+                }
+            })
+            .collect();
+        tracing::info!(
+            target: "shard.transition",
+            letter = %letter.to_ascii_uppercase(),
+            from = %from_state,
+            to = %ShardState::Warm,
+            refreshed_mb,
+            reason = "usn-refresh",
+        );
+        Some(Self::from_shards(shards))
+    }
+
     /// `true` iff the registry has no shards at all.
     #[must_use]
     pub(crate) const fn is_empty(&self) -> bool {

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -1182,6 +1182,169 @@ impl IndexManager {
         }
     }
 
+    /// Phase 5 (#95) — fold live USN journal deltas into every
+    /// `Warm` / `Hot` shard's in-memory body and persist a fresher
+    /// compact cache to disk.
+    ///
+    /// Driven from a periodic tick task in `lib.rs`
+    /// (`spawn_usn_refresh_controller`); the cadence defaults to
+    /// `cache::policy::USN_REFRESH_INTERVAL_SECS` (5 min) and is
+    /// overridable via `UFFS_USN_REFRESH_INTERVAL_SECS` for tests
+    /// and benchmarks.
+    ///
+    /// Three-phase like [`Self::ensure_warm_for_dispatch`] (Phase 4
+    /// re-promote in #93):
+    ///
+    /// 1. **Read-lock detect** — collect Warm/Hot drive letters.
+    /// 2. **Parallel USN refresh** — fan out into the blocking pool via
+    ///    [`tokio::task::JoinSet`] so one slow drive doesn't serialise the
+    ///    others (mirrors the #93 pattern).  Each closure is
+    ///    `catch_unwind`-wrapped so a panicking USN apply on one drive doesn't
+    ///    lose the letter identifier in the [`tokio::task::JoinSet`] error arm.
+    /// 3. **Per-letter write-lock swap** — drain results as they complete and
+    ///    `replace_warm_body` the registry; sub-µs Arc-swap per letter,
+    ///    cumulative contention < 10 µs even at N=7 drives.
+    ///
+    /// **Failure handling**: per-drive USN refresh failures (cache
+    /// missing, journal unavailable, drive G `error 1179`) are
+    /// warn-logged at `target: "shard.refresh"` and the shard's
+    /// previous body stays in place.  Aggregate counters are
+    /// emitted at info-level on completion so production telemetry
+    /// can monitor the refresh success rate.
+    ///
+    /// **Non-Windows behaviour**: the underlying
+    /// [`uffs_core::compact_loader::load_drive_with_usn_refresh`]
+    /// helper errors out by design (USN journals are NTFS-only),
+    /// so this loop becomes a no-op refresh tick that just walks
+    /// the registry and logs the per-drive errors.  The structure
+    /// is exercised on macOS / Linux for testing parity.
+    pub(crate) async fn refresh_usn_for_warm_shards(&self) {
+        use crate::cache::ShardState;
+
+        // ── Phase 1: read-lock detect Warm/Hot letters ─────────────
+        let letters: Vec<char> = {
+            let guard = self.index.read().await;
+            guard
+                .iter()
+                .filter(|shard| matches!(shard.state(), ShardState::Warm | ShardState::Hot))
+                .map(|shard| shard.drive)
+                .collect()
+        };
+        if letters.is_empty() {
+            return;
+        }
+
+        let total_start = Instant::now();
+        let total = letters.len();
+        tracing::info!(
+            target: "shard.refresh",
+            count = total,
+            interval_secs = crate::cache::policy::usn_refresh_interval_secs(),
+            "USN refresh tick starting",
+        );
+
+        // ── Phase 2: parallel USN refresh via JoinSet ──────────────
+        let mut load_set: tokio::task::JoinSet<(
+            char,
+            anyhow::Result<Arc<uffs_core::compact::DriveCompactIndex>>,
+        )> = tokio::task::JoinSet::new();
+        for letter in letters {
+            load_set.spawn_blocking(move || {
+                // `catch_unwind` mirrors the #93 pattern: convert a
+                // panicking refresh closure into a typed error so
+                // the JoinSet's error arm doesn't lose the letter.
+                let result = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| {
+                    uffs_core::compact_loader::load_drive_with_usn_refresh(letter)
+                        .map(|(body, _timing)| Arc::new(body))
+                }))
+                .unwrap_or_else(|_payload| {
+                    Err(anyhow::anyhow!(
+                        "panic in USN refresh blocking closure for drive {letter}"
+                    ))
+                });
+                (letter, result)
+            });
+        }
+
+        // ── Phase 3: drain + per-letter write-lock swap ────────────
+        let mut refreshed = 0_usize;
+        let mut failed = 0_usize;
+        while let Some(joined) = load_set.join_next().await {
+            if self.apply_one_refresh_result(joined).await {
+                refreshed += 1;
+            } else {
+                failed += 1;
+            }
+        }
+
+        tracing::info!(
+            target: "shard.refresh",
+            refreshed,
+            failed,
+            total,
+            total_ms = total_start.elapsed().as_millis(),
+            "USN refresh tick complete",
+        );
+    }
+
+    /// Apply a single drained [`tokio::task::JoinSet::join_next`]
+    /// result from the Phase 5 (#95) USN refresh fan-out.
+    ///
+    /// Returns `true` when the body was successfully Arc-swapped
+    /// into the registry; `false` on any failure (panicked closure,
+    /// USN refresh helper error, registry race where the shard
+    /// demoted between detect and swap).  The caller (
+    /// [`Self::refresh_usn_for_warm_shards`]) accumulates the
+    /// boolean into per-tick success/failure counters.
+    ///
+    /// Extracted from the parent so the parent stays under
+    /// clippy's strict-gate cognitive-complexity ceiling.
+    async fn apply_one_refresh_result(
+        &self,
+        joined: Result<
+            (
+                char,
+                anyhow::Result<Arc<uffs_core::compact::DriveCompactIndex>>,
+            ),
+            tokio::task::JoinError,
+        >,
+    ) -> bool {
+        let (letter, result) = match joined {
+            Ok(pair) => pair,
+            Err(join_err) => {
+                tracing::warn!(
+                    target: "shard.refresh",
+                    error = %join_err,
+                    "blocking-task aborted before completion; shard kept previous body",
+                );
+                return false;
+            }
+        };
+        let body = match result {
+            Ok(body) => body,
+            Err(err) => {
+                tracing::warn!(
+                    target: "shard.refresh",
+                    drive = %letter,
+                    error = %err,
+                    "USN refresh failed; shard kept previous body",
+                );
+                return false;
+            }
+        };
+        let mut guard = self.index.write().await;
+        let Some(new_registry) = guard.replace_warm_body(letter, body) else {
+            // Race: the shard demoted between Phase 1 detect and
+            // the swap.  No-op; the next promote will USN-refresh
+            // via DiskBodyLoader.
+            return false;
+        };
+        *guard = Arc::new(new_registry);
+        drop(guard);
+        self.bump_index_version();
+        true
+    }
+
     /// Per-shard `(drive_letter, queries_total)` snapshot for tests.
     ///
     /// Test-only escape hatch so integration tests in `crate::index::tests`

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -974,54 +974,88 @@ impl IndexManager {
             return;
         }
 
-        // ── Phase 2: spawn-blocking body load ──────────────────
-        // For each Parked/Cold letter, hop onto the blocking pool
-        // for the I/O + decrypt + decompress + runtime-mmap
-        // materialisation.  `load_compact_cache` returns `None` on
+        // ── Phase 2: parallel body load via JoinSet ────────────
+        // For each Parked/Cold letter, fan out one
+        // `tokio::task::spawn_blocking` task into the blocking
+        // pool for the I/O + decrypt + decompress + runtime-mmap
+        // materialisation.  `BodyLoader::load` returns `None` on
         // any non-fatal failure (missing cache file, stale, decrypt
         // error); we trace and skip — the shard stays in its
         // current tier and the search will dispatch against the
         // unchanged active subset.
         //
-        // Phases 2 + 3 are interleaved per letter so a slow
-        // disk-read on letter A doesn't block the swap for letter
-        // B that's already loaded.  Serialised on purpose:
-        // promoting N drives in a single hot-path query is rare
-        // (idle-timer demote is per-drive) and the write-lock
-        // contention from N parallel swaps would dwarf the
-        // serialisation cost.
+        // **Why parallel** (#93): the cold-boot WARM path loads N
+        // drives in parallel from the same on-disk caches and
+        // completes in ~max(per-drive); the original serial loop
+        // here did sum(per-drive) and was 2–3× slower on real
+        // workloads (15.1 s for 6 drives in v0.5.80, vs. 5.7 s
+        // for 7 drives at `daemon start`).  Each
+        // per-letter write-lock swap is a sub-µs pointer-swap;
+        // even at N=7 the cumulative contention is < 10 µs, well
+        // below the per-drive load cost (~1 s+).
+        //
+        // Each closure runs in its own blocking thread, so panics
+        // are caught here via `catch_unwind` to keep the letter
+        // identifier in the JoinSet result; without this the
+        // `JoinError` arm would lose the panicking letter.
+        let mut load_set: tokio::task::JoinSet<(
+            char,
+            Option<Arc<uffs_core::compact::DriveCompactIndex>>,
+        )> = tokio::task::JoinSet::new();
         for letter in needs_promote {
             let loader = Arc::clone(&self.body_loader);
-            let load_result = tokio::task::spawn_blocking(move || loader.load(letter)).await;
-            let body = match load_result {
-                Ok(Some(body_arc)) => body_arc,
-                Ok(None) => {
-                    tracing::warn!(
-                        target: "shard.transition",
-                        drive = %letter,
-                        reason = "promote-on-search",
-                        "compact-cache load returned None; shard stays in current tier",
-                    );
-                    continue;
-                }
-                Err(join_err) => {
+            load_set.spawn_blocking(move || {
+                // `catch_unwind` lives in `std` (needs unwinding
+                // runtime); `AssertUnwindSafe` lives in `core` (the
+                // production lint enforces `core` imports for items
+                // that are available there).
+                let body = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| {
+                    loader.load(letter)
+                }))
+                .unwrap_or_else(|_payload| {
                     tracing::error!(
                         target: "shard.transition",
                         drive = %letter,
-                        error = %join_err,
                         reason = "promote-on-search",
                         "blocking-task panic during cache load; shard stays in current tier",
+                    );
+                    None
+                });
+                (letter, body)
+            });
+        }
+
+        // ── Phase 3: drain results, per-letter write-lock swap ─
+        // `promote_letter` is `Option`-returning so a benign
+        // race (another task promoted between our read-detect
+        // and write-swap, or a demote landed on top of the
+        // Parked state we observed) drops the freshly-loaded
+        // body Arc and leaves the canonical registry alone.
+        while let Some(join_result) = load_set.join_next().await {
+            let (letter, body_opt) = match join_result {
+                Ok(pair) => pair,
+                Err(join_err) => {
+                    // Task aborted (shutdown / cancel) — letter
+                    // identity is lost but the daemon stays up
+                    // and the shard stays in its current tier.
+                    tracing::warn!(
+                        target: "shard.transition",
+                        error = %join_err,
+                        reason = "promote-on-search",
+                        "blocking-task aborted before completion; shard stays in current tier",
                     );
                     continue;
                 }
             };
-
-            // ── Phase 3: write-lock atomic swap ────────────────
-            // `promote_letter` is `Option`-returning so a benign
-            // race (another task promoted between our read-detect
-            // and write-swap, or a demote landed on top of the
-            // Parked state we observed) drops the freshly-loaded
-            // body Arc and leaves the canonical registry alone.
+            let Some(body) = body_opt else {
+                tracing::warn!(
+                    target: "shard.transition",
+                    drive = %letter,
+                    reason = "promote-on-search",
+                    "compact-cache load returned None; shard stays in current tier",
+                );
+                continue;
+            };
             let mut guard = self.index.write().await;
             if let Some(new_registry) = guard.promote_letter(letter, body) {
                 *guard = Arc::new(new_registry);

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -1971,6 +1971,86 @@ async fn ensure_warm_for_dispatch_promotes_in_parallel() {
     );
 }
 
+// ── Phase 5 (#95) — IndexManager::refresh_usn_for_warm_shards ──────
+
+/// Fast-path contract: refresh tick on an empty registry returns
+/// immediately without panicking and without mutating any state.
+/// Pins the early-return at the top of
+/// [`IndexManager::refresh_usn_for_warm_shards`] so future
+/// refactors can't accidentally call into the [`tokio::task::JoinSet`]
+/// phase with an empty `letters` vec.
+#[tokio::test]
+async fn refresh_usn_for_warm_shards_no_op_when_empty() {
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    assert!(mgr.shard_states_for_test().await.is_empty());
+
+    mgr.refresh_usn_for_warm_shards().await;
+
+    assert!(
+        mgr.shard_states_for_test().await.is_empty(),
+        "empty-registry refresh tick must keep the registry empty",
+    );
+}
+
+/// Fast-path contract: refresh tick on a registry with no
+/// `Warm`/`Hot` shards (everything Parked) is also a no-op.
+/// Pins that the read-lock detect skips Parked/Cold shards
+/// without ever entering the [`tokio::task::JoinSet`] phase.
+#[tokio::test]
+async fn refresh_usn_for_warm_shards_no_op_when_no_warm_or_hot() {
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+
+    mgr.refresh_usn_for_warm_shards().await;
+
+    assert_eq!(
+        mgr.shard_states_for_test().await,
+        vec![('C', ShardState::Parked)],
+        "Parked shard must stay Parked through refresh tick",
+    );
+}
+
+/// Cross-platform graceful-failure contract: on macOS / Linux the
+/// underlying [`uffs_core::compact_loader::load_drive_with_usn_refresh`]
+/// helper errors out by design (USN journals are NTFS-only).  The
+/// refresh tick must NOT panic, NOT lose the existing in-memory body,
+/// and NOT mutate `index_version`.  On Windows this same test
+/// exercises the success path (USN replay applied + body swapped),
+/// but the assertions above (state preservation + body retained)
+/// still hold because `replace_warm_body` keeps the previous body
+/// on any registry race.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn refresh_usn_for_warm_shards_handles_helper_errors_gracefully() {
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+
+    let states_before = mgr.shard_states_for_test().await;
+    assert_eq!(states_before, vec![
+        ('C', ShardState::Warm),
+        ('D', ShardState::Warm),
+    ]);
+
+    // The refresh tick walks Warm shards, calls the helper, and on
+    // non-Windows every call errors with `PlatformNotSupported`.
+    // The test passes if the call returns cleanly.
+    mgr.refresh_usn_for_warm_shards().await;
+
+    let states_after = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states_after, states_before,
+        "shards must keep Warm state when USN refresh helper errors",
+    );
+}
+
 // ── Phase 3 Commit D — IndexManager::demote_idle_shards ────────────
 
 /// `add_drive` calls `DriveStats::mark_loaded_at(now_ms)` on the

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -1831,6 +1831,146 @@ async fn ensure_warm_for_dispatch_handles_panicking_body_loader_gracefully() {
     );
 }
 
+// ── Phase 5 (#93) — parallel re-promote ────────────────────────────
+
+/// A `BodyLoader` that sleeps for `delay` before returning a clone
+/// of `body`, and records the peak number of concurrent calls
+/// in flight.  Used to verify that
+/// [`IndexManager::ensure_warm_for_dispatch`] fans out per-letter
+/// loads across the blocking pool instead of serialising them.
+struct SlowBodyLoader {
+    body: Arc<uffs_core::compact::DriveCompactIndex>,
+    delay: core::time::Duration,
+    in_flight: core::sync::atomic::AtomicUsize,
+    peak_in_flight: core::sync::atomic::AtomicUsize,
+}
+
+impl SlowBodyLoader {
+    fn new(body: Arc<uffs_core::compact::DriveCompactIndex>, delay: core::time::Duration) -> Self {
+        Self {
+            body,
+            delay,
+            in_flight: core::sync::atomic::AtomicUsize::new(0),
+            peak_in_flight: core::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    fn peak(&self) -> usize {
+        self.peak_in_flight
+            .load(core::sync::atomic::Ordering::Acquire)
+    }
+}
+
+impl crate::cache::body_loader::BodyLoader for SlowBodyLoader {
+    fn load(&self, _letter: char) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
+        use core::sync::atomic::Ordering;
+
+        let now = self.in_flight.fetch_add(1, Ordering::AcqRel) + 1;
+        // Bump peak via a CAS loop: read the current peak, write
+        // back `now` only if it's strictly larger.  Pure `fetch_max`
+        // would be one call but isn't stable on all targets we
+        // build; the loop is portable and the contention window is
+        // microscopic (only the first few in-flight loaders ever
+        // raise the peak).
+        let mut prev = self.peak_in_flight.load(Ordering::Acquire);
+        while now > prev {
+            match self.peak_in_flight.compare_exchange_weak(
+                prev,
+                now,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(actual) => prev = actual,
+            }
+        }
+        std::thread::sleep(self.delay);
+        self.in_flight.fetch_sub(1, Ordering::AcqRel);
+        Some(Arc::clone(&self.body))
+    }
+}
+
+/// Pin the parallelisation contract of `ensure_warm_for_dispatch`
+/// (#93): with N Parked drives and a `BodyLoader::load` that
+/// sleeps `delay`, total wall must be `~delay`, not `N × delay`.
+///
+/// The pre-fix serial loop took `sum(per-drive)`; the `JoinSet` fan-out
+/// completes in `~max(per-drive)` plus a few µs of write-lock
+/// contention.  We assert two things:
+///
+/// 1. `peak_in_flight >= 2` — the loader observed concurrent calls.
+/// 2. Wall < `1.5 × delay` — comfortably below the `3 × delay` a serial loop
+///    would take with N=3.  The 1.5× upper bound leaves headroom for
+///    blocking-pool ramp-up and CI variance.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn ensure_warm_for_dispatch_promotes_in_parallel() {
+    use core::time::Duration;
+
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+
+    // Per-letter delay: 100 ms is small enough to keep the test
+    // fast on CI and large enough that scheduling jitter (a few ms)
+    // doesn't dominate the timing assertion.
+    let delay = Duration::from_millis(100);
+    let body = Arc::new(build_test_drive());
+    let loader = Arc::new(SlowBodyLoader::new(Arc::clone(&body), delay));
+    // `with_body_loader_for_test` takes `Arc<dyn BodyLoader>`; clone
+    // a coerced handle for the manager so we keep `loader` typed
+    // as `Arc<SlowBodyLoader>` for the `.peak()` assertion below.
+    let loader_dyn: Arc<dyn crate::cache::body_loader::BodyLoader> =
+        Arc::clone(&loader) as Arc<dyn crate::cache::body_loader::BodyLoader>;
+
+    let mgr = IndexManager::with_body_loader_for_test(None, tx, loader_dyn);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+    mgr.add_drive(build_test_drive_e()).await;
+
+    // Demote all three to Parked so they all need the loader.
+    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(mgr.demote_letter_for_test('D', ShardState::Parked).await);
+    assert!(mgr.demote_letter_for_test('E', ShardState::Parked).await);
+
+    let start = std::time::Instant::now();
+    mgr.ensure_warm_for_dispatch(&['C', 'D', 'E'], &[]).await;
+    let elapsed = start.elapsed();
+
+    // All three shards promoted.
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states,
+        vec![
+            ('C', ShardState::Warm),
+            ('D', ShardState::Warm),
+            ('E', ShardState::Warm),
+        ],
+        "all three Parked shards must be Warm after ensure_warm_for_dispatch"
+    );
+
+    // Concurrent loaders observed.
+    assert!(
+        loader.peak() >= 2,
+        "expected ≥ 2 concurrent loader calls in flight; got peak = {} \
+         (parallelism regression — re-promote went serial again)",
+        loader.peak(),
+    );
+
+    // Wall ≈ delay, not N × delay.  The serial loop pre-#93 would
+    // have taken ≥ 300 ms for delay=100 ms × 3 drives; we accept
+    // up to 1.5× (150 ms) to keep the test robust against CI jitter
+    // and blocking-pool ramp-up.
+    let upper_bound = delay.mul_f32(1.5);
+    assert!(
+        elapsed < upper_bound,
+        "expected parallel re-promote (≤ {} ms), got {} ms — \
+         serial pre-#93 baseline would be ≥ {} ms",
+        upper_bound.as_millis(),
+        elapsed.as_millis(),
+        delay.as_millis() * 3,
+    );
+}
+
 // ── Phase 3 Commit D — IndexManager::demote_idle_shards ────────────
 
 /// `add_drive` calls `DriveStats::mark_loaded_at(now_ms)` on the

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -262,6 +262,13 @@ pub async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
     // Phase 3 Commit D — periodic shard idle-demote sweep.
     let _idle_demote_task = spawn_idle_demote_controller(Arc::clone(&idx));
 
+    // Phase 5 (#95) — periodic background USN refresh of Warm/Hot
+    // shards so search results reflect live filesystem state without
+    // waiting for the next idle-tier transition.  Cadence is the
+    // `UFFS_USN_REFRESH_INTERVAL_SECS`-overridable
+    // `cache::policy::USN_REFRESH_INTERVAL_SECS` (5 min default).
+    let _usn_refresh_task = spawn_usn_refresh_controller(Arc::clone(&idx));
+
     // Run idle timer (blocks until shutdown or timeout) then tear
     // everything down.  Returns `!` so `force_exit_with_watchdog`
     // covers the post-await tail.
@@ -647,6 +654,38 @@ fn spawn_idle_demote_controller(idx: Arc<index::IndexManager>) -> tokio::task::J
         loop {
             interval.tick().await;
             idx.demote_idle_shards(cache::unix_now_ms()).await;
+        }
+    })
+}
+
+/// Spawn the Phase 5 (#95) background USN refresh controller —
+/// every `UFFS_USN_REFRESH_INTERVAL_SECS` (default 5 min), ask
+/// `IndexManager::refresh_usn_for_warm_shards` to walk every Warm/Hot
+/// shard, fold live USN journal deltas into the in-memory body, and
+/// persist a fresher compact cache to disk.
+///
+/// The first tick is skipped so cold-boot's existing
+/// `load_drive_with_usn_refresh` path (the new #94 cold-boot WARM
+/// flow) handles the t=0 USN apply.  Subsequent ticks keep the
+/// in-memory state diverging by at most one interval from the live
+/// filesystem.
+///
+/// On non-Windows the underlying refresh helper errors out by
+/// design (USN journals are NTFS-only); the loop still runs and
+/// logs the per-drive `anyhow` errors so the timer mechanics are
+/// exercised on dev machines, but no body changes.
+fn spawn_usn_refresh_controller(idx: Arc<index::IndexManager>) -> tokio::task::JoinHandle<()> {
+    let interval_secs = cache::policy::usn_refresh_interval_secs();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(core::time::Duration::from_secs(interval_secs));
+        // Skip the first tick (fires immediately at task spawn).
+        // The cold-boot path through `load_drive` (#94) already
+        // applied USN deltas; the next refresh comes one interval
+        // later.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            idx.refresh_usn_for_warm_shards().await;
         }
     })
 }


### PR DESCRIPTION
Closes #93. Closes #94. Closes #95. Closes #96.

Fixes four post-Phase-4 issues identified during the v0.5.80 reference-host validation: a 2.6× perf regression in the Phase 4 re-promote path (#93), two correctness bugs that served stale data on warm cache load (#94), the absence of a background USN refresh timer (#95), and silent-failure modes in the compact-cache loader that hid root causes from production logs (#96).

## What's in this PR

Two commits on `after-phase-4-fixes`:

| Commit | Issues | Files |
|---|---|---|
| [`89848e27d`](https://github.com/skyllc-ai/UltraFastFileSearch/commit/89848e27d) | #93 + env-var idle TTLs | `index/mod.rs`, `index/tests.rs`, `cache/policy.rs` |
| [`0c05791c7`](https://github.com/skyllc-ai/UltraFastFileSearch/commit/0c05791c7) | #94, #95, #96 | 9 files in `uffs-core` and `uffs-daemon` |

## #93 — Parallelize Phase 4 re-promote

Replaced the serial `for letter in needs_promote { spawn_blocking; await; swap; }` loop in `IndexManager::ensure_warm_for_dispatch` with a `tokio::task::JoinSet` fan-out so per-letter body loads run concurrently in the blocking pool. Each closure is `std::panic::catch_unwind`-wrapped to preserve the letter identifier through panics.

**Real-world impact.** v0.5.80 reference host: 6-drive Phase 4 re-promote dropped from **15.1 s sequential** to **~max(per-drive)** parallel — matching the existing 5.7 s cold-boot WARM baseline that was already parallel.

**Bonus:** added `UFFS_HOT_TO_WARM_IDLE_SECS` / `UFFS_WARM_TO_PARKED_IDLE_SECS` / `UFFS_PARKED_TO_COLD_IDLE_SECS` env-var overrides cached via `OnceLock` so the 30 min Warm→Parked idle can be compressed for fast iteration:

```bash
UFFS_WARM_TO_PARKED_IDLE_SECS=360 \
UFFS_HOT_TO_WARM_IDLE_SECS=60 \
    uffs daemon start --drive C,D,E,F,G,M,S
```

## #94 — USN replay on warm cache load + Phase 4 re-promote

The user's conceptual model:

| Tier | USN replay needed? |
|---|---|
| **COLD** (full MFT scan) | No — IS the truth |
| **WARM** (cached snapshot) | **Yes** — stale by definition |
| **Phase 4 re-promote** | **Yes** — Parked snapshot from boot |

Two bugs in v0.5.80 violated this:

1. `compact_loader::try_compact_cache_hit` returned the on-disk compact cache directly without USN replay. **5/7 drives at the v0.5.80 reference run served stale data.**
2. `DiskBodyLoader::load` (Phase 4 re-promote) bypassed TTL entirely with `load_compact_cache(letter, u64::MAX, 0, true)`. **A daemon up for a week served week-old indices on every re-promote.**

### Fix

- New `pub fn load_drive_with_usn_refresh(letter)` in `uffs-core/src/compact_loader.rs` — Windows-conditional helper that goes through `MftReader::read_index_cached` → `apply_usn_updates_to_fresh_index` (existing infra), rebuilds compact, and submits a background compact-cache save. Non-Windows stub returns an `anyhow` error so callers fall back transparently.
- New `RefreshTiming` struct (`mft` / `compact` / `trigram` / `total` ms).
- `compact_loader::load_drive` — **removed** the `try_compact_cache_hit` fast-path bypass. Cold-boot WARM now always goes through MftIndex (cache + USN replay on Windows; offline-file is a no-op).
- `DiskBodyLoader::load` — primary path is now `load_drive_with_usn_refresh`; falls back to bare `load_compact_cache` if the helper errors (drive G `error 1179`, journal unavailable, non-Windows).

**Cost.** Cold-boot WARM at N=7 drives parallel moves from ~5.7 s to ~7–10 s (one-time per daemon start) per the issue's predicted budget.

## #95 — Background USN refresh timer

A daemon up for an hour previously served 1-hour-stale data; up for a week, 1-week-stale. No background USN apply existed (`uffs-daemon` had zero USN references).

### Fix

- New `spawn_usn_refresh_controller` task in `lib.rs` — ticks every `UFFS_USN_REFRESH_INTERVAL_SECS` (default 300 s = 5 min, env-var overridable). Mirrors `spawn_idle_demote_controller`'s structure.
- New `IndexManager::refresh_usn_for_warm_shards` — three-phase **read-lock detect** → **parallel `JoinSet` USN refresh** → **per-letter `replace_warm_body` Arc-swap**. Mirrors the #93 parallelism pattern; `catch_unwind`-wrapped per closure. Aggregate `refreshed`/`failed`/`total_ms` emitted at info-level on `target: "shard.refresh"`.
- New `ShardRegistry::replace_warm_body(letter, body)` — swaps the body of a Warm/Hot shard while preserving stats; returns rebuilt registry; emits `reason = "usn-refresh"` on `target: "shard.transition"`.
- New `cache::policy::USN_REFRESH_INTERVAL_SECS` constant + `UFFS_USN_REFRESH_INTERVAL_SECS` env-var override cached via `OnceLock`.

## #96 — Structured `LoadCacheError`

`load_compact_cache` previously returned `Option<DriveCompactIndex>` and silently collapsed **eight failure modes** into a single `None`. Production logs showed "compact cache miss" with no way to distinguish "file missing on first boot" from "decryption failed (key rotated)" from "stale by epoch" from "runtime tempfile collision".

### Fix

- New `pub enum LoadCacheError` with variants for each path: `Missing`, `StaleByTtl`, `StaleVsMft`, `StaleByEpoch`, `Io`, `KeyUnavailable`, `DecryptFailed`, `DecompressFailed`, `ParseError`, `RuntimeTempfile`, `Deserialize`.
- `load_compact_cache` now returns `Result<DriveCompactIndex, LoadCacheError>`.
- `is_compact_cache_fresh` (`bool`) replaced by `check_compact_cache_freshness` (`Result<(), LoadCacheError>`).
- All callers updated to log the structured error at appropriate levels.

## Tests

`cargo test -p uffs-daemon -p uffs-core --lib` → **157 passed, 0 failed** (was 153 before; net +4 new tests).

| Test | Coverage |
|---|---|
| `ensure_warm_for_dispatch_promotes_in_parallel` | #93 — `SlowBodyLoader` records peak in-flight; pins peak ≥ 2 and wall ≤ 1.5 × delay |
| `read_env_secs_falls_back_when_env_unset` | env-var override fallback contract |
| `refresh_usn_for_warm_shards_no_op_when_empty` | #95 — fast-path early-return |
| `refresh_usn_for_warm_shards_no_op_when_no_warm_or_hot` | #95 — Parked-only registry skips JoinSet |
| `refresh_usn_for_warm_shards_handles_helper_errors_gracefully` | #95 — cross-platform graceful failure |

## Lint gates

| Gate | Status |
|---|---|
| `cargo test -p uffs-daemon -p uffs-core --lib` | 157 passed |
| `just lint-prod` | clean |
| `just lint-tests` | clean |
| `just check-windows` | clean |
| `lint-pre-push` (rustdoc + doc-tests + smoke + xwin) | 167 s ✅ |

## Risk

Medium. The cold-boot path change (#94) adds ~2 s per drive of compact rebuild work, taking N=7-drive parallel cold-boot from ~5.7 s to ~7–10 s. This is a **one-time cost per daemon start** and is acceptable per the issue spec. The Phase 4 re-promote change is pure improvement (parallel + USN-refreshed). The USN refresh timer (#95) runs entirely in the background with `catch_unwind` per-drive isolation; per-drive failures don't cascade.

## Manual Windows verify checklist

After merge, suggested steps on the v0.5.80 reference host:

1. **Cold-boot WARM regression.** `daemon kill && daemon start --drive C,D,E,F,G,M,S`. Look for `target=shard.transition reason=promote` lines and the new `target=shard.transition "♻️ USN-refreshed body ready"` lines (one per drive). Total parallel time should be ≤ 10 s.
2. **Phase 4 re-promote regression.** `UFFS_WARM_TO_PARKED_IDLE_SECS=360 daemon start ...`, wait ~6.5 min, run `*` query — observe parallel re-promote with USN deltas applied. Total should be < 5 s for N=6 drives (vs 15.1 s sequential pre-#93).
3. **Background refresh tick.** `UFFS_USN_REFRESH_INTERVAL_SECS=60 daemon start ...`, watch for `target=shard.refresh "USN refresh tick complete"` lines every minute with `refreshed=N` matching the Warm/Hot drive count.
4. **Stale-cache detection.** Touch a file; within one refresh interval the daemon search should return it.

