### PR TITLE
chore(ci): unbreak Dependabot PR pipeline (title prefix + advisory crash)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,15 @@ updates:
     labels:
       - "dependencies"
       - "rust"
+    # Use `chore` so the generated PR title (`chore(deps): bump foo …`)
+    # passes `.github/workflows/commitlint.yml`'s Conventional Commits
+    # allowlist (`feat|fix|perf|refactor|docs|test|build|ci|chore|style|
+    # revert`).  `deps` would be rejected — the previous setting was the
+    # root cause of the 2026-05 Dependabot pipeline stall (see PR #125).
+    # `chore(deps): …` is also the default Dependabot upstream uses and
+    # the most common convention in OSS Rust crates.
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     # Group minor/patch updates to reduce PR noise
     groups:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -213,8 +213,20 @@ jobs:
             gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_ID}" \
               -f body="${BODY}" >/dev/null
           else
+            # Pass --repo explicitly so `gh` does not try to infer the
+            # repo slug from the working directory's git remote — this
+            # job runs without an `actions/checkout` step, so a remote-
+            # less invocation crashes with `fatal: not a git repository`
+            # and the script's `set -euo pipefail` propagates the
+            # failure, defeating the advisory-mode `exit 0` below.
+            # (Discovered while diagnosing the stalled Dependabot tokio
+            # PR #125 — the workflow was supposed to be advisory but
+            # this single bug turned every non-conforming title into a
+            # red required-check.)
             echo "::notice::Posting new advisory comment"
-            gh pr comment "${PR_NUMBER}" --body "${BODY}"
+            gh pr comment "${PR_NUMBER}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --body "${BODY}"
           fi
 
           # ADVISORY MODE: exit 0 even on non-conformance.


### PR DESCRIPTION
## Summary

Two surgical fixes that unblock the Dependabot auto-merge happy-path, surfaced while diagnosing the stalled tokio bump PR #125.

## Root causes (from PR #125 logs)

1. **Title prefix `deps(deps):` is not in the CC allowlist.**

   `@/Users/.../.github/workflows/commitlint.yml:124` only accepts:

       feat|fix|perf|refactor|docs|test|build|ci|chore|style|revert

   But `@/Users/.../.github/dependabot.yml` set the cargo-ecosystem prefix to `deps`, producing titles like `deps(deps): bump tokio …` that the allowlist rejects.  The github-actions ecosystem block already used `ci` (valid), so it stays untouched.

2. **Advisory step crashes without an `actions/checkout`.**

   The non-conforming branch of the script calls `gh pr comment "${PR_NUMBER}"` without `--repo`, expecting `gh` to infer the repo slug from the working directory's git remote.  But the job runs without `actions/checkout`, so `gh` errors out:

       failed to run git: fatal: not a git repository (or any of the parent directories): .git

   Bash's `set -euo pipefail` then propagated the failure past the script's documented `exit 0` advisory-mode escape hatch — turning every non-conforming title into a red **required** check rather than the documented advisory warning.

## Fixes

| File | Change |
|---|---|
| `@/Users/.../.github/dependabot.yml` | cargo-ecosystem `prefix: "deps"` → `prefix: "chore"` so generated titles read `chore(deps): bump foo …` (matches the upstream Dependabot default and the common OSS Rust convention). |
| `@/Users/.../.github/workflows/commitlint.yml` | Pass `--repo "${GITHUB_REPOSITORY}"` to `gh pr comment` so the advisory step works in a checkout-less workflow.  In-line comment captures the bug history. |

## What this does NOT fix

PR #125 also fails `cargo vet check --locked` (`tokio:1.52.2 missing ["safe-to-deploy"]`) — that's a pre-existing, orthogonal limitation: `@/Users/.../.github/workflows/cargo-vet-refresh.yml` runs **weekly** on Mondays, and any in-flight Dependabot bump between refreshes needs a manual `cargo vet regenerate imports` push.  I'll handle PR #125's vet refresh in a separate commit on its branch.

## Verification

- `just lint-fast`: ✅ green
- `just lint-pre-push` (14 gates): ✅ all green
- Manual review of advisory-mode escape hatch: `exit 0` is now reachable after the `gh pr comment` call regardless of whether a git remote is configured.

## Future-proofing

Comments in both edited files explicitly tie the changes to the PR #125 incident so a future maintainer reading them understands the constraint and won't accidentally regress.

Refs: PR #125 stall analysis · plan task R1a (commitlint advisory mode).