### PR TITLE
feat(daemon): shorter default idle TTLs for fast dev iteration

### DIFF
--- a/crates/uffs-daemon/src/cache/policy.rs
+++ b/crates/uffs-daemon/src/cache/policy.rs
@@ -10,15 +10,20 @@
 //! Adaptive TTL controllers live in Phase 6; for now every shard
 //! shares the same fixed thresholds:
 //!
-//! * **Hot → Warm** at [`HOT_TO_WARM_IDLE_SECS`] (5 min idle, default).
-//! * **Warm → Parked** at [`WARM_TO_PARKED_IDLE_SECS`] (30 min idle, default).
+//! * **Hot → Warm** at [`HOT_TO_WARM_IDLE_SECS`] (1 min idle, default).
+//! * **Warm → Parked** at [`WARM_TO_PARKED_IDLE_SECS`] (5 min idle, default).
 //! * **Parked → Cold** at [`PARKED_TO_COLD_IDLE_SECS`] (24 h idle, default).
 //!
-//! Each default is overridable at daemon startup via env var so
-//! Phase 5 testing flows can compress the 30 min Warm → Parked
-//! idle into a 6 min cycle (or any other duration) without
-//! shipping a non-default policy to end users.  The override is
-//! read once and cached; restart the daemon to pick up a change.
+//! These defaults give a fast Hot → Parked test cycle (~6 min) so
+//! the Phase 4 re-promote path is exercisable during normal dev
+//! iteration without dragging in `UFFS_*_IDLE_SECS` env-var
+//! overrides on every launch.  Production users who want longer
+//! retention windows can still set the overrides; the env-var
+//! pathway is unchanged.
+//!
+//! Each default is overridable at daemon startup via env var.
+//! The override is read once and cached; restart the daemon to
+//! pick up a change.
 //!
 //! ```text
 //! UFFS_HOT_TO_WARM_IDLE_SECS=60      \
@@ -43,16 +48,28 @@ use super::shard::ShardState;
 /// drives don't re-warm just because their bloom got faulted in by
 /// a wildcard scan.
 ///
+/// 60 s default makes the Hot → Warm transition observable in
+/// normal dev iteration; the runtime-mmap rebuild on the next
+/// query is sub-millisecond so the demotion is essentially free.
+///
 /// Consumed by [`crate::index::IndexManager::demote_idle_shards`]
 /// (Phase 3 Commit D) via [`next_state_for_idle`].
-pub(crate) const HOT_TO_WARM_IDLE_SECS: u64 = 300;
+pub(crate) const HOT_TO_WARM_IDLE_SECS: u64 = 60;
 
 /// Default for the `Warm` → `Parked` idle threshold.
 ///
 /// Overridable at daemon startup via [`WARM_TO_PARKED_IDLE_ENV`].
 /// `Parked` drops the runtime mmap (the records / names columns
 /// are released; bloom + trie persist for Phase 4+ search-skip).
-pub(crate) const WARM_TO_PARKED_IDLE_SECS: u64 = 1800;
+///
+/// 5 min default lets dev iteration exercise the Phase 4
+/// re-promote path (which #93 parallelised) without waiting the
+/// 30 min the original prototype used.  The bloom + trie pre-check
+/// from Commit F means a Parked re-promote only re-decrypts the
+/// compact body when the query actually hits the drive, so the
+/// extra demote/promote churn at this cadence is bounded by query
+/// pattern, not by the timer alone.
+pub(crate) const WARM_TO_PARKED_IDLE_SECS: u64 = 300;
 
 /// Default for the `Parked` → `Cold` idle threshold.
 ///

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -1116,9 +1116,9 @@ impl IndexManager {
     ///
     /// Phase 3 Commit D — driven from a 30 s tick task in `lib.rs`
     /// (see `spawn_idle_demote_controller`).  The tick cadence is
-    /// shorter than every TTL by design: a Hot shard idle for 5
-    /// minutes can race past the `HOT_TO_WARM_IDLE_SECS`
-    /// (300 s) boundary at most one tick (30 s) before the
+    /// shorter than every TTL by design: a Hot shard idle for 1
+    /// minute can race past the `HOT_TO_WARM_IDLE_SECS`
+    /// (60 s) boundary at most one tick (30 s) before the
     /// controller observes it.  See `cache::policy` for the
     /// per-tier thresholds.
     ///


### PR DESCRIPTION
Drops the in-source idle TTL defaults so dev iteration can exercise the Phase 4 re-promote path (parallelised in [#93](https://github.com/skyllc-ai/UltraFastFileSearch/issues/93) via [PR #98](https://github.com/skyllc-ai/UltraFastFileSearch/pull/98)) without waiting 30 min on every launch or remembering to set the `UFFS_*_IDLE_SECS` env vars.

## Defaults

| Constant | Before | After |
|---|---:|---:|
| `HOT_TO_WARM_IDLE_SECS` | 300 s (5 min) | **60 s (1 min)** |
| `WARM_TO_PARKED_IDLE_SECS` | 1800 s (30 min) | **300 s (5 min)** |
| `PARKED_TO_COLD_IDLE_SECS` | 86 400 s (24 h) | unchanged |

Total Hot → Parked test cycle drops from **35 min → ~6 min**, the iteration time the upcoming Phase 5 (Windows pressure) work needs.

## Why this is safe

- The bloom + path-trie pre-check from Phase 4 Commit F means a Parked re-promote only re-decrypts the compact body when a query actually hits the drive — extra demote/promote churn at this cadence is bounded by query pattern, not by the timer alone.
- Phase 4's #93 fix made re-promotion parallel; the perf cost of more frequent re-promotes is bounded by `max(per-drive)`, not `sum`.
- The compile-time invariant `HOT < WARM < PARKED` still holds (60 < 300 < 86 400).
- The `UFFS_*_IDLE_SECS` env-var override pathway is unchanged. Production users who want longer retention can still set the overrides at daemon startup.

## Verification

- `cargo test -p uffs-daemon --lib` — **157 passed** (zero hardcoded numeric assertions affected; tests reference the named constants).
- `just lint-prod` ✅
- `just lint-tests` ✅
- `just check-windows` (xwin cross-compile) ✅

## Files

| File | Change |
|---|---|
| `crates/uffs-daemon/src/cache/policy.rs` | const values + module-level + per-const doc updates |
| `crates/uffs-daemon/src/index/mod.rs` | one stale doc comment ("Hot shard idle for 5 minutes / 300 s" → "1 minute / 60 s") |

No behavioral change for users who already set the env-var overrides; only the bare-launch defaults shift.