### PR TITLE
feat(daemon): Phase 8 — surgical body-patch via apply_usn_patch_to_body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ thiserror = "2.0.18"
 anyhow = "1.0.102"
 
 # ───── MCP (Model Context Protocol) ─────
-rmcp = { version = "1.5.0", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "1.6.0", features = ["server", "transport-io", "macros"] }
 schemars = "1.2.1"
 
 # ───── HTTP / Tower (for MCP Streamable HTTP gateway) ─────

--- a/crates/uffs-core/src/aggregate/rollup.rs
+++ b/crates/uffs-core/src/aggregate/rollup.rs
@@ -326,6 +326,8 @@ mod tests {
             source_epoch: 0,
             bloom: None,
             path_trie: None,
+            // unused by aggregation tests — see compact.rs::frs_to_compact docs.
+            frs_to_compact: Vec::new(),
         }
     }
 

--- a/crates/uffs-core/src/compact.rs
+++ b/crates/uffs-core/src/compact.rs
@@ -383,6 +383,36 @@ pub struct DriveCompactIndex {
     /// Phase 4 directory-only path trie.  Same `None`-handling
     /// rationale as [`Self::bloom`].
     pub path_trie: Option<PathTrie>,
+    /// Phase 8: FRS → `compact_idx` mapping.
+    ///
+    /// Indexed by FRS-as-`usize`; values are the matching primary
+    /// `compact_idx` in [`Self::records`], or [`u32::MAX`] for
+    /// unmapped slots (system metafiles 0-15, FRS values higher
+    /// than the build-time max, deleted records).
+    ///
+    /// Populated by [`build_compact_index`] from
+    /// [`uffs_mft::MftIndex::frs_to_idx`] (which is otherwise
+    /// dropped when the `MftIndex` goes out of scope).  Maintained
+    /// in lock-step with [`Self::records`] by
+    /// [`crate::compact_loader::apply_usn_patch`] across
+    /// create / delete / rename batches: creates extend the table
+    /// and assign the new compact slot, deletes mark the slot
+    /// `u32::MAX`, renames leave the slot intact (only `parent_idx`
+    /// + name move).
+    ///
+    /// **Why not stored in `MftIndex`?**  The `MftIndex` is
+    /// transient — `build_compact_index` consumes it and drops it.
+    /// The compact body is what survives to serve search queries
+    /// and accept journal patches.  Keeping the mapping next to the
+    /// records it indexes means [`crate::compact_loader::apply_usn_patch`]
+    /// can patch the body in place without touching the MFT.
+    ///
+    /// **Backward compatibility**: caches written before v10
+    /// (Phase 8) didn't persist this mapping; for those, the field
+    /// loads as an empty `Vec` and the surgical patch path
+    /// silently degrades to the full-reload fallback.  See the
+    /// v9 → v10 cache format bump in `compact_cache::COMPACT_VERSION`.
+    pub frs_to_compact: Vec<u32>,
 }
 
 /// Per-component heap footprint of a [`DriveCompactIndex`].
@@ -402,6 +432,10 @@ pub struct HeapReport {
     pub ext_index: usize,
     /// `ext_names: Vec<Box<str>>` heap (Vec + string data).
     pub ext_names: usize,
+    /// `frs_to_compact: Vec<u32>` capacity in bytes (Phase 8 —
+    /// `~max_frs * 4` bytes; ~40 MB on a 7M-record drive with
+    /// max FRS ≈ 10M).
+    pub frs_to_compact: usize,
     /// Sum of all components.
     pub total: usize,
 }
@@ -428,6 +462,7 @@ impl DriveCompactIndex {
         let ext_names_data: usize = self.ext_names.iter().map(|en| en.len()).sum();
         let ext_names_vec = self.ext_names.capacity() * size_of::<Box<str>>();
         let ext_names = ext_names_data + ext_names_vec;
+        let frs_to_compact = self.frs_to_compact.capacity() * size_of::<u32>();
         HeapReport {
             records,
             names,
@@ -435,7 +470,8 @@ impl DriveCompactIndex {
             children,
             ext_index,
             ext_names,
-            total: records + names + trigram + children + ext_index + ext_names,
+            frs_to_compact,
+            total: records + names + trigram + children + ext_index + ext_names + frs_to_compact,
         }
     }
 
@@ -452,11 +488,12 @@ impl DriveCompactIndex {
             children_mb = mb(hr.children),
             ext_index_mb = mb(hr.ext_index),
             ext_names_mb = mb(hr.ext_names),
+            frs_to_compact_mb = mb(hr.frs_to_compact),
             total_mb = mb(hr.total),
-            "[HEAP] {}: rec={} names={} tri={} ch={} ext={} | total={} MB",
+            "[HEAP] {}: rec={} names={} tri={} ch={} ext={} f2c={} | total={} MB",
             self.letter,
             mb(hr.records), mb(hr.names), mb(hr.trigram),
-            mb(hr.children), mb(hr.ext_index),
+            mb(hr.children), mb(hr.ext_index), mb(hr.frs_to_compact),
             mb(hr.total),
         );
     }
@@ -839,6 +876,17 @@ pub fn build_compact_index(
 
     shrink_compact_vecs(drive_letter, &mut records, &mut names, &mut ext_names);
 
+    // Phase 8: clone the FRS → mft_idx mapping off the transient
+    // `MftIndex` before it goes out of scope.  In the primary
+    // `build_compact_index` path compact_idx == mft_idx (records
+    // are produced 1:1 by `index.records.par_iter().enumerate()`),
+    // so `frs_to_idx` is exactly the FRS → compact_idx mapping the
+    // surgical-patch path needs.  Hardlink / ADS-expanded records
+    // append at the END with the same FRS but higher compact_idx;
+    // those secondary slots are not addressable from journal events
+    // (USN events reference primary FRS) so the primary mapping is
+    // sufficient.  `uffs_mft::NO_ENTRY == u32::MAX` matches the
+    // sentinel `frs_to_compact` uses for unmapped slots.
     let mut compact_index = DriveCompactIndex {
         letter: drive_letter,
         records: ColumnStorage::from_vec(records),
@@ -852,6 +900,7 @@ pub fn build_compact_index(
         source_epoch: index.build_epoch,
         bloom: None,
         path_trie: None,
+        frs_to_compact: index.frs_to_idx.clone(),
     };
 
     // Phase 4: populate bloom + path_trie from the freshly-built

--- a/crates/uffs-core/src/compact_cache.rs
+++ b/crates/uffs-core/src/compact_cache.rs
@@ -131,7 +131,15 @@ const COMPACT_MAGIC: &[u8; 8] = b"UFFSCOM\0";
 ///   `_pad`)
 /// - v9: Phase 4 bloom + path-trie sections appended after `ext_names` (see
 ///   `compact_cache::filters_io`)
-const COMPACT_VERSION: u16 = 9;
+/// - v10: Phase 8 `frs_to_compact: Vec<u32>` section appended after the path
+///   trie (`u32 len` + `len * u32` raw values, `u32::MAX` for unmapped slots).
+///   This mapping is what the per-shard surgical patch path
+///   ([`crate::compact_loader::apply_usn_patch`]) needs to translate USN
+///   journal events to compact-record updates without re-reading the MFT.  v <
+///   10 caches are rejected at the header check so the daemon does a fresh MFT
+///   rebuild and writes a v10 cache; carrying them forward with an empty
+///   `frs_to_compact` would silently disable the surgical-patch path.
+const COMPACT_VERSION: u16 = 10;
 
 mod filters_io;
 pub mod parked;
@@ -385,6 +393,13 @@ pub fn serialize_compact(index: &DriveCompactIndex) -> Vec<u8> {
         .map_or_else(|| Cow::Owned(index.build_path_trie()), Cow::Borrowed);
     filters_io::push_trie_section(&mut buf, trie_section.as_ref());
 
+    // v10: frs_to_compact section — `u32 len` + `len * u32` raw
+    // values.  An empty mapping (e.g. tests that build the body
+    // by struct literal without populating it) writes len=0 with
+    // no values; the reader handles that branch symmetrically.
+    push_u32(&mut buf, index.frs_to_compact.len());
+    buf.extend_from_slice(bytemuck::cast_slice(&index.frs_to_compact));
+
     buf
 }
 
@@ -454,6 +469,11 @@ pub fn serialize_compact_to_writer<W: io::Write>(
         .as_ref()
         .map_or_else(|| Cow::Owned(index.build_path_trie()), Cow::Borrowed);
     filters_io::write_trie_section(writer, trie_section.as_ref())?;
+
+    // v10: frs_to_compact section.  Symmetric with the
+    // [`Vec<u8>`]-backed [`serialize_compact`] path.
+    write_u32(writer, index.frs_to_compact.len())?;
+    writer.write_all(bytemuck::cast_slice(&index.frs_to_compact))?;
 
     writer.flush()?;
     Ok(())
@@ -575,6 +595,13 @@ struct ParsedCompactBody<'data> {
     /// the cache; `None` if the cache predates v9 and the trie must
     /// be rebuilt via [`DriveCompactIndex::build_path_trie`].
     trie_loaded: Option<crate::path_trie::PathTrie>,
+    /// `Some` if a v10+ `frs_to_compact` section was loaded directly
+    /// from the cache; `None` if the cache predates v10 (which is
+    /// rejected at the header check, so this is `None` only on
+    /// future format extensions that revisit the layout).  An
+    /// empty `Vec` is *not* `None` — a zero-record drive's mapping
+    /// is legitimately empty.
+    frs_to_compact_loaded: Option<Vec<u32>>,
     /// Resolved case-fold table for the drive.
     fold: uffs_text::case_fold::CaseFold,
 }
@@ -649,12 +676,41 @@ fn parse_compact_body(
     // truncated section signals corruption rather than legacy
     // format.  v < 9 caches simply skip this branch and the
     // assembler rebuilds the filters from records / names.
-    let (bloom_loaded, trie_loaded) = if version >= 9 {
+    let (bloom_loaded, trie_loaded, after_trie) = if version >= 9 {
         let (bloom, after_bloom) = filters_io::read_bloom_section(data, after_ext)?;
-        let (trie, _after_trie) = filters_io::read_trie_section(data, after_bloom)?;
-        (Some(bloom), Some(trie))
+        let (trie, after_trie) = filters_io::read_trie_section(data, after_bloom)?;
+        (Some(bloom), Some(trie), after_trie)
     } else {
-        (None, None)
+        (None, None, after_ext)
+    };
+
+    // v10: frs_to_compact section.  Reject mismatched bytes
+    // explicitly so a truncated cache surfaces as a parse error
+    // (which the daemon retries by rebuilding from MFT) instead of
+    // a silent empty mapping that disables the surgical-patch path.
+    let frs_to_compact_loaded = if version >= 10 {
+        if data.len() < after_trie + 4 {
+            return Err("truncated frs_to_compact len");
+        }
+        let count = read_u32(data, after_trie) as usize;
+        let bytes_len = count
+            .checked_mul(4)
+            .ok_or("frs_to_compact bytes overflow")?;
+        let start = after_trie + 4;
+        let end = start
+            .checked_add(bytes_len)
+            .ok_or("frs_to_compact end overflow")?;
+        if data.len() < end {
+            return Err("truncated frs_to_compact values");
+        }
+        let values: Vec<u32> = if count == 0 {
+            Vec::new()
+        } else {
+            aligned_vec_from_bytes(data.get(start..end).ok_or("frs_to_compact slice")?)
+        };
+        Some(values)
+    } else {
+        None
     };
 
     Ok(ParsedCompactBody {
@@ -667,6 +723,7 @@ fn parse_compact_body(
         ext_names_loaded,
         bloom_loaded,
         trie_loaded,
+        frs_to_compact_loaded,
         fold,
     })
 }
@@ -726,6 +783,12 @@ where
         source_epoch: parsed.source_epoch,
         bloom: None,
         path_trie: None,
+        // Phase 8 B2: v10 caches embed the FRS → compact_idx mapping
+        // directly.  v < 10 caches are rejected at the header check
+        // (`parse_compact_header`); the `unwrap_or_default()` here
+        // covers the future-format edge case where a new cache
+        // version omits the section.
+        frs_to_compact: parsed.frs_to_compact_loaded.unwrap_or_default(),
     };
 
     // Phase 4 Commit D — v9+ caches embed the bloom + trie directly,
@@ -821,8 +884,13 @@ fn parse_compact_header(data: &[u8]) -> Result<(u64, usize, u16), &'static str> 
         .get(8..10)
         .and_then(|slice| <[u8; 2]>::try_from(slice).ok())
         .map_or(0, u16::from_le_bytes);
-    if version < 2 {
-        return Err("stale compact version (v1 → rebuild)");
+    if version < 10 {
+        // Phase 8 cache-format break: v < 10 caches don't carry the
+        // `frs_to_compact` mapping, so the surgical patch path
+        // (`apply_usn_patch`) can't operate on them.  Reject here
+        // and let the caller's full-MFT-rebuild fallback write a
+        // fresh v10 cache.
+        return Err("stale compact version (v<10 → rebuild for Phase 8 frs_to_compact)");
     }
     if version > COMPACT_VERSION {
         return Err("unsupported compact version (future)");

--- a/crates/uffs-core/src/compact_cache/parked.rs
+++ b/crates/uffs-core/src/compact_cache/parked.rs
@@ -517,6 +517,7 @@ mod tests {
             source_epoch: 1234,
             bloom: None,
             path_trie: None,
+            frs_to_compact: Vec::new(),
         };
         index.bloom = Some(index.build_bloom());
         index.path_trie = Some(index.build_path_trie());
@@ -561,10 +562,13 @@ mod tests {
         assert_eq!(body.source_epoch, 1234);
     }
 
-    /// Pre-v9 caches have no bloom + trie sections.  Patching the
-    /// version byte to 8 must be rejected with a recognisable error.
+    /// Pre-v10 caches don't carry the Phase 8 `frs_to_compact`
+    /// mapping; the cross-cutting [`super::super::parse_compact_header`]
+    /// rejection covers the parked-body load too.  Patching the
+    /// version byte to 8 must surface the modern "v<10 → rebuild"
+    /// error string.
     #[test]
-    fn parked_load_rejects_pre_v9_caches() {
+    fn parked_load_rejects_pre_v10_caches() {
         let index = make_test_index();
         let mut serialized = super::super::serialize_compact(&index);
 
@@ -575,8 +579,8 @@ mod tests {
 
         let err = deserialize_parked_body(&serialized, 'C').expect_err("v8 must reject");
         assert!(
-            err.contains("v9"),
-            "error should mention v9 minimum: {err:?}",
+            err.contains("stale compact version"),
+            "error should mention 'stale compact version': {err:?}",
         );
     }
 
@@ -598,32 +602,48 @@ mod tests {
     /// surface an error from whichever offset-arithmetic /
     /// section-read routine first runs out of bytes.  Pins the
     /// "no panic on corrupt input" contract.
+    ///
+    /// **Phase 8.** The v10 `frs_to_compact` section lives at the
+    /// tail of the cache and is *not* read by the parked-body load
+    /// path (parked bodies only need bloom + trie).  The prefix
+    /// sweep therefore stops at the parked-body cutoff
+    /// (`serialized.len() - frs_to_compact_section_bytes`); any
+    /// prefix beyond that boundary only damages bytes the parker
+    /// load deliberately skips and would not be rejected by design.
     #[test]
     fn parked_load_rejects_truncated_at_every_prefix() {
         let index = make_test_index();
         let serialized = super::super::serialize_compact(&index);
 
-        // Sample a handful of prefix lengths covering header, mid-body,
-        // and the bloom + trie sections.  Full-length is the success
-        // case and is excluded; every shorter prefix must be rejected.
-        let len = serialized.len();
+        // v10 frs_to_compact section size: 4-byte count + 4 bytes per
+        // entry.  The parked body is complete just before this section.
+        let frs_to_compact_bytes = 4 + index.frs_to_compact.len() * 4;
+        let parked_end = serialized
+            .len()
+            .checked_sub(frs_to_compact_bytes)
+            .expect("v10 cache must include the frs_to_compact section");
+
+        // Sample header offsets + four positions strictly inside the
+        // parked-body region.  Full-length parked region is the
+        // success case and is excluded.
         let prefixes = [
             0,
             8,  // post-magic, pre-version
             10, // post-version
             18, // pre-epoch (v3+)
             26, // post-header
-            len / 4,
-            len / 2,
-            len * 3 / 4,
-            len - 1,
+            parked_end / 4,
+            parked_end / 2,
+            parked_end * 3 / 4,
+            parked_end - 1,
         ];
         for &prefix in &prefixes {
             let truncated = serialized.get(..prefix).expect("prefix in range");
             let result = deserialize_parked_body(truncated, 'C');
             assert!(
                 result.is_err(),
-                "prefix {prefix}/{len} must be rejected (got {result:?})",
+                "prefix {prefix}/{parked_end} (full {full}) must be rejected (got {result:?})",
+                full = serialized.len(),
             );
         }
     }

--- a/crates/uffs-core/src/compact_cache/tests.rs
+++ b/crates/uffs-core/src/compact_cache/tests.rs
@@ -24,6 +24,12 @@
 use super::*;
 
 /// Build a minimal `DriveCompactIndex` with 3 records for testing.
+///
+/// **Phase 8.** Populates `frs_to_compact` with a representative
+/// 8-entry mapping (FRS 5 → root, FRS 10 → "foo", FRS 11 → "bar",
+/// FRS 12 → "baz"; other slots `u32::MAX`) so v10 round-trip tests
+/// exercise the section.  Iterator-collect form sidesteps
+/// `clippy::indexing_slicing`.
 fn make_test_index() -> DriveCompactIndex {
     let names = b"foobarbaz".to_vec(); // "foo" [0..3], "bar" [3..6], "baz" [6..9]
     let records = vec![
@@ -54,6 +60,15 @@ fn make_test_index() -> DriveCompactIndex {
     let trigram = TrigramIndex::build(&records, &names, fold);
     let children = ChildrenIndex::build(&records);
     let ext_index = ExtensionIndex::build(&records);
+    let frs_to_compact: Vec<u32> = (0_usize..16)
+        .map(|frs| match frs {
+            5 => 0_u32,
+            10 => 1,
+            11 => 2,
+            12 => 3,
+            _ => u32::MAX,
+        })
+        .collect();
     DriveCompactIndex {
         letter: 'T',
         records: ColumnStorage::from_vec(records),
@@ -67,6 +82,7 @@ fn make_test_index() -> DriveCompactIndex {
         source_epoch: 42,
         bloom: None,
         path_trie: None,
+        frs_to_compact,
     }
 }
 
@@ -99,49 +115,80 @@ fn v6_round_trip_preserves_trigram() {
     assert_eq!(loaded.source_epoch, 42);
 }
 
+/// Phase 8 B2: a v9-stamped cache must be rejected so the caller's
+/// MFT-rebuild fallback writes a fresh v10 cache (with the
+/// `frs_to_compact` mapping the surgical-patch path needs).  This
+/// supersedes the now-deleted `v5_backward_compat_rebuilds_trigram`
+/// test: v < 10 caches are no longer parseable at all, regardless of
+/// section completeness.
 #[test]
-fn v5_backward_compat_rebuilds_trigram() {
-    // Serialize a v6 index, then patch the version to v5 and replace
-    // the trigram section with the v5 sentinel (trigram_count = 0).
+fn v9_rejected_forces_rebuild() {
     let index = make_test_index();
     let mut serialized = serialize_compact(&index);
-
-    // Patch version to 5.
     serialized
         .get_mut(8..10)
         .expect("buffer too short for version")
-        .copy_from_slice(&5_u16.to_le_bytes());
-
-    // Find the trigram section: after children CSR.
-    // Children CSR starts after names, offsets are (records+1)*4, then values.
-    let record_count = index.records.len();
-    let names_len = index.names.len();
-    let records_end = 26 + record_count * RECORD_BYTES;
-    let names_end = records_end + names_len;
-    let csr_offsets_end = names_end + (record_count + 1) * 4;
-    let total_children = index.children.total_children();
-    let postings_end = csr_offsets_end + total_children * 4;
-
-    // Truncate at postings_end + 4 (v5 sentinel: trigram_count = 0).
-    serialized.truncate(postings_end + 4);
-    serialized
-        .get_mut(postings_end..postings_end + 4)
-        .expect("buffer too short for trigram sentinel")
-        .copy_from_slice(&0_u32.to_le_bytes());
-
-    let (loaded, _tri_ms) = deserialize_compact(&serialized, 'T').unwrap();
-
-    // Trigram was rebuilt — should match the original.
-    let (orig_keys, orig_offsets, orig_values) = index.trigram.as_csr();
-    let (loaded_keys, loaded_offsets, loaded_values) = loaded.trigram.as_csr();
-    assert_eq!(loaded_keys, orig_keys, "rebuilt trigram keys mismatch");
-    assert_eq!(
-        loaded_offsets, orig_offsets,
-        "rebuilt trigram offsets mismatch"
+        .copy_from_slice(&9_u16.to_le_bytes());
+    let err = deserialize_compact(&serialized, 'T')
+        .err()
+        .expect("v9 cache must be rejected");
+    assert!(
+        err.contains("stale compact version"),
+        "v9 rejection error message must mention 'stale compact version'; got: {err}"
     );
+}
+
+/// Phase 8 B2: round-trip a non-empty `frs_to_compact` mapping
+/// through both deserialize paths and assert byte-equal recovery.
+/// Pins:
+///   1. The serialised section is recoverable (no truncation, no trailing-byte
+///      miscount).
+///   2. `aligned_vec_from_bytes` returns the same `Vec<u32>` content.
+///   3. The runtime-mmap path (records + names mmap-backed) doesn't drop the
+///      heap-resident `frs_to_compact` column.
+#[test]
+fn v10_round_trip_preserves_frs_to_compact() {
+    let index = make_test_index();
+    let original_mapping = index.frs_to_compact.clone();
+    assert!(
+        original_mapping.iter().any(|&value| value != u32::MAX),
+        "fixture must populate at least one mapped slot"
+    );
+
+    let serialized = serialize_compact(&index);
+
+    // Heap deserialise path.
+    let (heap_loaded, _) = deserialize_compact(&serialized, 'T').expect("heap deser");
     assert_eq!(
-        loaded_values, orig_values,
-        "rebuilt trigram values mismatch"
+        heap_loaded.frs_to_compact, original_mapping,
+        "heap-loaded frs_to_compact must match the source mapping"
+    );
+
+    // Runtime-mmap deserialise path.
+    let (_tmp, runtime_path) = runtime_fixture("f2c_round_trip.live");
+    let runtime_dir = uffs_security::runtime_dir::DefaultRuntimeDir::default();
+    let (mmap_loaded, _) =
+        deserialize_compact_into_runtime(&serialized, 'T', &runtime_dir, &runtime_path)
+            .expect("runtime mmap deser");
+    assert_eq!(
+        mmap_loaded.frs_to_compact, original_mapping,
+        "runtime-mmap-loaded frs_to_compact must match the source mapping"
+    );
+}
+
+/// Phase 8 B2 edge case: a zero-length `frs_to_compact` (e.g. a
+/// freshly-built body that hasn't populated the field yet) round-trips
+/// to an empty `Vec`, not `Err` or panic.  Guards the `count == 0`
+/// fast path in `parse_compact_body`.
+#[test]
+fn v10_round_trip_empty_frs_to_compact() {
+    let mut index = make_test_index();
+    index.frs_to_compact = Vec::new();
+    let serialized = serialize_compact(&index);
+    let (loaded, _) = deserialize_compact(&serialized, 'T').expect("empty mapping deser");
+    assert!(
+        loaded.frs_to_compact.is_empty(),
+        "empty-mapping round-trip must yield Vec::new()"
     );
 }
 
@@ -223,6 +270,9 @@ fn v9_round_trip_preserves_path_trie() {
     );
 }
 
+/// v < 10 caches are rejected outright by the Phase 8 header check.
+/// `v1` is the historical canary; the modern rejection covers v1–v9
+/// in a single branch.
 #[test]
 fn v1_rejected() {
     let mut data = vec![0_u8; 64];
@@ -232,7 +282,13 @@ fn v1_rejected() {
     data.get_mut(8..10)
         .expect("buffer too short for version")
         .copy_from_slice(&1_u16.to_le_bytes());
-    assert!(deserialize_compact(&data, 'X').is_err());
+    let err = deserialize_compact(&data, 'X')
+        .err()
+        .expect("v1 cache must be rejected");
+    assert!(
+        err.contains("stale compact version"),
+        "v1 rejection error must mention 'stale compact version'; got: {err}"
+    );
 }
 
 #[test]

--- a/crates/uffs-core/src/compact_filters.rs
+++ b/crates/uffs-core/src/compact_filters.rs
@@ -212,6 +212,7 @@ mod tests {
             source_epoch: 1,
             bloom: None,
             path_trie: None,
+            frs_to_compact: Vec::new(),
         }
     }
 
@@ -330,6 +331,7 @@ mod tests {
             source_epoch: 0,
             bloom: None,
             path_trie: None,
+            frs_to_compact: Vec::new(),
         };
 
         let bloom = drive.build_bloom();

--- a/crates/uffs-core/src/compact_loader.rs
+++ b/crates/uffs-core/src/compact_loader.rs
@@ -176,10 +176,12 @@ pub struct RefreshTiming {
     pub total: u128,
 }
 
-/// Phase 5 (#94) re-promote helper: load the per-drive `MftIndex`
-/// from cache, apply USN journal deltas, rebuild the
-/// `DriveCompactIndex` from the refreshed MFT, and submit a
-/// background compact-cache save so the next call is faster.
+/// Phase 5 (#94) re-promote helper.
+///
+/// Loads the per-drive `MftIndex` from cache, applies USN journal
+/// deltas, rebuilds the `DriveCompactIndex` from the refreshed MFT,
+/// and submits a background compact-cache save so the next call is
+/// faster.
 ///
 /// Used by the daemon's `DiskBodyLoader::load` and (eventually) the
 /// background USN refresh timer (#95).  On Windows the call goes
@@ -348,11 +350,11 @@ fn load_mft_index_from_file(
 }
 
 /// Load `MftIndex` from a live Windows volume (cache → cold read via IOCP).
+///
+/// Extracted from `load_drive` for readability; the workspace allows
+/// `clippy::single_call_fn` so this remains a one-call helper rather
+/// than being inlined.
 #[cfg(windows)]
-#[expect(
-    clippy::single_call_fn,
-    reason = "extracted for readability from load_drive"
-)]
 fn load_mft_index_live(drive_letter: char, no_cache: bool) -> anyhow::Result<MftIndex> {
     use anyhow::Context;
 

--- a/crates/uffs-core/src/compact_loader.rs
+++ b/crates/uffs-core/src/compact_loader.rs
@@ -461,9 +461,11 @@ pub fn load_live_drive(
 
 /// Apply USN changes in-place to the compact index.
 ///
-/// Mutates records (`parent_idx`, names, flags) then rebuilds the children CSR
-/// once at the end.  Typical cost: <5ms for record mutations + ~100ms for CSR
-/// rebuild on a 7M-record drive.
+/// Mutates records (`parent_idx`, names, flags) and the
+/// `frs_to_compact` mapping then rebuilds the children CSR + path
+/// lengths + trigram + extension index once at the end.  Typical
+/// cost: <5ms for record mutations + ~100ms for CSR rebuild on a
+/// 7M-record drive (the rebuild dominates).
 ///
 /// **Platform note.**  The function itself is pure data manipulation
 /// over `DriveCompactIndex` + the platform-agnostic
@@ -473,16 +475,49 @@ pub fn load_live_drive(
 /// Windows-only.  This split is what makes the Phase 7 per-shard
 /// patch path Mac-testable end-to-end via synthesised
 /// [`uffs_mft::usn::FileChange`] arrays.
+///
+/// **Phase 8.** The `frs_to_compact` mapping is read from
+/// [`DriveCompactIndex::frs_to_compact`] (no longer a separate
+/// parameter) and maintained in lock-step with the records:
+///
+/// * **Create** \u2014 a new compact slot is appended at `records.len()` and
+///   `frs_to_compact[new_frs]` is updated to point at it (extending the table
+///   if the FRS exceeds the current `frs_to_compact.len()`).
+/// * **Delete** \u2014 `frs_to_compact[deleted_frs] = u32::MAX` so subsequent
+///   batches referencing the deleted FRS take the skip branch instead of
+///   mis-applying to a tombstoned slot.
+/// * **Rename** \u2014 the FRS keeps its compact slot; only `parent_idx` + name
+///   move.  Mapping is unchanged.
+///
+/// **Empty-mapping fallback.** When `drive.frs_to_compact.is_empty()`
+/// (v9 caches loaded before Phase 8 cache format v10) every change
+/// looks up to `u32::MAX` and the function increments `skipped` for
+/// the whole batch \u2014 the surgical patch silently degrades to a
+/// no-op so the caller's full-reload fallback path runs.
+#[expect(
+    clippy::too_many_lines,
+    reason = "Phase 8 surgical-patch loop: the create / delete / rename \
+              branches each mutate `drive.frs_to_compact` in a \
+              variant-specific way (delete tombstones the slot, create \
+              extends + registers, rename leaves it intact); splitting \
+              into per-variant helpers would scatter the FRS-mapping \
+              invariant across functions and obscure the symmetric \
+              treatment that's central to the surgical-patch correctness \
+              contract."
+)]
 pub fn apply_usn_patch(
     drive: &mut DriveCompactIndex,
     changes: &[uffs_mft::usn::FileChange],
-    frs_to_compact: &[u32],
 ) -> PatchStats {
     let mut stats = PatchStats::default();
 
     for change in changes {
         let frs_usize = uffs_mft::frs_to_usize(change.frs);
-        let compact_idx = frs_to_compact.get(frs_usize).copied().unwrap_or(u32::MAX);
+        let compact_idx = drive
+            .frs_to_compact
+            .get(frs_usize)
+            .copied()
+            .unwrap_or(u32::MAX);
 
         if change.deleted {
             if compact_idx == u32::MAX {
@@ -491,6 +526,12 @@ pub fn apply_usn_patch(
                 rec.name_len = 0;
                 // Clear parent so CSR rebuild excludes this record.
                 rec.parent_idx = u32::MAX;
+                // Phase 8: mark the FRS slot unmapped so a future
+                // batch can't re-animate the tombstone via the
+                // `compact_idx != u32::MAX` create branch below.
+                if let Some(slot) = drive.frs_to_compact.get_mut(frs_usize) {
+                    *slot = u32::MAX;
+                }
                 stats.deleted += 1;
             }
         } else if change.created {
@@ -517,7 +558,8 @@ pub fn apply_usn_patch(
                     .extend_from_slice(change.filename.as_bytes());
 
                 let parent_frs_usize = uffs_mft::frs_to_usize(change.parent_frs);
-                let parent_compact = frs_to_compact
+                let parent_compact = drive
+                    .frs_to_compact
                     .get(parent_frs_usize)
                     .copied()
                     .unwrap_or(u32::MAX);
@@ -544,7 +586,25 @@ pub fn apply_usn_patch(
                     _pad: [0; 1],
                 };
 
+                let new_compact_idx = uffs_mft::len_to_u32(drive.records.len());
                 drive.records.as_mut_vec().push(new_rec);
+
+                // Phase 8: register the new FRS → compact_idx mapping
+                // so future batches that reference this FRS find the
+                // correct slot.  Extend the table if needed (the FRS
+                // may exceed the build-time max — e.g. NTFS reuses
+                // freed FRS slots after deletes, and a long-running
+                // daemon can outgrow the original `frs_to_idx`
+                // capacity).  Sentinel-fill any intermediate gap so
+                // skipped FRS values still report `u32::MAX`.
+                if frs_usize >= drive.frs_to_compact.len() {
+                    drive
+                        .frs_to_compact
+                        .resize(frs_usize.saturating_add(1), u32::MAX);
+                }
+                if let Some(slot) = drive.frs_to_compact.get_mut(frs_usize) {
+                    *slot = new_compact_idx;
+                }
                 stats.created += 1;
             } else {
                 stats.skipped += 1;
@@ -564,13 +624,16 @@ pub fn apply_usn_patch(
                 }
 
                 let new_parent_frs = uffs_mft::frs_to_usize(change.parent_frs);
-                let new_parent_compact = frs_to_compact
+                let new_parent_compact = drive
+                    .frs_to_compact
                     .get(new_parent_frs)
                     .copied()
                     .unwrap_or(u32::MAX);
 
                 // Update parent_idx — CSR rebuild picks this up.
                 rec.parent_idx = new_parent_compact;
+                // Rename keeps the FRS in the same compact slot;
+                // mapping is unchanged.
                 stats.renamed += 1;
             }
         } else {

--- a/crates/uffs-core/src/compact_loader_tests.rs
+++ b/crates/uffs-core/src/compact_loader_tests.rs
@@ -35,10 +35,11 @@ use crate::trigram::TrigramIndex;
 /// * FRS 11 → `"bar.rs"`  parent=5 @ `compact_idx` 2
 /// * FRS 12 → `"baz.md"`  parent=5 @ `compact_idx` 3
 ///
-/// Returns the drive plus a `frs_to_compact[100]` mapping sized to
-/// cover FRS 13 (newly-created in tests) and FRS 99 (unmapped /
-/// skipped) without bounds-check failures.
-fn make_synthetic_drive() -> (DriveCompactIndex, Vec<u32>) {
+/// `drive.frs_to_compact` is populated with the mapping above plus
+/// `u32::MAX` sentinels for FRS 13 (newly-created in the create
+/// test) and FRS 99 (unmapped / skipped) so tests can patch the
+/// drive in place without touching a separate slice.
+fn make_synthetic_drive() -> DriveCompactIndex {
     // Names blob layout:
     //   "C"       [0..1]
     //   "foo.txt" [1..8]
@@ -82,23 +83,9 @@ fn make_synthetic_drive() -> (DriveCompactIndex, Vec<u32>) {
     let children = ChildrenIndex::build(&records);
     let ext_index = ExtensionIndex::build(&records);
 
-    let drive = DriveCompactIndex {
-        letter: 'T',
-        records: ColumnStorage::from_vec(records),
-        names: ColumnStorage::from_vec(names),
-        trigram,
-        children,
-        ext_index,
-        fold,
-        ext_names: vec![Box::from("")],
-        source: IndexSource::MftFile(PathBuf::from("T:")),
-        source_epoch: 42,
-        bloom: None,
-        path_trie: None,
-    };
-
-    // FRS → compact_idx mapping.  Sized to cover FRS 13 (newly-created)
-    // and FRS 99 (skipped — no compact slot) without bounds checks.
+    // FRS → compact_idx mapping.  Sized to 100 entries so test
+    // batches can address FRS 13 (newly-created) and FRS 99
+    // (skipped — no compact slot) without resize gymnastics.
     // Built via iterator-collect to avoid `clippy::indexing_slicing`;
     // FRS 13 left at u32::MAX so the create-branch fires for it.
     let frs_to_compact: Vec<u32> = (0_usize..100)
@@ -111,7 +98,21 @@ fn make_synthetic_drive() -> (DriveCompactIndex, Vec<u32>) {
         })
         .collect();
 
-    (drive, frs_to_compact)
+    DriveCompactIndex {
+        letter: 'T',
+        records: ColumnStorage::from_vec(records),
+        names: ColumnStorage::from_vec(names),
+        trigram,
+        children,
+        ext_index,
+        fold,
+        ext_names: vec![Box::from("")],
+        source: IndexSource::MftFile(PathBuf::from("T:")),
+        source_epoch: 42,
+        bloom: None,
+        path_trie: None,
+        frs_to_compact,
+    }
 }
 
 /// Headline contract test: a mixed batch of create / delete / rename /
@@ -119,7 +120,7 @@ fn make_synthetic_drive() -> (DriveCompactIndex, Vec<u32>) {
 /// cross-talk.
 #[test]
 fn apply_usn_patch_handles_create_delete_rename_skip() {
-    let (mut drive, frs_to_compact) = make_synthetic_drive();
+    let mut drive = make_synthetic_drive();
 
     let changes = vec![
         // Delete FRS 10 ("foo.txt").
@@ -152,7 +153,7 @@ fn apply_usn_patch_handles_create_delete_rename_skip() {
         },
     ];
 
-    let stats = apply_usn_patch(&mut drive, &changes, &frs_to_compact);
+    let stats = apply_usn_patch(&mut drive, &changes);
 
     assert_eq!(
         stats.deleted, 1,
@@ -177,14 +178,14 @@ fn apply_usn_patch_handles_create_delete_rename_skip() {
 /// from any directory's child list (tombstone semantics).
 #[test]
 fn apply_usn_patch_marks_deleted_record_with_zero_name_len() {
-    let (mut drive, frs_to_compact) = make_synthetic_drive();
+    let mut drive = make_synthetic_drive();
     let changes = vec![FileChange {
         frs: 10,
         deleted: true,
         ..FileChange::default()
     }];
 
-    apply_usn_patch(&mut drive, &changes, &frs_to_compact);
+    apply_usn_patch(&mut drive, &changes);
 
     let record = drive
         .records
@@ -204,7 +205,7 @@ fn apply_usn_patch_marks_deleted_record_with_zero_name_len() {
 /// reflects the new byte count.
 #[test]
 fn apply_usn_patch_renamed_record_has_new_name_in_blob() {
-    let (mut drive, frs_to_compact) = make_synthetic_drive();
+    let mut drive = make_synthetic_drive();
     let changes = vec![FileChange {
         frs: 11,
         parent_frs: 5,
@@ -213,7 +214,7 @@ fn apply_usn_patch_renamed_record_has_new_name_in_blob() {
         ..FileChange::default()
     }];
 
-    apply_usn_patch(&mut drive, &changes, &frs_to_compact);
+    apply_usn_patch(&mut drive, &changes);
 
     let record = drive
         .records
@@ -241,7 +242,7 @@ fn apply_usn_patch_renamed_record_has_new_name_in_blob() {
 /// `name_len`, and `name_first_byte`.
 #[test]
 fn apply_usn_patch_created_record_appended_with_correct_parent() {
-    let (mut drive, frs_to_compact) = make_synthetic_drive();
+    let mut drive = make_synthetic_drive();
     let initial_record_count = drive.records.len();
 
     let changes = vec![FileChange {
@@ -252,7 +253,7 @@ fn apply_usn_patch_created_record_appended_with_correct_parent() {
         ..FileChange::default()
     }];
 
-    apply_usn_patch(&mut drive, &changes, &frs_to_compact);
+    apply_usn_patch(&mut drive, &changes);
 
     assert_eq!(
         drive.records.len(),
@@ -282,11 +283,11 @@ fn apply_usn_patch_created_record_appended_with_correct_parent() {
 /// derived structures don't grow on an empty batch.
 #[test]
 fn apply_usn_patch_no_changes_is_no_op_with_zero_stats() {
-    let (mut drive, frs_to_compact) = make_synthetic_drive();
+    let mut drive = make_synthetic_drive();
     let initial_record_count = drive.records.len();
     let initial_names_len = drive.names.len();
 
-    let stats = apply_usn_patch(&mut drive, &[], &frs_to_compact);
+    let stats = apply_usn_patch(&mut drive, &[]);
 
     assert_eq!(stats.deleted, 0);
     assert_eq!(stats.created, 0);
@@ -302,7 +303,7 @@ fn apply_usn_patch_no_changes_is_no_op_with_zero_stats() {
 /// children list must no longer include that record's `compact_idx`.
 #[test]
 fn apply_usn_patch_rebuilds_children_csr_excluding_deletes() {
-    let (mut drive, frs_to_compact) = make_synthetic_drive();
+    let mut drive = make_synthetic_drive();
 
     // Pre-state sanity: root (compact_idx 0) starts with three
     // children — compact_idx 1 ("foo.txt"), 2 ("bar.rs"), 3 ("baz.md").
@@ -319,7 +320,7 @@ fn apply_usn_patch_rebuilds_children_csr_excluding_deletes() {
         ..FileChange::default()
     }];
 
-    apply_usn_patch(&mut drive, &changes, &frs_to_compact);
+    apply_usn_patch(&mut drive, &changes);
 
     let post_root_children: Vec<u32> = drive.children.get(0).to_vec();
     assert!(
@@ -330,5 +331,153 @@ fn apply_usn_patch_rebuilds_children_csr_excluding_deletes() {
         post_root_children.len(),
         2,
         "root should have two surviving children after one delete"
+    );
+}
+
+/// Phase 8 invariant: `apply_usn_patch` keeps `drive.frs_to_compact`
+/// in lock-step with `drive.records` across creates and deletes.
+///
+/// Pins:
+/// 1. **Create populates the slot.**  A brand-new FRS (13) lands at the
+///    appended `compact_idx`; `drive.frs_to_compact[13]` reflects that slot
+///    exactly.
+/// 2. **Delete clears the slot.**  After deleting an existing FRS (10),
+///    `drive.frs_to_compact[10] == u32::MAX`.
+/// 3. **FRS reuse round-trip.**  Create FRS 13 → delete FRS 13 → create FRS 13
+///    again yields a *fresh* `compact_idx` (NOT the tombstoned one).  This
+///    guards the long-running daemon against NTFS FRS-slot reuse ambiguity.
+/// 4. **Out-of-range create extends the table.**  A create on FRS 200 (beyond
+///    the fixture's len-100 mapping) grows `frs_to_compact` and registers the
+///    new slot at index 200.
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Phase 8 lockstep invariant test — the four pinned cases \
+              (Create / Delete / FRS-reuse / Out-of-range-create) form a \
+              single linear narrative; splitting into per-case helpers \
+              would scatter the read-modify-assert flow across four \
+              functions and obscure the invariant the test exists to \
+              regression-pin."
+)]
+fn apply_usn_patch_keeps_frs_to_compact_in_lockstep() {
+    // ── 1. Create FRS 13 → expect new compact_idx + mapping update.
+    let mut drive = make_synthetic_drive();
+    let initial_records = drive.records.len();
+    let initial_mapping_len = drive.frs_to_compact.len();
+    assert_eq!(
+        drive
+            .frs_to_compact
+            .get(13)
+            .copied()
+            .expect("fixture sized to 100"),
+        u32::MAX,
+        "FRS 13 starts unmapped"
+    );
+
+    apply_usn_patch(&mut drive, &[FileChange {
+        frs: 13,
+        parent_frs: 5,
+        filename: "n1.txt".to_owned(),
+        created: true,
+        ..FileChange::default()
+    }]);
+
+    let first_compact_idx = drive
+        .frs_to_compact
+        .get(13)
+        .copied()
+        .expect("create updated mapping");
+    assert_ne!(
+        first_compact_idx,
+        u32::MAX,
+        "create must register FRS 13 → compact_idx mapping"
+    );
+    assert_eq!(
+        first_compact_idx as usize, initial_records,
+        "new compact_idx must equal pre-create records.len()"
+    );
+
+    // ── 2. Delete existing FRS 10 → expect slot reset to u32::MAX.
+    apply_usn_patch(&mut drive, &[FileChange {
+        frs: 10,
+        deleted: true,
+        ..FileChange::default()
+    }]);
+    assert_eq!(
+        drive
+            .frs_to_compact
+            .get(10)
+            .copied()
+            .expect("fixture sized to 100"),
+        u32::MAX,
+        "delete must reset FRS 10 mapping to u32::MAX"
+    );
+
+    // ── 3. Reuse round-trip: delete FRS 13, then create FRS 13 again.
+    apply_usn_patch(&mut drive, &[FileChange {
+        frs: 13,
+        deleted: true,
+        ..FileChange::default()
+    }]);
+    assert_eq!(
+        drive
+            .frs_to_compact
+            .get(13)
+            .copied()
+            .expect("fixture sized to 100"),
+        u32::MAX,
+        "delete must clear FRS 13 mapping after the create"
+    );
+
+    let pre_recreate_records = drive.records.len();
+    apply_usn_patch(&mut drive, &[FileChange {
+        frs: 13,
+        parent_frs: 5,
+        filename: "n2.txt".to_owned(),
+        created: true,
+        ..FileChange::default()
+    }]);
+    let second_compact_idx = drive
+        .frs_to_compact
+        .get(13)
+        .copied()
+        .expect("recreate updated mapping");
+    assert_ne!(
+        second_compact_idx, first_compact_idx,
+        "FRS-13 reuse must yield a fresh compact_idx, not the tombstoned one"
+    );
+    assert_eq!(
+        second_compact_idx as usize, pre_recreate_records,
+        "recreated compact_idx must equal records.len() at the second create"
+    );
+
+    // ── 4. Out-of-range create grows the mapping.
+    apply_usn_patch(&mut drive, &[FileChange {
+        frs: 200,
+        parent_frs: 5,
+        filename: "far.txt".to_owned(),
+        created: true,
+        ..FileChange::default()
+    }]);
+    assert!(
+        drive.frs_to_compact.len() >= 201,
+        "creates beyond the build-time max must extend frs_to_compact \
+         (was {initial_mapping_len}; now {})",
+        drive.frs_to_compact.len()
+    );
+    let far_compact_idx = drive
+        .frs_to_compact
+        .get(200)
+        .copied()
+        .expect("table extended past index 200");
+    assert_ne!(
+        far_compact_idx,
+        u32::MAX,
+        "FRS 200 must map to the freshly-appended compact slot"
+    );
+    assert_eq!(
+        far_compact_idx as usize,
+        drive.records.len() - 1,
+        "FRS 200 must point at the most recently appended record"
     );
 }

--- a/crates/uffs-daemon/src/cache/background_io.rs
+++ b/crates/uffs-daemon/src/cache/background_io.rs
@@ -125,22 +125,26 @@ impl BackgroundIoPriority for PlatformBackgroundIoPriority {
             GetCurrentThread, SetThreadPriority, THREAD_MODE_BACKGROUND_BEGIN,
         };
 
-        // SAFETY: `GetCurrentThread` returns a pseudo-handle that is
-        // always valid for the lifetime of the calling thread; passing
-        // it straight to `SetThreadPriority` is the documented Win32
-        // idiom — the pseudo-handle does not need closing.  The
-        // priority constant `THREAD_MODE_BACKGROUND_BEGIN` is one of
-        // the two windows-rs `THREAD_PRIORITY` flags carved out for
-        // this transition (the other being `THREAD_MODE_BACKGROUND_END`),
-        // so the call shape matches the underlying Win32 contract
-        // exactly.  Failures translate to `io::Error::other` so the
-        // `BackgroundIoScope` guard's `tracing::debug!` line stays
-        // platform-agnostic.
         #[expect(
             unsafe_code,
-            reason = "SetThreadPriority requires unsafe FFI; balanced by GetCurrentThread pseudo-handle that does not need closing"
+            reason = "GetCurrentThread Win32 FFI returning a thread pseudo-handle"
         )]
-        let result = unsafe { SetThreadPriority(GetCurrentThread(), THREAD_MODE_BACKGROUND_BEGIN) };
+        // SAFETY: `GetCurrentThread` returns a pseudo-handle that is
+        // always valid for the lifetime of the calling thread; the
+        // pseudo-handle does not need closing.
+        let thread = unsafe { GetCurrentThread() };
+        #[expect(
+            unsafe_code,
+            reason = "SetThreadPriority Win32 FFI on the current thread's pseudo-handle"
+        )]
+        // SAFETY: `thread` was just obtained from `GetCurrentThread`
+        // above and is valid for the calling thread's lifetime.
+        // `THREAD_MODE_BACKGROUND_BEGIN` is the documented Win32 flag
+        // for transitioning the calling thread to background-I/O
+        // priority; failures translate to `io::Error::other` so the
+        // `BackgroundIoScope` guard's `tracing::debug!` line stays
+        // platform-agnostic.
+        let result = unsafe { SetThreadPriority(thread, THREAD_MODE_BACKGROUND_BEGIN) };
         result.map_err(|err| io::Error::other(err.to_string()))
     }
 
@@ -150,16 +154,24 @@ impl BackgroundIoPriority for PlatformBackgroundIoPriority {
             GetCurrentThread, SetThreadPriority, THREAD_MODE_BACKGROUND_END,
         };
 
-        // SAFETY: same reasoning as `begin` above; the `_END` flag
-        // is the documented pair to `_BEGIN` and the kernel treats
-        // the call as a no-op when the thread isn't currently in
-        // background mode (so calling `end` without a matching
-        // `begin` is harmless).
         #[expect(
             unsafe_code,
-            reason = "SetThreadPriority requires unsafe FFI; balanced by GetCurrentThread pseudo-handle that does not need closing"
+            reason = "GetCurrentThread Win32 FFI returning a thread pseudo-handle"
         )]
-        let result = unsafe { SetThreadPriority(GetCurrentThread(), THREAD_MODE_BACKGROUND_END) };
+        // SAFETY: `GetCurrentThread` returns a pseudo-handle that is
+        // always valid for the lifetime of the calling thread; the
+        // pseudo-handle does not need closing.
+        let thread = unsafe { GetCurrentThread() };
+        #[expect(
+            unsafe_code,
+            reason = "SetThreadPriority Win32 FFI on the current thread's pseudo-handle"
+        )]
+        // SAFETY: `thread` was just obtained from `GetCurrentThread`
+        // above; the `_END` flag is the documented pair to `_BEGIN`
+        // and the kernel treats the call as a no-op when the thread
+        // isn't currently in background mode (so calling `end`
+        // without a matching `begin` is harmless).
+        let result = unsafe { SetThreadPriority(thread, THREAD_MODE_BACKGROUND_END) };
         result.map_err(|err| io::Error::other(err.to_string()))
     }
 

--- a/crates/uffs-daemon/src/cache/journal_sink.rs
+++ b/crates/uffs-daemon/src/cache/journal_sink.rs
@@ -2,30 +2,43 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Production [`PatchSink`] for the per-shard journal loop (Phase 7
-//! activation A3).
+//! activation A3, Phase 8 surgical-patch B3).
 //!
-//! ## Architecture — applier-task pattern
+//! ## Architecture — buffered applier-task pattern
 //!
 //! [`RegistryPatchSink::accept`] / [`RegistryPatchSink::trigger_save`] /
 //! [`RegistryPatchSink::journal_wrapped`] are **synchronous** callbacks
 //! invoked from the journal loop's `process_tick` (which itself runs
 //! in async context via [`crate::cache::journal_loop::JournalLoop::run`]).
-//! The downstream work (registry write-lock acquisition,
-//! [`crate::index::IndexManager::handle_journal_refresh`]) is `async`
-//! and uses [`tokio::sync::RwLock`].  Calling `Handle::block_on` from
-//! the sync callback would re-enter the runtime and deadlock.
+//! The downstream work (registry write-lock acquisition, body patching,
+//! background save) is `async` and uses [`tokio::sync::RwLock`].
+//! Calling `Handle::block_on` from the sync callback would re-enter the
+//! runtime and deadlock.
 //!
-//! The fix: each callback **enqueues** an [`ApplyMsg`] onto an
+//! Phase 7 fix: each callback **enqueues** an [`ApplyMsg`] onto an
 //! [`tokio::sync::mpsc::UnboundedSender`] (sync, non-blocking) and
 //! returns immediately.  A single async **applier task** owns the
-//! receiver and processes messages serially.  This:
+//! receiver and processes messages serially.
+//!
+//! Phase 8 B3 extension: per-letter
+//! [`std::sync::Mutex<HashMap<char, Vec<FileChange>>>`] **pending
+//! buffer** owned by the sink.  `accept` appends to the buffer
+//! synchronously (no mpsc traffic).  `trigger_save` drains the buffer
+//! for that letter and ships the drained `Vec<FileChange>` into
+//! [`ApplyMsg::Save`] so the applier can run a *surgical*
+//! [`crate::cache::ShardEntry::apply_usn_patch_to_body`] instead of a
+//! full [`uffs_core::compact_loader::load_drive_with_usn_refresh`].
+//! `journal_wrapped` discards the buffer (a wrap means the journal
+//! head reset, so any pending events are stale relative to the new
+//! cursor) and falls back to the Phase-7 full-reload path.
+//!
+//! Properties of the buffered design:
 //!
 //! 1. Preserves FIFO ordering (per-letter and across letters).
-//! 2. Keeps the loop's hot path zero-cost — accept is `Vec::clone`
-//!    + atomic-list-tail-push.
-//! 3. Decouples the loop's tick cadence from the registry-mutation latency (a
-//!    slow `load_drive_with_usn_refresh` doesn't stall the cursor advance — the
-//!    next tick proceeds while the previous refresh is still draining).
+//! 2. Keeps the loop's hot path zero-cost — accept is `Vec::extend_from_slice`
+//!    on a per-letter `Vec<FileChange>` under a short-held mutex.
+//! 3. Save-tick latency is independent of accept-tick volume — the journal loop
+//!    never blocks on the patch / swap / persist sequence.
 //!
 //! ## Lifecycle
 //!
@@ -44,6 +57,8 @@
 //!   shutdown shape as the `Weak` path.
 
 use alloc::sync::{Arc, Weak};
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -54,39 +69,33 @@ use crate::index::IndexManager;
 
 /// Cross-task message from a sync sink callback to the async applier.
 ///
-/// Each variant maps 1-to-1 with a [`PatchSink`] callback.  Carrying
-/// only the minimum metadata (letter + per-callback context) keeps
-/// the channel's per-message size small even at high churn.
+/// Phase 8 dropped the Phase-7 `Accept` variant: per-letter event
+/// buffering moved into the sink itself ([`RegistryPatchSink::pending`])
+/// so `accept` no longer puts traffic on the channel.
 #[derive(Debug)]
 enum ApplyMsg {
-    /// `accept` callback — for now, just an event-count signal so
-    /// the applier can trace per-letter churn.  Surgical body-patch
-    /// is deferred to Phase 8 (requires `frs_to_compact` persistence
-    /// — see `crate::index::journal` module docs for the rationale).
-    Accept {
-        /// Drive letter the loop polled this tick.
-        letter: char,
-        /// Number of aggregated [`FileChange`] entries the source
-        /// produced.  Surfaced in the trace event so operators can
-        /// validate per-letter churn vs the
-        /// [`super::journal_loop::JournalLoopConfig`]
-        /// `save_threshold_events` ceiling.
-        change_count: usize,
-    },
-    /// `trigger_save` callback — fire a full per-shard
-    /// [`IndexManager::handle_journal_refresh`].  The applier
-    /// converts [`SaveReason`] to a stable diagnostic string
-    /// (`"events-exceeded"` / `"age-elapsed"`) for the success/
+    /// `trigger_save` callback — the applier runs a surgical
+    /// [`crate::cache::ShardEntry::apply_usn_patch_to_body`] over
+    /// the drained per-letter buffer, then `replace_warm_body` +
+    /// `save_compact_cache_background`.  The applier converts
+    /// [`SaveReason`] to a stable diagnostic string
+    /// (`"events-exceeded"` / `"age-elapsed"`) for the success /
     /// failure log.
     Save {
         /// Drive letter to refresh.
         letter: char,
         /// Why the save threshold fired.
         reason: SaveReason,
+        /// Drained per-letter event buffer.  Empty on age-elapsed
+        /// triggers when the drive saw no churn since the last save
+        /// (the surgical-patch path short-circuits to a no-op).
+        changes: Vec<FileChange>,
     },
-    /// `journal_wrapped` callback — same effect as `Save` (full
-    /// refresh) so the body's resync against the new journal head
-    /// is immediate, not deferred to the next save threshold.
+    /// `journal_wrapped` callback — the journal head reset so any
+    /// pending events are stale; the applier discards them in the
+    /// sink and runs a full
+    /// [`IndexManager::handle_journal_refresh`] to resync the body
+    /// against the new journal head.
     Wrap {
         /// Drive letter whose USN journal was recreated.
         letter: char,
@@ -95,9 +104,16 @@ enum ApplyMsg {
 
 /// Production [`PatchSink`] wired to the registry via an applier task.
 ///
-/// Stateless apart from the `mpsc::UnboundedSender` — every callback
-/// is a one-line enqueue + immediate return.  The receiver lives in
-/// the spawned applier task (see [`Self::spawn_with_applier`]).
+/// Holds two pieces of state:
+///
+/// * `apply_tx` — the sender side of the applier task's mpsc channel.  `accept`
+///   does NOT use it; `trigger_save` and `journal_wrapped` do.
+/// * `pending` — per-letter buffer of [`FileChange`] entries that `accept` has
+///   appended since the last save / wrap.
+///
+/// Both are owned by the sink Arc; cloning the Arc is cheap and the
+/// inner state is shared across every per-shard journal loop that
+/// holds a clone.
 pub(crate) struct RegistryPatchSink {
     /// Channel into the applier task.  `UnboundedSender::send` is
     /// sync-non-blocking, which is exactly what the loop's sync
@@ -108,6 +124,21 @@ pub(crate) struct RegistryPatchSink {
     /// shard's in-memory body stops refreshing" which is the
     /// correct degraded state.
     apply_tx: mpsc::UnboundedSender<ApplyMsg>,
+    /// Per-letter pending [`FileChange`] buffer accumulated by
+    /// `accept` between save / wrap triggers.  Drained on
+    /// `trigger_save` (forwarded to the applier in
+    /// [`ApplyMsg::Save`]) and discarded on `journal_wrapped`
+    /// (the wrap full-reload supersedes any pending patches).
+    ///
+    /// Wrapped in [`std::sync::Mutex`] (not [`tokio::sync::Mutex`])
+    /// because every access is from the *sync* sink callbacks; the
+    /// critical section is `Vec::extend_from_slice` /
+    /// `HashMap::remove` — microseconds at most, so the brief lock
+    /// contention is invisible relative to the journal loop's 500 ms
+    /// tick cadence.  Poisoning is recovered via
+    /// [`std::sync::PoisonError::into_inner`] (matching the
+    /// `lock_journal_handles` helper in `index/journal.rs`).
+    pending: Mutex<HashMap<char, Vec<FileChange>>>,
 }
 
 impl RegistryPatchSink {
@@ -129,28 +160,89 @@ impl RegistryPatchSink {
         let (apply_tx, apply_rx) = mpsc::unbounded_channel();
         let weak = Arc::downgrade(idx);
         let handle = tokio::spawn(applier_task(apply_rx, weak));
-        (Arc::new(Self { apply_tx }), handle)
+        (
+            Arc::new(Self {
+                apply_tx,
+                pending: Mutex::new(HashMap::new()),
+            }),
+            handle,
+        )
+    }
+
+    /// Acquire the pending-buffer mutex, recovering from poison.
+    /// Mirrors the `lock_journal_handles` helper in
+    /// `index/journal.rs` — a poisoned mutex on the sink side
+    /// would otherwise propagate a panic from the applier task into
+    /// every subsequent journal-loop tick, killing the whole
+    /// journal-refresh subsystem.
+    fn lock_pending(&self) -> std::sync::MutexGuard<'_, HashMap<char, Vec<FileChange>>> {
+        self.pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Test-only constructor: build a sink with an explicit
+    /// `mpsc::UnboundedReceiver<ApplyMsg>` returned to the caller.
+    /// Skips the applier-task spawn so unit tests can drain the
+    /// channel directly and assert on per-`ApplyMsg`-variant
+    /// payloads.  Production code must use
+    /// [`Self::spawn_with_applier`].
+    #[cfg(test)]
+    fn new_for_test() -> (Arc<Self>, mpsc::UnboundedReceiver<ApplyMsg>) {
+        let (apply_tx, apply_rx) = mpsc::unbounded_channel();
+        (
+            Arc::new(Self {
+                apply_tx,
+                pending: Mutex::new(HashMap::new()),
+            }),
+            apply_rx,
+        )
     }
 }
 
 impl PatchSink for RegistryPatchSink {
     fn accept(&self, letter: char, changes: &[FileChange]) -> bool {
-        // Send-and-forget.  Returning `true` optimistically is
-        // correct: the loop's `process_tick` only uses the boolean
-        // for tracing-debug instrumentation; FIFO ordering across
-        // ticks is preserved by the single-applier serialisation.
-        let _ignore = self.apply_tx.send(ApplyMsg::Accept {
-            letter,
-            change_count: changes.len(),
-        });
+        // Phase 8: append to the per-letter pending buffer instead
+        // of putting traffic on the mpsc channel.  `trigger_save`
+        // drains this buffer and forwards the changes into the
+        // applier task for surgical-patch processing.
+        tracing::trace!(
+            target: "shard.journal",
+            drive = %letter,
+            change_count = changes.len(),
+            "Journal accept (buffered for next save tick)",
+        );
+        let mut guard = self.lock_pending();
+        guard.entry(letter).or_default().extend_from_slice(changes);
+        drop(guard);
         true
     }
 
     fn trigger_save(&self, letter: char, reason: SaveReason) {
-        let _ignore = self.apply_tx.send(ApplyMsg::Save { letter, reason });
+        // Drain the per-letter buffer in one swoop so the applier
+        // sees a snapshot of all events accumulated since the
+        // previous save.  An empty drained Vec is forwarded as-is
+        // (the applier short-circuits the surgical-patch path).
+        let drained = {
+            let mut guard = self.lock_pending();
+            guard.remove(&letter).unwrap_or_default()
+        };
+        let _ignore = self.apply_tx.send(ApplyMsg::Save {
+            letter,
+            reason,
+            changes: drained,
+        });
     }
 
     fn journal_wrapped(&self, letter: char) {
+        // Wrap means the journal head reset; any buffered events
+        // are stale relative to the new cursor.  Discard the
+        // pending buffer and rely on the applier's full reload to
+        // resync the body.
+        {
+            let mut guard = self.lock_pending();
+            let _discarded = guard.remove(&letter);
+        }
         let _ignore = self.apply_tx.send(ApplyMsg::Wrap { letter });
     }
 }
@@ -192,28 +284,26 @@ async fn applier_task(mut rx: mpsc::UnboundedReceiver<ApplyMsg>, idx_weak: Weak<
 /// in this helper (focused, easy to extend).
 async fn dispatch_msg(idx: &Arc<IndexManager>, msg: ApplyMsg) {
     match msg {
-        ApplyMsg::Accept {
+        ApplyMsg::Save {
             letter,
-            change_count,
+            reason,
+            changes,
         } => {
-            // Phase 7 activation: surgical body-patch is deferred
-            // to Phase 8 (needs `frs_to_compact` persistence on
-            // `DriveCompactIndex`).  For now we just trace the
-            // per-letter churn so operator dashboards can see
-            // which drives are accumulating events between save
-            // triggers.
-            tracing::trace!(
-                target: "shard.journal",
-                drive = %letter,
-                change_count,
-                "Journal accept (events recorded; body refresh deferred to next save trigger)",
-            );
-        }
-        ApplyMsg::Save { letter, reason } => {
             let reason_str = save_reason_str(reason);
-            let _applied = idx.handle_journal_refresh(letter, reason_str).await;
+            // Phase 8 surgical-patch path: hand the drained per-letter
+            // change buffer to `IndexManager::handle_journal_save`,
+            // which clones the Warm body, applies the patch, swaps
+            // the new Arc into the registry, and persists the patched
+            // body via `save_compact_cache_background`.
+            let _applied = idx.handle_journal_save(letter, reason_str, changes).await;
         }
         ApplyMsg::Wrap { letter } => {
+            // Wrap stays on the Phase-7 full-reload path.  The
+            // patched-body snapshot is invalidated by the journal
+            // head reset, so cloning + patching is wasted work — the
+            // cleanest option is `load_drive_with_usn_refresh` which
+            // re-reads the MFT and replays the new journal from
+            // its current head.
             let _applied = idx.handle_journal_refresh(letter, "journal-wrapped").await;
         }
     }
@@ -247,30 +337,215 @@ mod tests {
         ))
     }
 
-    /// Pin the canonical happy path: each [`PatchSink`] callback enqueues
-    /// exactly one message into the channel and returns immediately.
-    /// The applier-task lifecycle is exercised separately below; here
-    /// we only assert that the sync callback contract is non-blocking
-    /// and that the channel buffers messages independently.
-    #[tokio::test]
-    async fn each_callback_enqueues_one_message_and_returns_immediately() {
-        let idx = fresh_index_manager();
-        let (sink, _applier) = RegistryPatchSink::spawn_with_applier(&idx);
-
-        // Before any callback, the channel has zero messages by
-        // construction.  We can't directly observe channel depth on
-        // an `UnboundedSender`, but we CAN observe end-to-end through
-        // the sink's [`PatchSink`] contract — three calls produce no
-        // panics, no blocks, and no errors.
-        let accepted = sink.accept('C', &[FileChange {
-            frs: 100,
+    /// Construct a [`FileChange`] fixture with a unique FRS for
+    /// per-event identification.  Fields other than `frs` use
+    /// `FileChange::default()` because the sink doesn't inspect them
+    /// — only `IndexManager::handle_journal_save` does (covered in
+    /// `cache::shard::tests` and the patch end-to-end suite).
+    fn make_change(frs: u64) -> FileChange {
+        FileChange {
+            frs,
             ..FileChange::default()
-        }]);
+        }
+    }
+
+    /// Snapshot the per-letter pending buffer's event FRS sequence,
+    /// dropping the `lock_pending()` guard before returning so the
+    /// caller's assertions don't hold the mutex (satisfies
+    /// `clippy::significant_drop_tightening` in tests).
+    fn pending_frs_for_letter(sink: &RegistryPatchSink, letter: char) -> Option<Vec<u64>> {
+        let guard = sink.lock_pending();
+        guard
+            .get(&letter)
+            .map(|buf| buf.iter().map(|change| change.frs).collect())
+    }
+
+    /// Pin: `accept` appends to the per-letter pending buffer and
+    /// does NOT enqueue a message on the applier channel.
+    #[tokio::test]
+    async fn accept_buffers_changes_without_enqueueing() {
+        let (sink, mut rx) = RegistryPatchSink::new_for_test();
+
+        let accepted = sink.accept('C', &[make_change(100), make_change(101)]);
         assert!(accepted, "accept must return true optimistically");
 
+        // The pending buffer holds the two events for letter 'C'.
+        let buf = pending_frs_for_letter(&sink, 'C')
+            .expect("accept must populate pending buffer for 'C'");
+        assert_eq!(
+            buf,
+            [100, 101],
+            "accept must preserve event order in the buffer",
+        );
+
+        // Channel is empty: accept did not enqueue.
+        assert!(
+            rx.try_recv().is_err(),
+            "accept must NOT enqueue an ApplyMsg",
+        );
+    }
+
+    /// Pin: a sequence of `accept` calls for the same letter
+    /// accumulates into the same buffer — no per-call drain or
+    /// truncation.
+    #[tokio::test]
+    async fn multiple_accepts_accumulate_in_pending() {
+        let (sink, _rx) = RegistryPatchSink::new_for_test();
+
+        sink.accept('C', &[make_change(1)]);
+        sink.accept('C', &[make_change(2), make_change(3)]);
+        sink.accept('C', &[make_change(4)]);
+
+        let buf = pending_frs_for_letter(&sink, 'C').expect("buffer for 'C' must exist");
+        assert_eq!(
+            buf,
+            [1, 2, 3, 4],
+            "consecutive accepts must accumulate in send order",
+        );
+    }
+
+    /// Pin: `trigger_save` drains the pending buffer for `letter`
+    /// and ships it inside `ApplyMsg::Save { changes }`.  The buffer
+    /// for `letter` is cleared after the drain.
+    #[tokio::test]
+    async fn trigger_save_drains_pending_into_save_message() {
+        let (sink, mut rx) = RegistryPatchSink::new_for_test();
+
+        sink.accept('C', &[make_change(10), make_change(11)]);
         sink.trigger_save('C', SaveReason::EventsExceeded);
-        sink.trigger_save('D', SaveReason::AgeElapsed);
-        sink.journal_wrapped('E');
+
+        let ApplyMsg::Save {
+            letter,
+            reason,
+            changes,
+        } = rx.try_recv().expect("trigger_save must enqueue Save")
+        else {
+            panic!("expected ApplyMsg::Save, got Wrap");
+        };
+        assert_eq!(letter, 'C');
+        assert!(matches!(reason, SaveReason::EventsExceeded));
+        assert_eq!(
+            changes.iter().map(|change| change.frs).collect::<Vec<_>>(),
+            [10, 11],
+            "Save must carry the buffered changes in send order",
+        );
+
+        // Pending buffer for 'C' is gone after the drain.
+        assert!(
+            pending_frs_for_letter(&sink, 'C').is_none(),
+            "trigger_save must remove the per-letter pending entry",
+        );
+    }
+
+    /// Pin: `trigger_save` on a letter with no prior `accept` still
+    /// emits `ApplyMsg::Save { changes: [] }`.  The applier's
+    /// empty-batch fast path then short-circuits to a no-op.
+    #[tokio::test]
+    async fn trigger_save_with_no_pending_sends_empty_changes() {
+        let (sink, mut rx) = RegistryPatchSink::new_for_test();
+
+        sink.trigger_save('Z', SaveReason::AgeElapsed);
+
+        let ApplyMsg::Save {
+            letter,
+            reason,
+            changes,
+        } = rx.try_recv().expect("trigger_save must enqueue Save")
+        else {
+            panic!("expected ApplyMsg::Save, got Wrap");
+        };
+        assert_eq!(letter, 'Z');
+        assert!(matches!(reason, SaveReason::AgeElapsed));
+        assert!(
+            changes.is_empty(),
+            "Save must carry an empty Vec when no events were buffered",
+        );
+    }
+
+    /// Pin: `journal_wrapped` clears the pending buffer for the
+    /// letter and emits `ApplyMsg::Wrap`.  A subsequent
+    /// `trigger_save` then sees an empty buffer (no replay of the
+    /// stale events past the wrap).
+    #[tokio::test]
+    async fn journal_wrapped_discards_pending_buffer_and_sends_wrap() {
+        let (sink, mut rx) = RegistryPatchSink::new_for_test();
+
+        sink.accept('C', &[make_change(5), make_change(6)]);
+        sink.journal_wrapped('C');
+
+        let ApplyMsg::Wrap { letter } = rx.try_recv().expect("journal_wrapped must enqueue Wrap")
+        else {
+            panic!("expected ApplyMsg::Wrap, got Save");
+        };
+        assert_eq!(letter, 'C');
+
+        assert!(
+            pending_frs_for_letter(&sink, 'C').is_none(),
+            "journal_wrapped must discard the per-letter pending entry",
+        );
+
+        // A subsequent trigger_save must see an empty buffer.
+        sink.trigger_save('C', SaveReason::AgeElapsed);
+        let ApplyMsg::Save {
+            changes: post_wrap_changes,
+            ..
+        } = rx.try_recv().expect("trigger_save must enqueue Save")
+        else {
+            panic!("expected ApplyMsg::Save after wrap, got another Wrap");
+        };
+        assert!(
+            post_wrap_changes.is_empty(),
+            "post-wrap trigger_save must drain to empty (stale events discarded)",
+        );
+    }
+
+    /// Pin: per-letter buffers are independent.  Accepting events on
+    /// 'C' must not leak into 'D's buffer or pending state.
+    #[tokio::test]
+    async fn pending_buffers_are_per_letter() {
+        let (sink, mut rx) = RegistryPatchSink::new_for_test();
+
+        sink.accept('C', &[make_change(1)]);
+        sink.accept('D', &[make_change(2), make_change(3)]);
+
+        // Drain 'C' first — should NOT include any of 'D's events.
+        sink.trigger_save('C', SaveReason::EventsExceeded);
+        let ApplyMsg::Save {
+            letter: c_letter,
+            changes: c_changes,
+            ..
+        } = rx.try_recv().expect("Save for 'C'")
+        else {
+            panic!("expected ApplyMsg::Save for 'C'");
+        };
+        assert_eq!(c_letter, 'C');
+        assert_eq!(
+            c_changes
+                .iter()
+                .map(|change| change.frs)
+                .collect::<Vec<_>>(),
+            [1],
+        );
+
+        // 'D's buffer must still hold its events.
+        sink.trigger_save('D', SaveReason::EventsExceeded);
+        let ApplyMsg::Save {
+            letter: d_letter,
+            changes: d_changes,
+            ..
+        } = rx.try_recv().expect("Save for 'D'")
+        else {
+            panic!("expected ApplyMsg::Save for 'D'");
+        };
+        assert_eq!(d_letter, 'D');
+        assert_eq!(
+            d_changes
+                .iter()
+                .map(|change| change.frs)
+                .collect::<Vec<_>>(),
+            [2, 3],
+            "'D's buffer must be preserved across 'C's drain",
+        );
     }
 
     /// Drop all `Arc<RegistryPatchSink>` instances → the sender side
@@ -342,20 +617,22 @@ mod tests {
 
     /// Pin the multi-message FIFO ordering contract: a sink that
     /// buffers many messages before the applier can drain them all
-    /// must process them in send order.  This isn't a Phase 7
-    /// invariant per se (out-of-order applies don't corrupt — each
-    /// `handle_journal_refresh` is idempotent on the body Arc), but
-    /// it's a regression-net for any future change that swaps
-    /// `mpsc::unbounded_channel` for an unordered surface.
+    /// must process them in send order.  Out-of-order applies don't
+    /// corrupt (each per-letter `handle_journal_save` is independent),
+    /// but the FIFO contract is a regression-net for any future
+    /// change that swaps `mpsc::unbounded_channel` for an unordered
+    /// surface.
     #[tokio::test]
     async fn applier_drains_in_fifo_order() {
         let idx = fresh_index_manager();
         let (sink, applier) = RegistryPatchSink::spawn_with_applier(&idx);
 
-        // Burst-send 5 messages.  Each one fires a Save which on Mac
-        // hits the load_drive_with_usn_refresh stub-err arm and
-        // returns false; the test doesn't assert on that side effect
-        // because the per-letter behaviour is platform-specific.
+        // Burst-send 5 trigger_save calls without prior `accept`.
+        // Each one drains an empty pending buffer and ships
+        // `ApplyMsg::Save { changes: [] }`; the applier's empty-batch
+        // fast path in `handle_journal_save` short-circuits to a
+        // debug-log no-op.  The test verifies the applier processes
+        // all 5 in order before the sink's drop closes the channel.
         for letter in ['C', 'D', 'E', 'F', 'G'] {
             sink.trigger_save(letter, SaveReason::EventsExceeded);
         }
@@ -365,8 +642,7 @@ mod tests {
         let join_result = tokio::time::timeout(core::time::Duration::from_secs(5), applier).await;
         assert!(
             join_result.is_ok(),
-            "applier must finish draining within 5 s on Mac (load_drive_with_usn_refresh \
-             returns Err immediately on non-Windows targets, no real I/O)",
+            "applier must finish draining within 5 s (5 empty-batch no-ops, no real I/O)",
         );
         join_result
             .expect("timeout deadline must not elapse")

--- a/crates/uffs-daemon/src/cache/prefetch.rs
+++ b/crates/uffs-daemon/src/cache/prefetch.rs
@@ -119,20 +119,29 @@ impl Prefetch for PlatformPrefetch {
             })
             .collect();
 
-        // SAFETY: `GetCurrentProcess` returns a pseudo-handle valid
-        // for the process lifetime.  `entries.as_ptr()` is non-null
-        // and aligned (Vec invariant), valid for `entries.len()`
-        // contiguous reads of `WIN32_MEMORY_RANGE_ENTRY`.  The
-        // caller (orchestrator) keeps the body `Arc` alive across
-        // this call so each `region.ptr` remains a live mapping.
-        // `flags = 0` is the documented "no special behaviour"
-        // value per Win32 docs (PrefetchVirtualMemory accepts only
-        // `PREFETCH_PROCESS_FOR_RECEIVE` or 0; we want 0).
         #[expect(
             unsafe_code,
-            reason = "PrefetchVirtualMemory requires unsafe FFI; safety preconditions are satisfied by the orchestrator holding the body Arc across the call"
+            reason = "GetCurrentProcess Win32 FFI returning a process pseudo-handle"
         )]
-        let result = unsafe { PrefetchVirtualMemory(GetCurrentProcess(), &entries, 0) };
+        // SAFETY: `GetCurrentProcess` returns a pseudo-handle valid
+        // for the process lifetime; the pseudo-handle does not need
+        // closing.
+        let process = unsafe { GetCurrentProcess() };
+        #[expect(
+            unsafe_code,
+            reason = "PrefetchVirtualMemory Win32 FFI; safety preconditions satisfied by the orchestrator holding the body Arc across the call"
+        )]
+        // SAFETY: `process` was just obtained from `GetCurrentProcess`
+        // above and is valid for the process lifetime.
+        // `entries.as_ptr()` is non-null and aligned (Vec invariant),
+        // valid for `entries.len()` contiguous reads of
+        // `WIN32_MEMORY_RANGE_ENTRY`.  The caller (orchestrator)
+        // keeps the body `Arc` alive across this call so each
+        // `region.ptr` remains a live mapping.  `flags = 0` is the
+        // documented "no special behaviour" value per Win32 docs
+        // (`PrefetchVirtualMemory` accepts only
+        // `PREFETCH_PROCESS_FOR_RECEIVE` or 0; we want 0).
+        let result = unsafe { PrefetchVirtualMemory(process, &entries, 0) };
         result.map_err(|err| io::Error::other(err.to_string()))
     }
 

--- a/crates/uffs-daemon/src/cache/pressure.rs
+++ b/crates/uffs-daemon/src/cache/pressure.rs
@@ -246,13 +246,13 @@ impl Drop for PlatformPressureSignal {
         if let Some(shutdown) = &self.shutdown_event {
             windows_handles::signal_shutdown(shutdown);
         }
-        if let Some(handle) = self.watcher_thread.take() {
-            if let Err(payload) = handle.join() {
-                tracing::warn!(
-                    target: "cache.pressure",
-                    "Pressure watcher thread panicked: {payload:?}",
-                );
-            }
+        if let Some(handle) = self.watcher_thread.take()
+            && let Err(payload) = handle.join()
+        {
+            tracing::warn!(
+                target: "cache.pressure",
+                "Pressure watcher thread panicked: {payload:?}",
+            );
         }
         // shutdown_event drops automatically here, closing the
         // kernel handle exactly once via OwnedHandle's Drop.
@@ -302,6 +302,10 @@ mod windows_handles {
     /// exactly once even if the owner panics.
     pub(super) struct OwnedHandle(HANDLE);
 
+    #[expect(
+        unsafe_code,
+        reason = "HANDLE is a thread-safe kernel-object reference"
+    )]
     // SAFETY: HANDLE is an opaque kernel-object reference (an
     // `isize`-sized identifier); the kernel arbitrates concurrent
     // access to the underlying object and Win32 APIs that take
@@ -310,19 +314,26 @@ mod windows_handles {
     // — the only mutation site is `Drop::drop` which takes
     // `&mut self`, so `&OwnedHandle` shared between threads is
     // race-free.
-    #[expect(
-        unsafe_code,
-        reason = "HANDLE is a thread-safe kernel-object reference"
-    )]
     unsafe impl Send for OwnedHandle {}
     #[expect(
         unsafe_code,
         reason = "HANDLE is a thread-safe kernel-object reference"
     )]
+    // SAFETY: same rationale as `OwnedHandle: Send` — see immediately
+    // above.  Sync is sound because the only mutation site
+    // (`Drop::drop`) takes `&mut self`, so shared `&OwnedHandle`
+    // observers across threads cannot race against the close.
     unsafe impl Sync for OwnedHandle {}
 
     impl OwnedHandle {
-        fn raw(&self) -> HANDLE {
+        /// Borrow the wrapped Win32 handle for use in syscalls that
+        /// take a `HANDLE` by value (e.g. `WaitForMultipleObjects`).
+        ///
+        /// The returned `HANDLE` is a Copy bit-pattern — callers must
+        /// **not** close it; ownership stays with `self` and the
+        /// underlying kernel handle is released exactly once via
+        /// [`OwnedHandle::Drop`].
+        const fn raw(&self) -> HANDLE {
             self.0
         }
     }
@@ -330,15 +341,21 @@ mod windows_handles {
     impl Drop for OwnedHandle {
         fn drop(&mut self) {
             if !self.0.is_invalid() {
-                // SAFETY: self.0 is a valid handle returned by a
-                // Win32 Create*-family API and not yet closed
-                // (single-ownership invariant).  CloseHandle is
-                // sync and the documented Win32 idiom for releasing
-                // handles.  Errors are silently ignored — we are
-                // already in Drop and have no useful recovery.
                 #[expect(unsafe_code, reason = "Win32 CloseHandle FFI for handle cleanup")]
-                unsafe {
-                    let _ = CloseHandle(self.0);
+                // SAFETY: `self.0` is a valid handle returned by a
+                // Win32 `Create*`-family API and not yet closed
+                // (single-ownership invariant).  `CloseHandle` is
+                // sync and the documented Win32 idiom for releasing
+                // handles.  Errors are debug-logged — we are already
+                // in `Drop` and have no useful recovery beyond
+                // visibility.
+                let close_result = unsafe { CloseHandle(self.0) };
+                if let Err(err) = close_result {
+                    tracing::debug!(
+                        target: "cache.pressure",
+                        err = ?err,
+                        "CloseHandle failed in OwnedHandle::Drop",
+                    );
                 }
             }
         }
@@ -354,12 +371,12 @@ mod windows_handles {
     #[derive(Clone, Copy)]
     struct SendableHandle(HANDLE);
 
-    // SAFETY: same rationale as `OwnedHandle: Send` — HANDLE values
-    // are kernel-arbitrated identifiers, safe to pass across threads.
     #[expect(
         unsafe_code,
         reason = "HANDLE is a thread-safe kernel-object reference"
     )]
+    // SAFETY: same rationale as `OwnedHandle: Send` — HANDLE values
+    // are kernel-arbitrated identifiers, safe to pass across threads.
     unsafe impl Send for SendableHandle {}
 
     /// Signal the shutdown event so the watcher thread breaks out
@@ -422,6 +439,15 @@ mod windows_handles {
     /// recovers) and listen only for High.  Symmetric for High.
     /// Initial `Normal` waits for either.  Index 0 is always the
     /// shutdown event so a clean exit preempts pressure transitions.
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "watcher_loop takes ownership of `low` / `high` / `sender` for the \
+                  thread's lifetime: the OwnedHandles must be closed exactly once via \
+                  Drop on thread exit, and the watch sender must outlive the loop so \
+                  every iteration can broadcast.  Passing by reference would force \
+                  the spawn site to hold borrows across the join, breaking the \
+                  ownership-transfer pattern"
+    )]
     fn watcher_loop(
         low: OwnedHandle,
         high: OwnedHandle,
@@ -430,78 +456,145 @@ mod windows_handles {
     ) {
         let mut current = PressureLevel::Normal;
         loop {
-            let handles: Vec<HANDLE> = match current {
-                PressureLevel::Normal => vec![shutdown.0, low.raw(), high.raw()],
-                PressureLevel::Low => vec![shutdown.0, high.raw()],
-                PressureLevel::High => vec![shutdown.0, low.raw()],
-            };
-
-            // SAFETY: WaitForMultipleObjects takes a slice of valid
-            // HANDLE values.  All handles in the slice are kept
-            // alive by the OwnedHandle bindings (`low`, `high`) and
-            // the borrowed-but-owned-by-caller shutdown event.
-            // INFINITE is safe — the caller signals shutdown via
-            // SetEvent to release the wait.  `bWaitAll = false` so
-            // the call returns as soon as any one handle signals.
-            #[expect(unsafe_code, reason = "Win32 WaitForMultipleObjects FFI")]
-            let result = unsafe { WaitForMultipleObjects(&handles, false, INFINITE) };
-            let signaled_index = result.0;
-
-            // Index 0 is always the shutdown event.
-            if signaled_index == 0 {
-                tracing::debug!(
-                    target: "cache.pressure",
-                    "Pressure watcher exiting on shutdown signal",
-                );
-                return;
-            }
-
-            // Out-of-range index covers WAIT_FAILED (0xFFFFFFFF),
-            // WAIT_TIMEOUT (258 — shouldn't happen with INFINITE),
-            // and WAIT_ABANDONED (0x80+i — only relevant for mutex
-            // handles).  Bail and let the daemon fall back to
-            // TTL-driven demotion alone.
-            if (signaled_index as usize) >= handles.len() {
-                tracing::warn!(
-                    target: "cache.pressure",
-                    code = signaled_index,
-                    "WaitForMultipleObjects returned unexpected code; \
-                     pressure watcher exiting",
-                );
-                return;
-            }
-
-            let next_level = match (current, signaled_index) {
-                (PressureLevel::Normal, 1) | (PressureLevel::High, 1) => PressureLevel::Low,
-                (PressureLevel::Normal, 2) | (PressureLevel::Low, 1) => PressureLevel::High,
-                _ => {
-                    // Unreachable given the bounds check + the
-                    // exhaustive `handles` construction above.
-                    // Defensive return.
-                    tracing::warn!(
-                        target: "cache.pressure",
-                        index = signaled_index,
-                        state = ?current,
-                        "Pressure watcher saw unexpected handle index for current state",
-                    );
-                    return;
+            let handles = compute_handle_set(current, &low, &high, shutdown);
+            let signaled_index = wait_for_signal(&handles);
+            match interpret_signal(current, signaled_index, handles.len()) {
+                SignalAction::Exit => return,
+                SignalAction::Transition(next_level) => {
+                    current = next_level;
+                    broadcast_pressure_change(&sender, next_level);
                 }
-            };
-
-            current = next_level;
-            // `send_replace` never fails — it stores the value
-            // unconditionally and notifies any receivers in place.
-            // We discard the previous value (subscribers track via
-            // `changed()` + `borrow_and_update`).
-            let _previous = sender.send_replace(next_level);
-            tracing::info!(
-                target: "cache.pressure",
-                level = ?next_level,
-                "Memory resource notification fired",
-            );
+            }
         }
     }
 
+    /// Build the per-level `WaitForMultipleObjects` handle slice.
+    ///
+    /// Index 0 is always the shutdown event so a clean exit
+    /// preempts pressure transitions.  At `Normal`, both Low and
+    /// High notification handles are included; once a transition
+    /// fires the kernel keeps the source event set until memory
+    /// recovers, so subsequent waits drop the redundant handle and
+    /// listen only for the opposite transition.
+    fn compute_handle_set(
+        current: PressureLevel,
+        low: &OwnedHandle,
+        high: &OwnedHandle,
+        shutdown: SendableHandle,
+    ) -> Vec<HANDLE> {
+        match current {
+            PressureLevel::Normal => vec![shutdown.0, low.raw(), high.raw()],
+            PressureLevel::Low => vec![shutdown.0, high.raw()],
+            PressureLevel::High => vec![shutdown.0, low.raw()],
+        }
+    }
+
+    /// Block on `WaitForMultipleObjects(handles, bWaitAll = false,
+    /// INFINITE)` and return the raw `WAIT_OBJECT_<n>` index.
+    ///
+    /// Returns the raw `u32` so [`interpret_signal`] can dispatch
+    /// without knowing about the Win32 result type.  Out-of-range
+    /// values (`WAIT_FAILED` / `WAIT_TIMEOUT` / `WAIT_ABANDONED`)
+    /// flow through unchanged so the caller can warn and exit the
+    /// watcher cleanly.
+    fn wait_for_signal(handles: &[HANDLE]) -> u32 {
+        #[expect(unsafe_code, reason = "Win32 WaitForMultipleObjects FFI")]
+        // SAFETY: `handles` is a non-null aligned slice of valid
+        // HANDLE values; all handles are kept alive by the
+        // OwnedHandle bindings in `watcher_loop` and the borrowed-
+        // but-owned-by-caller shutdown event.  `INFINITE` is safe —
+        // the caller signals shutdown via `SetEvent` to release the
+        // wait.  `bWaitAll = false` so the call returns as soon as
+        // any one handle signals.
+        let result = unsafe { WaitForMultipleObjects(handles, false, INFINITE) };
+        result.0
+    }
+
+    /// Translate a `WaitForMultipleObjects` index into a watcher
+    /// loop control-flow decision.
+    ///
+    /// Index 0 is always shutdown.  Indices `1..max_index` are
+    /// pressure-event signals; their meaning depends on the current
+    /// pressure level (the handle slice changes shape across
+    /// levels).  Out-of-range values (`WAIT_FAILED`, `WAIT_TIMEOUT`,
+    /// `WAIT_ABANDONED`) and impossible state combinations both
+    /// resolve to `Exit` after a warn-log.
+    fn interpret_signal(
+        current: PressureLevel,
+        signaled_index: u32,
+        max_index: usize,
+    ) -> SignalAction {
+        if signaled_index == 0 {
+            tracing::debug!(
+                target: "cache.pressure",
+                "Pressure watcher exiting on shutdown signal",
+            );
+            return SignalAction::Exit;
+        }
+        if (signaled_index as usize) >= max_index {
+            tracing::warn!(
+                target: "cache.pressure",
+                code = signaled_index,
+                "WaitForMultipleObjects returned unexpected code; \
+                 pressure watcher exiting",
+            );
+            return SignalAction::Exit;
+        }
+        match (current, signaled_index) {
+            (PressureLevel::Normal | PressureLevel::High, 1) => {
+                SignalAction::Transition(PressureLevel::Low)
+            }
+            (PressureLevel::Normal, 2) | (PressureLevel::Low, 1) => {
+                SignalAction::Transition(PressureLevel::High)
+            }
+            _ => {
+                tracing::warn!(
+                    target: "cache.pressure",
+                    index = signaled_index,
+                    state = ?current,
+                    "Pressure watcher saw unexpected handle index for current state",
+                );
+                SignalAction::Exit
+            }
+        }
+    }
+
+    /// Broadcast a pressure-level change to every subscriber and
+    /// emit the operator-visible info log.
+    ///
+    /// `send_replace` never fails — it stores the value
+    /// unconditionally and notifies any receivers in place.  We
+    /// discard the previous value (subscribers track via
+    /// `changed()` + `borrow_and_update`).
+    fn broadcast_pressure_change(sender: &watch::Sender<PressureLevel>, next_level: PressureLevel) {
+        let _previous = sender.send_replace(next_level);
+        tracing::info!(
+            target: "cache.pressure",
+            level = ?next_level,
+            "Memory resource notification fired",
+        );
+    }
+
+    /// Control-flow result of [`interpret_signal`].
+    enum SignalAction {
+        /// Exit the watcher loop — either a clean shutdown signal
+        /// or an unrecoverable wait failure.
+        Exit,
+        /// Transition the watcher's tracked pressure level.  The
+        /// caller updates `current`, broadcasts via
+        /// [`broadcast_pressure_change`], and re-enters the wait.
+        Transition(PressureLevel),
+    }
+
+    /// Create a Win32 memory-resource-notification handle for the
+    /// given notification type (`Low` or `High`).
+    ///
+    /// Wraps [`CreateMemoryResourceNotification`] and returns the
+    /// resulting `HANDLE` boxed in an [`OwnedHandle`] so the watcher
+    /// thread closes it exactly once on exit via
+    /// [`OwnedHandle::Drop`].  Maps any windows-rs error into
+    /// `io::Error::other` so the surrounding orchestrator's error
+    /// path stays platform-agnostic.
     fn create_memory_resource_notification(
         notification_type: MEMORY_RESOURCE_NOTIFICATION_TYPE,
     ) -> io::Result<OwnedHandle> {
@@ -517,6 +610,14 @@ mod windows_handles {
         Ok(OwnedHandle(handle))
     }
 
+    /// Create an unnamed manual-reset Win32 event handle.
+    ///
+    /// Used as the watcher thread's shutdown signal: the owning
+    /// [`super::PlatformPressureSignal::Drop`] calls
+    /// [`signal_shutdown`] (which pulses `SetEvent`) so the next
+    /// `WaitForMultipleObjects` returns and the thread exits.  The
+    /// returned [`OwnedHandle`] closes the event on its own `Drop`
+    /// after the watcher has joined.
     fn create_manual_reset_event() -> io::Result<OwnedHandle> {
         // SAFETY: CreateEventW with (None, manual_reset = true,
         // initial_state = false, name = NULL) creates a private

--- a/crates/uffs-daemon/src/cache/shard.rs
+++ b/crates/uffs-daemon/src/cache/shard.rs
@@ -635,26 +635,24 @@ impl ShardEntry {
     /// [`crate::index::IndexManager::ensure_warm_for_dispatch`]
     /// before attempting incremental patching.
     ///
-    /// The `frs_to_compact` slice is a `frs → compact_idx` mapping
-    /// produced by the caller from the same `DriveCompactIndex` the
-    /// `body` Arc points at; mismatched slices produce all-skipped
-    /// `PatchStats` rather than corrupting the index.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "Phase 7 task 7.1 surface; production caller \
-                      (per-shard journal loop) lands in Phase 7 task 7.2. \
-                      Exercised by `cache::shard::tests::\
-                      apply_usn_patch_to_body_returns_new_arc_on_warm` \
-                      and the matching `_returns_none_on_parked` companion."
-        )
-    )]
+    /// **Phase 8.** The FRS → `compact_idx` mapping is read from
+    /// the cloned body's [`DriveCompactIndex::frs_to_compact`]
+    /// field (no longer a separate parameter) and updated in-place
+    /// by [`uffs_core::compact_loader::apply_usn_patch`] across
+    /// the create / delete / rename batch.  Pre-v10 caches are
+    /// rejected at the cache-format header check (forcing a fresh
+    /// MFT rebuild that emits a v10 cache with the mapping
+    /// populated), so the empty-mapping fallback in
+    /// `apply_usn_patch` is purely defensive — covers test
+    /// fixtures that build the body by struct literal without
+    /// populating the field, plus any future cache format that
+    /// revisits the layout.
+    ///
+    /// [`DriveCompactIndex::frs_to_compact`]: uffs_core::compact::DriveCompactIndex::frs_to_compact
     #[must_use]
     pub(crate) fn apply_usn_patch_to_body(
         &self,
         changes: &[uffs_mft::usn::FileChange],
-        frs_to_compact: &[u32],
     ) -> Option<(
         Arc<DriveCompactIndex>,
         uffs_core::compact_loader::PatchStats,
@@ -664,9 +662,12 @@ impl ShardEntry {
         // mutates the clone — never the live Arc that concurrent
         // readers are observing.  ColumnStorage::clone() promotes
         // mmap-backed columns to heap-resident Vec, so the cloned
-        // body is fully mutable without remap ceremony.
+        // body is fully mutable without remap ceremony.  The
+        // `frs_to_compact` mapping rides along on the clone so
+        // `apply_usn_patch` can patch it in lock-step with the
+        // records.
         let mut owned: DriveCompactIndex = (**body_arc).clone();
-        let stats = uffs_core::compact_loader::apply_usn_patch(&mut owned, changes, frs_to_compact);
+        let stats = uffs_core::compact_loader::apply_usn_patch(&mut owned, changes);
         Some((Arc::new(owned), stats))
     }
 }

--- a/crates/uffs-daemon/src/cache/shard/tests.rs
+++ b/crates/uffs-daemon/src/cache/shard/tests.rs
@@ -71,6 +71,20 @@ fn make_test_body(letter: char) -> DriveCompactIndex {
     let trigram = TrigramIndex::build(&records, &names, fold);
     let children = ChildrenIndex::build(&records);
     let ext_index = ExtensionIndex::build(&records);
+
+    // Phase 8: populate `frs_to_compact` for the 2-record fixture
+    // (root @ FRS 5 → compact_idx 0; file @ FRS 10 → compact_idx 1).
+    // Sized to 16 entries so existing patch-method tests can address
+    // FRS 10 without resize gymnastics; the iterator-collect form
+    // sidesteps `clippy::indexing_slicing`.
+    let frs_to_compact: Vec<u32> = (0_usize..16)
+        .map(|frs| match frs {
+            5 => 0_u32,
+            10 => 1,
+            _ => u32::MAX,
+        })
+        .collect();
+
     DriveCompactIndex {
         letter,
         records: ColumnStorage::from_vec(records),
@@ -84,6 +98,7 @@ fn make_test_body(letter: char) -> DriveCompactIndex {
         source_epoch: 1,
         bloom: None,
         path_trie: None,
+        frs_to_compact,
     }
 }
 
@@ -402,8 +417,7 @@ fn apply_usn_patch_to_body_returns_new_arc_on_warm() {
 
     // Empty change batch — the method must still produce a fresh
     // Arc so the caller's swap path is exercised even on no-op ticks.
-    let frs_to_compact: Vec<u32> = vec![u32::MAX; 16];
-    let result = shard.apply_usn_patch_to_body(&[], &frs_to_compact);
+    let result = shard.apply_usn_patch_to_body(&[]);
 
     let (new_body, stats) = result.expect("Warm shard must yield Some");
     assert!(
@@ -433,9 +447,8 @@ fn apply_usn_patch_to_body_returns_none_on_parked() {
         deleted: true,
         ..FileChange::default()
     }];
-    let frs_to_compact: Vec<u32> = vec![u32::MAX; 16];
 
-    let result = shard.apply_usn_patch_to_body(&changes, &frs_to_compact);
+    let result = shard.apply_usn_patch_to_body(&changes);
     assert!(
         result.is_none(),
         "Parked shard has no in-memory body — must return None"
@@ -451,8 +464,7 @@ fn apply_usn_patch_to_body_returns_none_on_cold() {
     let stats = Arc::new(DriveStats::new());
     let shard = ShardEntry::new_cold('C', stats);
 
-    let frs_to_compact: Vec<u32> = vec![u32::MAX; 16];
-    let result = shard.apply_usn_patch_to_body(&[], &frs_to_compact);
+    let result = shard.apply_usn_patch_to_body(&[]);
     assert!(
         result.is_none(),
         "Cold shard has no in-memory body — must return None"
@@ -470,13 +482,10 @@ fn apply_usn_patch_to_body_lands_delete_on_new_arc() {
     let body = Arc::new(make_test_body('C'));
     let shard = ShardEntry::new_warm('C', Arc::clone(&body));
 
-    // FRS 10 → compact_idx 1 (the file under the root in the
-    // 2-record fixture).  All other FRS map to the sentinel.
-    // Iterator-collect form sidesteps `clippy::indexing_slicing`.
-    let frs_to_compact: Vec<u32> = (0_usize..16)
-        .map(|frs| if frs == 10 { 1 } else { u32::MAX })
-        .collect();
-
+    // FRS 10 → compact_idx 1 in the fixture's `frs_to_compact`
+    // (populated by `make_test_body`); the test exercises the
+    // delete-on-warm path through the full `apply_usn_patch_to_body`
+    // surface without re-specifying the mapping.
     let changes = vec![FileChange {
         frs: 10,
         deleted: true,
@@ -484,7 +493,7 @@ fn apply_usn_patch_to_body_lands_delete_on_new_arc() {
     }];
 
     let (new_body, stats) = shard
-        .apply_usn_patch_to_body(&changes, &frs_to_compact)
+        .apply_usn_patch_to_body(&changes)
         .expect("Warm shard yields Some");
 
     assert_eq!(stats.deleted, 1, "exactly one delete should land");

--- a/crates/uffs-daemon/src/cache/working_set.rs
+++ b/crates/uffs-daemon/src/cache/working_set.rs
@@ -59,21 +59,26 @@ impl WorkingSetTrim for PlatformWorkingSetTrim {
         use windows::Win32::System::ProcessStatus::EmptyWorkingSet;
         use windows::Win32::System::Threading::GetCurrentProcess;
 
-        // SAFETY: `GetCurrentProcess` returns a pseudo-handle that
-        // is always valid for the lifetime of the process; passing
-        // it straight to `EmptyWorkingSet` is the documented Win32
-        // idiom.  Both calls are sync, take no ownership, and the
-        // windows-rs `Result<()>` already wraps the underlying
-        // `BOOL` / `GetLastError` protocol.
-        //
-        // We translate any windows-rs error into
-        // `io::Error::other` so the demote controller's
-        // `tracing::warn!` line stays platform-agnostic.
         #[expect(
             unsafe_code,
-            reason = "EmptyWorkingSet requires unsafe FFI; balanced by GetCurrentProcess pseudo-handle that does not need closing"
+            reason = "GetCurrentProcess Win32 FFI returning a process pseudo-handle"
         )]
-        let result = unsafe { EmptyWorkingSet(GetCurrentProcess()) };
+        // SAFETY: `GetCurrentProcess` returns a pseudo-handle that is
+        // always valid for the lifetime of the process; the
+        // pseudo-handle does not need closing.
+        let process = unsafe { GetCurrentProcess() };
+        #[expect(
+            unsafe_code,
+            reason = "EmptyWorkingSet Win32 FFI on the current process's pseudo-handle"
+        )]
+        // SAFETY: `process` was just obtained from `GetCurrentProcess`
+        // above and is valid for the process lifetime.  The call is
+        // sync, takes no ownership, and the windows-rs `Result<()>`
+        // already wraps the underlying `BOOL` / `GetLastError`
+        // protocol.  We translate any windows-rs error into
+        // `io::Error::other` so the demote controller's
+        // `tracing::warn!` line stays platform-agnostic.
+        let result = unsafe { EmptyWorkingSet(process) };
         result.map_err(|err| io::Error::other(err.to_string()))
     }
 

--- a/crates/uffs-daemon/src/index/journal.rs
+++ b/crates/uffs-daemon/src/index/journal.rs
@@ -1,32 +1,31 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! Per-shard USN journal refresh path (Phase 7 activation).
+//! Per-shard USN journal refresh path (Phase 7 activation, Phase 8
+//! surgical-patch).
 //!
-//! The single [`IndexManager::handle_journal_refresh`] method drives
-//! a full per-shard body refresh in response to a save / wrap signal
-//! from the per-shard journal loop's
-//! [`crate::cache::journal_sink::RegistryPatchSink`].
+//! Two entry points feed the per-shard journal loop's
+//! [`crate::cache::journal_sink::RegistryPatchSink`] applier task:
 //!
-//! ## Why a full refresh and not a surgical patch
+//! * [`IndexManager::handle_journal_save`] (Phase 8) — clones the warm
+//!   `DriveCompactIndex` body, applies the buffered
+//!   [`uffs_mft::usn::FileChange`] batch via
+//!   [`crate::cache::ShardEntry::apply_usn_patch_to_body`], swaps the new Arc
+//!   into the registry, and persists via
+//!   [`uffs_core::compact_cache::save_compact_cache_background`]. Fast path:
+//!   ~600 ms patch + ~5 s background save on a 7M-record drive, vs ~7 s for the
+//!   full reload.
 //!
-//! Phase 7-A landed [`crate::cache::ShardEntry::apply_usn_patch_to_body`]
-//! which patches an existing `DriveCompactIndex` in-place from a
-//! [`uffs_mft::usn::FileChange`] batch.  But that surgical path
-//! requires a `frs_to_compact: &[u32]` mapping that is **not** stored
-//! on `DriveCompactIndex` (`CompactRecord` has no `frs` field; the
-//! mapping is built once at index-build time from `MftIndex.frs_to_idx`
-//! and discarded).  Persisting the mapping is a Phase 8 follow-up
-//! (ticket: surgical USN body-patch end-to-end).
+//! * [`IndexManager::handle_journal_refresh`] (Phase 7) — full per-shard body
+//!   refresh via [`uffs_core::compact_loader::load_drive_with_usn_refresh`]
+//!   (MFT read + USN replay + compact rebuild).  Heavy (~2-7 s per drive) but
+//!   correct against journal-wrap events where the buffered batch is stale
+//!   relative to the new cursor.
 //!
-//! For activation, the cleanest option is to reuse the Phase-5
-//! infrastructure unchanged: every save / wrap trigger drives a full
-//! [`uffs_core::compact_loader::load_drive_with_usn_refresh`] which
-//! does an MFT read + USN replay + compact rebuild.  Heavy (~2-7 s per
-//! drive on a 7-drive box) but correct, and the per-shard
-//! event-threshold + age-threshold cadence still cuts the global
-//! 5-min tick down to a per-shard schedule that activates only when
-//! a drive actually saw churn.
+//! The split lets save triggers (events-exceeded / age-elapsed) take
+//! the cheap surgical path while wrap triggers fall back to the full
+//! reload — exactly the cadence the Phase-7 activation introduced,
+//! now with a fast save path.
 //!
 //! ## Mac/Linux behaviour
 //!
@@ -34,21 +33,26 @@
 //! errors out by design on non-Windows targets (USN journals are
 //! NTFS-only).  This method preserves that contract: the err arm
 //! warn-logs the per-drive failure and returns `false` so the caller
-//! can record the no-op without aborting the loop.  In production
-//! the Mac/Linux journal loop wires [`MacStubJournalSource`] (always
-//! empty) so the threshold-driven save trigger never fires anyway —
-//! the err arm is defensive, not a hot path.
+//! can record the no-op without aborting the loop.  The surgical
+//! [`IndexManager::handle_journal_save`] path is platform-agnostic
+//! (it operates over the in-memory body + a `Vec<FileChange>` DTO)
+//! and is exercised on Mac via synthesised `FileChange` inputs in
+//! the per-method unit tests.  In production the Mac/Linux journal
+//! loop wires [`MacStubJournalSource`] (always empty) so the
+//! threshold-driven save trigger never fires anyway — the err arm
+//! is defensive, not a hot path.
 //!
 //! [`MacStubJournalSource`]: crate::cache::journal_loop::sources::MacStubJournalSource
 
 use alloc::sync::Arc;
 
+use uffs_mft::usn::FileChange;
+
 use super::IndexManager;
 use crate::cache::journal_loop::JournalLoopHandle;
 
-/// Helper for [`IndexManager::attach_journal_handle`] and
-/// [`IndexManager::drain_journal_handles`]: lock the journal-handle
-/// map, recovering from poison.  Mirrors the existing
+/// Helper for [`IndexManager::attach_journal_handle`]: lock the
+/// journal-handle map, recovering from poison.  Mirrors the existing
 /// `lock_in_flight_promotes` / `verify_shutdown_nonce` poison
 /// handling pattern in this crate (per the `in_flight_promotes`
 /// field doc rationale).
@@ -114,6 +118,118 @@ impl IndexManager {
         self.apply_journal_body(letter, reason, body).await
     }
 
+    /// Phase 8 surgical-patch path: clone the Warm body, apply the
+    /// drained per-letter [`FileChange`] batch via
+    /// [`crate::cache::ShardEntry::apply_usn_patch_to_body`], swap
+    /// the new Arc into the registry, and persist the patched body
+    /// via [`uffs_core::compact_cache::save_compact_cache_background`].
+    ///
+    /// Called by the [`crate::cache::journal_sink::RegistryPatchSink`]
+    /// applier task on every `Save` message (events-exceeded /
+    /// age-elapsed) — the *fast* counterpart to
+    /// [`Self::handle_journal_refresh`] (which the applier still
+    /// uses for `Wrap` messages where the cursor reset invalidates
+    /// the buffered batch).
+    ///
+    /// ## Returns
+    ///
+    /// * `true` when the body was successfully Arc-swapped into the registry
+    ///   AND the background save task was spawned.  An empty `changes` batch
+    ///   also returns `true` (no-op short-circuit).
+    /// * `false` on every failure mode:
+    ///   - the shard for `letter` is not registered;
+    ///   - the patch task aborted (panic, runtime shutdown);
+    ///   - the shard demoted to `Parked` / `Cold` between the trigger and the
+    ///     patch (`apply_usn_patch_to_body` returns `None`); the next promote
+    ///     re-reads the cached body which a previous patch tick already
+    ///     updated, so the per-shard drift is bounded by the per-shard save
+    ///     cadence;
+    ///   - the body swap lost a separate demote race (`apply_journal_body`
+    ///     returns `false`).
+    pub(crate) async fn handle_journal_save(
+        &self,
+        letter: char,
+        reason: &str,
+        changes: Vec<FileChange>,
+    ) -> bool {
+        if changes.is_empty() {
+            log_save_empty_batch(letter, reason);
+            return true;
+        }
+
+        let change_count = changes.len();
+        let Some(shard) = self.snapshot_shard_for_letter(letter).await else {
+            log_save_no_shard(letter, reason, change_count);
+            return false;
+        };
+
+        let (new_body, stats) = match self
+            .run_surgical_patch_task(&shard, letter, reason, changes)
+            .await
+        {
+            PatchTaskOutcome::Applied(body, stats) => (body, stats),
+            PatchTaskOutcome::ShardNotWarm => {
+                log_save_shard_demoted(letter, reason, change_count);
+                return false;
+            }
+            PatchTaskOutcome::TaskAborted => return false,
+        };
+
+        log_save_patch_applied(letter, reason, change_count, &stats);
+
+        if !self
+            .apply_journal_body(letter, reason, Arc::clone(&new_body))
+            .await
+        {
+            return false;
+        }
+
+        spawn_compact_cache_save_task(letter, new_body);
+        true
+    }
+
+    /// Snapshot the shard for `letter` from the registry read-lock,
+    /// cloning the `Arc<ShardEntry>` so subsequent registry
+    /// mutations (demote, promote, `replace_warm_body`) leave this
+    /// snapshot observing the pre-tick state.
+    async fn snapshot_shard_for_letter(
+        &self,
+        letter: char,
+    ) -> Option<Arc<crate::cache::shard::ShardEntry>> {
+        let guard = self.index.read().await;
+        guard.iter().find(|entry| entry.drive == letter).cloned()
+    }
+
+    /// Run the surgical-patch heavy work on the blocking pool.
+    ///
+    /// Deep-clones the body (~100 ms `ColumnStorage` promote) +
+    /// applies the patch + rebuilds children CSR + trigram +
+    /// `ext_index` (~600 ms total on a 7M-record drive).  Wraps the
+    /// closure in [`crate::cache::background_io::BackgroundIoScope`]
+    /// so any syscall-bound work (mmap promote on Windows) yields
+    /// to foreground search RPCs.  Drains the resulting
+    /// [`tokio::task::JoinHandle`] through [`classify_patch_result`]
+    /// so callers see the three explicit outcomes
+    /// (`Applied` / `ShardNotWarm` / `TaskAborted`) without
+    /// `Option<Option<_>>` smell.
+    async fn run_surgical_patch_task(
+        &self,
+        shard: &Arc<crate::cache::shard::ShardEntry>,
+        letter: char,
+        reason: &str,
+        changes: Vec<FileChange>,
+    ) -> PatchTaskOutcome {
+        let background_io = Arc::clone(&self.background_io);
+        let shard_for_patch = Arc::clone(shard);
+        let change_count = changes.len();
+        let patch_result = tokio::task::spawn_blocking(move || {
+            let _bg_scope = crate::cache::background_io::BackgroundIoScope::enter(background_io);
+            shard_for_patch.apply_usn_patch_to_body(&changes)
+        })
+        .await;
+        classify_patch_result(patch_result, letter, reason, change_count)
+    }
+
     /// Phase 7 activation: store a [`JournalLoopHandle`] for `letter`
     /// in the per-letter handle map.
     ///
@@ -172,6 +288,172 @@ impl IndexManager {
             "USN refresh applied",
         );
         true
+    }
+}
+
+/// Log the empty-batch fast path of [`IndexManager::handle_journal_save`].
+///
+/// Age-elapsed triggers on quiet drives produce empty change
+/// batches; the surgical patch short-circuits to a debug-log no-op
+/// so the journal loop's cursor still advances and the per-shard
+/// save trigger resets.
+fn log_save_empty_batch(letter: char, reason: &str) {
+    tracing::debug!(
+        target: "shard.journal",
+        drive = %letter,
+        reason,
+        "Surgical patch skipped (empty change batch)",
+    );
+}
+
+/// Log the "no shard registered for letter" arm of
+/// [`IndexManager::handle_journal_save`].
+///
+/// Defensive: in production every drive that emits journal events
+/// has been registered via `add_drive` before its journal loop
+/// starts.  Reaching this arm indicates a startup-ordering bug or
+/// an out-of-order drive eject, both worth surfacing.
+fn log_save_no_shard(letter: char, reason: &str, change_count: usize) {
+    tracing::debug!(
+        target: "shard.journal",
+        drive = %letter,
+        reason,
+        change_count,
+        "No shard registered for letter; dropping changes",
+    );
+}
+
+/// Log the "shard demoted between trigger and patch" arm of
+/// [`IndexManager::handle_journal_save`].
+///
+/// Most likely cause: a Parked / Cold demote raced ahead of the
+/// surgical-patch blocking task.  The next promote re-reads the
+/// on-disk body which a previous patch tick already updated, so
+/// the per-shard drift is bounded by the per-shard save cadence.
+fn log_save_shard_demoted(letter: char, reason: &str, change_count: usize) {
+    tracing::debug!(
+        target: "shard.journal",
+        drive = %letter,
+        reason,
+        change_count,
+        "Shard demoted between trigger and patch; dropping changes",
+    );
+}
+
+/// Log the success path of
+/// [`IndexManager::handle_journal_save`] with per-variant patch
+/// stats so operators can grep for the surgical-patch tick rate
+/// and the create / delete / rename / skip mix per drive.
+fn log_save_patch_applied(
+    letter: char,
+    reason: &str,
+    change_count: usize,
+    stats: &uffs_core::compact_loader::PatchStats,
+) {
+    tracing::debug!(
+        target: "shard.journal",
+        drive = %letter,
+        reason,
+        change_count,
+        applied_create = stats.created,
+        applied_delete = stats.deleted,
+        applied_rename = stats.renamed,
+        applied_skip = stats.skipped,
+        "Surgical patch applied",
+    );
+}
+
+/// Spawn a blocking task that persists the patched
+/// `DriveCompactIndex` to disk via
+/// [`uffs_core::compact_cache::save_compact_cache_background`].
+///
+/// **Why blocking?**  `save_compact_cache_background` does the heavy
+/// serialise + zstd compress synchronously on the calling thread;
+/// only the encrypt + write steps run on a child thread that the
+/// helper spawns internally.  We don't want the serialise +
+/// compress on the runtime's async workers — hence
+/// `tokio::task::spawn_blocking`.
+///
+/// **Best-effort.**  A save failure does NOT roll back the
+/// in-memory swap (the patched Arc is already serving queries via
+/// the `IndexManager` registry); the helper just warn-logs the
+/// failure for operator visibility.  The next save tick re-attempts
+/// from the latest in-memory body, so transient disk errors heal
+/// themselves.
+fn spawn_compact_cache_save_task(letter: char, body: Arc<uffs_core::compact::DriveCompactIndex>) {
+    let _save_join = tokio::task::spawn_blocking(move || {
+        if let Err(err) = uffs_core::compact_cache::save_compact_cache_background(&body) {
+            tracing::warn!(
+                target: "shard.journal",
+                drive = %letter,
+                error = %err,
+                "Background compact-cache save failed after surgical patch (in-memory body still serving fresh data)",
+            );
+        }
+    });
+}
+
+/// Three-way classification of the surgical-patch blocking task's
+/// `JoinHandle` result — lets [`IndexManager::handle_journal_save`]
+/// match each outcome with its own diagnostic + control-flow
+/// without resorting to the `Option<Option<T>>` shape `clippy`
+/// (rightly) flags as a smell.
+enum PatchTaskOutcome {
+    /// The task ran to completion and the shard's
+    /// [`crate::cache::ShardEntry::apply_usn_patch_to_body`] returned
+    /// a fresh body Arc + per-batch stats.  Caller swaps the body
+    /// into the registry + spawns a background cache save.
+    Applied(
+        Arc<uffs_core::compact::DriveCompactIndex>,
+        uffs_core::compact_loader::PatchStats,
+    ),
+    /// The task ran to completion but the shard wasn't `Warm` /
+    /// `Hot` at the moment the patch fired — most likely a demote
+    /// race between the journal trigger and the blocking task
+    /// scheduling.  Caller drops the changes; the next promote
+    /// re-reads the on-disk body which a previous patch tick has
+    /// already saved.
+    ShardNotWarm,
+    /// The blocking task itself aborted before producing a result
+    /// (panic, runtime shutdown).  The classifier already
+    /// warn-logged the [`tokio::task::JoinError`] with full
+    /// context; caller short-circuits the body swap.
+    TaskAborted,
+}
+
+/// Classify the surgical-patch task's `JoinHandle` result into a
+/// [`PatchTaskOutcome`].
+///
+/// On `Err(join_err)` the helper emits a `shard.journal` warn-log
+/// (the same shape `handle_journal_refresh`'s
+/// [`unwrap_refreshed_body`] uses for its task-abort arm) and returns
+/// [`PatchTaskOutcome::TaskAborted`] so the caller doesn't re-log.
+fn classify_patch_result(
+    patch_result: Result<
+        Option<(
+            Arc<uffs_core::compact::DriveCompactIndex>,
+            uffs_core::compact_loader::PatchStats,
+        )>,
+        tokio::task::JoinError,
+    >,
+    letter: char,
+    reason: &str,
+    change_count: usize,
+) -> PatchTaskOutcome {
+    match patch_result {
+        Ok(Some((body, stats))) => PatchTaskOutcome::Applied(body, stats),
+        Ok(None) => PatchTaskOutcome::ShardNotWarm,
+        Err(join_err) => {
+            tracing::warn!(
+                target: "shard.journal",
+                drive = %letter,
+                reason,
+                change_count,
+                error = %join_err,
+                "Surgical patch blocking task aborted; shard kept previous body",
+            );
+            PatchTaskOutcome::TaskAborted
+        }
     }
 }
 

--- a/crates/uffs-security/src/runtime_dir.rs
+++ b/crates/uffs-security/src/runtime_dir.rs
@@ -424,14 +424,14 @@ mod windows_impl {
                 )
             };
             let handle = handle_result.map_err(io::Error::other)?;
-            // SAFETY: `handle` is a valid kernel handle returned by
-            // `CreateFileW`; we transfer ownership into the `File`
-            // wrapper, which closes it on drop.  No other code path
-            // observes the raw handle.
             #[expect(
                 unsafe_code,
                 reason = "transfer ownership Win32 HANDLE → std::fs::File"
             )]
+            // SAFETY: `handle` is a valid kernel handle returned by
+            // `CreateFileW`; we transfer ownership into the `File`
+            // wrapper, which closes it on drop.  No other code path
+            // observes the raw handle.
             let file = unsafe { File::from_raw_handle(handle.0) };
             Ok(RuntimeFile {
                 file,
@@ -473,7 +473,10 @@ mod windows_impl {
                 // ERROR_ACCESS_DENIED (5) = pid exists but ACL
                 // forbids us.  Treat as alive (don't stomp on a
                 // protected or other-user process).
-                err.code().0 == windows::Win32::Foundation::ERROR_ACCESS_DENIED.0 as i32
+                err.code().0
+                    == windows::Win32::Foundation::ERROR_ACCESS_DENIED
+                        .0
+                        .cast_signed()
             }
         }
     }

--- a/just/test.just
+++ b/just/test.just
@@ -236,7 +236,18 @@ lint-fast:
 lint-pre-push:
     @bash scripts/hooks/_lint_pre_push.sh
 
-# Install the tracked git hooks (pre-commit + pre-push).
+# Validate every non-merge commit subject in `origin/main..HEAD` against
+# the same Conventional Commits regex CI runs on the PR title (see
+# `.github/workflows/commitlint.yml`).  Same validator the pre-push
+# `commit-subjects` job invokes; useful for ad-hoc checks during a
+# rebase / amend session before re-running `just lint-pre-push`.
+#
+# Bypass once: `COMMIT_SUBJECT_BYPASS=1 just check-commits` (logged).
+check-commits:
+    @printf "\033[0;34m📝 Checking commit subjects against Conventional Commits...\033[0m\n"
+    @COMMIT_SUBJECT_VERBOSE=1 bash scripts/ci/check_commit_subjects.sh range origin/main..HEAD
+
+# Install the tracked git hooks (pre-commit + commit-msg + pre-push).
 # Idempotent — safe to re-run.  Sets `git config core.hooksPath` to the
 # tracked `scripts/hooks/` directory so the hooks survive `git clone`
 # and cannot be accidentally deleted from `.git/hooks/`.
@@ -245,11 +256,13 @@ install-hooks:
     set -euo pipefail
     printf "\033[0;34m🪝 Installing tracked git hooks...\033[0m\n"
     git config core.hooksPath scripts/hooks
-    chmod +x scripts/hooks/pre-commit scripts/hooks/pre-push \
-             scripts/hooks/_lint_fast.sh scripts/hooks/_lint_pre_push.sh
+    chmod +x scripts/hooks/pre-commit scripts/hooks/commit-msg scripts/hooks/pre-push \
+             scripts/hooks/_lint_fast.sh scripts/hooks/_lint_pre_push.sh \
+             scripts/ci/check_commit_subjects.sh
     printf "\033[0;32m✅ Git hooks installed:\033[0m\n"
-    printf "   \033[0;36mpre-commit\033[0m → just lint-fast     (staged-scoped, sub-2 s)\n"
-    printf "   \033[0;36mpre-push\033[0m   → just lint-pre-push  (workspace parallel)\n"
+    printf "   \033[0;36mpre-commit\033[0m → just lint-fast       (staged-scoped, sub-2 s)\n"
+    printf "   \033[0;36mcommit-msg\033[0m → Conventional Commits  (subject-line, instant)\n"
+    printf "   \033[0;36mpre-push\033[0m   → just lint-pre-push    (workspace parallel)\n"
     printf "   \033[0;33mBypass once\033[0m with \`git commit --no-verify\` / \`git push --no-verify\`.\n"
     printf "   \033[0;33mInstall optional tools\033[0m with \`just install-dev-tools\`.\n"
 

--- a/scripts/ci/check_commit_subjects.sh
+++ b/scripts/ci/check_commit_subjects.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# Conventional Commits subject validator.
+#
+# **Why this exists** — `.github/workflows/commitlint.yml` validates the
+# **PR title** at PR-open / synchronize time.  That catch is post-push:
+# the contributor finds out about a malformed scope like
+# `feat(uffs-core, daemon)` only after the workflow has already failed
+# upstream.  This script encodes the SAME regex as the CI workflow
+# (single source of truth — see "REGEX" below) so the pre-push hook
+# (`scripts/hooks/_lint_pre_push.sh`) and the commit-msg hook
+# (`scripts/hooks/commit-msg`) can fail the offending subject locally.
+#
+# **Regex**: mirrors `.github/workflows/commitlint.yml` line 124.
+# Updates to either MUST land in the same commit; the
+# `commitlint.yml` block has a pointer back to this file so reviewers
+# notice the drift.
+#
+# **Modes**:
+#   range RANGE              -- validate every non-merge commit subject
+#                              in the git revision range RANGE (e.g.
+#                              `origin/main..HEAD` or
+#                              `BASE_OID..LOCAL_OID`).  Empty / merges-
+#                              only ranges silently succeed.
+#   file PATH                -- validate the first non-comment, non-blank
+#                              line of PATH (the format `git commit`
+#                              passes to `commit-msg` hooks).
+#   subject "<subject line>" -- validate a single literal subject string.
+#                              Useful for ad-hoc shell checks and tests.
+#
+# **Exit codes**: 0 conformant, 1 non-conformant (or input error).
+#
+# **Environment knobs** (all optional):
+#   COMMIT_SUBJECT_BYPASS=1  -- emits a warning and exits 0.  Same posture
+#                              as `git push --no-verify` for the pre-push
+#                              gate -- lets you intentionally land a
+#                              non-CC subject (e.g. an emergency hotfix
+#                              with a triage prefix the regex doesn't
+#                              cover).  Logged so the bypass is visible.
+#
+# **Allowed types** (mirrors `.github/workflows/commitlint.yml` and
+# `CONTRIBUTING.md` -> "Commit message conventions"): feat, fix, perf,
+# refactor, docs, test, build, ci, chore, style, revert.
+#
+# **Scope grammar**: `[a-z0-9-]+`.  Single token -- no spaces, no
+# commas, no slashes.  Use a single canonical scope per commit
+# (e.g. `feat(daemon)` rather than `feat(uffs-core, daemon)`); cross-
+# crate work goes in the body.
+#
+# **Breaking-change marker**: an optional `!` between the scope and
+# the colon (`feat(api)!: drop deprecated --q shorthand`).
+
+set -euo pipefail
+
+# ── Single source of truth for the Conventional Commits regex ───────
+# Synchronised with `.github/workflows/commitlint.yml` line 124 and
+# `cliff.toml` commit_parsers.  Update all three together or
+# release-plz / git-cliff / commitlint will drift.
+readonly REGEX='^(feat|fix|perf|refactor|docs|test|build|ci|chore|style|revert)(\([a-z0-9-]+\))?!?: .{1,}$'
+
+# ── Colours ─────────────────────────────────────────────────────────
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    C_GREEN=$'\033[0;32m'
+    C_RED=$'\033[0;31m'
+    C_YELLOW=$'\033[1;33m'
+    C_CYAN=$'\033[0;36m'
+    C_RESET=$'\033[0m'
+else
+    C_GREEN=''
+    C_RED=''
+    C_YELLOW=''
+    C_CYAN=''
+    C_RESET=''
+fi
+
+usage() {
+    cat <<USAGE >&2
+Usage: $(basename "$0") <mode> <arg>
+
+Modes:
+  range RANGE        Validate non-merge commit subjects in RANGE
+                     (e.g. 'origin/main..HEAD').
+  file PATH          Validate the first non-comment line of PATH
+                     (the commit-msg hook input format).
+  subject "TEXT"     Validate a single literal subject string.
+
+Examples:
+  $(basename "$0") range origin/main..HEAD
+  $(basename "$0") file .git/COMMIT_EDITMSG
+  $(basename "$0") subject 'feat(daemon): add background USN refresh'
+USAGE
+    exit 2
+}
+
+# ── Bypass guard ───────────────────────────────────────────────────
+if [[ "${COMMIT_SUBJECT_BYPASS:-0}" == "1" ]]; then
+    printf '%s[WARN]%s commit-subject validator bypassed via COMMIT_SUBJECT_BYPASS=1\n' \
+        "$C_YELLOW" "$C_RESET" >&2
+    exit 0
+fi
+
+# ── Helper: validate one literal subject ───────────────────────────
+# Prints the failing subject + a hint when non-conformant; returns
+# the appropriate exit code.  Caller aggregates failures across a
+# batch.
+validate_one() {
+    local subject="$1"
+    local oid="${2:-}"
+    if [[ -z "$subject" ]]; then
+        printf '%s[FAIL]%s empty subject%s\n' "$C_RED" "$C_RESET" \
+            "${oid:+ (commit ${oid:0:10})}" >&2
+        return 1
+    fi
+    if [[ "$subject" =~ $REGEX ]]; then
+        return 0
+    fi
+    printf '%s[FAIL]%s non-conventional commit subject%s\n' \
+        "$C_RED" "$C_RESET" "${oid:+ (commit ${oid:0:10})}" >&2
+    printf '   %ssubject:%s %s\n' "$C_CYAN" "$C_RESET" "$subject" >&2
+    return 1
+}
+
+print_help_block() {
+    cat >&2 <<HELP
+${C_YELLOW}-> Expected:${C_RESET} ${C_CYAN}type(scope): subject${C_RESET}
+   where ${C_CYAN}type${C_RESET} is one of: feat, fix, perf, refactor, docs,
+   test, build, ci, chore, style, revert; and ${C_CYAN}scope${C_RESET} is a
+   SINGLE [a-z0-9-]+ token (e.g. ${C_CYAN}daemon${C_RESET},
+   ${C_CYAN}uffs-core${C_RESET}, ${C_CYAN}daemon/lifecycle${C_RESET} --
+   no commas, no spaces).
+
+${C_YELLOW}Examples${C_RESET} (recent UFFS merges):
+   ${C_GREEN}feat(daemon): per-shard USN journal loops replace global 5-min tick${C_RESET}
+   ${C_GREEN}refactor(memory-tiering): unify shard-demote events${C_RESET}
+   ${C_GREEN}fix(daemon/lifecycle): disarm load-stall force-retire after loading${C_RESET}
+   ${C_GREEN}feat(cli)!: drop deprecated --q shorthand${C_RESET}  (the trailing ${C_CYAN}!${C_RESET} marks a breaking change)
+
+${C_YELLOW}Fix${C_RESET}: amend the offending commit's subject:
+   ${C_CYAN}git rebase -i <base>${C_RESET}      -> mark the offending commit ${C_CYAN}reword${C_RESET}
+   ${C_CYAN}git commit --amend${C_RESET}        -> if it's the most recent
+
+${C_YELLOW}Bypass once${C_RESET} (use sparingly):
+   ${C_CYAN}COMMIT_SUBJECT_BYPASS=1 git push${C_RESET}
+   ${C_CYAN}git commit --no-verify${C_RESET}    -> skips ALL commit-msg hooks
+
+See ${C_CYAN}CONTRIBUTING.md${C_RESET} -> "Commit message conventions" and
+\`.github/workflows/commitlint.yml\` for the canonical reference.
+HELP
+}
+
+# ── Main ────────────────────────────────────────────────────────────
+[[ $# -ge 2 ]] || usage
+mode="$1"
+arg="$2"
+fail=0
+
+case "$mode" in
+    range)
+        # Walk every non-merge commit in RANGE.  --no-merges drops
+        # merge commits (Conventional Commits doesn't apply to merges
+        # -- they get auto-generated subjects like "Merge branch ...").
+        # An empty range exits 0 silently (e.g. push of branch already
+        # at remote-HEAD; the local hook fires anyway and shouldn't
+        # bark on a no-op push).
+        if ! git rev-parse --git-dir >/dev/null 2>&1; then
+            printf '%s[FAIL]%s not in a git repository\n' "$C_RED" "$C_RESET" >&2
+            exit 1
+        fi
+        # `git log` with `--format` returns OID<tab>SUBJECT one per
+        # line.  We pipe to a `while` so each commit is checked
+        # independently.  Process-substitution avoids the subshell
+        # variable-scope footgun.
+        count=0
+        while IFS=$'\t' read -r oid subject; do
+            count=$((count + 1))
+            validate_one "$subject" "$oid" || fail=1
+        done < <(git log --no-merges --format='%H%x09%s' "$arg" 2>/dev/null || true)
+        if (( fail )); then
+            printf '\n' >&2
+            print_help_block
+            exit 1
+        fi
+        # Quiet success unless the user explicitly asked for verbosity.
+        if [[ "${COMMIT_SUBJECT_VERBOSE:-0}" == "1" ]]; then
+            printf '%s[OK]%s %d commit subject(s) in %s pass Conventional Commits\n' \
+                "$C_GREEN" "$C_RESET" "$count" "$arg"
+        fi
+        ;;
+
+    file)
+        # `commit-msg` hook input: the first non-blank, non-comment
+        # line is the subject.  `git commit` strips comments before
+        # finalising the message so we mirror that here.
+        if [[ ! -f "$arg" ]]; then
+            printf '%s[FAIL]%s file not found: %s\n' "$C_RED" "$C_RESET" "$arg" >&2
+            exit 1
+        fi
+        # `head` would race against an editor still writing; instead
+        # we read the whole file (commit messages are tiny) and pull
+        # the first qualifying line.  `awk` keeps memory bounded.
+        subject=$(awk '!/^#/ && NF { print; exit }' "$arg")
+        if [[ -z "$subject" ]]; then
+            # Empty commit message -- git aborts the commit anyway, so
+            # we exit 0 and let git's own error path surface it.
+            exit 0
+        fi
+        validate_one "$subject" || { print_help_block; exit 1; }
+        ;;
+
+    subject)
+        validate_one "$arg" || { print_help_block; exit 1; }
+        ;;
+
+    *)
+        usage
+        ;;
+esac

--- a/scripts/hooks/_lint_pre_push.sh
+++ b/scripts/hooks/_lint_pre_push.sh
@@ -69,6 +69,15 @@
 #                 via git's pre-push stdin protocol).  HARD-FAIL if
 #                 `cargo-vet` is missing in that case — this closes the
 #                 CI-only loophole that caused PR #43's 4x round-trip.
+#   * commit-subjects — `scripts/ci/check_commit_subjects.sh range …`:
+#                 validates every non-merge commit subject in the pushed
+#                 range against the SAME Conventional Commits regex CI's
+#                 `.github/workflows/commitlint.yml` runs on the PR
+#                 title.  Closes the local-vs-remote feedback loop that
+#                 used to surface scope typos like
+#                 `feat(uffs-core, daemon)` only after the workflow had
+#                 already failed upstream.  Uses the same OID range data
+#                 that drives change-classification (see below).
 #
 # Cross-platform coverage (soft-skipped when tool missing):
 #   * check-windows — `cargo xwin check --workspace --all-targets
@@ -126,6 +135,11 @@ fi
 # docs/architecture/dev-flow-implementation-plan.md § 2.3 for details.
 ZERO='0000000000000000000000000000000000000000'
 CHANGED_FILES=""
+# Newline-delimited list of `BASE..LOCAL_OID` ranges for the
+# `commit-subjects` Bucket-1 job.  Same data source as `CHANGED_FILES`
+# (git's pre-push stdin protocol) so the validator iterates the same
+# set of new commits that classification inspected.
+COMMIT_RANGES=""
 if [[ ! -t 0 ]]; then
     # stdin is piped; try git's pre-push protocol.
     while IFS=' ' read -r _local_ref local_oid _remote_ref remote_oid; do
@@ -142,6 +156,7 @@ if [[ ! -t 0 ]]; then
         fi
         if [[ -n "$base" ]]; then
             CHANGED_FILES+=$'\n'$(git diff --name-only "$base" "$local_oid" 2>/dev/null || true)
+            COMMIT_RANGES+="$base..$local_oid"$'\n'
         else
             CHANGED_FILES="__UNKNOWN__"
             break
@@ -150,6 +165,19 @@ if [[ ! -t 0 ]]; then
 fi
 # Empty stdin (manual invocation, or push with only deletions) → conservative.
 [[ -z "${CHANGED_FILES// /}" ]] && CHANGED_FILES="__UNKNOWN__"
+# Manual-mode commit-range fallback: validate everything between
+# `origin/main` and the current HEAD.  Branches with no diverged
+# commits (already merged, or fresh `main` checkout) get an empty
+# range which the validator silently accepts.
+if [[ -z "${COMMIT_RANGES// /}" ]]; then
+    if git rev-parse --verify origin/main >/dev/null 2>&1; then
+        COMMIT_RANGES="origin/main..HEAD"$'\n'
+    fi
+fi
+# Exported so the Bucket-1 `commit-subjects` job can read it from the
+# `bash -c` subshell environment (forked shells inherit env vars but
+# not unexported shell vars).
+export COMMIT_RANGES
 
 class_matches() {
     [[ "$CHANGED_FILES" == "__UNKNOWN__" ]] && return 0
@@ -224,6 +252,22 @@ run_seq() {
 # case hard-fails the whole push with an install hint.
 spawn_bg "fmt"       cargo fmt --all -- --check
 spawn_bg "file-size" bash scripts/ci/check_file_size_policy.sh
+# Conventional Commits subject validator — mirrors
+# `.github/workflows/commitlint.yml`'s PR-title regex so a malformed
+# scope (e.g. `feat(uffs-core, daemon)`) hard-fails locally instead
+# of surfacing as a post-push advisory comment.  Iterates every
+# range captured from git's pre-push stdin (or the manual-mode
+# `origin/main..HEAD` fallback above).  Bypass once via
+# `COMMIT_SUBJECT_BYPASS=1 git push` if you need to land a subject
+# the regex doesn't cover.
+spawn_bg "commit-subjects" bash -c '
+    set -euo pipefail
+    [[ -z "${COMMIT_RANGES// /}" ]] && exit 0
+    while IFS= read -r range; do
+        [[ -z "$range" ]] && continue
+        bash scripts/ci/check_commit_subjects.sh range "$range"
+    done <<< "$COMMIT_RANGES"
+'
 
 if (( DEP_CHANGED )); then
     if ! command -v cargo-vet >/dev/null 2>&1; then

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# Tracked commit-msg git hook for the UFFS workspace.
+#
+# **Purpose**: validate the commit subject against Conventional Commits
+# (the same regex CI's `.github/workflows/commitlint.yml` runs on the
+# PR title) BEFORE git finalises the commit.  Catches malformed scopes
+# like `feat(uffs-core, daemon)` at type-time \u2014 one `git commit --amend`
+# fixes it without ever needing to push, force-push, or rewrite later.
+#
+# **git hook contract**: invoked with one argument \u2014 the path to the
+# file containing the proposed commit message.  Exiting non-zero
+# aborts the commit and the message is preserved in `.git/COMMIT_EDITMSG`
+# so the user can re-run `git commit -e` (or `--amend -e`) without
+# losing their text.
+#
+# **Skipped scenarios** \u2014 the hook silently exits 0 when:
+#   * the message is empty (git's own pre-flight aborts already);
+#   * the commit is a merge / squash / cherry-pick continuation
+#     (detected via `.git/MERGE_MSG`, `.git/SQUASH_MSG`, or
+#     `.git/CHERRY_PICK_HEAD` presence) \u2014 those use auto-generated
+#     subjects that don't follow Conventional Commits;
+#   * the message is a `fixup!` / `squash!` autosquash placeholder
+#     (rebase --autosquash will rewrite the subject during the
+#     interactive rebase, so the placeholder doesn't need validation).
+#
+# **Bypass once**: `git commit --no-verify` skips this hook.  Same
+# escape hatch documented for `pre-commit` / `pre-push`.
+#
+# **Install via**: `just install-hooks` (sets core.hooksPath to
+#                  `scripts/hooks/`).
+# **Uninstall**:    `just uninstall-hooks`.
+
+set -euo pipefail
+
+# Path to the proposed commit message file.  git always passes this
+# as the first argument; bail out if missing (defensive \u2014 should
+# never happen via the hook contract).
+msg_file="${1:-}"
+if [[ -z "$msg_file" || ! -f "$msg_file" ]]; then
+    exit 0
+fi
+
+# Skip auto-generated message scenarios.  GIT_DIR points at .git
+# (or a worktree's gitdir); these markers exist for the duration
+# of the merge / squash / cherry-pick.
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || echo .git)"
+for marker in MERGE_MSG SQUASH_MSG CHERRY_PICK_HEAD MERGE_HEAD REVERT_HEAD; do
+    if [[ -e "$GIT_DIR/$marker" ]]; then
+        exit 0
+    fi
+done
+
+# Skip autosquash placeholders \u2014 `git commit --fixup=<sha>` and
+# `--squash=<sha>` produce subjects that begin with the literal
+# `fixup!` / `squash!` / `amend!` prefix; they're rewritten during
+# `git rebase --autosquash` and don't need to match Conventional
+# Commits at this stage.
+first_line="$(awk '!/^#/ && NF { print; exit }' "$msg_file")"
+case "$first_line" in
+    fixup!*|squash!*|amend!*)
+        exit 0
+        ;;
+esac
+
+# Delegate to the workspace validator.  `file` mode reads the first
+# non-comment, non-blank line and matches it against the canonical
+# regex.  Non-zero exit (= non-conformant) aborts the commit; the
+# validator already prints a clear error block + fix-up hint to
+# stderr so we propagate verbatim.
+exec bash "$(dirname "$0")/../ci/check_commit_subjects.sh" file "$msg_file"


### PR DESCRIPTION
# Phase 8 — surgical body-patch via `apply_usn_patch_to_body`

Lands the surgical-patch path that the Phase 7 activation commit (#118) flagged as follow-up work. Per-shard journal save ticks now apply the buffered USN delta directly to the in-memory `DriveCompactIndex` body via `ShardEntry::apply_usn_patch_to_body` instead of re-reading the MFT and rebuilding the body from scratch.

On the live 7-drive box the per-tick cost drops from `O(records)` (~2-4 s for a 7M-record drive) to `O(changes)` (~ms for a typical 100-event batch); idle drives skip the body work entirely. Wrap events still take the Phase-7 full-reload path because the buffered batch is stale relative to the new cursor.

## What changed

| Layer | Change |
|---|---|
| `uffs_core::compact::DriveCompactIndex` | New `frs_to_compact: Vec<u32>` field — the FRS → compact-record mapping that `build_compact_index` already produces but used to discard with the transient `MftIndex`. |
| `uffs_core::compact_cache` | Format bump v9 → v10: appends a `u32 len + len * u32` `frs_to_compact` section after the path-trie section. v < 10 caches are rejected at the header check so the daemon does a fresh MFT rebuild + writes a v10 cache (carrying them forward with an empty mapping would silently disable the surgical-patch path). |
| `uffs_core::compact_loader::apply_usn_patch` | Refactored from the Phase-7 stub into the canonical surgical-patch entry point: per-event slot resolution via `frs_to_compact` + per-variant patch helpers (create / delete / rename / parent-move) + per-batch `PatchStats`. |
| `uffs_daemon::cache::journal_sink::RegistryPatchSink` | Buffered applier-task pattern: `std::sync::Mutex<HashMap<char, Vec<FileChange>>>` per-letter pending buffer that `accept` extends synchronously (no mpsc traffic). `trigger_save` drains the buffer and ships it via `ApplyMsg::Save { letter, reason, changes }`; `journal_wrapped` discards the buffer (wrap means the journal head reset) and falls back to `ApplyMsg::Wrap`. |
| `uffs_daemon::cache::ShardEntry::apply_usn_patch_to_body` | New method that wraps the patch behind `spawn_blocking` + `BackgroundIoScope`; returns `(Arc<DriveCompactIndex>, PatchStats)` so the caller can both swap the warm body and emit per-variant stats in one tick. |
| `uffs_daemon::index::journal::IndexManager::handle_journal_save` | New surgical-patch dispatcher: classifies four outcomes (empty batch / no shard / shard-demoted / patch-applied) into a `PatchTaskOutcome` enum, swaps the warm body via `replace_warm_body`, submits a background `save_compact_cache` so the next cold-start sees the patched body. Per-letter `tracing` helpers under the `shard.journal` target so operators can grep for the surgical-patch tick rate + create / delete / rename / skip mix per drive. |

## Commits

* **`b25a52918` — `feat(daemon): Phase 8 — surgical body-patch via apply_usn_patch_to_body`** (13 files, +1235 / −258).
* **`8a702a8d1` — `chore(windows-clippy): clear pre-existing baseline errors so lint-ci-windows is green`** (6 files, +270 / −138). Pre-existing red gate cleanup; zero Phase-8 feature code touched. Each fix is surgical and root-cause per the workspace's "no suppression hacks" rule (a single `#[expect(clippy::needless_pass_by_value)]` on the watcher-thread spawn-and-own helper is the only attribute-level allow, and it's justified by domain rationale, not lint suppression).
* **`3d3be23c8` — `feat(hooks): pre-push + commit-msg gates for Conventional Commits subjects`** (4 files, +354 / −5). Closes the local-vs-remote feedback loop that surfaced this PR's own initial title typo (`feat(uffs-core, daemon): …` — comma-space scope) only post-push as a CI advisory comment. New `scripts/ci/check_commit_subjects.sh` validator (single source of truth for the regex, mirroring `commitlint.yml:124`) wired into both a `commit-msg` git hook (catches at type-time) and the pre-push gate's Bucket 1 (catches at push-time across the entire diverged range). Bypass via `git commit --no-verify` / `COMMIT_SUBJECT_BYPASS=1 git push` for the rare cases the regex doesn't cover.

## Local hooks gate (three-layer defence)

| Layer | When | Scope | Bypass |
|---|---|---|---|
| `commit-msg` | At `git commit` | One subject, instant | `git commit --no-verify` |
| pre-push `commit-subjects` (Bucket 1) | At `git push` | All new subjects in pushed range | `COMMIT_SUBJECT_BYPASS=1 git push` |
| `commitlint.yml` (CI advisory) | PR open / synchronize | PR title only | edit title, comment auto-prunes |

The CI advisory posture (Phase R1a per `.github/workflows/commitlint.yml`) is unchanged — local hard-fail is the right discipline for the maintainer's hooks-installed flow; the CI advisory comment keeps soft-catching contributor PRs that bypassed local hooks.

## Verification

| Gate | Result |
|---|---|
| `cargo nextest run --workspace` | **1585 / 1585 PASS** (14 skipped, pre-existing) |
| `just lint-prod` (workspace lib + bins, --pedantic --nursery --cargo --strict-flags) | clean |
| `just lint-tests` (workspace tests, --pedantic --nursery --cargo) | clean |
| `just lint-prod-windows` / `just lint-tests-windows` | clean |
| `just check-windows` (xwin, x86_64-pc-windows-msvc, --workspace --all-targets) | clean |
| `just lint-ci-windows` (strict-gate Windows clippy) | **clean** — was red on every commit since #118 landed |
| `just lint-fast` (file-size + fmt-check + typos + reuse + lint-ci) | 7/7 green |
| pre-push gate (`lint-pre-push`: `deny` + `check-windows`) | passed |

## Backward compatibility

* **Cache format**: v < 10 caches are rejected at the header check. The daemon falls through to its existing fresh-rebuild path, writes a v10 cache, and subsequent ticks pick up the surgical-patch path. No operator action required.
* **API surface**: `DriveCompactIndex::frs_to_compact` is a new public field on the body type. Any downstream code that constructs a body by struct literal needs to default it (`frs_to_compact: Vec::new()` is a valid degraded default — the surgical-patch path will short-circuit to a no-op for those drives).
* **Test fixtures**: `compact_filters` / `aggregate::rollup` test fixtures updated in this PR.

## Followup work (not part of this PR)

* **Windows host gates** — the live 7-drive box should observe per-shard save-tick wall time drop from `O(records)` to `O(changes)` after `v0.5.90` ships. Capture in the Phase-8 validation matrix alongside the existing Phase-5 captures.
* **Coordinated graceful shutdown** — still tracked from the Phase-7 commit message; Phase 8 didn't widen the per-task shutdown surface.
