### PR TITLE
feat(daemon): Phase 5 traits + wiring — WorkingSetTrim + Prefetch (5.1, 5.2, 5.4, 5.5, 5.8, 5.9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ windows = { version = "0.62.2", features = [
   "Win32_System_Ioctl",
   "Win32_System_Memory",
   "Win32_System_Pipes",
+  "Win32_System_ProcessStatus",
   "Win32_System_SystemInformation",
   "Win32_System_Threading",
   "Win32_System_Time",

--- a/crates/uffs-daemon/src/cache/mod.rs
+++ b/crates/uffs-daemon/src/cache/mod.rs
@@ -30,8 +30,10 @@
 
 pub(crate) mod body_loader;
 pub(crate) mod policy;
+pub(crate) mod prefetch;
 pub(crate) mod registry;
 pub(crate) mod shard;
+pub(crate) mod working_set;
 
 // Phase 1 surface: only `ShardRegistry` and `ShardState` are referenced
 // from outside this module (in `crate::index`).  The other types

--- a/crates/uffs-daemon/src/cache/prefetch.rs
+++ b/crates/uffs-daemon/src/cache/prefetch.rs
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Region kernel-prefetch hook (Phase 5 task 5.2).
+//!
+//! On Windows the records + names columns of a re-promoted shard
+//! are mmap'd, so we want the kernel to start paging them in *before*
+//! the search actually dereferences a record.  `PrefetchVirtualMemory`
+//! is the Win32 API for that — single syscall, batched per region,
+//! kernel does the I/O while the search-thread is still acquiring
+//! the registry write-lock and swapping the Arc.
+//!
+//! On Mac / Linux the columns may be heap-resident (`ColumnStorage::Vec`)
+//! or mmap'd (`ColumnStorage::Mmap`).  `posix_madvise(MADV_WILLNEED)`
+//! is harmless on either: heap pages are already resident; mmap pages
+//! get an async readahead nudge.  The trait stays the same; only the
+//! impl differs.
+//!
+//! The trait is held by [`crate::index::IndexManager`] as
+//! `Arc<dyn Prefetch>` so production wires the platform impl and
+//! the Phase 5 unit tests inject a recording fake (see
+//! [`tests::RecordingPrefetch`]) to assert the hook fires with the
+//! right (records, names) regions on every promote.
+
+use std::io;
+
+/// One memory region for [`Prefetch::hint`].
+///
+/// Wraps a raw `*const u8` + length so the slice can travel through
+/// the trait method's `Send + Sync` bounds.  Raw pointers are
+/// always safe to pass between threads — the safety contract is
+/// on **dereference**, which only happens inside the platform impl
+/// under the kernel's own synchronisation (the mmap stays alive
+/// for the lifetime of the body `Arc`).
+///
+/// `Copy + Clone` because the platform impls walk the slice into
+/// the kernel's batched-prefetch struct (`WIN32_MEMORY_RANGE_ENTRY`
+/// on Windows; per-region `posix_madvise` on Mac/Linux); shallow
+/// copies are correct and cheap.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PrefetchRegion {
+    /// First byte of the region.  Must be page-aligned for
+    /// `PrefetchVirtualMemory`; the kernel rounds down on
+    /// `posix_madvise` so alignment is best-effort.
+    pub ptr: *const u8,
+    /// Length in bytes.  `0` is a documented no-op on every
+    /// platform we ship.
+    pub len: usize,
+}
+
+#[expect(
+    unsafe_code,
+    reason = "raw pointer Send/Sync wrapper: transmission is safe; dereference is guarded by the body Arc kept alive across hint()"
+)]
+// SAFETY: A raw pointer carries no ownership; transmitting one
+// between threads is sound.  The dereference inside the platform
+// impls is guarded by the body `Arc` keeping the underlying
+// allocation / mmap alive across the entire `hint()` call.
+unsafe impl Send for PrefetchRegion {}
+#[expect(
+    unsafe_code,
+    reason = "raw pointer Send/Sync wrapper: transmission is safe; dereference is guarded by the body Arc kept alive across hint()"
+)]
+// SAFETY: Sharing a raw pointer + length across threads has no
+// aliasing implications until dereference, which (per `Send` impl
+// above) is guarded by the body `Arc` kept alive across `hint()`.
+unsafe impl Sync for PrefetchRegion {}
+
+/// Region kernel-prefetch hook.
+///
+/// Implementations are held as `Arc<dyn Prefetch>` on
+/// [`crate::index::IndexManager`].  Called from
+/// [`crate::index::IndexManager::ensure_warm_for_dispatch`] inside
+/// the per-letter `spawn_blocking` task, just after
+/// `BodyLoader::load` returns the freshly-loaded body and before
+/// the registry write-lock swap (Phase 5 task 5.5).
+///
+/// Implementors must be `Send + Sync + 'static` so the orchestrator
+/// can `Arc::clone` the trait object into each blocking task.  The
+/// function is `&self` so concurrent promotes (one per drive letter)
+/// are safe.
+pub(crate) trait Prefetch: Send + Sync + 'static {
+    /// Hint to the kernel that the supplied virtual-address regions
+    /// are about to be touched.  Best-effort; any I/O error is
+    /// logged at the call site and the daemon continues.  An empty
+    /// `regions` slice is a documented no-op on every platform.
+    fn hint(&self, regions: &[PrefetchRegion]) -> io::Result<()>;
+}
+
+/// Production prefetch implementation.
+///
+/// On Windows: single `PrefetchVirtualMemory` syscall with a stack-
+/// allocated `WIN32_MEMORY_RANGE_ENTRY[]` built from `regions`.  On
+/// Mac/Linux: per-region `posix_madvise(_, _, MADV_WILLNEED)` —
+/// errors collapse into the first nonzero return.
+///
+/// Phase 5 task 5.2 — paired with the Phase-5 dogfood gate
+/// "promote-on-search latency drops on the next-after-promote query".
+pub(crate) struct PlatformPrefetch;
+
+impl Prefetch for PlatformPrefetch {
+    #[cfg(target_os = "windows")]
+    fn hint(&self, regions: &[PrefetchRegion]) -> io::Result<()> {
+        use windows::Win32::System::Memory::{PrefetchVirtualMemory, WIN32_MEMORY_RANGE_ENTRY};
+        use windows::Win32::System::Threading::GetCurrentProcess;
+
+        if regions.is_empty() {
+            return Ok(());
+        }
+
+        // Translate our wrapper to the Win32 struct.  Layouts are
+        // independent so we can't `transmute` the slice — explicit
+        // map+collect is the only sound option.
+        let entries: Vec<WIN32_MEMORY_RANGE_ENTRY> = regions
+            .iter()
+            .map(|region| WIN32_MEMORY_RANGE_ENTRY {
+                VirtualAddress: region.ptr.cast::<core::ffi::c_void>().cast_mut(),
+                NumberOfBytes: region.len,
+            })
+            .collect();
+
+        // SAFETY: `GetCurrentProcess` returns a pseudo-handle valid
+        // for the process lifetime.  `entries.as_ptr()` is non-null
+        // and aligned (Vec invariant), valid for `entries.len()`
+        // contiguous reads of `WIN32_MEMORY_RANGE_ENTRY`.  The
+        // caller (orchestrator) keeps the body `Arc` alive across
+        // this call so each `region.ptr` remains a live mapping.
+        // `flags = 0` is the documented "no special behaviour"
+        // value per Win32 docs (PrefetchVirtualMemory accepts only
+        // `PREFETCH_PROCESS_FOR_RECEIVE` or 0; we want 0).
+        #[expect(
+            unsafe_code,
+            reason = "PrefetchVirtualMemory requires unsafe FFI; safety preconditions are satisfied by the orchestrator holding the body Arc across the call"
+        )]
+        let result = unsafe { PrefetchVirtualMemory(GetCurrentProcess(), &entries, 0) };
+        result.map_err(|err| io::Error::other(err.to_string()))
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn hint(&self, regions: &[PrefetchRegion]) -> io::Result<()> {
+        if regions.is_empty() {
+            return Ok(());
+        }
+
+        // Per-region `posix_madvise(MADV_WILLNEED)`.  Heap regions
+        // are already resident, so the kernel collapses the call
+        // to a no-op; mmap'd regions get an async readahead nudge.
+        // We bail at the first error — the demote controller logs
+        // the failure and keeps going.
+        for region in regions {
+            #[expect(
+                unsafe_code,
+                reason = "posix_madvise requires unsafe FFI; safety preconditions are satisfied by the orchestrator holding the body Arc across the call"
+            )]
+            // SAFETY: `region.ptr` is the start of a live byte
+            // range owned by the body `Arc` the orchestrator
+            // keeps alive across this call.  `posix_madvise`
+            // takes a `*mut c_void` but is documented as not
+            // mutating the bytes; the cast is per-platform safe
+            // because the kernel only touches page-table state.
+            let result = unsafe {
+                libc::posix_madvise(
+                    region.ptr.cast::<core::ffi::c_void>().cast_mut(),
+                    region.len,
+                    libc::POSIX_MADV_WILLNEED,
+                )
+            };
+            if result != 0_i32 {
+                return Err(io::Error::from_raw_os_error(result));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::sync::Mutex;
+
+    use super::{Prefetch, PrefetchRegion};
+
+    /// Phase 5 task 5.9 fake.  Records every `hint()` call with
+    /// the (ptr, len) pairs as plain integers so the assertion
+    /// can match against the body's records / names regions
+    /// without juggling raw pointers.
+    pub(crate) struct RecordingPrefetch {
+        // `(usize, usize)` not `PrefetchRegion` because the
+        // assertion side wants to compare against integers
+        // captured by the test, not raw pointers that need
+        // re-derivation.  The cast ptr → usize is identity;
+        // the payload semantics are preserved.
+        calls: Mutex<Vec<Vec<(usize, usize)>>>,
+    }
+
+    impl RecordingPrefetch {
+        pub(crate) const fn new() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        /// Snapshot of every recorded `hint()` invocation, in
+        /// call-order.  Each entry is the full `regions` slice
+        /// of that call (so a 2-region promote shows as a
+        /// `[Vec<(_,_)>; 1]` with a 2-element inner vec).
+        pub(crate) fn calls(&self) -> Vec<Vec<(usize, usize)>> {
+            self.calls
+                .lock()
+                .expect("RecordingPrefetch mutex never poisoned in tests")
+                .clone()
+        }
+    }
+
+    impl Prefetch for RecordingPrefetch {
+        fn hint(&self, regions: &[PrefetchRegion]) -> std::io::Result<()> {
+            let snapshot: Vec<(usize, usize)> = regions
+                .iter()
+                .map(|region| (region.ptr as usize, region.len))
+                .collect();
+            // Mutex poisoning would only happen if a previous
+            // `hint()` panicked while holding the lock.  In tests
+            // we treat that as an outright failure rather than
+            // hide it behind an `Ok(())` — surface the panic so
+            // the suite tells us the fake is misbehaving.
+            //
+            // Guard scope tightened to the push so clippy's
+            // `significant_drop_tightening` is satisfied; the
+            // mutex is released the moment the snapshot lands.
+            {
+                let mut guard = self.calls.lock().map_err(|err| {
+                    std::io::Error::other(format!("RecordingPrefetch mutex poisoned: {err}"))
+                })?;
+                guard.push(snapshot);
+            };
+            Ok(())
+        }
+    }
+
+    /// Smoke-test the production stub on every platform: empty
+    /// regions are a no-op; non-empty regions complete without
+    /// panic.  Uses a heap allocation we own so the pointer is
+    /// guaranteed live for the call.
+    #[test]
+    fn platform_prefetch_handles_empty_and_heap_regions() {
+        use super::PlatformPrefetch;
+
+        let prefetch = PlatformPrefetch;
+
+        // Empty slice: documented no-op.
+        prefetch
+            .hint(&[])
+            .expect("empty hint() never errors on any platform");
+
+        // Heap region: kernel sees a live virtual-address range
+        // backed by anonymous private pages.  `MADV_WILLNEED` /
+        // `PrefetchVirtualMemory` may collapse to a no-op for
+        // already-resident pages but must not panic or error.
+        let buffer = vec![0_u8; 4096];
+        let region = PrefetchRegion {
+            ptr: buffer.as_ptr(),
+            len: buffer.len(),
+        };
+        // On Windows, `PrefetchVirtualMemory` rejects ranges that
+        // aren't part of a memory-mapped file with `ERROR_INVALID_
+        // PARAMETER`.  That's an error, not a panic — accept either
+        // outcome to keep the smoke-test cross-platform: the real
+        // contract is "no panic, no crash".
+        drop(prefetch.hint(&[region]));
+        // Buffer must outlive the call, which it does syntactically.
+        drop(buffer);
+    }
+
+    /// Recording fake captures every region as (ptr-as-usize,
+    /// len) so tests can assert without juggling raw pointers.
+    #[test]
+    fn recording_prefetch_captures_every_region_in_order() {
+        let prefetch = RecordingPrefetch::new();
+        assert!(prefetch.calls().is_empty());
+
+        let buf_a = [0_u8; 16];
+        let buf_b = [0_u8; 32];
+        let regions_first = [PrefetchRegion {
+            ptr: buf_a.as_ptr(),
+            len: buf_a.len(),
+        }];
+        let regions_second = [
+            PrefetchRegion {
+                ptr: buf_a.as_ptr(),
+                len: buf_a.len(),
+            },
+            PrefetchRegion {
+                ptr: buf_b.as_ptr(),
+                len: buf_b.len(),
+            },
+        ];
+
+        prefetch.hint(&regions_first).unwrap();
+        prefetch.hint(&regions_second).unwrap();
+
+        let captured = prefetch.calls();
+        assert_eq!(captured.len(), 2, "two hint() calls recorded");
+        let first = captured.first().expect("two recorded calls");
+        assert_eq!(first.len(), 1);
+        assert_eq!(
+            *first.first().expect("first call recorded one region"),
+            (buf_a.as_ptr() as usize, 16_usize),
+        );
+        let second = captured.get(1).expect("two recorded calls");
+        assert_eq!(second.len(), 2);
+        assert_eq!(
+            *second.first().expect("second call recorded two regions"),
+            (buf_a.as_ptr() as usize, 16_usize),
+        );
+        assert_eq!(
+            *second.get(1).expect("second call recorded two regions"),
+            (buf_b.as_ptr() as usize, 32_usize),
+        );
+    }
+}

--- a/crates/uffs-daemon/src/cache/working_set.rs
+++ b/crates/uffs-daemon/src/cache/working_set.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Process-level working-set trim hook (Phase 5 task 5.1).
+//!
+//! After a demote we want the kernel to reclaim pages the daemon no
+//! longer needs.  On Windows that's a single `EmptyWorkingSet` call —
+//! the OS scans the process's working set and trims everything that
+//! isn't pinned, then queues writebacks for any dirty pages.  On
+//! macOS / Linux there's no process-level equivalent that respects
+//! mmap'd file backing (Linux has `madvise(MADV_DONTNEED)`, but it's
+//! per-region and the demote path already releases those Arcs); the
+//! kernel's own page-reclaim runs the show.  So Mac/Linux ship a
+//! no-op stub and the trait is purely a Windows hook.
+//!
+//! The trait is held by [`crate::index::IndexManager`] as
+//! `Arc<dyn WorkingSetTrim>` so production wires the platform impl
+//! and the Phase 5 unit tests inject a counting fake (see
+//! [`tests::CountingWorkingSetTrim`]) to assert the hook fires
+//! exactly once per demote batch.
+
+use std::io;
+
+/// Process-level working-set trim hook.
+///
+/// Implementations are held as `Arc<dyn WorkingSetTrim>` on
+/// [`crate::index::IndexManager`].  Called at the end of every
+/// demote batch in [`crate::index::IndexManager::demote_idle_shards`]
+/// (Phase 5 task 5.4).  The call is process-wide, not per-shard:
+/// on Windows `EmptyWorkingSet` operates on the current process,
+/// so coalescing all demotes in a batch into a single trim
+/// avoids redundant syscalls and pager work.
+///
+/// Implementors must be `Send + Sync + 'static` to satisfy the
+/// `Arc<dyn ...>` bound; the function is `&self` so concurrent
+/// calls from the demote-controller and the (future) pressure
+/// subscriber are both safe.
+pub(crate) trait WorkingSetTrim: Send + Sync + 'static {
+    /// Trim the daemon's working set.  Best-effort; any I/O error
+    /// is logged at the call site and the daemon continues.  On
+    /// Mac/Linux this returns `Ok(())` immediately (no-op).
+    fn trim(&self) -> io::Result<()>;
+}
+
+/// Production working-set trim implementation.
+///
+/// On Windows: thin wrapper around the Win32 `EmptyWorkingSet`
+/// API.  On Mac/Linux: no-op (the per-region `madvise` calls the
+/// demote path's `Arc::drop` triggers handle reclaim; there's no
+/// process-level equivalent that's safe to call mid-flight).
+///
+/// Phase 5 task 5.1 — paired with the Phase-5 dogfood gate
+/// "working set drops in Task Manager within 5 s of demote".
+pub(crate) struct PlatformWorkingSetTrim;
+
+impl WorkingSetTrim for PlatformWorkingSetTrim {
+    #[cfg(target_os = "windows")]
+    fn trim(&self) -> io::Result<()> {
+        use windows::Win32::System::ProcessStatus::EmptyWorkingSet;
+        use windows::Win32::System::Threading::GetCurrentProcess;
+
+        // SAFETY: `GetCurrentProcess` returns a pseudo-handle that
+        // is always valid for the lifetime of the process; passing
+        // it straight to `EmptyWorkingSet` is the documented Win32
+        // idiom.  Both calls are sync, take no ownership, and the
+        // windows-rs `Result<()>` already wraps the underlying
+        // `BOOL` / `GetLastError` protocol.
+        //
+        // We translate any windows-rs error into
+        // `io::Error::other` so the demote controller's
+        // `tracing::warn!` line stays platform-agnostic.
+        #[expect(
+            unsafe_code,
+            reason = "EmptyWorkingSet requires unsafe FFI; balanced by GetCurrentProcess pseudo-handle that does not need closing"
+        )]
+        let result = unsafe { EmptyWorkingSet(GetCurrentProcess()) };
+        result.map_err(|err| io::Error::other(err.to_string()))
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn trim(&self) -> io::Result<()> {
+        // Mac/Linux: no-op stub.  See module docs for rationale.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::WorkingSetTrim;
+
+    /// Phase 5 task 5.8 fake.  Counts every `trim()` invocation so
+    /// the demote-batch test can assert the hook fires exactly once
+    /// per batch (not once per shard, not zero).
+    pub(crate) struct CountingWorkingSetTrim {
+        calls: AtomicUsize,
+    }
+
+    impl CountingWorkingSetTrim {
+        pub(crate) const fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        pub(crate) fn calls(&self) -> usize {
+            self.calls.load(Ordering::Acquire)
+        }
+    }
+
+    impl WorkingSetTrim for CountingWorkingSetTrim {
+        fn trim(&self) -> std::io::Result<()> {
+            self.calls.fetch_add(1, Ordering::AcqRel);
+            Ok(())
+        }
+    }
+
+    /// Smoke-test the production no-op stub on Mac/Linux: returns
+    /// `Ok(())` immediately, no panic, no I/O.
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn platform_working_set_trim_is_noop_on_unix() {
+        let trim = super::PlatformWorkingSetTrim;
+        for _ in 0_i32..32_i32 {
+            trim.trim().expect("Mac/Linux trim() never errors");
+        }
+    }
+
+    /// Counting fake increments exactly once per call and returns
+    /// `Ok(())`.  Pinned here (not in `index/tests.rs`) so the
+    /// fake's contract is colocated with its definition.
+    #[test]
+    fn counting_working_set_trim_increments_atomically() {
+        let trim = CountingWorkingSetTrim::new();
+        assert_eq!(trim.calls(), 0);
+
+        for expected in 1..=5 {
+            trim.trim().expect("counting trim never errors");
+            assert_eq!(trim.calls(), expected);
+        }
+    }
+}

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -135,6 +135,27 @@ pub(crate) struct IndexManager {
     /// Commit-E integration tests inject fakes via
     /// [`Self::with_body_loader_for_test`].
     body_loader: Arc<dyn crate::cache::body_loader::BodyLoader>,
+    /// Process-level working-set trim hook (Phase 5 task 5.1).
+    /// Called once at the end of every demote batch in
+    /// [`Self::demote_idle_shards`] (task 5.4).  Production wires
+    /// [`crate::cache::working_set::PlatformWorkingSetTrim`]
+    /// (Mac/Linux no-op, Windows `EmptyWorkingSet`); the Phase 5
+    /// tests inject
+    /// [`crate::cache::working_set::tests::CountingWorkingSetTrim`]
+    /// to assert exactly-once invocation per batch.
+    working_set_trim: Arc<dyn crate::cache::working_set::WorkingSetTrim>,
+    /// Region kernel-prefetch hook (Phase 5 task 5.2).  Called
+    /// inside the per-letter `spawn_blocking` task in
+    /// [`Self::ensure_warm_for_dispatch`] right after the body
+    /// loader returns the freshly-loaded body (task 5.5), so the
+    /// kernel can start paging in records + names while the
+    /// orchestrator acquires the registry write-lock.  Production
+    /// wires [`crate::cache::prefetch::PlatformPrefetch`] (Windows
+    /// `PrefetchVirtualMemory`, Mac/Linux `posix_madvise`); the
+    /// Phase 5 tests inject
+    /// [`crate::cache::prefetch::tests::RecordingPrefetch`] to assert the
+    /// records + names regions reach the kernel.
+    prefetch: Arc<dyn crate::cache::prefetch::Prefetch>,
 }
 
 impl IndexManager {
@@ -148,24 +169,29 @@ impl IndexManager {
     /// the initial value is not performance-critical.
     #[must_use]
     pub(crate) fn new(data_dir: Option<PathBuf>, events: EventSender) -> Self {
-        Self::new_with_body_loader(
+        Self::new_with_lifecycle_hooks(
             data_dir,
             events,
             Arc::new(crate::cache::body_loader::DiskBodyLoader),
+            Arc::new(crate::cache::working_set::PlatformWorkingSetTrim),
+            Arc::new(crate::cache::prefetch::PlatformPrefetch),
         )
     }
 
-    /// Inner constructor that also threads a custom body-loader.
+    /// Inner constructor that threads custom lifecycle hooks
+    /// (body loader + working-set trim + prefetch).
     ///
     /// Production code calls [`Self::new`] which wires the
-    /// `DiskBodyLoader`; the Commit-E tests use this path through
-    /// [`Self::with_body_loader_for_test`] to inject fakes
-    /// (fixed body, missing body, panicking loader) without
-    /// touching the platform cache directory.
-    fn new_with_body_loader(
+    /// platform impls; the Phase 5 unit tests use this path
+    /// through [`Self::with_lifecycle_hooks_for_test`] to inject
+    /// counting / recording fakes without touching the platform
+    /// cache directory or the process working set.
+    fn new_with_lifecycle_hooks(
         data_dir: Option<PathBuf>,
         events: EventSender,
         body_loader: Arc<dyn crate::cache::body_loader::BodyLoader>,
+        working_set_trim: Arc<dyn crate::cache::working_set::WorkingSetTrim>,
+        prefetch: Arc<dyn crate::cache::prefetch::Prefetch>,
     ) -> Self {
         let cpus = std::thread::available_parallelism().map_or(4, core::num::NonZeroUsize::get);
         Self {
@@ -186,6 +212,8 @@ impl IndexManager {
             startup_duration_us: AtomicU64::new(0),
             drive_timings: RwLock::new(std::collections::HashMap::new()),
             body_loader,
+            working_set_trim,
+            prefetch,
         }
     }
 
@@ -194,13 +222,43 @@ impl IndexManager {
     /// Used by the Commit-E integration tests to inject deterministic
     /// fakes — no platform cache directory touched, no
     /// process-global env-var override, no `tempfile`-juggling.
+    /// Threads the production [`PlatformWorkingSetTrim`] (no-op on
+    /// Mac/Linux) and [`PlatformPrefetch`] for the lifecycle hooks
+    /// since pre-Phase-5 tests don't care about them.
+    ///
+    /// [`PlatformWorkingSetTrim`]: crate::cache::working_set::PlatformWorkingSetTrim
+    /// [`PlatformPrefetch`]: crate::cache::prefetch::PlatformPrefetch
     #[cfg(test)]
     pub(crate) fn with_body_loader_for_test(
         data_dir: Option<PathBuf>,
         events: EventSender,
         body_loader: Arc<dyn crate::cache::body_loader::BodyLoader>,
     ) -> Self {
-        Self::new_with_body_loader(data_dir, events, body_loader)
+        Self::new_with_lifecycle_hooks(
+            data_dir,
+            events,
+            body_loader,
+            Arc::new(crate::cache::working_set::PlatformWorkingSetTrim),
+            Arc::new(crate::cache::prefetch::PlatformPrefetch),
+        )
+    }
+
+    /// Test-only constructor that swaps in custom hooks for the
+    /// full memory-tiering lifecycle (body loader + working-set
+    /// trim + prefetch).  Phase 5 tasks 5.8 + 5.9 inject counting
+    /// / recording fakes here so the demote-batch and promote-on-
+    /// search assertions can assert exactly-once invocation and
+    /// the right (records, names) regions without touching the
+    /// process's actual working set or kernel page cache.
+    #[cfg(test)]
+    pub(crate) fn with_lifecycle_hooks_for_test(
+        data_dir: Option<PathBuf>,
+        events: EventSender,
+        body_loader: Arc<dyn crate::cache::body_loader::BodyLoader>,
+        working_set_trim: Arc<dyn crate::cache::working_set::WorkingSetTrim>,
+        prefetch: Arc<dyn crate::cache::prefetch::Prefetch>,
+    ) -> Self {
+        Self::new_with_lifecycle_hooks(data_dir, events, body_loader, working_set_trim, prefetch)
     }
 
     /// Acquire an owned search-concurrency permit.
@@ -1005,6 +1063,7 @@ impl IndexManager {
         )> = tokio::task::JoinSet::new();
         for letter in needs_promote {
             let loader = Arc::clone(&self.body_loader);
+            let prefetch = Arc::clone(&self.prefetch);
             load_set.spawn_blocking(move || {
                 // `catch_unwind` lives in `std` (needs unwinding
                 // runtime); `AssertUnwindSafe` lives in `core` (the
@@ -1022,6 +1081,40 @@ impl IndexManager {
                     );
                     None
                 });
+
+                // ── Phase 5 task 5.5 — prefetch hint ─────────────
+                // Best-effort kernel-prefetch on the records +
+                // names regions while we're still in the blocking
+                // task, before the orchestrator acquires the
+                // registry write-lock for the swap.  Mac/Linux:
+                // `posix_madvise(MADV_WILLNEED)` per region;
+                // Windows: single `PrefetchVirtualMemory` call.
+                // The body `Arc` keeps the underlying allocation
+                // / mmap alive across this call so the raw
+                // pointers stay valid (Send/Sync wrapper:
+                // `PrefetchRegion`).  Errors are logged and
+                // ignored — the shard still promotes.
+                if let Some(body_arc) = body.as_ref() {
+                    let regions = [
+                        crate::cache::prefetch::PrefetchRegion {
+                            ptr: body_arc.records.as_slice().as_ptr().cast::<u8>(),
+                            len: size_of_val(body_arc.records.as_slice()),
+                        },
+                        crate::cache::prefetch::PrefetchRegion {
+                            ptr: body_arc.names.as_slice().as_ptr(),
+                            len: body_arc.names.as_slice().len(),
+                        },
+                    ];
+                    if let Err(err) = prefetch.hint(&regions) {
+                        tracing::warn!(
+                            target: "shard.transition",
+                            drive = %letter,
+                            error = %err,
+                            reason = "promote-on-search",
+                            "Prefetch::hint failed; shard still promotes",
+                        );
+                    }
+                }
                 (letter, body)
             });
         }
@@ -1180,6 +1273,24 @@ impl IndexManager {
         // ── Phase 3: single index-version bump for the batch ───────
         if applied > 0 {
             self.bump_index_version();
+
+            // ── Phase 4: working-set trim (Phase 5 task 5.4) ─────
+            // Process-level hook called once per batch (not once
+            // per shard) — on Windows `EmptyWorkingSet` is process-
+            // wide so coalescing matters; on Mac/Linux the call is
+            // a no-op stub.  Best-effort: any I/O error is logged
+            // and the daemon continues.  Runs after the index-
+            // version bump so the demote is fully observable to
+            // searches before we ask the kernel to reclaim pages.
+            if let Err(err) = self.working_set_trim.trim() {
+                tracing::warn!(
+                    target: "shard.transition",
+                    error = %err,
+                    applied,
+                    reason = "demote-batch",
+                    "WorkingSetTrim::trim failed; daemon continues",
+                );
+            }
         }
     }
 

--- a/crates/uffs-daemon/src/index/tests.rs
+++ b/crates/uffs-daemon/src/index/tests.rs
@@ -2859,3 +2859,150 @@ async fn drives_rpc_returns_empty_vec_when_registry_is_empty() {
         "no shards loaded → empty drives vec — CLI renders `(none loaded)`"
     );
 }
+
+/// Phase 5 task **5.8** — `demote_idle_shards` invokes the
+/// `WorkingSetTrim::trim()` hook **exactly once** per applied
+/// batch, not once per shard.  Pins the contract documented on
+/// the trait: process-level call, coalesced across the batch
+/// (Windows `EmptyWorkingSet` is process-wide so per-shard calls
+/// would be wasted syscalls).
+///
+/// Topology: 3 drives all backdated past `WARM_TO_PARKED_IDLE_SECS`
+/// so the controller demotes them in a single batch.  Inject a
+/// `CountingWorkingSetTrim` fake; assert `calls() == 1` after the
+/// tick.
+#[tokio::test]
+async fn demote_idle_shards_invokes_working_set_trim_once_per_batch() {
+    use crate::cache::policy::WARM_TO_PARKED_IDLE_SECS;
+    use crate::cache::prefetch::PlatformPrefetch;
+    use crate::cache::working_set::tests::CountingWorkingSetTrim;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let counting_trim = Arc::new(CountingWorkingSetTrim::new());
+    let mgr = IndexManager::with_lifecycle_hooks_for_test(
+        None,
+        tx,
+        Arc::new(crate::cache::body_loader::DiskBodyLoader),
+        Arc::clone(&counting_trim) as Arc<dyn crate::cache::working_set::WorkingSetTrim>,
+        Arc::new(PlatformPrefetch),
+    );
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+    mgr.add_drive(build_test_drive_e()).await;
+
+    // Backdate every shard's last_query_at_ms past the Warm→Parked
+    // threshold so the controller picks up all three in one batch.
+    let last_query_ms = 1_000_000_000_u64;
+    for letter in ['C', 'D', 'E'] {
+        assert!(
+            mgr.backdate_last_query_at_ms_for_test(letter, last_query_ms)
+                .await
+        );
+    }
+
+    // Pre-batch: hook never fired.
+    assert_eq!(counting_trim.calls(), 0, "no demote yet → no trim");
+
+    let now_ms = last_query_ms + WARM_TO_PARKED_IDLE_SECS * 1000;
+    mgr.demote_idle_shards(now_ms).await;
+
+    // Post-batch: every shard demoted, hook fired exactly once.
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(states, vec![
+        ('C', crate::cache::ShardState::Parked),
+        ('D', crate::cache::ShardState::Parked),
+        ('E', crate::cache::ShardState::Parked),
+    ]);
+    assert_eq!(
+        counting_trim.calls(),
+        1,
+        "WorkingSetTrim::trim() fires once per batch, not per shard"
+    );
+
+    // Idempotent on a second tick: nothing to demote → no trim.
+    mgr.demote_idle_shards(now_ms).await;
+    assert_eq!(
+        counting_trim.calls(),
+        1,
+        "no-op tick must not re-trim — coalescing depends on `applied > 0`",
+    );
+}
+
+/// Phase 5 task **5.9** — `ensure_warm_for_dispatch` invokes the
+/// `Prefetch::hint()` hook with the freshly-loaded body's
+/// records + names regions, in that order, before the registry
+/// write-lock swap.  Pins the contract that the kernel-prefetch
+/// runs while the orchestrator is still in the blocking task so
+/// the syscall overlaps with the lock acquisition.
+///
+/// Topology: 1 drive (C), demoted to Parked.  Inject a
+/// `FixedBodyLoader` so the body Arc handed to `Prefetch::hint`
+/// is byte-identical to the one we constructed pre-test;
+/// `RecordingPrefetch` captures every region as `(ptr-as-usize,
+/// len)` so the assertion can match on the body's
+/// `records.as_ptr()` and `names.as_ptr()` directly.
+#[tokio::test]
+async fn ensure_warm_for_dispatch_invokes_prefetch_with_records_and_names_regions() {
+    use crate::cache::ShardState;
+    use crate::cache::prefetch::tests::RecordingPrefetch;
+    use crate::cache::working_set::PlatformWorkingSetTrim;
+
+    let (tx, _rx) = crate::events::event_channel();
+
+    // Build the fixed body up front so we can compare regions
+    // against it after promote.
+    let body = Arc::new(build_test_drive());
+    let recording_prefetch = Arc::new(RecordingPrefetch::new());
+    let mgr = IndexManager::with_lifecycle_hooks_for_test(
+        None,
+        tx,
+        Arc::new(FixedBodyLoader {
+            body: Arc::clone(&body),
+        }),
+        Arc::new(PlatformWorkingSetTrim),
+        Arc::clone(&recording_prefetch) as Arc<dyn crate::cache::prefetch::Prefetch>,
+    );
+    mgr.add_drive(build_test_drive()).await;
+    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+
+    // Pre-promote: no prefetch calls.
+    assert!(recording_prefetch.calls().is_empty());
+
+    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
+
+    // Shard promoted (the Phase-3 contract this test depends on).
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(states, vec![('C', ShardState::Warm)]);
+
+    // Prefetch invoked exactly once, with two regions in a fixed
+    // order: records first (typed slice → byte length), names
+    // second (raw `u8` slice → length is element count == bytes).
+    let calls = recording_prefetch.calls();
+    assert_eq!(
+        calls.len(),
+        1,
+        "exactly one Prefetch::hint() call per promoted shard"
+    );
+    let regions = &calls[0];
+    assert_eq!(
+        regions.len(),
+        2,
+        "regions: [records, names] — fixed order, no extras"
+    );
+
+    let expected_records_ptr = body.records.as_slice().as_ptr() as usize;
+    let expected_records_len = size_of_val(body.records.as_slice());
+    let expected_names_ptr = body.names.as_slice().as_ptr() as usize;
+    let expected_names_len = body.names.as_slice().len();
+
+    assert_eq!(
+        regions[0],
+        (expected_records_ptr, expected_records_len),
+        "records region matches the body's records.as_slice()",
+    );
+    assert_eq!(
+        regions[1],
+        (expected_names_ptr, expected_names_len),
+        "names region matches the body's names.as_slice()",
+    );
+}


### PR DESCRIPTION
## Summary

Phase 5 of the local-only memory-tiering implementation plan.  Six tasks in one PR: the two new lifecycle-hook traits, their wiring into the existing demote / promote orchestrators, and the Mac deterministic tests that pin the hooks fire on the right code paths.

The remaining Phase 5 tasks (5.3 + 5.6 + 5.7 + 5.10 — pressure subscriber, cascade-demote, background-mode, LRU-order test) follow in PR-c.

PR sequence:
- **PR #103 (PR-a)** — Phase 5.11 status RPC display fix.  ✅ Merged.
- **PR #?? (this one, PR-b)** — Phase 5 traits + wiring (5.1 + 5.2 + 5.4 + 5.5 + 5.8 + 5.9).
- **PR ?? (PR-c)** — Phase 5 pressure + cascade + background mode + LRU test (5.3 + 5.6 + 5.7 + 5.10).

## Tasks shipped

### 5.1 — `WorkingSetTrim` trait (`cache/working_set.rs`)

- Process-level trim hook: `fn trim(&self) -> io::Result<()>`.
- `PlatformWorkingSetTrim`: Windows `EmptyWorkingSet(GetCurrentProcess())` via windows-rs (added `Win32_System_ProcessStatus` feature to the workspace `windows` dep); Mac/Linux returns `Ok(())` immediately (no process-level equivalent that respects mmap'd file backing — the per-region madvise that `Arc::drop` runs handles reclaim).
- `tests::CountingWorkingSetTrim` — atomic counter, deterministic, used by 5.8.

### 5.2 — `Prefetch` trait (`cache/prefetch.rs`)

- Region kernel-prefetch hook: `fn hint(&self, regions: &[PrefetchRegion]) -> io::Result<()>`.
- `PrefetchRegion { ptr: *const u8, len: usize }` with explicit `unsafe impl Send + Sync` (raw-pointer transmission is sound; dereference is guarded by the body `Arc` kept alive across the call).  SAFETY comments + `#[expect(unsafe_code, reason)]` follow the `bulk_iocp.rs` pattern so production lint passes.
- `PlatformPrefetch`: Windows single `PrefetchVirtualMemory` with a stack-allocated `WIN32_MEMORY_RANGE_ENTRY[]`; Mac/Linux loops `posix_madvise(_, _, MADV_WILLNEED)` per region (heap regions are no-op'd by the kernel; mmap regions get a readahead nudge).
- `tests::RecordingPrefetch` — captures every `hint()` call as `Vec<Vec<(usize, usize)>>` so 5.9 can match against body region pointers without juggling raw-ptr equality.

### 5.4 — Wire `trim()` into `demote_idle_shards`

Single call per applied batch, after the index-version bump, gated on `applied > 0` so empty-batch ticks don't fire the syscall.  Errors logged at `target: "shard.transition"` reason `"demote-batch"`; daemon continues on failure.  Coalescing matters: `EmptyWorkingSet` is process-wide on Windows, so per-shard calls would be wasted syscalls for a multi-shard batch.

### 5.5 — Wire `hint()` into `ensure_warm_for_dispatch` promote path

Hooked inside the per-letter `spawn_blocking` task, right after `BodyLoader::load` returns `Some(body)` and before the registry write-lock swap.  Kernel prefetch overlaps with lock acquisition.  Two regions, fixed order: **records** (typed slice, byte length via `size_of_val`) then **names** (raw `u8` slice).  Body `Arc` keeps the underlying allocation / mmap alive across the call.  Errors logged and ignored — the shard still promotes.

### IndexManager constructors

- Replaced `new_with_body_loader` with `new_with_lifecycle_hooks` that threads body-loader + working-set-trim + prefetch.
- `new()` wires `PlatformWorkingSetTrim` + `PlatformPrefetch`.
- `with_body_loader_for_test` (existing tests) keeps backward compat — gets the platform hooks for free.
- New `with_lifecycle_hooks_for_test` for the Phase 5 tests that need to inject all three fakes.

### 5.8 + 5.9 — Mac tests

- `demote_idle_shards_invokes_working_set_trim_once_per_batch` — 3 drives backdated past `WARM_TO_PARKED_IDLE_SECS`, single batch demote, asserts `counting_trim.calls() == 1` (not 3, not 0).  Plus a follow-up no-op tick that asserts `applied > 0` gating prevents redundant trims.
- `ensure_warm_for_dispatch_invokes_prefetch_with_records_and_names_regions` — demote C→Parked, ensure-warm, asserts the `RecordingPrefetch` captured exactly one `hint()` call with two regions whose `(ptr-as-usize, len)` match `body.records.as_slice()` and `body.names.as_slice()` respectively, in that order.
- Plus four colocated unit tests in `cache/working_set` and `cache/prefetch` covering the platform stubs and the recording / counting fakes.

## Mac gate

```
just lint-fast            ✅
cargo nextest --workspace  ✅ 1496 passed, 14 skipped
just check-windows         ✅
just check-all-targets     ✅
```

Refs: `docs/refactor/memory-tiering-implementation-plan.md` (local-only) tasks 5.1, 5.2, 5.4, 5.5, 5.8, 5.9.