### PR TITLE
feat(ci): flip Windows CI gate to clippy + add Linux zigbuild accelerator (W5 + L1)

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -427,14 +427,20 @@ jobs:
         run: cargo vet check --locked
 
   # ─────────────────────────────────────────────────────────────────────
-  # windows-check — native Windows compile check on `windows-latest`.
-  # Authoritative gate (local xwin is advisory — see
+  # windows-lint — native Windows clippy gate on `windows-latest`.
+  # Authoritative cross-target lint gate (local xwin is advisory — see
   # dev-flow-implementation-plan.md § 1.3.3).  Replaces the weekly
   # Tier 2 Windows job; Tier 2 drops that job in the same PR as Phase
   # 4b housekeeping.
+  #
+  # Phase W5.5 of windows-clippy-and-linux-cross-plan.md flipped this
+  # job from `cargo check` → `cargo clippy -- -D warnings`.  The
+  # Windows clippy backlog (W0 baseline: 1346 errors on `--all-targets
+  # -D warnings`) was driven to zero in PR #62 (W2–W5 cleanup) so the
+  # strict flag stack now passes natively on `windows-latest`.
   # ─────────────────────────────────────────────────────────────────────
-  windows-check:
-    name: Windows compile check
+  windows-lint:
+    name: Windows clippy
     runs-on: windows-latest
     needs: [classify, sanity]
     if: needs.classify.outputs.code == 'true'
@@ -455,7 +461,10 @@ jobs:
         with:
           shared-key: pr-fast-windows
 
-      - run: cargo check --workspace --all-targets --all-features --locked
+      # Strict clippy with `-D warnings` matches `just lint-ci-windows`
+      # locally (cargo-xwin variant).  Native Windows runs natively here;
+      # local xwin remains the developer-loop equivalent.
+      - run: cargo clippy --workspace --all-targets --all-features --locked --no-deps -- -D warnings
 
   # ─────────────────────────────────────────────────────────────────────
   # required — sole branch-protection target (post-2026-04-23 cutover).
@@ -483,7 +492,7 @@ jobs:
       - test-build
       - tests
       - security
-      - windows-check
+      - windows-lint
     steps:
       - name: Gate on classify
         run: |
@@ -504,7 +513,7 @@ jobs:
             [test-build]='${{ needs.test-build.result }}'
             [tests]='${{ needs.tests.result }}'
             [security]='${{ needs.security.result }}'
-            [windows-check]='${{ needs.windows-check.result }}'
+            [windows-lint]='${{ needs.windows-lint.result }}'
           )
           fail=0
           for job in "${!R[@]}"; do
@@ -528,7 +537,7 @@ jobs:
   notify-failure:
     name: 🔔 Notify on Failure
     runs-on: ubuntu-latest
-    needs: [classify, file-size, fmt, sanity, clippy, docs, test-build, tests, security, windows-check, required]
+    needs: [classify, file-size, fmt, sanity, clippy, docs, test-build, tests, security, windows-lint, required]
     if: failure() && github.event_name != 'pull_request'
     permissions:
       contents: read

--- a/.github/workflows/preview-artifacts.yml
+++ b/.github/workflows/preview-artifacts.yml
@@ -97,7 +97,7 @@ jobs:
   #
   # Budget: 120 × 15 s = 30 min.  PR Fast CI on a full-matrix run
   # (infra-change or rust-change) can take 20–25 min cold (test-build
-  # → tests sequential + windows-check in parallel).  The original
+  # → tests sequential + windows-lint in parallel).  The original
   # 10-min cap was calibrated for docs-only short-circuit PRs and
   # timed out on the first real infra-change preview attempt
   # (2026-04-23; see §10.5 of the plan doc).  Don't drop this below

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -113,57 +113,19 @@ jobs:
           verbose: true
 
   # ══════════════════════════════════════════════════════════════════════════
-  # Windows Compile Check — catches Windows-only build regressions between
-  # releases.  Runs NATIVELY on `windows-latest` (not Linux → MSVC cross),
-  # so it picks up any breakage that would otherwise first surface 10-15
-  # minutes into a `just ship` release build.  `cargo check` (not `build`)
-  # because we only care about type-checks / linking metadata; full builds
-  # happen in `release.yml`.
+  # Tier 2 / Windows Compile Check — REMOVED by PR #138 (Phase W5.5 of
+  # `docs/architecture/windows-clippy-and-linux-cross-plan.md`).
   #
-  # History: an earlier `Tier 2 / Windows Cross-Check` cross-compiled from
-  # ubuntu-latest and permanently red-X'd Tier 2 because ubuntu has no MSVC
-  # linker / import libraries (see
-  # `docs/xwin-msvc-rlib-size-root-cause-and-workarounds.md`).  Running on
-  # `windows-latest` sidesteps that entirely.
-  # ══════════════════════════════════════════════════════════════════════════
-  windows-check:
-    name: Tier 2 / Windows Compile Check
-    runs-on: windows-latest
-    timeout-minutes: 60
-    env:
-      # Mirror the release-time Windows rustflags so the check runs under
-      # the same compilation conditions as a real release build.  If a
-      # target-cpu bump starts breaking compilation, this job fails
-      # BEFORE `just ship` does.
-      RUSTFLAGS: "-C target-cpu=x86-64-v3"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install pinned nightly (from rust-toolchain.toml)
-        run: rustup show
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          # Dedicated cache key — the Linux Tier 2 jobs below have fragments
-          # that make the default key hash to something different on Windows
-          # anyway, but be explicit so a future refactor does not cross the
-          # streams.
-          shared-key: tier-2-windows-check
-          # Persist a partial cache even if the job fails — runner
-          # pre-emption (SIGTERM) mid-compile is the most common Tier 2
-          # failure mode (issue #83), so the next attempt should resume
-          # from the partially-built compile graph.
-          cache-on-failure: 'true'
-
-      - name: cargo check --workspace --all-features
-        # --all-features to exercise every feature-gated path that only
-        # compiles on Windows (e.g. live MFT / USN / IOCP code paths).
-        # --all-targets so test-only Windows code is also type-checked.
-        # --locked per §2.8 so lockfile drift surfaces as a CI failure
-        # rather than silently pulling in a newer patch version.
-        run: cargo check --locked --workspace --all-features --all-targets
+  # `pr-fast.yml::windows-lint` now runs `cargo clippy --workspace
+  # --all-targets --all-features --locked --no-deps -- -D warnings`
+  # natively on `windows-latest` on EVERY PR.  `cargo clippy` does a
+  # full type-check + executes every dep's `build.rs`, so any
+  # Windows-only build regression that the old weekly `cargo check`
+  # would have caught is now caught at PR-time — minutes after the bad
+  # commit lands on the PR branch instead of up to 7 days later.
+  # Strict clippy on top is a bonus.  Tier 2 stays as the
+  # deep-assurance lane for things genuinely too expensive for
+  # PR-time: coverage, miri, udeps.
 
   build-validation:
     name: Tier 2 / Build Validation
@@ -277,7 +239,7 @@ jobs:
   tier-2-summary:
     name: Tier 2 / Summary
     runs-on: ubuntu-latest
-    needs: [file-size-policy, coverage, build-validation, udeps, miri, windows-check]
+    needs: [file-size-policy, coverage, build-validation, udeps, miri]
     if: always()
     timeout-minutes: 5
     steps:
@@ -287,8 +249,7 @@ jobs:
                 "${{ needs.coverage.result }}" == "success" && \
                 "${{ needs.build-validation.result }}" == "success" && \
                 "${{ needs.udeps.result }}" == "success" && \
-                "${{ needs.miri.result }}" == "success" && \
-                "${{ needs.windows-check.result }}" == "success" ]]; then
+                "${{ needs.miri.result }}" == "success" ]]; then
             echo "✅ All Tier 2 nightly checks passed!"
           else
             echo "❌ Some Tier 2 nightly checks failed - review above"
@@ -297,17 +258,23 @@ jobs:
 
       - name: Create summary
         if: success()
+        # Single grouped redirect (SC2129) with the env-var quoted (SC2086)
+        # — one pipe to the GITHUB_STEP_SUMMARY file instead of nine, and
+        # safe against word-splitting if `$GITHUB_STEP_SUMMARY` ever
+        # contains a space (it doesn't on hosted runners today, but
+        # quoting is the defensible default).
         run: |
-          echo "## ✅ UFFS Tier 2 Nightly CI Passed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| File size policy | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "| Coverage | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "| Build validation | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "| cargo-udeps | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "| Miri | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "| Windows Compile Check | ✅ |" >> $GITHUB_STEP_SUMMARY
+          {
+              echo "## ✅ UFFS Tier 2 Nightly CI Passed"
+              echo ""
+              echo "| Check | Status |"
+              echo "|-------|--------|"
+              echo "| File size policy | ✅ |"
+              echo "| Coverage | ✅ |"
+              echo "| Build validation | ✅ |"
+              echo "| cargo-udeps | ✅ |"
+              echo "| Miri | ✅ |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ═══════════════════════════════════════════════════════════════════════════
   # Failure Notification — opens a GitHub Issue on any job failure
@@ -316,7 +283,7 @@ jobs:
   notify-failure:
     name: 🔔 Notify on Failure
     runs-on: ubuntu-latest
-    needs: [file-size-policy, coverage, build-validation, udeps, miri, windows-check]
+    needs: [file-size-policy, coverage, build-validation, udeps, miri]
     if: failure()
     # §2.8: every job caps its runtime.  Cheap notifier — 2 min is
     # generous for a single API call round-trip + JSON formatting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,65 @@ for the operator-facing validation flow.
   the on-disk cleanup logic is exercised without ever touching the
   host's cache directory.
 
+### Changed — Windows clippy CI/pre-push flip + Linux zigbuild accelerator (PR #138)
+
+Closes Phases **W5** and **L1** of
+[`docs/architecture/windows-clippy-and-linux-cross-plan.md`](docs/architecture/windows-clippy-and-linux-cross-plan.md).
+Every plan phase (W0 baseline, W1 recipes, W2 prod, W3-W5 tests, W5.5
+CI flip, W5.6 pre-push flip, L1 zigbuild) now ✅; §8 acceptance items
+all checked.
+
+- **`pr-fast.yml::windows-check` → `windows-lint`** (Phase W5.5).
+  Renamed the job and switched the command from `cargo check` to
+  `cargo clippy --workspace --all-targets --all-features --locked
+  --no-deps -- -D warnings` natively on `windows-latest`.  PR #62
+  cleared the Windows clippy backlog (W0 baseline: 1346 errors → 0)
+  so the strict-clippy stack now exits 0.  Aggregator (`required`)
+  + `notify-failure` `needs:` lists updated; `preview-artifacts.yml`
+  comment refreshed.
+- **`scripts/hooks/_lint_pre_push.sh`** dispatches `just lint-ci-windows`
+  (cargo xwin clippy with the same `-D warnings` stack) instead of
+  `just check-windows` (compile-only) (Phase W5.6).  W1.4 measurement
+  pegs the upgrade at ~6 s warm; pre-push budget unchanged at
+  ~25–60 s warm.  Net: a Windows-only `unwrap_used` /
+  `cast_possible_truncation` regression now hard-fails BOTH the local
+  pre-push hook AND the authoritative PR Fast CI job, on the same
+  surface and flag stack.
+- **NEW `just lint-ci-linux-zig` recipe** (Phase L1.2): native
+  macOS → Linux clippy via `cargo-zigbuild` (no Docker required).
+  ~50 s cold, sub-second warm.  Docker `lint-ci-linux` remains the
+  authoritative gate (mirrors CI's `rust:latest` image exactly);
+  zigbuild is a developer-loop accelerator for fast inner-loop sweeps.
+  `check-all-targets` prefers zigbuild when `zig` + `cargo-zigbuild`
+  are both on PATH, falls back to Docker, soft-skips when neither.
+- **`install-dev-tools`** extended (macOS hosts only) to install
+  `zig 0.14.1` from the official `ziglang.org` tarball into
+  `~/.local/zig/0.14.1/`, symlink it into `~/.cargo/bin/zig`, install
+  `cargo-zigbuild`, and add the `x86_64-unknown-linux-gnu` rustup
+  target.  Pinned to 0.14.1 because Homebrew's `zig` formula tracks
+  latest (currently 0.16.x) which has unrelated incompat issues with
+  `psm`'s `src/arch/x86_64.s` ATT-syntax assembly.
+- **Two non-obvious gotchas baked into the L1 recipe** (surfaced
+  during empirical L1.3 verification):
+  1. Recipe overrides `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS`
+     to pin `target-cpu=x86-64-v3` (matches `release.yml`'s Linux
+     baseline) for the cross-compile only.  `.cargo/config.toml`'s
+     default `target-cpu=native` resolves to `apple-m4` on macOS,
+     which `cargo-zigbuild` propagates to `zig cc -mcpu=native`,
+     which corrupts zig's integrated-assembler dialect detection
+     for hand-written x86_64 SIMD asm in `psm` and `blake3`.
+  2. Recipe invokes `cargo-zigbuild clippy` directly (the binary
+     exposes `clippy` / `check` / `test` as proper subcommands)
+     rather than `cargo zigbuild clippy` (cargo plugin form), which
+     always routes into the `zigbuild` build subcommand.
+- **Docs**: `CONTRIBUTING.md` four-layer table + cross-platform
+  section refreshed for the new gate names + flag stack;
+  `windows-clippy-and-linux-cross-plan.md` gets a `Status (2026-05-06)`
+  header with every phase ✅, both gotchas documented, §8 acceptance
+  criteria all checked, §9 cross-references refreshed;
+  `dev-flow-implementation-plan.md` + `dev-flow.md` + `supply-chain-posture.md`
+  updated for the post-W5 job names.
+
 ### Fixed — Dependabot pipeline (PR #126)
 
 - **`dependabot.yml` cargo-ecosystem prefix** flipped from `deps` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,8 +132,8 @@ for the operator-facing validation flow.
 Closes Phases **W5** and **L1** of
 [`docs/architecture/windows-clippy-and-linux-cross-plan.md`](docs/architecture/windows-clippy-and-linux-cross-plan.md).
 Every plan phase (W0 baseline, W1 recipes, W2 prod, W3-W5 tests, W5.5
-CI flip, W5.6 pre-push flip, L1 zigbuild) now ✅; §8 acceptance items
-all checked.
+CI flip, W5.6 pre-push flip, W5 follow-on Tier-2 redundancy cleanup,
+L1 zigbuild) now ✅; §8 acceptance items all checked.
 
 - **`pr-fast.yml::windows-check` → `windows-lint`** (Phase W5.5).
   Renamed the job and switched the command from `cargo check` to
@@ -178,13 +178,25 @@ all checked.
      exposes `clippy` / `check` / `test` as proper subcommands)
      rather than `cargo zigbuild clippy` (cargo plugin form), which
      always routes into the `zigbuild` build subcommand.
+- **`tier-2.yml::windows-check` REMOVED** (W5 follow-on, plan §5).
+  Pre-W5.5 it ran `cargo check --workspace --all-features
+  --all-targets` weekly on `windows-latest` as the backstop catching
+  Windows-only regressions before `just ship`.  With `windows-lint`
+  now running strict clippy on every PR (which does a full
+  type-check + executes every dep's `build.rs`), the weekly job
+  became strictly redundant.  Tombstoned with an inline comment in
+  `tier-2.yml` explaining the removal; references in the
+  `tier-2-summary` and `notify-failure` `needs:` lists + the success
+  conditional + the summary-table line all dropped.  Tier 2 stays
+  the deep-assurance lane (coverage, miri, udeps).
 - **Docs**: `CONTRIBUTING.md` four-layer table + cross-platform
   section refreshed for the new gate names + flag stack;
   `windows-clippy-and-linux-cross-plan.md` gets a `Status (2026-05-06)`
-  header with every phase ✅, both gotchas documented, §8 acceptance
-  criteria all checked, §9 cross-references refreshed;
-  `dev-flow-implementation-plan.md` + `dev-flow.md` + `supply-chain-posture.md`
-  updated for the post-W5 job names.
+  header with every phase ✅ (including the Tier 2 follow-on),
+  both L1 gotchas documented, §8 acceptance criteria all checked,
+  §9 cross-references refreshed; `dev-flow-implementation-plan.md`
+  + `dev-flow.md` + `supply-chain-posture.md` updated for the
+  post-W5 job names and the Tier 2 removal.
 
 ### Fixed — Dependabot pipeline (PR #126)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,31 +64,34 @@ UFFS uses a shift-left pipeline: cheap checks fire close to the keystroke, expen
 | Layer | Trigger | Recipe | Budget | What it runs |
 |------|--------|--------|--------|-------------|
 | **IDE save** | On save | `rust-analyzer` | instant | type-check-on-save, clippy-on-save |
-| **pre-commit** | `git commit` | `just lint-fast` | sub-2 s (docs-only) / 15–25 s warm (`*.rs` staged) | `fmt --check`, **`lint-prod`** (ultra-strict: pedantic + nursery + cargo + unwrap_used + missing_docs_in_private_items), **`lint-tests`** (same base + unwrap allowed), **`lint-ci`** (CI-mirror `-D warnings --all-targets`), **`check-windows`** (`cargo xwin check` of Windows-only `#[cfg(windows)]` paths) — all when `*.rs` staged; plus `taplo fmt --check` (if `*.toml` staged), `typos`, `reuse lint`, file-size policy — all in parallel; missing optional tools soft-skip |
-| **pre-push** | `git push` | `just lint-pre-push` | 25–40 s warm | Same three ultra-strict clippy passes + **Windows `cargo xwin check`** + `fmt --check` + `rustdoc -D warnings` + `cargo deny check` + `nextest run --no-run` (test-binary link check) + file-size policy + `typos` + `reuse lint` — all in parallel. Full parity with `just ship` Phase 1 lint surface plus cross-platform Windows coverage; only the full test runtime (`nextest run`) is deferred to CI. |
-| **PR CI** | on PR to `main` | `.github/workflows/pr-fast.yml` | minutes | PR-blocking matrix (classify → file-size, fmt, sanity, clippy, docs, test-build, tests, security, windows-check, required).  The `classify` job short-circuits docs-only / dep-only / infra-only PRs so heavy jobs only run when code actually changed.  Linux jobs run on `ubuntu-22.04`; `windows-check` runs natively on `windows-latest` (so `#[cfg(windows)]` compile errors now surface at PR time, not release time).  Tier 2 weekly workflow (`.github/workflows/tier-2.yml`) runs coverage + udeps + miri out of the critical path. |
+| **pre-commit** | `git commit` | `just lint-fast` | sub-2 s (docs-only) / 15–25 s warm (`*.rs` staged) | `fmt --check`, **`lint-prod`** (ultra-strict: pedantic + nursery + cargo + unwrap_used + missing_docs_in_private_items), **`lint-tests`** (same base + unwrap allowed), **`lint-ci`** (CI-mirror `-D warnings --all-targets`) — all when `*.rs` staged; plus `taplo fmt --check` (if `*.toml` staged), `typos`, `reuse lint`, file-size policy — all in parallel; missing optional tools soft-skip.  Windows xwin lint lives at pre-push, not pre-commit (40–90 s cold cost violates T1 budget). |
+| **pre-push** | `git push` | `just lint-pre-push` | 25–60 s warm | Same three ultra-strict clippy passes + **Windows `cargo xwin clippy -- -D warnings`** (`lint-ci-windows`, Phase W5.6) + `fmt --check` + `rustdoc -D warnings` + `cargo deny check` + `nextest run --no-run` (test-binary link check) + file-size policy + `typos` + `reuse lint` — all in parallel.  Full parity with `just ship` Phase 1 lint surface plus cross-platform Windows clippy coverage; only the full test runtime (`nextest run`) is deferred to CI. |
+| **PR CI** | on PR to `main` | `.github/workflows/pr-fast.yml` | minutes | PR-blocking matrix (classify → file-size, fmt, sanity, clippy, docs, test-build, tests, security, **windows-lint**, required).  The `classify` job short-circuits docs-only / dep-only / infra-only PRs so heavy jobs only run when code actually changed.  Linux jobs run on `ubuntu-22.04`; **`windows-lint`** runs `cargo clippy -- -D warnings` natively on `windows-latest` (Phase W5.5) so both `#[cfg(windows)]` compile errors and lint regressions surface at PR time.  Tier 2 weekly workflow (`.github/workflows/tier-2.yml`) runs coverage + udeps + miri out of the critical path. |
 | **Release** | manual today; automated after release-automation R4 | `just ship` today; release-plz release PR after R4 | minutes | today: version bump + `release/vX.Y.Z` PR + signed commit + auto-tag + binary build.  **Target state** (see [`docs/architecture/release-automation-plan.md`](docs/architecture/release-automation-plan.md)): release-plz opens `chore(release): prepare vX.Y.Z` PR automatically from conventional commits on `main`; merging that PR creates the tag; `release.yml` builds binaries as today. |
 
 The ultra-strict flag stack — `common_flags` / `prod_flags` / `test_flags` — is defined in `@/Users/rnio/Private/Github/UltraFastFileSearch/just/shared.just:21-26` and pulled in identically by the local hooks and by `just ship` Phase 1, so **the rules a commit is checked against locally are the exact rules CI enforces**.
 
 ### Cross-platform coverage
 
-As of the 2026-04-23 Phase 4 cutover, `pr-fast.yml`'s `windows-check` job runs natively on `windows-latest` so Windows compile errors surface at PR time.  The pre-commit / pre-push hooks still run `cargo xwin check` against `x86_64-pc-windows-msvc` as an advisory pre-PR gate (local fast-feedback); the CI `windows-check` is the authoritative one.  Breakdown:
+As of Phase W5 of [`docs/architecture/windows-clippy-and-linux-cross-plan.md`](docs/architecture/windows-clippy-and-linux-cross-plan.md), `pr-fast.yml`'s `windows-lint` job runs strict `cargo clippy -- -D warnings` natively on `windows-latest` so both compile errors and lint regressions on `#[cfg(windows)]` paths surface at PR time.  Pre-push runs the cross-compiled equivalent (`just lint-ci-windows`, ~6 s warm) as an advisory local mirror; CI on `windows-latest` is authoritative.  Breakdown:
 
-- **Windows** — `cargo xwin check --workspace --all-targets --all-features` via `cargo-xwin` (provisions the MSVC SDK under `~/Library/Caches/xwin/`). Runs in **2–5 s warm** once the SDK is cached. Mandatory at pre-commit (when `*.rs` is staged) and pre-push.
-- **Linux** — covered by CI matrix (`ubuntu-22.04`); a local Docker-based gate is available via `just lint-ci-linux` for conscious cross-platform sweeps but is **not** run at pre-push (minutes-scale, disproportionate for commit-time).
+- **Windows** — `cargo xwin clippy --workspace --all-targets --all-features --no-deps -- -D warnings` via `cargo-xwin` (provisions the MSVC SDK under `~/Library/Caches/xwin/`).  Runs in **~6 s warm** once the SDK is cached.  Wired into pre-push (advisory) and `pr-fast.yml::windows-lint` (authoritative native).
+- **Linux** — covered by CI's native `clippy` job on `ubuntu-22.04`.  Two local options for ad-hoc sweeps: **`just lint-ci-linux-zig`** (native macOS → Linux via `cargo-zigbuild`; ~50 s cold / sub-second warm; needs `zig 0.14.1` + `cargo-zigbuild` from `just install-dev-tools`) or **`just lint-ci-linux`** (Docker; mirrors CI's `rust:latest` image exactly; minutes-scale).  Neither runs at pre-push by default.  The zig version is pinned to **0.14.1** — Homebrew's `zig` formula tracks the latest release (currently 0.16.x) which has incompat issues with `psm` and `blake3` x86_64 hand-written SIMD assembly, so `install-dev-tools` downloads the tarball from `ziglang.org` instead.
 - **macOS / native host** — covered by the three native clippy passes (`lint-ci` / `lint-prod` / `lint-tests`) at both pre-commit and pre-push.
 
-For a full sweep across all three targets, run `just check-all-targets` (native + xwin + Docker Linux). The recipe soft-skips tools that are not installed and reports which targets were exercised.
+For a full sweep across all three targets, run `just check-all-targets` (native + xwin + zigbuild-or-Docker Linux).  The recipe prefers zigbuild when `zig` is on `PATH`, falls back to Docker, and soft-skips when neither is available.
 
 ### First-time setup
 
 ```bash
 just install-hooks         # sets core.hooksPath → scripts/hooks/
-just install-dev-tools     # installs typos-cli + taplo-cli + cargo-xwin + x86_64-pc-windows-msvc target; prints pipx hint for `reuse`
+just install-dev-tools     # installs typos-cli + taplo-cli + cargo-xwin + x86_64-pc-windows-msvc target;
+                           # on macOS hosts also installs zig 0.14.1 (from ziglang.org — NOT brew) +
+                           # cargo-zigbuild + x86_64-unknown-linux-gnu target;
+                           # prints pipx hint for `reuse`
 ```
 
-Re-run `just install-hooks` after any rebase that touches `scripts/hooks/` — it's idempotent. The first time `cargo xwin check` runs it will download the MSVC SDK into `~/Library/Caches/xwin/` (~1–2 GB); subsequent runs reuse the cache.
+Re-run `just install-hooks` after any rebase that touches `scripts/hooks/` — it's idempotent.  The first time `cargo xwin clippy` runs it will download the MSVC SDK into `~/Library/Caches/xwin/` (~1–2 GB); subsequent runs reuse the cache.  `zig` lands in `~/.local/zig/0.14.1/` with a symlink in `~/.cargo/bin/zig` so it shadows any `brew install zig` you may have done previously.
 
 ### Running gates manually
 
@@ -96,9 +99,11 @@ Re-run `just install-hooks` after any rebase that touches `scripts/hooks/` — i
 just lint-fast             # the pre-commit bundle on demand
 just lint-pre-push         # the pre-push bundle on demand
 just lint-ci               # the single clippy gate that CI runs (`--all-targets --all-features --no-deps`)
-just lint-ci-linux         # same clippy gate under a Linux x86_64 Docker image (catches macOS↔Linux drift)
-just check-windows         # cargo xwin check against x86_64-pc-windows-msvc (Windows cross-platform gate)
-just check-all-targets     # full sweep: native + Windows (xwin) + Linux (Docker)
+just lint-ci-linux         # same clippy gate under a Linux x86_64 Docker image (authoritative cross-target)
+just lint-ci-linux-zig     # same clippy gate via cargo-zigbuild (native macOS → Linux; no Docker; faster)
+just check-windows         # cargo xwin check against x86_64-pc-windows-msvc (compile-only fast check)
+just lint-ci-windows       # cargo xwin clippy -- -D warnings (matches `pr-fast.yml::windows-lint`)
+just check-all-targets     # full sweep: native + Windows (xwin) + Linux (zigbuild or Docker)
 just phase1-test           # the full `just ship` Phase-1 validation (pre-ship rehearsal)
 ```
 

--- a/docs/architecture/dev-flow-implementation-plan.md
+++ b/docs/architecture/dev-flow-implementation-plan.md
@@ -1039,7 +1039,10 @@ jobs:
   `PR Fast CI / required` aggregate.
 - `tier-2.yml` → **keep as-is** except: drop `windows-check` job
   (now in `pr-fast.yml`).  Tier 2 stays the deep-assurance lane
-  (coverage, miri, udeps).
+  (coverage, miri, udeps).  **DONE** in PR #138 (W5 follow-on) once
+  `pr-fast.yml::windows-lint` flipped to strict clippy and strictly
+  subsumed Tier 2's weekly compile-check; tombstone comment in
+  `tier-2.yml` documents the removal.
 
 ### 2.6 `scripts/ci/ci-pipeline.rs` → workspace binary `scripts/ci-pipeline/`
 
@@ -1236,7 +1239,7 @@ green**.
 - Create `preview-artifacts.yml` (stub, artifact build only, no smoke
   runner yet — that's Phase 5).
 - Keep `ci.yml` intact; both workflows run in parallel for one week.
-- Update `tier-2.yml` — drop `windows-check` job (now in `pr-fast.yml`).
+- Update `tier-2.yml` — drop `windows-check` job (now in `pr-fast.yml`).  **DONE** in PR #138 (W5 follow-on, see above).
 - Confirm `.github/dependabot.yml` tracks both new workflows.
 
 **Validation** (each item MUST pass before Phase 4 cutover):

--- a/docs/architecture/dev-flow-implementation-plan.md
+++ b/docs/architecture/dev-flow-implementation-plan.md
@@ -117,7 +117,7 @@ Cargo.toml or lockfile bump can break any of those.  Infra-only PRs
 | `cargo check --locked` | `code_changed` | T2 | always present |
 | test-compile (`nextest --no-run --locked`) | `code_changed` | T2 | `cargo-nextest` required; hard-fail on missing (pinned in `.config/nextest.toml`) |
 | **nextest `pre-push-smoke` profile** | `code_changed` | **T2 (new)** | same; hard-fail on missing |
-| **Windows xwin check (local)** | `code_changed` | T2 | **advisory locally**: soft-skip with install hint when `cargo-xwin` missing.  Hard-gated at T3 by native `windows-check` job. |
+| **Windows xwin clippy (local)** | `code_changed` | T2 | **advisory locally**: soft-skip with install hint when `cargo-xwin` missing.  Hard-gated at T3 by native `windows-lint` job (Phase W5.5 of `windows-clippy-and-linux-cross-plan.md` flipped this from `cargo check` to `cargo clippy -- -D warnings`). |
 | pr-fast required aggregate | always | T3 | n/a |
 
 ### 1.3.2 Advisory gates (soft-skip; install hint printed on miss)
@@ -139,7 +139,8 @@ is the exact bug that caused the v0.5.71 four-round-trip incident.
 **Windows xwin is deliberately split** between advisory-local and
 hard-required-remote.  Rationale: `cargo-xwin` downloads the MSVC SDK on
 first run (~400 MB) and not all contributors want that footprint.  The
-PR-fast native `windows-check` job is the authoritative gate; the local
+PR-fast native `windows-lint` job (Phase W5.5; runs `cargo clippy -- -D
+warnings` on `windows-latest`) is the authoritative gate; the local
 xwin step is an ergonomics win for contributors who already have it
 installed.  This is **not** a regression of the v1 "hard xwin" position
 — the feedback correctly flagged that treating a 400 MB download as a
@@ -180,7 +181,7 @@ where supported):**
 7. `cargo deny check` — runs when `dep_changed`, advisory otherwise
 8. `cargo nextest run --no-run --workspace --all-targets --all-features --locked` (test compile)
 9. `cargo nextest run --profile pre-push-smoke --locked` (new)
-10. `cargo xwin check --workspace --all-targets --all-features --target x86_64-pc-windows-msvc --locked` — **advisory locally** (soft-skip with install hint if `cargo-xwin` missing; authoritative gate is PR-fast native `windows-check`)
+10. `cargo xwin clippy --workspace --all-targets --all-features --target x86_64-pc-windows-msvc --no-deps -- -D warnings` (`just lint-ci-windows`, Phase W5.6) — **advisory locally** (soft-skip with install hint if `cargo-xwin` missing; authoritative gate is PR-fast native `windows-lint` on `windows-latest`)
 
 The first red in Bucket 2 aborts the rest (fail-fast).  Bucket 1
 continues to completion so the user sees all cheap-check results in
@@ -678,6 +679,14 @@ jobs:
       - run: cargo deny check --locked
       - run: cargo vet check --locked
 
+  # NOTE: This sample shows the original Phase 4 `windows-check`
+  # job (cargo check).  Phase W5.5 of
+  # `windows-clippy-and-linux-cross-plan.md` renamed it to
+  # `windows-lint` and switched the command to
+  # `cargo clippy --workspace --all-targets --all-features --locked
+  # --no-deps -- -D warnings`.  The live workflow at
+  # `.github/workflows/pr-fast.yml::windows-lint` is the source of
+  # truth; this snippet is preserved for historical context only.
   windows-check:
     name: Windows compile check
     runs-on: windows-latest
@@ -1505,7 +1514,7 @@ Measured against current `v0.5.71` baseline:
 |---|---|---|
 | Median time to first actionable failure after `git push` | CI (~5 min to first red) | T2 pre-push (&lt; 30 s) |
 | PR-blocking full-pipeline wall time | 8-15 min (ci.yml) | &lt; 8 min (pr-fast) |
-| Windows regression detection latency | release-time (~15 min into `just ship`) | PR-time (pr-fast windows-check) |
+| Windows regression detection latency | release-time (~15 min into `just ship`) | PR-time (pr-fast `windows-lint`, post-W5.5: clippy `-D warnings` not just compile-check) |
 | Cargo-vet round-trip incidents per release | 1-3 today | 0 (hard-gated at T1) |
 | Ship resumable state bugs per month | ≥1 (v0.5.71) | 0 after Phase 6 |
 
@@ -1863,9 +1872,14 @@ the `uffs-client` package.  Runtime remains within budget.
   external observers (branch protection, GitHub search for "vet")
   expect a distinct `Security` check in the check-runs list.  Cost
   is ~10 s on warm cache.
-- `windows-check` uses `cargo check` (not `build`) — the PR-fast lane
-  only needs compile-confidence.  Full release-shaped builds move to
-  `preview-artifacts.yml` where they belong.
+- `windows-check` originally used `cargo check` (not `build`) — the
+  PR-fast lane only needs compile-confidence.  Full release-shaped
+  builds live in `preview-artifacts.yml` where they belong.  **Phase
+  W5.5 update**: `windows-check` was renamed to `windows-lint` and the
+  command flipped to `cargo clippy --workspace --all-targets
+  --all-features --locked --no-deps -- -D warnings` once the Windows
+  clippy backlog hit zero (PR #62 cleared 1346 errors → 0).  PR-fast
+  Windows now catches both compile errors AND lint regressions.
 
 #### Phase 4b — Actions hardening retrofit
 

--- a/docs/architecture/dev-flow.md
+++ b/docs/architecture/dev-flow.md
@@ -153,7 +153,7 @@ and `.github/workflows/tier-2.yml` (all as of commit `185ed8825`).
 | test COMPILE (`nextest --no-run`) | — | ✅ | ✅ (test-build) | — |
 | test EXECUTE (`nextest run`) | — | **❌** | ✅ | via coverage |
 | **`cargo test --doc`** | — | **❌** | ✅ | — |
-| Windows compile (`cargo-xwin`) | ✅ if *.rs staged + xwin | ✅ if xwin | — | ✅ native |
+| Windows xwin clippy (`lint-ci-windows`, `cargo xwin clippy -- -D warnings`) | — (Phase 2 budget cap) | ✅ if xwin (advisory; W5.6 upgraded from `check` to `clippy`) | ✅ native (`pr-fast.yml::windows-lint`, W5.5) | ✅ native (Tier 2 `windows-check`, redundant post-W5) |
 | `taplo fmt --check` | ✅ if *.toml staged | — | — | — |
 | `typos` | ✅ optional | ✅ optional | — | — |
 | `reuse lint` (SPDX) | ✅ optional | ✅ optional | — | — |
@@ -168,8 +168,9 @@ CI catches something local never runs.
 
 ### 3.3 Measured budgets (current)
 
-- **Pre-commit** — 2 s docs-only, 15–25 s with Rust changes warm sccache,
-  40–90 s cold-xwin.  Stays under the "must not block flow" threshold.
+- **Pre-commit** — 2 s docs-only, 15–25 s with Rust changes warm sccache.
+  Stays under the "must not block flow" threshold.  (Phase 2 removed xwin
+  from this tier — its 40–90 s cold cost violated the T1 budget.)
 - **Pre-push** — 23–45 s warm, 60–90 s cold.  Heaviest jobs: rustdoc and
   nextest `--no-run` share the same target-dir.  File-locking serializes
   them; the non-cargo jobs (deny, typos, reuse, file-size) genuinely run
@@ -647,8 +648,8 @@ from each repo's `.pre-commit-config.yaml` / `Makefile.toml` /
 | **polars** | ruff + black + minimal Rust | none | Mixed Python/Rust project. |
 | **clap** | fmt + clippy | none | Heavy CI matrix. |
 | **bytes** | fmt | none | Tiny; CI-heavy. |
-| **UFFS (current)** | clippy trio + xwin + file-size + typos + reuse + taplo | clippy trio + rustdoc + deny + test-compile + xwin + file-size + typos + reuse | Deeper local gates than any above. |
-| **UFFS (proposed)** | (same as current) | (current) + **cargo-vet** + **doc-tests** | Closes the two CI-only gates whose inputs are 100% local. |
+| **UFFS (current, post-W5/L1)** | clippy trio + file-size + typos + reuse + taplo | clippy trio + rustdoc + doctests + deny + test-compile + smoke + **xwin clippy (`lint-ci-windows`)** + cargo-vet (when dep-changed) + commit-subjects + file-size + typos + reuse | Deeper local gates than any above; pre-push now strict-lints Windows-gated code via cargo-xwin clippy. |
+| **UFFS (initial baseline, 2025)** | clippy trio + xwin + file-size + typos + reuse + taplo | clippy trio + rustdoc + deny + test-compile + xwin + file-size + typos + reuse | Pre-Phase-2 baseline kept here for historical reference — xwin lived at pre-commit and was a compile-only check. |
 
 **Takeaway**: UFFS is already ahead of typical Rust OSS posture on local
 coverage.  The shift-left work here is about closing two specific holes,

--- a/docs/architecture/dev-flow.md
+++ b/docs/architecture/dev-flow.md
@@ -153,7 +153,7 @@ and `.github/workflows/tier-2.yml` (all as of commit `185ed8825`).
 | test COMPILE (`nextest --no-run`) | — | ✅ | ✅ (test-build) | — |
 | test EXECUTE (`nextest run`) | — | **❌** | ✅ | via coverage |
 | **`cargo test --doc`** | — | **❌** | ✅ | — |
-| Windows xwin clippy (`lint-ci-windows`, `cargo xwin clippy -- -D warnings`) | — (Phase 2 budget cap) | ✅ if xwin (advisory; W5.6 upgraded from `check` to `clippy`) | ✅ native (`pr-fast.yml::windows-lint`, W5.5) | ✅ native (Tier 2 `windows-check`, redundant post-W5) |
+| Windows xwin clippy (`lint-ci-windows`, `cargo xwin clippy -- -D warnings`) | — (Phase 2 budget cap) | ✅ if xwin (advisory; W5.6 upgraded from `check` to `clippy`) | ✅ native (`pr-fast.yml::windows-lint`, W5.5) | — (Tier 2 `windows-check` removed in PR #138, strictly subsumed by T3 `windows-lint`) |
 | `taplo fmt --check` | ✅ if *.toml staged | — | — | — |
 | `typos` | ✅ optional | ✅ optional | — | — |
 | `reuse lint` (SPDX) | ✅ optional | ✅ optional | — | — |

--- a/docs/architecture/security/supply-chain-posture.md
+++ b/docs/architecture/security/supply-chain-posture.md
@@ -70,7 +70,7 @@ control lands or a deferred item is promoted.
 | Import refresh | `cargo-vet-refresh.yml` | Weekly `cargo vet regenerate imports` → PR | Mondays 08:00 UTC | GitHub schedules |
 | Structural audit | `cargo-geiger` via `just geiger` | unsafe / build.rs / proc-macro footprint | On-demand (monthly) | No |
 | Semantic SAST | `codeql.yml` (Rust, public preview) | Dataflow-based bug patterns (path / SQL / regex injection, crypto misuse, unvalidated redirects) | PR + Tuesdays 06:30 UTC | Informational (not a required gate yet) |
-| Windows regression check | Tier 2 `windows-check` job | `cargo check --workspace --all-features --all-targets` on `windows-latest` | Weekly (Mondays 06:00 UTC) | GitHub schedules |
+| Windows regression check | `pr-fast.yml::windows-lint` job | `cargo clippy --workspace --all-targets --all-features --locked --no-deps -- -D warnings` on `windows-latest` | **Every PR** (was weekly Tier 2 pre-PR-#138; now PR-time) | GitHub-required-check |
 | Human review for minor/major bumps | Dependabot PRs for minor + major + security advisories are NOT auto-merged | Minor / major / security-advisory bumps | Every Dependabot PR | GitHub enforces |
 | Gated auto-merge for patch bumps | `dependabot-auto-merge.yml` | Only `version-update:semver-patch` bumps with NO active security advisory, gated on all required checks (cargo-deny, cargo-vet, clippy, tests, doc-tests, file-size policy) + branch-protection rules (signed commits, required reviews) | Every Dependabot PR | Gates enforced via required checks + branch protection |
 
@@ -85,7 +85,7 @@ control lands or a deferred item is promoted.
 | Malicious `build.rs` / proc-macro executing in CI | **High** | Dependabot PRs run with **read-only `GITHUB_TOKEN`** + no repo secrets (GitHub default); `permissions:` block denies writes elsewhere; `cargo-vet` imports from Mozilla/Google are the primary vetting signal for new build-script crates | **Medium** — blast radius bounded (runner has no sensitive tokens); new unaudited crate bumps are caught by `cargo vet check`, forcing a conscious decision |
 | Release binary swapped on GitHub Release page | Medium | SHA256 `CHECKSUMS.txt` + SLSA build-provenance attestation via `gh attestation verify` | Low — requires attacker to also swap attestation, which is stored in GitHub Attestations API (separate audit trail) |
 | SBOM swapped on GitHub Release page (misleading component inventory) | Medium | `sbom-*.cdx.json` files are covered by the same SLSA attestation as the binaries — `gh attestation verify` on the SBOM matches only if the bytes match this workflow run | Low — inherits the binary-swap residual |
-| Windows-only build regression lands on main and only surfaces at release time | Low | Tier 2 `windows-check` job runs weekly on `windows-latest`; `cargo check --workspace --all-features --all-targets` catches type / link errors before `just ship` does | Low — up to a week of lag between merge and detection (acceptable given human-review gating on every merge) |
+| Windows-only build regression lands on main and only surfaces at release time | Low | `pr-fast.yml::windows-lint` job runs strict `cargo clippy -- -D warnings` natively on `windows-latest` on every PR (post-PR-#138 / Phase W5.5).  `cargo clippy` does a full type-check + executes every dep's `build.rs`, so any Windows-only build regression is caught at PR-time | Very low — minutes-scale detection latency, hard-gates merge to `main` |
 | Semantic bug class (path / SQL / regex injection, crypto misuse) slipping past clippy | Medium | `codeql.yml` Rust SAST on every PR + weekly baseline | Medium — Rust support is in public preview; false-negative rate unknown |
 | Rollback attack (release an older vulnerable commit) | Medium | `commit_sha` ancestor-of-main guard in `release.yml` | Low |
 | Rogue `v*` tag push by write-access user | Low | `tag-protection-v-prefix` ruleset blocks deletion + update | **Medium on creation** — GitHub API does not support `Integration` bypass for user-owned repos, so `creation` rule not enforced (bot couldn't push tags if it were).  Partial protection only. |
@@ -355,7 +355,7 @@ on `main` at branch-open time.
 - `supply-chain/audits.toml` — our local audit records (starts empty)
 - `supply-chain/imports.lock` — pinned upstream audit snapshots
 - `.github/workflows/pr-fast.yml` — required per-PR gate (fmt, clippy, docs, tests, **windows-lint** [native `cargo clippy -- -D warnings` on `windows-latest` post-W5.5], `cargo-deny` + `cargo-vet check` in `security` job) (Tier 1)
-- `.github/workflows/tier-2.yml` — weekly coverage / udeps / Miri / Windows compile check
+- `.github/workflows/tier-2.yml` — weekly coverage / udeps / Miri (Windows compile check removed in PR #138 — superseded by `pr-fast.yml::windows-lint`'s per-PR strict clippy)
 - `.github/workflows/release.yml` — SLSA attestation + ancestor check + CycloneDX SBOM
 - `.github/workflows/codeql.yml` — Rust SAST (public preview)
 - `.github/workflows/dependabot-review.yml` — dep-tree growth annotation

--- a/docs/architecture/security/supply-chain-posture.md
+++ b/docs/architecture/security/supply-chain-posture.md
@@ -354,7 +354,7 @@ on `main` at branch-open time.
 - `supply-chain/config.toml` — `cargo-vet` imports + exemptions
 - `supply-chain/audits.toml` — our local audit records (starts empty)
 - `supply-chain/imports.lock` — pinned upstream audit snapshots
-- `.github/workflows/pr-fast.yml` — required per-PR gate (fmt, clippy, docs, tests, windows-check, `cargo-deny` + `cargo-vet check` in `security` job) (Tier 1)
+- `.github/workflows/pr-fast.yml` — required per-PR gate (fmt, clippy, docs, tests, **windows-lint** [native `cargo clippy -- -D warnings` on `windows-latest` post-W5.5], `cargo-deny` + `cargo-vet check` in `security` job) (Tier 1)
 - `.github/workflows/tier-2.yml` — weekly coverage / udeps / Miri / Windows compile check
 - `.github/workflows/release.yml` — SLSA attestation + ancestor check + CycloneDX SBOM
 - `.github/workflows/codeql.yml` — Rust SAST (public preview)

--- a/docs/architecture/windows-clippy-and-linux-cross-plan.md
+++ b/docs/architecture/windows-clippy-and-linux-cross-plan.md
@@ -13,9 +13,69 @@ UFFS — Windows Clippy + Linux Native Cross-Check Plan
 > [`release-automation-plan.md`](release-automation-plan.md)
 > (post-merge concerns).  This plan owns **making the super-strict
 > lint flow actually strict on every target we ship to** —
-> currently the strict `clippy` stack only runs natively on macOS
-> and in Docker for Linux; the Windows gate is `cargo check` only
-> (type-check, not lint), and no native macOS → Linux path exists.
+> originally the strict `clippy` stack only ran natively on macOS
+> and in Docker for Linux; the Windows gate was `cargo check` only
+> (type-check, not lint), and no native macOS → Linux path existed.
+
+## Status (2026-05-06)
+
+All phases now closed:
+
+| Phase | Lands in | Status |
+|---|---|---|
+| W0 baseline | (in-doc) | ✅ 2026-04-24 |
+| W1 xwin clippy recipes | PR #61 | ✅ |
+| W2 prod gate | PR #62 (W2–W5 cleanup) | ✅ v0.5.72 |
+| W3 test T1 mechanical | PR #62 | ✅ v0.5.72 |
+| W4 test T2 targeted | PR #62 | ✅ v0.5.72 |
+| W5 test T3 + CI/pre-push flip | PR #138 (this) | ✅ |
+| L1 zigbuild accelerator | PR #138 (this) | ✅ |
+| L2 CI parity verification | (deferred; CI Docker image already mirrors `rust:latest`) | ⏭ |
+| P1 plan codification | landed with W0/W1 | ✅ |
+
+The Windows clippy backlog (W0 baseline: 1346 errors on the
+authoritative `--all-targets -D warnings` pass) was driven to zero in
+PR #62 (v0.5.72).  PR #138 closes the loop by upgrading both gates
+that had been left on `cargo check`:
+
+- `pr-fast.yml::windows-check` (CI) → `pr-fast.yml::windows-lint`
+  running `cargo clippy --workspace --all-targets --all-features
+  --locked --no-deps -- -D warnings` natively on `windows-latest`.
+- `scripts/hooks/_lint_pre_push.sh` (local) → `just lint-ci-windows`
+  (cargo-xwin clippy with the same flag stack), ≈6 s warm.
+
+And adds the L1 zigbuild accelerator: `just lint-ci-linux-zig` runs
+the full Linux clippy gate natively on macOS via `cargo-zigbuild` (no
+Docker required) in ~50 s cold and sub-second warm.  The Docker
+`lint-ci-linux` path remains authoritative; zigbuild is a
+developer-loop accelerator only.
+
+Two non-obvious wrinkles surfaced during L1.3 empirical verification
+on this workspace and are now baked into the recipe + install path:
+
+1. **Zig version pin (0.14.1).**  Homebrew's `zig` formula tracks
+   latest (currently 0.16.x) which has unrelated incompat issues with
+   `psm`'s `src/arch/x86_64.s` ATT-syntax assembly.  zig 0.14.1
+   compiles `psm` cleanly (and works around a separate `blake3`
+   dialect-detection issue when paired with the rustflags override
+   below).  `just install-dev-tools` therefore downloads the official
+   ziglang.org tarball into `~/.local/zig/0.14.1/` and symlinks it
+   into `~/.cargo/bin/zig` so it shadows any `brew install zig`.
+
+2. **`target-cpu=native` rustflags override.**  `.cargo/config.toml`
+   sets `rustflags = ["-C", "target-cpu=native", …]` for the Linux
+   target so native Linux builds get host-tuned codegen.  On a macOS
+   host that resolves to `apple-m4`, which `cargo-zigbuild`
+   propagates to `zig cc -mcpu=native` alongside `-target
+   x86_64-linux-gnu`.  The combined flag set corrupts zig's
+   integrated-assembler dialect detection, producing thousands of
+   `unrecognized instruction mnemonic` errors when compiling the
+   x86_64 SIMD hand-written assembly that ships in `psm` and
+   `blake3`.  The recipe overrides
+   `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS` to pin
+   `target-cpu=x86-64-v3` (the same baseline `release.yml`'s Linux
+   matrix uses) for the cross-compile only — native Linux builds via
+   the Docker path are unaffected.
 
 ## 0. TL;DR
 
@@ -24,9 +84,9 @@ UFFS — Windows Clippy + Linux Native Cross-Check Plan
 | Strict clippy flag stack | `prod_flags` + `test_flags` + `-D warnings` (see `@/Users/rnio/Private/Github/UltraFastFileSearch/just/shared.just:28-30`) | **Unchanged** — zero flag churn; only the surface it runs on changes |
 | macOS host gate | `lint-prod` + `lint-tests` + `lint-ci` — strict ✅ | **Unchanged** |
 | Linux-in-Docker gate | `lint-ci-linux` — `-D warnings` ✅ | **Unchanged** (stays the authoritative Linux gate) |
-| Linux native from macOS | Blocked (`zstd-sys` `build.rs` needs a C cross-compiler Apple `cc` can't provide) | **`cargo-zigbuild`** accelerator — handles C deps via `zig cc`; Docker path stays authoritative |
-| Windows local (macOS → Win) | `cargo xwin check` only (type-check, no lint) — see `@/Users/rnio/Private/Github/UltraFastFileSearch/just/dev.just:52-55` | **`cargo xwin clippy`** with the same three-pass flag stack (prod / tests / CI) |
-| Windows CI | `cargo check` on `windows-latest` — see `@/Users/rnio/Private/Github/UltraFastFileSearch/.github/workflows/pr-fast.yml:436-458` | **`cargo clippy -- -D warnings`** on `windows-latest` |
+| Linux native from macOS | Blocked (`zstd-sys` `build.rs` needs a C cross-compiler Apple `cc` can't provide) → ✅ **`cargo-zigbuild`** accelerator now wired (`just lint-ci-linux-zig`) | **Done** — handles C deps via `zig cc`; Docker path stays authoritative |
+| Windows local (macOS → Win) | `cargo xwin check` only (type-check, no lint) → ✅ **pre-push now runs `just lint-ci-windows`** (cargo xwin clippy `-- -D warnings`) | **Done** — same three-pass flag stack |
+| Windows CI | `cargo check` on `windows-latest` → ✅ **`cargo clippy -- -D warnings`** on `windows-latest` (`pr-fast.yml::windows-lint`) | **Done** |
 | Windows clippy backlog (prod: `--lib --bins`) | **93** errors (measured W0, 2026-04-24) | **0** after Phase W2 |
 | Windows clippy backlog (tests: `--tests`) | **1,342** errors (measured W0) | **0** after Phases W3 – W5 |
 | Windows clippy backlog (ci: `--all-targets -D warnings`) | **1,346** errors (measured W0) | **0** after W5 |
@@ -361,21 +421,23 @@ If a single lint rule (typically `significant_drop_tightening`) accumulates > 3 
 
 ## 8. Acceptance criteria (rollup)
 
-- [ ] `just lint-prod-windows` + `just lint-tests-windows` + `just lint-ci-windows` exist and are green.
-- [ ] `just lint-ci-linux-zig` exists and green; Docker path unchanged and still green.
-- [ ] PR Fast CI `windows-lint` job runs `cargo clippy -- -D warnings` natively on `windows-latest`; `required` aggregator gates on it.
-- [ ] Zero blanket `#[allow]` added in this workstream; fewer than 20 `#[expect(…, reason = …)]` across the Windows surface (budget revised from 10 after W0 revealed cast-family FFI site density).
-- [ ] Every `#[expect]` has an inline justification comment referencing either the FFI signature it accommodates or an open ticket to remove it.
-- [ ] CONTRIBUTING.md + `dev-flow-implementation-plan.md` + `release-automation-plan.md` cross-reference this plan.
-- [ ] "New Windows code must be lint-clean from day 1" rule enforced at pre-push after W2 (prod) and at PR CI after W5 (full).
+- [x] `just lint-prod-windows` + `just lint-tests-windows` + `just lint-ci-windows` exist and are green.  (PR #61 / PR #62)
+- [x] `just lint-ci-linux-zig` exists and green; Docker path unchanged and still green.  (PR #138 — verified locally on macOS arm64 with `zig 0.14.1` (pinned, see Status section) + `cargo-zigbuild 0.22.3` against `x86_64-unknown-linux-gnu` target; ~50 s cold, sub-second warm.)
+- [x] PR Fast CI `windows-lint` job runs `cargo clippy -- -D warnings` natively on `windows-latest`; `required` aggregator gates on it.  (PR #138)
+- [x] Zero blanket `#[allow]` added in this workstream; fewer than 20 `#[expect(…, reason = …)]` across the Windows surface (budget revised from 10 after W0 revealed cast-family FFI site density).  (PR #62)
+- [x] Every `#[expect]` has an inline justification comment referencing either the FFI signature it accommodates or an open ticket to remove it.  (PR #62)
+- [x] CONTRIBUTING.md + `dev-flow-implementation-plan.md` + `release-automation-plan.md` cross-reference this plan.  (PR #138 refreshed CONTRIBUTING.md text for the post-W5 state.)
+- [x] "New Windows code must be lint-clean from day 1" rule enforced at pre-push after W2 (prod) and at PR CI after W5 (full).  (PR #138 — pre-push hook now runs `just lint-ci-windows`, CI runs strict `cargo clippy -- -D warnings`.)
 
 ## 9. Cross-references
 
 - **Strict lint flag stack source of truth**: `@/Users/rnio/Private/Github/UltraFastFileSearch/just/shared.just:28-30`
-- **Current Linux Docker gate**: `@/Users/rnio/Private/Github/UltraFastFileSearch/just/test.just:82-107`
-- **Current Windows xwin check gate (local)**: `@/Users/rnio/Private/Github/UltraFastFileSearch/just/dev.just:52-55`
-- **Current Windows CI gate**: `@/Users/rnio/Private/Github/UltraFastFileSearch/.github/workflows/pr-fast.yml:436-458`
-- **Pre-push hook runner**: `@/Users/rnio/Private/Github/UltraFastFileSearch/scripts/hooks/_lint_pre_push.sh`
+- **Linux Docker lint gate**: `@/Users/rnio/Private/Github/UltraFastFileSearch/just/test.just:82-107`
+- **Linux zigbuild lint gate (Phase L1, native macOS → Linux)**: `@/Users/rnio/Private/Github/UltraFastFileSearch/just/test.just:142-190`
+- **Windows xwin compile-check (local fast path)**: `@/Users/rnio/Private/Github/UltraFastFileSearch/just/dev.just:171-174`
+- **Windows xwin clippy gate (`lint-ci-windows`, mirrors CI's strict pass)**: `@/Users/rnio/Private/Github/UltraFastFileSearch/just/test.just:132-140`
+- **Windows CI gate (`pr-fast.yml::windows-lint`, native `windows-latest`)**: `@/Users/rnio/Private/Github/UltraFastFileSearch/.github/workflows/pr-fast.yml:429-467`
+- **Pre-push hook runner (calls `lint-ci-windows`)**: `@/Users/rnio/Private/Github/UltraFastFileSearch/scripts/hooks/_lint_pre_push.sh:316-318`
 - **Gate architecture**: `@/Users/rnio/Private/Github/UltraFastFileSearch/docs/architecture/dev-flow-implementation-plan.md`
 - **Release architecture**: `@/Users/rnio/Private/Github/UltraFastFileSearch/docs/architecture/release-automation-plan.md`
 - **Cargo-zigbuild upstream**: https://github.com/rust-cross/cargo-zigbuild

--- a/docs/architecture/windows-clippy-and-linux-cross-plan.md
+++ b/docs/architecture/windows-clippy-and-linux-cross-plan.md
@@ -29,6 +29,7 @@ All phases now closed:
 | W3 test T1 mechanical | PR #62 | ✅ v0.5.72 |
 | W4 test T2 targeted | PR #62 | ✅ v0.5.72 |
 | W5 test T3 + CI/pre-push flip | PR #138 (this) | ✅ |
+| W5 follow-on — Tier 2 `windows-check` removal | PR #138 (this) | ✅ |
 | L1 zigbuild accelerator | PR #138 (this) | ✅ |
 | L2 CI parity verification | (deferred; CI Docker image already mirrors `rust:latest`) | ⏭ |
 | P1 plan codification | landed with W0/W1 | ✅ |
@@ -43,6 +44,15 @@ that had been left on `cargo check`:
   --locked --no-deps -- -D warnings` natively on `windows-latest`.
 - `scripts/hooks/_lint_pre_push.sh` (local) → `just lint-ci-windows`
   (cargo-xwin clippy with the same flag stack), ≈6 s warm.
+
+PR #138 also drops the now-redundant Tier 2 `windows-check` job
+(plan §5 follow-on).  Pre-W5.5 it ran `cargo check --workspace
+--all-features --all-targets` weekly on `windows-latest` as the
+backstop catching Windows-only regressions before `just ship`.
+With `windows-lint` now running strict clippy on every PR (which
+does a full type-check + executes every dep's `build.rs`), the
+weekly job became strictly redundant and was tombstoned with an
+inline comment in `tier-2.yml` explaining the removal.
 
 And adds the L1 zigbuild accelerator: `just lint-ci-linux-zig` runs
 the full Linux clippy gate natively on macOS via `cargo-zigbuild` (no

--- a/just/dev.just
+++ b/just/dev.just
@@ -175,13 +175,22 @@ check-windows:
 
 # Cross-platform compile check across all three supported targets.
 #
-# Runs native (host) + Linux (via Docker, through `lint-ci-linux`) +
-# Windows (via xwin, through `check-windows`).  Intended as a manual
-# "pre-PR sweep"; the pre-push hook runs the host + Windows subset only
-# (Linux-in-Docker is too slow for a commit-time gate — CI covers it).
+# Runs native (host) + Linux (via cargo-zigbuild when `zig` is on PATH,
+# else Docker `lint-ci-linux`) + Windows (via xwin, through
+# `check-windows`).  Intended as a manual "pre-PR sweep"; the pre-push
+# hook runs the host + Windows subset only (Linux is too slow for a
+# commit-time gate — CI covers it).
 #
-# Skips silently if a prerequisite tool (cargo-xwin, docker) is missing,
-# but reports which targets were exercised so you know the coverage.
+# Linux path order (Phase L1.4 of windows-clippy-and-linux-cross-plan.md):
+#   1. Prefer `just lint-ci-linux-zig` (native, ~10–20 s warm) when
+#      `zig` and `cargo-zigbuild` are both available.
+#   2. Fall back to `just lint-ci-linux` (Docker, authoritative —
+#      mirrors CI's `rust:latest` image exactly).
+#   3. Skip with a hint when neither is available.
+#
+# Skips silently if a prerequisite tool (cargo-xwin, zig, docker) is
+# missing, but reports which targets were exercised so you know the
+# coverage.
 check-all-targets:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -196,11 +205,15 @@ check-all-targets:
     else
         printf "\033[1;33m   ⚠  cargo-xwin not installed — skipping; install with: \033[0;36mcargo install cargo-xwin\033[0m\n\n"
     fi
-    printf "\033[0;36m   ── Linux x86_64-unknown-linux-gnu (Docker) ──\033[0m\n"
-    if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    printf "\033[0;36m   ── Linux x86_64-unknown-linux-gnu ──\033[0m\n"
+    if command -v zig >/dev/null 2>&1 && command -v cargo-zigbuild >/dev/null 2>&1; then
+        printf "\033[0;36m   · using cargo-zigbuild (native, no Docker)\033[0m\n"
+        just lint-ci-linux-zig
+    elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+        printf "\033[0;36m   · using Docker (authoritative; install \033[0;36mzig\033[0m + \033[0;36mcargo-zigbuild\033[0m for the faster path)\033[0m\n"
         just lint-ci-linux
     else
-        printf "\033[1;33m   ⚠  Docker not available — skipping; start Docker Desktop / colima / OrbStack\033[0m\n"
+        printf "\033[1;33m   ⚠  Neither zigbuild nor Docker available — skipping; install one via \033[0;36mjust install-dev-tools\033[0m\n"
     fi
     printf "\033[0;32m✅ Cross-platform check complete\033[0m\n"
 

--- a/just/test.just
+++ b/just/test.just
@@ -208,7 +208,7 @@ lint-all:
 #   IDE save   → rust-analyzer check-on-save
 #   pre-commit → `just lint-fast`       (staged-scoped, sub-2 s)
 #   pre-push   → `just lint-pre-push`   (workspace-parallel, ≤ 60 s)
-#   PR CI      → .github/workflows/pr-fast.yml (classify-gated matrix + native windows-check)
+#   PR CI      → .github/workflows/pr-fast.yml (classify-gated matrix + native windows-lint)
 # Recipes below back both the git hooks and manual invocations so the
 # two surfaces never drift — see `scripts/hooks/_lint_*.sh` for the
 # shared parallel runners.

--- a/just/test.just
+++ b/just/test.just
@@ -110,13 +110,14 @@ lint-ci-linux:
 #
 # The Windows counterpart of `lint-prod` / `lint-tests` / `lint-ci` — mirrors
 # the exact same flag stack so the strict clippy rules apply identically on
-# Windows-gated code.  Until Phase W5 of
-# `docs/architecture/windows-clippy-and-linux-cross-plan.md` lands, these
-# recipes emit hundreds of lints (W0 baseline: prod=93, tests=1342, ci=1346)
-# and are therefore not yet wired into `lint-all` or the pre-push hook.
-# They exist as the authoritative surface the Windows backlog is being
-# converged against phase by phase.  Requires `cargo-xwin` + target
-# `x86_64-pc-windows-msvc` (both from `just install-dev-tools`).
+# Windows-gated code.  Phase W5 of
+# `docs/architecture/windows-clippy-and-linux-cross-plan.md` cleared the
+# backlog (W0 baseline: prod=93, tests=1342, ci=1346 → zero) so these
+# recipes now exit 0 against the workspace.  `lint-ci-windows` is wired
+# into the pre-push hook (W5.6) and `pr-fast.yml`'s `windows-lint` job
+# runs the equivalent native clippy on `windows-latest` (W5.5).  Requires
+# `cargo-xwin` + target `x86_64-pc-windows-msvc` (both from
+# `just install-dev-tools`).
 #
 # Ultra-strict Windows production linting (workspace lints on --lib --bins).
 lint-prod-windows:
@@ -128,13 +129,65 @@ lint-tests-windows:
     @printf "\033[0;34m🪟 Windows strict test lint (cargo xwin clippy)...\033[0m\n"
     cargo xwin clippy --workspace --tests --all-features --target x86_64-pc-windows-msvc --no-deps -- {{ test_flags }}
 
-# This is the gate the PR Fast CI `windows-check` job will adopt after Phase
-# W5 (see cross-target plan) completes.
-#
-# Windows CI lint gating (all-targets, deny warnings).
+# Authoritative cross-target lint gate for Windows — mirrors the strict
+# `cargo clippy --all-targets --all-features --no-deps -- -D warnings`
+# stack the `pr-fast.yml::windows-lint` job runs natively on
+# `windows-latest` (Phase W5.5).  Pre-push runs this via
+# `scripts/hooks/_lint_pre_push.sh` (Phase W5.6) so new Windows-gated
+# code is gated on the same surface CI enforces.
 lint-ci-windows:
     @printf "\033[0;34m🚨 Windows CI lint gating (cargo xwin clippy)...\033[0m\n"
     cargo xwin clippy --workspace --all-targets --all-features --target x86_64-pc-windows-msvc --no-deps -- -D warnings
+
+# Native macOS → Linux clippy sweep via cargo-zigbuild (Phase L1.2 of
+# `docs/architecture/windows-clippy-and-linux-cross-plan.md`).
+#
+# Faster inner-loop alternative to `lint-ci-linux` (which uses Docker).
+# The Docker path stays authoritative because it mirrors CI's exact
+# `rust:latest` image; this recipe is a developer accelerator that
+# avoids spinning up a container for quick local sweeps.
+#
+# How it works: `cargo-zigbuild`'s `clippy` subcommand sets up a `zig
+# cc` wrapper as the C cross-compiler so `cc-rs` (which drives
+# `zstd-sys` / `psm` / `blake3` build.rs files) produces native Linux
+# x86_64 ELF objects from a macOS host — no Docker, no Linux VM, no
+# separate cross-toolchain install.
+#
+# Pinned to `zig 0.14.1`.  Homebrew's `zig` formula tracks latest
+# (currently 0.16.x), which has unrelated incompat issues with `psm`
+# and `blake3` x86_64 hand-written SIMD assembly that are not worth
+# working around at this layer.  `just install-dev-tools` installs
+# 0.14.1 from the official ziglang.org tarball into `~/.local/zig/`
+# and symlinks it into `~/.cargo/bin/`.
+#
+# Requires: `zig 0.14.1` and `cargo-zigbuild` (both installed by
+# `just install-dev-tools` on macOS hosts).
+lint-ci-linux-zig:
+    @printf "\033[0;34m🦎 Linux x86_64 clippy via cargo-zigbuild (native macOS → Linux)...\033[0m\n"
+    @if ! command -v zig >/dev/null 2>&1; then printf "\033[0;31m❌ zig not found — install with: \033[0;36mjust install-dev-tools\033[0m\n"; exit 1; fi
+    @if ! command -v cargo-zigbuild >/dev/null 2>&1; then printf "\033[0;31m❌ cargo-zigbuild not found — install with: \033[0;36mjust install-dev-tools\033[0m\n"; exit 1; fi
+    # Override `.cargo/config.toml`'s `target-cpu=native` rustflags for
+    # the cross-compile target.  On macOS the host CPU is `apple-m4`
+    # (or similar arm64 codename) which cargo-zigbuild propagates to
+    # `zig cc -mcpu=native`.  Combined with `-target x86_64-linux-gnu`
+    # this corrupts the integrated assembler's dialect detection for
+    # hand-written x86_64 SIMD assembly in transitive deps (`psm`'s
+    # `src/arch/x86_64.s`, `blake3`'s `c/blake3_*_x86-64_unix.S`),
+    # producing thousands of `unrecognized instruction mnemonic` /
+    # `invalid operand` errors that look like syntax issues but are
+    # really architecture-confusion.  Pin to `x86-64-v3` (the same
+    # baseline `release.yml`'s Linux matrix uses) so behaviour matches
+    # CI as closely as possible.
+    #
+    # Note: invoke the cargo-zigbuild binary directly (not via the `cargo
+    # zigbuild` subcommand-plugin pattern).  `cargo zigbuild` always
+    # routes into the `zigbuild` build subcommand and rejects further
+    # subcommand args; the binary itself exposes `clippy` / `check` /
+    # `test` / etc. as proper subcommands that wire up the same zig-cc
+    # linker shim cargo-zigbuild's `zigbuild` does.
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C target-cpu=x86-64-v3 -C link-arg=-Wl,--gc-sections" \
+        cargo-zigbuild clippy --workspace --all-targets --all-features --target x86_64-unknown-linux-gnu --no-deps -- -D warnings
+    @printf "\033[0;32m✅ Linux clippy gate (zigbuild) passed\033[0m\n"
 
 # Host-only on purpose — Windows (`lint-*-windows`) and Linux-in-Docker
 # (`lint-ci-linux`) are separate recipes.  They will be wired into this
@@ -198,20 +251,78 @@ install-dev-tools:
     else
         printf "   \033[0;32m✓\033[0m taplo already installed\n"
     fi
-    # cargo-xwin is required by the pre-commit / pre-push `check-windows`
-    # gate.  Optional on Windows hosts (where `cargo check` is native), but
-    # effectively mandatory on macOS / Linux dev machines since CI only
-    # runs Ubuntu and cannot catch Windows-specific compile errors.
+    # cargo-xwin is required by the pre-commit / pre-push `lint-ci-windows`
+    # gate (Phase W5.6).  Optional on Windows hosts (where `cargo clippy`
+    # is native), but effectively mandatory on macOS / Linux dev machines
+    # since CI's authoritative `windows-lint` job runs on `windows-latest`
+    # and we need the local mirror to catch issues before PR.
     if ! command -v cargo-xwin >/dev/null 2>&1; then
         cargo install --locked cargo-xwin
     else
         printf "   \033[0;32m✓\033[0m cargo-xwin already installed\n"
     fi
     # Ensure the Windows cross-compilation target is available for
-    # `cargo xwin check`.  `rustup target add` is idempotent.
+    # `cargo xwin clippy`.  `rustup target add` is idempotent.
     rustup target add x86_64-pc-windows-msvc >/dev/null 2>&1 || true
     if rustup target list --installed 2>/dev/null | grep -q '^x86_64-pc-windows-msvc$'; then
         printf "   \033[0;32m✓\033[0m x86_64-pc-windows-msvc target installed\n"
+    fi
+    # zig + cargo-zigbuild back the `lint-ci-linux-zig` accelerator
+    # (Phase L1).  Optional but recommended on macOS hosts — lets
+    # contributors run the Linux clippy sweep natively (no Docker)
+    # for fast inner-loop checks.  The Docker `lint-ci-linux` path
+    # remains authoritative; this is a dev-loop accelerator only.
+    #
+    # zig is pinned to 0.14.1 (Homebrew's `zig` formula tracks latest,
+    # currently 0.16.x, which has incompat issues with `psm` and
+    # `blake3` x86_64 hand-written SIMD assembly that are not worth
+    # working around at this layer).  Install via the official
+    # ziglang.org tarball; symlink onto PATH via `~/.cargo/bin/zig`.
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        ZIG_PIN="0.14.1"
+        ZIG_DIR="$HOME/.local/zig/${ZIG_PIN}"
+        ZIG_LINK="$HOME/.cargo/bin/zig"
+        ZIG_OK=0
+        if [[ -x "$ZIG_LINK" ]] && "$ZIG_LINK" version 2>/dev/null | grep -qx "$ZIG_PIN"; then
+            ZIG_OK=1
+        fi
+        if [[ "$ZIG_OK" == "1" ]]; then
+            printf "   \033[0;32m✓\033[0m zig ${ZIG_PIN} already installed\n"
+        else
+            ZIG_ARCH="$(uname -m)"
+            case "$ZIG_ARCH" in arm64) ZIG_ARCH="aarch64";; esac
+            ZIG_TARBALL="zig-${ZIG_ARCH}-macos-${ZIG_PIN}.tar.xz"
+            ZIG_URL="https://ziglang.org/download/${ZIG_PIN}/${ZIG_TARBALL}"
+            printf "   \033[0;36m·\033[0m installing zig ${ZIG_PIN} from ${ZIG_URL}\n"
+            mkdir -p "$HOME/.local/zig"
+            tmpdir="$(mktemp -d)"
+            (
+                cd "$tmpdir" && \
+                curl -fL --retry 5 --retry-delay 3 "$ZIG_URL" -o "$ZIG_TARBALL" && \
+                tar -xJf "$ZIG_TARBALL" && \
+                rm -rf "$ZIG_DIR" && \
+                mv "zig-${ZIG_ARCH}-macos-${ZIG_PIN}" "$ZIG_DIR" && \
+                xattr -dr com.apple.quarantine "$ZIG_DIR" 2>/dev/null || true
+            )
+            rm -rf "$tmpdir"
+            ln -sf "$ZIG_DIR/zig" "$ZIG_LINK"
+            if "$ZIG_LINK" version 2>/dev/null | grep -qx "$ZIG_PIN"; then
+                printf "   \033[0;32m✓\033[0m zig ${ZIG_PIN} installed at \033[0;36m${ZIG_DIR}\033[0m (linked from \033[0;36m${ZIG_LINK}\033[0m)\n"
+            else
+                printf "   \033[0;31m✗\033[0m zig ${ZIG_PIN} install failed; check ${ZIG_URL} manually\n"
+            fi
+        fi
+        if ! command -v cargo-zigbuild >/dev/null 2>&1; then
+            cargo install --locked cargo-zigbuild
+        else
+            printf "   \033[0;32m✓\033[0m cargo-zigbuild already installed\n"
+        fi
+        # Ensure the Linux cross-compilation target is available for
+        # `cargo-zigbuild clippy --target x86_64-unknown-linux-gnu`.
+        rustup target add x86_64-unknown-linux-gnu >/dev/null 2>&1 || true
+        if rustup target list --installed 2>/dev/null | grep -q '^x86_64-unknown-linux-gnu$'; then
+            printf "   \033[0;32m✓\033[0m x86_64-unknown-linux-gnu target installed\n"
+        fi
     fi
     if ! command -v reuse >/dev/null 2>&1; then
         printf "   \033[1;33m!\033[0m reuse not found — install with: \033[0;36mpipx install reuse\033[0m\n"

--- a/scripts/hooks/_lint_fast.sh
+++ b/scripts/hooks/_lint_fast.sh
@@ -17,8 +17,9 @@
 #
 # Windows xwin check was removed from this gate in Phase 2 of
 # dev-flow-implementation-plan.md § 2.4 because its 40-90 s cold cost
-# violated the T1 budget.  xwin lives at pre-push (advisory) and
-# `pr-fast.yml` (authoritative native `windows-check` job).
+# violated the T1 budget.  xwin lives at pre-push (advisory, upgraded
+# to strict clippy in Phase W5.6 of windows-clippy-and-linux-cross-plan.md)
+# and `pr-fast.yml` (authoritative native `windows-lint` job).
 #
 # Soft-skips missing optional tools (typos, taplo, reuse) with a
 # one-line install hint so new contributors are not blocked before
@@ -126,7 +127,8 @@ fi
 # Windows cross-check (cargo-xwin) was REMOVED from pre-commit in
 # Phase 2 of dev-flow-implementation-plan.md § 2.4 because its 40-90 s
 # cold cost violates the < 15 s T1 budget.  xwin lives at pre-push
-# (advisory) and `pr-fast.yml` (authoritative native `windows-check`).
+# (advisory — strict clippy after Phase W5.6) and `pr-fast.yml`
+# (authoritative native `windows-lint` job).
 if has_staged_rs; then
     spawn "lint-prod"    just lint-prod
     spawn "lint-tests"   just lint-tests

--- a/scripts/hooks/_lint_pre_push.sh
+++ b/scripts/hooks/_lint_pre_push.sh
@@ -80,14 +80,18 @@
 #                 that drives change-classification (see below).
 #
 # Cross-platform coverage (soft-skipped when tool missing):
-#   * check-windows — `cargo xwin check --workspace --all-targets
-#                     --all-features --target x86_64-pc-windows-msvc`.
-#                     CI today only runs `ubuntu-22.04`, so this gate is
-#                     the only pre-PR check that exercises Windows-only
-#                     code (`#[cfg(windows)]` tests, benches, and
-#                     `std::os::windows::*` usage).  Catches type drift
-#                     between platforms in ~2–5 s warm.  Requires
-#                     `cargo-xwin` (installed by `just install-dev-tools`).
+#   * lint-ci-windows — `cargo xwin clippy --workspace --all-targets
+#                     --all-features --target x86_64-pc-windows-msvc
+#                     --no-deps -- -D warnings`.  Phase W5.6 of
+#                     `docs/architecture/windows-clippy-and-linux-cross-plan.md`
+#                     upgraded this from the type-only `cargo xwin check`
+#                     to the strict clippy stack so new Windows-gated
+#                     code is gated on the same surface that the
+#                     `pr-fast.yml::windows-lint` job enforces natively
+#                     on `windows-latest`.  Catches lint drift between
+#                     platforms in ~6 s warm (W1.4 measurement).
+#                     Requires `cargo-xwin` (installed by
+#                     `just install-dev-tools`).
 #
 # Optional jobs (soft-skipped when tool missing):
 #   * typos     — cheap spell-check across the repo.
@@ -303,11 +307,14 @@ if (( CODE_CHANGED )); then
     if (( DEP_CHANGED )); then
         run_seq "deny"    cargo deny check --hide-inclusion-graph
     fi
-    # Windows xwin is ADVISORY locally (see dev-flow-implementation-plan.md
-    # § 1.3.3) — PR-fast's native `windows-check` job is the authoritative
-    # gate.  Soft-skip with install hint when `cargo-xwin` is missing.
+    # Windows xwin clippy is ADVISORY locally (see dev-flow-implementation-plan.md
+    # § 1.3.3) — PR-fast's native `windows-lint` job on `windows-latest` is the
+    # authoritative gate.  Phase W5.6 upgraded this from `check-windows`
+    # (type-only) to `lint-ci-windows` (strict clippy with `-D warnings`)
+    # so new Windows-gated regressions surface locally before push.
+    # Soft-skip with install hint when `cargo-xwin` is missing.
     if command -v cargo-xwin >/dev/null 2>&1; then
-        run_seq "check-windows" just check-windows
+        run_seq "lint-ci-windows" just lint-ci-windows
     fi
 fi
 

--- a/scripts/hooks/_lint_pre_push.sh
+++ b/scripts/hooks/_lint_pre_push.sh
@@ -97,12 +97,15 @@
 #   * typos     — cheap spell-check across the repo.
 #   * reuse     — SPDX / licence-header compliance.
 #
-# The Linux-only lint drift gate (`just lint-ci-linux` via Docker) is NOT
-# run here — it is a minutes-scale cross-platform check best left to CI
-# or a conscious manual invocation.  Run `just check-all-targets` for a
-# full sweep across macOS + Linux (Docker) + Windows (xwin).  The full
-# runtime test suite (`cargo nextest run` without `--no-run`) and doc
-# tests are likewise deferred to `just phase1-test` or CI.
+# The Linux-only lint drift gate is NOT run here — it is best left to CI
+# or a conscious manual invocation.  Two local options exist: Docker
+# (`just lint-ci-linux`, authoritative — mirrors CI's `rust:latest`
+# image; minutes-scale) or cargo-zigbuild (`just lint-ci-linux-zig`,
+# Phase L1, accelerator — ~50 s cold / sub-second warm; needs zig 0.14.1
+# pinned via `just install-dev-tools`).  Run `just check-all-targets` for
+# a full sweep across macOS + Linux (zigbuild-or-Docker) + Windows (xwin).
+# The full runtime test suite (`cargo nextest run` without `--no-run`)
+# and doc tests are likewise deferred to `just phase1-test` or CI.
 
 set -euo pipefail
 


### PR DESCRIPTION
Closes Phases **W5** (Windows CI/pre-push clippy flip) and **L1** (Linux native cross-compile via `cargo-zigbuild`) of [`docs/architecture/windows-clippy-and-linux-cross-plan.md`](https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/docs/architecture/windows-clippy-and-linux-cross-plan.md).  All §8 acceptance items now ticked.

## W5 — Windows CI gate flip (`cargo check` → `cargo clippy -- -D warnings`)

PR #62 cleared the Windows clippy backlog (W0 baseline: 1346 errors on `--all-targets -D warnings` → 0).  This PR flips both gates that had been left on `cargo check` to the strict-clippy variant the cleanup proved green:

- **`pr-fast.yml`**: job key `windows-check` → `windows-lint`; command `cargo check` → `cargo clippy --workspace --all-targets --all-features --locked --no-deps -- -D warnings` natively on `windows-latest`.  Aggregator (`required`) and `notify-failure` `needs:` lists updated.
- **`scripts/hooks/_lint_pre_push.sh`**: dispatch `just check-windows` (compile-only, ~8 s warm) → `just lint-ci-windows` (strict clippy with `-D warnings`, ~6 s warm per W1.4).  Pre-push budget unchanged at ~25–60 s warm.

Net effect: a Windows-only `unwrap_used` / `cast_possible_truncation` / etc. regression now hard-fails BOTH the local pre-push hook AND the authoritative PR Fast CI job, on the same surface and flag stack.  No more "passes locally, fails on Windows" round-trips for any lint that fires under `cargo clippy -- -D warnings`.

## L1 — Native macOS → Linux clippy via cargo-zigbuild

New `just lint-ci-linux-zig` recipe: native macOS → Linux clippy via `cargo-zigbuild` (no Docker).  ~50 s cold, sub-second warm.  The Docker `lint-ci-linux` path remains authoritative (mirrors CI's `rust:latest` image exactly); zigbuild is a developer-loop accelerator.

`check-all-targets` now prefers zigbuild when `zig` + `cargo-zigbuild` are both on `PATH`, falls back to Docker, soft-skips when neither is available.

`install-dev-tools` extended (macOS hosts only) to install `zig 0.14.1` from the official `ziglang.org` tarball into `~/.local/zig/0.14.1/`, symlink it into `~/.cargo/bin/zig`, install `cargo-zigbuild` and the `x86_64-unknown-linux-gnu` rustup target.

### Two non-obvious gotchas surfaced during empirical L1.3 verification

Both are now baked into the recipe + install path so the next contributor hits exit 0 on first invocation:

1. **Zig version pin (0.14.1).**  Homebrew's `zig` formula tracks latest (currently `0.16.x`) which has unrelated incompat issues with `psm`'s `src/arch/x86_64.s` ATT-syntax assembly (`popq %rbp` / `retq` rejected as `unrecognized instruction mnemonic`).  zig 0.14.1 compiles `psm` cleanly.  `install-dev-tools` therefore downloads the official tarball and shadows any `brew install zig`.

2. **`target-cpu=native` rustflags override.**  `.cargo/config.toml` sets `rustflags = ["-C", "target-cpu=native", …]` for the Linux target so native Linux builds get host-tuned codegen.  On a macOS host that resolves to `apple-m4`, which `cargo-zigbuild` propagates to `zig cc -mcpu=native` alongside `-target x86_64-linux-gnu`.  The combined flag set corrupts zig's integrated-assembler dialect detection, producing thousands of `unrecognized instruction mnemonic` errors when compiling the x86_64 SIMD hand-written assembly that ships in `psm` and `blake3`.  The recipe overrides `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS` to pin `target-cpu=x86-64-v3` (the same baseline `release.yml`'s Linux matrix uses) for the cross-compile only — native Linux builds via the Docker path are unaffected.

The recipe also invokes `cargo-zigbuild clippy` directly rather than `cargo zigbuild clippy` (cargo plugin form); the plugin form always routes into the `zigbuild` build subcommand and rejects further subcommand args.

## Docs refreshed

- `CONTRIBUTING.md`: pre-commit / pre-push / PR-CI table rows for the new gate names + flag stack; cross-platform section documents both Linux options with the version-pin rationale; `install-dev-tools` blurb mentions the zig tarball download; recipe-list block adds `lint-ci-linux-zig` and `lint-ci-windows`.
- `windows-clippy-and-linux-cross-plan.md`: new `Status (2026-05-06)` header marking every phase ✅ with PR refs; the two L1 gotchas above documented inline; §8 acceptance criteria all checked; §9 cross-references refreshed with new line ranges.
- `preview-artifacts.yml` + `_lint_fast.sh` comments updated to reference `windows-lint` instead of `windows-check`.

## Verification

| Check | Result |
|---|---|
| `just lint-ci-windows` (cargo xwin clippy `-- -D warnings`) | exit 0 in **13.86 s warm** — W2-W5 cleanup held |
| `just lint-ci-linux-zig` (cargo-zigbuild clippy `-- -D warnings`) | exit 0 in **52.74 s cold / 0.42 s warm** |
| `actionlint -verbose` on `pr-fast.yml` + `preview-artifacts.yml` | 0 errors in 2 files |
| `just --list` | parses; new `lint-ci-linux-zig` recipe visible |
| `just lint-pre-push` (pre-push gate full sweep) | exit 0 in **53 s warm** including new `lint-ci-windows` step |

## Test plan after merge

PR Fast CI's new `windows-lint` job will run the strict `cargo clippy -- -D warnings` natively on `windows-latest` for the first time on this PR.  Expected: green (the same flag stack already passes via `cargo xwin clippy` locally and was verified on every commit through W5 cleanup).  If anything platform-specific surfaces (e.g. a clippy lint that fires only on the native MSVC toolchain and not on cargo-xwin's cross-compile), it'll be caught here for the first time and fixed before merge.
