### PR TITLE
fix(daemon): PR-f — refresh last_query_at_ms on promote to prevent demote thrash

### DIFF
--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -1206,6 +1206,36 @@ impl IndexManager {
             };
             let mut guard = self.index.write().await;
             if let Some(new_registry) = guard.promote_letter(letter, body) {
+                // PR-f — refresh the freshly-promoted shard's
+                // `last_query_at_ms` to "now" so the demote-idle
+                // controller's first 30 s tick after this promote sees
+                // a fresh idle clock rather than the stale value the
+                // shard carried from before parking.  Without this
+                // bump, a shard whose last_query_at_ms is more than
+                // `WARM_TO_PARKED_IDLE_SECS` (default 300 s) in the
+                // past — common when re-promoting after a long idle
+                // window — will be re-demoted on the very next tick,
+                // before `record_search_dispatch` runs at the end of
+                // the search to stamp the canonical timestamp.  The
+                // observed promote-then-immediate-demote thrash on
+                // the v0.5.85 Windows soak (G/F/M demoted within 0.5
+                // –5 s of their respective promotes) was caused
+                // exactly by this gap.  See the regression test
+                // `promote_resets_idle_clock_against_thrash` in
+                // `crate::index::tests::idle_demote`.
+                //
+                // Mirrors the seed in `Self::add_drive` line 988 and
+                // `Self::replace_drive` line 1017; uses
+                // `mark_loaded_at` (single-store, no
+                // queries_total bump) so the per-drive query count
+                // stays accurate.
+                let now_ms = unix_now_ms();
+                if let Some(shard) = new_registry
+                    .iter()
+                    .find(|shard| shard.drive.eq_ignore_ascii_case(&letter))
+                {
+                    shard.stats.mark_loaded_at(now_ms);
+                }
                 *guard = Arc::new(new_registry);
                 drop(guard);
                 self.bump_index_version();

--- a/crates/uffs-daemon/src/index/tests/idle_demote.rs
+++ b/crates/uffs-daemon/src/index/tests/idle_demote.rs
@@ -682,3 +682,109 @@ impl tracing::field::Visit for FieldCapture {
         self.fields.push((field.name().to_owned(), stripped));
     }
 }
+
+// ── PR-f — promote-side `mark_loaded_at` regression test ──────────
+
+/// Pin the PR-f fix at
+/// `@/Users/rnio/Private/Github/UltraFastFileSearch/crates/uffs-daemon/src/
+/// index/mod.rs:1208` — promoting a Parked shard whose `last_query_at_ms` is
+/// older than `WARM_TO_PARKED_IDLE_SECS` must NOT cause an
+/// immediate-re-demote on the very next idle tick.
+///
+/// **Background:** the v0.5.85 Windows soak captured a clear
+/// promote-then-immediate-demote thrash in the daemon log (lines
+/// 5540 → 5733 of `LOG/windows 0.5.85`):
+///
+/// ```text
+/// 21:46:59.819  letter=G from=parked to=warm restored_mb=1
+/// 21:47:04.754  letter=G from=warm   to=parked freed_mb=1
+///                              ↑ only 4.9 s of "warm" life
+/// 21:47:11      letter=G from=parked to=warm restored_mb=1   ← thrash
+/// ```
+///
+/// Three drives (G/F/M) were re-demoted within 0.5 – 5 s of their
+/// promotes, then re-promoted seconds later when the search
+/// finally completed `ensure_warm_for_dispatch` and ran
+/// `record_search_dispatch`.
+///
+/// **Root cause:** `IndexManager::ensure_warm_for_dispatch`'s
+/// per-letter promote loop did the registry write-swap but did
+/// not stamp `last_query_at_ms` on the freshly-promoted shard.
+/// The shard inherited its pre-park value from the previous
+/// `Arc<DriveStats>` (preserved by `new_warm_with_stats`).  When
+/// the shard had been Parked for > 5 min, that inherited value
+/// was already past `WARM_TO_PARKED_IDLE_SECS`, so the very next
+/// 30-s `demote_idle_shards` tick (firing while the search was
+/// still awaiting other concurrent loads) re-demoted the shard
+/// before the eventual `record_search_dispatch` could refresh it.
+///
+/// **Fix:** call `shard.stats.mark_loaded_at(now_ms)` right after
+/// the promote write-swap, mirroring the seed in
+/// `Self::add_drive` and `Self::replace_drive`.
+///
+/// **Test sequence:**
+///
+/// 1. Add C with a fresh load timestamp (Phase-3 default).
+/// 2. Park C, then backdate `last_query_at_ms` to a deep-past value (year 2001,
+///    ≪ `WARM_TO_PARKED_IDLE_SECS` ago by any real wall clock).  This
+///    faithfully reproduces the v0.5.85 state: a parked shard whose timestamp
+///    is from a long time ago.
+/// 3. Promote C via `ensure_warm_for_dispatch`.
+/// 4. Immediately fire one `demote_idle_shards(unix_now_ms())` tick — the same
+///    race-window the Windows soak hit.
+/// 5. Assert C is still Warm.  Without PR-f, `idle_secs` would be
+///    `(unix_now_ms() - 1_000_000_000) / 1000 ≫ 300`, so the shard would
+///    re-demote.  With PR-f, `last_query_at_ms ≈ unix_now_ms()` after the
+///    promote, so `idle_secs ≈ 0` and the shard stays Warm.
+#[tokio::test]
+async fn promote_resets_idle_clock_against_thrash() {
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let body = Arc::new(build_test_drive());
+    let loader = Arc::new(FixedBodyLoader {
+        body: Arc::clone(&body),
+    });
+    let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
+    mgr.add_drive(build_test_drive()).await;
+
+    // ── Step 1–2: Park C and backdate `last_query_at_ms` to
+    // simulate a shard that has been Parked for a very long time
+    // (the production thrash precondition).
+    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    let ancient_ts_ms = 1_000_000_000_u64; // 2001-09-09T01:46:40Z
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test('C', ancient_ts_ms)
+            .await,
+        "test fixture must be able to backdate last_query_at_ms",
+    );
+
+    // ── Step 3: Promote.  PR-f bumps `last_query_at_ms` to
+    // ~`unix_now_ms()` inside the registry write-swap.
+    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
+    assert_eq!(
+        mgr.shard_states_for_test().await,
+        vec![('C', ShardState::Warm)],
+        "ensure_warm_for_dispatch must promote Parked → Warm",
+    );
+
+    // ── Step 4: Idle tick at "real now".  Without PR-f the demote
+    // controller sees the still-stale ancient_ts_ms → idle_secs
+    // ~25 years → re-demote.  With PR-f the promote refreshed the
+    // timestamp → idle_secs ≈ 0 → no demote.
+    let now_ms = crate::cache::unix_now_ms();
+    mgr.demote_idle_shards(now_ms).await;
+
+    // ── Step 5: Assert no re-demote.  Pre-PR-f this assertion
+    // fails: states_post_tick == [('C', Parked)].  Post-PR-f the
+    // shard stays Warm.
+    assert_eq!(
+        mgr.shard_states_for_test().await,
+        vec![('C', ShardState::Warm)],
+        "promote must refresh `last_query_at_ms` so the next idle \
+         tick sees a fresh idle clock; without the PR-f \
+         `mark_loaded_at(now_ms)` bump, this re-demotes immediately \
+         (the v0.5.85 Windows soak thrash captured at \
+         `LOG/windows 0.5.85` lines 5540 → 5733)",
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the **promote-then-immediate-demote thrash** captured live on the v0.5.85 Windows soak. When `IndexManager::ensure_warm_for_dispatch` promoted a Parked shard back to Warm, the new `ShardEntry` inherited its pre-park `last_query_at_ms` from the preserved `Arc<DriveStats>`. If the shard had been Parked for longer than `WARM_TO_PARKED_IDLE_SECS` (default 300 s) — the common case — the very next 30 s `demote_idle_shards` tick re-demoted the shard before `record_search_dispatch` could stamp a fresh timestamp.

This is the only Phase-5 regression observed in the live soak; the other lines (5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 5.10, 5.11) are all behaving correctly.

## Live evidence (Windows v0.5.85, 2026-04-30)

From `LOG/windows 0.5.85` lines 5540 → 5733:

```
21:46:59.819  letter=G from=parked to=warm   restored_mb=1
21:47:04.754  letter=G from=warm   to=parked freed_mb=1     ← only 4.9 s warm
21:47:11      letter=G from=parked to=warm   restored_mb=1   ← thrash
```

Drives G/F/M each round-tripped within 0.5 – 5 s of their respective promotes — far shorter than `WARM_TO_PARKED_IDLE_SECS`.

## Root cause

`IndexManager::ensure_warm_for_dispatch` did the registry write-swap with `promote_letter` but did **not** stamp `last_query_at_ms` on the freshly-promoted shard. Because `new_warm_with_stats` preserves the `Arc<DriveStats>` from before parking, the shard came back with a stale timestamp, often days/hours old.

The demote controller fires every 30 s, so the race window between "shard is Warm in registry" and "search completes and calls `record_search_dispatch`" was wide enough to consistently re-demote on the very first tick.

## Fix

Stamp `shard.stats.mark_loaded_at(now_ms)` inside the registry write-swap immediately after `promote_letter`, mirroring the seed in `Self::add_drive` (line 988) and `Self::replace_drive` (line 1017). `mark_loaded_at` uses a single relaxed store with no `queries_total` bump so per-drive query counts stay accurate.

## Regression test

`promote_resets_idle_clock_against_thrash` (in `crates/uffs-daemon/src/index/tests/idle_demote.rs`):

1. Add C, Park C, backdate `last_query_at_ms` to year 2001.
2. Promote via `ensure_warm_for_dispatch`.
3. Immediately fire one `demote_idle_shards(unix_now_ms())` tick.
4. Assert C is still Warm.

**Pre-fix:** test fails with `[('C', Parked)]` (re-demotes on the immediate tick).
**Post-fix:** test passes (idle_secs ≈ 0 after promote → no demote).

All 11 `idle_demote` tests pass; full `uffs-daemon` suite at 181/181.

## Diff size

```
 crates/uffs-daemon/src/index/mod.rs               | +30  (7 functional lines + 23 of doc-comment)
 crates/uffs-daemon/src/index/tests/idle_demote.rs | +106 (regression test + extensive docs)
```

## Hard-rules audit

- **No suppression hacks** — surgical 7-line fix at the root cause. No `#[allow]`, no `#[ignore]`, no test relaxation.
- **Surgical correct fix** — one `mark_loaded_at` call mirroring two existing call sites (`add_drive`, `replace_drive`). Uses single relaxed store, no `queries_total` side effect.
- **Preserve contracts** — promote and demote public surfaces unchanged; the controller contract (`record_search_dispatch` is the canonical timestamp source) is preserved; `mark_loaded_at` is the sanctioned "freshly-loaded shard" seed already used elsewhere.
- **Strengthen tests** — adds a deterministic regression test that fails pre-fix, passes post-fix, and pins the v0.5.85 Windows-soak log lines as the ground-truth artifact.

## Local validation

- `cargo fmt --all -- --check` ✅
- `cargo clippy -p uffs-daemon --all-targets --all-features -- -D warnings` ✅
- `cargo nextest run -p uffs-daemon` ✅ (181/181 tests)
- `lint-pre-push` (file-size, typos, reuse, cargo-check, lint-ci, lint-prod, lint-tests, rustdoc, doc-tests, tests, smoke, check-windows) ✅ (62 s)

## Follow-up (post-merge)

Resume Phase 6 Commit B (DaemonConfig with serde + toml) on `feat/memory-tiering-phase-6` after this lands. Adaptive TTL formulas (Commit A) are ready to surface once the config wiring is in.