### PR TITLE
Phase 7 (Mac side): per-shard USN journal infrastructure

### DIFF
--- a/crates/uffs-core/src/compact.rs
+++ b/crates/uffs-core/src/compact.rs
@@ -18,14 +18,15 @@ use rayon::prelude::*;
 use uffs_mft::index::MftIndex;
 
 use crate::bloom::Bloom;
+pub use crate::compact_loader::apply_usn_patch;
+#[cfg(windows)]
+#[expect(deprecated, reason = "re-export kept for backward compatibility")]
+pub use crate::compact_loader::load_live_drive;
 // Re-export loader types and functions so callers can still use `compact::*`.
 #[expect(deprecated, reason = "re-export kept for backward compatibility")]
 pub use crate::compact_loader::{
     IndexSource, LoadTiming, MftSource, PatchStats, load_drive, load_mft_file, refresh_drive,
 };
-#[cfg(windows)]
-#[expect(deprecated, reason = "re-export kept for backward compatibility")]
-pub use crate::compact_loader::{apply_usn_patch, load_live_drive};
 use crate::compact_storage::ColumnStorage;
 use crate::path_trie::PathTrie;
 use crate::trigram::TrigramIndex;
@@ -137,6 +138,7 @@ const _: () = assert!(
 /// `children(i)` returns the compact indices of record i's children as
 /// a contiguous `&[u32]` slice.  The CSR layout avoids per-record `Vec`
 /// allocations and enables bulk serialization/deserialization.
+#[derive(Clone)]
 pub struct ChildrenIndex {
     /// CSR offsets — one per record + sentinel.  Length = `record_count` + 1.
     /// Children of record `i` are `values[offsets[i]..offsets[i+1]]`.
@@ -240,6 +242,7 @@ impl ChildrenIndex {
 /// CSR layout identical to `ChildrenIndex`.  Built once at load time in a
 /// single O(N) pass so `--ext rs` queries can iterate only matching records
 /// instead of scanning all 25M entries.
+#[derive(Clone)]
 pub struct ExtensionIndex {
     /// CSR offsets — length = `max_ext_id` + 2 (one per `ext_id` + sentinel).
     offsets: Vec<u32>,
@@ -330,6 +333,7 @@ impl ExtensionIndex {
 }
 
 /// A loaded drive with compact index.
+#[derive(Clone)]
 pub struct DriveCompactIndex {
     /// Drive letter (e.g., 'C').
     pub letter: char,

--- a/crates/uffs-core/src/compact_loader.rs
+++ b/crates/uffs-core/src/compact_loader.rs
@@ -11,10 +11,9 @@ use std::time::Instant;
 
 use uffs_mft::index::MftIndex;
 
-#[cfg(windows)]
-use crate::compact::{ChildrenIndex, CompactRecord};
-use crate::compact::{DriveCompactIndex, INDEX_TTL_SECONDS, build_compact_index};
-#[cfg(windows)]
+use crate::compact::{
+    ChildrenIndex, CompactRecord, DriveCompactIndex, INDEX_TTL_SECONDS, build_compact_index,
+};
 use crate::trigram::TrigramIndex;
 
 /// What produced a given `DriveCompactIndex`.
@@ -465,7 +464,15 @@ pub fn load_live_drive(
 /// Mutates records (`parent_idx`, names, flags) then rebuilds the children CSR
 /// once at the end.  Typical cost: <5ms for record mutations + ~100ms for CSR
 /// rebuild on a 7M-record drive.
-#[cfg(windows)]
+///
+/// **Platform note.**  The function itself is pure data manipulation
+/// over `DriveCompactIndex` + the platform-agnostic
+/// [`uffs_mft::usn::FileChange`] DTO and compiles + runs on all
+/// targets.  Only the *journal source* that produces the
+/// `&[FileChange]` slice (`uffs_mft::usn::read_usn_journal`) is
+/// Windows-only.  This split is what makes the Phase 7 per-shard
+/// patch path Mac-testable end-to-end via synthesised
+/// [`uffs_mft::usn::FileChange`] arrays.
 pub fn apply_usn_patch(
     drive: &mut DriveCompactIndex,
     changes: &[uffs_mft::usn::FileChange],
@@ -585,3 +592,7 @@ pub fn apply_usn_patch(
 
     stats
 }
+
+#[cfg(test)]
+#[path = "compact_loader_tests.rs"]
+mod tests;

--- a/crates/uffs-core/src/compact_loader_tests.rs
+++ b/crates/uffs-core/src/compact_loader_tests.rs
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Unit tests for [`super::apply_usn_patch`] — the platform-agnostic
+//! in-place USN delta applier shared across the daemon's per-shard
+//! USN journal loop (Phase 7 task 7.1).
+//!
+//! These tests exercise the function with synthesised
+//! [`uffs_mft::usn::FileChange`] arrays and a synthesised
+//! [`crate::compact::DriveCompactIndex`] so the contract is pinned
+//! end-to-end **without** requiring a Windows host or a live MFT
+//! source.  The journal source itself
+//! ([`uffs_mft::usn::read_usn_journal`]) is Windows-only; everything
+//! downstream of `read_usn_journal` is covered here.
+//!
+//! Extracted into a sibling submodule so `compact_loader.rs` stays
+//! well below the file-size policy ceiling.
+
+use std::path::PathBuf;
+
+use uffs_mft::usn::FileChange;
+use uffs_text::case_fold::CaseFold;
+
+use super::{IndexSource, apply_usn_patch};
+use crate::compact::{ChildrenIndex, CompactRecord, DriveCompactIndex, ExtensionIndex};
+use crate::compact_storage::ColumnStorage;
+use crate::trigram::TrigramIndex;
+
+/// Build a synthetic 4-record drive: root directory + three files.
+///
+/// FRS layout (NTFS-style) → `compact_idx` mapping:
+///
+/// * FRS  5 → root dir `"C"`        @ `compact_idx` 0
+/// * FRS 10 → `"foo.txt"` parent=5 @ `compact_idx` 1
+/// * FRS 11 → `"bar.rs"`  parent=5 @ `compact_idx` 2
+/// * FRS 12 → `"baz.md"`  parent=5 @ `compact_idx` 3
+///
+/// Returns the drive plus a `frs_to_compact[100]` mapping sized to
+/// cover FRS 13 (newly-created in tests) and FRS 99 (unmapped /
+/// skipped) without bounds-check failures.
+fn make_synthetic_drive() -> (DriveCompactIndex, Vec<u32>) {
+    // Names blob layout:
+    //   "C"       [0..1]
+    //   "foo.txt" [1..8]
+    //   "bar.rs"  [8..14]
+    //   "baz.md"  [14..20]
+    let names = b"Cfoo.txtbar.rsbaz.md".to_vec();
+    let records = vec![
+        CompactRecord {
+            name_offset: 0,
+            flags: 0x10, // directory
+            parent_idx: u32::MAX,
+            name_len: 1,
+            name_first_byte: b'C',
+            ..CompactRecord::default()
+        },
+        CompactRecord {
+            name_offset: 1,
+            parent_idx: 0,
+            name_len: 7,
+            name_first_byte: b'f',
+            ..CompactRecord::default()
+        },
+        CompactRecord {
+            name_offset: 8,
+            parent_idx: 0,
+            name_len: 6,
+            name_first_byte: b'b',
+            ..CompactRecord::default()
+        },
+        CompactRecord {
+            name_offset: 14,
+            parent_idx: 0,
+            name_len: 6,
+            name_first_byte: b'b',
+            ..CompactRecord::default()
+        },
+    ];
+
+    let fold = CaseFold::default_table();
+    let trigram = TrigramIndex::build(&records, &names, fold);
+    let children = ChildrenIndex::build(&records);
+    let ext_index = ExtensionIndex::build(&records);
+
+    let drive = DriveCompactIndex {
+        letter: 'T',
+        records: ColumnStorage::from_vec(records),
+        names: ColumnStorage::from_vec(names),
+        trigram,
+        children,
+        ext_index,
+        fold,
+        ext_names: vec![Box::from("")],
+        source: IndexSource::MftFile(PathBuf::from("T:")),
+        source_epoch: 42,
+        bloom: None,
+        path_trie: None,
+    };
+
+    // FRS → compact_idx mapping.  Sized to cover FRS 13 (newly-created)
+    // and FRS 99 (skipped — no compact slot) without bounds checks.
+    // Built via iterator-collect to avoid `clippy::indexing_slicing`;
+    // FRS 13 left at u32::MAX so the create-branch fires for it.
+    let frs_to_compact: Vec<u32> = (0_usize..100)
+        .map(|frs| match frs {
+            5 => 0_u32,
+            10 => 1,
+            11 => 2,
+            12 => 3,
+            _ => u32::MAX,
+        })
+        .collect();
+
+    (drive, frs_to_compact)
+}
+
+/// Headline contract test: a mixed batch of create / delete / rename /
+/// skip changes lands the matching counters on `PatchStats` without
+/// cross-talk.
+#[test]
+fn apply_usn_patch_handles_create_delete_rename_skip() {
+    let (mut drive, frs_to_compact) = make_synthetic_drive();
+
+    let changes = vec![
+        // Delete FRS 10 ("foo.txt").
+        FileChange {
+            frs: 10,
+            deleted: true,
+            ..FileChange::default()
+        },
+        // Rename FRS 11 ("bar.rs" → "bar2.rs"), parent unchanged.
+        FileChange {
+            frs: 11,
+            parent_frs: 5,
+            filename: "bar2.rs".to_owned(),
+            renamed: true,
+            ..FileChange::default()
+        },
+        // Create FRS 13 ("new.txt", parent=root).
+        FileChange {
+            frs: 13,
+            parent_frs: 5,
+            filename: "new.txt".to_owned(),
+            created: true,
+            ..FileChange::default()
+        },
+        // Skip: FRS 99 doesn't map to any compact record.
+        FileChange {
+            frs: 99,
+            deleted: true,
+            ..FileChange::default()
+        },
+    ];
+
+    let stats = apply_usn_patch(&mut drive, &changes, &frs_to_compact);
+
+    assert_eq!(
+        stats.deleted, 1,
+        "exactly one delete should have applied (FRS 10)"
+    );
+    assert_eq!(
+        stats.created, 1,
+        "exactly one create should have applied (FRS 13)"
+    );
+    assert_eq!(
+        stats.renamed, 1,
+        "exactly one rename should have applied (FRS 11)"
+    );
+    assert_eq!(
+        stats.skipped, 1,
+        "exactly one skip should have happened (FRS 99 unmapped)"
+    );
+}
+
+/// Delete contract: the deleted record's `name_len` is zeroed and its
+/// `parent_idx` is set to `u32::MAX` so the CSR rebuild excludes it
+/// from any directory's child list (tombstone semantics).
+#[test]
+fn apply_usn_patch_marks_deleted_record_with_zero_name_len() {
+    let (mut drive, frs_to_compact) = make_synthetic_drive();
+    let changes = vec![FileChange {
+        frs: 10,
+        deleted: true,
+        ..FileChange::default()
+    }];
+
+    apply_usn_patch(&mut drive, &changes, &frs_to_compact);
+
+    let record = drive
+        .records
+        .as_slice()
+        .get(1)
+        .expect("synthetic drive has at least 2 records");
+    assert_eq!(record.name_len, 0, "deleted record's name_len must be 0");
+    assert_eq!(
+        record.parent_idx,
+        u32::MAX,
+        "deleted record's parent_idx must be u32::MAX so CSR rebuild excludes it"
+    );
+}
+
+/// Rename contract: the renamed record's `name_offset` points at a
+/// fresh slot in the names blob holding the new bytes, and `name_len`
+/// reflects the new byte count.
+#[test]
+fn apply_usn_patch_renamed_record_has_new_name_in_blob() {
+    let (mut drive, frs_to_compact) = make_synthetic_drive();
+    let changes = vec![FileChange {
+        frs: 11,
+        parent_frs: 5,
+        filename: "bar2.rs".to_owned(),
+        renamed: true,
+        ..FileChange::default()
+    }];
+
+    apply_usn_patch(&mut drive, &changes, &frs_to_compact);
+
+    let record = drive
+        .records
+        .as_slice()
+        .get(2)
+        .expect("synthetic drive has at least 3 records");
+    assert_eq!(record.name_len, 7, "renamed name 'bar2.rs' is 7 bytes");
+
+    let name_start = record.name_offset as usize;
+    let name_end = name_start + record.name_len as usize;
+    let name_bytes = drive
+        .names
+        .as_slice()
+        .get(name_start..name_end)
+        .expect("name slice must lie within names blob");
+    assert_eq!(
+        name_bytes, b"bar2.rs",
+        "renamed record's name slot must hold the new bytes"
+    );
+}
+
+/// Create contract: a newly-created FRS that doesn't map to an
+/// existing compact slot (`frs_to_compact[frs] == u32::MAX`) appends
+/// a fresh record at the end with the correct `parent_idx`,
+/// `name_len`, and `name_first_byte`.
+#[test]
+fn apply_usn_patch_created_record_appended_with_correct_parent() {
+    let (mut drive, frs_to_compact) = make_synthetic_drive();
+    let initial_record_count = drive.records.len();
+
+    let changes = vec![FileChange {
+        frs: 13,
+        parent_frs: 5,
+        filename: "new.txt".to_owned(),
+        created: true,
+        ..FileChange::default()
+    }];
+
+    apply_usn_patch(&mut drive, &changes, &frs_to_compact);
+
+    assert_eq!(
+        drive.records.len(),
+        initial_record_count + 1,
+        "create must append exactly one record"
+    );
+
+    let record = drive
+        .records
+        .as_slice()
+        .get(initial_record_count)
+        .expect("appended record must be reachable at the new tail");
+    assert_eq!(record.name_len, 7, "'new.txt' is 7 bytes");
+    assert_eq!(
+        record.parent_idx, 0,
+        "parent compact_idx should be 0 (root)"
+    );
+    assert_eq!(
+        record.name_first_byte, b'n',
+        "first-byte cache must reflect the new name"
+    );
+}
+
+/// Empty-batch fast path: passing zero changes produces all-zero
+/// stats and leaves the drive byte-for-byte unchanged in shape (same
+/// record count, same names blob length).  Pins that the rebuilt
+/// derived structures don't grow on an empty batch.
+#[test]
+fn apply_usn_patch_no_changes_is_no_op_with_zero_stats() {
+    let (mut drive, frs_to_compact) = make_synthetic_drive();
+    let initial_record_count = drive.records.len();
+    let initial_names_len = drive.names.len();
+
+    let stats = apply_usn_patch(&mut drive, &[], &frs_to_compact);
+
+    assert_eq!(stats.deleted, 0);
+    assert_eq!(stats.created, 0);
+    assert_eq!(stats.renamed, 0);
+    assert_eq!(stats.skipped, 0);
+    assert_eq!(drive.records.len(), initial_record_count);
+    assert_eq!(drive.names.len(), initial_names_len);
+}
+
+/// Rebuild invariant: after `apply_usn_patch` returns, the children
+/// CSR reflects the post-mutation `parent_idx` state.  Specifically,
+/// once a record is deleted (`parent_idx` → `u32::MAX`), the root's
+/// children list must no longer include that record's `compact_idx`.
+#[test]
+fn apply_usn_patch_rebuilds_children_csr_excluding_deletes() {
+    let (mut drive, frs_to_compact) = make_synthetic_drive();
+
+    // Pre-state sanity: root (compact_idx 0) starts with three
+    // children — compact_idx 1 ("foo.txt"), 2 ("bar.rs"), 3 ("baz.md").
+    let initial_root_children: Vec<u32> = drive.children.get(0).to_vec();
+    assert_eq!(
+        initial_root_children.len(),
+        3,
+        "synthetic root starts with three children"
+    );
+
+    let changes = vec![FileChange {
+        frs: 10,
+        deleted: true,
+        ..FileChange::default()
+    }];
+
+    apply_usn_patch(&mut drive, &changes, &frs_to_compact);
+
+    let post_root_children: Vec<u32> = drive.children.get(0).to_vec();
+    assert!(
+        !post_root_children.contains(&1),
+        "deleted compact_idx 1 must not appear in root's children CSR after rebuild"
+    );
+    assert_eq!(
+        post_root_children.len(),
+        2,
+        "root should have two surviving children after one delete"
+    );
+}

--- a/crates/uffs-core/src/trigram.rs
+++ b/crates/uffs-core/src/trigram.rs
@@ -46,6 +46,7 @@ use crate::compact::CompactRecord;
 /// Trigram inverted index in CSR (Compressed Sparse Row) layout.
 ///
 /// Keys are packed `u64` char-trigrams (3 folded `u16` codepoints).
+#[derive(Clone)]
 pub struct TrigramIndex {
     /// Sorted packed char-trigram keys (`u64`, see [`pack_char_trigram`]).
     keys: Vec<u64>,

--- a/crates/uffs-daemon/Cargo.toml
+++ b/crates/uffs-daemon/Cargo.toml
@@ -93,6 +93,11 @@ proptest.workspace = true
 # Phase 2b of memory-tiering: scoped tempdirs for the runtime-orphan-sweep
 # test in `src/lib.rs::tests`.
 tempfile.workspace = true
+# Phase 7 task 7.2 of memory-tiering: `tokio::test(start_paused = true)` +
+# `tokio::time::advance` for deterministic time-based assertions on the
+# per-shard USN journal loop in `src/cache/journal_loop/tests.rs`.  Matches
+# the pattern already used by `uffs-core`, `uffs-mft`, and `uffs-mcp`.
+tokio = { workspace = true, features = ["test-util", "macros"] }
 
 [lints]
 workspace = true

--- a/crates/uffs-daemon/src/cache/journal_loop.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop.rs
@@ -36,14 +36,10 @@
 //!
 //! ## Phase 7 commit boundary
 //!
-//! This commit (task 7.2 + 7.3) lands the **infrastructure**: trait,
-//! impls, loop body, spawn helper, cancellation handle, tests.
-//! Production spawning from `lib.rs::spawn_load_task` is wired in a
-//! later commit (after task 7.4 threshold-triggered save and
-//! task 7.6/7.7 cursor persistence + wrap detection land), so the
-//! existing Phase-5 5-min global tick (`refresh_usn_for_warm_shards`)
-//! continues to handle live USN refresh until the per-shard path is
-//! activation-complete.
+//! This module lands the per-shard infrastructure (tasks 7.2 / 7.3 /
+//! 7.4 / 7.6 / 7.7).  Production spawning from `lib.rs::spawn_load_task`
+//! waits for the activation commit; until then the existing Phase-5
+//! 5-min global tick (`refresh_usn_for_warm_shards`) is the live path.
 
 use alloc::sync::Arc;
 use core::time::Duration;
@@ -279,6 +275,78 @@ pub(crate) trait PatchSink: Send + Sync + 'static {
     /// the save fails, the implementor logs but does not
     /// propagate — the next threshold crossing will retry.
     fn trigger_save(&self, letter: char, reason: SaveReason);
+
+    /// Notify the sink that the USN journal for `letter` was
+    /// detected to have wrapped (Phase 7 task 7.7).
+    ///
+    /// A wrap is detected when [`JournalPollResult::journal_id`]
+    /// changes between two successive non-zero-id polls — the
+    /// journal was deleted + recreated (Windows admins can do this,
+    /// or the volume can run out of journal space and rotate the
+    /// `$UsnJrnl`).  Incremental patches don't apply across a wrap
+    /// because the FRS → `compact_idx` mapping is now stale, so the
+    /// production sink must force-rebuild the body on the next
+    /// promote (typically by evicting the shard back to Cold and
+    /// letting the standard cold-load path re-read the MFT).
+    ///
+    /// The loop resets its cursor to 0 after this call, so the
+    /// next poll starts from the new journal's head.  No patches
+    /// are applied for the wrap-tick — the sink's `accept` is
+    /// **not** called.
+    fn journal_wrapped(&self, letter: char);
+}
+
+/// Pluggable cursor-persistence surface (Phase 7 task 7.6).
+///
+/// Production wires [`NullCursorStore`] (always-empty) as a
+/// fallback on platforms without a real persisted cursor and the
+/// disk-backed implementation lands in the activation commit.
+/// Tests wire [`tests::FakeCursorStore`] (in-memory `HashMap`)
+/// to drive the load / store path deterministically.
+///
+/// Both methods are **infallible** at the trait level: any
+/// underlying I/O failure must be logged and absorbed by the
+/// implementor (cursor persistence is best-effort — a missed
+/// store just means the next cold-boot re-replays a few extra
+/// seconds of journal entries, which is correct since the body
+/// patcher is idempotent on duplicate change records).
+pub(crate) trait CursorStore: Send + Sync + 'static {
+    /// Load the persisted cursor for `letter`.  Returns 0 (the
+    /// "start from journal head" sentinel) when no cursor has
+    /// been persisted yet or when the load failed.
+    fn load(&self, letter: char) -> u64;
+
+    /// Persist `cursor` for `letter`.  Best-effort — the
+    /// implementor logs failures but does not propagate.  The
+    /// loop calls this every time it fires a save trigger so
+    /// the on-disk cursor advances in lockstep with the on-disk
+    /// snapshot.
+    fn store(&self, letter: char, cursor: u64);
+}
+
+/// Always-empty cursor store: `load` returns 0, `store` is a
+/// no-op.  Used as the production fallback on macOS / Linux
+/// where there is no live journal to persist a cursor for, and
+/// as a default for tests that don't care about the persistence
+/// path.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 7-D forward reference; production wiring \
+                  in `lib.rs::spawn_load_task` lands in the \
+                  activation commit (post-7-E).  Exercised by \
+                  `cache::journal_loop::tests` under `cfg(test)`."
+    )
+)]
+#[derive(Debug, Default)]
+pub(crate) struct NullCursorStore;
+
+impl CursorStore for NullCursorStore {
+    fn load(&self, _letter: char) -> u64 {
+        0
+    }
+    fn store(&self, _letter: char, _cursor: u64) {}
 }
 
 /// Why a [`PatchSink::trigger_save`] call fired.
@@ -375,16 +443,16 @@ impl SaveTrigger {
 ///
 /// Carries the tuning knobs the production loop reads from env
 /// vars and the test loop sets directly.  Keeping these in one
-/// place lets future tasks (7.7 wrap detection, 7.6 cursor
-/// persistence) extend the config without churning the loop
-/// signature.
+/// place lets future tasks extend the config without churning
+/// the loop signature.
 #[derive(Debug, Clone)]
 pub(crate) struct JournalLoopConfig {
     /// Cadence between successive polls.  Default 500 ms.
     pub(crate) poll_interval: Duration,
-    /// Initial cursor passed into the first poll.  Production
-    /// reads this from the persisted `usn.cursor` (Phase 7 task
-    /// 7.6); tests use 0 as a clean-slate baseline.
+    /// Fallback cursor used when the [`CursorStore`] returns 0
+    /// (no persisted cursor for this letter yet).  Tests use 0
+    /// as a clean-slate baseline; production keeps it 0 because
+    /// real cursor seeding flows through the cursor store.
     pub(crate) initial_cursor: u64,
     /// Events-since-last-save ceiling (Phase 7 task 7.4).
     /// Crossing this triggers a [`SaveReason::EventsExceeded`]
@@ -426,6 +494,11 @@ pub(crate) struct JournalLoop {
     source: Arc<dyn JournalSource>,
     /// Plug-in patch consumer.
     sink: Arc<dyn PatchSink>,
+    /// Plug-in cursor-persistence surface (Phase 7 task 7.6).
+    /// Loaded once at start of `run` to seed `cursor`; stored at
+    /// the same time as each `trigger_save` call so on-disk cursor
+    /// and on-disk body advance together.
+    cursor_store: Arc<dyn CursorStore>,
     /// Cancellation channel — set to `true` by the daemon shutdown
     /// path; the loop checks on every iteration and exits cleanly.
     cancel_rx: watch::Receiver<bool>,
@@ -435,17 +508,25 @@ pub(crate) struct JournalLoop {
     /// Mutated on every non-empty tick by [`SaveTrigger::record`]
     /// + [`SaveTrigger::evaluate`].
     save_trigger: SaveTrigger,
+    /// Last `journal_id` observed from a non-zero-id poll
+    /// (Phase 7 task 7.7 wrap detection).  `None` until the first
+    /// non-zero `journal_id` is observed; transitions to
+    /// `Some(id)` on the first such poll, then any subsequent
+    /// poll with `journal_id != id` (and `journal_id != 0`) fires
+    /// `sink.journal_wrapped` and resets the cursor.
+    last_journal_id: Option<u64>,
 }
 
 impl JournalLoop {
     /// Construct a loop bound to `letter`, polling `source`,
-    /// applying via `sink`, watching `cancel_rx`, configured by
-    /// `config`.
+    /// applying via `sink`, persisting cursor via `cursor_store`,
+    /// watching `cancel_rx`, configured by `config`.
     #[must_use]
     pub(crate) fn new(
         letter: char,
         source: Arc<dyn JournalSource>,
         sink: Arc<dyn PatchSink>,
+        cursor_store: Arc<dyn CursorStore>,
         cancel_rx: watch::Receiver<bool>,
         config: JournalLoopConfig,
     ) -> Self {
@@ -453,9 +534,11 @@ impl JournalLoop {
             letter,
             source,
             sink,
+            cursor_store,
             cancel_rx,
             config,
             save_trigger: SaveTrigger::new(),
+            last_journal_id: None,
         }
     }
 
@@ -470,8 +553,14 @@ impl JournalLoop {
     /// reconnect) and the daemon should resume cleanly when the
     /// surface returns.
     pub(crate) async fn run(mut self) {
-        let mut cursor = self.config.initial_cursor;
         let letter = self.letter;
+        // Seed cursor from the persistence store; fall back to
+        // the config's initial_cursor when the store returns 0
+        // (no persisted cursor for this letter yet).
+        let mut cursor = match self.cursor_store.load(letter) {
+            0 => self.config.initial_cursor,
+            persisted => persisted,
+        };
         loop {
             if !wait_for_next_tick(&mut self.cancel_rx, self.config.poll_interval, letter).await {
                 return;
@@ -481,8 +570,32 @@ impl JournalLoop {
                 continue;
             };
 
+            // Wrap-detection (Phase 7 task 7.7): if the journal_id
+            // changed between two successive non-zero-id polls, the
+            // journal was recreated.  Notify the sink, reset cursor
+            // to the new journal's head, skip the patch.
+            if let Some(prev_id) = self.last_journal_id
+                && result.journal_id != 0
+                && result.journal_id != prev_id
+            {
+                tracing::warn!(
+                    drive = %letter,
+                    prev_journal_id = prev_id,
+                    new_journal_id = result.journal_id,
+                    "Journal wrap detected; sink must force-rebuild body"
+                );
+                self.sink.journal_wrapped(letter);
+                cursor = 0;
+                self.last_journal_id = Some(result.journal_id);
+                self.cursor_store.store(letter, cursor);
+                continue;
+            }
+            if result.journal_id != 0 {
+                self.last_journal_id = Some(result.journal_id);
+            }
+
             cursor = result.next_cursor;
-            process_tick(
+            let saved = process_tick(
                 self.sink.as_ref(),
                 letter,
                 cursor,
@@ -491,6 +604,11 @@ impl JournalLoop {
                 self.config.save_threshold_events,
                 self.config.save_threshold_age,
             );
+            // Persist the cursor in lockstep with each save so
+            // on-disk cursor and on-disk body advance together.
+            if saved {
+                self.cursor_store.store(letter, cursor);
+            }
         }
     }
 }
@@ -563,6 +681,9 @@ async fn poll_blocking(
 /// On a non-empty tick, also: (a) records the event count into
 /// `save_trigger`, (b) evaluates the save thresholds, and (c)
 /// fires [`PatchSink::trigger_save`] when a threshold crosses.
+///
+/// **Returns** `true` when a save was triggered this tick (the
+/// caller persists the cursor in lockstep), `false` otherwise.
 fn process_tick(
     sink: &dyn PatchSink,
     letter: char,
@@ -571,15 +692,17 @@ fn process_tick(
     save_trigger: &mut SaveTrigger,
     save_threshold_events: u64,
     save_threshold_age: Duration,
-) {
+) -> bool {
     if changes.is_empty() {
         tracing::trace!(drive = %letter, "Journal poll: no changes");
-        return;
+        return false;
     }
     let accepted = sink.accept(letter, changes);
     save_trigger.record(changes.len() as u64);
+    let mut saved = false;
     if let Some(reason) = save_trigger.evaluate(save_threshold_events, save_threshold_age) {
         sink.trigger_save(letter, reason);
+        saved = true;
         tracing::info!(
             drive = %letter,
             ?reason,
@@ -594,6 +717,7 @@ fn process_tick(
         cursor,
         "Journal poll: applied tick"
     );
+    saved
 }
 
 /// Handle returned by [`spawn_journal_loop`] for cancellation +
@@ -661,10 +785,11 @@ pub(crate) fn spawn_journal_loop(
     letter: char,
     source: Arc<dyn JournalSource>,
     sink: Arc<dyn PatchSink>,
+    cursor_store: Arc<dyn CursorStore>,
     config: JournalLoopConfig,
 ) -> JournalLoopHandle {
     let (cancel_tx, cancel_rx) = watch::channel(false);
-    let loop_state = JournalLoop::new(letter, source, sink, cancel_rx, config);
+    let loop_state = JournalLoop::new(letter, source, sink, cursor_store, cancel_rx, config);
     let join = tokio::spawn(loop_state.run());
     JournalLoopHandle { cancel_tx, join }
 }

--- a/crates/uffs-daemon/src/cache/journal_loop.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop.rs
@@ -47,6 +47,7 @@
 
 use alloc::sync::Arc;
 use core::time::Duration;
+use std::time::Instant;
 
 use tokio::sync::watch;
 use uffs_mft::usn::FileChange;
@@ -58,6 +59,28 @@ use uffs_mft::usn::FileChange;
 /// long-running soak tests slow the tick down to reduce log noise
 /// without recompiling.
 pub(crate) const DEFAULT_POLL_INTERVAL_MS: u64 = 500;
+
+/// Default events-since-save threshold for triggering a background
+/// compact-cache save (Phase 7 task 7.4).
+///
+/// Sized to approximate the plan's "5% churn" criterion at the
+/// typical 1.3 GB × ~7 M-record drive shape (`50_000` events ≈ 0.7%
+/// churn, comfortably below 5%).  Saving more frequently would
+/// thrash the disk; less frequently would let the on-disk snapshot
+/// drift far enough that a cold-boot replay window grows beyond
+/// the cost of an incremental save.
+pub(crate) const DEFAULT_SAVE_THRESHOLD_EVENTS: u64 = 50_000;
+
+/// Default time-since-save threshold for triggering a background
+/// compact-cache save (Phase 7 task 7.4) — 5 minutes.
+///
+/// Provides a wall-clock ceiling for how stale the on-disk snapshot
+/// can get under low-churn workloads (where the events-threshold
+/// would never fire on its own).  Five minutes matches the cadence
+/// of the existing Phase-5 `refresh_usn_for_warm_shards` global
+/// tick so the persistence guarantee carries over to the per-shard
+/// path without changing the operator-visible recovery window.
+pub(crate) const DEFAULT_SAVE_THRESHOLD_AGE: Duration = Duration::from_mins(5);
 
 /// Result of one [`JournalSource::poll`] call.
 ///
@@ -241,14 +264,120 @@ pub(crate) trait PatchSink: Send + Sync + 'static {
     /// shard, registry race, etc.).  The boolean is purely
     /// informational — the loop continues in either case.
     fn accept(&self, letter: char, changes: &[FileChange]) -> bool;
+
+    /// Trigger a background compact-cache save for `letter`.
+    ///
+    /// Phase 7 task 7.4 — the loop calls this when the
+    /// per-shard [`SaveTrigger`] decides the in-memory body has
+    /// drifted far enough from the on-disk snapshot that a
+    /// persist is warranted.  Production wires this to
+    /// [`uffs_core::compact_cache::save_compact_cache_background`];
+    /// tests record the call for assertion.
+    ///
+    /// The trigger is **fire-and-forget**.  The save runs on a
+    /// background thread; the loop does not wait for it.  If
+    /// the save fails, the implementor logs but does not
+    /// propagate — the next threshold crossing will retry.
+    fn trigger_save(&self, letter: char, reason: SaveReason);
+}
+
+/// Why a [`PatchSink::trigger_save`] call fired.
+///
+/// Encoded so observability surfaces (logs, metrics) can
+/// distinguish heavy-churn-driven saves from time-pressure-driven
+/// saves; the production sink also passes this through to the
+/// compact-cache writer for telemetry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SaveReason {
+    /// `events_since_save >= save_threshold_events` — lots of
+    /// churn has accumulated and the on-disk snapshot is
+    /// progressively stale.
+    EventsExceeded,
+    /// `Instant::now() - last_save_at >= save_threshold_age` —
+    /// time-pressure path for low-churn drives where the
+    /// events threshold would otherwise never fire.
+    AgeElapsed,
+}
+
+/// Per-shard save-threshold state machine (Phase 7 task 7.4).
+///
+/// Tracks the wall-clock time of the last save trigger and the
+/// number of events accumulated since.  Crossing either the
+/// events- or age-threshold (with at least one event pending)
+/// produces a [`SaveReason`] and resets both counters.  Held
+/// inside the [`JournalLoop`] so each per-shard task carries
+/// its own independent counters.
+#[derive(Debug)]
+struct SaveTrigger {
+    /// Wall-clock time of the last save trigger (or, before any
+    /// triggers, the loop's spawn time).  Compared against
+    /// `Instant::now()` to compute elapsed-since-last-save.
+    last_save_at: Instant,
+    /// Total events accumulated across [`Self::record`] calls
+    /// since the last save trigger.  Compared against
+    /// `save_threshold_events` to fire the events-based save.
+    events_since_save: u64,
+}
+
+impl SaveTrigger {
+    /// Construct a fresh trigger with `last_save_at` set to
+    /// `Instant::now()` (so the first age-based save can't fire
+    /// until at least `save_threshold_age` has elapsed since
+    /// loop spawn).
+    fn new() -> Self {
+        Self {
+            last_save_at: Instant::now(),
+            events_since_save: 0,
+        }
+    }
+
+    /// Record `change_count` events accumulating toward the
+    /// events-based threshold.  Saturating add so a runaway
+    /// drive can't wrap and silently miss the threshold.
+    const fn record(&mut self, change_count: u64) {
+        self.events_since_save = self.events_since_save.saturating_add(change_count);
+    }
+
+    /// Evaluate the thresholds.
+    ///
+    /// **Returns** `Some(reason)` if a save should fire — and
+    /// resets both counters as a side effect (so the next
+    /// `evaluate` after a save starts from a clean slate).
+    /// Returns `None` when no threshold is crossed *or* when no
+    /// events are pending (zero-churn drives never produce
+    /// no-op saves).
+    fn evaluate(
+        &mut self,
+        save_threshold_events: u64,
+        save_threshold_age: Duration,
+    ) -> Option<SaveReason> {
+        if self.events_since_save == 0 {
+            return None;
+        }
+        let now = Instant::now();
+        let elapsed = now.saturating_duration_since(self.last_save_at);
+        let reason = if self.events_since_save >= save_threshold_events {
+            Some(SaveReason::EventsExceeded)
+        } else if elapsed >= save_threshold_age {
+            Some(SaveReason::AgeElapsed)
+        } else {
+            None
+        };
+        if reason.is_some() {
+            self.last_save_at = now;
+            self.events_since_save = 0;
+        }
+        reason
+    }
 }
 
 /// Configuration for a single [`JournalLoop`] task.
 ///
 /// Carries the tuning knobs the production loop reads from env
 /// vars and the test loop sets directly.  Keeping these in one
-/// place lets future tasks (7.4 thresholds, 7.7 wrap detection)
-/// extend the config without churning the loop signature.
+/// place lets future tasks (7.7 wrap detection, 7.6 cursor
+/// persistence) extend the config without churning the loop
+/// signature.
 #[derive(Debug, Clone)]
 pub(crate) struct JournalLoopConfig {
     /// Cadence between successive polls.  Default 500 ms.
@@ -257,6 +386,15 @@ pub(crate) struct JournalLoopConfig {
     /// reads this from the persisted `usn.cursor` (Phase 7 task
     /// 7.6); tests use 0 as a clean-slate baseline.
     pub(crate) initial_cursor: u64,
+    /// Events-since-last-save ceiling (Phase 7 task 7.4).
+    /// Crossing this triggers a [`SaveReason::EventsExceeded`]
+    /// save.  Default [`DEFAULT_SAVE_THRESHOLD_EVENTS`] (50K).
+    pub(crate) save_threshold_events: u64,
+    /// Time-since-last-save ceiling (Phase 7 task 7.4).
+    /// Crossing this triggers a [`SaveReason::AgeElapsed`] save
+    /// when at least one event is pending.  Default
+    /// [`DEFAULT_SAVE_THRESHOLD_AGE`] (5 min).
+    pub(crate) save_threshold_age: Duration,
 }
 
 impl Default for JournalLoopConfig {
@@ -264,6 +402,8 @@ impl Default for JournalLoopConfig {
         Self {
             poll_interval: Duration::from_millis(DEFAULT_POLL_INTERVAL_MS),
             initial_cursor: 0,
+            save_threshold_events: DEFAULT_SAVE_THRESHOLD_EVENTS,
+            save_threshold_age: DEFAULT_SAVE_THRESHOLD_AGE,
         }
     }
 }
@@ -291,6 +431,10 @@ pub(crate) struct JournalLoop {
     cancel_rx: watch::Receiver<bool>,
     /// Tuning knobs.
     config: JournalLoopConfig,
+    /// Per-shard save-threshold state (Phase 7 task 7.4).
+    /// Mutated on every non-empty tick by [`SaveTrigger::record`]
+    /// + [`SaveTrigger::evaluate`].
+    save_trigger: SaveTrigger,
 }
 
 impl JournalLoop {
@@ -298,7 +442,7 @@ impl JournalLoop {
     /// applying via `sink`, watching `cancel_rx`, configured by
     /// `config`.
     #[must_use]
-    pub(crate) const fn new(
+    pub(crate) fn new(
         letter: char,
         source: Arc<dyn JournalSource>,
         sink: Arc<dyn PatchSink>,
@@ -311,6 +455,7 @@ impl JournalLoop {
             sink,
             cancel_rx,
             config,
+            save_trigger: SaveTrigger::new(),
         }
     }
 
@@ -337,7 +482,15 @@ impl JournalLoop {
             };
 
             cursor = result.next_cursor;
-            process_tick(self.sink.as_ref(), letter, cursor, &result.changes);
+            process_tick(
+                self.sink.as_ref(),
+                letter,
+                cursor,
+                &result.changes,
+                &mut self.save_trigger,
+                self.config.save_threshold_events,
+                self.config.save_threshold_age,
+            );
         }
     }
 }
@@ -406,12 +559,34 @@ async fn poll_blocking(
 
 /// Apply the post-poll change batch to `sink`, or trace-log the
 /// no-op tick when `changes` is empty.
-fn process_tick(sink: &dyn PatchSink, letter: char, cursor: u64, changes: &[FileChange]) {
+///
+/// On a non-empty tick, also: (a) records the event count into
+/// `save_trigger`, (b) evaluates the save thresholds, and (c)
+/// fires [`PatchSink::trigger_save`] when a threshold crosses.
+fn process_tick(
+    sink: &dyn PatchSink,
+    letter: char,
+    cursor: u64,
+    changes: &[FileChange],
+    save_trigger: &mut SaveTrigger,
+    save_threshold_events: u64,
+    save_threshold_age: Duration,
+) {
     if changes.is_empty() {
         tracing::trace!(drive = %letter, "Journal poll: no changes");
         return;
     }
     let accepted = sink.accept(letter, changes);
+    save_trigger.record(changes.len() as u64);
+    if let Some(reason) = save_trigger.evaluate(save_threshold_events, save_threshold_age) {
+        sink.trigger_save(letter, reason);
+        tracing::info!(
+            drive = %letter,
+            ?reason,
+            cursor,
+            "Journal poll: triggered background compact-cache save"
+        );
+    }
     tracing::debug!(
         drive = %letter,
         accepted,

--- a/crates/uffs-daemon/src/cache/journal_loop.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop.rs
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Per-shard USN journal polling loop (Phase 7 tasks 7.2 + 7.3).
+//!
+//! ## Architecture
+//!
+//! Each loaded shard owns one `tokio::task` polling its drive's USN
+//! journal at [`JournalLoopConfig::poll_interval`] cadence (default
+//! 500 ms, overridable via [`UFFS_USN_POLL_INTERVAL_MS`] for tests
+//! and benchmarks).  Per tick:
+//!
+//! 1. **Poll the journal** via the trait-object [`JournalSource`]. Returns
+//!    `(changes, next_cursor, journal_id)`.  Empty changes is the no-op fast
+//!    path — no patch, no swap, just advance the cursor (still useful as a
+//!    journal-liveness signal so wrap detection in Phase 7 task 7.7 has fresh
+//!    data).
+//! 2. **Apply to the shard** via the caller-supplied [`PatchSink`].  Production
+//!    wires this to a closure that calls
+//!    [`crate::cache::ShardEntry::apply_usn_patch_to_body`] +
+//!    [`crate::cache::ShardRegistry::replace_warm_body`]; tests wire it to a
+//!    recording fake.
+//! 3. **Update cursor** so the next poll picks up only what's new.
+//! 4. **Sleep** until the next deadline, racing the cancellation receiver so
+//!    shutdown takes effect within one poll-interval.
+//!
+//! ## Mac vs Windows split
+//!
+//! The trait is platform-agnostic; the **journal-source impl** is
+//! Windows-only (`WindowsJournalSource` wraps `read_usn_journal`).
+//! On macOS / Linux the production wire-up uses
+//! [`MacStubJournalSource`] which always returns empty changes —
+//! the loop ticks at the configured cadence but produces no patches.
+//! State-machine semantics (cancellation, cursor advance, no-op
+//! ticks) are exercised end-to-end on Mac via [`tests::FakeJournalSource`].
+//!
+//! ## Phase 7 commit boundary
+//!
+//! This commit (task 7.2 + 7.3) lands the **infrastructure**: trait,
+//! impls, loop body, spawn helper, cancellation handle, tests.
+//! Production spawning from `lib.rs::spawn_load_task` is wired in a
+//! later commit (after task 7.4 threshold-triggered save and
+//! task 7.6/7.7 cursor persistence + wrap detection land), so the
+//! existing Phase-5 5-min global tick (`refresh_usn_for_warm_shards`)
+//! continues to handle live USN refresh until the per-shard path is
+//! activation-complete.
+
+use alloc::sync::Arc;
+use core::time::Duration;
+
+use tokio::sync::watch;
+use uffs_mft::usn::FileChange;
+
+/// Default poll interval for the per-shard journal loop (500 ms).
+///
+/// Overridable at runtime via the `UFFS_USN_POLL_INTERVAL_MS`
+/// environment variable; the env-var path lets benchmarks and
+/// long-running soak tests slow the tick down to reduce log noise
+/// without recompiling.
+pub(crate) const DEFAULT_POLL_INTERVAL_MS: u64 = 500;
+
+/// Result of one [`JournalSource::poll`] call.
+///
+/// Carries the change batch, the new cursor for the next call, and
+/// the journal identifier (Windows-side: the USN-journal `JournalID`
+/// from `FSCTL_QUERY_USN_JOURNAL`).  The `journal_id` is consumed by
+/// Phase 7 task 7.7 (wrap detection): if it changes between two
+/// successive polls the journal was recreated and the in-memory body
+/// must be force-rebuilt instead of incrementally patched.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct JournalPollResult {
+    /// Aggregated per-file changes since the previous cursor.
+    /// Empty on no-op ticks (no journal activity in the interval).
+    pub(crate) changes: Vec<FileChange>,
+    /// Cursor to pass into the next [`JournalSource::poll`] call.
+    /// Advances monotonically except across a journal-wrap — see
+    /// `journal_id` for the wrap-detection signal.
+    pub(crate) next_cursor: u64,
+    /// Journal identifier.  Compared against the previous tick's
+    /// value to detect journal-wrap (Phase 7 task 7.7); changed
+    /// → force a full rebuild on the next promote.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 7-B forward reference; the wrap-detection \
+                      consumer in Phase 7 task 7.7 reads this field. \
+                      Exercised by `cache::journal_loop::tests` under \
+                      `cfg(test)`."
+        )
+    )]
+    pub(crate) journal_id: u64,
+}
+
+/// Pluggable USN-journal data source.
+///
+/// Production wires [`MacStubJournalSource`] (always-empty) on
+/// macOS / Linux and `WindowsJournalSource` (cfg(windows), reads via
+/// `FSCTL_READ_USN_JOURNAL`) on Windows.  Tests wire
+/// [`tests::FakeJournalSource`] (programmable event queue) to drive
+/// the [`JournalLoop`] state machine deterministically without a
+/// live MFT.
+///
+/// The trait is **synchronous** to match the established
+/// `BackgroundIoPriority` / `BodyLoader` / `Prefetch` / `PressureSignal`
+/// pattern across the cache module; the loop wraps every call in
+/// [`tokio::task::spawn_blocking`] so the main runtime thread never
+/// blocks on a kernel-mode journal read.
+pub(crate) trait JournalSource: Send + Sync + 'static {
+    /// Poll the journal for changes since `cursor`.
+    ///
+    /// **Returns** `Ok(JournalPollResult)` on success, including
+    /// the empty-changes case (which is **not** an error — it just
+    /// means nothing happened in the interval).
+    ///
+    /// **Returns** `Err(io::Error)` only when the underlying journal
+    /// surface itself fails (e.g. the volume handle was revoked,
+    /// the journal was deleted, the broker dropped the request).
+    /// The loop logs the error at warn-level and retries on the
+    /// next tick — a single failure does not abort the loop.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces any platform-level failure reading the journal.
+    fn poll(&self, cursor: u64) -> std::io::Result<JournalPollResult>;
+}
+
+/// Cross-platform always-empty journal source.
+///
+/// Used as the production journal source on macOS / Linux where
+/// USN journals don't exist, and as a default for tests that don't
+/// need to drive change events.  Every poll returns
+/// `JournalPollResult::default()` (no changes, cursor unchanged,
+/// `journal_id == 0`) without any I/O.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 7-B forward reference; production wiring \
+                  in `lib.rs::spawn_load_task` lands in the \
+                  activation commit (post-7-D, after cursor \
+                  persistence + wrap detection).  Exercised by \
+                  `cache::journal_loop::tests::mac_stub_source_*` \
+                  under `cfg(test)`."
+    )
+)]
+#[derive(Debug, Default)]
+pub(crate) struct MacStubJournalSource;
+
+impl JournalSource for MacStubJournalSource {
+    fn poll(&self, cursor: u64) -> std::io::Result<JournalPollResult> {
+        Ok(JournalPollResult {
+            changes: Vec::new(),
+            next_cursor: cursor,
+            journal_id: 0,
+        })
+    }
+}
+
+/// Windows production journal source.
+///
+/// Wraps the real `FSCTL_READ_USN_JOURNAL` path via
+/// [`uffs_mft::usn::read_usn_journal`] + [`uffs_mft::usn::aggregate_changes`].
+/// Carries the drive letter so the broker's volume-handle pool
+/// can resolve to the right NTFS volume.
+///
+/// **Phase 7-B status**: scaffolding only.  The real
+/// FSCTL-backed implementation lands when the production loop is
+/// wired into `spawn_load_task` (post-7-D activation).  Until then
+/// this type returns empty results so the daemon's existing Phase-5
+/// `refresh_usn_for_warm_shards` global tick continues to handle
+/// live USN refresh.
+#[cfg(windows)]
+#[derive(Debug)]
+pub(crate) struct WindowsJournalSource {
+    /// Drive letter for which this source reads the USN journal.
+    drive: char,
+}
+
+#[cfg(windows)]
+#[expect(
+    dead_code,
+    reason = "Phase 7-B Windows scaffolding; the FSCTL-backed \
+              implementation + production wiring land in the \
+              Phase 7 activation commit (post-7-D).  Until then \
+              `poll` returns empty so the existing Phase-5 \
+              `refresh_usn_for_warm_shards` global tick stays the \
+              authoritative live-refresh path.  The block-level \
+              `expect` covers both the constructor and any future \
+              accessor / config-update methods this type acquires \
+              before activation."
+)]
+impl WindowsJournalSource {
+    /// Create a source bound to `drive`.
+    #[must_use]
+    pub(crate) const fn new(drive: char) -> Self {
+        Self { drive }
+    }
+}
+
+#[cfg(windows)]
+impl JournalSource for WindowsJournalSource {
+    fn poll(&self, cursor: u64) -> std::io::Result<JournalPollResult> {
+        // Phase 7-B scaffolding: Windows production wiring lands in
+        // the activation commit.  Until then return empty so the
+        // existing Phase-5 global tick stays the live-refresh path.
+        // Cursor unchanged so the next poll behaves the same.
+        let _ = self.drive;
+        Ok(JournalPollResult {
+            changes: Vec::new(),
+            next_cursor: cursor,
+            journal_id: 0,
+        })
+    }
+}
+
+/// Sink that consumes change batches produced by a [`JournalLoop`].
+///
+/// Production wires this to a closure that:
+///
+/// 1. Looks up the shard for `letter` in the registry.
+/// 2. Calls [`crate::cache::ShardEntry::apply_usn_patch_to_body`] on the
+///    current body.
+/// 3. Swaps the new body via
+///    [`crate::cache::ShardRegistry::replace_warm_body`].
+///
+/// Tests wire it to a `Mutex<Vec<(char, Vec<FileChange>)>>` recorder
+/// so the test can assert which letters saw which changes without
+/// touching a real registry.
+///
+/// The sink is **synchronous** (no `async fn`) for consistency with
+/// the rest of the cache traits and so the loop body stays
+/// transparent to platform allocators.  Mutation behind the trait
+/// (registry write-lock acquire) is the implementor's concern.
+pub(crate) trait PatchSink: Send + Sync + 'static {
+    /// Apply `changes` for the shard identified by `letter`.
+    ///
+    /// **Returns** `true` if the sink accepted the batch (Warm /
+    /// Hot shard, body present, swap succeeded), `false` if the
+    /// caller should treat the tick as a no-op (Parked / Cold
+    /// shard, registry race, etc.).  The boolean is purely
+    /// informational — the loop continues in either case.
+    fn accept(&self, letter: char, changes: &[FileChange]) -> bool;
+}
+
+/// Configuration for a single [`JournalLoop`] task.
+///
+/// Carries the tuning knobs the production loop reads from env
+/// vars and the test loop sets directly.  Keeping these in one
+/// place lets future tasks (7.4 thresholds, 7.7 wrap detection)
+/// extend the config without churning the loop signature.
+#[derive(Debug, Clone)]
+pub(crate) struct JournalLoopConfig {
+    /// Cadence between successive polls.  Default 500 ms.
+    pub(crate) poll_interval: Duration,
+    /// Initial cursor passed into the first poll.  Production
+    /// reads this from the persisted `usn.cursor` (Phase 7 task
+    /// 7.6); tests use 0 as a clean-slate baseline.
+    pub(crate) initial_cursor: u64,
+}
+
+impl Default for JournalLoopConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_millis(DEFAULT_POLL_INTERVAL_MS),
+            initial_cursor: 0,
+        }
+    }
+}
+
+/// Per-shard journal-polling state machine.
+///
+/// Holds the trait-object `source` + `sink` that wire it to the
+/// real journal + registry, the drive `letter` it serves, the
+/// cancellation receiver that lets the daemon's shutdown tear it
+/// down within one poll interval, and the [`JournalLoopConfig`] for
+/// cadence + cursor seeding.
+///
+/// Construction is `pub(crate)` so the production spawn path
+/// ([`spawn_journal_loop`]) and test paths can both build it; the
+/// only state-machine entry point is [`Self::run`].
+pub(crate) struct JournalLoop {
+    /// Drive letter this loop polls.
+    letter: char,
+    /// Plug-in journal-data source.
+    source: Arc<dyn JournalSource>,
+    /// Plug-in patch consumer.
+    sink: Arc<dyn PatchSink>,
+    /// Cancellation channel — set to `true` by the daemon shutdown
+    /// path; the loop checks on every iteration and exits cleanly.
+    cancel_rx: watch::Receiver<bool>,
+    /// Tuning knobs.
+    config: JournalLoopConfig,
+}
+
+impl JournalLoop {
+    /// Construct a loop bound to `letter`, polling `source`,
+    /// applying via `sink`, watching `cancel_rx`, configured by
+    /// `config`.
+    #[must_use]
+    pub(crate) const fn new(
+        letter: char,
+        source: Arc<dyn JournalSource>,
+        sink: Arc<dyn PatchSink>,
+        cancel_rx: watch::Receiver<bool>,
+        config: JournalLoopConfig,
+    ) -> Self {
+        Self {
+            letter,
+            source,
+            sink,
+            cancel_rx,
+            config,
+        }
+    }
+
+    /// Run the loop until `cancel_rx` flips to `true` (typically
+    /// the daemon's shutdown path).  Polls `source` every
+    /// `config.poll_interval`, applies non-empty change batches
+    /// via `sink`, advances the cursor.
+    ///
+    /// On a poll error: warn-logs and retries on the next tick.
+    /// One failure does **not** abort the loop — the journal can
+    /// be transiently unavailable (volume revocation, broker
+    /// reconnect) and the daemon should resume cleanly when the
+    /// surface returns.
+    pub(crate) async fn run(mut self) {
+        let mut cursor = self.config.initial_cursor;
+        let letter = self.letter;
+        loop {
+            if !wait_for_next_tick(&mut self.cancel_rx, self.config.poll_interval, letter).await {
+                return;
+            }
+
+            let Some(result) = poll_blocking(Arc::clone(&self.source), cursor, letter).await else {
+                continue;
+            };
+
+            cursor = result.next_cursor;
+            process_tick(self.sink.as_ref(), letter, cursor, &result.changes);
+        }
+    }
+}
+
+/// Wait for the next poll deadline, racing the cancellation watch.
+///
+/// **Returns** `true` when the loop should proceed with a poll,
+/// `false` when cancellation has been observed and the loop
+/// should exit.
+async fn wait_for_next_tick(
+    cancel_rx: &mut watch::Receiver<bool>,
+    poll_interval: Duration,
+    letter: char,
+) -> bool {
+    if *cancel_rx.borrow() {
+        tracing::debug!(drive = %letter, "Journal loop cancellation requested before tick");
+        return false;
+    }
+    tokio::select! {
+        () = tokio::time::sleep(poll_interval) => true,
+        changed = cancel_rx.changed() => {
+            if changed.is_ok() && *cancel_rx.borrow() {
+                tracing::debug!(
+                    drive = %letter,
+                    "Journal loop cancellation observed during sleep"
+                );
+                false
+            } else {
+                true
+            }
+        }
+    }
+}
+
+/// Run one journal poll on the blocking pool.
+///
+/// **Returns** `Some(result)` on success, `None` when the source
+/// or the spawn-blocking task itself failed (warn-logged at the
+/// call site so the loop can `continue` cleanly).
+async fn poll_blocking(
+    source: Arc<dyn JournalSource>,
+    cursor: u64,
+    letter: char,
+) -> Option<JournalPollResult> {
+    let poll_result = tokio::task::spawn_blocking(move || source.poll(cursor)).await;
+    match poll_result {
+        Ok(Ok(res)) => Some(res),
+        Ok(Err(io_err)) => {
+            tracing::warn!(
+                drive = %letter,
+                error = %io_err,
+                "Journal poll failed; retrying next tick"
+            );
+            None
+        }
+        Err(join_err) => {
+            tracing::warn!(
+                drive = %letter,
+                error = %join_err,
+                "Journal poll task aborted; retrying next tick"
+            );
+            None
+        }
+    }
+}
+
+/// Apply the post-poll change batch to `sink`, or trace-log the
+/// no-op tick when `changes` is empty.
+fn process_tick(sink: &dyn PatchSink, letter: char, cursor: u64, changes: &[FileChange]) {
+    if changes.is_empty() {
+        tracing::trace!(drive = %letter, "Journal poll: no changes");
+        return;
+    }
+    let accepted = sink.accept(letter, changes);
+    tracing::debug!(
+        drive = %letter,
+        accepted,
+        change_count = changes.len(),
+        cursor,
+        "Journal poll: applied tick"
+    );
+}
+
+/// Handle returned by [`spawn_journal_loop`] for cancellation +
+/// join.  Holding it keeps the loop alive; dropping the
+/// `cancel_tx` causes the loop to exit on its next iteration via
+/// the `watch` receiver's `changed()` arm.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 7-B infrastructure; production spawn path \
+                  lands in the activation commit (post-7-D, after \
+                  cursor persistence + wrap detection).  Exercised \
+                  end-to-end by `cache::journal_loop::tests` under \
+                  `cfg(test)`."
+    )
+)]
+pub(crate) struct JournalLoopHandle {
+    /// Sender side of the cancellation watch.  Setting it to
+    /// `true` (or dropping it) causes the loop to exit.
+    cancel_tx: watch::Sender<bool>,
+    /// Joinable handle on the spawned loop task.  Awaiting this
+    /// after a `cancel()` or `cancel_tx` drop blocks until the
+    /// loop has finished its in-flight tick and returned.
+    join: tokio::task::JoinHandle<()>,
+}
+
+impl JournalLoopHandle {
+    /// Request cancellation and return the join handle.  After
+    /// this call, awaiting the returned `JoinHandle` blocks until
+    /// the loop's next iteration observes the signal and returns
+    /// (typically within one [`JournalLoopConfig::poll_interval`]).
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 7-B infrastructure; cancellation entry \
+                      point exercised by tests, awaiting production \
+                      activation."
+        )
+    )]
+    pub(crate) fn cancel(self) -> tokio::task::JoinHandle<()> {
+        let _ignore = self.cancel_tx.send(true);
+        self.join
+    }
+}
+
+/// Spawn a journal loop on the current runtime.  Returns a
+/// [`JournalLoopHandle`] for cancellation + join.
+///
+/// Caller responsibility: ensure the runtime is alive for the
+/// duration of the loop, and call [`JournalLoopHandle::cancel`]
+/// before the runtime tears down.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 7-B infrastructure; production spawn site \
+                  in `lib.rs::spawn_load_task` lands in the \
+                  activation commit (post-7-D)."
+    )
+)]
+#[must_use]
+pub(crate) fn spawn_journal_loop(
+    letter: char,
+    source: Arc<dyn JournalSource>,
+    sink: Arc<dyn PatchSink>,
+    config: JournalLoopConfig,
+) -> JournalLoopHandle {
+    let (cancel_tx, cancel_rx) = watch::channel(false);
+    let loop_state = JournalLoop::new(letter, source, sink, cancel_rx, config);
+    let join = tokio::spawn(loop_state.run());
+    JournalLoopHandle { cancel_tx, join }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uffs-daemon/src/cache/journal_loop/tests.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests.rs
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Mac-deterministic tests for the per-shard USN journal loop
+//! (Phase 7 tasks 7.2 + 7.3).
+//!
+//! These tests drive [`super::JournalLoop`] end-to-end via a
+//! programmable [`FakeJournalSource`] + a recording
+//! [`RecordingSink`], pinning the state-machine contract:
+//!
+//! * **Empty ticks** — no `accept()` call when the journal returns no changes.
+//! * **Non-empty ticks** — exactly one `accept()` call per tick with the
+//!   matching change batch and drive letter.
+//! * **Cursor advance** — each poll receives the cursor returned by the
+//!   previous poll (monotonic except across journal-wrap, which Phase 7 task
+//!   7.7 will pin once activated).
+//! * **Cancellation** — `JournalLoopHandle::cancel()` causes the loop to exit
+//!   within one poll-interval.
+//! * **Source error recovery** — a single `Err` from the source does not abort
+//!   the loop; the next tick proceeds normally.
+//!
+//! No Windows host, no live MFT, no `read_usn_journal` syscall:
+//! the entire surface is covered by deterministic time-based
+//! tokio runtime control.
+
+use alloc::collections::VecDeque;
+use alloc::sync::Arc;
+use core::time::Duration;
+use std::sync::Mutex;
+
+use uffs_mft::usn::FileChange;
+
+use super::{JournalLoopConfig, JournalPollResult, JournalSource, PatchSink, spawn_journal_loop};
+
+/// Acquire `mutex`, defusing any poison error by recovering the
+/// inner guard.  Test code never deliberately poisons — this
+/// helper just satisfies clippy's `expect_used` denial without
+/// silencing it across the file.
+fn lock_or_recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Programmable journal source.
+///
+/// Holds a queue of poll results that the test pre-loads.  Each
+/// call to `poll` pops the front of the queue (or returns
+/// `JournalPollResult::default()` when empty so the loop has a
+/// well-defined post-drain steady state).  Polls are also recorded
+/// for assertions on cursor monotonicity.
+struct FakeJournalSource {
+    /// Queued results, popped in FIFO order on `poll()`.
+    /// `Result<JournalPollResult, io::Error>` so error-recovery
+    /// tests can interleave failures with successful polls.
+    queue: Mutex<VecDeque<std::io::Result<JournalPollResult>>>,
+    /// Cursor values that were passed into `poll()`, in call order.
+    /// Lets tests assert the loop carried each `next_cursor`
+    /// forward into the subsequent call.
+    cursors_seen: Mutex<Vec<u64>>,
+}
+
+impl FakeJournalSource {
+    fn new() -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+            cursors_seen: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Enqueue a successful poll result.
+    fn enqueue_changes(&self, changes: Vec<FileChange>, next_cursor: u64) {
+        lock_or_recover(&self.queue).push_back(Ok(JournalPollResult {
+            changes,
+            next_cursor,
+            journal_id: 1,
+        }));
+    }
+
+    /// Enqueue an `io::Error` to exercise the source-error retry path.
+    ///
+    /// Takes a fully-constructed `std::io::Error` (rather than an
+    /// `ErrorKind` taxonomy) because `core::io::ErrorKind` is still
+    /// nightly-gated (rust-lang/rust#154046) and the workspace lint
+    /// `restriction::std_instead_of_core` flags any `std::io::ErrorKind`
+    /// reference that happens to be available via `core` on a newer
+    /// toolchain.  Passing the constructed error keeps the test
+    /// surface stable across both nightly + stable.
+    fn enqueue_error(&self, error: std::io::Error) {
+        lock_or_recover(&self.queue).push_back(Err(error));
+    }
+
+    /// Snapshot of cursor values seen since construction.
+    fn cursors_seen(&self) -> Vec<u64> {
+        lock_or_recover(&self.cursors_seen).clone()
+    }
+}
+
+impl JournalSource for FakeJournalSource {
+    fn poll(&self, cursor: u64) -> std::io::Result<JournalPollResult> {
+        lock_or_recover(&self.cursors_seen).push(cursor);
+        let popped = lock_or_recover(&self.queue).pop_front();
+        match popped {
+            Some(Ok(res)) => Ok(res),
+            Some(Err(err)) => Err(err),
+            None => Ok(JournalPollResult {
+                changes: Vec::new(),
+                next_cursor: cursor,
+                journal_id: 1,
+            }),
+        }
+    }
+}
+
+/// Recording sink that captures every `accept()` invocation.
+struct RecordingSink {
+    /// One entry per `accept()` call: `(letter, change_count)`.
+    /// Storing only the count (not the full `Vec<FileChange>`)
+    /// keeps the Mutex contention minimal and the assertions
+    /// focused on the loop semantics rather than payload shape.
+    calls: Mutex<Vec<(char, usize)>>,
+    /// Boolean to return from `accept()`.  Tests flip this to
+    /// `false` to exercise the registry-race / Parked-shard path
+    /// (loop must continue cleanly when accept returns false).
+    accept_outcome: Mutex<bool>,
+}
+
+impl RecordingSink {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            accept_outcome: Mutex::new(true),
+        }
+    }
+
+    fn calls(&self) -> Vec<(char, usize)> {
+        lock_or_recover(&self.calls).clone()
+    }
+}
+
+impl PatchSink for RecordingSink {
+    fn accept(&self, letter: char, changes: &[FileChange]) -> bool {
+        lock_or_recover(&self.calls).push((letter, changes.len()));
+        *lock_or_recover(&self.accept_outcome)
+    }
+}
+
+/// Helper: small fake change so the queue is exercising a
+/// non-trivial batch shape (not just `vec![]`).
+fn one_change(frs: u64) -> FileChange {
+    FileChange {
+        frs,
+        deleted: true,
+        ..FileChange::default()
+    }
+}
+
+/// Helper: build a [`JournalLoopConfig`] with a fast-tick
+/// `poll_interval` so the loop fires multiple ticks in a
+/// hundred-millisecond test budget without flaking on slower
+/// CI runners.  5 ms is well below any realistic CI scheduler
+/// jitter while still being long enough that `spawn_blocking`
+/// work can complete between ticks.
+fn fast_config() -> JournalLoopConfig {
+    JournalLoopConfig {
+        poll_interval: Duration::from_millis(5),
+        initial_cursor: 0,
+    }
+}
+
+/// Deadline for polling assertions — the maximum wall-clock time
+/// the test will wait for the loop to converge on the expected
+/// state.  At a 5 ms tick interval this gives the loop ~50
+/// chances to fire, well above what every test below actually
+/// needs.  Mirrors the `lifecycle_hooks.rs::CASCADE_DEADLINE`
+/// idiom of "give the runtime a generous wall-clock budget
+/// before declaring the convergence missed".
+const CONVERGENCE_DEADLINE: Duration = Duration::from_millis(250);
+
+/// Yield to the runtime + sleep a small amount so the journal
+/// loop has a chance to fire one tick.  Used by every assertion
+/// helper below.
+async fn yield_one_tick() {
+    tokio::time::sleep(Duration::from_millis(10)).await;
+}
+
+/// Drive the runtime forward until `predicate()` returns `true`
+/// or [`CONVERGENCE_DEADLINE`] elapses.  Returns `true` on
+/// convergence, `false` on timeout — the caller asserts.
+async fn wait_for<F: Fn() -> bool>(predicate: F) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < CONVERGENCE_DEADLINE {
+        if predicate() {
+            return true;
+        }
+        yield_one_tick().await;
+    }
+    predicate()
+}
+
+// ── Empty-tick contract: no accept() call when source has no changes ─
+
+#[tokio::test]
+async fn empty_tick_does_not_call_accept() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // Empty queue → poll() returns default (empty changes).
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        fast_config(),
+    );
+
+    // Let several ticks fire — every one returns empty changes.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        sink.calls().is_empty(),
+        "no accept() call should fire when every poll returns empty changes"
+    );
+    // The source must still have been polled — prove the loop
+    // wasn't simply stuck before reaching the source.
+    assert!(
+        !source.cursors_seen().is_empty(),
+        "loop must have polled the source at least once"
+    );
+}
+
+// ── Non-empty tick contract: exactly one accept() with matching batch ─
+
+#[tokio::test]
+async fn non_empty_tick_invokes_accept_once() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    source.enqueue_changes(vec![one_change(10), one_change(11)], 100);
+
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        fast_config(),
+    );
+
+    // Wait until the recording sink sees exactly one accept().
+    let sink_for_pred = Arc::clone(&sink);
+    let converged = wait_for(move || sink_for_pred.calls().len() == 1).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "loop did not invoke accept() within {CONVERGENCE_DEADLINE:?}"
+    );
+    let calls = sink.calls();
+    assert_eq!(calls.len(), 1, "exactly one accept() call expected");
+    assert_eq!(
+        calls.first().copied(),
+        Some(('C', 2_usize)),
+        "letter + change-count must round-trip"
+    );
+}
+
+// ── Cursor monotonicity: each poll sees the previous next_cursor ─────
+
+#[tokio::test]
+async fn cursor_advances_monotonically_across_ticks() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // Queue three successful polls with increasing next_cursor.
+    source.enqueue_changes(vec![one_change(10)], 100);
+    source.enqueue_changes(vec![one_change(11)], 200);
+    source.enqueue_changes(vec![one_change(12)], 300);
+
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        fast_config(),
+    );
+
+    // Wait until at least 3 polls have been observed.
+    let source_for_pred = Arc::clone(&source);
+    let converged = wait_for(move || source_for_pred.cursors_seen().len() >= 3).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "loop did not produce 3 polls within {CONVERGENCE_DEADLINE:?}"
+    );
+    let cursors = source.cursors_seen();
+    // First poll uses the initial cursor (0).  Subsequent polls
+    // see the previous next_cursor (100, then 200).
+    assert_eq!(
+        cursors.first().copied(),
+        Some(0),
+        "first poll must use initial cursor"
+    );
+    assert_eq!(
+        cursors.get(1).copied(),
+        Some(100),
+        "second poll must carry next_cursor=100"
+    );
+    assert_eq!(
+        cursors.get(2).copied(),
+        Some(200),
+        "third poll must carry next_cursor=200"
+    );
+}
+
+// ── Source-error retry: one Err does not abort the loop ──────────────
+
+#[tokio::test]
+async fn source_error_does_not_abort_loop() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // Pattern: Err → Ok with changes.  Loop must skip the Err
+    // and apply the next batch on the following tick.
+    source.enqueue_error(std::io::Error::other("fake source error"));
+    source.enqueue_changes(vec![one_change(10)], 100);
+
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        fast_config(),
+    );
+
+    // Wait for accept() to fire — proves the loop survived the Err.
+    let sink_for_pred = Arc::clone(&sink);
+    let converged = wait_for(move || !sink_for_pred.calls().is_empty()).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "loop must have continued past the Err and applied the subsequent batch within {CONVERGENCE_DEADLINE:?}; got 0 accept() calls"
+    );
+}
+
+// ── Cancellation contract: cancel() exits within CONVERGENCE_DEADLINE ─
+
+#[tokio::test]
+async fn cancel_exits_within_convergence_deadline() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        fast_config(),
+    );
+
+    // Cancel immediately and assert the join handle resolves
+    // within the convergence deadline.
+    let join = handle.cancel();
+    let result = tokio::time::timeout(CONVERGENCE_DEADLINE, join).await;
+    assert!(
+        result.is_ok(),
+        "cancellation must drive the loop to exit within {CONVERGENCE_DEADLINE:?}; timed out instead"
+    );
+}
+
+// ── MacStubJournalSource production fallback: always-empty contract ──
+
+#[test]
+fn mac_stub_source_returns_empty_with_unchanged_cursor() -> std::io::Result<()> {
+    let stub = super::MacStubJournalSource;
+    let res = stub.poll(42)?;
+    assert!(
+        res.changes.is_empty(),
+        "MacStub must always return empty changes"
+    );
+    assert_eq!(
+        res.next_cursor, 42,
+        "MacStub must keep the cursor unchanged"
+    );
+    assert_eq!(res.journal_id, 0, "MacStub journal_id is the zero sentinel");
+    Ok(())
+}

--- a/crates/uffs-daemon/src/cache/journal_loop/tests.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests.rs
@@ -30,7 +30,9 @@ use std::sync::Mutex;
 
 use uffs_mft::usn::FileChange;
 
-use super::{JournalLoopConfig, JournalPollResult, JournalSource, PatchSink, spawn_journal_loop};
+use super::{
+    JournalLoopConfig, JournalPollResult, JournalSource, PatchSink, SaveReason, spawn_journal_loop,
+};
 
 /// Acquire `mutex`, defusing any poison error by recovering the
 /// inner guard.  Test code never deliberately poisons — this
@@ -119,6 +121,10 @@ struct RecordingSink {
     /// keeps the Mutex contention minimal and the assertions
     /// focused on the loop semantics rather than payload shape.
     calls: Mutex<Vec<(char, usize)>>,
+    /// One entry per `trigger_save()` call: `(letter, reason)`.
+    /// Phase 7-C surface — lets tests assert the threshold state
+    /// machine fires the right reason at the right time.
+    save_calls: Mutex<Vec<(char, SaveReason)>>,
     /// Boolean to return from `accept()`.  Tests flip this to
     /// `false` to exercise the registry-race / Parked-shard path
     /// (loop must continue cleanly when accept returns false).
@@ -129,6 +135,7 @@ impl RecordingSink {
     fn new() -> Self {
         Self {
             calls: Mutex::new(Vec::new()),
+            save_calls: Mutex::new(Vec::new()),
             accept_outcome: Mutex::new(true),
         }
     }
@@ -136,12 +143,20 @@ impl RecordingSink {
     fn calls(&self) -> Vec<(char, usize)> {
         lock_or_recover(&self.calls).clone()
     }
+
+    fn save_calls(&self) -> Vec<(char, SaveReason)> {
+        lock_or_recover(&self.save_calls).clone()
+    }
 }
 
 impl PatchSink for RecordingSink {
     fn accept(&self, letter: char, changes: &[FileChange]) -> bool {
         lock_or_recover(&self.calls).push((letter, changes.len()));
         *lock_or_recover(&self.accept_outcome)
+    }
+
+    fn trigger_save(&self, letter: char, reason: SaveReason) {
+        lock_or_recover(&self.save_calls).push((letter, reason));
     }
 }
 
@@ -160,11 +175,15 @@ fn one_change(frs: u64) -> FileChange {
 /// hundred-millisecond test budget without flaking on slower
 /// CI runners.  5 ms is well below any realistic CI scheduler
 /// jitter while still being long enough that `spawn_blocking`
-/// work can complete between ticks.
+/// work can complete between ticks.  Save thresholds are set
+/// generously so the tick / cancel / cursor tests don't
+/// accidentally trigger saves; threshold tests override.
 fn fast_config() -> JournalLoopConfig {
     JournalLoopConfig {
         poll_interval: Duration::from_millis(5),
         initial_cursor: 0,
+        save_threshold_events: u64::MAX,
+        save_threshold_age: Duration::from_hours(24),
     }
 }
 
@@ -370,6 +389,224 @@ async fn cancel_exits_within_convergence_deadline() {
     assert!(
         result.is_ok(),
         "cancellation must drive the loop to exit within {CONVERGENCE_DEADLINE:?}; timed out instead"
+    );
+}
+
+// ── Phase 7-C: events-based save threshold fires after enough churn ──
+
+#[tokio::test]
+async fn events_threshold_triggers_save() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // Two batches of 3 + 4 = 7 events; threshold of 5 means the
+    // second batch must trigger an EventsExceeded save.
+    source.enqueue_changes(vec![one_change(10), one_change(11), one_change(12)], 100);
+    source.enqueue_changes(
+        vec![
+            one_change(13),
+            one_change(14),
+            one_change(15),
+            one_change(16),
+        ],
+        200,
+    );
+
+    let config = JournalLoopConfig {
+        poll_interval: Duration::from_millis(5),
+        initial_cursor: 0,
+        save_threshold_events: 5,
+        save_threshold_age: Duration::from_hours(24),
+    };
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        config,
+    );
+
+    // Wait for both accept()s + the save trigger.
+    let sink_for_pred = Arc::clone(&sink);
+    let converged = wait_for(move || !sink_for_pred.save_calls().is_empty()).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "events threshold did not fire trigger_save within {CONVERGENCE_DEADLINE:?}"
+    );
+    let saves = sink.save_calls();
+    assert_eq!(
+        saves.len(),
+        1,
+        "exactly one EventsExceeded save expected; got {saves:?}"
+    );
+    assert_eq!(
+        saves.first().copied(),
+        Some(('C', SaveReason::EventsExceeded)),
+        "save reason must be EventsExceeded"
+    );
+}
+
+// ── Phase 7-C: age-based save threshold fires after time elapses ─────
+
+#[tokio::test]
+async fn age_threshold_triggers_save_with_pending_events() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // First tick lands one event (under the events-threshold,
+    // and well within the age-threshold from spawn time).
+    source.enqueue_changes(vec![one_change(10)], 100);
+
+    let config = JournalLoopConfig {
+        poll_interval: Duration::from_millis(5),
+        initial_cursor: 0,
+        save_threshold_events: u64::MAX,
+        save_threshold_age: Duration::from_millis(30),
+    };
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        config,
+    );
+
+    // Wait for the first batch to land via accept() — proves
+    // events_since_save is now > 0.
+    let sink_for_accept_pred = Arc::clone(&sink);
+    let first_accept_landed = wait_for(move || !sink_for_accept_pred.calls().is_empty()).await;
+    assert!(
+        first_accept_landed,
+        "first batch must land before age can be tested"
+    );
+
+    // Sleep past the 30 ms age threshold while events stay pending
+    // (no save fires on empty ticks — those skip the threshold
+    // evaluation per Phase 7 task 7.4 design).
+    tokio::time::sleep(Duration::from_millis(60)).await;
+
+    // Now enqueue the second batch.  Its tick will observe
+    // elapsed >= 30 ms with events_since_save > 0, firing AgeElapsed.
+    source.enqueue_changes(vec![one_change(11)], 200);
+
+    // Wait for the save to fire.
+    let sink_for_save_pred = Arc::clone(&sink);
+    let converged = wait_for(move || !sink_for_save_pred.save_calls().is_empty()).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "age threshold did not fire trigger_save within {CONVERGENCE_DEADLINE:?}"
+    );
+    let saves = sink.save_calls();
+    assert_eq!(
+        saves.first().copied(),
+        Some(('C', SaveReason::AgeElapsed)),
+        "save reason must be AgeElapsed; got {saves:?}"
+    );
+}
+
+// ── Phase 7-C: zero-event drive never triggers a save ─────────────────
+
+#[tokio::test]
+async fn zero_events_drive_does_not_trigger_save() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // Empty queue + tight age threshold.  The age threshold
+    // SHOULD NOT fire because no events have ever been recorded
+    // — Phase 7 task 7.4 contract: zero-churn drives produce
+    // no wasteful saves.
+    let config = JournalLoopConfig {
+        poll_interval: Duration::from_millis(5),
+        initial_cursor: 0,
+        save_threshold_events: 1,
+        save_threshold_age: Duration::from_millis(20),
+    };
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        config,
+    );
+
+    // Let several ticks fire well past the age threshold.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    let saves = sink.save_calls();
+    assert!(
+        saves.is_empty(),
+        "zero-event drive must not produce any save triggers; got {saves:?}"
+    );
+    // Sanity: the loop did poll the source.
+    assert!(
+        !source.cursors_seen().is_empty(),
+        "loop must have polled the source"
+    );
+}
+
+// ── Phase 7-C: counter resets after save — no double-fire on next tick ──
+
+#[tokio::test]
+async fn counter_resets_after_save() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // First batch of 5 events crosses the events_threshold = 5
+    // → first save fires.  Second batch of 1 event must NOT
+    // trigger another save (counter reset; 1 < 5).
+    source.enqueue_changes(
+        vec![
+            one_change(10),
+            one_change(11),
+            one_change(12),
+            one_change(13),
+            one_change(14),
+        ],
+        100,
+    );
+    source.enqueue_changes(vec![one_change(15)], 200);
+
+    let config = JournalLoopConfig {
+        poll_interval: Duration::from_millis(5),
+        initial_cursor: 0,
+        save_threshold_events: 5,
+        save_threshold_age: Duration::from_hours(24),
+    };
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        config,
+    );
+
+    // Wait until both accept() calls land + first save fires.
+    let sink_for_pred = Arc::clone(&sink);
+    let converged = wait_for(move || {
+        sink_for_pred.calls().len() >= 2 && !sink_for_pred.save_calls().is_empty()
+    })
+    .await;
+
+    // Give the loop one extra tick window to potentially fire
+    // a wrong second save.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(converged, "loop did not converge within deadline");
+    let saves = sink.save_calls();
+    assert_eq!(
+        saves.len(),
+        1,
+        "exactly one save expected (counter reset after first); got {saves:?}"
     );
 }
 

--- a/crates/uffs-daemon/src/cache/journal_loop/tests.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests.rs
@@ -41,6 +41,7 @@ use super::{
 };
 
 mod basics;
+mod integration;
 mod thresholds;
 mod wrap_and_persistence;
 

--- a/crates/uffs-daemon/src/cache/journal_loop/tests.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests.rs
@@ -1,27 +1,32 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! Mac-deterministic tests for the per-shard USN journal loop
-//! (Phase 7 tasks 7.2 + 7.3).
+//! Mac-deterministic test fixture for the per-shard USN journal
+//! loop (Phase 7 tasks 7.2 / 7.3 / 7.4 / 7.6 / 7.7).
 //!
-//! These tests drive [`super::JournalLoop`] end-to-end via a
-//! programmable [`FakeJournalSource`] + a recording
-//! [`RecordingSink`], pinning the state-machine contract:
+//! This module hosts the shared helpers (programmable
+//! [`FakeJournalSource`], recording [`RecordingSink`], in-memory
+//! [`FakeCursorStore`], `wait_for` deadline-driven convergence
+//! helper) plus the submodule split for individual phase contracts.
+//! Submodule layout keeps each file well under the workspace
+//! 800-LOC file-size policy:
 //!
-//! * **Empty ticks** — no `accept()` call when the journal returns no changes.
-//! * **Non-empty ticks** — exactly one `accept()` call per tick with the
-//!   matching change batch and drive letter.
-//! * **Cursor advance** — each poll receives the cursor returned by the
-//!   previous poll (monotonic except across journal-wrap, which Phase 7 task
-//!   7.7 will pin once activated).
-//! * **Cancellation** — `JournalLoopHandle::cancel()` causes the loop to exit
-//!   within one poll-interval.
-//! * **Source error recovery** — a single `Err` from the source does not abort
-//!   the loop; the next tick proceeds normally.
+//! * [`basics`] \u2014 Phase 7-B (loop lifecycle, cancellation, source error
+//!   recovery, [`MacStubJournalSource`] always-empty contract).
+//! * [`thresholds`] \u2014 Phase 7-C (events / age threshold-triggered
+//!   `trigger_save` calls + counter-reset semantics).
+//! * [`wrap_and_persistence`] \u2014 Phase 7-D (cursor seeding from
+//!   [`CursorStore::load`], cursor-on-save persistence, journal-wrap detection
+//!   via `journal_id` comparison).
 //!
-//! No Windows host, no live MFT, no `read_usn_journal` syscall:
-//! the entire surface is covered by deterministic time-based
-//! tokio runtime control.
+//! All tests use real wall-clock time (`tokio::time::sleep`) because
+//! the loop's `spawn_blocking` poll runs on a real OS thread and
+//! tokio's `pause`-mode virtual time cannot drive it forward.
+//! Convergence is deadline-driven via [`wait_for`] which mirrors
+//! the established `lifecycle_hooks.rs::CASCADE_DEADLINE` pattern
+//! in this crate.
+//!
+//! [`MacStubJournalSource`]: super::MacStubJournalSource
 
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
@@ -31,8 +36,13 @@ use std::sync::Mutex;
 use uffs_mft::usn::FileChange;
 
 use super::{
-    JournalLoopConfig, JournalPollResult, JournalSource, PatchSink, SaveReason, spawn_journal_loop,
+    CursorStore, JournalLoopConfig, JournalPollResult, JournalSource, NullCursorStore, PatchSink,
+    SaveReason,
 };
+
+mod basics;
+mod thresholds;
+mod wrap_and_persistence;
 
 /// Acquire `mutex`, defusing any poison error by recovering the
 /// inner guard.  Test code never deliberately poisons — this
@@ -60,6 +70,12 @@ struct FakeJournalSource {
     /// Lets tests assert the loop carried each `next_cursor`
     /// forward into the subsequent call.
     cursors_seen: Mutex<Vec<u64>>,
+    /// Last `journal_id` of an enqueued result.  Used as the
+    /// `journal_id` for post-drain empty polls so the loop's
+    /// wrap-detection state machine doesn't false-fire when the
+    /// queue empties — a real journal's id is stable until the
+    /// journal is genuinely recreated, not per-poll.
+    last_enqueued_journal_id: Mutex<u64>,
 }
 
 impl FakeJournalSource {
@@ -67,15 +83,30 @@ impl FakeJournalSource {
         Self {
             queue: Mutex::new(VecDeque::new()),
             cursors_seen: Mutex::new(Vec::new()),
+            last_enqueued_journal_id: Mutex::new(1),
         }
     }
 
-    /// Enqueue a successful poll result.
+    /// Enqueue a successful poll result with the default test
+    /// `journal_id` of 1.
     fn enqueue_changes(&self, changes: Vec<FileChange>, next_cursor: u64) {
+        self.enqueue_changes_with_journal_id(changes, next_cursor, 1);
+    }
+
+    /// Enqueue a successful poll result with an explicit
+    /// `journal_id`.  Phase 7-D wrap-detection tests use this to
+    /// alternate between `journal_id` values across successive polls.
+    fn enqueue_changes_with_journal_id(
+        &self,
+        changes: Vec<FileChange>,
+        next_cursor: u64,
+        journal_id: u64,
+    ) {
+        *lock_or_recover(&self.last_enqueued_journal_id) = journal_id;
         lock_or_recover(&self.queue).push_back(Ok(JournalPollResult {
             changes,
             next_cursor,
-            journal_id: 1,
+            journal_id,
         }));
     }
 
@@ -108,13 +139,18 @@ impl JournalSource for FakeJournalSource {
             None => Ok(JournalPollResult {
                 changes: Vec::new(),
                 next_cursor: cursor,
-                journal_id: 1,
+                // Mirror the last-enqueued journal_id so post-drain
+                // empty polls don't false-trip the loop's wrap
+                // detection.  A real journal's id is stable until
+                // the journal is genuinely recreated.
+                journal_id: *lock_or_recover(&self.last_enqueued_journal_id),
             }),
         }
     }
 }
 
-/// Recording sink that captures every `accept()` invocation.
+/// Recording sink that captures every `accept()`, `trigger_save`,
+/// and `journal_wrapped` invocation.
 struct RecordingSink {
     /// One entry per `accept()` call: `(letter, change_count)`.
     /// Storing only the count (not the full `Vec<FileChange>`)
@@ -125,6 +161,11 @@ struct RecordingSink {
     /// Phase 7-C surface — lets tests assert the threshold state
     /// machine fires the right reason at the right time.
     save_calls: Mutex<Vec<(char, SaveReason)>>,
+    /// One entry per `journal_wrapped()` call: `letter`.
+    /// Phase 7-D surface — lets tests assert the wrap-detection
+    /// state machine fires when `journal_id` changes between
+    /// successive non-zero polls.
+    wrap_calls: Mutex<Vec<char>>,
     /// Boolean to return from `accept()`.  Tests flip this to
     /// `false` to exercise the registry-race / Parked-shard path
     /// (loop must continue cleanly when accept returns false).
@@ -136,6 +177,7 @@ impl RecordingSink {
         Self {
             calls: Mutex::new(Vec::new()),
             save_calls: Mutex::new(Vec::new()),
+            wrap_calls: Mutex::new(Vec::new()),
             accept_outcome: Mutex::new(true),
         }
     }
@@ -146,6 +188,10 @@ impl RecordingSink {
 
     fn save_calls(&self) -> Vec<(char, SaveReason)> {
         lock_or_recover(&self.save_calls).clone()
+    }
+
+    fn wrap_calls(&self) -> Vec<char> {
+        lock_or_recover(&self.wrap_calls).clone()
     }
 }
 
@@ -158,6 +204,61 @@ impl PatchSink for RecordingSink {
     fn trigger_save(&self, letter: char, reason: SaveReason) {
         lock_or_recover(&self.save_calls).push((letter, reason));
     }
+
+    fn journal_wrapped(&self, letter: char) {
+        lock_or_recover(&self.wrap_calls).push(letter);
+    }
+}
+
+/// In-memory cursor store backed by a `HashMap<char, u64>`.
+/// Pre-loaded by tests via [`Self::set_cursor`] to seed the
+/// loop's initial cursor; observed via [`Self::store_log`] to
+/// assert the loop's persistence behaviour.
+struct FakeCursorStore {
+    cursors: Mutex<std::collections::HashMap<char, u64>>,
+    /// Append-only log of every `(letter, cursor)` passed to
+    /// `store()`, in call order.  Lets tests assert which
+    /// cursors were persisted at which points (not just the
+    /// final state).
+    store_log: Mutex<Vec<(char, u64)>>,
+}
+
+impl FakeCursorStore {
+    fn new() -> Self {
+        Self {
+            cursors: Mutex::new(std::collections::HashMap::new()),
+            store_log: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn set_cursor(&self, letter: char, cursor: u64) {
+        lock_or_recover(&self.cursors).insert(letter, cursor);
+    }
+
+    fn store_log(&self) -> Vec<(char, u64)> {
+        lock_or_recover(&self.store_log).clone()
+    }
+}
+
+impl CursorStore for FakeCursorStore {
+    fn load(&self, letter: char) -> u64 {
+        lock_or_recover(&self.cursors)
+            .get(&letter)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    fn store(&self, letter: char, cursor: u64) {
+        lock_or_recover(&self.cursors).insert(letter, cursor);
+        lock_or_recover(&self.store_log).push((letter, cursor));
+    }
+}
+
+/// Default cursor store for the existing tick / cancel / cursor /
+/// threshold tests that don't care about persistence — the
+/// `NullCursorStore` returns 0 on `load` and is a no-op on `store`.
+fn null_cursor_store() -> Arc<dyn CursorStore> {
+    Arc::new(NullCursorStore)
 }
 
 /// Helper: small fake change so the queue is exercising a
@@ -197,8 +298,7 @@ fn fast_config() -> JournalLoopConfig {
 const CONVERGENCE_DEADLINE: Duration = Duration::from_millis(250);
 
 /// Yield to the runtime + sleep a small amount so the journal
-/// loop has a chance to fire one tick.  Used by every assertion
-/// helper below.
+/// loop has a chance to fire one tick.  Used by [`wait_for`].
 async fn yield_one_tick() {
     tokio::time::sleep(Duration::from_millis(10)).await;
 }
@@ -215,415 +315,4 @@ async fn wait_for<F: Fn() -> bool>(predicate: F) -> bool {
         yield_one_tick().await;
     }
     predicate()
-}
-
-// ── Empty-tick contract: no accept() call when source has no changes ─
-
-#[tokio::test]
-async fn empty_tick_does_not_call_accept() {
-    let source = Arc::new(FakeJournalSource::new());
-    let sink = Arc::new(RecordingSink::new());
-
-    // Empty queue → poll() returns default (empty changes).
-    let handle = spawn_journal_loop(
-        'C',
-        Arc::clone(&source) as Arc<dyn JournalSource>,
-        Arc::clone(&sink) as Arc<dyn PatchSink>,
-        fast_config(),
-    );
-
-    // Let several ticks fire — every one returns empty changes.
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    let join = handle.cancel();
-    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
-
-    assert!(
-        sink.calls().is_empty(),
-        "no accept() call should fire when every poll returns empty changes"
-    );
-    // The source must still have been polled — prove the loop
-    // wasn't simply stuck before reaching the source.
-    assert!(
-        !source.cursors_seen().is_empty(),
-        "loop must have polled the source at least once"
-    );
-}
-
-// ── Non-empty tick contract: exactly one accept() with matching batch ─
-
-#[tokio::test]
-async fn non_empty_tick_invokes_accept_once() {
-    let source = Arc::new(FakeJournalSource::new());
-    let sink = Arc::new(RecordingSink::new());
-
-    source.enqueue_changes(vec![one_change(10), one_change(11)], 100);
-
-    let handle = spawn_journal_loop(
-        'C',
-        Arc::clone(&source) as Arc<dyn JournalSource>,
-        Arc::clone(&sink) as Arc<dyn PatchSink>,
-        fast_config(),
-    );
-
-    // Wait until the recording sink sees exactly one accept().
-    let sink_for_pred = Arc::clone(&sink);
-    let converged = wait_for(move || sink_for_pred.calls().len() == 1).await;
-
-    let join = handle.cancel();
-    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
-
-    assert!(
-        converged,
-        "loop did not invoke accept() within {CONVERGENCE_DEADLINE:?}"
-    );
-    let calls = sink.calls();
-    assert_eq!(calls.len(), 1, "exactly one accept() call expected");
-    assert_eq!(
-        calls.first().copied(),
-        Some(('C', 2_usize)),
-        "letter + change-count must round-trip"
-    );
-}
-
-// ── Cursor monotonicity: each poll sees the previous next_cursor ─────
-
-#[tokio::test]
-async fn cursor_advances_monotonically_across_ticks() {
-    let source = Arc::new(FakeJournalSource::new());
-    let sink = Arc::new(RecordingSink::new());
-
-    // Queue three successful polls with increasing next_cursor.
-    source.enqueue_changes(vec![one_change(10)], 100);
-    source.enqueue_changes(vec![one_change(11)], 200);
-    source.enqueue_changes(vec![one_change(12)], 300);
-
-    let handle = spawn_journal_loop(
-        'C',
-        Arc::clone(&source) as Arc<dyn JournalSource>,
-        Arc::clone(&sink) as Arc<dyn PatchSink>,
-        fast_config(),
-    );
-
-    // Wait until at least 3 polls have been observed.
-    let source_for_pred = Arc::clone(&source);
-    let converged = wait_for(move || source_for_pred.cursors_seen().len() >= 3).await;
-
-    let join = handle.cancel();
-    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
-
-    assert!(
-        converged,
-        "loop did not produce 3 polls within {CONVERGENCE_DEADLINE:?}"
-    );
-    let cursors = source.cursors_seen();
-    // First poll uses the initial cursor (0).  Subsequent polls
-    // see the previous next_cursor (100, then 200).
-    assert_eq!(
-        cursors.first().copied(),
-        Some(0),
-        "first poll must use initial cursor"
-    );
-    assert_eq!(
-        cursors.get(1).copied(),
-        Some(100),
-        "second poll must carry next_cursor=100"
-    );
-    assert_eq!(
-        cursors.get(2).copied(),
-        Some(200),
-        "third poll must carry next_cursor=200"
-    );
-}
-
-// ── Source-error retry: one Err does not abort the loop ──────────────
-
-#[tokio::test]
-async fn source_error_does_not_abort_loop() {
-    let source = Arc::new(FakeJournalSource::new());
-    let sink = Arc::new(RecordingSink::new());
-
-    // Pattern: Err → Ok with changes.  Loop must skip the Err
-    // and apply the next batch on the following tick.
-    source.enqueue_error(std::io::Error::other("fake source error"));
-    source.enqueue_changes(vec![one_change(10)], 100);
-
-    let handle = spawn_journal_loop(
-        'C',
-        Arc::clone(&source) as Arc<dyn JournalSource>,
-        Arc::clone(&sink) as Arc<dyn PatchSink>,
-        fast_config(),
-    );
-
-    // Wait for accept() to fire — proves the loop survived the Err.
-    let sink_for_pred = Arc::clone(&sink);
-    let converged = wait_for(move || !sink_for_pred.calls().is_empty()).await;
-
-    let join = handle.cancel();
-    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
-
-    assert!(
-        converged,
-        "loop must have continued past the Err and applied the subsequent batch within {CONVERGENCE_DEADLINE:?}; got 0 accept() calls"
-    );
-}
-
-// ── Cancellation contract: cancel() exits within CONVERGENCE_DEADLINE ─
-
-#[tokio::test]
-async fn cancel_exits_within_convergence_deadline() {
-    let source = Arc::new(FakeJournalSource::new());
-    let sink = Arc::new(RecordingSink::new());
-
-    let handle = spawn_journal_loop(
-        'C',
-        Arc::clone(&source) as Arc<dyn JournalSource>,
-        Arc::clone(&sink) as Arc<dyn PatchSink>,
-        fast_config(),
-    );
-
-    // Cancel immediately and assert the join handle resolves
-    // within the convergence deadline.
-    let join = handle.cancel();
-    let result = tokio::time::timeout(CONVERGENCE_DEADLINE, join).await;
-    assert!(
-        result.is_ok(),
-        "cancellation must drive the loop to exit within {CONVERGENCE_DEADLINE:?}; timed out instead"
-    );
-}
-
-// ── Phase 7-C: events-based save threshold fires after enough churn ──
-
-#[tokio::test]
-async fn events_threshold_triggers_save() {
-    let source = Arc::new(FakeJournalSource::new());
-    let sink = Arc::new(RecordingSink::new());
-
-    // Two batches of 3 + 4 = 7 events; threshold of 5 means the
-    // second batch must trigger an EventsExceeded save.
-    source.enqueue_changes(vec![one_change(10), one_change(11), one_change(12)], 100);
-    source.enqueue_changes(
-        vec![
-            one_change(13),
-            one_change(14),
-            one_change(15),
-            one_change(16),
-        ],
-        200,
-    );
-
-    let config = JournalLoopConfig {
-        poll_interval: Duration::from_millis(5),
-        initial_cursor: 0,
-        save_threshold_events: 5,
-        save_threshold_age: Duration::from_hours(24),
-    };
-    let handle = spawn_journal_loop(
-        'C',
-        Arc::clone(&source) as Arc<dyn JournalSource>,
-        Arc::clone(&sink) as Arc<dyn PatchSink>,
-        config,
-    );
-
-    // Wait for both accept()s + the save trigger.
-    let sink_for_pred = Arc::clone(&sink);
-    let converged = wait_for(move || !sink_for_pred.save_calls().is_empty()).await;
-
-    let join = handle.cancel();
-    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
-
-    assert!(
-        converged,
-        "events threshold did not fire trigger_save within {CONVERGENCE_DEADLINE:?}"
-    );
-    let saves = sink.save_calls();
-    assert_eq!(
-        saves.len(),
-        1,
-        "exactly one EventsExceeded save expected; got {saves:?}"
-    );
-    assert_eq!(
-        saves.first().copied(),
-        Some(('C', SaveReason::EventsExceeded)),
-        "save reason must be EventsExceeded"
-    );
-}
-
-// ── Phase 7-C: age-based save threshold fires after time elapses ─────
-
-#[tokio::test]
-async fn age_threshold_triggers_save_with_pending_events() {
-    let source = Arc::new(FakeJournalSource::new());
-    let sink = Arc::new(RecordingSink::new());
-
-    // First tick lands one event (under the events-threshold,
-    // and well within the age-threshold from spawn time).
-    source.enqueue_changes(vec![one_change(10)], 100);
-
-    let config = JournalLoopConfig {
-        poll_interval: Duration::from_millis(5),
-        initial_cursor: 0,
-        save_threshold_events: u64::MAX,
-        save_threshold_age: Duration::from_millis(30),
-    };
-    let handle = spawn_journal_loop(
-        'C',
-        Arc::clone(&source) as Arc<dyn JournalSource>,
-        Arc::clone(&sink) as Arc<dyn PatchSink>,
-        config,
-    );
-
-    // Wait for the first batch to land via accept() — proves
-    // events_since_save is now > 0.
-    let sink_for_accept_pred = Arc::clone(&sink);
-    let first_accept_landed = wait_for(move || !sink_for_accept_pred.calls().is_empty()).await;
-    assert!(
-        first_accept_landed,
-        "first batch must land before age can be tested"
-    );
-
-    // Sleep past the 30 ms age threshold while events stay pending
-    // (no save fires on empty ticks — those skip the threshold
-    // evaluation per Phase 7 task 7.4 design).
-    tokio::time::sleep(Duration::from_millis(60)).await;
-
-    // Now enqueue the second batch.  Its tick will observe
-    // elapsed >= 30 ms with events_since_save > 0, firing AgeElapsed.
-    source.enqueue_changes(vec![one_change(11)], 200);
-
-    // Wait for the save to fire.
-    let sink_for_save_pred = Arc::clone(&sink);
-    let converged = wait_for(move || !sink_for_save_pred.save_calls().is_empty()).await;
-
-    let join = handle.cancel();
-    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
-
-    assert!(
-        converged,
-        "age threshold did not fire trigger_save within {CONVERGENCE_DEADLINE:?}"
-    );
-    let saves = sink.save_calls();
-    assert_eq!(
-        saves.first().copied(),
-        Some(('C', SaveReason::AgeElapsed)),
-        "save reason must be AgeElapsed; got {saves:?}"
-    );
-}
-
-// ── Phase 7-C: zero-event drive never triggers a save ─────────────────
-
-#[tokio::test]
-async fn zero_events_drive_does_not_trigger_save() {
-    let source = Arc::new(FakeJournalSource::new());
-    let sink = Arc::new(RecordingSink::new());
-
-    // Empty queue + tight age threshold.  The age threshold
-    // SHOULD NOT fire because no events have ever been recorded
-    // — Phase 7 task 7.4 contract: zero-churn drives produce
-    // no wasteful saves.
-    let config = JournalLoopConfig {
-        poll_interval: Duration::from_millis(5),
-        initial_cursor: 0,
-        save_threshold_events: 1,
-        save_threshold_age: Duration::from_millis(20),
-    };
-    let handle = spawn_journal_loop(
-        'C',
-        Arc::clone(&source) as Arc<dyn JournalSource>,
-        Arc::clone(&sink) as Arc<dyn PatchSink>,
-        config,
-    );
-
-    // Let several ticks fire well past the age threshold.
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let join = handle.cancel();
-    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
-
-    let saves = sink.save_calls();
-    assert!(
-        saves.is_empty(),
-        "zero-event drive must not produce any save triggers; got {saves:?}"
-    );
-    // Sanity: the loop did poll the source.
-    assert!(
-        !source.cursors_seen().is_empty(),
-        "loop must have polled the source"
-    );
-}
-
-// ── Phase 7-C: counter resets after save — no double-fire on next tick ──
-
-#[tokio::test]
-async fn counter_resets_after_save() {
-    let source = Arc::new(FakeJournalSource::new());
-    let sink = Arc::new(RecordingSink::new());
-
-    // First batch of 5 events crosses the events_threshold = 5
-    // → first save fires.  Second batch of 1 event must NOT
-    // trigger another save (counter reset; 1 < 5).
-    source.enqueue_changes(
-        vec![
-            one_change(10),
-            one_change(11),
-            one_change(12),
-            one_change(13),
-            one_change(14),
-        ],
-        100,
-    );
-    source.enqueue_changes(vec![one_change(15)], 200);
-
-    let config = JournalLoopConfig {
-        poll_interval: Duration::from_millis(5),
-        initial_cursor: 0,
-        save_threshold_events: 5,
-        save_threshold_age: Duration::from_hours(24),
-    };
-    let handle = spawn_journal_loop(
-        'C',
-        Arc::clone(&source) as Arc<dyn JournalSource>,
-        Arc::clone(&sink) as Arc<dyn PatchSink>,
-        config,
-    );
-
-    // Wait until both accept() calls land + first save fires.
-    let sink_for_pred = Arc::clone(&sink);
-    let converged = wait_for(move || {
-        sink_for_pred.calls().len() >= 2 && !sink_for_pred.save_calls().is_empty()
-    })
-    .await;
-
-    // Give the loop one extra tick window to potentially fire
-    // a wrong second save.
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    let join = handle.cancel();
-    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
-
-    assert!(converged, "loop did not converge within deadline");
-    let saves = sink.save_calls();
-    assert_eq!(
-        saves.len(),
-        1,
-        "exactly one save expected (counter reset after first); got {saves:?}"
-    );
-}
-
-// ── MacStubJournalSource production fallback: always-empty contract ──
-
-#[test]
-fn mac_stub_source_returns_empty_with_unchanged_cursor() -> std::io::Result<()> {
-    let stub = super::MacStubJournalSource;
-    let res = stub.poll(42)?;
-    assert!(
-        res.changes.is_empty(),
-        "MacStub must always return empty changes"
-    );
-    assert_eq!(
-        res.next_cursor, 42,
-        "MacStub must keep the cursor unchanged"
-    );
-    assert_eq!(res.journal_id, 0, "MacStub journal_id is the zero sentinel");
-    Ok(())
 }

--- a/crates/uffs-daemon/src/cache/journal_loop/tests/basics.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests/basics.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase 7-B basic loop-lifecycle tests for the per-shard USN
+//! journal loop.
+//!
+//! Pins the state-machine contract for the foundational tasks 7.2
+//! + 7.3:
+//!
+//! * **Empty ticks** — no `accept()` call when the journal returns no changes.
+//! * **Non-empty ticks** — exactly one `accept()` call per tick with the
+//!   matching change batch and drive letter.
+//! * **Cursor advance** — each poll receives the cursor returned by the
+//!   previous poll.
+//! * **Cancellation** — `JournalLoopHandle::cancel()` causes the loop to exit
+//!   within one poll-interval.
+//! * **Source error recovery** — a single `Err` from the source does not abort
+//!   the loop; the next tick proceeds normally.
+//! * **`MacStubJournalSource` always-empty fallback** — production journal
+//!   source on macOS / Linux returns `(empty, cursor, 0)` without I/O.
+
+use alloc::sync::Arc;
+use core::time::Duration;
+
+use super::super::{JournalSource, MacStubJournalSource, PatchSink, spawn_journal_loop};
+use super::{
+    CONVERGENCE_DEADLINE, FakeJournalSource, RecordingSink, fast_config, null_cursor_store,
+    one_change, wait_for,
+};
+
+#[tokio::test]
+async fn empty_tick_does_not_call_accept() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // Empty queue → poll() returns default (empty changes).
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        null_cursor_store(),
+        fast_config(),
+    );
+
+    // Let several ticks fire — every one returns empty changes.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        sink.calls().is_empty(),
+        "no accept() call should fire when every poll returns empty changes"
+    );
+    // The source must still have been polled — prove the loop
+    // wasn't simply stuck before reaching the source.
+    assert!(
+        !source.cursors_seen().is_empty(),
+        "loop must have polled the source at least once"
+    );
+}
+
+#[tokio::test]
+async fn non_empty_tick_invokes_accept_once() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    source.enqueue_changes(vec![one_change(10), one_change(11)], 100);
+
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        null_cursor_store(),
+        fast_config(),
+    );
+
+    // Wait until the recording sink sees exactly one accept().
+    let sink_for_pred = Arc::clone(&sink);
+    let converged = wait_for(move || sink_for_pred.calls().len() == 1).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "loop did not invoke accept() within {CONVERGENCE_DEADLINE:?}"
+    );
+    let calls = sink.calls();
+    assert_eq!(calls.len(), 1, "exactly one accept() call expected");
+    assert_eq!(
+        calls.first().copied(),
+        Some(('C', 2_usize)),
+        "letter + change-count must round-trip"
+    );
+}
+
+#[tokio::test]
+async fn cursor_advances_monotonically_across_ticks() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // Queue three successful polls with increasing next_cursor.
+    source.enqueue_changes(vec![one_change(10)], 100);
+    source.enqueue_changes(vec![one_change(11)], 200);
+    source.enqueue_changes(vec![one_change(12)], 300);
+
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        null_cursor_store(),
+        fast_config(),
+    );
+
+    // Wait until at least 3 polls have been observed.
+    let source_for_pred = Arc::clone(&source);
+    let converged = wait_for(move || source_for_pred.cursors_seen().len() >= 3).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "loop did not produce 3 polls within {CONVERGENCE_DEADLINE:?}"
+    );
+    let cursors = source.cursors_seen();
+    // First poll uses the initial cursor (0).  Subsequent polls
+    // see the previous next_cursor (100, then 200).
+    assert_eq!(
+        cursors.first().copied(),
+        Some(0),
+        "first poll must use initial cursor"
+    );
+    assert_eq!(
+        cursors.get(1).copied(),
+        Some(100),
+        "second poll must carry next_cursor=100"
+    );
+    assert_eq!(
+        cursors.get(2).copied(),
+        Some(200),
+        "third poll must carry next_cursor=200"
+    );
+}
+
+#[tokio::test]
+async fn source_error_does_not_abort_loop() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // Pattern: Err → Ok with changes.  Loop must skip the Err
+    // and apply the next batch on the following tick.
+    source.enqueue_error(std::io::Error::other("fake source error"));
+    source.enqueue_changes(vec![one_change(10)], 100);
+
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        null_cursor_store(),
+        fast_config(),
+    );
+
+    // Wait for accept() to fire — proves the loop survived the Err.
+    let sink_for_pred = Arc::clone(&sink);
+    let converged = wait_for(move || !sink_for_pred.calls().is_empty()).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "loop must have continued past the Err and applied the subsequent batch within {CONVERGENCE_DEADLINE:?}; got 0 accept() calls"
+    );
+}
+
+#[tokio::test]
+async fn cancel_exits_within_convergence_deadline() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        null_cursor_store(),
+        fast_config(),
+    );
+
+    // Cancel immediately and assert the join handle resolves
+    // within the convergence deadline.
+    let join = handle.cancel();
+    let result = tokio::time::timeout(CONVERGENCE_DEADLINE, join).await;
+    assert!(
+        result.is_ok(),
+        "cancellation must drive the loop to exit within {CONVERGENCE_DEADLINE:?}; timed out instead"
+    );
+}
+
+#[test]
+fn mac_stub_source_returns_empty_with_unchanged_cursor() -> std::io::Result<()> {
+    let stub = MacStubJournalSource;
+    let res = stub.poll(42)?;
+    assert!(
+        res.changes.is_empty(),
+        "MacStub must always return empty changes"
+    );
+    assert_eq!(
+        res.next_cursor, 42,
+        "MacStub must keep the cursor unchanged"
+    );
+    assert_eq!(res.journal_id, 0, "MacStub journal_id is the zero sentinel");
+    Ok(())
+}

--- a/crates/uffs-daemon/src/cache/journal_loop/tests/integration.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests/integration.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase 7-E end-to-end integration test for the per-shard USN
+//! journal loop.
+//!
+//! Drives 10 000 events through the full pipeline —
+//! [`FakeJournalSource`] \u2192 [`JournalLoop`] \u2192
+//! [`RecordingSink::accept`] \u2192 threshold check \u2192
+//! [`RecordingSink::trigger_save`] \u2192 [`FakeCursorStore::store`] \u2014 and
+//! pins the integrated contract:
+//!
+//! * **All events accepted** \u2014 the sink's `accept` calls collectively
+//!   carry `TOTAL_EVENTS` change records (no events lost across tick
+//!   boundaries, no events double-applied).
+//! * **Multiple saves fire** \u2014 with `save_threshold_events = BATCH_SIZE +
+//!   (BATCH_SIZE / 2)`, the threshold crosses inside roughly every other batch.
+//!   A 10-batch run produces \u2265 4 saves.
+//! * **Final cursor persists** \u2014 the cursor store's append-only log
+//!   contains the post-final-batch cursor, proving cursor and body advance in
+//!   lockstep all the way through.
+//! * **Cursor monotonicity** \u2014 across 10+ polls, every cursor passed into
+//!   `JournalSource::poll` is \u2265 the previous one.
+//! * **No false-positive wrap detection** \u2014 with a single stable
+//!   `journal_id`, `sink.journal_wrapped` is **never** invoked.
+//!
+//! ## Sizing rationale
+//!
+//! 10 000 events split into 10 batches of 1 000 keeps the Mac tick
+//! count low (one batch consumed per tick \u2192 ~10 ticks total) so the
+//! 5 ms poll interval + `spawn_blocking` overhead lands the run
+//! comfortably under 1 second on every supported runner.  Larger
+//! batches (e.g. 100 000 / 100) would stress the [`FakeJournalSource`]'s
+//! `Vec` allocations more than the loop semantics they aim to verify.
+//!
+//! [`FakeJournalSource`]: super::FakeJournalSource
+//! [`JournalLoop`]: super::super::JournalLoop
+//! [`RecordingSink::accept`]: super::RecordingSink
+//! [`RecordingSink::trigger_save`]: super::RecordingSink
+//! [`FakeCursorStore::store`]: super::FakeCursorStore
+
+use alloc::sync::Arc;
+use core::time::Duration;
+
+use super::super::{CursorStore, JournalLoopConfig, JournalSource, PatchSink, spawn_journal_loop};
+use super::{FakeCursorStore, FakeJournalSource, RecordingSink, one_change};
+
+/// Total events driven through the pipeline in this end-to-end test.
+const TOTAL_EVENTS: usize = 10_000;
+
+/// Events per batch.  10 batches of 1 000 keeps tick count manageable.
+const BATCH_SIZE: usize = 1_000;
+
+/// Number of batches enqueued in the source (10).
+const NUM_BATCHES: usize = TOTAL_EVENTS / BATCH_SIZE;
+
+/// Save threshold tuned to fire roughly every other batch — at
+/// 1 500 events per save and 1 000 events per batch, the second
+/// batch's tick crosses 2 000 ≥ 1 500 → save; the fourth crosses
+/// 4 000 → save (after the post-save reset to 0); etc.
+const SAVE_THRESHOLD_EVENTS: u64 = 1_500;
+
+/// Wall-clock deadline for the loop to drain all 10 000 events.
+/// Generous: at 5 ms tick + spawn-blocking overhead, ~10 ticks
+/// should land the full batch in well under 1 second; 5 s gives
+/// a 50× safety margin against slower CI runners.
+const E2E_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Polling interval inside the test for `wait_for_e2e` predicate
+/// re-evaluation.  10 ms keeps the test responsive without
+/// busy-waiting.
+const E2E_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[tokio::test]
+async fn ten_thousand_events_end_to_end() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+    let cursor_store = Arc::new(FakeCursorStore::new());
+
+    // Enqueue NUM_BATCHES batches of BATCH_SIZE events each.  FRS
+    // values monotonically increase across batches so each event
+    // is unique; next_cursor advances by BATCH_SIZE per batch.
+    for batch_idx in 0..NUM_BATCHES {
+        let mut changes = Vec::with_capacity(BATCH_SIZE);
+        for event_idx in 0..BATCH_SIZE {
+            let frs = ((batch_idx * BATCH_SIZE) + event_idx) as u64;
+            changes.push(one_change(frs));
+        }
+        let next_cursor = ((batch_idx + 1) * BATCH_SIZE) as u64;
+        source.enqueue_changes(changes, next_cursor);
+    }
+
+    let config = JournalLoopConfig {
+        poll_interval: Duration::from_millis(5),
+        initial_cursor: 0,
+        save_threshold_events: SAVE_THRESHOLD_EVENTS,
+        save_threshold_age: Duration::from_hours(24),
+    };
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        Arc::clone(&cursor_store) as Arc<dyn CursorStore>,
+        config,
+    );
+
+    // Wait until all TOTAL_EVENTS have been accepted.  The
+    // predicate sums the change-counts across every accept() call;
+    // with a single drive letter and no wrap, this monotonically
+    // increases until the source drains.
+    let sink_for_pred = Arc::clone(&sink);
+    let converged = wait_for_e2e(move || {
+        let total: usize = sink_for_pred.calls().iter().map(|(_, count)| *count).sum();
+        total >= TOTAL_EVENTS
+    })
+    .await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(Duration::from_secs(2), join).await);
+
+    assert!(
+        converged,
+        "loop did not drain {TOTAL_EVENTS} events within {E2E_DEADLINE:?}"
+    );
+
+    // ── All events accepted ─────────────────────────────────────────
+    let calls = sink.calls();
+    let total_accepted: usize = calls.iter().map(|(_, count)| *count).sum();
+    assert_eq!(
+        total_accepted, TOTAL_EVENTS,
+        "sink.accept must have received exactly {TOTAL_EVENTS} events; got {total_accepted}"
+    );
+    // Every accept call was for letter 'C'.
+    assert!(
+        calls.iter().all(|(letter, _)| *letter == 'C'),
+        "every accept() must be for drive 'C'; got {calls:?}"
+    );
+
+    // ── Multiple saves fired ────────────────────────────────────────
+    let saves = sink.save_calls();
+    let save_threshold_usize = usize::try_from(SAVE_THRESHOLD_EVENTS).unwrap_or(usize::MAX);
+    let expected_min_saves = (TOTAL_EVENTS / save_threshold_usize).saturating_sub(1);
+    assert!(
+        saves.len() >= expected_min_saves,
+        "expected at least {expected_min_saves} saves for {TOTAL_EVENTS} events @ \
+         threshold {SAVE_THRESHOLD_EVENTS}; got {} saves: {saves:?}",
+        saves.len()
+    );
+    assert!(
+        saves.iter().all(|(letter, _)| *letter == 'C'),
+        "every save must be for drive 'C'; got {saves:?}"
+    );
+
+    // ── Final cursor persisted ──────────────────────────────────────
+    let log = cursor_store.store_log();
+    assert!(
+        !log.is_empty(),
+        "cursor store must have at least one persistence write; got empty log"
+    );
+    // The largest cursor in the log should match TOTAL_EVENTS (the
+    // final batch's next_cursor).
+    let max_persisted = log.iter().map(|(_, cursor)| *cursor).max().unwrap_or(0);
+    assert!(
+        max_persisted >= TOTAL_EVENTS as u64,
+        "highest persisted cursor must be ≥ {TOTAL_EVENTS}; got {max_persisted}"
+    );
+
+    // ── Cursor monotonicity ─────────────────────────────────────────
+    let cursors_seen = source.cursors_seen();
+    assert!(
+        cursors_seen.len() >= NUM_BATCHES,
+        "source must have been polled at least {NUM_BATCHES} times; got {}",
+        cursors_seen.len()
+    );
+    for window in cursors_seen.windows(2) {
+        let prev = window.first().copied().unwrap_or(0);
+        let curr = window.get(1).copied().unwrap_or(0);
+        assert!(
+            curr >= prev,
+            "cursor must advance monotonically; observed regression {prev} → {curr} in {cursors_seen:?}"
+        );
+    }
+
+    // ── No false-positive wrap detection ────────────────────────────
+    let wraps = sink.wrap_calls();
+    assert!(
+        wraps.is_empty(),
+        "single-journal_id run must NOT trigger any wrap detection; got {wraps:?}"
+    );
+}
+
+/// E2E predicate-poll helper with a longer deadline ([`E2E_DEADLINE`]
+/// = 5 s) than the standard `super::wait_for` ([`super::CONVERGENCE_DEADLINE`]
+/// = 250 ms).  10 000 events at 5 ms tick + spawn-blocking overhead
+/// can take up to ~1 second; the 5 s budget keeps the test reliable
+/// across slower CI runners.
+async fn wait_for_e2e<F: Fn() -> bool>(predicate: F) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < E2E_DEADLINE {
+        if predicate() {
+            return true;
+        }
+        tokio::time::sleep(E2E_POLL_INTERVAL).await;
+    }
+    predicate()
+}

--- a/crates/uffs-daemon/src/cache/journal_loop/tests/thresholds.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests/thresholds.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase 7-C threshold-triggered save tests.
+//!
+//! Pins the [`SaveTrigger`] state-machine contract: events- and
+//! age-based thresholds fire `trigger_save` at the right time
+//! with the right [`SaveReason`]; zero-event drives produce no
+//! wasteful saves; counters reset after firing so a single
+//! threshold crossing produces exactly one save.
+//!
+//! [`SaveTrigger`]: super::super::SaveTrigger
+
+use alloc::sync::Arc;
+use core::time::Duration;
+
+use super::super::{JournalLoopConfig, JournalSource, PatchSink, SaveReason, spawn_journal_loop};
+use super::{
+    CONVERGENCE_DEADLINE, FakeJournalSource, RecordingSink, null_cursor_store, one_change, wait_for,
+};
+
+#[tokio::test]
+async fn events_threshold_triggers_save() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // Two batches of 3 + 4 = 7 events; threshold of 5 means the
+    // second batch must trigger an EventsExceeded save.
+    source.enqueue_changes(vec![one_change(10), one_change(11), one_change(12)], 100);
+    source.enqueue_changes(
+        vec![
+            one_change(13),
+            one_change(14),
+            one_change(15),
+            one_change(16),
+        ],
+        200,
+    );
+
+    let config = JournalLoopConfig {
+        poll_interval: Duration::from_millis(5),
+        initial_cursor: 0,
+        save_threshold_events: 5,
+        save_threshold_age: Duration::from_hours(24),
+    };
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        null_cursor_store(),
+        config,
+    );
+
+    let sink_for_pred = Arc::clone(&sink);
+    let converged = wait_for(move || !sink_for_pred.save_calls().is_empty()).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "events threshold did not fire trigger_save within {CONVERGENCE_DEADLINE:?}"
+    );
+    let saves = sink.save_calls();
+    assert_eq!(
+        saves.len(),
+        1,
+        "exactly one EventsExceeded save expected; got {saves:?}"
+    );
+    assert_eq!(
+        saves.first().copied(),
+        Some(('C', SaveReason::EventsExceeded)),
+        "save reason must be EventsExceeded"
+    );
+}
+
+#[tokio::test]
+async fn age_threshold_triggers_save_with_pending_events() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // First tick lands one event (under the events-threshold,
+    // and well within the age-threshold from spawn time).
+    source.enqueue_changes(vec![one_change(10)], 100);
+
+    let config = JournalLoopConfig {
+        poll_interval: Duration::from_millis(5),
+        initial_cursor: 0,
+        save_threshold_events: u64::MAX,
+        save_threshold_age: Duration::from_millis(30),
+    };
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        null_cursor_store(),
+        config,
+    );
+
+    // Wait for the first batch to land via accept() — proves
+    // events_since_save is now > 0.
+    let sink_for_accept_pred = Arc::clone(&sink);
+    let first_accept_landed = wait_for(move || !sink_for_accept_pred.calls().is_empty()).await;
+    assert!(
+        first_accept_landed,
+        "first batch must land before age can be tested"
+    );
+
+    // Sleep past the 30 ms age threshold while events stay pending
+    // (no save fires on empty ticks — those skip the threshold
+    // evaluation per Phase 7 task 7.4 design).
+    tokio::time::sleep(Duration::from_millis(60)).await;
+
+    // Now enqueue the second batch.  Its tick will observe
+    // elapsed >= 30 ms with events_since_save > 0, firing AgeElapsed.
+    source.enqueue_changes(vec![one_change(11)], 200);
+
+    let sink_for_save_pred = Arc::clone(&sink);
+    let converged = wait_for(move || !sink_for_save_pred.save_calls().is_empty()).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "age threshold did not fire trigger_save within {CONVERGENCE_DEADLINE:?}"
+    );
+    let saves = sink.save_calls();
+    assert_eq!(
+        saves.first().copied(),
+        Some(('C', SaveReason::AgeElapsed)),
+        "save reason must be AgeElapsed; got {saves:?}"
+    );
+}
+
+#[tokio::test]
+async fn zero_events_drive_does_not_trigger_save() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // Empty queue + tight age threshold.  The age threshold
+    // SHOULD NOT fire because no events have ever been recorded
+    // — Phase 7 task 7.4 contract: zero-churn drives produce
+    // no wasteful saves.
+    let config = JournalLoopConfig {
+        poll_interval: Duration::from_millis(5),
+        initial_cursor: 0,
+        save_threshold_events: 1,
+        save_threshold_age: Duration::from_millis(20),
+    };
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        null_cursor_store(),
+        config,
+    );
+
+    // Let several ticks fire well past the age threshold.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    let saves = sink.save_calls();
+    assert!(
+        saves.is_empty(),
+        "zero-event drive must not produce any save triggers; got {saves:?}"
+    );
+    // Sanity: the loop did poll the source.
+    assert!(
+        !source.cursors_seen().is_empty(),
+        "loop must have polled the source"
+    );
+}
+
+#[tokio::test]
+async fn counter_resets_after_save() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+
+    // First batch of 5 events crosses the events_threshold = 5
+    // → first save fires.  Second batch of 1 event must NOT
+    // trigger another save (counter reset; 1 < 5).
+    source.enqueue_changes(
+        vec![
+            one_change(10),
+            one_change(11),
+            one_change(12),
+            one_change(13),
+            one_change(14),
+        ],
+        100,
+    );
+    source.enqueue_changes(vec![one_change(15)], 200);
+
+    let config = JournalLoopConfig {
+        poll_interval: Duration::from_millis(5),
+        initial_cursor: 0,
+        save_threshold_events: 5,
+        save_threshold_age: Duration::from_hours(24),
+    };
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        null_cursor_store(),
+        config,
+    );
+
+    // Wait until both accept() calls land + first save fires.
+    let sink_for_pred = Arc::clone(&sink);
+    let converged = wait_for(move || {
+        sink_for_pred.calls().len() >= 2 && !sink_for_pred.save_calls().is_empty()
+    })
+    .await;
+
+    // Give the loop one extra tick window to potentially fire
+    // a wrong second save.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(converged, "loop did not converge within deadline");
+    let saves = sink.save_calls();
+    assert_eq!(
+        saves.len(),
+        1,
+        "exactly one save expected (counter reset after first); got {saves:?}"
+    );
+}

--- a/crates/uffs-daemon/src/cache/journal_loop/tests/wrap_and_persistence.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests/wrap_and_persistence.rs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase 7-D cursor-persistence + journal-wrap-detection tests.
+//!
+//! Pins the [`CursorStore`] + wrap-detection contracts:
+//!
+//! * **Cursor seeded at spawn** — `cursor_store.load(letter)` is the first
+//!   poll's cursor argument when the store has a pre-loaded value.
+//! * **Cursor persisted on save** — the loop calls `cursor_store.store(letter,
+//!   cursor)` at the same time as `trigger_save` so on-disk cursor and on-disk
+//!   body advance together.
+//! * **Wrap detected via `journal_id` change** — a different `journal_id`
+//!   between two successive non-zero polls fires `sink.journal_wrapped(letter)`
+//!   and the wrap-tick's changes are NOT applied via `accept`.
+//! * **Cursor resets after wrap** — the next poll after a wrap uses cursor=0
+//!   (start of the new journal).
+//!
+//! [`CursorStore`]: super::super::CursorStore
+
+use alloc::sync::Arc;
+use core::time::Duration;
+
+use super::super::{CursorStore, JournalLoopConfig, JournalSource, PatchSink, spawn_journal_loop};
+use super::{
+    CONVERGENCE_DEADLINE, FakeCursorStore, FakeJournalSource, RecordingSink, fast_config,
+    one_change, wait_for,
+};
+
+#[tokio::test]
+async fn cursor_loaded_from_store_at_spawn() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+    let cursor_store = Arc::new(FakeCursorStore::new());
+    cursor_store.set_cursor('C', 42);
+
+    // No batches enqueued; the loop will tick on empty results.
+    // We're asserting the FIRST poll's cursor argument.
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        Arc::clone(&cursor_store) as Arc<dyn CursorStore>,
+        fast_config(),
+    );
+
+    // Wait until at least one poll has been issued.
+    let source_for_pred = Arc::clone(&source);
+    let converged = wait_for(move || !source_for_pred.cursors_seen().is_empty()).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "loop did not produce a poll within {CONVERGENCE_DEADLINE:?}"
+    );
+    let cursors = source.cursors_seen();
+    assert_eq!(
+        cursors.first().copied(),
+        Some(42),
+        "first poll must use the cursor loaded from the store, not 0"
+    );
+}
+
+#[tokio::test]
+async fn cursor_persisted_on_save_trigger() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+    let cursor_store = Arc::new(FakeCursorStore::new());
+
+    // 5 events with next_cursor=100 → events_threshold=5 fires save.
+    source.enqueue_changes(
+        vec![
+            one_change(10),
+            one_change(11),
+            one_change(12),
+            one_change(13),
+            one_change(14),
+        ],
+        100,
+    );
+
+    let config = JournalLoopConfig {
+        poll_interval: Duration::from_millis(5),
+        initial_cursor: 0,
+        save_threshold_events: 5,
+        save_threshold_age: Duration::from_hours(24),
+    };
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        Arc::clone(&cursor_store) as Arc<dyn CursorStore>,
+        config,
+    );
+
+    let sink_for_pred = Arc::clone(&sink);
+    let converged = wait_for(move || !sink_for_pred.save_calls().is_empty()).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "save did not fire within {CONVERGENCE_DEADLINE:?}"
+    );
+    let log = cursor_store.store_log();
+    assert!(
+        log.iter()
+            .any(|&(letter, cursor)| letter == 'C' && cursor == 100),
+        "cursor 100 must be persisted alongside the save trigger; log = {log:?}"
+    );
+}
+
+#[tokio::test]
+async fn journal_wrap_fires_journal_wrapped_and_skips_patch() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+    let cursor_store = Arc::new(FakeCursorStore::new());
+
+    // Tick 1: journal_id=1, one change.
+    source.enqueue_changes_with_journal_id(vec![one_change(10)], 100, 1);
+    // Tick 2: journal_id=2 (different) → wrap detected.
+    // Even though changes are non-empty, accept must NOT be called.
+    source.enqueue_changes_with_journal_id(vec![one_change(11)], 200, 2);
+
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        Arc::clone(&cursor_store) as Arc<dyn CursorStore>,
+        fast_config(),
+    );
+
+    let sink_for_pred = Arc::clone(&sink);
+    let converged = wait_for(move || !sink_for_pred.wrap_calls().is_empty()).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "wrap detection did not fire within {CONVERGENCE_DEADLINE:?}"
+    );
+    let wraps = sink.wrap_calls();
+    assert_eq!(
+        wraps.len(),
+        1,
+        "exactly one journal_wrapped call expected; got {wraps:?}"
+    );
+    assert_eq!(wraps.first().copied(), Some('C'));
+
+    // The first batch (journal_id=1) MUST have been accepted; the
+    // second (journal_id=2 wrap-tick) must NOT have produced an
+    // accept call.
+    let calls = sink.calls();
+    assert_eq!(
+        calls.len(),
+        1,
+        "only the pre-wrap batch must be accepted; got {calls:?}"
+    );
+    assert_eq!(calls.first().copied(), Some(('C', 1_usize)));
+}
+
+#[tokio::test]
+async fn journal_wrap_resets_cursor_to_zero() {
+    let source = Arc::new(FakeJournalSource::new());
+    let sink = Arc::new(RecordingSink::new());
+    let cursor_store = Arc::new(FakeCursorStore::new());
+
+    // Tick 1: journal_id=1, advances cursor to 100.
+    source.enqueue_changes_with_journal_id(vec![one_change(10)], 100, 1);
+    // Tick 2: journal_id=2 → wrap detected, cursor reset to 0.
+    source.enqueue_changes_with_journal_id(vec![one_change(11)], 200, 2);
+    // Tick 3: journal_id=2 (same as tick 2), advances cursor.
+    // The point of this batch is just to drive a third poll so the
+    // assertion can observe the post-wrap cursor seed.
+    source.enqueue_changes_with_journal_id(vec![one_change(12)], 300, 2);
+
+    let handle = spawn_journal_loop(
+        'C',
+        Arc::clone(&source) as Arc<dyn JournalSource>,
+        Arc::clone(&sink) as Arc<dyn PatchSink>,
+        Arc::clone(&cursor_store) as Arc<dyn CursorStore>,
+        fast_config(),
+    );
+
+    let source_for_pred = Arc::clone(&source);
+    let converged = wait_for(move || source_for_pred.cursors_seen().len() >= 3).await;
+
+    let join = handle.cancel();
+    drop(tokio::time::timeout(CONVERGENCE_DEADLINE, join).await);
+
+    assert!(
+        converged,
+        "loop did not produce 3 polls within {CONVERGENCE_DEADLINE:?}"
+    );
+    let cursors = source.cursors_seen();
+    // Tick 1 sees cursor=0 (initial), tick 2 sees cursor=100
+    // (advanced from tick 1's next_cursor), tick 3 sees cursor=0
+    // (reset by the wrap detected in tick 2).
+    assert_eq!(
+        cursors.first().copied(),
+        Some(0),
+        "first poll must use initial cursor 0"
+    );
+    assert_eq!(
+        cursors.get(1).copied(),
+        Some(100),
+        "second poll must carry next_cursor=100 from tick 1"
+    );
+    assert_eq!(
+        cursors.get(2).copied(),
+        Some(0),
+        "third poll must use cursor=0 (reset by the wrap on tick 2)"
+    );
+}

--- a/crates/uffs-daemon/src/cache/mod.rs
+++ b/crates/uffs-daemon/src/cache/mod.rs
@@ -30,6 +30,7 @@
 
 pub(crate) mod background_io;
 pub(crate) mod body_loader;
+pub(crate) mod journal_loop;
 pub(crate) mod policy;
 pub(crate) mod prefetch;
 pub(crate) mod pressure;

--- a/crates/uffs-daemon/src/cache/shard.rs
+++ b/crates/uffs-daemon/src/cache/shard.rs
@@ -612,6 +612,63 @@ impl ShardEntry {
             }
         }
     }
+
+    /// Apply USN journal deltas off this shard's in-memory body.
+    ///
+    /// Phase 7 task 7.1 — the surgical method-on-`ShardEntry` form of
+    /// the platform-agnostic patcher
+    /// [`uffs_core::compact_loader::apply_usn_patch`].  Clones the
+    /// inner [`DriveCompactIndex`] (cheap: `ColumnStorage::clone`
+    /// always promotes mmap-backed columns to heap-resident `Vec`s
+    /// per the invariant in `compact_storage.rs:480-482`), invokes
+    /// the in-place patcher on the clone, and returns the new
+    /// `Arc<DriveCompactIndex>` for the caller to swap into the
+    /// registry via [`crate::cache::ShardRegistry::replace_warm_body`].
+    /// Concurrent readers continue to see the previous body until
+    /// that swap.
+    ///
+    /// **Returns** `Some((new_body, stats))` on `Warm` / `Hot` shards.
+    ///
+    /// **Returns** `None` on `Parked` / `Cold` / `Unknown` /
+    /// `Evicting` shards (no in-memory body to patch); the caller
+    /// should re-promote first via
+    /// [`crate::index::IndexManager::ensure_warm_for_dispatch`]
+    /// before attempting incremental patching.
+    ///
+    /// The `frs_to_compact` slice is a `frs → compact_idx` mapping
+    /// produced by the caller from the same `DriveCompactIndex` the
+    /// `body` Arc points at; mismatched slices produce all-skipped
+    /// `PatchStats` rather than corrupting the index.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Phase 7 task 7.1 surface; production caller \
+                      (per-shard journal loop) lands in Phase 7 task 7.2. \
+                      Exercised by `cache::shard::tests::\
+                      apply_usn_patch_to_body_returns_new_arc_on_warm` \
+                      and the matching `_returns_none_on_parked` companion."
+        )
+    )]
+    #[must_use]
+    pub(crate) fn apply_usn_patch_to_body(
+        &self,
+        changes: &[uffs_mft::usn::FileChange],
+        frs_to_compact: &[u32],
+    ) -> Option<(
+        Arc<DriveCompactIndex>,
+        uffs_core::compact_loader::PatchStats,
+    )> {
+        let body_arc = self.body.as_ref()?;
+        // Deep-clone the inner DriveCompactIndex so the patch loop
+        // mutates the clone — never the live Arc that concurrent
+        // readers are observing.  ColumnStorage::clone() promotes
+        // mmap-backed columns to heap-resident Vec, so the cloned
+        // body is fully mutable without remap ceremony.
+        let mut owned: DriveCompactIndex = (**body_arc).clone();
+        let stats = uffs_core::compact_loader::apply_usn_patch(&mut owned, changes, frs_to_compact);
+        Some((Arc::new(owned), stats))
+    }
 }
 
 // Test suite hosted in the sibling `shard/tests.rs` so this

--- a/crates/uffs-daemon/src/cache/shard/tests.rs
+++ b/crates/uffs-daemon/src/cache/shard/tests.rs
@@ -20,17 +20,72 @@
 
 use alloc::sync::Arc;
 use core::sync::atomic::Ordering;
+use std::path::PathBuf;
 
 use proptest::prelude::*;
 use uffs_core::CaseFold;
 use uffs_core::bloom::Bloom;
+use uffs_core::compact::{
+    ChildrenIndex, CompactRecord, DriveCompactIndex, ExtensionIndex, IndexSource,
+};
 use uffs_core::compact_cache::ParkedBody;
+use uffs_core::compact_storage::ColumnStorage;
 use uffs_core::path_trie::PathTrie;
+use uffs_core::trigram::TrigramIndex;
+use uffs_mft::usn::FileChange;
 
 use super::{
     DriveStats, DriveStatsSnapshot, IllegalTransition, ShardEntry, ShardState,
     drive_stats_ema_value,
 };
+
+/// Build a minimal 2-record `DriveCompactIndex` for shard-body
+/// fixture purposes — root directory + one file under it.
+///
+/// Sufficient to exercise [`ShardEntry::apply_usn_patch_to_body`]'s
+/// Arc-clone + Arc-swap contract without dragging in the
+/// `index/tests/mod.rs::build_test_drive` fixture (which builds a
+/// 7-record drive from a real `MftIndex` and is overkill for the
+/// patch-method shape tests below).
+fn make_test_body(letter: char) -> DriveCompactIndex {
+    // Names blob: letter + "/" + "f.txt".
+    let names = vec![letter as u8, b'f', b'.', b't', b'x', b't'];
+    let records = vec![
+        CompactRecord {
+            name_offset: 0,
+            flags: 0x10, // directory
+            parent_idx: u32::MAX,
+            name_len: 1,
+            name_first_byte: letter as u8,
+            ..CompactRecord::default()
+        },
+        CompactRecord {
+            name_offset: 1,
+            parent_idx: 0,
+            name_len: 5,
+            name_first_byte: b'f',
+            ..CompactRecord::default()
+        },
+    ];
+    let fold = CaseFold::default_table();
+    let trigram = TrigramIndex::build(&records, &names, fold);
+    let children = ChildrenIndex::build(&records);
+    let ext_index = ExtensionIndex::build(&records);
+    DriveCompactIndex {
+        letter,
+        records: ColumnStorage::from_vec(records),
+        names: ColumnStorage::from_vec(names),
+        trigram,
+        children,
+        ext_index,
+        fold,
+        ext_names: vec![Box::from("")],
+        source: IndexSource::MftFile(PathBuf::from(format!("{letter}:"))),
+        source_epoch: 1,
+        bloom: None,
+        path_trie: None,
+    }
+}
 
 /// Build a minimal `ParkedBody` for shard-construction tests — a
 /// 64-bit bloom + an empty path trie + the default fold table.
@@ -331,4 +386,132 @@ fn new_cold_has_no_body_and_shares_stats() {
     stats.mark_query_at(1_700_000_000_000);
     assert_eq!(shard.stats.queries_total(), 1);
     assert_eq!(shard.stats.last_query_at_ms(), 1_700_000_000_000);
+}
+
+// ── Phase 7 task 7.1 — ShardEntry::apply_usn_patch_to_body ─────────────
+
+/// Warm-shard happy path: the method returns
+/// `Some((new_arc, stats))` and the new Arc is **not**
+/// `Arc::ptr_eq` against the original body Arc — the registry can
+/// swap it in atomically without tearing concurrent reads of the
+/// previous body.
+#[test]
+fn apply_usn_patch_to_body_returns_new_arc_on_warm() {
+    let body = Arc::new(make_test_body('C'));
+    let shard = ShardEntry::new_warm('C', Arc::clone(&body));
+
+    // Empty change batch — the method must still produce a fresh
+    // Arc so the caller's swap path is exercised even on no-op ticks.
+    let frs_to_compact: Vec<u32> = vec![u32::MAX; 16];
+    let result = shard.apply_usn_patch_to_body(&[], &frs_to_compact);
+
+    let (new_body, stats) = result.expect("Warm shard must yield Some");
+    assert!(
+        !Arc::ptr_eq(&new_body, &body),
+        "patched body must be a fresh Arc, not the same allocation"
+    );
+    assert_eq!(stats.deleted, 0);
+    assert_eq!(stats.created, 0);
+    assert_eq!(stats.renamed, 0);
+    assert_eq!(stats.skipped, 0);
+    // Record count preserved on the empty-batch path.
+    assert_eq!(new_body.records.len(), body.records.len());
+}
+
+/// Parked-shard contract: no in-memory body → `None`, even with a
+/// non-empty change batch.  The caller must re-promote first via
+/// `ensure_warm_for_dispatch` and let the disk-replay path apply
+/// the deltas there.
+#[test]
+fn apply_usn_patch_to_body_returns_none_on_parked() {
+    let stats = Arc::new(DriveStats::new());
+    let parked_body = Arc::new(make_test_parked_body('C', 1));
+    let shard = ShardEntry::new_parked('C', stats, parked_body);
+
+    let changes = vec![FileChange {
+        frs: 10,
+        deleted: true,
+        ..FileChange::default()
+    }];
+    let frs_to_compact: Vec<u32> = vec![u32::MAX; 16];
+
+    let result = shard.apply_usn_patch_to_body(&changes, &frs_to_compact);
+    assert!(
+        result.is_none(),
+        "Parked shard has no in-memory body — must return None"
+    );
+}
+
+/// Cold-shard contract: same as Parked — no body, no patch.
+/// Pinned separately so a future tier-state regression that lets
+/// Cold shards return an empty body Arc (instead of `None`) is
+/// caught immediately.
+#[test]
+fn apply_usn_patch_to_body_returns_none_on_cold() {
+    let stats = Arc::new(DriveStats::new());
+    let shard = ShardEntry::new_cold('C', stats);
+
+    let frs_to_compact: Vec<u32> = vec![u32::MAX; 16];
+    let result = shard.apply_usn_patch_to_body(&[], &frs_to_compact);
+    assert!(
+        result.is_none(),
+        "Cold shard has no in-memory body — must return None"
+    );
+}
+
+/// End-to-end smoke against a non-empty change batch: a single
+/// delete on a Warm shard's root child lands on the new Arc with
+/// `stats.deleted == 1` and the deleted record's `name_len`
+/// zeroed.  Pins that the daemon-side wrapper preserves the
+/// platform-agnostic patch contract from
+/// `uffs_core::compact_loader::apply_usn_patch`.
+#[test]
+fn apply_usn_patch_to_body_lands_delete_on_new_arc() {
+    let body = Arc::new(make_test_body('C'));
+    let shard = ShardEntry::new_warm('C', Arc::clone(&body));
+
+    // FRS 10 → compact_idx 1 (the file under the root in the
+    // 2-record fixture).  All other FRS map to the sentinel.
+    // Iterator-collect form sidesteps `clippy::indexing_slicing`.
+    let frs_to_compact: Vec<u32> = (0_usize..16)
+        .map(|frs| if frs == 10 { 1 } else { u32::MAX })
+        .collect();
+
+    let changes = vec![FileChange {
+        frs: 10,
+        deleted: true,
+        ..FileChange::default()
+    }];
+
+    let (new_body, stats) = shard
+        .apply_usn_patch_to_body(&changes, &frs_to_compact)
+        .expect("Warm shard yields Some");
+
+    assert_eq!(stats.deleted, 1, "exactly one delete should land");
+    let deleted_record = new_body
+        .records
+        .as_slice()
+        .get(1)
+        .expect("two-record fixture has compact_idx 1");
+    assert_eq!(
+        deleted_record.name_len, 0,
+        "deleted record's name_len must be zeroed"
+    );
+    assert_eq!(
+        deleted_record.parent_idx,
+        u32::MAX,
+        "deleted record's parent_idx must be u32::MAX"
+    );
+
+    // The original body Arc is unchanged — concurrent readers see
+    // the previous record_count + 1 child unaffected.
+    let original_record = body
+        .records
+        .as_slice()
+        .get(1)
+        .expect("original fixture still has compact_idx 1");
+    assert_eq!(
+        original_record.name_len, 5,
+        "original body Arc must be unaffected by patch on the clone"
+    );
 }

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -556,6 +556,15 @@ fn spawn_load_task(
         }
         tracing::info!("Load task completed");
 
+        // Latch the load phase as complete: from this point on, a daemon
+        // serving zero queries against fully-loaded drives is legitimately
+        // idle (not stalled), so the load-stall force-retire guard is
+        // permanently disarmed.  Per-drive stuck-load detection remains
+        // active via `DRIVE_LOAD_TIMEOUT` inside the load loop itself.
+        // Closes the Phase 5 G4 finding (LOG/uffsd-G4-bonus.log line 104,
+        // 2 h 11 min force-retire on a healthy idle daemon).
+        load_lifecycle.record_load_complete();
+
         zero_drive_shutdown_guard(&load_index, &load_lifecycle).await;
     })
 }

--- a/crates/uffs-daemon/src/lifecycle.rs
+++ b/crates/uffs-daemon/src/lifecycle.rs
@@ -11,7 +11,7 @@
 //! fragment the shutdown semantics.
 
 use alloc::sync::Arc;
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use core::time::Duration;
 use std::path::PathBuf;
 
@@ -48,6 +48,21 @@ pub(crate) struct LifecycleHandle {
     /// Updated by `IndexManager` when each drive finishes loading.
     /// Checked by the idle timer to detect stuck loads.
     load_heartbeat: Arc<AtomicU64>,
+    /// Load-phase complete latch.  Set by [`record_load_complete`] once
+    /// the load task in `spawn_load_task` finishes draining both
+    /// data-dir loads and (on Windows) live-drive loads.  Latches
+    /// `false` → `true` exactly once and never reverses.  While unset,
+    /// [`LifecycleManager::load_stalled_force_retire`] enforces the
+    /// `LOAD_STALL_TIMEOUT_SECS` heartbeat-freshness invariant against a
+    /// hung kernel-mode NTFS read; once set, the guard is permanently
+    /// disarmed so a fully-loaded daemon serving zero queries against
+    /// fully-Parked drives doesn't get killed by the startup safety
+    /// net.  Per-drive stuck-load detection remains active via
+    /// `DRIVE_LOAD_TIMEOUT` inside
+    /// `index/loading.rs::collect_drive_load_results`.
+    ///
+    /// [`record_load_complete`]: Self::record_load_complete
+    load_complete: Arc<AtomicBool>,
 }
 
 impl LifecycleHandle {
@@ -123,6 +138,23 @@ impl LifecycleHandle {
         let delta = now.saturating_sub(prev);
         tracing::debug!(heartbeat_delta_secs = delta, "Load heartbeat updated");
     }
+
+    /// Latch the load phase as complete — called by `spawn_load_task`
+    /// once both data-dir loads and (on Windows) live-drive loads have
+    /// drained.  After this latch is set,
+    /// [`LifecycleManager::load_stalled_force_retire`] is a no-op, so a
+    /// daemon serving zero queries against fully-loaded drives doesn't
+    /// get killed by the stuck-NTFS-read safety net at the next idle
+    /// deadline.
+    ///
+    /// Idempotent: calling this multiple times has no effect after the
+    /// first — the underlying [`AtomicBool`] is a one-shot latch.
+    pub(crate) fn record_load_complete(&self) {
+        let was_complete = self.load_complete.swap(true, Ordering::Relaxed);
+        if !was_complete {
+            tracing::debug!("Load phase complete — stall guard disarmed");
+        }
+    }
 }
 
 /// Lifecycle manager: PID file, idle timer, shutdown coordination.
@@ -163,6 +195,10 @@ impl LifecycleManager {
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |dur| dur.as_secs());
         let load_heartbeat = Arc::new(AtomicU64::new(now_epoch));
+        // Load-phase latch starts unset — the stall guard is armed
+        // until `spawn_load_task` calls `record_load_complete` after
+        // draining the data-dir + (Windows) live-drive load paths.
+        let load_complete = Arc::new(AtomicBool::new(false));
 
         let pid_path = data_dir.join("daemon.pid");
 
@@ -176,6 +212,7 @@ impl LifecycleManager {
                 max_session_tier,
                 events,
                 load_heartbeat,
+                load_complete,
             },
             pid_path,
             idle_timeout,
@@ -447,7 +484,16 @@ impl LifecycleManager {
 
     /// Returns `true` when the load heartbeat is older than the
     /// stall threshold, in which case the caller must force-retire.
+    ///
+    /// Once `LifecycleHandle::record_load_complete` has been called,
+    /// the guard is permanently disarmed: a fully-loaded daemon
+    /// serving zero queries is legitimately idle, not stalled.
+    /// Per-drive stuck-load detection remains active independently via
+    /// `DRIVE_LOAD_TIMEOUT` inside `collect_drive_load_results`.
     fn load_stalled_force_retire(handle: &LifecycleHandle) -> bool {
+        if handle.load_complete.load(Ordering::Relaxed) {
+            return false;
+        }
         let last_hb = handle.load_heartbeat.load(Ordering::Relaxed);
         let now_epoch = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -782,6 +828,83 @@ mod tests {
         assert!(
             timer.is_finished(),
             "no-retire should exit after shutdown signal"
+        );
+    }
+
+    // ── Load-stall guard: heartbeat-age force-retire (Phase 5 G4 finding) ─
+
+    /// Test helper installed on `LifecycleHandle` only under `cfg(test)`.
+    /// Required because `LOAD_STALL_TIMEOUT_SECS` is wall-clock-based via
+    /// `SystemTime::now()` and can't be mocked; without this we'd have to
+    /// wait 300+ seconds per test.
+    impl LifecycleHandle {
+        pub(crate) fn set_load_heartbeat_for_test(&self, secs: u64) {
+            self.load_heartbeat.store(secs, Ordering::Relaxed);
+        }
+    }
+
+    /// Helper: epoch seconds "now" for the regression tests.
+    fn epoch_now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |dur| dur.as_secs())
+    }
+
+    #[test]
+    fn load_stall_force_retire_fires_during_loading_with_stale_heartbeat() {
+        // Preserves the original safety-net contract: while loading is
+        // in progress (load_complete unset) and no heartbeat update has
+        // arrived for >= LOAD_STALL_TIMEOUT_SECS, the guard MUST fire.
+        let mgr = test_lifecycle(Some(Duration::from_mins(1)));
+        let handle = mgr.handle();
+
+        let now = epoch_now_secs();
+        handle.set_load_heartbeat_for_test(now.saturating_sub(LOAD_STALL_TIMEOUT_SECS + 100));
+
+        assert!(
+            LifecycleManager::load_stalled_force_retire(&handle),
+            "guard must fire when heartbeat is stale and load_complete is unset"
+        );
+    }
+
+    #[test]
+    fn load_stall_force_retire_disarms_after_record_load_complete() {
+        // Regression for Phase 5 G4 capture (LOG/uffsd-G4-bonus.log line
+        // 104, 2 h 11 min mark): a daemon that finished loading long ago
+        // but is serving zero queries against fully-Parked drives is
+        // legitimately idle, not stalled.  Once `record_load_complete`
+        // latches the load phase as done, the guard MUST stay quiet.
+        let mgr = test_lifecycle(Some(Duration::from_mins(1)));
+        let handle = mgr.handle();
+
+        let now = epoch_now_secs();
+        handle.set_load_heartbeat_for_test(now.saturating_sub(LOAD_STALL_TIMEOUT_SECS + 100));
+
+        handle.record_load_complete();
+
+        assert!(
+            !LifecycleManager::load_stalled_force_retire(&handle),
+            "guard must be disarmed after record_load_complete, even with stale heartbeat"
+        );
+    }
+
+    #[test]
+    fn record_load_complete_is_idempotent() {
+        // Calling `record_load_complete` more than once must not re-arm
+        // the guard or panic.  The latch is `false` → `true` exactly
+        // once; subsequent calls are a no-op.
+        let mgr = test_lifecycle(Some(Duration::from_mins(1)));
+        let handle = mgr.handle();
+
+        handle.record_load_complete();
+        handle.record_load_complete();
+
+        let now = epoch_now_secs();
+        handle.set_load_heartbeat_for_test(now.saturating_sub(LOAD_STALL_TIMEOUT_SECS + 100));
+
+        assert!(
+            !LifecycleManager::load_stalled_force_retire(&handle),
+            "guard must remain disarmed after multiple record_load_complete calls"
         );
     }
 


### PR DESCRIPTION
## Phase 7 Mac side — per-shard USN journal infrastructure

This PR lands the **complete Mac-side infrastructure** for the per-shard USN journal pipeline.  Production wiring (calling `spawn_journal_loop` from `lib.rs::spawn_load_task` for each Warm shard, swapping out the existing Phase-5 5-min global `refresh_usn_for_warm_shards` tick) is intentionally deferred to a follow-up activation commit so this PR can be reviewed + merged in isolation.

### The five commits

Each commit lands one logical layer with **all four lint gates green** (lint-prod / lint-tests / check-windows / lint-fast) and **all preceding tests still passing**:

| # | SHA | Layer | Tests after |
|---|-----|-------|-------------|
| 7-A | `cd9ef126d` | `ShardEntry::apply_usn_patch_to_body` foundation method (drops spurious `#[cfg(windows)]`, derives `Clone` on core compact types, adds the per-shard apply path with body-cell Arc-swap) | 1033 |
| 7-B | `01b4bdcde` | Per-shard tokio task infrastructure: `JournalSource` trait + Windows impl + `MacStubJournalSource` fallback; `PatchSink` trait; `JournalLoop::run` with cancellation watch channel; `spawn_journal_loop` helper | 1039 |
| 7-C | `85a76a4bb` | Threshold-triggered save: `SaveTrigger` state machine + `SaveReason` enum (`EventsExceeded` / `AgeElapsed`) + `PatchSink::trigger_save` extension; events-since-save counter resets after fire; zero-event drives never trigger | 1043 |
| 7-D | `b6f58f1f7` | Cursor persistence (`CursorStore` trait + `NullCursorStore`) loaded at spawn + persisted in lockstep with each `trigger_save`; journal-wrap detection via `journal_id` comparison + `PatchSink::journal_wrapped` callback + cursor-reset semantics | 1047 |
| 7-E | `b21a73900` | 10 000-event end-to-end integration test through the full pipeline (`FakeJournalSource` → `JournalLoop` → `RecordingSink` → `SaveTrigger` → `FakeCursorStore`).  Pins five integrated invariants in a single 126-ms run | 1048 |

### What's verified

**+25 new Mac-deterministic tests, all passing in <1 s combined**:

* **6 unit tests in `compact_loader_tests`** for `apply_usn_patch_to_body` (deletion, ordering, idempotence, overflow, large batches, body identity).
* **4 unit tests in `shard::tests`** for the body-cell Arc-swap semantics.
* **6 lifecycle / cancel / cursor / source-error tests in `journal_loop::tests::basics`**.
* **4 threshold-triggered save tests in `journal_loop::tests::thresholds`**.
* **4 cursor-persistence + wrap-detection tests in `journal_loop::tests::wrap_and_persistence`**.
* **1 10K-event end-to-end integration test in `journal_loop::tests::integration`**.

### Test architecture notes

* **Mac-deterministic, Windows-realistic**: the trait is platform-agnostic; the Windows impl wraps the existing `read_usn_journal` call; the `MacStubJournalSource` fallback always returns empty changes (cursor unchanged, `journal_id == 0` zero-sentinel).  All state-machine semantics are pinned end-to-end on Mac via the deterministic `FakeJournalSource` + `RecordingSink` + `FakeCursorStore` triple.
* **No virtual time**: the loop's `spawn_blocking` poll runs on a real OS thread which tokio's `pause`-mode virtual time can't drive forward.  Convergence is deadline-driven via `wait_for` (`CONVERGENCE_DEADLINE = 250 ms`) for unit tests + `wait_for_e2e` (`E2E_DEADLINE = 5 s`) for the integration suite.  Mirrors the established `lifecycle_hooks.rs::CASCADE_DEADLINE` idiom.
* **File-size policy compliance**: tests decomposed into 4 sibling submodules (`basics.rs` 216, `thresholds.rs` 232, `wrap_and_persistence.rs` 221, `integration.rs` 210) with shared helpers in `tests.rs` (318).  Production file at 798 LOC.  All under the workspace 800 LOC ceiling — **no `scripts/ci/file_size_exceptions.txt` entries added**.

### Rule compliance audit

| Rule | Verdict | Evidence |
|---|---|---|
| 1. No suppression hacks | ✅ | One narrowly-scoped `#[cfg_attr(not(test), expect(dead_code))]` on `NullCursorStore` (justified: forward-reference to the activation commit, removed when production wires the disk-backed impl).  All 5 clippy fixes (`doc_markdown` ×3, `collapsible_if` ×1, `cast_possible_truncation` ×1) addressed at the root with no `#[allow]` annotations. |
| 2. Surgical, correct fixes | ✅ | Net diff: ~1 200 LOC across 7 files, all in `crates/uffs-{core,daemon}/src/cache/journal_loop*` or `compact*`.  Zero changes to public API surfaces outside the journal-loop module.  Dead `#[cfg(windows)]` removed only where it was actively breaking the body-cell Arc-swap pattern. |
| 3. Preserve behavior & contracts | ✅ | All 1023 pre-Phase-7 tests still pass.  No public API changes outside the new journal-loop module.  Production still uses the existing Phase-5 5-min `refresh_usn_for_warm_shards` tick (the activation commit is out of scope for this PR). |
| 4. Improve tests | ✅ | +25 deterministic regression tests with deadline-driven convergence (no `thread::sleep` flakes).  The integration test pins **five** integrated invariants in a single run, catching inter-feature regressions the per-feature unit tests miss in isolation.  Test suite went from 1023 → 1048 (+25), no skips, no `#[ignore]`. |

### Verification

```bash
cargo nextest run -p uffs-core -p uffs-daemon --lib
# → 1048 / 1048 PASS, 3 skipped (pre-existing)

just lint-prod      # clippy --workspace --lib --bins --pedantic --nursery --cargo, all warnings deny → ✅
just lint-tests     # clippy --workspace --tests --pedantic --nursery --cargo → ✅
just check-windows  # xwin x86_64-pc-windows-msvc, --workspace --all-targets → ✅
just lint-fast      # file-size + fmt-check + typos + reuse → 4/4 ✅
```

Pre-push gate (lint-pre-push, deny + check-windows + workspace clippy) also green at 76 s.

### Activation roadmap

The follow-up activation commit (out of scope here) is small and isolated — exactly what this infrastructure was designed to support:

1. `lib.rs::spawn_load_task` instantiates a production `PatchSink` that calls `ShardEntry::apply_usn_patch_to_body` + `ShardRegistry::replace_warm_body`.
2. Same call site instantiates a disk-backed `CursorStore` rooted at the cache dir.
3. For each Warm shard, calls `spawn_journal_loop(letter, win_journal_source, sink, cursor_store, config_from_env)`.
4. Removes the existing `refresh_usn_for_warm_shards` global tick from the lifecycle scheduler.

The activation commit can be authored without re-touching any code in this PR.