### PR TITLE
feat(daemon): Phase 8-D + 8-E — forget/status_drives commands

### DIFF
--- a/crates/uffs-cli/src/args.rs
+++ b/crates/uffs-cli/src/args.rs
@@ -120,6 +120,26 @@ pub enum DaemonAction {
         /// Override the default 30-min pin window.
         pin_minutes: Option<u32>,
     },
+    /// Evict drive(s) from the registry and delete their on-disk
+    /// caches (Phase 8-D).
+    ///
+    /// Refuses non-`Cold` drives unless `force = true`; with
+    /// `force` the daemon auto-hibernates each drive first
+    /// (clearing pins) before unlinking the cache files.
+    Forget {
+        /// Drive letter(s) to forget (must be non-empty).
+        drives: Vec<char>,
+        /// Force-forget non-`Cold` drives by auto-hibernating first.
+        force: bool,
+    },
+    /// Per-drive tier + telemetry table (Phase 8-E).
+    ///
+    /// Operator-facing companion to `daemon status`: surfaces tier,
+    /// pin expiry, query rate (EWMA), resident bytes, and last-query
+    /// timestamps for every drive the registry knows about — Cold
+    /// shards included so `forget` candidates are visible without
+    /// cross-referencing tracing logs.
+    StatusDrives,
 }
 
 /// Parse `uffs daemon <action> [flags...]` from raw args.
@@ -140,8 +160,11 @@ pub fn parse_daemon_action(args: &[String]) -> Result<DaemonAction, anyhow::Erro
         "load" => Ok(parse_daemon_load(rest)),
         "hibernate" => Ok(parse_daemon_hibernate(rest)),
         "preload" => parse_daemon_preload(rest),
+        "forget" => parse_daemon_forget(rest),
+        "status_drives" | "status-drives" => Ok(DaemonAction::StatusDrives),
         other => anyhow::bail!(
-            "Unknown daemon action: '{other}'. Use: start, status, stats, stop, kill, restart, load, hibernate, preload"
+            "Unknown daemon action: '{other}'. Use: start, status, stats, stop, kill, \
+             restart, load, hibernate, preload, forget, status_drives"
         ),
     }
 }
@@ -316,6 +339,49 @@ fn parse_daemon_preload(rest: &[String]) -> Result<DaemonAction, anyhow::Error> 
     })
 }
 
+/// Parse `uffs daemon forget <DRIVES...> [--force]` /
+/// `[--drive D]` / `[--drives A,B]`.
+///
+/// Empty drive list is rejected — the daemon would reply with
+/// `ERR_INVALID_PARAMS`, but a CLI-side error is faster and more
+/// actionable.
+///
+/// `--force` (also `-f`) flips the auto-hibernate-then-evict path on,
+/// matching the wire-level
+/// [`uffs_client::protocol::response::ForgetParams::force`] field.  Without
+/// `--force`, the daemon refuses non-`Cold` drives with `ERR_DRIVE_BUSY` and
+/// the CLI surfaces the listing.
+///
+/// # Errors
+///
+/// Returns an error when the resulting drive list is empty.
+fn parse_daemon_forget(rest: &[String]) -> Result<DaemonAction, anyhow::Error> {
+    let mut drives = Vec::new();
+    let mut force = false;
+    let mut iter = rest.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--drive" | "-d" | "--drives" => {
+                if let Some(val) = iter.next() {
+                    extend_drives_from_csv(&mut drives, val);
+                }
+            }
+            "--force" | "-f" => force = true,
+            other => {
+                // Bare positional drive letter.
+                extend_drives_from_csv(&mut drives, other);
+            }
+        }
+    }
+    if drives.is_empty() {
+        anyhow::bail!(
+            "`uffs daemon forget` requires at least one drive letter; \
+             see `uffs daemon forget --help`"
+        );
+    }
+    Ok(DaemonAction::Forget { drives, force })
+}
+
 /// Append every drive letter parsed from a comma-separated value to
 /// `drives`.  Tolerates `"C,D"`, `"c,d"`, `"C:,D:"`, single-letter
 /// values, and whitespace.  Silently skips entries that don't parse
@@ -423,6 +489,11 @@ ACTIONS:
     [DRIVE...]         Drive letter(s); at least one required
     --drives A,B       Drive letter(s) as comma-separated list
     --pin-minutes N    Pin window in minutes (default: 30)
+  forget             Evict drive(s) from registry and delete on-disk caches
+    [DRIVE...]         Drive letter(s); at least one required
+    --drives A,B       Drive letter(s) as comma-separated list
+    --force            Auto-hibernate non-Cold drives first (default: refuse)
+  status_drives      Per-drive tier + telemetry table (Hot/Warm/Parked/Cold)
 ";
 
 /// Print daemon help.

--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -9,6 +9,7 @@ use uffs_client::daemon_ctl::{pid_file_path, socket_path};
 use uffs_client::protocol::response::{DaemonStatus, DriveInfo, ShardTier};
 
 use crate::args::DaemonAction;
+use crate::commands::daemon_tiering;
 
 /// Execute a daemon management action.
 ///
@@ -48,13 +49,13 @@ pub fn daemon(action: &DaemonAction) -> Result<()> {
             drives,
             no_cache,
         } => daemon_load(mft_file, data_dir.as_deref(), drives, *no_cache),
-        DaemonAction::Hibernate { drives } => {
-            crate::commands::daemon_tiering::daemon_hibernate(drives)
-        }
+        DaemonAction::Hibernate { drives } => daemon_tiering::daemon_hibernate(drives),
         DaemonAction::Preload {
             drives,
             pin_minutes,
-        } => crate::commands::daemon_tiering::daemon_preload(drives, *pin_minutes),
+        } => daemon_tiering::daemon_preload(drives, *pin_minutes),
+        DaemonAction::Forget { drives, force } => daemon_tiering::daemon_forget(drives, *force),
+        DaemonAction::StatusDrives => daemon_tiering::daemon_status_drives(),
     }
 }
 

--- a/crates/uffs-cli/src/commands/daemon_tiering.rs
+++ b/crates/uffs-cli/src/commands/daemon_tiering.rs
@@ -13,7 +13,7 @@
 use anyhow::{Context, Result};
 use uffs_client::connect_sync::UffsClientSync;
 use uffs_client::protocol::response::{
-    DEFAULT_PRELOAD_PIN_MINUTES, HibernateParams, PreloadParams,
+    DEFAULT_PRELOAD_PIN_MINUTES, DriveTierStatus, ForgetParams, HibernateParams, PreloadParams,
 };
 
 /// `uffs daemon hibernate [DRIVES...]` — demote loaded shards to `Cold`.
@@ -141,10 +141,182 @@ pub fn daemon_preload(drives: &[char], pin_minutes: Option<u32>) -> Result<()> {
     Ok(())
 }
 
+/// `uffs daemon forget <DRIVES...> [--force]` — evict drive(s) from
+/// the registry and delete every per-drive on-disk cache artefact.
+///
+/// Without `--force` the daemon refuses non-`Cold` drives with
+/// `ERR_DRIVE_BUSY` (`-4`); the CLI surfaces that message verbatim
+/// so the operator sees which drives are blocking the call.  With
+/// `--force` the daemon auto-hibernates each non-`Cold` drive
+/// first (clearing pins implicitly via the registry rebuild),
+/// then deletes the cache files.
+///
+/// # Errors
+///
+/// Returns an error when the daemon is not running, the `forget`
+/// RPC fails (network / serialisation / `ERR_DRIVE_BUSY`), or any
+/// per-drive errors land in the response's `errors` field — the
+/// CLI surfaces those as part of stdout, but a non-empty `errors`
+/// list is still surfaced as a non-zero exit so scripted callers
+/// can branch on success.
+///
+/// # Example
+///
+/// ```bash
+/// $ uffs daemon forget C --force
+/// Daemon forgot 1 drive(s); freed 12.4 MiB:
+///   Forgotten:        C
+///   Already absent:   (none)
+/// ```
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+pub fn daemon_forget(drives: &[char], force: bool) -> Result<()> {
+    let mut client = UffsClientSync::connect_raw()
+        .map_err(|err| anyhow::anyhow!("Daemon is not running: {err}"))?;
+
+    let params = ForgetParams {
+        drives: drives.to_vec(),
+        force,
+    };
+    let response = client
+        .forget(&params)
+        .with_context(|| "forget RPC failed")?;
+
+    let total = response.forgotten.len() + response.already_absent.len();
+    println!(
+        "Daemon forgot {total} drive(s); freed {}:",
+        format_bytes(response.freed_bytes)
+    );
+    println!(
+        "  Forgotten:        {}",
+        format_drive_list(&response.forgotten)
+    );
+    println!(
+        "  Already absent:   {}",
+        format_drive_list(&response.already_absent)
+    );
+    if !response.errors.is_empty() {
+        println!("  Errors:");
+        for err in &response.errors {
+            println!("    {err}");
+        }
+        anyhow::bail!("forget completed with errors (see stdout above)");
+    }
+    Ok(())
+}
+
+/// `uffs daemon status_drives` — render the per-drive tier +
+/// telemetry table.
+///
+/// Operator-facing companion to `daemon status`: surfaces tier,
+/// pin expiry, query rate (EWMA), resident-bytes, and last-query
+/// timestamps for every drive the registry knows about — including
+/// `Cold` shards (encrypted cache on disk, zero RAM) so `forget`
+/// candidates are visible without cross-referencing tracing logs.
+///
+/// Output is a fixed-width table with one row per drive, sorted by
+/// drive letter (ASCII ascending) so the order is stable across
+/// re-runs.
+///
+/// # Errors
+///
+/// Returns an error when the daemon is not running or the
+/// `status_drives` RPC fails (network / serialisation).  An empty
+/// registry produces a "no drives loaded" hint instead of an
+/// empty table.
+///
+/// # Example
+///
+/// ```bash
+/// $ uffs daemon status_drives
+/// DRIVE  TIER    RESIDENT     QPM   LAST QUERY (ms)   PIN UNTIL (ms)
+/// C      hot     1.20 GiB   45.30   1700000000000     1700001800000
+/// D      warm    843 MiB     2.10   1699999940000     -
+/// E      parked  12 MiB      0.00   1699999600000     -
+/// F      cold    0 B         0.00   -                 -
+/// ```
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+pub fn daemon_status_drives() -> Result<()> {
+    let mut client = UffsClientSync::connect_raw()
+        .map_err(|err| anyhow::anyhow!("Daemon is not running: {err}"))?;
+
+    let response = client
+        .status_drives()
+        .with_context(|| "status_drives RPC failed")?;
+
+    if response.drives.is_empty() {
+        println!("(no drives loaded)");
+        return Ok(());
+    }
+
+    println!(
+        "{:<6} {:<7} {:<10} {:<7} {:<17} {:<14}",
+        "DRIVE", "TIER", "RESIDENT", "QPM", "LAST QUERY (ms)", "PIN UNTIL (ms)",
+    );
+    for drive in &response.drives {
+        print_status_drive_row(drive);
+    }
+    Ok(())
+}
+
+/// Render a single [`DriveTierStatus`] row in the same layout as
+/// the header in [`daemon_status_drives`].
+///
+/// Split out so the column widths stay co-located between the
+/// header and the per-row writer — easier to keep aligned when the
+/// schema gains a new column in a future sub-phase.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_status_drive_row(drive: &DriveTierStatus) {
+    let last_query = if drive.last_query_at_ms > 0 {
+        drive.last_query_at_ms.to_string()
+    } else {
+        "-".to_owned()
+    };
+    let pin_until = if drive.pin_until_unix_ms > 0 {
+        drive.pin_until_unix_ms.to_string()
+    } else {
+        "-".to_owned()
+    };
+    println!(
+        "{:<6} {:<7} {:<10} {:<7.2} {:<17} {:<14}",
+        drive.letter,
+        drive.tier,
+        format_bytes(drive.resident_bytes),
+        drive.query_rate_per_min,
+        last_query,
+        pin_until,
+    );
+}
+
+/// Humanise a byte count into a fixed-width string.  Uses binary
+/// units (KiB / MiB / GiB) since the underlying `resident_bytes`
+/// reports `Vec::capacity * size_of`, which is naturally
+/// power-of-two-aligned.
+///
+/// Implemented with pure integer arithmetic (no floats) so the
+/// strict `clippy::float_arithmetic` gate stays satisfied — the
+/// `.2` GiB rendering uses `(bytes % GIB) * 100 / GIB` to compute
+/// the hundredths digit directly.
+fn format_bytes(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = 1024 * KIB;
+    const GIB: u64 = 1024 * MIB;
+    if bytes >= GIB {
+        let whole = bytes / GIB;
+        let hundredths = (bytes % GIB).saturating_mul(100) / GIB;
+        format!("{whole}.{hundredths:02} GiB")
+    } else if bytes >= MIB {
+        format!("{} MiB", bytes / MIB)
+    } else if bytes >= KIB {
+        format!("{} KiB", bytes / KIB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
 /// Render a slice of drive letters as a comma-separated list, or
 /// `"(none)"` when the slice is empty.  Keeps the per-line output
-/// in [`daemon_hibernate`] / [`daemon_preload`] visually aligned
-/// even on no-op calls.
+/// in [`daemon_hibernate`] / [`daemon_preload`] / [`daemon_forget`]
+/// visually aligned even on no-op calls.
 fn format_drive_list(drives: &[char]) -> String {
     if drives.is_empty() {
         "(none)".to_owned()

--- a/crates/uffs-client/src/connect_sync_tiering.rs
+++ b/crates/uffs-client/src/connect_sync_tiering.rs
@@ -4,22 +4,23 @@
 //! Memory-tiering RPC helpers for [`crate::connect_sync::UffsClientSync`].
 //!
 //! Split off [`crate::connect_sync`] so the tiering RPC cluster
-//! (`hibernate`, `preload`, plus `forget` / `status_drives` in later
-//! sub-phases 8-D / 8-E) lives next to the
-//! [`crate::protocol::response_tiering`] wire types it consumes —
-//! same sibling-module pattern as the daemon-state cluster
-//! (`response_status` ↔ inline `connect_sync` helpers).
+//! (`hibernate`, `preload`, `forget`, `status_drives`) lives next
+//! to the [`crate::protocol::response_tiering`] wire types it
+//! consumes — same sibling-module pattern as the daemon-state
+//! cluster (`response_status` ↔ inline `connect_sync` helpers).
 //!
-//! Phase 8-B / 8-C — paired with the daemon-side handlers in
+//! Phase 8-B … 8-E — paired with the daemon-side handlers in
 //! `crates/uffs-daemon/src/handler.rs` (`handle_hibernate`,
-//! `handle_preload`).  Both helpers do the typed envelope dance:
-//! serialise the params struct, fire the JSON-RPC, deserialise the
-//! response into the matching wire type.
+//! `handle_preload`, `handle_forget`, `handle_status_drives`).
+//! Every helper does the typed-envelope dance: serialise the
+//! params struct, fire the JSON-RPC, deserialise the response
+//! into the matching wire type.
 
 use crate::connect_sync::UffsClientSync;
 use crate::error::ClientError;
 use crate::protocol::response::{
-    HibernateParams, HibernateResponse, PreloadParams, PreloadResponse,
+    ForgetParams, ForgetResponse, HibernateParams, HibernateResponse, PreloadParams,
+    PreloadResponse, StatusDrivesParams, StatusDrivesResponse,
 };
 
 impl UffsClientSync {
@@ -68,6 +69,49 @@ impl UffsClientSync {
         let payload =
             serde_json::to_value(params).map_err(|err| ClientError::Protocol(err.to_string()))?;
         let result = self.send_request("preload", Some(payload))?;
+        serde_json::from_value(result).map_err(|err| ClientError::Protocol(err.to_string()))
+    }
+
+    /// Evict drive(s) from the registry and unlink their on-disk
+    /// cache files via the daemon's `forget` RPC.
+    ///
+    /// Without `params.force`, the daemon refuses non-`Cold` drives
+    /// with [`crate::protocol::ERR_DRIVE_BUSY`] (`-4`); the helper
+    /// surfaces that as [`ClientError::Protocol`] with the daemon's
+    /// listing of the busy drives.  With `params.force` the daemon
+    /// auto-hibernates each non-`Cold` drive first.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ClientError` on I/O, protocol, or `ERR_DRIVE_BUSY`
+    /// failure.  Per-drive `permission denied`-style errors land in
+    /// [`ForgetResponse::errors`] without failing the call.
+    pub fn forget(&mut self, params: &ForgetParams) -> Result<ForgetResponse, ClientError> {
+        let payload =
+            serde_json::to_value(params).map_err(|err| ClientError::Protocol(err.to_string()))?;
+        let result = self.send_request("forget", Some(payload))?;
+        serde_json::from_value(result).map_err(|err| ClientError::Protocol(err.to_string()))
+    }
+
+    /// Per-drive tier + telemetry table via the daemon's
+    /// `status_drives` RPC.
+    ///
+    /// Operator-facing companion to [`Self::status_raw`] — widens
+    /// the tier marker into a structured row per drive
+    /// (`resident_bytes`, `query_rate_per_min`, `pin_until_unix_ms`,
+    /// …) so a CLI can render a table without cross-referencing
+    /// tracing logs.  Sends an empty params object (the wire type is
+    /// a unit struct that round-trips as `{}`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `ClientError` on I/O, protocol, or timeout failure.
+    /// An empty registry produces an `Ok` with `drives = []` rather
+    /// than an error.
+    pub fn status_drives(&mut self) -> Result<StatusDrivesResponse, ClientError> {
+        let payload = serde_json::to_value(StatusDrivesParams)
+            .map_err(|err| ClientError::Protocol(err.to_string()))?;
+        let result = self.send_request("status_drives", Some(payload))?;
         serde_json::from_value(result).map_err(|err| ClientError::Protocol(err.to_string()))
     }
 }

--- a/crates/uffs-daemon/src/cache/cache_cleaner.rs
+++ b/crates/uffs-daemon/src/cache/cache_cleaner.rs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Per-drive cache-file cleanup hook for the Phase 8-D `forget` RPC.
+//!
+//! `IndexManager::forget_drive` removes a shard from the registry
+//! **and** purges every per-drive artefact from the platform cache
+//! directory (encrypted compact body, USN cursor, MFT index, lock).
+//! The on-disk side effect is wrapped in this trait so:
+//!
+//! * Production gets [`PlatformCacheCleaner`] which calls
+//!   [`uffs_core::compact_cache::compact_cache_path`] and friends to resolve
+//!   the real platform paths and unlinks them via [`std::fs::remove_file`].
+//! * Tests inject [`CountingCacheCleaner`] (and the temp-dir-backed helper
+//!   [`delete_drive_cache_files`] is unit-tested directly with a
+//!   [`tempfile::TempDir`]) so the registry-eviction behaviour can be verified
+//!   without ever touching the host's real cache directory — which would
+//!   otherwise be a destructive operation when a test asks the daemon to
+//!   "forget drive C".
+//!
+//! Mirrors the [`super::body_loader::BodyLoader`] /
+//! [`super::working_set::WorkingSetTrim`] hook pattern (Phase 5):
+//! one `Arc<dyn Trait>` field on
+//! [`crate::index::constructors::LifecycleHooks`], the production
+//! impl is wired in [`super::body_loader::DiskBodyLoader`]-style at
+//! daemon bootstrap, and the test escape hatches stay narrow.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Per-drive cache cleanup operation.
+///
+/// Used by [`crate::index::IndexManager::forget_drive`] to delete
+/// every on-disk artefact tied to a specific drive letter once the
+/// shard has been evicted from the in-memory registry.
+///
+/// Implementations report a `(freed_bytes, errors)` pair: the byte
+/// total is summed across every successfully-unlinked file, and the
+/// errors vector carries one prefixed string per failure (`"<path>:
+/// <io::Error>"`).  Missing files are **not** errors — `forget` is
+/// idempotent on already-absent caches so a re-run after a partial
+/// failure makes progress instead of looping.
+pub(crate) trait CacheCleaner: Send + Sync + 'static {
+    /// Delete every per-drive cache file for `letter`.
+    ///
+    /// Returns `(freed_bytes, errors)`.  `freed_bytes` is the sum of
+    /// `metadata.len()` over every file actually removed; `errors`
+    /// is empty on full success and one entry per non-`NotFound`
+    /// `io::Error` otherwise.
+    fn forget(&self, letter: char) -> (u64, Vec<String>);
+}
+
+/// Production implementation that resolves the four canonical
+/// per-drive paths via the public helpers in
+/// [`uffs_core::compact_cache`] and [`uffs_mft::cache`], then
+/// unlinks each via [`std::fs::remove_file`].
+///
+/// The four paths cover every on-disk artefact a daemon writes per
+/// drive:
+///
+/// 1. `<cache_dir>/<lower>_compact.uffs` — encrypted compact body (the
+///    Cold-tier source-of-truth for re-promote).
+/// 2. `<cache_dir>/<lower>_usn.cursor` — Phase 7 USN cursor used by the
+///    per-shard journal loop on Windows.
+/// 3. `<cache_dir>/<UPPER>_index.uffs` — full MFT index cache (used by the
+///    loader on cold boot).
+/// 4. `<cache_dir>/<UPPER>_index.lock` — fcntl lock file paired with
+///    `_index.uffs`.
+pub(crate) struct PlatformCacheCleaner;
+
+impl CacheCleaner for PlatformCacheCleaner {
+    fn forget(&self, letter: char) -> (u64, Vec<String>) {
+        let paths = drive_cache_paths(letter);
+        delete_drive_cache_files(&paths)
+    }
+}
+
+/// The four canonical cache-file paths a daemon owns per drive.
+///
+/// Exposed at module scope so the unit test in this file's `tests`
+/// submodule can drive [`delete_drive_cache_files`] against a
+/// [`tempfile::TempDir`] without dragging the platform paths into
+/// the test fixture.
+fn drive_cache_paths(letter: char) -> [PathBuf; 4] {
+    [
+        uffs_core::compact_cache::compact_cache_path(letter),
+        uffs_core::compact_cache::usn_cursor_path(letter),
+        uffs_mft::cache::cache_file_path(letter),
+        uffs_mft::cache::cache_lock_path(letter),
+    ]
+}
+
+/// Unlink every regular-file path in `paths`, returning the total
+/// byte count of successfully-removed files plus any per-path
+/// errors.
+///
+/// Behaviour:
+///
+/// * Missing paths are silent no-ops (idempotent re-runs).
+/// * Non-file entries (directories, sockets, …) are skipped — the daemon only
+///   writes regular files into its cache directory, so a non-file at one of
+///   these paths is structural and the safer action is "leave it for the
+///   operator" rather than recurse.
+/// * `permission denied` and other genuine errors land in the returned
+///   `Vec<String>` prefixed with the offending path's `Display` form.
+fn delete_drive_cache_files(paths: &[PathBuf]) -> (u64, Vec<String>) {
+    let mut freed: u64 = 0;
+    let mut errors: Vec<String> = Vec::new();
+    for path in paths {
+        match std::fs::symlink_metadata(path) {
+            Ok(meta) if meta.is_file() => {
+                let size = meta.len();
+                match std::fs::remove_file(path) {
+                    Ok(()) => freed = freed.saturating_add(size),
+                    Err(err) => errors.push(format_path_error(path, &err)),
+                }
+            }
+            // Non-file (dir / symlink / fifo) — leave alone.  The
+            // daemon's writers (`atomic_write` + `save_compact_cache`)
+            // only ever produce regular files at these paths; anything
+            // else is a structural surprise the operator should
+            // investigate manually.
+            Ok(_) => {}
+            // Idempotent: missing file is success.
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => errors.push(format_path_error(path, &err)),
+        }
+    }
+    (freed, errors)
+}
+
+/// Render a single `(path, error)` pair into the
+/// `"<path>: <io::Error>"` string format documented on
+/// [`CacheCleaner::forget`].
+fn format_path_error(path: &Path, err: &io::Error) -> String {
+    format!("{}: {err}", path.display())
+}
+
+// ── Test fakes ─────────────────────────────────────────────────────
+
+/// Counting test fake.  Records every `forget(letter)` call so the
+/// integration tests in `crate::index::tests::forget_status` can
+/// assert on the per-letter call sequence without touching the
+/// host filesystem.
+///
+/// Reports a fixed `freed_per_call` byte count and an empty error
+/// vector — the daemon-side error-aggregation paths are exercised
+/// separately by an `ErroringCacheCleaner` in the same test module.
+#[cfg(test)]
+pub(crate) struct CountingCacheCleaner {
+    calls: std::sync::Mutex<Vec<char>>,
+    freed_per_call: u64,
+}
+
+#[cfg(test)]
+impl CountingCacheCleaner {
+    /// Create a fresh counter with `freed_per_call` reported on
+    /// every successful `forget`.
+    #[must_use]
+    pub(crate) fn new(freed_per_call: u64) -> Self {
+        Self {
+            calls: std::sync::Mutex::new(Vec::new()),
+            freed_per_call,
+        }
+    }
+
+    /// Snapshot the per-letter call sequence.  Cloned out of the
+    /// internal `Mutex` so the assertion site doesn't have to hold
+    /// the lock.
+    pub(crate) fn calls(&self) -> Vec<char> {
+        self.calls
+            .lock()
+            .expect("CountingCacheCleaner::calls — mutex poisoned in test fixture")
+            .clone()
+    }
+}
+
+#[cfg(test)]
+impl CacheCleaner for CountingCacheCleaner {
+    fn forget(&self, letter: char) -> (u64, Vec<String>) {
+        self.calls
+            .lock()
+            .expect("CountingCacheCleaner::forget — mutex poisoned in test fixture")
+            .push(letter);
+        (self.freed_per_call, Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::{fs, io};
+
+    use tempfile::TempDir;
+
+    use super::{delete_drive_cache_files, format_path_error};
+
+    /// `delete_drive_cache_files` returns `(0, [])` when every path
+    /// in the input slice is missing (idempotent re-run after a
+    /// previous `forget` call).
+    #[test]
+    fn missing_files_yield_zero_freed_and_no_errors() {
+        let tmp = TempDir::new().expect("tempdir");
+        let paths = [
+            tmp.path().join("a.uffs"),
+            tmp.path().join("b.cursor"),
+            tmp.path().join("c.lock"),
+        ];
+
+        let (freed, errors) = delete_drive_cache_files(&paths);
+
+        assert_eq!(freed, 0);
+        assert!(errors.is_empty());
+    }
+
+    /// `delete_drive_cache_files` sums file sizes correctly across
+    /// a mix of present and missing paths.
+    #[test]
+    fn freed_bytes_sum_across_present_files() {
+        let tmp = TempDir::new().expect("tempdir");
+        let path_a = tmp.path().join("a.uffs");
+        let path_b = tmp.path().join("b.cursor");
+        let path_missing = tmp.path().join("missing.lock");
+        fs::write(&path_a, vec![0_u8; 17]).expect("seed a");
+        fs::write(&path_b, vec![0_u8; 23]).expect("seed b");
+
+        let (freed, errors) =
+            delete_drive_cache_files(&[path_a.clone(), path_b.clone(), path_missing]);
+
+        assert_eq!(freed, 40, "17 + 23 = 40 freed bytes");
+        assert!(
+            errors.is_empty(),
+            "missing file is not an error; got: {errors:?}"
+        );
+        assert!(!path_a.exists(), "a.uffs must be unlinked");
+        assert!(!path_b.exists(), "b.cursor must be unlinked");
+    }
+
+    /// Directories and other non-file entries at the cache paths
+    /// are skipped without an error — the daemon only writes
+    /// regular files, so a directory there is structural and left
+    /// alone.
+    #[test]
+    fn non_file_entries_are_skipped_silently() {
+        let tmp = TempDir::new().expect("tempdir");
+        let path_dir = tmp.path().join("subdir");
+        fs::create_dir(&path_dir).expect("seed subdir");
+
+        let (freed, errors) = delete_drive_cache_files(core::slice::from_ref(&path_dir));
+
+        assert_eq!(freed, 0);
+        assert!(errors.is_empty());
+        assert!(path_dir.exists(), "non-file entry must be left in place");
+    }
+
+    /// `format_path_error` produces the `"<path>: <error>"` format
+    /// the wire schema documents, so the CLI can grep an `errors`
+    /// list and match drive-letter prefixes consistently.
+    #[test]
+    fn format_path_error_includes_display_and_message() {
+        let err = io::Error::new(io::ErrorKind::PermissionDenied, "denied");
+        let path = Path::new("/var/cache/uffs/Z_compact.uffs");
+
+        let rendered = format_path_error(path, &err);
+
+        assert!(rendered.contains("/var/cache/uffs/Z_compact.uffs"));
+        assert!(rendered.contains("denied"));
+    }
+}

--- a/crates/uffs-daemon/src/cache/mod.rs
+++ b/crates/uffs-daemon/src/cache/mod.rs
@@ -30,6 +30,7 @@
 
 pub(crate) mod background_io;
 pub(crate) mod body_loader;
+pub(crate) mod cache_cleaner;
 pub(crate) mod cursor_store;
 pub(crate) mod journal_loop;
 pub(crate) mod journal_sink;

--- a/crates/uffs-daemon/src/cache/registry.rs
+++ b/crates/uffs-daemon/src/cache/registry.rs
@@ -221,15 +221,10 @@ impl ShardRegistry {
     ///
     /// Match is case-insensitive — see [`Self::replace`] for the
     /// rationale.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "Phase 3 consumer (tier-transition cleanup); exercised \
-                      by `cache::registry::tests::remove_missing_is_noop` \
-                      under `cfg(test)`."
-        )
-    )]
+    ///
+    /// Phase 8-D `forget` activates this as a production consumer:
+    /// [`crate::index::IndexManager::forget_drives`] calls `remove`
+    /// after the eviction guard checks pass.
     #[must_use]
     pub(crate) fn remove(&self, drive: char) -> Self {
         let shards: Vec<Arc<ShardEntry>> = self

--- a/crates/uffs-daemon/src/cache/shard.rs
+++ b/crates/uffs-daemon/src/cache/shard.rs
@@ -625,11 +625,28 @@ impl ShardEntry {
     /// Atomic store — no registry rebuild required, so a
     /// `preload C:` against an already-Hot drive can extend the
     /// pin window without producing a `shard.transition` event.
-    /// Pass `0` to clear the pin (today only used by the future
-    /// 8-D `forget --force` path; hibernate clears the pin
-    /// implicitly by rebuilding the shard as `Cold`).
+    /// Pass `0` to clear the pin (used by the 8-D `forget --force`
+    /// path; hibernate clears the pin implicitly by rebuilding the
+    /// shard as `Cold`).
     pub(crate) fn pin_until(&self, pin_until_ms: u64) {
         self.pin_until_ms.store(pin_until_ms, Ordering::Release);
+    }
+
+    /// Read the absolute pin-expiry timestamp (Unix-millis).
+    ///
+    /// Returns `0` when the shard has never been pinned (the
+    /// constructors initialise [`Self::pin_until_ms`] to `0`); the
+    /// "pin elapsed" case is indistinguishable from "never pinned"
+    /// here — callers that need the live distinction use
+    /// [`Self::is_pinned`] which folds the `now_ms` comparison in.
+    ///
+    /// Phase 8-E `status_drives` surfaces this raw value so the
+    /// operator-facing CLI table can render either "pinned until
+    /// HH:MM" or a hyphen ("-") depending on whether the value
+    /// has elapsed against the operator's local clock.
+    #[must_use]
+    pub(crate) fn pin_until_ms_value(&self) -> u64 {
+        self.pin_until_ms.load(Ordering::Acquire)
     }
 
     /// Cheap clone of the in-memory body, present only for

--- a/crates/uffs-daemon/src/handler.rs
+++ b/crates/uffs-daemon/src/handler.rs
@@ -4,13 +4,13 @@
 //! JSON-RPC request handler: dispatches methods to [`IndexManager`].
 
 use uffs_client::protocol::response::{
-    DEFAULT_PRELOAD_PIN_MINUTES, FacetValuesParams, FacetValuesResponse, HibernateParams,
-    HibernateResponse, LoadDriveParams, LoadDriveResponse, PreloadParams, PreloadResponse,
-    RefreshParams, SearchPayload,
+    DEFAULT_PRELOAD_PIN_MINUTES, FacetValuesParams, FacetValuesResponse, ForgetParams,
+    ForgetResponse, HibernateParams, HibernateResponse, LoadDriveParams, LoadDriveResponse,
+    PreloadParams, PreloadResponse, RefreshParams, SearchPayload, StatusDrivesResponse,
 };
 use uffs_client::protocol::{
-    AggregateSpecWire, ERR_INVALID_PARAMS, ERR_METHOD_NOT_FOUND, ERR_NOT_IMPLEMENTED,
-    RpcErrorResponse, RpcRequest, RpcResponse, SearchParams,
+    AggregateSpecWire, ERR_DRIVE_BUSY, ERR_INVALID_PARAMS, ERR_METHOD_NOT_FOUND, RpcErrorResponse,
+    RpcRequest, RpcResponse, SearchParams,
 };
 
 /// Maximum pattern length to prevent regex `DoS` (`S4.4.3`).
@@ -61,15 +61,15 @@ impl RequestHandler {
             "facet_values" => self.handle_facet_values(id, req).await,
             "keepalive" => self.handle_keepalive(id, req),
             "shutdown" => self.handle_shutdown(id, req),
-            // Phase 8-B / 8-C — operator-driven memory tiering.
+            // Phase 8-B … 8-E — operator-driven memory tiering.
             // Phase 8-A scaffolded these arms with NotImplemented
-            // stubs; this commit fills in `hibernate` and `preload`
-            // and leaves `forget` / `status_drives` for sub-phases
-            // 8-D / 8-E respectively.
+            // stubs; sub-phases 8-B / 8-C / 8-D / 8-E filled in
+            // `hibernate`, `preload`, `forget`, and `status_drives`
+            // respectively.
             "hibernate" => self.handle_hibernate(id, req).await,
             "preload" => self.handle_preload(id, req).await,
-            "forget" => Self::handle_forget(id),
-            "status_drives" => Self::handle_status_drives(id),
+            "forget" => self.handle_forget(id, req).await,
+            "status_drives" => self.handle_status_drives(id).await,
             _ => serde_json::to_string(&RpcErrorResponse::error(
                 Some(id),
                 ERR_METHOD_NOT_FOUND,
@@ -613,37 +613,79 @@ impl RequestHandler {
         serde_json::to_string(&RpcResponse::success(id, result)).unwrap_or_default()
     }
 
-    /// Handle `forget` method (Phase 8-A stub).
+    /// Handle `forget` method (Phase 8-D).
     ///
-    /// Returns [`ERR_NOT_IMPLEMENTED`] until sub-phase 8-D fills in
-    /// the cache-file deletion + registry-eviction logic.
-    fn handle_forget(id: u64) -> String {
-        Self::not_implemented_response(id, "forget", "8-D")
+    /// Parses [`ForgetParams`] from the JSON-RPC envelope and
+    /// dispatches to [`IndexManager::forget_drives`].  Empty
+    /// `drives` is rejected up-front with [`ERR_INVALID_PARAMS`];
+    /// non-`Cold` drives without `force = true` produce a
+    /// top-level [`ERR_DRIVE_BUSY`] refusal listing the busy
+    /// drives.  Successful runs return [`ForgetResponse`] populated
+    /// from [`crate::index::forget_drive::ForgetOutcome`].
+    async fn handle_forget(&self, id: u64, req: &RpcRequest) -> String {
+        use crate::index::forget_drive::ForgetOutcomeOrBusy;
+
+        let params: ForgetParams = req
+            .params
+            .as_ref()
+            .and_then(|val| serde_json::from_value(val.clone()).ok())
+            .unwrap_or_default();
+        if params.drives.is_empty() {
+            return serde_json::to_string(&RpcErrorResponse::error(
+                Some(id),
+                ERR_INVALID_PARAMS,
+                "forget: `drives` must contain at least one drive letter",
+            ))
+            .unwrap_or_default();
+        }
+
+        match self.index.forget_drives(&params.drives, params.force).await {
+            ForgetOutcomeOrBusy::Busy(busy) => {
+                let listing = busy
+                    .iter()
+                    .map(|(letter, state)| format!("{letter} ({state})"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let message = format!(
+                    "forget refused: drive(s) busy: {listing}. \
+                     Pass `force = true` to auto-hibernate first."
+                );
+                serde_json::to_string(&RpcErrorResponse::error(Some(id), ERR_DRIVE_BUSY, &message))
+                    .unwrap_or_default()
+            }
+            ForgetOutcomeOrBusy::Ok(outcome) => {
+                let response = ForgetResponse {
+                    forgotten: outcome
+                        .forgotten
+                        .into_iter()
+                        .map(|letter| letter.to_ascii_uppercase())
+                        .collect(),
+                    already_absent: outcome
+                        .already_absent
+                        .into_iter()
+                        .map(|letter| letter.to_ascii_uppercase())
+                        .collect(),
+                    freed_bytes: outcome.freed_bytes,
+                    errors: outcome.errors,
+                };
+                let result = serde_json::to_value(&response).unwrap_or_default();
+                serde_json::to_string(&RpcResponse::success(id, result)).unwrap_or_default()
+            }
+        }
     }
 
-    /// Handle `status_drives` method (Phase 8-A stub).
+    /// Handle `status_drives` method (Phase 8-E).
     ///
-    /// Returns [`ERR_NOT_IMPLEMENTED`] until sub-phase 8-E fills in
-    /// the per-drive tier + telemetry snapshot.
-    fn handle_status_drives(id: u64) -> String {
-        Self::not_implemented_response(id, "status_drives", "8-E")
-    }
-
-    /// Build a uniform `ERR_NOT_IMPLEMENTED` response for the Phase
-    /// 8-A scaffolding stage.
-    ///
-    /// Centralises the message format so every stub renders the same
-    /// `<method>: not yet implemented (Phase <sub_phase>)` shape — gives
-    /// operators a single greppable signature to flag method-not-yet-
-    /// implemented hits in daemon logs without ambiguity.
-    fn not_implemented_response(id: u64, method: &str, sub_phase: &str) -> String {
-        let message = format!("{method}: not yet implemented (Phase {sub_phase})");
-        serde_json::to_string(&RpcErrorResponse::error(
-            Some(id),
-            ERR_NOT_IMPLEMENTED,
-            &message,
-        ))
-        .unwrap_or_default()
+    /// No params — the unit-struct
+    /// [`uffs_client::protocol::response::StatusDrivesParams`]
+    /// serialises as `{}` so callers omitting the envelope flow
+    /// through unchanged.  Dispatches to
+    /// [`IndexManager::status_drives`] and returns the per-drive
+    /// tier + telemetry snapshot directly.
+    async fn handle_status_drives(&self, id: u64) -> String {
+        let response: StatusDrivesResponse = self.index.status_drives().await;
+        let result = serde_json::to_value(&response).unwrap_or_default();
+        serde_json::to_string(&RpcResponse::success(id, result)).unwrap_or_default()
     }
 
     /// Handle `shutdown` method.

--- a/crates/uffs-daemon/src/index/constructors.rs
+++ b/crates/uffs-daemon/src/index/constructors.rs
@@ -74,6 +74,12 @@ pub(crate) struct LifecycleHooks {
     pub(crate) pressure: Arc<dyn crate::cache::pressure::PressureSignal>,
     /// Thread-level background-I/O priority hook (Phase 5 task 5.7).
     pub(crate) background_io: Arc<dyn crate::cache::background_io::BackgroundIoPriority>,
+    /// Per-drive cache-file cleanup hook (Phase 8-D `forget` RPC).
+    /// Production uses [`crate::cache::cache_cleaner::PlatformCacheCleaner`];
+    /// tests inject [`crate::cache::cache_cleaner::CountingCacheCleaner`]
+    /// so registry-eviction behaviour can be verified without
+    /// touching the host's real cache directory.
+    pub(crate) cache_cleaner: Arc<dyn crate::cache::cache_cleaner::CacheCleaner>,
 }
 
 impl LifecycleHooks {
@@ -90,6 +96,7 @@ impl LifecycleHooks {
             prefetch: Arc::new(crate::cache::prefetch::PlatformPrefetch),
             pressure: Arc::new(crate::cache::pressure::PlatformPressureSignal::new()),
             background_io: Arc::new(crate::cache::background_io::PlatformBackgroundIoPriority),
+            cache_cleaner: Arc::new(crate::cache::cache_cleaner::PlatformCacheCleaner),
         }
     }
 }
@@ -141,6 +148,7 @@ impl IndexManager {
             prefetch,
             pressure,
             background_io,
+            cache_cleaner,
         } = hooks;
         let cpus = std::thread::available_parallelism().map_or(4, core::num::NonZeroUsize::get);
         Self {
@@ -165,6 +173,7 @@ impl IndexManager {
             prefetch,
             pressure,
             background_io,
+            cache_cleaner,
             in_flight_promotes: Arc::new(StdMutex::new(std::collections::HashMap::new())),
             journal_handles: Arc::new(StdMutex::new(std::collections::HashMap::new())),
             config,

--- a/crates/uffs-daemon/src/index/forget_drive.rs
+++ b/crates/uffs-daemon/src/index/forget_drive.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase 8-D — operator-driven `forget` RPC.
+//!
+//! Pairs the registry-eviction half of `forget` with the on-disk
+//! cleanup half ([`crate::cache::cache_cleaner::CacheCleaner`]).
+//!
+//! Three-phase orchestration mirrors the
+//! [`super::tiering_ops::IndexManager::hibernate_shards`] /
+//! [`super::tiering_ops::IndexManager::preload_drive`] pattern:
+//!
+//! 1. **Read-lock detect.**  A single `self.index.read()` enumerates the
+//!    `(letter, current_tier)` tuples for every drive in the request.  If
+//!    `force == false` and any drive is non-`Cold`, the entire request is
+//!    refused with [`ForgetOutcomeOrBusy::Busy`] — handler maps this to
+//!    [`uffs_client::protocol::ERR_DRIVE_BUSY`] so a typo on one of five drives
+//!    doesn't accidentally forget the other four.
+//! 2. **Optional auto-hibernate (force only).**  Each non-`Cold` drive is
+//!    demoted to `Cold` via [`super::IndexManager::demote_letter_with_reason`]
+//!    tagged with [`crate::cache::registry::DemoteReason::OperatorHibernate`].
+//!    The pin is cleared as a side effect (the rebuilt `ShardEntry` starts with
+//!    `pin_until_ms = 0`).
+//! 3. **Evict + clean.**  The drive is removed from the registry via
+//!    [`crate::cache::ShardRegistry::remove`] and the on-disk cache files are
+//!    unlinked via the injected [`crate::cache::cache_cleaner::CacheCleaner`].
+//!    Per-drive classification:
+//!
+//!    * `freed_bytes > 0` ⇒ [`ForgetOutcome::forgotten`].
+//!    * `freed_bytes == 0` and no errors ⇒ [`ForgetOutcome::already_absent`]
+//!      (idempotent re-run after a previous successful `forget`).
+//!    * Any per-path errors ⇒ [`ForgetOutcome::errors`] entries prefixed with
+//!      the drive letter; the drive still goes into `forgotten` if anything was
+//!      unlinked, otherwise into `already_absent` only when there were truly no
+//!      errors.
+
+use alloc::sync::Arc;
+
+use super::IndexManager;
+use crate::cache::registry::DemoteReason;
+use crate::cache::{ShardState, unix_now_ms};
+
+/// Outcome of a successful [`IndexManager::forget_drives`] call.
+///
+/// Each drive in the input request lands in exactly one of
+/// [`Self::forgotten`] or [`Self::already_absent`] (unless an I/O
+/// error pushed it into [`Self::errors`] only).  Mirrors the
+/// [`uffs_client::protocol::response::ForgetResponse`] wire shape so
+/// the handler can build the wire response with one
+/// `serde::Serialize` call.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct ForgetOutcome {
+    /// Drives whose cache files were deleted in this call (any
+    /// `freed_bytes > 0`).
+    pub forgotten: Vec<char>,
+    /// Drives that had no cache files on disk and weren't loaded in
+    /// the registry (idempotent no-op, e.g. a re-run after a previous
+    /// successful `forget`).
+    pub already_absent: Vec<char>,
+    /// Cumulative bytes freed across every successfully-forgotten
+    /// drive.
+    pub freed_bytes: u64,
+    /// Per-drive errors, prefixed with the drive letter
+    /// (`"Z: <path>: permission denied"`).
+    pub errors: Vec<String>,
+}
+
+/// Result of the read-lock detection phase.
+///
+/// `Busy` is the all-or-nothing refusal path: at least one
+/// requested drive is non-`Cold` and the caller didn't pass
+/// `force = true`, so the handler returns
+/// [`uffs_client::protocol::ERR_DRIVE_BUSY`] with the full list in
+/// the message.  Operators get a single actionable error rather
+/// than discovering halfway through that 4 of 5 drives were
+/// already freed.
+///
+/// `Ok` carries the populated [`ForgetOutcome`] — including any
+/// per-drive I/O errors from the cache-cleaner phase.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ForgetOutcomeOrBusy {
+    /// Forget completed; some drives may still have I/O errors
+    /// surfaced under [`ForgetOutcome::errors`].
+    Ok(ForgetOutcome),
+    /// All-or-nothing refusal: one or more drives are non-`Cold`
+    /// and `force` was `false`.  Vec carries `(letter, current_tier)`
+    /// for every refused drive in registry order.
+    Busy(Vec<(char, ShardState)>),
+}
+
+impl IndexManager {
+    /// Phase 8-D — multi-drive `forget` orchestration.
+    ///
+    /// Empty `drives` is rejected at the handler layer with
+    /// [`uffs_client::protocol::ERR_INVALID_PARAMS`]; this method
+    /// trusts the caller to have already enforced that invariant.
+    ///
+    /// `force = false` (default) refuses the whole request when any
+    /// drive is non-`Cold`.  `force = true` auto-hibernates every
+    /// non-`Cold` drive (clearing pins implicitly via the registry
+    /// rebuild) before evicting + cleaning.
+    ///
+    /// Returns [`ForgetOutcomeOrBusy::Busy`] when the all-or-nothing
+    /// refusal triggers; otherwise [`ForgetOutcomeOrBusy::Ok`] with
+    /// the populated [`ForgetOutcome`].
+    pub(crate) async fn forget_drives(&self, drives: &[char], force: bool) -> ForgetOutcomeOrBusy {
+        // ── Phase 1: read-lock detect ──────────────────────────────
+        //
+        // Enumerate (letter, current_tier) tuples for every requested
+        // drive.  Drives not in the registry record `None` so the
+        // cleaner phase still gets a chance to remove stale on-disk
+        // files (idempotent re-run semantics).
+        let mut snapshots: Vec<(char, Option<ShardState>)> = Vec::with_capacity(drives.len());
+        let mut busy: Vec<(char, ShardState)> = Vec::new();
+        let guard = self.index.read().await;
+        for &requested in drives {
+            let found = guard
+                .iter()
+                .find(|shard| shard.drive.eq_ignore_ascii_case(&requested))
+                .map(|shard| (shard.drive, shard.state()));
+            match found {
+                Some((drive, state)) => {
+                    if !force && state != ShardState::Cold {
+                        busy.push((drive, state));
+                    }
+                    snapshots.push((drive, Some(state)));
+                }
+                None => {
+                    // Use the requested letter verbatim — case
+                    // preserved for the operator audit trail.
+                    snapshots.push((requested, None));
+                }
+            }
+        }
+        // Explicit drop to release the read lock before the
+        // (potentially long-lived) write-lock work below.
+        drop(guard);
+
+        if !busy.is_empty() {
+            return ForgetOutcomeOrBusy::Busy(busy);
+        }
+
+        // ── Phase 2: optional auto-hibernate (force only) ──────────
+        //
+        // Demote every non-Cold drive to Cold first so the eviction
+        // step below sees a stable shard.  The registry rebuild
+        // implicitly clears any pin (the new `ShardEntry` starts at
+        // `pin_until_ms = 0`).  Each demote bumps `index_version`
+        // independently — same pattern as `hibernate_shards`'s
+        // per-letter `demote_letter_with_reason` calls.
+        if force {
+            self.auto_hibernate_for_forget(&snapshots).await;
+        }
+
+        // ── Phase 3: per-drive evict + clean ───────────────────────
+        let mut outcome = ForgetOutcome::default();
+        for &(letter, _) in &snapshots {
+            self.forget_one(letter, &mut outcome).await;
+        }
+        ForgetOutcomeOrBusy::Ok(outcome)
+    }
+
+    /// Auto-hibernate every non-`Cold` drive in `snapshots` to
+    /// `Cold` so the eviction phase below works against a stable
+    /// shard.  Caller must have already verified `force = true`.
+    ///
+    /// One write-lock acquisition per non-Cold drive (matches
+    /// `hibernate_shards`'s per-letter rebuild pattern).  Pins are
+    /// cleared implicitly — the rebuilt `ShardEntry` starts at
+    /// `pin_until_ms = 0`.
+    async fn auto_hibernate_for_forget(&self, snapshots: &[(char, Option<ShardState>)]) {
+        for &(drive, state_opt) in snapshots {
+            let Some(state) = state_opt else {
+                continue;
+            };
+            if state == ShardState::Cold {
+                continue;
+            }
+            let mut guard = self.index.write().await;
+            let Some(new_registry) = guard.demote_letter_with_reason(
+                drive,
+                ShardState::Cold,
+                DemoteReason::OperatorHibernate,
+            ) else {
+                // Race: shard moved to Cold or vanished between
+                // detect and write-lock.  Either way, the eviction
+                // phase below will pick up where we left off.
+                continue;
+            };
+            *guard = Arc::new(new_registry);
+            drop(guard);
+            self.bump_index_version();
+        }
+    }
+
+    /// Single-drive evict + clean step.
+    ///
+    /// Removes the shard from the registry (no-op if it wasn't
+    /// loaded) and unlinks every on-disk cache artefact via the
+    /// injected [`crate::cache::cache_cleaner::CacheCleaner`].
+    /// Classifies the result into [`ForgetOutcome::forgotten`] /
+    /// [`ForgetOutcome::already_absent`] / [`ForgetOutcome::errors`]
+    /// per the rules documented on [`ForgetOutcome`] above.
+    async fn forget_one(&self, letter: char, outcome: &mut ForgetOutcome) {
+        // Step 1: evict from registry (idempotent — `remove` is a
+        // no-op when the letter isn't present).
+        let mut guard = self.index.write().await;
+        let new_registry = guard.remove(letter);
+        *guard = Arc::new(new_registry);
+        drop(guard);
+        self.bump_index_version();
+
+        // Step 2: unlink on-disk cache files (idempotent — missing
+        // files are silent no-ops in the platform cleaner).
+        let (freed, errors) = self.cache_cleaner.forget(letter);
+
+        // Step 3: classify.
+        outcome.freed_bytes = outcome.freed_bytes.saturating_add(freed);
+        for err in errors {
+            outcome.errors.push(format!("{letter}: {err}"));
+        }
+        if freed > 0 {
+            outcome.forgotten.push(letter);
+        } else {
+            // No bytes freed and no errors: idempotent no-op.  No
+            // bytes freed but errors present: the per-drive errors
+            // already capture the failure — don't double-report by
+            // adding the letter to `already_absent`.
+            //
+            // The wire contract is "every input drive lands in
+            // exactly one of forgotten/already_absent unless errors
+            // captured it"; the handler reads `errors` separately
+            // so the operator sees the failure.
+            let had_errors = outcome
+                .errors
+                .last()
+                .is_some_and(|err| err.starts_with(&format!("{letter}:")));
+            if !had_errors {
+                outcome.already_absent.push(letter);
+            }
+        }
+
+        // Tracing breadcrumb so operators grepping `forget` can
+        // correlate registry eviction with cache-file deletion.
+        // `unix_now_ms()` is sampled here only for the event
+        // timestamp; the orchestration above doesn't need a clock
+        // read.
+        tracing::info!(
+            target: "shard.transition",
+            drive = %letter,
+            freed_bytes = freed,
+            ts_ms = unix_now_ms(),
+            reason = "operator-forget",
+            "forget: drive evicted from registry and cache files unlinked",
+        );
+    }
+}

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -14,6 +14,7 @@ mod aggregation;
 mod constructors;
 mod dispatch;
 mod drives;
+pub(crate) mod forget_drive;
 mod hotload;
 mod info;
 mod journal;
@@ -23,6 +24,7 @@ mod projection;
 mod refresh;
 pub(crate) mod search;
 mod stats;
+mod status_drives;
 mod test_helpers;
 #[cfg(test)]
 mod tests;
@@ -233,6 +235,20 @@ pub(crate) struct IndexManager {
     /// `refresh_usn_for_warm_shards` global tick to
     /// [`Self::handle_journal_refresh`] (per-shard, threshold-driven).
     background_io: Arc<dyn crate::cache::background_io::BackgroundIoPriority>,
+    /// Per-drive cache-file cleanup hook (Phase 8-D `forget` RPC).
+    ///
+    /// Called from [`Self::forget_drive`] after the in-memory
+    /// shard has been evicted from the registry, to delete every
+    /// per-drive on-disk artefact (encrypted compact body, USN
+    /// cursor, MFT index, lock file).  Production wires
+    /// [`crate::cache::cache_cleaner::PlatformCacheCleaner`] which
+    /// resolves the canonical cache paths via
+    /// [`uffs_core::compact_cache`] / [`uffs_mft::cache`] and
+    /// unlinks each via [`std::fs::remove_file`]; tests inject
+    /// [`crate::cache::cache_cleaner::CountingCacheCleaner`] so
+    /// registry-eviction behaviour can be verified deterministically
+    /// without ever touching the host's cache directory.
+    cache_cleaner: Arc<dyn crate::cache::cache_cleaner::CacheCleaner>,
     /// Per-letter single-flight dedup for body loads — PR-e fix
     /// for the thundering-herd promote stampede observed on
     /// Windows v0.5.83 MCP-validation soak (see

--- a/crates/uffs-daemon/src/index/status_drives.rs
+++ b/crates/uffs-daemon/src/index/status_drives.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase 8-E — operator-facing per-drive tier + telemetry table.
+//!
+//! Sibling to [`super::drives`] (the legacy `drives` RPC, which
+//! returns a slimmer `DriveInfo` row used by the bare `status` CLI).
+//! `status_drives` widens the row to include pin state, query rate,
+//! resident-bytes, and promotion counters so operators can decide
+//! whether to `hibernate` / `preload` / `forget` a drive without
+//! cross-referencing tracing logs.
+//!
+//! Three sources contribute to each row:
+//!
+//! * [`crate::cache::shard::ShardEntry`] — tier (`shard.state()`), in-memory
+//!   body for the `resident_bytes` calculation, pin expiry
+//!   (`pin_until_ms_value`).
+//! * [`crate::cache::shard::DriveStats`] — query counters (`queries_total`),
+//!   EMA-decayed query rate (`decay_ema_qpm`), `last_query_at_ms`.
+//! * [`crate::cache::shard::ShardEntry::parked_body`] — bloom + trie
+//!   `size_bytes()` for `Parked` shards (which have no `body` but still hold
+//!   non-trivial RAM).
+//!
+//! The wire response is sorted by drive letter (case-insensitive
+//! ascending) so the CLI table is stable across daemon
+//! reconfigurations even when load order changes.
+
+use uffs_client::protocol::response::{DriveTierStatus, StatusDrivesResponse};
+
+use super::IndexManager;
+use crate::cache::shard::ShardEntry;
+use crate::cache::{ShardState, unix_now_ms};
+
+impl IndexManager {
+    /// Phase 8-E — build the per-drive tier + telemetry snapshot.
+    ///
+    /// Walks the registry under a single read-lock and builds one
+    /// [`DriveTierStatus`] row per shard.  The `now_ms` clock used
+    /// for the EMA decay is sampled once per call so every row in
+    /// the same response shares the same wall-clock anchor.
+    ///
+    /// The output is sorted by drive letter (ASCII ascending) so the
+    /// CLI table is stable across re-runs — load order is an
+    /// implementation detail of the boot-time loader, not something
+    /// operators want surfaced in their dashboards.
+    pub(crate) async fn status_drives(&self) -> StatusDrivesResponse {
+        let now_ms = unix_now_ms();
+        // Read-lock the registry and produce the rows inside the
+        // guard's lifetime, then `drop(guard)` before sorting so the
+        // lock is released as quickly as possible (mirrors the
+        // pattern used in [`super::drives::IndexManager::drives`]).
+        let mut drives: Vec<DriveTierStatus> = {
+            let guard = self.index.read().await;
+            let rows: Vec<DriveTierStatus> =
+                guard.iter().map(|shard| build_row(shard, now_ms)).collect();
+            drop(guard);
+            rows
+        };
+        drives.sort_by(|lhs, rhs| {
+            lhs.letter
+                .to_ascii_uppercase()
+                .cmp(&rhs.letter.to_ascii_uppercase())
+        });
+        StatusDrivesResponse { drives }
+    }
+}
+
+/// Build a single [`DriveTierStatus`] row for `shard`.
+///
+/// Pure read-only — never mutates the shard.  `now_ms` is the wall
+/// clock anchor for the EMA decay (passed in from the caller so
+/// every row in one `status_drives` response shares the same
+/// timestamp).
+fn build_row(shard: &ShardEntry, now_ms: u64) -> DriveTierStatus {
+    let state = shard.state();
+    let tier = shard_state_label(state).to_owned();
+    let resident_bytes = resident_bytes_for(shard, state);
+    let last_query_at_ms = shard.stats.last_query_at_ms();
+    let pin_until_unix_ms = shard.pin_until_ms_value();
+
+    // Decay the EMA against the response's anchor `now_ms`.  This
+    // mutates the per-shard counter (sliding-window decay is
+    // observation-driven), which is fine because we hold the
+    // registry's read lock — concurrent searches go through
+    // `mark_query_at` which uses the same `last_decay_ms` slot.
+    let query_rate_per_min = shard.stats.decay_ema_qpm(now_ms);
+
+    DriveTierStatus {
+        letter: shard.drive,
+        tier,
+        resident_bytes,
+        query_rate_per_min,
+        last_query_at_ms: i64_from_u64_saturating(last_query_at_ms),
+        // The wire format documents `promotions_total` as the
+        // cumulative Cold → Hot promotion count.  Today the daemon
+        // does not maintain a dedicated counter for this — Phase 9
+        // (`shard.transition` event aggregation) will plumb one
+        // through.  Surface `0` for now so the field round-trips
+        // cleanly without lying about activity.
+        promotions_total: 0,
+        pin_until_unix_ms: i64_from_u64_saturating(pin_until_unix_ms),
+    }
+}
+
+/// Convert a `u64` Unix-millis to the wire format's `i64` shape,
+/// saturating at [`i64::MAX`] for any value that would overflow.
+///
+/// In practice the registry's timestamps are monotonically derived
+/// from [`std::time::SystemTime::duration_since`] and stay well
+/// under [`i64::MAX`] (year 292 277 026 596 AD), so the saturating
+/// branch is unreachable in production — but `try_from` is more
+/// honest than a `as` truncation cast.
+fn i64_from_u64_saturating(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+/// Compute `resident_bytes` for a shard given its tier.
+///
+/// * `Hot` / `Warm` → `body.heap_size_bytes().total` (the in-memory
+///   `DriveCompactIndex` footprint — what an OOM trace would attribute to this
+///   drive).
+/// * `Parked` → `parked_body.size_bytes()` (the bloom + path trie we kept
+///   across the demote so the search hot path can still answer "this drive
+///   doesn't have anything matching" without a re-promote).
+/// * `Cold` / `Unknown` / `Evicting` → `0` (the encrypted compact cache lives
+///   on disk only).
+fn resident_bytes_for(shard: &ShardEntry, state: ShardState) -> u64 {
+    match state {
+        ShardState::Hot | ShardState::Warm => shard.body().map_or(0, |body| {
+            u64::try_from(body.heap_size_bytes().total).unwrap_or(u64::MAX)
+        }),
+        ShardState::Parked => shard
+            .parked_body()
+            .map_or(0, |pb| u64::try_from(pb.size_bytes()).unwrap_or(u64::MAX)),
+        ShardState::Cold | ShardState::Unknown | ShardState::Evicting => 0,
+    }
+}
+
+/// Lowercase tier label matching
+/// [`uffs_client::protocol::response::ShardTier`]'s wire form.
+///
+/// The wire format documents lowercase strings (matching `serde`
+/// rename-all = "lowercase") so the CLI can match on `"hot"` /
+/// `"warm"` / etc. without colour-coding sprinkled through the
+/// daemon side.
+const fn shard_state_label(state: ShardState) -> &'static str {
+    match state {
+        ShardState::Unknown => "unknown",
+        ShardState::Cold => "cold",
+        ShardState::Parked => "parked",
+        ShardState::Warm => "warm",
+        ShardState::Hot => "hot",
+        ShardState::Evicting => "evicting",
+    }
+}

--- a/crates/uffs-daemon/src/index/tests/forget_status.rs
+++ b/crates/uffs-daemon/src/index/tests/forget_status.rs
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Operator-driven `forget` (Phase 8-D) and `status_drives`
+//! (Phase 8-E) tests for [`super::IndexManager`].
+//!
+//! `forget` tests pin the eviction guard (busy-without-force vs.
+//! force-auto-hibernate), the registry-eviction step, the
+//! cache-cleaner side effect (verified via the
+//! [`crate::cache::cache_cleaner::CountingCacheCleaner`] fake), and
+//! the per-drive classification (`forgotten` vs. `already_absent`).
+//!
+//! `status_drives` tests pin the per-drive row builder: tier
+//! mapping, resident-bytes calculation across the
+//! Hot/Warm/Parked/Cold ladder, pin-expiry surfacing, and the
+//! deterministic ascending sort.
+//!
+//! Every test uses [`super::IndexManager::with_lifecycle_hooks_for_test`]
+//! to inject a [`CountingCacheCleaner`] (and a [`FixedBodyLoader`]
+//! for the preload-then-forget sequences) so the host's real cache
+//! directory is **never** touched — a "forget drive C" call against
+//! the platform paths would be catastrophic in CI.
+
+#![expect(
+    clippy::std_instead_of_alloc,
+    reason = "test fixtures — `std::sync::Arc` matches the rest of the daemon's \
+              test fixtures, no need to switch to `alloc::sync::Arc` for tests"
+)]
+
+use std::sync::Arc;
+
+use super::{FixedBodyLoader, build_test_drive, build_test_drive_d, build_test_drive_e};
+use crate::cache::ShardState;
+use crate::cache::cache_cleaner::CountingCacheCleaner;
+use crate::index::IndexManager;
+use crate::index::constructors::LifecycleHooks;
+use crate::index::forget_drive::ForgetOutcomeOrBusy;
+
+/// Build an `IndexManager` with the supplied `cache_cleaner` and
+/// (optional) `body_loader` injected, threading
+/// [`LifecycleHooks::production`] for every other hook.
+///
+/// Centralised so the per-test boilerplate stays focused on the
+/// behaviour under test rather than the hook bundle assembly.
+fn make_manager(
+    cleaner: Arc<CountingCacheCleaner>,
+    body_loader: Option<Arc<dyn crate::cache::body_loader::BodyLoader>>,
+) -> IndexManager {
+    let (tx, _rx) = crate::events::event_channel();
+    let mut hooks = LifecycleHooks::production();
+    hooks.cache_cleaner = cleaner as Arc<dyn crate::cache::cache_cleaner::CacheCleaner>;
+    if let Some(loader) = body_loader {
+        hooks.body_loader = loader;
+    }
+    IndexManager::with_lifecycle_hooks_for_test(
+        None,
+        tx,
+        hooks,
+        Arc::new(crate::config::Config::default()),
+    )
+}
+
+// ── 8-D forget ──────────────────────────────────────────────────────
+
+/// Phase 8-D — forgetting a `Cold` drive evicts it from the registry,
+/// invokes the cache cleaner, and reports `forgotten` with the freed
+/// byte count.
+#[tokio::test]
+async fn forget_cold_drive_evicts_and_unlinks() {
+    let cleaner = Arc::new(CountingCacheCleaner::new(1_024));
+    let mgr = make_manager(Arc::clone(&cleaner), None);
+    mgr.add_drive(build_test_drive()).await;
+    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+
+    let outcome = mgr.forget_drives(&['C'], false).await;
+
+    let ForgetOutcomeOrBusy::Ok(out) = outcome else {
+        panic!("expected Ok outcome on Cold-drive forget; got {outcome:?}");
+    };
+    assert_eq!(out.forgotten, vec!['C']);
+    assert!(out.already_absent.is_empty());
+    assert_eq!(out.freed_bytes, 1_024);
+    assert!(out.errors.is_empty());
+
+    assert_eq!(
+        cleaner.calls(),
+        vec!['C'],
+        "cache cleaner must have been invoked exactly once for C"
+    );
+    let states = mgr.shard_states_for_test().await;
+    assert!(
+        states.is_empty(),
+        "registry must be empty after forget; got {states:?}"
+    );
+}
+
+/// Phase 8-D — forgetting a non-`Cold` drive without `force = true`
+/// is a top-level refusal that lists the busy drive's tier and
+/// leaves the registry untouched.
+#[tokio::test]
+async fn forget_warm_without_force_refuses_with_busy_listing() {
+    let cleaner = Arc::new(CountingCacheCleaner::new(0));
+    let mgr = make_manager(Arc::clone(&cleaner), None);
+    mgr.add_drive(build_test_drive()).await; // C lands in Warm.
+
+    let outcome = mgr.forget_drives(&['C'], false).await;
+
+    let ForgetOutcomeOrBusy::Busy(busy) = outcome else {
+        panic!("expected Busy refusal for Warm drive without force; got {outcome:?}");
+    };
+    assert_eq!(busy, vec![('C', ShardState::Warm)]);
+    assert!(
+        cleaner.calls().is_empty(),
+        "cache cleaner must NOT have been invoked on the refused path"
+    );
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states,
+        vec![('C', ShardState::Warm)],
+        "registry must be untouched on refusal"
+    );
+}
+
+/// Phase 8-D — `force = true` auto-hibernates non-`Cold` drives
+/// before evicting + cleaning, and the cache cleaner is invoked
+/// exactly once per requested drive.
+#[tokio::test]
+async fn forget_warm_with_force_auto_hibernates_then_evicts() {
+    let cleaner = Arc::new(CountingCacheCleaner::new(2_048));
+    let mgr = make_manager(Arc::clone(&cleaner), None);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+
+    let outcome = mgr.forget_drives(&['C', 'D'], true).await;
+
+    let ForgetOutcomeOrBusy::Ok(out) = outcome else {
+        panic!("expected Ok outcome with force; got {outcome:?}");
+    };
+    assert_eq!(out.forgotten, vec!['C', 'D']);
+    assert_eq!(out.freed_bytes, 4_096, "2 drives × 2_048 bytes each");
+    assert!(out.already_absent.is_empty());
+    assert!(out.errors.is_empty());
+
+    assert_eq!(
+        cleaner.calls(),
+        vec!['C', 'D'],
+        "cache cleaner invoked once per drive in input order"
+    );
+    let states = mgr.shard_states_for_test().await;
+    assert!(states.is_empty(), "registry must be empty");
+}
+
+/// Phase 8-D — forgetting an unknown drive is idempotent: the
+/// cache cleaner runs (so any stale on-disk file from a previous
+/// daemon instance gets cleaned up), and the drive lands in
+/// `already_absent` when the cleaner reports zero freed bytes.
+#[tokio::test]
+async fn forget_unknown_drive_is_idempotent_already_absent() {
+    let cleaner = Arc::new(CountingCacheCleaner::new(0));
+    let mgr = make_manager(Arc::clone(&cleaner), None);
+    mgr.add_drive(build_test_drive()).await; // C only.
+
+    let outcome = mgr.forget_drives(&['Z'], false).await;
+
+    let ForgetOutcomeOrBusy::Ok(out) = outcome else {
+        panic!("expected Ok for unknown drive; got {outcome:?}");
+    };
+    assert!(out.forgotten.is_empty());
+    assert_eq!(out.already_absent, vec!['Z']);
+    assert_eq!(out.freed_bytes, 0);
+    assert!(out.errors.is_empty());
+
+    assert_eq!(
+        cleaner.calls(),
+        vec!['Z'],
+        "cleaner still runs for unknown drives so stale on-disk files are purged"
+    );
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(
+        states,
+        vec![('C', ShardState::Warm)],
+        "C must remain Warm — the unknown-drive forget call must not touch other drives"
+    );
+}
+
+/// Phase 8-D — forgetting a `Hot`-pinned drive with `force = true`
+/// clears the pin (via the registry rebuild) and proceeds to
+/// evict + clean.  The pin is implicitly cleared because
+/// `demote_letter_with_reason` rebuilds the shard with a fresh
+/// `ShardEntry` whose `pin_until_ms` starts at `0`.
+#[tokio::test]
+async fn forget_pinned_hot_drive_with_force_clears_pin() {
+    use crate::index::tiering_ops::PreloadOutcome;
+
+    let cleaner = Arc::new(CountingCacheCleaner::new(512));
+    let body = Arc::new(build_test_drive());
+    let loader = Arc::new(FixedBodyLoader {
+        body: Arc::clone(&body),
+    });
+    let mgr = make_manager(
+        Arc::clone(&cleaner),
+        Some(loader as Arc<dyn crate::cache::body_loader::BodyLoader>),
+    );
+    mgr.add_drive(build_test_drive()).await;
+    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+
+    // Preload C → Hot + pin.
+    let preload = mgr.preload_drive('C', 30).await;
+    assert!(matches!(preload, PreloadOutcome::Promoted { .. }));
+
+    // Pre-condition assertion: C is Hot and pinned.
+    let pre_states = mgr.shard_states_for_test().await;
+    assert_eq!(pre_states, vec![('C', ShardState::Hot)]);
+
+    // Force-forget must succeed despite the pin.
+    let outcome = mgr.forget_drives(&['C'], true).await;
+    let ForgetOutcomeOrBusy::Ok(out) = outcome else {
+        panic!("expected Ok with force; got {outcome:?}");
+    };
+    assert_eq!(out.forgotten, vec!['C']);
+    assert_eq!(out.freed_bytes, 512);
+
+    let post_states = mgr.shard_states_for_test().await;
+    assert!(post_states.is_empty());
+}
+
+/// Phase 8-D — multi-drive forget where one drive is busy and
+/// `force` is `false` refuses the entire request (all-or-nothing).
+/// The non-busy drives stay loaded; the cleaner is never invoked.
+#[tokio::test]
+async fn forget_mixed_request_refuses_when_any_drive_busy_without_force() {
+    let cleaner = Arc::new(CountingCacheCleaner::new(0));
+    let mgr = make_manager(Arc::clone(&cleaner), None);
+    mgr.add_drive(build_test_drive()).await; // C: Warm
+    mgr.add_drive(build_test_drive_d()).await; // D: Warm
+    assert!(mgr.demote_letter_for_test('D', ShardState::Cold).await);
+    // Now: C is Warm, D is Cold.
+
+    let outcome = mgr.forget_drives(&['C', 'D'], false).await;
+
+    let ForgetOutcomeOrBusy::Busy(busy) = outcome else {
+        panic!("expected all-or-nothing Busy refusal; got {outcome:?}");
+    };
+    assert_eq!(
+        busy,
+        vec![('C', ShardState::Warm)],
+        "only C should be reported as busy; D is Cold and would be safe"
+    );
+    assert!(
+        cleaner.calls().is_empty(),
+        "cleaner must NOT have run on the refused path"
+    );
+
+    // Both shards must still be present.
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(states, vec![
+        ('C', ShardState::Warm),
+        ('D', ShardState::Cold)
+    ]);
+}
+
+// ── 8-E status_drives ───────────────────────────────────────────────
+
+/// Phase 8-E — empty registry produces an empty `drives` vector.
+/// Mirrors the "no drives loaded" CLI hint.
+#[tokio::test]
+async fn status_drives_empty_registry_returns_empty_drives() {
+    let cleaner = Arc::new(CountingCacheCleaner::new(0));
+    let mgr = make_manager(cleaner, None);
+
+    let response = mgr.status_drives().await;
+
+    assert!(response.drives.is_empty());
+}
+
+/// Phase 8-E — a single Warm shard surfaces `tier = "warm"`,
+/// `resident_bytes > 0` (the body's heap footprint), and zero
+/// values for never-queried + never-pinned counters.
+#[tokio::test]
+async fn status_drives_single_warm_shard_full_snapshot() {
+    let cleaner = Arc::new(CountingCacheCleaner::new(0));
+    let mgr = make_manager(cleaner, None);
+    mgr.add_drive(build_test_drive()).await;
+
+    let response = mgr.status_drives().await;
+
+    let [row] = response.drives.as_slice() else {
+        panic!(
+            "expected exactly 1 drive in status_drives response; got {}",
+            response.drives.len()
+        );
+    };
+    assert_eq!(row.letter, 'C');
+    assert_eq!(row.tier, "warm");
+    assert!(
+        row.resident_bytes > 0,
+        "Warm shard must report nonzero resident_bytes (body heap footprint); got {}",
+        row.resident_bytes
+    );
+    assert_eq!(row.pin_until_unix_ms, 0, "no preload ⇒ no pin");
+    assert_eq!(row.promotions_total, 0, "Phase 9 placeholder, always 0");
+    assert!(
+        row.last_query_at_ms > 0,
+        "add_drive seeds last_query_at_ms via mark_loaded_at; got {}",
+        row.last_query_at_ms
+    );
+}
+
+/// Phase 8-E — mixed-tier registry produces one row per shard, with
+/// per-tier `resident_bytes` reflecting the source: Warm reads
+/// `body.heap_size_bytes().total`, Cold reads `0`.
+#[tokio::test]
+async fn status_drives_mixed_tier_distribution_one_row_per_shard() {
+    let cleaner = Arc::new(CountingCacheCleaner::new(0));
+    let mgr = make_manager(cleaner, None);
+    mgr.add_drive(build_test_drive()).await;
+    mgr.add_drive(build_test_drive_d()).await;
+    mgr.add_drive(build_test_drive_e()).await;
+
+    // C stays Warm; D demotes to Parked; E demotes to Cold.
+    assert!(mgr.demote_letter_for_test('D', ShardState::Parked).await);
+    assert!(mgr.demote_letter_for_test('E', ShardState::Cold).await);
+
+    let response = mgr.status_drives().await;
+
+    let [c_row, d_row, e_row] = response.drives.as_slice() else {
+        panic!(
+            "expected exactly 3 drives in status_drives response; got {}",
+            response.drives.len()
+        );
+    };
+
+    // Sorted ascending by letter.
+    assert_eq!(c_row.letter, 'C');
+    assert_eq!(c_row.tier, "warm");
+    assert!(
+        c_row.resident_bytes > 0,
+        "Warm shard reports nonzero resident_bytes (body heap)"
+    );
+
+    assert_eq!(d_row.letter, 'D');
+    assert_eq!(d_row.tier, "parked");
+    // Parked shards report parked_body.size_bytes() (bloom + trie).
+    // The tiny synthetic test fixture builds a non-empty trie + bloom,
+    // so resident_bytes should be > 0.
+    assert!(
+        d_row.resident_bytes > 0,
+        "Parked shard reports nonzero resident_bytes (bloom + trie); got {}",
+        d_row.resident_bytes
+    );
+
+    assert_eq!(e_row.letter, 'E');
+    assert_eq!(e_row.tier, "cold");
+    assert_eq!(
+        e_row.resident_bytes, 0,
+        "Cold shard reports zero resident_bytes (encrypted cache only on disk)"
+    );
+}
+
+/// Phase 8-E — preloaded (Hot + pinned) drive surfaces both
+/// `tier = "hot"` and `pin_until_unix_ms > 0`, so the CLI's pin
+/// column has a non-empty value to render.
+#[tokio::test]
+async fn status_drives_preloaded_hot_drive_surfaces_pin_expiry() {
+    use crate::index::tiering_ops::PreloadOutcome;
+
+    let cleaner = Arc::new(CountingCacheCleaner::new(0));
+    let body = Arc::new(build_test_drive());
+    let loader = Arc::new(FixedBodyLoader {
+        body: Arc::clone(&body),
+    });
+    let mgr = make_manager(
+        cleaner,
+        Some(loader as Arc<dyn crate::cache::body_loader::BodyLoader>),
+    );
+    mgr.add_drive(build_test_drive()).await;
+    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+
+    let preload = mgr.preload_drive('C', 30).await;
+    assert!(matches!(preload, PreloadOutcome::Promoted { .. }));
+
+    let response = mgr.status_drives().await;
+
+    let [row] = response.drives.as_slice() else {
+        panic!(
+            "expected exactly 1 drive in status_drives response; got {}",
+            response.drives.len()
+        );
+    };
+    assert_eq!(row.tier, "hot");
+    assert!(
+        row.pin_until_unix_ms > 0,
+        "preloaded shard must surface pin_until_unix_ms > 0; got {}",
+        row.pin_until_unix_ms
+    );
+}
+
+/// Phase 8-E — output is sorted by drive letter (ASCII ascending),
+/// even when shards were loaded in a different order.  Stable order
+/// across re-runs is part of the operator-facing contract.
+#[tokio::test]
+async fn status_drives_sorts_rows_by_letter_ascending() {
+    let cleaner = Arc::new(CountingCacheCleaner::new(0));
+    let mgr = make_manager(cleaner, None);
+
+    // Load in a deliberately scrambled order.
+    mgr.add_drive(build_test_drive_e()).await; // 'E' first
+    mgr.add_drive(build_test_drive()).await; // 'C' second
+    mgr.add_drive(build_test_drive_d()).await; // 'D' third
+
+    let response = mgr.status_drives().await;
+
+    let letters: Vec<char> = response.drives.iter().map(|drive| drive.letter).collect();
+    assert_eq!(
+        letters,
+        vec!['C', 'D', 'E'],
+        "rows must be sorted by drive letter ascending regardless of load order"
+    );
+}

--- a/crates/uffs-daemon/src/index/tests/mod.rs
+++ b/crates/uffs-daemon/src/index/tests/mod.rs
@@ -46,6 +46,7 @@ mod aggregate;
 mod aggregate_drilldown;
 mod body_loader_fakes;
 mod ensure_warm;
+mod forget_status;
 mod idle_demote;
 mod lifecycle_hooks;
 mod manager;


### PR DESCRIPTION
## Summary

Bundled implementation of the two remaining operator-driven memory-tiering commands. Adds the **`CacheCleaner` lifecycle hook**, implements **`forget`** (registry eviction + on-disk cache cleanup) and **`status_drives`** (per-drive tier + telemetry snapshot), and ships the CLI commands plus end-to-end tests.

**Closes Phase 8** of the memory-tiering implementation plan (sub-phases 8-A through 8-E).

| Sub-phase | Closes plan task | LOC |
|---|---|---|
| 8-D `forget` | 8.3 (full) | ~600 |
| 8-E `status_drives` | 8.4 (full) | ~400 |
| **Total** | **8.3 + 8.4** | **~1000** |

## Daemon primitives

- **NEW** `@/Users/.../uffs-daemon/src/cache/cache_cleaner.rs` (269 LOC) — `CacheCleaner` trait + `PlatformCacheCleaner` resolves the four canonical per-drive cache paths (`_compact.uffs`, `_usn.cursor`, `_index.uffs`, `_index.lock`) via `uffs_core`/`uffs_mft` and unlinks each. `delete_drive_cache_files` helper unit-tested directly with a `tempfile::TempDir` so the integration path **never touches** the host's real cache directory. `CountingCacheCleaner` test fake records the call sequence.
- **`@/Users/.../uffs-daemon/src/cache/shard.rs`** — `pin_until_ms_value` accessor on `ShardEntry` surfaces the raw pin-expiry timestamp for the `status_drives` wire output.
- **`@/Users/.../uffs-daemon/src/cache/registry.rs`** — drop `dead_code` expectation on `remove()` now that `forget_drives` consumes it in production.
- **`@/Users/.../uffs-daemon/src/index/constructors.rs`** — wire `CacheCleaner` into `LifecycleHooks` (struct field, `production()` default, destructure pattern, `IndexManager` init).

## Operator-driven IndexManager methods

- **NEW** `@/Users/.../uffs-daemon/src/index/forget_drive.rs` (257 LOC) — three-phase orchestration:
  1. **Read-lock detect.** Enumerate `(letter, current_tier)` for every requested drive; if `force=false` and any drive is non-`Cold`, return `ForgetOutcomeOrBusy::Busy(...)` so the handler surfaces `ERR_DRIVE_BUSY` **all-or-nothing**.
  2. **Optional auto-hibernate.** `force=true` demotes every non-`Cold` drive to `Cold` via `demote_letter_with_reason(Cold, OperatorHibernate)`, clearing pins implicitly via the registry rebuild.
  3. **Per-drive evict + clean.** `registry.remove(letter)` then `cache_cleaner.forget(letter)`. `freed_bytes>0` ⇒ `forgotten`; `freed_bytes==0` with no errors ⇒ `already_absent`. Unknown drives still flow through the cleaner (idempotent stale-cache purge).
- **NEW** `@/Users/.../uffs-daemon/src/index/status_drives.rs` (155 LOC) — walks the registry under one read-lock, builds `DriveTierStatus` rows, sorts ascending by drive letter (case-insensitive). `resident_bytes` per tier: Hot/Warm reads `body.heap_size_bytes().total`; Parked reads `parked_body.size_bytes()` (bloom + trie); Cold/Unknown/Evicting → `0`.

## Wire-format handlers

**`@/Users/.../uffs-daemon/src/handler.rs`** — replaces 8-A `NotImplemented` stubs:

- `handle_forget` parses `ForgetParams`, rejects empty drives with `ERR_INVALID_PARAMS`, maps the Busy refusal to `ERR_DRIVE_BUSY` with a listing of the busy drives in the message.
- `handle_status_drives` is parameter-free.
- Removes the now-unused `not_implemented_response` helper and `ERR_NOT_IMPLEMENTED` import.

## CLI surface

- **`@/Users/.../uffs-cli/src/args.rs`** — `Forget` and `StatusDrives` variants on `DaemonAction`; `parse_daemon_forget` helper; status_drives accepts both `status_drives` and `status-drives` tokens; updated `DAEMON_HELP`.
- **`@/Users/.../uffs-cli/src/commands/daemon_tiering.rs`** — `daemon_forget` + `daemon_status_drives` shims, `format_bytes` helper using **pure integer arithmetic** (no floats) so `clippy::float_arithmetic` stays satisfied.
- **`@/Users/.../uffs-cli/src/commands/daemon_mgmt.rs`** — `daemon_tiering` alias keeps the dispatcher arms inside the 800-LOC ceiling.
- **`@/Users/.../uffs-client/src/connect_sync_tiering.rs`** — typed `forget()` and `status_drives()` helpers on `UffsClientSync`.

## Tests (11 integration + 4 unit, 419 + 80 LOC)

**NEW** `@/Users/.../uffs-daemon/src/index/tests/forget_status.rs`:

| Test | What it pins |
|---|---|
| `forget_cold_drive_evicts_and_unlinks` | happy path: registry eviction + cache cleanup + freed bytes |
| `forget_warm_without_force_refuses_with_busy_listing` | top-level `ERR_DRIVE_BUSY` refusal; cleaner not invoked; registry untouched |
| `forget_warm_with_force_auto_hibernates_then_evicts` | force=true ⇒ auto-hibernate before evict; cleaner invoked once per drive |
| `forget_unknown_drive_is_idempotent_already_absent` | unknown drive ⇒ cleaner runs (purge stale on-disk); lands in `already_absent` |
| `forget_pinned_hot_drive_with_force_clears_pin` | force=true clears pin via registry rebuild; evict + clean succeed |
| `forget_mixed_request_refuses_when_any_drive_busy_without_force` | all-or-nothing: 1 busy drive in 2-drive request ⇒ entire call refused, both drives untouched |
| `status_drives_empty_registry_returns_empty_drives` | empty drives vector |
| `status_drives_single_warm_shard_full_snapshot` | tier=warm, resident_bytes>0, last_query_at_ms>0 |
| `status_drives_mixed_tier_distribution_one_row_per_shard` | Warm/Parked/Cold all surfaced; per-tier resident_bytes correct |
| `status_drives_preloaded_hot_drive_surfaces_pin_expiry` | pin_until_unix_ms>0 after preload |
| `status_drives_sorts_rows_by_letter_ascending` | scrambled load order ⇒ sorted output |

Plus **4 unit tests** in `@/Users/.../uffs-daemon/src/cache/cache_cleaner.rs` covering `delete_drive_cache_files` directly with a `tempfile::TempDir` (missing-files, freed-bytes-sum, non-file-skipped, format_path_error).

## Lint posture

- **Zero new clippy expectations.**
- **Zero new file-size exceptions.** `daemon_mgmt.rs` hits exactly 800 LOC via the `daemon_tiering` alias compression.
- **Slice-destructuring** (`let [c_row, d_row, e_row] = ... else panic!()`) used for assertion scaffolding instead of indexing+`#[expect(clippy::indexing_slicing)]` — stronger panic messages on shape mismatch.
- `format_bytes` uses pure integer math (`(bytes % GIB) * 100 / GIB`) for the `.2` GiB rendering — no `clippy::float_arithmetic` or `cast_precision_loss` expects needed.

## Verification

```
✅ [1] fmt          ✅ [1] file-size      ✅ [1] commit-subjects
✅ [1] typos        ✅ [1] reuse          ✅ [2] cargo-check (3s)
✅ [2] lint-ci (8s) ✅ [2] lint-prod (7s) ✅ [2] lint-tests (7s)
✅ [2] rustdoc (7s) ✅ [2] doc-tests (15s) ✅ [2] tests (3s)
✅ [2] smoke (8s)   ✅ [2] check-windows (6s)
```

`cargo nextest run --workspace`: **1625 passed, 14 skipped, 0 failed**.

## Plan reference

Closes plan tasks **8.3** (forget) and **8.4** (status_drives). Together with PR #122 (8-B + 8-C), this completes **Phase 8** of the memory-tiering implementation plan.

Refs: `docs/refactor/memory-tiering-implementation-plan.md` sub-phases 8-D and 8-E.