### PR TITLE
docs(memory-tiering): capture v0.6.0 readiness + bake-period exit criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,7 @@ for the operator-facing validation flow.
   into a red required check rather than the documented advisory
   warning.
 
-## [0.5.89] - 2026-04-25
+## [0.5.90] - 2026-04-25
 
 ### Fixed
 - **macOS arm64 release binaries SIGKILLed at launch** under macOS 26+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "clap",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "chrono",
  "itoa",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "axum",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4539,14 +4539,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4561,14 +4561,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.89"
+version = "0.5.90"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.89"
+version = "0.5.90"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires

--- a/docs/architecture/memory-tiering-bake-criteria.md
+++ b/docs/architecture/memory-tiering-bake-criteria.md
@@ -1,0 +1,236 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- Copyright (c) 2025-2026 SKY, LLC. -->
+
+# Memory-tiering v0.6.0 bake-period exit criteria
+
+**Audience:** the implementer maintaining `main` during the bake period
+between dual-platform readiness validation
+([`memory-tiering-readiness-validation-2026-05-05.md`](memory-tiering-readiness-validation-2026-05-05.md))
+and the v0.6.0 release cut.
+
+**Reference:**
+[`memory-tiering-implementation-plan.md`](../refactor/memory-tiering-implementation-plan.md)
+§6.2 — *"Per epic (v0.6.0 release): topic branch baked one week with no
+regressions."*
+
+This file makes "baked one week with no regressions" **operationally
+concrete** so the v0.6.0 cut decision is a checklist, not a judgment
+call.
+
+---
+
+## 0. What "bake" means
+
+The bake period is **observational, not active**.  No new operator-surface
+features land on `main` until v0.6.0 ships.  The implementer:
+
+1. Runs the dual-platform readiness pass once per day on a representative
+   workload.
+2. Watches the daemon's tracing logs for unexpected events.
+3. Records each day's result in the bake log (§4 below).
+4. Triggers the v0.6.0 cut iff §3 exit criteria are met.
+
+What **is** allowed to land on `main` during the bake:
+
+- Pure documentation changes.
+- Recipe / tooling improvements that do **not** change daemon behavior
+  (e.g., the `just use` resilience improvement is fine; a tracing-format
+  change is **not**).
+- Bug fixes for regressions surfaced during the bake — but the regression
+  must be characterized first (§2 failure protocol) and the fix must be
+  reviewed under PR-fast.
+
+What is **not** allowed:
+
+- New operator-surface RPCs.
+- Changes to the cache format, registry shape, or pin contract.
+- Changes to default tier values.
+- Anything that would invalidate the readiness capture in
+  [`memory-tiering-readiness-validation-2026-05-05.md`](memory-tiering-readiness-validation-2026-05-05.md).
+
+---
+
+## 1. Daily bake checks
+
+Run these every weekday during the bake period.  ~10 minutes wall-clock.
+
+### 1.1 Mac side (M-series ARM64)
+
+```bash
+just readiness 2>&1 | tee ~/uffs_bake/$(date +%Y-%m-%d)-mac.log
+```
+
+**Pass criteria:**
+
+- Exit code 0.
+- Final line: `══ ALL GOOD ══  150/150 steps passed`.
+- Phase 8 RPC summary table is present and within ±25 % of the reference
+  capture (per [`memory-tiering-readiness-validation-2026-05-05.md`](memory-tiering-readiness-validation-2026-05-05.md)
+  §2.2):
+  - `forget` mean ≤ 320 ms
+  - `hibernate` mean ≤ 320 ms
+  - `preload` mean ≤ 1 950 ms
+  - `status_drives` mean ≤ 320 ms
+
+### 1.2 Windows side (production NTFS host)
+
+```powershell
+just readiness *>&1 | Tee-Object -FilePath ~/uffs_bake/$(Get-Date -Format yyyy-MM-dd)-win.log
+```
+
+**Pass criteria:**
+
+- Exit code 0.
+- Final line: `══ ALL GOOD ══  150/150 steps passed`.
+- Phase 8 RPC summary within ±25 % of the reference capture
+  ([`memory-tiering-readiness-validation-2026-05-05.md`](memory-tiering-readiness-validation-2026-05-05.md)
+  §3.2):
+  - `forget` mean ≤ 320 ms
+  - `hibernate` mean ≤ 825 ms (variance is structural — see §3.2 of the
+    capture; the ceiling is on the **mean**, not the max)
+  - `preload` mean ≤ 4 080 ms
+  - `status_drives` mean ≤ 320 ms
+- COLD/WARM/HOT speedup ratio: HOT ≥ 100× COLD (the production-host
+  payoff that justifies the operator surface).
+
+### 1.3 Tracing-log audit (both platforms, daily)
+
+Inspect the daemon log captured during the readiness run for these
+red flags:
+
+```bash
+# Mac (or any Unix-like host)
+grep -E '\b(panic|OutOfMemoryError|FATAL|abort)\b' ~/uffs_bake/$(date +%Y-%m-%d)-mac.log
+grep -E 'BackgroundIoPriority.*begin failed' ~/uffs_bake/$(date +%Y-%m-%d)-mac.log
+```
+
+```powershell
+Select-String -Path ~/uffs_bake/$(Get-Date -Format yyyy-MM-dd)-win.log `
+    -Pattern '\b(panic|OutOfMemoryError|FATAL|abort)\b'
+Select-String -Path ~/uffs_bake/$(Get-Date -Format yyyy-MM-dd)-win.log `
+    -Pattern 'BackgroundIoPriority.*begin failed'
+```
+
+**Pass criteria:** every grep returns no matches (empty output).
+
+### 1.4 Process-stability snapshot (Windows only, daily)
+
+The daemon is restarted by every readiness run, but the bake should also
+catch slow leaks in the long-running daemon path.  Once per week,
+capture a 24 h `uffsd.exe` Working-Set trajectory:
+
+```powershell
+1..24 | ForEach-Object {
+    Get-Process uffsd | Select-Object Id, WS, PM, NPM, VM, CPU,
+        @{Name='ts'; Expression={ Get-Date -Format 'HH:mm:ss' }}
+    Start-Sleep -Seconds 3600
+} | Export-Csv -Path ~/uffs_bake/uffsd-ws-trace-$(Get-Date -Format yyyy-MM-dd).csv -NoTypeInformation
+```
+
+**Pass criteria:** Working Set at hour 24 ≤ 1.5× Working Set at hour 1
+(allows for normal cache fill-up but flags a runaway leak).
+
+---
+
+## 2. Failure protocol
+
+If **any** daily check fails:
+
+1. **Stop the bake clock.**  The 7-day countdown does not advance until
+   the regression is fixed and one full pass-day is observed.
+2. **Characterize the regression.**  Capture:
+   - The failing scenario / step.
+   - Full daemon log for the run.
+   - `git rev-parse HEAD` of `main` at the time of failure.
+   - Time of last clean run.
+3. **Open a regression PR.**  Title: `fix(daemon): bake-day-N regression
+   in scenario X`.  Link to the failing log.
+4. **Fix + merge under PR-fast.**  No bypass.
+5. **Restart the bake clock at day 1** the day after merge — the fix must
+   itself bake.  This is non-negotiable: a regression discovered on
+   bake-day 5 means a 6 + 1 = 7 day total bake, not a 5 + 2 = 7 day total.
+
+If the failure is a **flake** (transient, not reproducible on rerun):
+
+1. Re-run the failing check immediately.
+2. If the rerun passes, log the flake under §4 with `flake: <reason>`
+   and continue the bake (clock does not reset).
+3. If the same flake appears on **two non-consecutive days**, treat as a
+   real regression and reset.
+
+---
+
+## 3. Exit criteria for the v0.6.0 cut
+
+All of the following must be true to trigger `just ship` with the
+minor-bump invocation:
+
+- [ ] **7 consecutive bake-days** with all daily checks (§1) green.
+      "Consecutive" excludes weekends — 7 weekdays with at least one
+      Mac run and one Windows run each.
+- [ ] **At least one 24 h Working-Set trace** (§1.4) captured and within
+      pass criteria.
+- [ ] **CHANGELOG `Unreleased` section finalized** — every shipped PR
+      since v0.5.85 listed under the right heading
+      (`Added` / `Changed` / `Fixed`).
+- [ ] **Release notes drafted** in the v0.6.0 section, summarizing the
+      memory-tiering epic in operator-facing terms.  Primary input:
+      [`memory-tiering-readiness-validation-2026-05-05.md`](memory-tiering-readiness-validation-2026-05-05.md).
+- [ ] **Manual diff review** — `git log --oneline v0.5.85..main` walked
+      end-to-end with no surprise commits, no commits with empty / TODO
+      bodies, no commits that bypass branch protection.
+- [ ] **No open critical issues** in `gh issue list --label critical`.
+- [ ] **CI green on `main`** at the cut commit (no flaking PR-fast lanes).
+
+When all boxes are checked:
+
+```bash
+build/update_all_versions.rs minor   # 0.5.x → 0.6.0
+just ship
+```
+
+---
+
+## 4. Bake log
+
+Append one row per bake-day.  Times are PDT.  All-green days
+record the wall-clock of each readiness run and a one-word `notes`
+field; failure days record the failure summary and link the regression
+PR.
+
+| Day | Date       | Mac result   | Mac wall | Win result   | Win wall | Notes |
+|----:|------------|--------------|---------:|--------------|---------:|-------|
+| 0   | 2026-05-05 | 150/150 ✅ |    4m 30s | 150/150 ✅ |     ~12m | Reference capture — pre-bake validation. |
+|  1  |            |              |          |              |          |       |
+|  2  |            |              |          |              |          |       |
+|  3  |            |              |          |              |          |       |
+|  4  |            |              |          |              |          |       |
+|  5  |            |              |          |              |          |       |
+|  6  |            |              |          |              |          |       |
+|  7  |            |              |          |              |          |       |
+
+**Cut day:** the day after Day 7 if all rows are green.
+
+---
+
+## 5. Why the ±25 % tolerance
+
+The reference RPC means in §1.1 / §1.2 are wall-clock measurements on
+specific hosts (Mac M-series, production Windows host).  Day-to-day
+variation will come from:
+
+- Background OS activity (Spotlight reindex on Mac, Windows Update on
+  the Win host).
+- Disk-cache state at run time.
+- Per-drive `last_query_at_ms` history influencing `status_drives`
+  ordering / parsing.
+
+±25 % is wide enough to absorb this noise without masking real
+regressions.  Anything wider would tolerate a real performance regression
+of 25-50 %, which would be operator-visible by the time it landed in a
+release.  Anything tighter would produce daily flake rather than a
+useful signal.
+
+If the daily means trend monotonically upward over 4-5 days *within* the
+±25 % window, treat as a soft regression and characterize before the
+ceiling is hit.

--- a/docs/architecture/memory-tiering-readiness-validation-2026-05-05.md
+++ b/docs/architecture/memory-tiering-readiness-validation-2026-05-05.md
@@ -1,0 +1,272 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- Copyright (c) 2025-2026 SKY, LLC. -->
+
+# Memory-tiering operator-surface readiness validation — 2026-05-05
+
+**Status:** ALL GREEN  ·  150 / 150 scenarios passed on **both** platforms.
+
+**Audience:** anyone deciding whether the memory-tiering epic is ready to
+ship as `v0.6.0`.  This file is the canonical capture of the dual-platform
+operator-surface validation pass that closes Definition-of-Done item §6.2
+"All Mac gates green / Windows gates passed for the phases that need it"
+in [`memory-tiering-implementation-plan.md`](../refactor/memory-tiering-implementation-plan.md).
+
+**Companion docs:**
+
+- Operator runbook (Phase 5 G1-G8 captures, Phase 6 soak):
+  [`memory-tiering-windows-host-validation.md`](memory-tiering-windows-host-validation.md)
+- Bake-period exit criteria (what comes after this capture):
+  [`memory-tiering-bake-criteria.md`](memory-tiering-bake-criteria.md)
+- Source-of-truth tracker (gitignored working copy on the implementer's
+  machine):
+  `docs/refactor/memory-tiering-implementation-plan.md`
+
+---
+
+## 0. What this validates
+
+The Phase 8 operator-driven memory-tiering surface (`hibernate`, `preload`,
+`forget`, `status_drives`) plus the Phase 9 `promotions_total` counter
+wire — exercised end-to-end against **production-shape release binaries**,
+on **both** target platforms, in a single test harness.
+
+Specifically the capture covers:
+
+- **Lifecycle scenarios A-K** (11 scenarios, 65 steps) — the daemon
+  start/stop/kill/restart/auto-start/stats matrix.  Confirms the daemon
+  process model is sound under every realistic operator action.
+- **Phase 8 scenarios L-P** (5 scenarios, 41 steps) — `status_drives`
+  contract, `hibernate` end-to-end, `preload` pin contract, `forget
+  --force` destructive cleanup, full round-trip cycle.  Confirms each
+  operator command's RPC-level contract, including the `pin_until_ms`
+  override semantics and the `freed_bytes` reporting.
+- **Phase 9 scenarios Q-R** (2 scenarios, 24 steps) — `promotions_total`
+  counter increments exactly once per Cold→Hot transition (never on
+  AlreadyHot), and the search-driven re-promote latency profile traces
+  the full Warm-baseline → Cold → Warm → Hot cost ladder.
+
+Scenario S (Parked→Hot via TTL-gated demote) was skipped on both runs
+because it requires `--park-wait-secs > 0` to actually sleep through the
+warm-to-parked idle window.  S is exercised under the deferred Phase 6
+24 h soak documented in
+[`memory-tiering-windows-host-validation.md`](memory-tiering-windows-host-validation.md)
+§2.
+
+**150 = 11 + 5 + 2 + K-table = 65 lifecycle steps + 41 Phase 8 steps + 24
+Phase 9 steps + 4 K-table phases + 16 timing-table aggregations + 1 RPC
+summary.**  The exact step count is checked by the harness itself
+(`@/Users/rnio/Private/Github/UltraFastFileSearch/scripts/dev/daemon-readiness.rs:243`).
+
+---
+
+## 1. Reproduction
+
+```bash
+# Mac (M-series ARM64, ~/uffs_data offline data set):
+just readiness
+
+# Windows (production NTFS host, live auto-discover):
+just readiness
+```
+
+Equivalent direct invocation (both platforms):
+
+```bash
+rust-script scripts/dev/daemon-readiness.rs <data-dir-or-omit>
+```
+
+The harness self-builds a fresh release workspace, ensures any stale
+daemon is killed, then runs scenarios A-S sequentially.  Exit code is
+0 iff every step passed.
+
+---
+
+## 2. Mac capture — 2026-05-05 13:52 PDT
+
+| Field | Value |
+|---|---|
+| Host | M-series ARM64 (macOS) |
+| Binary | `target/release/uffs` (workspace `main` post-#130) |
+| Source | `--data-dir /Users/rnio/uffs_data` (offline data set) |
+| Pattern | `*.rs` |
+| Forget target | `G` |
+| Drives loaded | 7 (`C, D, E, F, G, M, S`) |
+| Wall-clock | 4 m 30 s |
+| Result | **150 / 150 passed** |
+
+### 2.1 COLD / WARM / HOT startup ladder (Scenario K)
+
+| Phase | Startup | Query | Total | Speedup vs COLD |
+|---|---:|---:|---:|---:|
+| COLD | 5 365 ms | 255 ms | 5 620 ms | — |
+| WARM | 5 326 ms | 255 ms | 5 581 ms | 1.0× |
+| HOT  |   255 ms | 253 ms |   508 ms | **11.1×** |
+
+WARM is essentially identical to COLD on Mac because the offline
+`~/uffs_data` workload is small enough that the encrypted-cache decrypt
+saves negligible time over a fresh in-memory parse.  Mac's payoff comes
+entirely from the daemon-resident HOT path.
+
+### 2.2 Phase 8 per-RPC timing summary
+
+| RPC | n | min | mean | max | total |
+|---|---:|---:|---:|---:|---:|
+| `forget`        |  2 | 255 ms |  255 ms |  255 ms |    510 ms |
+| `hibernate`     |  8 | 251 ms |  254 ms |  256 ms |  2 033 ms |
+| `preload`       |  7 | 254 ms | 1 559 ms | 2 542 ms | 10 914 ms |
+| `status_drives` | 19 | 250 ms |  253 ms |  255 ms |  4 821 ms |
+
+`hibernate` and `status_drives` are tight (3-5 ms variance) because
+they're pure-CPU under the registry write-lock / read-lock.  `preload`
+spans 254 ms (AlreadyHot pin-extension fast path) to 2 542 ms (Cold→Hot
+encrypted-cache decrypt + body load) — the variance is the work
+asymmetry between the two code paths, not noise.
+
+---
+
+## 3. Windows capture — 2026-05-05 (production host)
+
+| Field | Value |
+|---|---|
+| Host | Production Windows (7 NTFS volumes, live auto-discover) |
+| Binary | `C:\Users\rnio\bin\uffs.exe` (v0.5.90 via `just use`) |
+| Source | live NTFS drives (auto-discover) |
+| Pattern | `*.rs` |
+| Forget target | `G` |
+| Drives loaded | 7 (`C, D, E, F, G, M, S`) |
+| Result | **150 / 150 passed** |
+
+### 3.1 COLD / WARM / HOT startup ladder (Scenario K)
+
+| Phase | Startup | Query | Total | Speedup vs COLD |
+|---|---:|---:|---:|---:|
+| COLD | 69 617 ms | 253 ms | 69 870 ms | — |
+| WARM | 30 104 ms | 253 ms | 30 357 ms | **2.3×** |
+| HOT  |    254 ms | 253 ms |    507 ms | **137.8×** |
+
+This is the headline result of the entire memory-tiering epic.  On a
+production Windows host with ~2 GB of cumulative MFT across 7 NTFS
+volumes:
+
+- **COLD** = ~70 s (full MFT parse from `\\.\C:` etc.).
+- **WARM** = ~30 s (encrypted-compact-cache decrypt + body load —
+  validates the Phase 4 cache architecture: 2.3× faster than re-parse).
+- **HOT**  = 0.5 s (daemon already-resident, RAM-only path —
+  validates the entire Phase 8 operator surface end-to-end:
+  **137.8× speedup** over COLD).
+
+### 3.2 Phase 8 per-RPC timing summary
+
+| RPC | n | min | mean | max | total |
+|---|---:|---:|---:|---:|---:|
+| `forget`        |  2 | 253 ms |  253 ms |  253 ms |    506 ms |
+| `hibernate`     |  8 | 253 ms |  660 ms | 1 004 ms |  5 280 ms |
+| `preload`       |  7 | 253 ms | 3 262 ms | 5 779 ms | 22 840 ms |
+| `status_drives` | 19 | 253 ms |  253 ms |  255 ms |  4 818 ms |
+
+`status_drives` and `forget` match Mac exactly — they're CPU-bound and
+disk-bound respectively, with cross-platform-identical work shape.
+`hibernate` and `preload` are 2-3× slower than Mac, reflecting the
+dominant cost on Windows: **encrypted-cache decrypt + Win32 file I/O**
+(per-shard `mmap` + AES-GCM stream + body load).  This matches the
+expectation set in `docs/refactor/memory-budget-analysis.md`.
+
+`hibernate` variance on Windows (253 ms → 1 004 ms) is real and
+correlates with how much resident-body memory each call has to drop —
+the registry write-lock + N × `Arc` swap pays a higher cost when N
+grows.  The cost remains sub-second across the whole run, so it's
+**observed but not a bug**.
+
+---
+
+## 4. Cross-platform analysis
+
+### 4.1 RPC cost ladder
+
+| RPC | Mac mean | Win mean | Win/Mac | Class |
+|---|---:|---:|---:|---|
+| `status_drives` |   253 ms |   253 ms | **1.0×** | CPU-bound (register walk under read-lock) |
+| `forget`        |   255 ms |   253 ms | **1.0×** | OS-bound (`fs::remove_file` × 4) |
+| `hibernate`     |   254 ms |   660 ms | **2.6×** | RAM-bound (write-lock + N × `Arc` swap) |
+| `preload`       | 1 559 ms | 3 262 ms | **2.1×** | Disk-bound (cache decrypt + body load) |
+
+The clean pattern — **CPU-bound RPCs are platform-identical, I/O-bound
+RPCs are 2-3× slower on Windows** — is exactly what an architecture
+abstraction-layer audit would predict.  The portable-file-system /
+encrypted-cache layer is doing its job; the per-platform asymmetry shows
+up only where it has to (Win32 disk I/O).
+
+### 4.2 Phase 9 counter wire — verified end-to-end
+
+Scenario Q exercises the `promotions_total` counter contract on both
+platforms.  All assertions passed:
+
+| Step | Assertion | Mac | Windows |
+|---|---|---|---|
+| Q4  | First Cold→Hot increments 0 → 1 | ✅ 0→1 in 2 539 ms | ✅ 0→1 in 5 779 ms |
+| Q5  | AlreadyHot does **not** increment | ✅ stayed at 1 | ✅ stayed at 1 |
+| Q7  | Second Cold→Hot increments 1 → 2 | ✅ 1→2 in 2 529 ms | ✅ 1→2 in 5 259 ms |
+| Q8  | AlreadyHot ≥ 5× faster than Cold→Hot | ✅ 10.0× | ✅ **22.8×** |
+| Q9  | Two Cold→Hot calls have similar latency | ✅ Δ 0.4 % | ✅ Δ 9.0 % |
+
+The 22.8× Windows speedup on Q8 (AlreadyHot vs Cold→Hot) is the
+operator's most visible signal that the pin contract is doing real
+work — pinning a frequently-accessed drive avoids the 5-second decrypt
+penalty on every preload.
+
+### 4.3 Pin-contract semantics — verified end-to-end
+
+| Step | Assertion | Mac | Windows |
+|---|---|---|---|
+| N5  | `preload` Cold → Hot, sets `pin_until_ms` | ✅ | ✅ |
+| N7  | `pin_until_ms > 0` after preload | ✅ | ✅ |
+| N8  | Re-preload pinned drive uses fast path | ✅ 254 ms | ✅ 253 ms |
+| P7  | Explicit `hibernate` overrides pin | ✅ | ✅ |
+| P8  | Hibernated drive is `cold` (pin cleared) | ✅ | ✅ |
+
+The pin-vs-explicit-hibernate semantics (master plan §3 Phase 3) hold
+identically on both platforms.
+
+### 4.4 Search-driven re-promote ladder (Scenario R)
+
+| Step | Cost class | Mac | Windows |
+|---|---|---:|---:|
+| R4  | Warm-baseline search | 255 ms | 253 ms |
+| R6  | Cold → Warm (search-triggered cache decrypt) | 4 311 ms | **11 810 ms** |
+| R8  | Warm → Hot (preload, registry rebuild only) | 511 ms | 507 ms |
+| R9  | Hot search | 251 ms | 254 ms |
+
+R11 ("Cold→Warm ≥ 3× Warm baseline") passed at **16.9× on Mac** and
+**46.7× on Windows** — both far exceed the 3× floor, confirming the
+cache-decrypt cost dominates re-promote on both platforms.
+
+R8 (Warm→Hot via preload) is uniformly fast on both platforms because
+no body decryption is needed — the cache body is already resident, and
+preload just rebuilds the registry entry with a `Hot` shard.  This
+confirms the Phase 8-C design choice to keep `promote_letter_to_hot`
+free of decrypt cost when starting from `Warm`.
+
+---
+
+## 5. Conclusions for v0.6.0 cut
+
+This capture closes the validation half of the v0.6.0 Definition of Done
+(`memory-tiering-implementation-plan.md` §6.2):
+
+- ✅ Phase 8 operator surface validated end-to-end on Mac.
+- ✅ Phase 8 operator surface validated end-to-end on Windows.
+- ✅ Phase 9 `promotions_total` counter wire validated end-to-end on both.
+- ✅ Pin contract semantics validated on both.
+- ✅ Cross-platform RPC cost ladder traced and documented.
+
+**Remaining items for the v0.6.0 cut:**
+
+1. One-week bake on `main` per the criteria in
+   [`memory-tiering-bake-criteria.md`](memory-tiering-bake-criteria.md).
+2. CHANGELOG `Unreleased` → `0.6.0` finalize.
+3. Release notes drafted (this file is the primary input).
+4. Manual review of the diff `v0.5.85..v0.6.0`.
+5. `just ship` with `build/update_all_versions.rs minor`.
+
+The bake period now begins.  No new operator-surface features land on
+`main` until `v0.6.0` ships.

--- a/docs/architecture/memory-tiering-windows-host-validation.md
+++ b/docs/architecture/memory-tiering-windows-host-validation.md
@@ -12,6 +12,16 @@ local working copy on the implementer's machine).  Use this runbook
 when you want the **what to run on Windows** without the
 implementation-side context.
 
+**Companion docs (added 2026-05-05 alongside the v0.6.0 readiness pass):**
+
+- [`memory-tiering-readiness-validation-2026-05-05.md`](memory-tiering-readiness-validation-2026-05-05.md) —
+  dual-platform capture of the Phase 8 + 9 operator-surface readiness
+  pass (150 / 150 scenarios on Mac and Windows).  This is the canonical
+  validation evidence for the v0.6.0 cut.
+- [`memory-tiering-bake-criteria.md`](memory-tiering-bake-criteria.md) —
+  operationalised exit criteria for the one-week `main` bake that
+  precedes the v0.6.0 cut.
+
 The four Phase 5 operator gates that the all-Mac unit-test suite cannot
 exercise are listed in §1 below.  §2 covers the deferred Phase 6
 gate (24-h `min_tier = "Warm"` soak) since it shares the same

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -30,7 +30,7 @@
 # CI pipeline will auto-refresh on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed — use that flag (or plain `just ship`) while the upstream regression
 # persists.
-channel = "nightly-2026-05-03"
+channel = "nightly-2026-05-05"
 
 # Specify components that should always be available
 components = [


### PR DESCRIPTION
## Summary

Closes the validation half of the v0.6.0 Definition of Done (`docs/refactor/memory-tiering-implementation-plan.md` §6.2) and operationalises the one-week bake period that precedes the cut.

Two new files in `docs/architecture/`:

### 1. `memory-tiering-readiness-validation-2026-05-05.md`

Canonical capture of the Phase 8 + 9 operator-surface readiness pass on **both** target platforms.

**Result:** 150 / 150 scenarios passed on Mac (M-series ARM64) and Windows (production NTFS host).

| Metric | Mac | Windows |
|---|---:|---:|
| COLD startup | 5 365 ms | 69 617 ms |
| HOT startup | 255 ms | 254 ms |
| **HOT speedup** | **11.1×** | **137.8×** |

Phase 9 `promotions_total` counter wire verified end-to-end on both platforms — Q4 (0→1), Q5 AlreadyHot (unchanged), Q7 (1→2), Q8 (AlreadyHot 22.8× faster than Cold→Hot on Windows).

Cross-platform RPC cost ladder traced: `status_drives` + `forget` are platform-identical (CPU- / OS-bound), `hibernate` + `preload` are 2-3× slower on Windows (disk-bound, expected).

### 2. `memory-tiering-bake-criteria.md`

Daily-check spec, failure protocol, and concrete exit criteria for triggering the v0.6.0 cut.

- ±25 % per-RPC tolerance against the reference capture.
- 7 consecutive bake-days with all checks green ⇒ eligible to cut.
- Plus 24 h Working-Set trace, finalized CHANGELOG, drafted release notes, manual diff review of `v0.5.85..main`.

### 3. Cross-reference

Small companion-docs block added to the existing `memory-tiering-windows-host-validation.md` so anyone landing on the Phase 5 G1-G8 runbook discovers the new files.

## Bake period now begins

No new operator-surface features land on `main` until v0.6.0 ships. Pure docs / non-daemon-touching tooling (e.g. the `just use` resilience improvement still sitting in the working tree) is fine; anything that would invalidate the readiness capture is not.