### PR TITLE
feat(ci): gates manifest Phase 1 — source of truth + drift detector

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -195,6 +195,25 @@ jobs:
       - run: bash scripts/ci/check_file_size_policy.sh
 
   # ─────────────────────────────────────────────────────────────────────
+  # gates-drift — Phase 1 of `docs/architecture/gates-manifest-plan.md`.
+  # Verifies `scripts/ci/gates.toml` stays in lockstep with the gate
+  # set actually defined in `_lint_fast.sh`, `_lint_pre_push.sh`, and
+  # this file.  Always-on; sub-second; no classify gating (a manifest
+  # / consumer mismatch is meaningful regardless of which files
+  # changed in the PR).  Bypass not supported in CI — drift on `main`
+  # is a deliberate "fix-me-now" signal.
+  # ─────────────────────────────────────────────────────────────────────
+  gates-drift:
+    name: Gates manifest drift
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - run: bash scripts/ci/check_gates_drift.sh
+
+  # ─────────────────────────────────────────────────────────────────────
   # fmt — rustfmt check.  Gates on rust_changed (pure TOML / config /
   # docs edits don't need rustfmt).
   # ─────────────────────────────────────────────────────────────────────
@@ -485,6 +504,7 @@ jobs:
     needs:
       - classify
       - file-size
+      - gates-drift
       - fmt
       - sanity
       - clippy
@@ -506,6 +526,7 @@ jobs:
           set -u
           declare -A R=(
             [file-size]='${{ needs.file-size.result }}'
+            [gates-drift]='${{ needs.gates-drift.result }}'
             [fmt]='${{ needs.fmt.result }}'
             [sanity]='${{ needs.sanity.result }}'
             [clippy]='${{ needs.clippy.result }}'
@@ -537,7 +558,7 @@ jobs:
   notify-failure:
     name: 🔔 Notify on Failure
     runs-on: ubuntu-latest
-    needs: [classify, file-size, fmt, sanity, clippy, docs, test-build, tests, security, windows-lint, required]
+    needs: [classify, file-size, gates-drift, fmt, sanity, clippy, docs, test-build, tests, security, windows-lint, required]
     if: failure() && github.event_name != 'pull_request'
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,62 @@ for the operator-facing validation flow.
   the on-disk cleanup logic is exercised without ever touching the
   host's cache directory.
 
+### Added — Gates manifest Phase 1: source-of-truth + drift detector (PR #140)
+
+Phase 1 of [`docs/architecture/gates-manifest-plan.md`](docs/architecture/gates-manifest-plan.md)
+(itself the implementation companion to
+[`docs/architecture/dev-flow-implementation-plan.md` §2.7](docs/architecture/dev-flow-implementation-plan.md)).
+Closes the "documented but not implemented" status of §2.7 with the
+foundation for the upcoming Phase 2 + Phase 3 codegen work.
+
+- **NEW `scripts/ci/gates.toml`** — declarative source-of-truth for
+  the workspace's PR-time gate set (20 entries covering pre-commit /
+  pre-push / pr-fast tiers).  Each `[[gate]]` entry carries id,
+  label, command, tier membership, change-classification trigger,
+  hard/soft semantics, missing-tool detection key, expected runtime,
+  pre-push bucket assignment, and free-form notes.  Per-tier
+  consumer-name overrides via `consumer_names` table cover the few
+  gates whose hook id differs from their pr-fast.yml job name (e.g.
+  manifest `lint-ci` ⇄ pr-fast `clippy`, manifest `cargo-check` ⇄
+  pr-fast `sanity`, manifest `vet` + `deny` ⇄ pr-fast `security`).
+- **NEW `scripts/ci/check_gates_drift.sh`** — bidirectional drift
+  detector.  Forward direction: every manifest `[[gate]]` entry must
+  appear in its declared tiers' consumer files (pre-commit hook,
+  pre-push hook, pr-fast.yml).  Reverse direction: every gate
+  defined in a consumer (via `spawn`/`spawn_bg`/`run_seq` in the
+  hooks, or top-level YAML job under `jobs:` in pr-fast.yml) must
+  have a matching manifest entry — except for orchestration-only
+  jobs (`classify`, `required`, `notify-failure`).  Bash-only;
+  awk-based TOML parsing (no extra runtime deps).  Bypass once via
+  `BYPASS_GATES_DRIFT=1 git push` for emergency landings; CI has no
+  bypass — drift on `main` is a deliberate "fix-me-now" signal.
+- **MODIFIED `scripts/hooks/_lint_pre_push.sh`** — drift check
+  added as a new Bucket 1 step (cheap, parallel, fire-and-forget;
+  same tier as `fmt` / `file-size`).
+- **MODIFIED `.github/workflows/pr-fast.yml`** — NEW `gates-drift`
+  job (always-on, no classify gating; sub-second; modeled after
+  `file-size`).  Added to the `required` aggregator's `needs:`
+  list, success-conditional declare-A array, and `notify-failure`'s
+  `needs:` list so a manifest mismatch hard-blocks merge.
+- **NEW `just gates-drift`** recipe — manual invocation surface.
+- **MODIFIED docs/architecture/gates-manifest-plan.md** — Status
+  table updated (Phase 0 ✅, Phase 1 🟡 in flight); §9 action log
+  updated.
+
+Verification:
+- `bash scripts/ci/check_gates_drift.sh` — exit 0 against current
+  `main` (20 gates correctly matched).
+- Mutation tests: injecting a fake gate into the manifest fires the
+  forward-direction error; injecting a `spawn_bg "ghost-gate"` into
+  the pre-push hook fires the reverse-direction error; restoring
+  the original state returns to clean.
+- `BYPASS_GATES_DRIFT=1` exits 0 immediately with a tombstone log
+  line.
+- `actionlint` exit 0 on the modified `pr-fast.yml`.
+- `shellcheck scripts/ci/check_gates_drift.sh` exit 0 (3 SC2016
+  false-positive backtick warnings explicitly disabled with
+  inline directives).
+
 ### Changed — Windows clippy CI/pre-push flip + Linux zigbuild accelerator (PR #138)
 
 Closes Phases **W5** and **L1** of

--- a/docs/architecture/gates-manifest-plan.md
+++ b/docs/architecture/gates-manifest-plan.md
@@ -18,8 +18,8 @@ UFFS - Ultra Fast File Search
 
 | Phase | Description | Status |
 |---|---|---|
-| 0 | Plan + schema design | 🟡 in flight (this doc) |
-| 1 | Manifest + drift detector (no consumer changes) | ⏭ pending |
+| 0 | Plan + schema design | ✅ landed (PR #139) |
+| 1 | Manifest + drift detector (no consumer changes) | 🟡 in flight (PR #140) |
 | 2 | Codegen for `_lint_pre_push.sh` | ⏭ pending |
 | 3 | Codegen for `_lint_fast.sh` + `pr-fast.yml` + doc tables | ⏭ pending |
 
@@ -616,7 +616,7 @@ Other workflows are opaque to it.
 
 | Date | Event | PR |
 |---|---|---|
-| 2026-05-06 | Plan drafted | (this PR, target: `docs(plan): gates manifest`) |
-| TBD | Phase 1 lands (manifest + drift detector) | TBD |
+| 2026-05-06 | Plan drafted (this doc) + landed | #139 |
+| 2026-05-06 | Phase 1 in flight — manifest (`scripts/ci/gates.toml`) + drift detector (`scripts/ci/check_gates_drift.sh`) + pre-push Bucket 1 wiring + new `pr-fast.yml::gates-drift` job + `just gates-drift` recipe | #140 |
 | TBD | Phase 2 lands (`gen-hooks` for pre-push) | TBD |
 | TBD | Phase 3 lands (full migration) | TBD |

--- a/just/test.just
+++ b/just/test.just
@@ -189,6 +189,23 @@ lint-ci-linux-zig:
         cargo-zigbuild clippy --workspace --all-targets --all-features --target x86_64-unknown-linux-gnu --no-deps -- -D warnings
     @printf "\033[0;32m✅ Linux clippy gate (zigbuild) passed\033[0m\n"
 
+# Gate-manifest drift detector (Phase 1 of
+# `docs/architecture/gates-manifest-plan.md`).
+#
+# Verifies that every gate listed in `scripts/ci/gates.toml` is present
+# in the corresponding consumer file (`scripts/hooks/_lint_fast.sh`,
+# `scripts/hooks/_lint_pre_push.sh`, `.github/workflows/pr-fast.yml`),
+# and that every gate present in those consumers has a matching
+# manifest entry.  Hard-fails on mismatch; bypass once via
+# `BYPASS_GATES_DRIFT=1 git push` (mirrors `COMMIT_SUBJECT_BYPASS=1`).
+#
+# Wired into the pre-push hook (Bucket 1, fire-and-forget) and the
+# `pr-fast.yml::gates-drift` job so any new gate that gets added to a
+# consumer without the manifest (or vice versa) blocks merge until
+# the manifest is updated.
+gates-drift:
+    @bash scripts/ci/check_gates_drift.sh
+
 # Host-only on purpose — Windows (`lint-*-windows`) and Linux-in-Docker
 # (`lint-ci-linux`) are separate recipes.  They will be wired into this
 # sweep after their backlogs converge to zero (Phase W5 of the

--- a/scripts/ci/check_gates_drift.sh
+++ b/scripts/ci/check_gates_drift.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# UFFS gate-manifest drift detector.
+#
+# Phase 1 of `docs/architecture/gates-manifest-plan.md`.  Verifies
+# that every gate listed in `scripts/ci/gates.toml` is present in
+# the corresponding consumer file, and that every gate present in
+# the consumers has a matching manifest entry.
+#
+# Called by:
+#   - pre-push hook (Bucket 1, fire-and-forget)
+#   - `pr-fast.yml::gates-drift` job (PR-time hard gate)
+#   - `just gates-drift` (manual invocation)
+#
+# Exit codes:
+#   0  manifest and consumers agree on the gate set
+#   1  drift detected — one or more gates missing on either side
+#   2  manifest schema error (unparseable, missing required fields)
+#
+# Bypass: `BYPASS_GATES_DRIFT=1 git push` skips the pre-push step
+# (mirrors the existing `COMMIT_SUBJECT_BYPASS=1` pattern).  No CI
+# bypass — drift on `main` is a deliberate "fix-me-now" signal.
+
+set -euo pipefail
+
+# ── Paths ──────────────────────────────────────────────────────────────
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+MANIFEST="$REPO_ROOT/scripts/ci/gates.toml"
+HOOK_FAST="$REPO_ROOT/scripts/hooks/_lint_fast.sh"
+HOOK_PUSH="$REPO_ROOT/scripts/hooks/_lint_pre_push.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/pr-fast.yml"
+
+# ── Colours ────────────────────────────────────────────────────────────
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    C_BLUE=$'\033[0;34m'
+    C_CYAN=$'\033[0;36m'
+    C_GREEN=$'\033[0;32m'
+    C_YELLOW=$'\033[1;33m'
+    C_RED=$'\033[0;31m'
+    C_RESET=$'\033[0m'
+else
+    C_BLUE=''
+    C_CYAN=''
+    C_GREEN=''
+    C_YELLOW=''
+    C_RED=''
+    C_RESET=''
+fi
+
+# ── Optional bypass ────────────────────────────────────────────────────
+if [[ "${BYPASS_GATES_DRIFT:-0}" == "1" ]]; then
+    printf '%s⏭  gates-drift bypassed via BYPASS_GATES_DRIFT=1%s\n' \
+        "$C_YELLOW" "$C_RESET"
+    exit 0
+fi
+
+printf '%s🔎 gates-drift — manifest vs consumers%s\n' "$C_BLUE" "$C_RESET"
+
+# ── Sanity: required files exist ───────────────────────────────────────
+for f in "$MANIFEST" "$HOOK_FAST" "$HOOK_PUSH" "$WORKFLOW"; do
+    if [[ ! -f "$f" ]]; then
+        printf '%s❌ missing required file: %s%s\n' "$C_RED" "$f" "$C_RESET" >&2
+        exit 2
+    fi
+done
+
+# ── Manifest parsing (minimal TOML) ────────────────────────────────────
+# We deliberately do NOT shell out to `taplo`/`dasel` — the manifest
+# uses a small, regular subset of TOML and a grep-based parser keeps
+# this script self-contained.  Schema enforced by the awk below; any
+# manifest that doesn't fit gets a schema error (exit 2).
+#
+# AWK pass: emits one line per gate of the form
+#     <id>\t<tiers-csv>\t<gate_when>\t<hard>
+# where:
+#   id       = the kebab-case gate identifier
+#   tiers    = comma-separated subset of {pre-commit,pre-push,pr-fast}
+#   gate_when = always|rust_changed|dep_changed|infra_changed|code_changed
+#   hard     = true|false
+parse_manifest() {
+    awk '
+        # State machine: track whether we are inside a [[gate]] table.
+        /^\[\[gate\]\]$/ { in_gate=1; id=""; tiers=""; gw=""; hard=""; cn=""; next }
+        /^\[/             { in_gate=0; next }
+        !in_gate          { next }
+
+        /^id[ \t]*=[ \t]*"/ {
+            sub(/^id[ \t]*=[ \t]*"/, ""); sub(/".*$/, ""); id=$0
+        }
+        /^tiers[ \t]*=[ \t]*\[/ {
+            line=$0
+            sub(/^tiers[ \t]*=[ \t]*\[/, "", line)
+            sub(/\].*$/, "", line)
+            gsub(/[ "]/, "", line)
+            tiers=line
+        }
+        /^gate_when[ \t]*=[ \t]*"/ {
+            sub(/^gate_when[ \t]*=[ \t]*"/, ""); sub(/".*$/, ""); gw=$0
+        }
+        /^hard[ \t]*=/ {
+            sub(/^hard[ \t]*=[ \t]*/, ""); hard=$0
+        }
+        /^consumer_names[ \t]*=[ \t]*\{/ {
+            # Inline TOML table: { "pre-commit" = "fmt-check", ... }
+            # Keep the body as-is for downstream parsing.
+            line=$0
+            sub(/^consumer_names[ \t]*=[ \t]*\{/, "", line)
+            sub(/\}.*$/, "", line)
+            gsub(/ /, "", line)
+            cn=line
+        }
+        in_gate && id != "" {
+            ids[id]=1
+            if (tiers != "") tier_of[id]=tiers
+            if (gw    != "") when_of[id]=gw
+            if (hard  != "") hard_of[id]=hard
+            if (cn    != "") cn_of[id]=cn
+        }
+        END {
+            for (i in ids) {
+                printf "%s\t%s\t%s\t%s\t%s\n", \
+                    i, \
+                    (i in tier_of ? tier_of[i] : ""), \
+                    (i in when_of ? when_of[i] : ""), \
+                    (i in hard_of ? hard_of[i] : ""), \
+                    (i in cn_of ? cn_of[i] : "")
+            }
+        }
+    ' "$MANIFEST"
+}
+
+# Look up the per-tier consumer-side name for a gate id.  Falls back
+# to the gate id itself when no override is declared.
+#
+# Args: <consumer_names_csv> <tier>
+#       where consumer_names_csv looks like `"pre-commit"="fmt-check","pr-fast"="fmt"`
+consumer_name_for() {
+    local cn="$1" tier="$2" default="$3"
+    if [[ -z "$cn" ]]; then
+        printf '%s' "$default"
+        return
+    fi
+    # Extract the value after `"$tier"="..."` if present.
+    local match
+    match=$(printf '%s' "$cn" | tr ',' '\n' \
+        | grep -E "^\"$tier\"=\"" \
+        | head -n1 \
+        | sed -E 's/^"[^"]+"="([^"]+)".*$/\1/' || true)
+    if [[ -n "$match" ]]; then
+        printf '%s' "$match"
+    else
+        printf '%s' "$default"
+    fi
+}
+
+# ── Consumer scraping ──────────────────────────────────────────────────
+# Each consumer exposes its gate IDs via a unique, greppable pattern:
+#   _lint_fast.sh:      `spawn "<id>" ...`        (line starts with optional whitespace)
+#   _lint_pre_push.sh:  `spawn_bg "<id>" ...` or `run_seq "<id>" ...`
+#   pr-fast.yml:        `^  <id>:$` for top-level job blocks (2-space indent).
+#
+# Infrastructure jobs in pr-fast.yml are NOT gates and MUST be excluded
+# from the reverse-direction check (see WORKFLOW_INFRA_JOBS below).
+
+scrape_pre_commit() {
+    # Per-match extraction (grep -oE) so multi-spawn lines yield every id.
+    grep -vE '^\s*#' "$HOOK_FAST" \
+        | grep -oE 'spawn[[:space:]]+"[a-z][a-z-]*"' \
+        | sed -E 's/^spawn[[:space:]]+"([a-z][a-z-]*)"$/\1/' \
+        | sort -u
+}
+
+scrape_pre_push() {
+    # Match `spawn_bg "<id>"` / `run_seq "<id>"` anywhere on the line
+    # (some hook lines prefix with `command -v X && ` for soft-skip).
+    # Skip comment lines (the doc block's `#  * gate-name`).
+    # Per-match extraction (grep -oE) so multi-spawn lines yield every id.
+    grep -vE '^\s*#' "$HOOK_PUSH" \
+        | grep -oE '(spawn_bg|run_seq)[[:space:]]+"[a-z][a-z-]*"' \
+        | sed -E 's/^(spawn_bg|run_seq)[[:space:]]+"([a-z][a-z-]*)"$/\2/' \
+        | sort -u
+}
+
+scrape_pr_fast() {
+    # YAML jobs live under the `^jobs:$` header.  YAML triggers
+    # (`push:`, `pull_request:`, `merge_group:`, etc.) live under
+    # `on:` and would also match the 2-space-indent regex; restrict
+    # to lines below `jobs:` to avoid catching them.
+    awk '/^jobs:/{in_jobs=1; next} in_jobs && /^[a-z][a-zA-Z_-]+:/{exit} in_jobs && /^  [a-z][a-z-]+:$/{print}' "$WORKFLOW" \
+        | sed -E 's/^  ([a-z][a-z-]+):$/\1/' \
+        | sort -u
+}
+
+# Jobs in pr-fast.yml that exist for orchestration / branch protection
+# / failure handling, NOT for an individual gate.  These are EXEMPT
+# from the manifest — they have no matching `[[gate]]` entry.
+WORKFLOW_INFRA_JOBS=(
+    "classify"
+    "required"
+    "notify-failure"
+)
+
+# ── Mapping helpers ────────────────────────────────────────────────────
+# Map the manifest's `pr-fast` tier membership to the actual job name
+# in `pr-fast.yml`.  Most gates use the gate id as the job name; the
+# exceptions are listed here as `<gate_id>:<job_name>` pairs.
+#
+# Lookup convention: `${PRFAST_JOB_OVERRIDES[gate_id]}` returns the
+# overridden job name, or empty if no override.
+declare -A PRFAST_JOB_OVERRIDES=(
+    ["lint-ci"]="clippy"
+    ["rustdoc"]="docs"
+    ["lint-ci-windows"]="windows-lint"
+    ["cargo-check"]="sanity"
+    ["vet"]="security"
+    ["deny"]="security"
+)
+
+prfast_job_for() {
+    local id="$1"
+    if [[ -n "${PRFAST_JOB_OVERRIDES[$id]:-}" ]]; then
+        printf '%s' "${PRFAST_JOB_OVERRIDES[$id]}"
+    else
+        printf '%s' "$id"
+    fi
+}
+
+# ── Diff machinery ─────────────────────────────────────────────────────
+ERRORS=0
+
+emit_missing() {
+    local where="$1" id="$2" expected="$3"
+    # shellcheck disable=SC2016 # backticks are literal visual delimiters
+    printf '  %s❌%s [%s] gate `%s` listed in manifest but not found in %s\n' \
+        "$C_RED" "$C_RESET" "$where" "$id" "$expected" >&2
+    ERRORS=$(( ERRORS + 1 ))
+}
+
+emit_orphan() {
+    local where="$1" id="$2"
+    # shellcheck disable=SC2016 # backticks are literal visual delimiters
+    printf '  %s❌%s [%s] gate `%s` defined in consumer but missing from manifest\n' \
+        "$C_RED" "$C_RESET" "$where" "$id" >&2
+    ERRORS=$(( ERRORS + 1 ))
+}
+
+# ── Forward check: manifest → consumers ────────────────────────────────
+# For every [[gate]] in the manifest, every tier it claims must
+# actually contain it.  The grep'd consumer sets are O(n) so we
+# build them once and look up via grep -Fxq.
+PC_SET=$(scrape_pre_commit)
+PP_SET=$(scrape_pre_push)
+PR_SET=$(scrape_pr_fast)
+
+while IFS=$'\t' read -r id tiers _when _hard cn; do
+    [[ -z "$id" ]] && continue
+    IFS=',' read -ra TIER_LIST <<< "$tiers"
+    for t in "${TIER_LIST[@]}"; do
+        case "$t" in
+            pre-commit)
+                expected=$(consumer_name_for "$cn" "pre-commit" "$id")
+                grep -Fxq "$expected" <<< "$PC_SET" \
+                    || emit_missing "pre-commit" "$id" "_lint_fast.sh ('$expected')"
+                ;;
+            pre-push)
+                expected=$(consumer_name_for "$cn" "pre-push" "$id")
+                grep -Fxq "$expected" <<< "$PP_SET" \
+                    || emit_missing "pre-push" "$id" "_lint_pre_push.sh ('$expected')"
+                ;;
+            pr-fast)
+                expected_job=$(consumer_name_for "$cn" "pr-fast" "$(prfast_job_for "$id")")
+                grep -Fxq "$expected_job" <<< "$PR_SET" \
+                    || emit_missing "pr-fast" "$id" "pr-fast.yml job '$expected_job'"
+                ;;
+            tier-2)
+                # Out of scope for Phase 1.  Tier-2 has its own
+                # workflow with uniquely shaped jobs that don't fit
+                # the gate manifest schema.
+                ;;
+            *)
+                # shellcheck disable=SC2016 # backticks are literal visual delimiters
+                printf '  %s❌%s schema: gate `%s` has unknown tier `%s`\n' \
+                    "$C_RED" "$C_RESET" "$id" "$t" >&2
+                ERRORS=$(( ERRORS + 1 ))
+                ;;
+        esac
+    done
+done < <(parse_manifest)
+
+# ── Reverse check: consumers → manifest ────────────────────────────────
+# Every gate ID found in a consumer must have a matching manifest
+# entry on the corresponding tier.  Catches the "added a gate to the
+# hook but forgot the manifest" failure mode.
+
+# Build manifest-id-set per tier for reverse lookups.
+declare -A MANIFEST_PC=()
+declare -A MANIFEST_PP=()
+declare -A MANIFEST_PR=()
+while IFS=$'\t' read -r id tiers _when _hard cn; do
+    [[ -z "$id" ]] && continue
+    IFS=',' read -ra TIER_LIST <<< "$tiers"
+    for t in "${TIER_LIST[@]}"; do
+        case "$t" in
+            pre-commit)
+                MANIFEST_PC[$(consumer_name_for "$cn" "pre-commit" "$id")]=1 ;;
+            pre-push)
+                MANIFEST_PP[$(consumer_name_for "$cn" "pre-push" "$id")]=1 ;;
+            pr-fast)
+                MANIFEST_PR[$(consumer_name_for "$cn" "pr-fast" "$(prfast_job_for "$id")")]=1 ;;
+        esac
+    done
+done < <(parse_manifest)
+
+while IFS= read -r id; do
+    [[ -z "$id" ]] && continue
+    [[ -n "${MANIFEST_PC[$id]:-}" ]] || emit_orphan "pre-commit" "$id"
+done <<< "$PC_SET"
+
+while IFS= read -r id; do
+    [[ -z "$id" ]] && continue
+    [[ -n "${MANIFEST_PP[$id]:-}" ]] || emit_orphan "pre-push" "$id"
+done <<< "$PP_SET"
+
+while IFS= read -r id; do
+    [[ -z "$id" ]] && continue
+    # Skip infra jobs.
+    skip=0
+    for infra in "${WORKFLOW_INFRA_JOBS[@]}"; do
+        [[ "$id" == "$infra" ]] && { skip=1; break; }
+    done
+    (( skip )) && continue
+    [[ -n "${MANIFEST_PR[$id]:-}" ]] || emit_orphan "pr-fast" "$id"
+done <<< "$PR_SET"
+
+# ── Verdict ────────────────────────────────────────────────────────────
+if (( ERRORS > 0 )); then
+    printf '\n%s❌ gates-drift: %d mismatch(es) detected%s\n' \
+        "$C_RED" "$ERRORS" "$C_RESET" >&2
+    printf '   %sFix: update either %sscripts/ci/gates.toml%s%s or the\n' \
+        "$C_YELLOW" "$C_CYAN" "$C_RESET" "$C_YELLOW" >&2
+    printf '   %scorresponding consumer file so they agree.  Bypass once with:%s\n' \
+        "$C_YELLOW" "$C_RESET" >&2
+    printf '   %sBYPASS_GATES_DRIFT=1 git push%s\n' "$C_CYAN" "$C_RESET" >&2
+    exit 1
+fi
+
+printf '%s✅ gates-drift: manifest and consumers agree (%d gates)%s\n' \
+    "$C_GREEN" "$(parse_manifest | wc -l | tr -d ' ')" "$C_RESET"

--- a/scripts/ci/gates.toml
+++ b/scripts/ci/gates.toml
@@ -1,0 +1,488 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# UFFS quality-gate manifest — single source of truth for the gate
+# set enforced at pre-commit, pre-push, and PR Fast CI.
+#
+# This file is the implementation of Phase 1 of
+# `docs/architecture/gates-manifest-plan.md`.  See that doc for the
+# full schema spec, generator interface, and migration order.
+#
+# Phase 1 status: this manifest is INFORMATIONAL.  The consumer files
+# (`scripts/hooks/_lint_fast.sh`, `scripts/hooks/_lint_pre_push.sh`,
+# `.github/workflows/pr-fast.yml`) are still hand-maintained.  The
+# `scripts/ci/check_gates_drift.sh` drift detector verifies the
+# manifest stays in sync with what those files actually do — it
+# fails CI if any gate listed here is missing from the corresponding
+# consumer, or if a consumer-defined gate is missing from this file.
+#
+# Phase 2/3 will replace the hand-maintenance with codegen FROM this
+# file.  Until then, every gate change must be made in TWO places:
+# the consumer file AND this manifest.  The drift detector enforces
+# that you didn't forget either side.
+#
+# Field semantics: see `docs/architecture/gates-manifest-plan.md` §3.
+
+[manifest]
+version = 1
+generated_files = [
+  # Phase 1: empty — nothing is generated yet.
+  # Phase 2: "scripts/hooks/_lint_pre_push.sh"
+  # Phase 3: + "scripts/hooks/_lint_fast.sh", ".github/workflows/pr-fast.yml"
+]
+
+# Change-classification regexes used by the pre-push hook + CI's
+# `classify` job to gate condition-driven jobs.  These MUST be kept
+# in lockstep across consumers; the drift detector grep's for them.
+[classification]
+rust = '\.rs$'
+dep = '^(.*Cargo\.toml$|Cargo\.lock$|supply-chain/)'
+infra = '^(\.github/|scripts/|\.cargo/|\.config/|just/|rust-toolchain|clippy\.toml$|rustfmt\.toml$|deny\.toml$|REUSE\.toml$|codecov\.yml$)'
+docs = '\.md$'
+# code = (rust OR dep OR infra) — derived; not a regex
+
+# ─────────────────────────────────────────────────────────────────────
+# Always-on gates — fire regardless of change classification
+# ─────────────────────────────────────────────────────────────────────
+
+[[gate]]
+id = "fmt"
+label = "cargo fmt --check"
+command = ["cargo", "fmt", "--all", "--", "--check"]
+tiers = ["pre-commit", "pre-push", "pr-fast"]
+gate_when = "rust_changed"
+hard = true
+tool = "cargo"
+expected_runtime_secs = 1
+bucket = "bg"
+order = 10
+consumer_names = { "pre-commit" = "fmt-check" }
+notes = """
+Always-on at pre-push; gated on `rust_changed` at pre-commit (which
+is staged-scoped) and at pr-fast (`fmt` job's `if:` condition).
+Legacy: pre-commit hook calls it `fmt-check` (historical); pre-push
+and pr-fast call it `fmt`.  Phase 2/3 codegen will normalise.
+"""
+
+[[gate]]
+id = "file-size"
+label = "file-size policy"
+command = ["bash", "scripts/ci/check_file_size_policy.sh"]
+tiers = ["pre-commit", "pre-push", "pr-fast"]
+gate_when = "always"
+hard = true
+tool = "bash"
+expected_runtime_secs = 1
+bucket = "bg"
+order = 20
+notes = """
+Enforces the workspace's 800-LOC-per-Rust-file policy with a
+documented exception list at `scripts/ci/file_size_exceptions.txt`.
+"""
+
+[[gate]]
+id = "gates-drift"
+label = "Gate-manifest drift detector"
+command = ["bash", "scripts/ci/check_gates_drift.sh"]
+tiers = ["pre-push", "pr-fast"]
+gate_when = "always"
+hard = true
+tool = "bash"
+expected_runtime_secs = 1
+bucket = "bg"
+order = 25
+notes = """
+Phase 1 of `docs/architecture/gates-manifest-plan.md`.  Self-referential
+gate that verifies this manifest stays in lockstep with the gate set
+actually defined in `_lint_fast.sh`, `_lint_pre_push.sh`, and
+`pr-fast.yml`.  Bypass once via `BYPASS_GATES_DRIFT=1 git push`
+(mirrors `COMMIT_SUBJECT_BYPASS=1`); CI has no bypass — drift on
+`main` is a deliberate "fix-me-now" signal.
+"""
+
+[[gate]]
+id = "commit-subjects"
+label = "Conventional Commits subject validator"
+command = [
+  "bash",
+  "scripts/ci/check_commit_subjects.sh",
+  "range",
+  "{{COMMIT_RANGES}}",
+]
+tiers = ["pre-push"]
+gate_when = "always"
+hard = true
+tool = "bash"
+expected_runtime_secs = 1
+bucket = "bg"
+order = 30
+notes = """
+Validates every non-merge commit subject in the pushed range against
+the SAME Conventional Commits regex CI's
+`.github/workflows/commitlint.yml` runs on the PR title.  Closes the
+local-vs-remote feedback loop that used to surface scope typos like
+`feat(uffs-core, daemon)` only after the workflow had already failed
+upstream.  Bypass via `COMMIT_SUBJECT_BYPASS=1 git push`.
+"""
+
+# ─────────────────────────────────────────────────────────────────────
+# Rust-changed gates — fire when *.rs is touched
+# ─────────────────────────────────────────────────────────────────────
+
+[[gate]]
+id = "lint-prod"
+label = "ultra-strict production clippy (--lib --bins)"
+command = ["just", "lint-prod"]
+tiers = ["pre-commit", "pre-push"]
+gate_when = "rust_changed"
+hard = true
+tool = "cargo"
+expected_runtime_secs = 8
+bucket = "seq"
+order = 30
+flag_template = "prod_flags"
+notes = """
+Pedantic + nursery + cargo + unwrap_used + missing_docs_in_private_items.
+NOT in pr-fast (pr-fast's `clippy` job uses `lint-ci`'s --all-targets
+flag stack which subsumes lint-prod's --lib --bins).
+"""
+
+[[gate]]
+id = "lint-tests"
+label = "strict test clippy (--tests, unwrap allowed)"
+command = ["just", "lint-tests"]
+tiers = ["pre-commit", "pre-push"]
+gate_when = "rust_changed"
+hard = true
+tool = "cargo"
+expected_runtime_secs = 8
+bucket = "seq"
+order = 40
+flag_template = "test_flags"
+notes = """
+Same lint base as `lint-prod` with unwrap/expect allowed for test
+code.  Same not-in-pr-fast rationale.
+"""
+
+[[gate]]
+id = "lint-ci"
+label = "CI-mirror clippy (--all-targets -D warnings)"
+command = ["just", "lint-ci"]
+tiers = ["pre-commit", "pre-push", "pr-fast"]
+gate_when = "rust_changed"
+hard = true
+tool = "cargo"
+expected_runtime_secs = 10
+bucket = "seq"
+order = 20
+consumer_names = { "pr-fast" = "clippy" }
+notes = """
+The exact clippy flag stack `pr-fast.yml`'s `clippy` job runs.
+Kept in lockstep manually until Phase 2 codegen lands.
+"""
+
+[[gate]]
+id = "rustdoc"
+label = "rustdoc -D warnings"
+command = [
+  "env",
+  "RUSTDOCFLAGS=-Dwarnings",
+  "cargo",
+  "doc",
+  "--workspace",
+  "--all-features",
+  "--no-deps",
+  "--locked",
+]
+tiers = ["pre-push", "pr-fast"]
+gate_when = "rust_changed"
+hard = true
+tool = "cargo"
+expected_runtime_secs = 1
+bucket = "seq"
+order = 50
+consumer_names = { "pr-fast" = "docs" }
+notes = """
+Catches broken doc-links, unresolved `[symbol]` references, and any
+intra-doc cross-reference drift.  pr-fast's `docs` job runs both
+this and `doc-tests` in one step.
+"""
+
+[[gate]]
+id = "doc-tests"
+label = "cargo test --doc"
+command = [
+  "env",
+  "RUSTDOCFLAGS=-Dwarnings",
+  "cargo",
+  "test",
+  "--doc",
+  "--workspace",
+  "--all-features",
+  "--locked",
+]
+tiers = ["pre-push", "pr-fast"]
+gate_when = "rust_changed"
+hard = true
+tool = "cargo"
+expected_runtime_secs = 14
+bucket = "seq"
+order = 60
+consumer_names = { "pr-fast" = "docs" }
+notes = """
+Phase 1 addition (dev-flow §6.2): actually EXECUTES the `/// ```rust`
+blocks rustdoc only compiled.  CI catches this today, but the local
+gate closes a ~30 s round-trip for broken doctests.  Bundled into
+pr-fast's `docs` job alongside `rustdoc`.
+"""
+
+# ─────────────────────────────────────────────────────────────────────
+# Code-changed gates (rust|dep|infra) — fire when any code class touched
+# ─────────────────────────────────────────────────────────────────────
+
+[[gate]]
+id = "cargo-check"
+label = "cargo check --workspace --all-targets --all-features --locked"
+command = [
+  "cargo",
+  "check",
+  "--workspace",
+  "--all-targets",
+  "--all-features",
+  "--locked",
+]
+tiers = ["pre-push", "pr-fast"]
+gate_when = "code_changed"
+hard = true
+tool = "cargo"
+expected_runtime_secs = 1
+bucket = "seq"
+order = 10
+consumer_names = { "pr-fast" = "sanity" }
+notes = """
+Fastest compile gate; runs FIRST in Bucket 2 so the most likely
+failure class (type errors after a refactor) surfaces before
+clippy / rustdoc / tests pay their setup cost.  `pr-fast.yml`'s
+`sanity` job runs the equivalent.
+"""
+
+[[gate]]
+id = "test-build"
+label = "test compile (nextest --no-run)"
+command = [
+  "cargo",
+  "nextest",
+  "run",
+  "--workspace",
+  "--all-targets",
+  "--all-features",
+  "--no-run",
+  "--locked",
+  "--hide-progress-bar",
+]
+tiers = ["pre-push", "pr-fast"]
+gate_when = "code_changed"
+hard = true
+tool = "cargo-nextest"
+expected_runtime_secs = 4
+bucket = "seq"
+order = 70
+consumer_names = { "pre-push" = "tests" }
+notes = """
+Links every test binary without running it.  Catches `#[cfg(test)]`
+drift, missing dev-deps, and linker-level regressions that
+`cargo clippy --all-targets` (check-only, no linking) misses.
+Legacy: pre-push hook calls it `tests` (the run_seq label is
+`tests` even though the command is `--no-run`); pr-fast calls it
+`test-build`.  Phase 2/3 codegen will normalise.
+"""
+
+[[gate]]
+id = "smoke"
+label = "nextest pre-push-smoke profile"
+command = [
+  "cargo",
+  "nextest",
+  "run",
+  "--workspace",
+  "--profile",
+  "pre-push-smoke",
+  "--locked",
+]
+tiers = ["pre-push"]
+gate_when = "code_changed"
+hard = true
+tool = "cargo-nextest"
+expected_runtime_secs = 9
+bucket = "seq"
+order = 80
+notes = """
+Phase 1 addition (dev-flow §6.X): RUNS a fast unit-test subset
+(~6 s warm).  Excludes the validation suite and `uffs-client` shmem
+tests which would blow the budget.  Full suite still runs in CI.
+"""
+
+[[gate]]
+id = "tests"
+label = "full nextest run (PR CI)"
+command = [
+  "cargo",
+  "nextest",
+  "run",
+  "--workspace",
+  "--all-targets",
+  "--all-features",
+  "--locked",
+]
+tiers = ["pr-fast"]
+gate_when = "code_changed"
+hard = true
+tool = "cargo-nextest"
+expected_runtime_secs = 300
+notes = """
+The full test suite, deferred from pre-push (too slow) to PR CI.
+`pre-push` has the `smoke` subset above and `test-build` for compile
+confidence.
+"""
+
+# ─────────────────────────────────────────────────────────────────────
+# Dep-changed gates — fire when Cargo.{toml,lock} or supply-chain/ touched
+# ─────────────────────────────────────────────────────────────────────
+
+[[gate]]
+id = "vet"
+label = "cargo vet check --locked"
+command = ["cargo", "vet", "check", "--locked"]
+tiers = ["pre-push", "pr-fast"]
+gate_when = "dep_changed"
+hard = true
+tool = "cargo-vet"
+expected_runtime_secs = 2
+bucket = "bg"
+order = 40
+consumer_names = { "pr-fast" = "security" }
+notes = """
+HARD-FAIL if `cargo-vet` is missing when Cargo.{toml,lock} or
+supply-chain/** changed.  Closes the CI-only loophole that caused
+PR #43's 4x round-trip.  Soft-skip with install-hint advisory when
+the trigger doesn't fire.  pr-fast's `security` job bundles vet + deny.
+"""
+
+[[gate]]
+id = "deny"
+label = "cargo deny check"
+command = ["cargo", "deny", "check", "--hide-inclusion-graph"]
+tiers = ["pre-push", "pr-fast"]
+gate_when = "dep_changed"
+hard = true
+tool = "cargo-deny"
+expected_runtime_secs = 5
+bucket = "seq"
+order = 90
+consumer_names = { "pr-fast" = "security" }
+notes = """
+Advisories / bans / licences / sources.  Note: cargo-deny does not
+accept --locked (it reads Cargo.lock from disk directly); cargo-vet
+takes --locked on the bucket-1 side.  pr-fast's `security` job
+bundles vet + deny.
+"""
+
+# ─────────────────────────────────────────────────────────────────────
+# Cross-platform gate — Windows lint via cargo-xwin
+# ─────────────────────────────────────────────────────────────────────
+
+[[gate]]
+id = "lint-ci-windows"
+label = "Windows xwin clippy (-D warnings)"
+command = ["just", "lint-ci-windows"]
+tiers = ["pre-push", "pr-fast"]
+gate_when = "code_changed"
+hard = false
+tool = "cargo-xwin"
+expected_runtime_secs = 6
+bucket = "seq"
+order = 100
+consumer_names = { "pr-fast" = "windows-lint" }
+notes = """
+Phase W5.5 + W5.6 of `windows-clippy-and-linux-cross-plan.md` (PR
+#138) upgraded this from `cargo xwin check` (compile-only) to `cargo
+xwin clippy -- -D warnings`.
+
+Pre-push hook runs `just lint-ci-windows` (cross-compiled cargo-xwin
+clippy with the strict flag stack).  Soft-skip with install-hint
+when `cargo-xwin` missing (MSVC SDK download is ~400 MB; not all
+contributors want that footprint).
+
+Authoritative gate is `pr-fast.yml::windows-lint` which runs the
+equivalent strict clippy NATIVELY on `windows-latest`.
+"""
+
+# ─────────────────────────────────────────────────────────────────────
+# Optional / advisory gates — soft-skip with install hint
+# ─────────────────────────────────────────────────────────────────────
+
+[[gate]]
+id = "typos"
+label = "typos spell-check"
+command = ["typos", "."]
+tiers = ["pre-commit", "pre-push"]
+gate_when = "always"
+hard = false
+tool = "typos"
+expected_runtime_secs = 1
+bucket = "bg"
+order = 50
+notes = """
+Cheap workspace-wide spell-check.  Soft-skip with install hint when
+`typos` is missing (dev-loop nicety, not a hard prerequisite).
+"""
+
+[[gate]]
+id = "reuse"
+label = "reuse SPDX header check"
+command = ["reuse", "lint", "--quiet"]
+tiers = ["pre-commit", "pre-push"]
+gate_when = "always"
+hard = false
+tool = "reuse"
+expected_runtime_secs = 1
+bucket = "bg"
+order = 60
+notes = """
+SPDX licence header compliance.  Soft-skip with `pipx install reuse`
+hint when missing.
+"""
+
+[[gate]]
+id = "taplo"
+label = "taplo TOML format check (staged scope)"
+command = ["taplo", "fmt", "--check", "{{STAGED_TOML}}"]
+tiers = ["pre-commit"]
+gate_when = "always"
+hard = false
+tool = "taplo"
+expected_runtime_secs = 1
+bucket = "bg"
+order = 70
+notes = """
+Pre-commit only — `*.toml` staged-scope.  At pre-push there is no
+staged set; running over the whole workspace surfaces pre-existing
+TOML drift that is out of scope for the push being validated.
+"""
+
+[[gate]]
+id = "vet-fmt"
+label = "cargo-vet config format check"
+command = ["bash", "scripts/hooks/_check_vet_fmt.sh"]
+tiers = ["pre-commit"]
+gate_when = "always"
+hard = true
+tool = "bash"
+expected_runtime_secs = 1
+bucket = "bg"
+order = 80
+notes = """
+Catches `cargo vet` config drift (missing newlines, etc.) before
+push.  Hard at pre-commit only — at pre-push the `vet` gate already
+checks the same constraints transitively.
+"""

--- a/scripts/hooks/_lint_pre_push.sh
+++ b/scripts/hooks/_lint_pre_push.sh
@@ -259,6 +259,13 @@ run_seq() {
 # case hard-fails the whole push with an install hint.
 spawn_bg "fmt"       cargo fmt --all -- --check
 spawn_bg "file-size" bash scripts/ci/check_file_size_policy.sh
+# Gate-manifest drift detector — Phase 1 of
+# `docs/architecture/gates-manifest-plan.md`.  Verifies
+# `scripts/ci/gates.toml` stays in lockstep with the gate set actually
+# defined in `_lint_fast.sh`, `_lint_pre_push.sh`, and `pr-fast.yml`.
+# Cheap (sub-second), no cargo-lock contention.  Bypass once via
+# `BYPASS_GATES_DRIFT=1 git push` (mirrors `COMMIT_SUBJECT_BYPASS=1`).
+spawn_bg "gates-drift" bash scripts/ci/check_gates_drift.sh
 # Conventional Commits subject validator — mirrors
 # `.github/workflows/commitlint.yml`'s PR-title regex so a malformed
 # scope (e.g. `feat(uffs-core, daemon)`) hard-fails locally instead


### PR DESCRIPTION
Phase 1 of [`docs/architecture/gates-manifest-plan.md`](https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/docs/architecture/gates-manifest-plan.md) (the implementation companion to [`dev-flow-implementation-plan.md` §2.7](https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/docs/architecture/dev-flow-implementation-plan.md)).  Closes the "documented but not implemented" status of §2.7 with the foundation for the upcoming Phase 2 + Phase 3 codegen work.

## What lands

- **NEW `scripts/ci/gates.toml`** — declarative source-of-truth for the workspace's PR-time gate set. **20 gate entries** covering pre-commit / pre-push / pr-fast tiers. Each `[[gate]]` carries `id`, `label`, `command`, `tiers`, `gate_when`, `hard`, `tool`, `expected_runtime_secs`, `bucket`, `order`, optional `consumer_names` per-tier name overrides, and free-form `notes`.
- **NEW `scripts/ci/check_gates_drift.sh`** — bidirectional drift detector. Bash + awk; no extra runtime deps. Forward direction: every manifest entry must appear in its tiers' consumer files. Reverse direction: every gate id discovered in a consumer must have a matching manifest entry (orchestration-only jobs `classify` / `required` / `notify-failure` are explicitly exempt). Bypass once via `BYPASS_GATES_DRIFT=1 git push`; CI has no bypass.
- **MODIFIED `scripts/hooks/_lint_pre_push.sh`** — drift check added as a new Bucket 1 step (cheap, parallel, fire-and-forget; same tier as `fmt` / `file-size` / `commit-subjects`).
- **MODIFIED `.github/workflows/pr-fast.yml`** — NEW `gates-drift` job (always-on, no classify gating, sub-second). Added to `required.needs:`, the success-conditional `declare -A R=(...)` array, and `notify-failure.needs:` so manifest mismatch hard-blocks merge.
- **NEW `just gates-drift`** recipe — manual invocation surface.
- **MODIFIED docs** — `gates-manifest-plan.md` Status table marks Phase 0 ✅ landed, Phase 1 🟡 in flight; CHANGELOG entry added under [Unreleased].

## Verification

| Check | Result |
|---|---|
| `bash scripts/ci/check_gates_drift.sh` against current `main` | exit 0, **20 gates correctly matched** |
| Mutation test (manifest fake gate) | drift detector exits 1 with helpful message |
| Mutation test (consumer ghost gate) | drift detector exits 1 with helpful message |
| `BYPASS_GATES_DRIFT=1` env | exits 0 immediately with tombstone log line |
| `actionlint .github/workflows/pr-fast.yml` | exit 0 |
| `shellcheck scripts/ci/check_gates_drift.sh` | exit 0 (3 SC2016 false-positive backtick warnings disabled inline) |
| `just --list` | new `gates-drift` recipe visible |
| `just lint-pre-push` (full pre-push gate including new `gates-drift` step) | exit 0 in **61 s warm** |

## What this PR does NOT do

- **No codegen** — `_lint_fast.sh`, `_lint_pre_push.sh`, and `pr-fast.yml` continue to be hand-maintained. Adding a new gate still requires editing the consumer file AND the manifest in the same PR; the drift detector enforces that you didn't forget either side. Phase 2 (next PR after this lands) introduces `gen-hooks` for `_lint_pre_push.sh`. Phase 3 covers the remaining consumers.
- **No golden-file snapshots** — those land in Phase 2 alongside the first generator.
- **No `manifest.version` bump tooling** — the `manifest.version = 1` field in `gates.toml` is currently informational; Phase 2 wires it to the generator's compatibility check.

## Sequencing

Branched off `main` after PR #138 (W5/L1 closure) and PR #139 (plan doc) both landed. No dependency on any other in-flight PR. Phase 2 implementation comes after this lands.

## Plan reference

See [§5–§7 of `gates-manifest-plan.md`](https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/docs/architecture/gates-manifest-plan.md) for the full migration trajectory, golden-file verification strategy, risk analysis, and the open-questions section (which records the decisions that frame Phases 2-3: Rust generators over bash, TOML over YAML/JSON, `just` recipes stay hand-written, Tier 2 / release / codeql workflows out of scope).
