### PR TITLE
fix(core): self-heal v0.4.23 legacy <DRIVE>_compact.uffs directories on Unix

### DIFF
--- a/crates/uffs-core/src/compact_cache.rs
+++ b/crates/uffs-core/src/compact_cache.rs
@@ -149,6 +149,80 @@ pub fn compact_cache_path(drive_letter: char) -> PathBuf {
     uffs_mft::cache::cache_dir().join(format!("{drive_letter}_compact.uffs"))
 }
 
+/// Remove a stale **directory** at the compact-cache target path, if any.
+///
+/// # Background — the v0.4.23 legacy layout
+///
+/// Commit `a88041a30` (v0.4.23, 2026-03-28) introduced
+/// [`save_compact_cache`] with the wrong call shape:
+///
+/// ```ignore
+/// uffs_mft::cache::create_secure_dir(&path)?;          // BUG: makes <DRIVE>_compact.uffs a DIRECTORY
+/// uffs_mft::cache::atomic_write(&path, &encrypted)?;   // rename(.tmp, dir) → EISDIR on Mac/Linux
+/// ```
+///
+/// `create_secure_dir(<file_path>)` `mkdir -p`'d the cache *file path* as
+/// a (always-empty) directory; the subsequent `atomic_write` rename then
+/// failed silently with `EISDIR` (`os error 21`) on every Unix host.
+/// The fix landed in commit `335028444` (v0.4.27) — the call now passes
+/// `path.parent()` — but the empty legacy directories remain on disk for
+/// any user who ran v0.4.23 → v0.4.26.  Without this helper every
+/// subsequent `save_compact_cache(_background)` continues to fail
+/// silently on those drives, the demote→promote cycle finds no on-disk
+/// body, and search returns zero results from Parked drives.
+///
+/// # Behaviour
+///
+/// * Path doesn't exist (cold-boot first save) → `Ok(())`, no-op.
+/// * Path is a regular file (or symlink) → `Ok(())`; [`atomic_write`] will
+///   replace it.
+/// * Path is an **empty** directory → `remove_dir`, warn-log the recovery,
+///   return `Ok(())`.
+/// * Path is a **non-empty** directory → return the underlying `ENOTEMPTY`
+///   error and error-log; we deliberately refuse to `remove_dir_all` so any
+///   future bug producing populated state at this path surfaces loudly instead
+///   of silently destroying user data.  The v0.4.23 layout is empirically empty
+///   (verified against dogfood Mac filesystem state on 2026-04-28).
+///
+/// Self-heal: after the first successful `save_compact_cache(_background)`
+/// the path is a regular file and this helper is a metadata-only no-op
+/// on every subsequent call.
+///
+/// [`atomic_write`]: uffs_mft::cache::atomic_write
+fn purge_legacy_compact_cache_dir(path: &Path, drive: char) -> io::Result<()> {
+    let Ok(meta) = std::fs::symlink_metadata(path) else {
+        // Path doesn't exist — nothing to purge.  `symlink_metadata`
+        // (not `metadata`) so we don't follow a symlink and accidentally
+        // probe the wrong inode.
+        return Ok(());
+    };
+    if !meta.is_dir() {
+        // Already a regular file (or symlink) — `atomic_write`'s rename
+        // will replace it.
+        return Ok(());
+    }
+    match std::fs::remove_dir(path) {
+        Ok(()) => {
+            tracing::warn!(
+                drive = %drive,
+                path = %path.display(),
+                "Removed legacy v0.4.23 compact-cache directory; saving file at this path now",
+            );
+            Ok(())
+        }
+        Err(err) => {
+            tracing::error!(
+                drive = %drive,
+                path = %path.display(),
+                error = %err,
+                "Compact-cache path is a non-empty directory — refusing to remove. \
+                 Manual intervention required: inspect and remove the directory at this path.",
+            );
+            Err(err)
+        }
+    }
+}
+
 /// Process-static counter used by [`compact_runtime_tempfile_path`] to
 /// disambiguate re-entrant calls into the same daemon process.
 ///
@@ -763,6 +837,11 @@ pub fn save_compact_cache(index: &DriveCompactIndex) -> io::Result<()> {
     if let Some(dir) = path.parent() {
         uffs_mft::cache::create_secure_dir(dir)?;
     }
+    // Purge the v0.4.23 legacy directory at the cache file path before
+    // `atomic_write` (called inside `compress_encrypt_write_streaming`)
+    // hits an EISDIR rename failure.  No-op for cold-boot first saves
+    // and for every save after the first successful one.
+    purge_legacy_compact_cache_dir(&path, index.letter)?;
     uffs_mft::cache::compress_encrypt_write_streaming(
         |encoder| serialize_compact_to_writer(index, encoder),
         &path,
@@ -838,6 +917,10 @@ fn encrypt_and_write(
     let encrypted = uffs_security::crypto::encrypt_cache(&compressed, &key)?;
     // Drop compressed — only encrypted needed for write.
     drop(compressed);
+    // Purge the v0.4.23 legacy directory at the target path so the
+    // following `atomic_write` rename does not hit EISDIR.  Runs on the
+    // background thread so the (rare) error path keeps full context.
+    purge_legacy_compact_cache_dir(path, drive)?;
     uffs_mft::cache::atomic_write(path, &encrypted)?;
     if profile {
         let enc_write_ms = t_enc.elapsed().as_millis();

--- a/crates/uffs-core/src/compact_cache/tests.rs
+++ b/crates/uffs-core/src/compact_cache/tests.rs
@@ -401,3 +401,97 @@ fn heap_path_yields_vec_backed_columns() {
         "names column must NOT be Mmap-backed after deserialize_compact"
     );
 }
+
+// ─── Mac wake-up regression: purge_legacy_compact_cache_dir contract ───
+//
+// Pin the four-arm behaviour of [`super::purge_legacy_compact_cache_dir`]
+// so the v0.4.23 legacy-directory recovery path can never silently
+// regress.  Each test sets up the on-disk state directly inside a
+// `tempfile::TempDir` (no dependence on the global `cache_dir()`), then
+// exercises the helper and asserts both the return value and the
+// resulting filesystem state.
+
+/// Path doesn't exist → `Ok(())`, filesystem unchanged.  Cold-boot
+/// first save hits this arm.
+#[test]
+fn purge_legacy_dir_missing_path_is_noop() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("Z_compact.uffs");
+    assert!(!path.exists(), "precondition: path absent");
+
+    purge_legacy_compact_cache_dir(&path, 'Z').expect("missing path must be Ok(())");
+
+    assert!(
+        !path.exists(),
+        "missing path must remain missing after purge"
+    );
+}
+
+/// Path is a regular file → `Ok(())`, file untouched.  Steady-state
+/// after the first successful save lands here on every subsequent call.
+#[test]
+fn purge_legacy_dir_regular_file_is_noop() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("Z_compact.uffs");
+    std::fs::write(&path, b"existing cache bytes").expect("seed regular file");
+
+    purge_legacy_compact_cache_dir(&path, 'Z').expect("regular file must be Ok(())");
+
+    let bytes = std::fs::read(&path).expect("regular file must still be readable");
+    assert_eq!(
+        bytes, b"existing cache bytes",
+        "regular file content must survive purge unchanged"
+    );
+}
+
+/// Path is an **empty** directory (the v0.4.23 layout) → directory
+/// removed, helper returns `Ok(())`.  This is the actual legacy state
+/// observed on dogfood Mac filesystems on 2026-04-28.
+#[test]
+fn purge_legacy_dir_empty_directory_is_removed() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("Z_compact.uffs");
+    std::fs::create_dir(&path).expect("seed empty directory");
+    assert!(path.is_dir(), "precondition: path is empty dir");
+
+    purge_legacy_compact_cache_dir(&path, 'Z').expect("empty dir must be Ok(())");
+
+    assert!(
+        !path.exists(),
+        "empty legacy directory must be removed by purge"
+    );
+}
+
+/// Path is a **non-empty** directory → helper returns `Err` (the
+/// underlying `ENOTEMPTY`) and the directory is left intact.  Defensive
+/// guard against a hypothetical future regression that populates the
+/// path: we want the daemon to surface the failure loudly rather than
+/// silently `remove_dir_all` user data.
+#[test]
+fn purge_legacy_dir_non_empty_directory_is_refused() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("Z_compact.uffs");
+    std::fs::create_dir(&path).expect("seed dir");
+    std::fs::write(path.join("unexpected.bin"), b"surprise").expect("seed dir contents");
+
+    let err = purge_legacy_compact_cache_dir(&path, 'Z')
+        .expect_err("non-empty dir must propagate the underlying io::Error");
+    assert!(
+        matches!(
+            err.kind(),
+            io::ErrorKind::DirectoryNotEmpty | io::ErrorKind::Other
+        ),
+        "non-empty dir must produce DirectoryNotEmpty (or fall back to Other on \
+         older platforms); got {kind:?}",
+        kind = err.kind(),
+    );
+
+    assert!(
+        path.is_dir(),
+        "non-empty dir must remain on disk after refused purge",
+    );
+    assert!(
+        path.join("unexpected.bin").is_file(),
+        "non-empty dir contents must be untouched after refused purge",
+    );
+}


### PR DESCRIPTION
## Symptom

Mac dogfood (v0.5.82): after a Parked drive's idle TTL fires, `uffs search --drive C "*.rs"` returns zero results and the drive does not promote back to Warm — even though the drive cold-booted successfully at daemon start. Drive `F` (added later) works. Both observed simultaneously on the same daemon process.

## Root cause

Commit `a88041a30` (v0.4.23, 2026-03-28) introduced `save_compact_cache` with the wrong call shape:

```rust
uffs_mft::cache::create_secure_dir(&path)?;          // BUG: mkdir <DRIVE>_compact.uffs/
uffs_mft::cache::atomic_write(&path, &encrypted)?;   // rename(.tmp, dir) → EISDIR
```

`create_secure_dir(<file_path>)` `mkdir -p`'d the cache *file path* as a (always-empty) directory; the subsequent `atomic_write` rename then failed silently with `EISDIR (os error 21)` on every Unix host. Fixed in commit `335028444` (v0.4.27) via `create_secure_dir(path.parent())`, but the empty legacy directories remain on disk for any user who ran v0.4.23 → v0.4.26.

Verified on the affected Mac (2026-04-28):

```
drwx------@  2 rnio  staff   64 Mar 28 14:05 C_compact.uffs/   ← empty dir
drwx------@  2 rnio  staff   64 Mar 28 14:14 D_compact.uffs/
drwx------@  2 rnio  staff   64 Mar 28 14:14 E_compact.uffs/
-rw-------@  1 rnio  staff  ... Apr 28 16:53 F_compact.uffs    ← OK file
-rw-------@  1 rnio  staff  ... Apr 28 16:53 G_compact.uffs    ← OK file
drwx------@  2 rnio  staff   64 Mar 28 14:15 M_compact.uffs/
drwx------@  2 rnio  staff   64 Mar 28 14:15 S_compact.uffs/
```

Without recovery, every `save_compact_cache(_background)` continues to warn-fail on those drives; the demote→promote cycle finds no on-disk body; promote-on-search reads the directory as a file (`std::fs::read` → `EISDIR`) and returns `None`; search dispatch sees zero matches.

The `F` and `G` drives work because they were added to this Mac after v0.4.27; their paths were never poisoned. This perfectly matches the dogfood report (only `C/D/E/M/S` regressed).

Windows is unaffected because that NTFS host installed cleanly post-fix; the bug is platform-agnostic but only manifests on hosts that ran v0.4.23 → v0.4.26 (verified `std::fs::rename(file, dir)` returns `IsADirectory (raw_os 21)` on Mac via a stand-alone Rust repro).

## Fix

New `purge_legacy_compact_cache_dir(path, drive)` helper in `compact_cache.rs` called immediately before `atomic_write` in both save paths:

- `save_compact_cache` (sync path)
- `encrypt_and_write` (background save's actual writer)

Behaviour:

- missing → `Ok(())` (cold-boot first save)
- regular file / symlink → `Ok(())` (atomic_write will replace)
- **empty** directory → `remove_dir` + warn-log → `Ok(())`
- **non-empty** directory → propagate `ENOTEMPTY` + error-log

Deliberately uses `remove_dir` (empty-only) rather than `remove_dir_all` so any future regression producing populated state at this path surfaces loudly instead of silently destroying user data. The v0.4.23 layout is empirically empty (verified on dogfood Mac).

**Self-heal**: after the first successful save, the path is a regular file and the helper is a metadata-only no-op forever after. No daemon-startup scrubber, no separate migration tool — the next cold-boot `save_compact_cache_background` recovers each affected drive.

## Tests (4 new)

`compact_cache::tests::purge_legacy_dir_*` pin the four-arm contract deterministically using `tempfile::TempDir` (no dependence on the global `cache_dir()`):

- `purge_legacy_dir_missing_path_is_noop`
- `purge_legacy_dir_regular_file_is_noop`
- `purge_legacy_dir_empty_directory_is_removed` ← the v0.4.23 case
- `purge_legacy_dir_non_empty_directory_is_refused` ← defensive guard

## Verification

- `cargo nextest run -p uffs-core --lib` — 810 pass (incl. 4 new)
- `cargo nextest run -p uffs-daemon --lib` — 167 pass
- `cargo clippy --workspace --lib --tests` — clean
- `RUSTDOCFLAGS='-D rustdoc::broken-intra-doc-links' cargo doc -p uffs-core --no-deps` — clean
- Pre-push gate: fmt, file-size, typos, reuse, cargo-check, lint-ci, lint-prod, lint-tests, rustdoc, doc-tests, tests, smoke, check-windows — all green (67s)

## Manual recovery (already applied to the affected Mac)

For users who want to recover *before* deploying the patched binary:

```bash
# macOS / Linux
for d in $(ls ~/Library/Caches/com.uffs/ 2>/dev/null || ls ~/.cache/uffs/); do
  case "$d" in *_compact.uffs)
    target="$HOME/Library/Caches/com.uffs/$d"
    [ -d "$target" ] && [ -z "$(ls -A "$target")" ] && rmdir "$target" && echo "removed: $target" ;;
  esac
done
```

After the patched binary lands, this manual step is unnecessary — the daemon self-heals on its first cold-boot save.

## Files changed

- `crates/uffs-core/src/compact_cache.rs` (+83) — helper + two callsites
- `crates/uffs-core/src/compact_cache/tests.rs` (+94) — 4 regression tests
