### PR TITLE
feat(daemon): Phase 5.11 — status RPC enumerates Parked/Cold shards with tier markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.81] - 2026-04-25
+## [0.5.82] - 2026-04-25
 
 ### Fixed
 - **macOS arm64 release binaries SIGKILLed at launch** under macOS 26+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "anyhow",
  "clap",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "chrono",
  "itoa",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "anyhow",
  "axum",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4537,14 +4537,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4559,14 +4559,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.81"
+version = "0.5.82"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.81"
+version = "0.5.82"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires

--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use uffs_client::connect_sync::UffsClientSync;
 use uffs_client::daemon_ctl::{pid_file_path, socket_path};
-use uffs_client::protocol::response::DaemonStatus;
+use uffs_client::protocol::response::{DaemonStatus, DriveInfo, ShardTier};
 
 use crate::args::DaemonAction;
 
@@ -245,18 +245,46 @@ fn daemon_status() -> Result<()> {
         println!("RSS:           {} MB", rss / (1024 * 1024));
     }
 
-    // Also show loaded drives.
+    // Also show loaded drives.  The `drives` RPC returns every shard
+    // in the registry — Warm/Hot with their full memory breakdown,
+    // Parked/Cold with just the tier marker (no body in RAM).  Empty
+    // registry still renders `(none loaded)` so cold-boot detection in
+    // external scripts (api-validation, mcp-validation) keeps working.
     let drives = client.drives().with_context(|| "Failed to query drives")?;
     if drives.drives.is_empty() {
         println!("Drives:        (none loaded)");
     } else {
+        println!("Drives:");
         for dr in &drives.drives {
-            // Find memory info for this drive.
-            let mem = status.drive_memory.iter().find(|dm| dm.drive == dr.letter);
+            print_drive_line(dr, &status.drive_memory);
+        }
+    }
+    Ok(())
+}
+
+/// Render one row of the `Drives:` block in `daemon status`.
+///
+/// Format depends on the shard's tier (per Phase 5 task 5.11):
+/// * Warm/Hot — full breakdown (records count, source, memory rec= / names= /
+///   tri= / ch= / ext=).
+/// * Parked  — `[Parked]` marker + bloom + trie kept resident note.
+/// * Cold    — `[Cold]` marker only (no body, no filters).
+/// * Other   — fall back to the legacy single-line format so the formatter
+///   never panics on a state we haven't taught it about.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_drive_line(
+    dr: &DriveInfo,
+    drive_memory: &[uffs_client::protocol::response::DriveMemoryInfo],
+) {
+    let tier_marker = tier_marker(dr.tier);
+    match dr.tier {
+        Some(ShardTier::Warm | ShardTier::Hot) | None => {
+            let mem = drive_memory.iter().find(|dm| dm.drive == dr.letter);
             if let Some(dm) = mem {
                 let mb = |bytes: u64| bytes / (1024 * 1024);
                 println!(
-                    "  {}: — {:>10} records ({}) — {} MB  [rec={} names={} tri={} ch={} ext={}]",
+                    "  {} {}: — {:>10} records ({}) — {} MB  [rec={} names={} tri={} ch={} ext={}]",
+                    tier_marker,
                     dr.letter,
                     uffs_client::format::format_number_commas(dr.records as u64),
                     dr.source,
@@ -269,15 +297,45 @@ fn daemon_status() -> Result<()> {
                 );
             } else {
                 println!(
-                    "  {}: — {:>10} records ({})",
+                    "  {} {}: — {:>10} records ({})",
+                    tier_marker,
                     dr.letter,
                     uffs_client::format::format_number_commas(dr.records as u64),
                     dr.source
                 );
             }
         }
+        Some(ShardTier::Parked) => {
+            println!(
+                "  {} {}: — bloom + trie kept resident; body released",
+                tier_marker, dr.letter
+            );
+        }
+        Some(ShardTier::Cold) => {
+            println!(
+                "  {} {}: — encrypted cache only; nothing in RAM",
+                tier_marker, dr.letter
+            );
+        }
+        Some(ShardTier::Evicting | ShardTier::Unknown) => {
+            println!("  {} {}: — ({})", tier_marker, dr.letter, dr.source);
+        }
     }
-    Ok(())
+}
+
+/// Format the bracket-style tier marker for `daemon status`'s drive
+/// list.  An 8-character right-padded label so the per-drive lines
+/// align in the operator's terminal.
+const fn tier_marker(tier: Option<ShardTier>) -> &'static str {
+    match tier {
+        Some(ShardTier::Hot) => "[Hot]   ",
+        Some(ShardTier::Warm) => "[Warm]  ",
+        Some(ShardTier::Parked) => "[Parked]",
+        Some(ShardTier::Cold) => "[Cold]  ",
+        Some(ShardTier::Evicting) => "[Evict] ",
+        Some(ShardTier::Unknown) => "[?]     ",
+        None => "        ",
+    }
 }
 
 /// Print the "not running" message with optional stale-PID hint.

--- a/crates/uffs-cli/src/commands/system_status.rs
+++ b/crates/uffs-cli/src/commands/system_status.rs
@@ -11,7 +11,7 @@
 #[cfg(feature = "mcp-http-probe")]
 use anyhow::{Context, Result};
 use uffs_client::connect_sync::UffsClientSync;
-use uffs_client::protocol::response::DaemonStatus;
+use uffs_client::protocol::response::{DaemonStatus, ShardTier};
 
 /// `uffs status` — show combined system status.
 ///
@@ -93,25 +93,8 @@ fn print_daemon_status() {
     }
     println!("  Connections: {}", status.connections);
 
-    // Drive summary.
     if let Ok(drives) = client.drives() {
-        if drives.drives.is_empty() {
-            println!("  Drives:      (none loaded)");
-        } else {
-            let total_records: usize = drives.drives.iter().map(|dr| dr.records).sum();
-            println!(
-                "  Drives:      {} loaded ({} records)",
-                drives.drives.len(),
-                uffs_client::format::format_number_commas(total_records as u64),
-            );
-            for dr in &drives.drives {
-                println!(
-                    "    {}: {:>10} records",
-                    dr.letter,
-                    uffs_client::format::format_number_commas(dr.records as u64),
-                );
-            }
-        }
+        print_drive_summary(&drives.drives);
     }
 
     // Performance stats.
@@ -127,6 +110,79 @@ fn print_daemon_status() {
             println!("  Avg query:   {}", fmt(avg));
             println!("  Queries/s:   {:.2}", stats.queries_per_second);
         }
+    }
+}
+
+/// Render the `Drives:` block of `uffs status`.
+///
+/// Phase 5 task 5.11: enumerate every shard in the registry (Hot /
+/// Warm / Parked / Cold) and tag each row with its tier marker.
+/// `total_records` reflects only Warm/Hot bodies — Parked/Cold have
+/// no body in RAM, so their `records` field is 0 and excluded from
+/// the headline count.  Empty registry still renders `(none loaded)`
+/// so cold-boot detection in external scripts (`api-validation`,
+/// `cli-validation`, `mcp-validation`) keeps working.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_drive_summary(drives: &[uffs_client::protocol::response::DriveInfo]) {
+    if drives.is_empty() {
+        println!("  Drives:      (none loaded)");
+        return;
+    }
+
+    let total_records: usize = drives.iter().map(|dr| dr.records).sum();
+    let active = drives
+        .iter()
+        .filter(|dr| matches!(dr.tier, Some(ShardTier::Warm | ShardTier::Hot) | None))
+        .count();
+    let parked = drives
+        .iter()
+        .filter(|dr| matches!(dr.tier, Some(ShardTier::Parked)))
+        .count();
+    let cold = drives
+        .iter()
+        .filter(|dr| matches!(dr.tier, Some(ShardTier::Cold)))
+        .count();
+    println!(
+        "  Drives:      {} loaded ({} records, {active} active / {parked} parked / {cold} cold)",
+        drives.len(),
+        uffs_client::format::format_number_commas(total_records as u64),
+    );
+    for dr in drives {
+        let marker = compact_tier_marker(dr.tier);
+        match dr.tier {
+            Some(ShardTier::Parked) => {
+                println!("    {} {}: bloom + trie resident", marker, dr.letter);
+            }
+            Some(ShardTier::Cold) => {
+                println!("    {} {}: cache only (no RAM)", marker, dr.letter);
+            }
+            Some(ShardTier::Hot | ShardTier::Warm) | None => {
+                println!(
+                    "    {} {}: {:>10} records",
+                    marker,
+                    dr.letter,
+                    uffs_client::format::format_number_commas(dr.records as u64),
+                );
+            }
+            Some(ShardTier::Evicting | ShardTier::Unknown) => {
+                println!("    {} {}: ({})", marker, dr.letter, dr.source);
+            }
+        }
+    }
+}
+
+/// Compact tier marker for `uffs status`'s drive list — fixed-width
+/// bracket label per tier so the per-drive lines align in the
+/// combined system view.  Phase 5 task 5.11.
+const fn compact_tier_marker(tier: Option<ShardTier>) -> &'static str {
+    match tier {
+        Some(ShardTier::Hot) => "[H]",
+        Some(ShardTier::Warm) => "[W]",
+        Some(ShardTier::Parked) => "[P]",
+        Some(ShardTier::Cold) => "[C]",
+        Some(ShardTier::Evicting) => "[E]",
+        Some(ShardTier::Unknown) => "[?]",
+        None => "[ ]",
     }
 }
 

--- a/crates/uffs-client/src/protocol/response.rs
+++ b/crates/uffs-client/src/protocol/response.rs
@@ -12,7 +12,8 @@
 use serde::{Deserialize, Serialize};
 
 pub use super::response_status::{
-    DaemonStatus, DriveInfo, DriveMemoryInfo, DrivesResponse, StatsResponse, StatusResponse,
+    DaemonStatus, DriveInfo, DriveMemoryInfo, DrivesResponse, ShardTier, StatsResponse,
+    StatusResponse,
 };
 use super::{
     AggregateResultWire, BucketWire, RpcError, RpcErrorResponse, RpcRequest, RpcResponse,

--- a/crates/uffs-client/src/protocol/response_status.rs
+++ b/crates/uffs-client/src/protocol/response_status.rs
@@ -25,15 +25,55 @@ pub struct DrivesResponse {
     pub drives: Vec<DriveInfo>,
 }
 
+/// Memory-tiering state of a single shard, as surfaced over the wire.
+///
+/// Mirrors the daemon-internal `ShardState` enum (`crates/uffs-daemon/
+/// src/cache/shard.rs`) so external observers — the CLI status
+/// formatter, MCP, third-party tooling — can render the tier marker
+/// without depending on daemon internals.  Wire format is the
+/// lowercase tier name (`"hot"`, `"warm"`, `"parked"`, `"cold"`,
+/// `"unknown"`, `"evicting"`).
+///
+/// Added in Phase 5 (memory-tiering implementation plan §3 task
+/// 5.11) to fix the dogfood-discovered display gap where the status
+/// RPC enumerated only Warm/Hot shards and printed `Drives: (none
+/// loaded)` when every shard was Parked.  Older daemons (pre-v0.5.82)
+/// did not populate this field; the CLI treats `None` as "not
+/// reported" and falls back to the legacy format.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ShardTier {
+    /// Just discovered; no body, no bloom, no stats. Pre-load.
+    Unknown,
+    /// Encrypted cache exists but nothing in RAM.
+    Cold,
+    /// Bloom + trie loaded; full body dropped.
+    Parked,
+    /// Body fully loaded and searchable.
+    Warm,
+    /// Body loaded + pre-faulted via `Prefetch::hint`. Recent activity.
+    Hot,
+    /// Demote in progress. Transient.
+    Evicting,
+}
+
 /// Information about a loaded drive.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DriveInfo {
     /// Drive letter.
     pub letter: char,
-    /// Number of records in the compact index.
+    /// Number of records in the compact index.  `0` for `Parked` /
+    /// `Cold` shards whose body has been released.
     pub records: usize,
-    /// Source (e.g. `"cache"`, `"live"`, `"mft_file"`).
+    /// Source (e.g. `"cache"`, `"live"`, `"mft_file"`, `"parked"`,
+    /// `"cold"` for tier-demoted shards).
     pub source: String,
+    /// Memory-tiering state of this shard, populated by the daemon
+    /// from the registry's authoritative `ShardEntry::state()`.  Older
+    /// daemons (pre-v0.5.82) did not set this; the CLI treats `None`
+    /// as "no tier marker available" and renders accordingly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tier: Option<ShardTier>,
 }
 
 /// Response for the `status` method.

--- a/crates/uffs-daemon/src/index/drives.rs
+++ b/crates/uffs-daemon/src/index/drives.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! `drives` RPC handler — enumerates every shard in the registry,
+//! tagged with its memory-tiering tier marker.
+//!
+//! Phase 5 task 5.11 (memory-tiering implementation plan §3) split
+//! this off [`super::search`] when the combined module pushed past
+//! the workspace 800-LOC ceiling.  The pre-Phase-5 implementation
+//! filtered through `active_index()` (Warm/Hot only); the dogfood
+//! on 2026-04-28 surfaced that as a display bug — a daemon with all
+//! shards demoted to `Parked` rendered `Drives: (none loaded)`
+//! despite the bloom + trie still being resident.  This module's
+//! [`IndexManager::drives`] walks the registry directly so every
+//! tier round-trips to the CLI, with a synthetic `source` label
+//! ("parked" / "cold") for body-less shards so legacy CLI versions
+//! without the new `tier` field still render something readable.
+
+use uffs_client::protocol::response::{DriveInfo, DrivesResponse, ShardTier};
+
+use super::IndexManager;
+use crate::cache::ShardState;
+
+/// Map the daemon-internal `ShardState` to the wire-public `ShardTier`.
+///
+/// Bridges the `pub(crate) ShardState` (used for the atomic state
+/// machine) and the `pub ShardTier` (carried over RPC).  Kept tier-
+/// for-tier identical so the CLI's `[Hot]` / `[Warm]` / `[Parked]` /
+/// `[Cold]` markers reflect exactly what the registry holds.
+const fn shard_state_to_tier(state: ShardState) -> ShardTier {
+    match state {
+        ShardState::Unknown => ShardTier::Unknown,
+        ShardState::Cold => ShardTier::Cold,
+        ShardState::Parked => ShardTier::Parked,
+        ShardState::Warm => ShardTier::Warm,
+        ShardState::Hot => ShardTier::Hot,
+        ShardState::Evicting => ShardTier::Evicting,
+    }
+}
+
+/// Synthetic `source` label for body-less shards (`Parked` / `Cold`),
+/// returned verbatim in `DriveInfo::source` so legacy CLI versions
+/// without the `tier` field still render something operator-readable
+/// instead of an empty string.  Used only for shards where
+/// `ShardEntry::body()` is `None`.
+const fn tier_source_label(tier: ShardTier) -> &'static str {
+    match tier {
+        ShardTier::Hot => "hot",
+        ShardTier::Warm => "warm",
+        ShardTier::Parked => "parked",
+        ShardTier::Cold => "cold",
+        ShardTier::Evicting => "evicting",
+        ShardTier::Unknown => "unknown",
+    }
+}
+
+/// Render a `DriveCompactIndex::source` into the human-readable
+/// `DriveInfo::source` string the CLI prints inside the `()` after
+/// the records count.  Live MFT reads (path is `"C:"` etc.) collapse
+/// to the single word `"live"`; offline file-backed reads expose
+/// the path so the operator can tell which `.iocp` snapshot the
+/// daemon actually loaded.
+fn describe_index_source(source: &uffs_core::compact::IndexSource) -> String {
+    match source {
+        uffs_core::compact::IndexSource::MftFile(mft_path) => {
+            if mft_path.to_string_lossy().len() <= 2 {
+                "live".to_owned()
+            } else {
+                format!("file:{}", mft_path.display())
+            }
+        }
+    }
+}
+
+impl IndexManager {
+    /// Get loaded drives info — every shard in the registry, tagged
+    /// with its tier marker.
+    ///
+    /// Phase 5 task 5.11 (memory-tiering implementation plan §3)
+    /// widens this from "Warm/Hot only" to "every loaded shard",
+    /// driven by the 2026-04-28 dogfood: when all 7 drives demoted to
+    /// `Parked`, the registry still held them (their bloom + trie are
+    /// loaded, ready for re-promote on bloom hit), but the old
+    /// `drives()` filtered those out via `active_index()` and the CLI
+    /// rendered `Drives: (none loaded)`.
+    ///
+    /// Now we walk the registry directly: Warm/Hot shards keep their
+    /// records count + source from `body`; Parked/Cold shards report
+    /// `records: 0` and a synthetic `source` ("parked" / "cold") so
+    /// callers can render the tier without poking at internal state.
+    /// Every entry carries `tier: Some(_)` so older clients without
+    /// the field continue to deserialize, but new clients can drive
+    /// the formatter off the tier marker directly.
+    pub(crate) async fn drives(&self) -> DrivesResponse {
+        // Inner scope so the registry read-lock guard drops before
+        // the `DrivesResponse` is constructed —
+        // `clippy::significant_drop_tightening` flags the pattern
+        // where a guard's scope outlives the block that actually
+        // needs it, since concurrent writers (demote / promote)
+        // would block longer than necessary.
+        let drives: Vec<DriveInfo> = {
+            let guard = self.index.read().await;
+            guard
+                .iter()
+                .map(|shard| {
+                    let tier = shard_state_to_tier(shard.state());
+                    let (records, source) = shard.body().map_or_else(
+                        || (0_usize, tier_source_label(tier).to_owned()),
+                        |body| (body.records.len(), describe_index_source(&body.source)),
+                    );
+                    DriveInfo {
+                        letter: shard.drive,
+                        records,
+                        source,
+                        tier: Some(tier),
+                    }
+                })
+                .collect()
+        };
+        DrivesResponse { drives }
+    }
+}

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -10,6 +10,7 @@
 //! readability.
 
 mod aggregation;
+mod drives;
 mod predicates;
 mod projection;
 pub(crate) mod search;

--- a/crates/uffs-daemon/src/index/search.rs
+++ b/crates/uffs-daemon/src/index/search.rs
@@ -16,8 +16,7 @@ use std::io::Write;
 use std::time::Instant;
 
 use uffs_client::protocol::response::{
-    DriveInfo, DriveProfile, DrivesResponse, SearchPayload, SearchProfile, SearchResponse,
-    SearchRow,
+    DriveProfile, SearchPayload, SearchProfile, SearchResponse, SearchRow,
 };
 use uffs_client::protocol::{SearchFilterMode, SearchParams, SearchResponseMode};
 use uffs_core::search::backend::{
@@ -639,30 +638,6 @@ impl IndexManager {
             path_resolve_fn_ns,
             path_build_row_ns,
             drives: drive_profiles,
-        }
-    }
-
-    /// Get loaded drives info.
-    pub(crate) async fn drives(&self) -> DrivesResponse {
-        let snap = self.snapshot().await;
-        DrivesResponse {
-            drives: snap
-                .drives
-                .iter()
-                .map(|dr| DriveInfo {
-                    letter: dr.letter,
-                    records: dr.records.len(),
-                    source: match &dr.source {
-                        uffs_core::compact::IndexSource::MftFile(mft_path) => {
-                            if mft_path.to_string_lossy().len() <= 2 {
-                                "live".to_owned()
-                            } else {
-                                format!("file:{}", mft_path.display())
-                            }
-                        }
-                    },
-                })
-                .collect(),
         }
     }
 

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -2762,3 +2762,100 @@ async fn ensure_warm_for_dispatch_promotes_parked_when_bloom_hits() {
         "bloom hit must promote the shard back to Warm via the loader"
     );
 }
+
+/// Plan task **5.11**: `IndexManager::drives()` must enumerate every
+/// shard in the registry — Warm, Parked, *and* Cold — tagged with its
+/// `ShardTier` so the CLI status formatter can render the tier marker
+/// instead of printing `Drives: (none loaded)` when the registry holds
+/// only demoted shards.
+///
+/// Surfaced by the 2026-04-28 dogfood: at t=44m the daemon correctly
+/// had all 7 drives Parked (their bloom + path-trie still resident,
+/// ready for re-promote on bloom hit), but `daemon status` rendered
+/// the empty-registry path because the old `drives()` filtered
+/// through `active_index()` (Warm/Hot only).  The fix walks the
+/// registry directly; this test pins the contract.
+///
+/// Topology: 3 drives.  C stays Warm.  D demotes to Parked.  E
+/// demotes to Cold.  Assertions cover:
+/// * every shard is in the response (no filtering),
+/// * tiers map 1:1 from `ShardState` → `ShardTier`,
+/// * Warm shards carry the body's `records.len()`,
+/// * Parked / Cold shards report `records: 0` and a synthetic `source` label,
+/// * load-order is preserved (C, D, E).
+#[tokio::test]
+async fn drives_rpc_enumerates_warm_parked_and_cold_shards_with_tier_markers() {
+    use uffs_client::protocol::response::ShardTier;
+
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+    mgr.add_drive(build_test_drive_e()).await;
+
+    // Demote D → Parked (body released; bloom + trie resident).
+    assert!(mgr.demote_letter_for_test('D', ShardState::Parked).await);
+    // Demote E → Cold (no body, no filters).
+    assert!(mgr.demote_letter_for_test('E', ShardState::Cold).await);
+
+    let response = mgr.drives().await;
+    assert_eq!(
+        response.drives.len(),
+        3,
+        "every loaded shard must appear, including Parked and Cold"
+    );
+
+    // Load-order preserved (matches ShardRegistry::iter()).
+    let letters: Vec<char> = response.drives.iter().map(|dr| dr.letter).collect();
+    assert_eq!(letters, vec!['C', 'D', 'E'], "load order preserved");
+
+    // C — Warm: body present, records nonzero, tier=Warm,
+    // source from the body's IndexSource (live MFT path "C:").
+    let c = &response.drives[0];
+    assert_eq!(c.letter, 'C');
+    assert_eq!(c.tier, Some(ShardTier::Warm), "C remains Warm");
+    assert!(c.records > 0, "Warm shard reports its body's records.len()");
+    assert_eq!(c.source, "live", "Warm shard's body source flows through");
+
+    // D — Parked: no body, records=0, tier=Parked,
+    // source synthesized as "parked".
+    let d = &response.drives[1];
+    assert_eq!(d.letter, 'D');
+    assert_eq!(d.tier, Some(ShardTier::Parked), "D demoted to Parked");
+    assert_eq!(d.records, 0, "Parked shard has no body in RAM");
+    assert_eq!(
+        d.source, "parked",
+        "Parked shard surfaces a synthetic source label"
+    );
+
+    // E — Cold: no body, no filters, records=0, tier=Cold,
+    // source synthesized as "cold".
+    let e = &response.drives[2];
+    assert_eq!(e.letter, 'E');
+    assert_eq!(e.tier, Some(ShardTier::Cold), "E demoted to Cold");
+    assert_eq!(e.records, 0, "Cold shard has nothing in RAM");
+    assert_eq!(
+        e.source, "cold",
+        "Cold shard surfaces a synthetic source label"
+    );
+}
+
+/// Counter-test to the enumeration above: empty registry must still
+/// render the legacy `(none loaded)` path so cold-boot detection in
+/// external scripts (`scripts/windows/api-validation.rs`,
+/// `cli-validation.rs`, `mcp-validation.rs`) continues to fire on a
+/// truly empty daemon.  Pins that the formatter doesn't accidentally
+/// emit a tier-marker line for a registry that holds zero shards.
+#[tokio::test]
+async fn drives_rpc_returns_empty_vec_when_registry_is_empty() {
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx);
+
+    let response = mgr.drives().await;
+    assert!(
+        response.drives.is_empty(),
+        "no shards loaded → empty drives vec — CLI renders `(none loaded)`"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 5 task 5.11 from the local-only memory-tiering implementation plan.  Single-PR scope: just the status RPC display fix that the 2026-04-28 dogfood surfaced — every other Phase 5 task (5.1-5.10) lands in follow-up PRs.

## Why

At t=44m of the dogfood the daemon correctly had all 7 drives in `Parked` (their bloom + path-trie still resident, ready for re-promote on bloom hit) — but `daemon status` printed:

```
Drives:        (none loaded)
```

The shards existed in the registry; the formatter was filtering them through `IndexManager::snapshot()` → `active_index()` which only surfaces `Warm`/`Hot` shards.  Operator can't see the tiering at work.

## What

### Wire protocol (`uffs-client`)

- New `pub enum ShardTier { Unknown, Cold, Parked, Warm, Hot, Evicting }` mirroring the daemon-internal `ShardState`, lowercase serde.
- New `tier: Option<ShardTier>` field on `DriveInfo`, back-compat `#[serde(default, skip_serializing_if = "Option::is_none")]` so pre-v0.5.82 daemons still deserialize and the CLI falls back to the legacy format when tier info is missing.

### Daemon (`uffs-daemon`)

- Moved `IndexManager::drives()` into a new `crates/uffs-daemon/src/index/drives.rs` module to keep `search.rs` under the 800-LOC ceiling.
- Walks `ShardRegistry::iter()` directly (every shard, every tier) instead of `active_index()`.
- Warm/Hot shards keep their body's `records.len()` and `IndexSource` description; Parked/Cold shards report `records: 0` and a synthetic `source` (`parked` / `cold`).
- Read-lock guard tightened into an inner scope (`clippy::significant_drop_tightening`).

### CLI (`uffs-cli`)

- `daemon status`: `[Hot]` / `[Warm]` / `[Parked]` / `[Cold]` markers per drive; tier-specific descriptions for body-less shards.
- `uffs status` (combined view): compact `[H]`/`[W]`/`[P]`/`[C]` markers + headline summary `N loaded (X records, A active / P parked / C cold)`.
- Empty-registry path preserved (`Drives: (none loaded)`) so `scripts/windows/{api,cli,mcp}-validation.rs` cold-boot detection keeps working.

### Tests (`crates/uffs-daemon/src/index/tests.rs`)

- `drives_rpc_enumerates_warm_parked_and_cold_shards_with_tier_markers` — 3 drives, demote D→Parked + E→Cold, assert all three appear in load order with correct tier/records/source.
- `drives_rpc_returns_empty_vec_when_registry_is_empty` — pins the empty-registry contract so the CLI `(none loaded)` path is never silently broken.

## Mac gate

```
just lint-fast            ✅
cargo nextest --workspace  ✅ 1490 passed, 14 skipped
just check-windows         ✅
just check-all-targets     ✅
```

No suppression hacks; surgical fix; preserves the `drives()` RPC ABI for old clients (new field is opt-in).

Refs: `docs/refactor/memory-tiering-implementation-plan.md` (local-only) task 5.11.