### PR TITLE
chore: release v0.5.90 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,7 @@ for the operator-facing validation flow.
   into a red required check rather than the documented advisory
   warning.
 
-## [0.5.89] - 2026-04-25
+## [0.5.90] - 2026-04-25
 
 ### Fixed
 - **macOS arm64 release binaries SIGKILLed at launch** under macOS 26+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "clap",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "chrono",
  "itoa",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "axum",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4539,14 +4539,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4561,14 +4561,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.89"
+version = "0.5.90"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.89"
+version = "0.5.90"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -30,7 +30,7 @@
 # CI pipeline will auto-refresh on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed — use that flag (or plain `just ship`) while the upstream regression
 # persists.
-channel = "nightly-2026-05-03"
+channel = "nightly-2026-05-05"
 
 # Specify components that should always be available
 components = [


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.90**.  Binaries + GitHub Release v0.5.90 are already live (step 09).  This PR routes the corresponding commit through branch-protection rules.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

Local `main` had this commit with a different SHA before squash rewrote it onto main; recover with `git fetch origin && git reset --hard origin/main`.