### PR TITLE
fix(ci): keep release cache warm so releases stop paying cold-build tax

### DIFF
--- a/.github/workflows/release-cache-warm.yml
+++ b/.github/workflows/release-cache-warm.yml
@@ -1,0 +1,178 @@
+# SPDX-FileCopyright (c) 2025-2026 SKY, LLC.
+# SPDX-License-Identifier: MPL-2.0
+#
+# Release-cache warming.
+#
+# Why this workflow exists (issue #132):
+#
+#   `release.yml` saves a `v0-rust-release-${target}-…` cache at the end
+#   of every release run.  In principle the next release should restore
+#   it via Swatinem/rust-cache's automatic prefix-fallback (matching
+#   `v0-rust-release-${target}-${OS}-${arch}-`).  In practice every
+#   release reported `No cache found` because:
+#
+#     1. Releases are weekly-ish.  Each `just ship` runs `cargo update`,
+#        producing a different `Cargo.lock` hash and a different
+#        `Cargo.toml`-version-hash.  Exact-key match misses every time.
+#     2. Prefix-fallback would still find the previous release's cache
+#        — but **only if it still exists**.  GitHub Actions evicts
+#        caches via LRU at the 10-GB-per-repo cap, and unconditionally
+#        deletes them 7 days after their last access.  A weekly release
+#        cadence collides with the 7-day TTL: by the time `release.yml`
+#        runs again, the previous release's cache has been deleted, so
+#        prefix-fallback finds nothing.  Each release ships a
+#        from-scratch ~30-min build.
+#
+#   This workflow refreshes the same `release-${target}` cache on every
+#   `Cargo.lock`/`Cargo.toml`/`crates/**` push to `main`, plus a weekly
+#   schedule.  Both restore the cache (resetting its access-time so
+#   LRU/TTL eviction stops counting against it) and re-save it (so any
+#   newer dep code lands in the cache).  When `release.yml` next runs
+#   on a tag-dispatch from `auto-tag-release.yml`, the cache is fresh
+#   on `refs/heads/main` and prefix-fallback restores it.
+#
+#   Why not extend `release.yml` to also trigger on main pushes:
+#
+#     `release.yml` is the single source of truth for "did this version
+#     ship".  Adding a `push: branches: main` trigger there couples the
+#     warm-cache job to the production release flow's `concurrency:`
+#     group, `permissions:`, OIDC token issuance, and SLSA attestation
+#     scaffolding — none of which apply to a cache-warm run, all of
+#     which would have to be carefully gated.  A separate workflow
+#     keeps the contract clean: `release.yml` ships releases,
+#     `release-cache-warm.yml` keeps its caches hot.
+#
+# Cost calibration:
+#
+#   ~3 × 45 min CI per trigger × ~weekly Cargo.lock-touching pushes
+#   plus a weekly cron = ~5-10 hours/week on the public-repo free
+#   minutes.  Worth it: every release saves the same amount in
+#   wall-clock time (~30 min × 3 platforms = ~90 min cold-build per
+#   release), and the cache also accelerates failure-recovery re-runs
+#   of `release.yml` itself.
+
+name: 🔥 Release cache warm
+
+on:
+  push:
+    branches: [main]
+    paths:
+      # Only re-warm when something a release-mode build cares about
+      # changes.  Pure-docs / scripts / CHANGELOG-only changes don't
+      # invalidate the cache, so they shouldn't re-trigger a 45-min
+      # compile per platform.  Mirror the file set against
+      # `release.yml`'s `cargo build --workspace --bins` — anything
+      # that influences that command's input set must be listed here.
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'rust-toolchain.toml'
+      - '.cargo/config.toml'
+      # Also re-trigger if THIS workflow changes (so a config tweak
+      # to the warming logic re-runs against current main).
+      - '.github/workflows/release-cache-warm.yml'
+  schedule:
+    # Weekly cron — Monday 05:00 UTC.  Belt-and-suspenders for periods
+    # of dependency stability when no `Cargo.lock`-touching pushes
+    # happen for >7 days (the GitHub Actions cache TTL).  Without this,
+    # a 7-day quiet stretch would let every release-${target} cache
+    # age out, and the next release would pay the full cold-build tax.
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+    # Manual re-trigger.  Useful after rotating the cache (e.g. after
+    # a `cargo update` storm) when the operator wants the cache fresh
+    # on `main` before pushing the next release tag.
+
+# Cancel older in-flight warm runs when a new commit lands.  Cache-warm
+# is best-effort by design — only the latest commit's cache state is
+# interesting.  `release.yml` runs are NOT in this concurrency group,
+# so a tag-dispatched release won't be canceled by a same-time main
+# push.
+concurrency:
+  group: release-cache-warm-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  # Read repo contents.  No write scope — this workflow ships nothing.
+  contents: read
+  # Cache read/write happens via the actions/cache backend, not via
+  # the `actions:` permission scope.  Documented here for explicitness.
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Override `.cargo/config.toml`'s `rustc-wrapper = "sccache"` setting
+  # for the same reason `release.yml` does — sccache isn't preinstalled
+  # on GitHub-hosted runners and would crash every `cargo` invocation
+  # at exec time.  Empty `RUSTC_WRAPPER` disables the wrapper without
+  # touching `config.toml`.
+  RUSTC_WRAPPER: ""
+
+jobs:
+  warm:
+    # Mirrors `release.yml::build-release-binaries`'s matrix exactly.
+    # If you add or change a target there, change it here too —
+    # otherwise the new target's cache will not be warmed and its
+    # release runs will pay the cold-build tax.
+    name: 🔥 Warm ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.timeout }}
+    env:
+      RUSTFLAGS: ${{ matrix.rustflags }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            rustflags: "-C target-cpu=x86-64-v3"
+            timeout: 75
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            rustflags: "-C target-cpu=apple-m1 -C link-arg=-Wl,-dead_strip"
+            timeout: 45
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+            rustflags: "-C target-cpu=x86-64-v3 -C link-arg=-Wl,--gc-sections"
+            timeout: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Free up disk space (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          # Same recovery as `release.yml` — Polars + ring + LTO=fat
+          # exhausts ubuntu-22.04's default 14-GB free-budget.
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          sudo rm -rf /usr/local/share/boost /usr/local/graalvm
+          df -h /
+
+      - name: Install pinned nightly (from rust-toolchain.toml)
+        run: rustup show
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # MUST match `release.yml::build-release-binaries`'s shared-key
+          # exactly so this workflow's saves are reachable from
+          # release.yml's cache-restore step.
+          shared-key: release-${{ matrix.target }}
+          # Save even on a partial / failed build so a slow-evolving
+          # cache still progresses toward warm rather than alternating
+          # between empty and populated.
+          cache-on-failure: 'true'
+
+      - name: Pre-warm release-mode build cache
+        shell: bash
+        run: |
+          echo "🔥 Warming release cache for ${{ matrix.target }}"
+          echo "   RUSTFLAGS=$RUSTFLAGS"
+          # Identical invocation to `release.yml::build-release-binaries`.
+          # If that command's flags ever diverge from this one, the cache
+          # produced here will still hit on key but might not match the
+          # actual artifact set release.yml needs — keep them aligned.
+          # `--locked` per the workspace's §2.8 policy.
+          cargo build --locked --release --target ${{ matrix.target }} --workspace --bins
+          echo "✅ Cache warmed for ${{ matrix.target }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,17 @@ jobs:
           # previous compile graph; only crates whose sources actually
           # changed need recompilation.  `pr-fast.yml` uses the same
           # pattern; the divergence here was unintentional.
+          #
+          # The cache this step restores is kept warm by
+          # `release-cache-warm.yml` — that workflow runs the same
+          # `shared-key` build on every Cargo-affecting `main` push
+          # plus a weekly cron, so the cache's last-access timestamp
+          # is refreshed often enough to survive GitHub's 7-day TTL +
+          # 10-GB-cap LRU eviction.  Without it, releases paid the
+          # full cold-build tax every time (issue #132).  If you
+          # change the build invocation below, mirror the change in
+          # `release-cache-warm.yml::warm` so the warmed cache stays
+          # bit-compatible with what this job needs.
           shared-key: release-${{ matrix.target }}
           cache-on-failure: 'true'
 


### PR DESCRIPTION
## Summary

Closes #132.  Every UFFS release reported `No cache found` even though `release.yml` was correctly saving caches.  Root cause is the interaction between weekly release cadence and GitHub Actions' 7-day cache TTL: each release's cache was evicted before the next release ran.

Fix: a new `release-cache-warm.yml` workflow that re-warms the same `release-${target}` cache on every Cargo-affecting `main` push plus a weekly cron, so the cache's last-access timestamp stays fresh.

## Verification

`gh cache list` against today's repo state shows only `v0.5.90`'s caches (saved 13:01-13:34 UTC today during release run #88) — every previous release's cache has been evicted:

```
2026-05-05  refs/heads/main  v0-rust-release-aarch64-apple-darwin-...  580M
2026-05-05  refs/heads/main  v0-rust-release-x86_64-pc-windows-msvc-...  810M
2026-05-05  refs/heads/main  v0-rust-release-x86_64-unknown-linux-gnu-...  585M
```

Confirms the LRU+TTL eviction hypothesis:  the issue-#80 fix that switched from `key:` to `shared-key:` (2026-04-27, commit `888e7fa953`) was correct in principle but couldn't help in practice because there was no prior cache for the prefix-fallback to find.

## What this PR does

NEW workflow `.github/workflows/release-cache-warm.yml`:

- **Triggers**: `push: branches: [main]` with paths filter on Cargo-affecting files (Cargo.toml, Cargo.lock, crates/**, rust-toolchain.toml, .cargo/config.toml, the workflow file itself); weekly cron (Monday 05:00 UTC); `workflow_dispatch`.
- **Matrix**: mirrors `release.yml::build-release-binaries` exactly — 3 targets (Windows x64, Mac ARM64, Linux x64), same RUSTFLAGS, same timeouts.
- **Steps**: checkout → free-disk-space (Linux) → rustup → `Swatinem/rust-cache` with `shared-key: release-${{ matrix.target }}` → `cargo build --locked --release --target ${{ matrix.target }} --workspace --bins`.
- **Concurrency**: cancel-in-progress on same ref so dependabot bursts don't stack up.
- **Permissions**: `contents: read` only — no write scope, no OIDC, no attestations.

UPDATED `release.yml` cache-step comment with a forward-pointer to the new workflow and a 'keep these in lock-step' warning for the next maintainer who changes either side.

## Prevention

The new workflow's header doc explicitly explains why it exists (linked to issue #132), why it's separate from `release.yml` (avoid coupling to OIDC / SLSA / concurrency scaffolding), and the matrix-mirror rule: 'If you add or change a target in release.yml, change it here too — otherwise the new target's cache will not be warmed and its release runs will pay the cold-build tax.'

## Cost

~3 × 45 min CI per trigger × ~weekly Cargo-affecting pushes + a weekly cron = ~5-10 hours/week of public-repo free minutes.

Worth it: every release saves ~30 min wall-clock per platform × 3 platforms = ~90 min cold-build per release, and the cache also accelerates failure-recovery re-runs of `release.yml` itself.

## Validation

- `actionlint .github/workflows/release-cache-warm.yml` — exit 0.
- `actionlint .github/workflows/release.yml` — only pre-existing shellcheck warnings; no new issues from this PR.
- `just lint-pre-push` — green at 55s.

## Bake-period status

Permitted under `docs/architecture/memory-tiering-bake-criteria.md` §0 — pure CI tooling change, no daemon-behavior impact.