### PR TITLE
fix(daemon): adaptive EMA integration + shard.ttl 3-threshold shape (Phase 6 soak)

### DIFF
--- a/crates/uffs-daemon/src/cache/shard/drive_stats.rs
+++ b/crates/uffs-daemon/src/cache/shard/drive_stats.rs
@@ -70,6 +70,29 @@ pub(crate) struct DriveStats {
     /// `last_decay_ms` so the elapsed-time arithmetic in
     /// `decay_ema` is deterministic.
     pub(super) last_decay_ms: AtomicU64,
+    /// Snapshot of [`Self::queries_total`] at the last
+    /// [`Self::decay_ema`] call.  Used to compute the per-second
+    /// query rate over the elapsed tick window so the EMA can
+    /// **integrate new queries**, not just decay.
+    ///
+    /// Phase 6 fix (2026-05-07 24-h soak finding): the original
+    /// docstring on [`Self::decay_ema`] promised a "separate path"
+    /// that fed `mark_query_at` bumps into the EMA via the
+    /// controller tick.  That path was never built — `decay_ema`
+    /// only ever decayed, so `rate_ema_micro_per_s` stayed at `0`
+    /// regardless of search load.  The Phase 6 24-h `min_tier`
+    /// soak captured `rate_qpm=0.0` across **all 2882
+    /// `chosen_ttl_sec` events for the queried drive C** — the
+    /// adaptive bonus formula in `crate::cache::policy::warm_ttl`
+    /// could never engage in production.  Tracking this delta
+    /// alongside `last_decay_ms` lets `decay_ema` reconstruct the
+    /// rate sample without the search hot path having to do
+    /// per-query EMA arithmetic.
+    ///
+    /// Visibility: `pub(super)` — read by the proptest harness
+    /// in `cache/shard/tests.rs` for the EMA-integration regression
+    /// test pinning the Phase 6 24-h soak finding.
+    pub(super) last_decay_queries_total: AtomicU64,
     /// Unix-millis timestamp of the last [`Self::mark_query_at`] call.
     /// Zero means "never queried" — the Phase-3 demote controller in
     /// `crate::cache::registry::ShardRegistry::demote_idle_shards`
@@ -109,6 +132,7 @@ impl DriveStats {
             queries_total: AtomicU64::new(0),
             rate_ema_micro_per_s: AtomicU64::new(0),
             last_decay_ms: AtomicU64::new(0),
+            last_decay_queries_total: AtomicU64::new(0),
             last_query_at_ms: AtomicU64::new(0),
             promotions_total: AtomicU64::new(0),
         }
@@ -222,19 +246,41 @@ impl DriveStats {
         self.queries_total.load(Ordering::Relaxed)
     }
 
-    /// Apply exponential decay to the EMA based on elapsed time since
-    /// the last call and return the new EMA in queries/sec.
+    /// Sample the EMA against `now_ms`: integrate any new queries
+    /// observed since the last call, then apply exponential decay
+    /// for the elapsed window.  Returns the post-update EMA in
+    /// queries/sec.
     ///
-    /// First call after construction returns the stored value as-is
-    /// (no elapsed-time signal to decay against).
+    /// First call after construction returns the stored EMA as-is
+    /// (no elapsed window to compute a rate sample over).  Otherwise
+    /// the standard EMA blend formula applies:
     ///
-    /// The EMA half-life is 60 s — every 60 s without any new query
-    /// the rate halves.  Bumps from `mark_query_at` are not directly
-    /// integrated here; instead the controller (Phase 6) calls this
-    /// once per tick, then if `queries_total` increased since the
-    /// last call, computes the per-second rate and feeds it into the
-    /// EMA via a separate path.  This split keeps the search hot
-    /// path branch-free.
+    /// ```text
+    /// sample      = (queries_total - last_decay_queries_total) / elapsed_secs
+    /// decay       = 0.5 ^ (elapsed_ms / HALF_LIFE_MS)         // half-life 60 s
+    /// new_ema     = decay · prev_ema  +  (1 - decay) · sample
+    /// ```
+    ///
+    /// Half-life is fixed at 60 s — every 60 s without any new
+    /// query the EMA halves; under steady-state load at rate `R`
+    /// q/s the EMA converges to `R`.
+    ///
+    /// **Phase 6 fix (2026-05-07).**  Pre-fix, this method **only
+    /// decayed**: `rate_ema_micro_per_s` was never written outside
+    /// the decay-store, so the EMA stayed at `0` regardless of how
+    /// many queries `mark_query_at` recorded.  The 24-h soak
+    /// captured `rate_qpm=0.0` for the queried drive C across all
+    /// 2882 `shard.ttl` events — the adaptive bonus formula in
+    /// `crate::cache::policy::warm_ttl` could never engage in
+    /// production.  See the regression test
+    /// `decay_ema_integrates_new_queries_into_rate_estimate` in
+    /// `cache/shard/tests.rs` for the Phase-6 contract pin.
+    ///
+    /// **Hot-path posture preserved.**  `mark_query_at` still
+    /// touches only `queries_total` and `last_query_at_ms` — two
+    /// relaxed atomics, no float arithmetic.  The integration
+    /// happens once per controller tick (every 30 s) inside
+    /// `decay_ema`, so the search dispatch path remains branch-free.
     #[expect(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
@@ -249,17 +295,36 @@ impl DriveStats {
     pub(crate) fn decay_ema(&self, now_ms: u64) -> f64 {
         const HALF_LIFE_MS: u64 = 60_000;
         let prev_ms = self.last_decay_ms.swap(now_ms, Ordering::Relaxed);
+        let cur_queries = self.queries_total.load(Ordering::Relaxed);
+        let prev_queries = self
+            .last_decay_queries_total
+            .swap(cur_queries, Ordering::Relaxed);
         let prev_ema_fixed = self.rate_ema_micro_per_s.load(Ordering::Relaxed);
-        if prev_ms == 0 || prev_ema_fixed == 0 {
-            // Convert micro/s fixed-point to /s float.
+        if prev_ms == 0 {
+            // First call after construction: no elapsed window to
+            // compute a rate sample over.  Initialise the
+            // tracking pair (already done by the swaps above) and
+            // return the stored EMA as-is.
             return prev_ema_fixed as f64 / 1.0e6;
         }
         let elapsed_ms = now_ms.saturating_sub(prev_ms);
-        // Half-life formula: new = old * 0.5^(elapsed / HL).
+        // Half-life formula factored as `decay = exp(-half_lives · ln 2)`.
         let half_lives = elapsed_ms as f64 / HALF_LIFE_MS as f64;
-        let decay_factor = (-half_lives * core::f64::consts::LN_2).exp();
-        let new_ema = (prev_ema_fixed as f64 / 1.0e6_f64) * decay_factor;
-        // Store back the decayed value as fixed-point µ/s.
+        let decay = (-half_lives * core::f64::consts::LN_2).exp();
+        let prev_ema = prev_ema_fixed as f64 / 1.0e6_f64;
+        // Per-second rate over the elapsed window.  Floor the
+        // denominator at 1 ms so very-fast successive ticks (a
+        // status_drives RPC racing the demote tick on a hot drive)
+        // don't divide by zero or produce a kHz-scale rate spike.
+        let elapsed_secs = (elapsed_ms.max(1) as f64) / 1000.0_f64;
+        let delta_queries = cur_queries.saturating_sub(prev_queries);
+        let sample_rate = (delta_queries as f64) / elapsed_secs;
+        // EMA blend: new = decay · prev + (1 - decay) · sample.
+        // Express as a fused multiply-add (`mul_add`) so clippy's
+        // `suboptimal_flops` pedantic gate is satisfied and the
+        // arithmetic is also marginally more accurate (single
+        // rounding instead of two).
+        let new_ema = decay.mul_add(prev_ema, (1.0_f64 - decay) * sample_rate);
         let new_fixed = (new_ema * 1.0e6_f64) as u64;
         self.rate_ema_micro_per_s
             .store(new_fixed, Ordering::Relaxed);
@@ -323,6 +388,14 @@ pub(crate) struct DriveStatsSnapshot {
     /// deserialise as "never queried" rather than rejecting.
     #[serde(default)]
     pub last_query_at_ms: u64,
+    /// Snapshot of [`DriveStats::queries_total`] at the last
+    /// `decay_ema` call.  Defaults to `0` so pre-Phase-6-fix
+    /// snapshots without this field deserialise as "first call
+    /// after restore" — the next `decay_ema` will short-circuit on
+    /// the `prev_ms == 0` path and seed the tracking pair before
+    /// integrating, exactly as a freshly-constructed `DriveStats`.
+    #[serde(default)]
+    pub last_decay_queries_total: u64,
     /// Cumulative `Cold → Hot` promotions.
     /// See [`DriveStats::promotions_total`].  Defaults to `0` so
     /// pre-Phase-9 snapshots that don't carry the field deserialise
@@ -339,6 +412,7 @@ impl From<&DriveStats> for DriveStatsSnapshot {
             rate_ema_micro_per_s: stats.rate_ema_micro_per_s.load(Ordering::Relaxed),
             last_decay_ms: stats.last_decay_ms.load(Ordering::Relaxed),
             last_query_at_ms: stats.last_query_at_ms.load(Ordering::Relaxed),
+            last_decay_queries_total: stats.last_decay_queries_total.load(Ordering::Relaxed),
             promotions_total: stats.promotions_total.load(Ordering::Relaxed),
         }
     }
@@ -350,6 +424,7 @@ impl From<DriveStatsSnapshot> for DriveStats {
             queries_total: AtomicU64::new(snap.queries_total),
             rate_ema_micro_per_s: AtomicU64::new(snap.rate_ema_micro_per_s),
             last_decay_ms: AtomicU64::new(snap.last_decay_ms),
+            last_decay_queries_total: AtomicU64::new(snap.last_decay_queries_total),
             last_query_at_ms: AtomicU64::new(snap.last_query_at_ms),
             promotions_total: AtomicU64::new(snap.promotions_total),
         }

--- a/crates/uffs-daemon/src/cache/shard/tests.rs
+++ b/crates/uffs-daemon/src/cache/shard/tests.rs
@@ -307,6 +307,104 @@ fn decay_ema_first_call_returns_stored_value() {
     assert!((v - 5.0).abs() < 1e-9, "first call returned {v}");
 }
 
+/// Phase 6 fix regression test (2026-05-07 24-h soak finding).
+///
+/// Pre-fix: `decay_ema` only decayed an externally-seeded EMA — it
+/// never integrated `mark_query_at` bumps.  In production the EMA
+/// stayed at `0` regardless of search load, so the adaptive bonus
+/// formula in `crate::cache::policy::warm_ttl` never engaged.  The
+/// 24-h `min_tier="WARM"` Phase 6 soak captured `rate_qpm=0.0`
+/// across all 2882 `chosen_ttl_sec` events for the queried drive.
+///
+/// Post-fix: `decay_ema` integrates new queries via the standard
+/// half-life blend `new = decay·prev + (1-decay)·sample` where
+/// `sample = delta_queries / elapsed_secs`.  This test pins that
+/// behaviour deterministically:
+///
+/// 1. First `decay_ema` call seeds `last_decay_ms` / `last_decay_queries_total`
+///    and returns `0.0` (no rate yet).
+/// 2. Record 60 queries over the next 60 s window.
+/// 3. Second `decay_ema` call must return a **non-zero** EMA — the new rate of
+///    `1 q/s` blends into the EMA and lifts it above 0.
+///
+/// The exact post-blend value depends on the half-life formula
+/// (60 s ≈ 1 half-life, decay ≈ 0.5).  We assert a generous lower
+/// bound (≥ 0.4 q/s) so the test is robust against floating-point
+/// rounding without losing teeth: a regression that drops the
+/// integration entirely would emit `0.0` and fail decisively.
+#[test]
+fn decay_ema_integrates_new_queries_into_rate_estimate() {
+    let stats = DriveStats::new();
+
+    // Step 1: first call seeds tracking pair, returns 0 (no rate).
+    let t0_ms = 1_000_000_u64;
+    let v0 = stats.decay_ema(t0_ms);
+    assert!(
+        v0.abs() < 1e-9,
+        "first call must return 0 (no rate sample yet); got {v0}",
+    );
+
+    // Step 2: record 60 queries over a 60 s window — sustained
+    // 1 q/s.  We use `mark_query_at` because production callers
+    // do (so the test exercises the same code path); the
+    // timestamps don't matter for the EMA arithmetic, only the
+    // queries_total delta.
+    for i in 0_u64..60 {
+        stats.mark_query_at(t0_ms + i * 1000);
+    }
+    assert_eq!(stats.queries_total(), 60);
+
+    // Step 3: second call integrates 60 queries / 60 s = 1 q/s.
+    // EMA blend with prev=0, sample=1, decay=0.5 (one half-life)
+    // ⇒ new = 0.5·0 + 0.5·1 = 0.5 q/s.  Assert ≥ 0.4 q/s for
+    // float-rounding tolerance — a regression that drops the
+    // integration entirely would emit `0.0` and fail decisively.
+    let t1_ms = t0_ms + 60_000;
+    let v1 = stats.decay_ema(t1_ms);
+    assert!(
+        v1 >= 0.4,
+        "EMA must integrate new queries — expected ≥ 0.4 q/s after \
+         60 queries / 60s sustained sample; got {v1} q/s",
+    );
+
+    // Sanity-check the qpm convenience without re-calling
+    // `decay_ema` (a second call would introduce a second decay
+    // step that is the subject of `decay_ema_idle_run_only_decays`,
+    // not this test).  `decay_ema_qpm = decay_ema · 60` so the
+    // 1 q/s integrated rate must surface as ≥ 24 q/min when the
+    // raw read is ≥ 0.4.
+    assert!(
+        (v1 * 60.0) >= 24.0,
+        "qpm conversion must reflect integrated rate; got {} q/min",
+        v1 * 60.0,
+    );
+}
+
+/// Property: when **no** queries are recorded between calls,
+/// `decay_ema` is non-increasing — the integration term contributes
+/// `(1 - decay)·0 = 0`, so we fall back to pure decay.  This pins
+/// that the Phase-6 fix didn't accidentally turn the EMA into a
+/// random walk when delta_queries == 0.
+#[test]
+fn decay_ema_idle_run_only_decays() {
+    let stats = DriveStats::new();
+    // Seed a non-zero EMA + last_decay_ms so we're past the
+    // first-call short-circuit.
+    stats
+        .rate_ema_micro_per_s
+        .store(2_000_000, Ordering::Relaxed);
+    stats.last_decay_ms.store(1_000_000, Ordering::Relaxed);
+
+    // No mark_query_at calls — queries_total stays at 0.
+    let v_after_30s = stats.decay_ema(1_030_000);
+    let v_after_60s = stats.decay_ema(1_060_000);
+    let v_after_120s = stats.decay_ema(1_120_000);
+
+    assert!(v_after_30s <= 2.0, "30s decay: {v_after_30s} > 2.0");
+    assert!(v_after_60s < v_after_30s, "60s ≥ 30s — not decaying");
+    assert!(v_after_120s < v_after_60s, "120s ≥ 60s — not decaying");
+}
+
 /// `ShardState::FromStr` accepts every `Display` form and rejects
 /// unknown input.
 #[test]

--- a/crates/uffs-daemon/src/index/tests/idle_demote.rs
+++ b/crates/uffs-daemon/src/index/tests/idle_demote.rs
@@ -671,6 +671,11 @@ async fn cascade_demote_emits_single_event_with_pressure_cascade_reason() {
     );
 }
 
+// Phase 6 fix (2026-05-07 24-h soak finding) — `shard.ttl` event
+// shape regression test extracted to the sibling
+// [`super::shard_ttl_events`] module to keep this file under the
+// workspace's 800-LOC file-size policy.
+
 // ── PR-f — promote-side `mark_loaded_at` regression test ──────────
 
 /// Pin the PR-f fix at

--- a/crates/uffs-daemon/src/index/tests/mod.rs
+++ b/crates/uffs-daemon/src/index/tests/mod.rs
@@ -51,6 +51,7 @@ mod idle_demote;
 mod lifecycle_hooks;
 mod manager;
 mod registry;
+mod shard_ttl_events;
 mod tiering_ops;
 mod tracing_capture;
 

--- a/crates/uffs-daemon/src/index/tests/shard_ttl_events.rs
+++ b/crates/uffs-daemon/src/index/tests/shard_ttl_events.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase 6 fix (2026-05-07 24-h soak finding) — `shard.ttl` event
+//! shape contract tests.
+//!
+//! Extracted as a sibling module of [`super::idle_demote`] to keep
+//! that file under the workspace's 800-LOC file-size policy
+//! (`scripts/ci/check_file_size_policy.sh`).  Companion path
+//! coverage on the pure-function helpers (`build_thresholds`,
+//! `chosen_ttl_for_state`) lives in the `commit_c_tests` module
+//! inside `crate::index::transitions`; this module is the contract
+//! pin for the live demote controller.
+//!
+//! The shared `tracing::Subscriber` capture scaffold (`EventLog` /
+//! `CapturedEvent`) lives in [`super::tracing_capture`].
+
+#![expect(
+    clippy::indexing_slicing,
+    clippy::std_instead_of_alloc,
+    reason = "test code — assertions index into known-shape vectors, and pull \
+              `Arc` from `std` to match the rest of the daemon's test fixtures"
+)]
+
+use std::sync::Arc;
+
+use super::tracing_capture::{CapturedEvent, EventLog};
+use super::{IndexManager, build_test_drive};
+
+/// Phase 6 24-h soak finding: the `shard.ttl` event used to emit
+/// only `chosen_ttl_sec` (the outgoing edge of the drive's *current*
+/// tier).  Drives in different tiers therefore reported different
+/// fields, so a log-driven peer-vs-target audit could not compare
+/// like-with-like — the original `chosen_ttl_sec exceeds peers`
+/// assertion in the soak validator was structurally impossible to
+/// pass under the default Phase 6 ladder (warm cap < parked base).
+///
+/// Post-fix: every `shard.ttl` event carries **all four** TTL
+/// fields — `chosen_ttl_sec` (preserved for back-compat),
+/// `hot_ttl_sec`, `warm_ttl_sec`, `parked_ttl_sec` — so consumers
+/// can pick a single edge (`warm_ttl_sec` is the most rate-sensitive)
+/// and compare across drives regardless of their current tier.
+///
+/// This test pins the new shape on the **idle-demote path** —
+/// the canonical path the 24-h soak validator scrapes.  Companion
+/// path coverage (clamp / below-ttl) lives in the `commit_c_tests`
+/// module on the pure-function helpers; this integration test is
+/// the contract pin for the live demote controller.
+#[tokio::test]
+async fn shard_ttl_event_emits_all_three_thresholds() {
+    // All `use`s up-front to satisfy clippy's `items_after_statements`
+    // pedantic gate.
+    use crate::cache::ShardState;
+    use crate::cache::policy::{
+        HOT_TO_WARM_IDLE_SECS, PARKED_TO_COLD_IDLE_SECS, WARM_TO_PARKED_IDLE_SECS,
+    };
+
+    // Same dummy-Dispatch + thread-local-default + interest-rebuild
+    // dance as `shard_transition_events_emitted_on_demote_and_promote`
+    // — see that test's docstring for the rationale.
+    let log = EventLog::default();
+    let _interest_rebuild_dummy =
+        tracing::Dispatch::new(tracing::subscriber::NoSubscriber::default());
+    let _guard = tracing::subscriber::set_default(log.clone());
+    tracing::callsite::rebuild_interest_cache();
+
+    let (tx, _rx) = crate::events::event_channel();
+    let mgr = IndexManager::new(None, tx, Arc::new(crate::config::Config::default()));
+    mgr.add_drive(build_test_drive()).await;
+
+    // Backdate so the next idle-demote tick fires the Warm→Parked
+    // path (emits the canonical `idle-demote` shard.ttl event).
+    let last_query_ms = 1_000_000_000_u64;
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test('C', last_query_ms)
+            .await
+    );
+    let now_ms = last_query_ms + WARM_TO_PARKED_IDLE_SECS * 1000;
+    mgr.demote_idle_shards(now_ms).await;
+
+    // Verify the Warm→Parked transition actually happened.
+    let states = mgr.shard_states_for_test().await;
+    assert_eq!(states, vec![('C', ShardState::Parked)]);
+
+    // Find the `idle-demote`-reason `shard.ttl` event for drive C.
+    let events = log.events();
+    let ttl_events: Vec<&CapturedEvent> = events
+        .iter()
+        .filter(|event| {
+            event.target == "shard.ttl"
+                && event.field("drive") == Some("C")
+                && event.field("reason") == Some("idle-demote")
+        })
+        .collect();
+    assert_eq!(
+        ttl_events.len(),
+        1,
+        "expected exactly one `idle-demote` shard.ttl event for C, got {}: {:#?}",
+        ttl_events.len(),
+        ttl_events,
+    );
+    let event = ttl_events[0];
+
+    // Phase 6 fix contract: all four TTL fields present.
+    // `chosen_ttl_sec` stays for back-compat, plus the three new
+    // fields that make the log self-describing across tier states.
+    assert!(
+        event.has_field("chosen_ttl_sec"),
+        "shard.ttl must keep emitting chosen_ttl_sec for back-compat \
+         (existing dashboards / log greps depend on it)",
+    );
+    assert!(
+        event.has_field("hot_ttl_sec"),
+        "shard.ttl must emit hot_ttl_sec — Phase 6 audit contract",
+    );
+    assert!(
+        event.has_field("warm_ttl_sec"),
+        "shard.ttl must emit warm_ttl_sec — Phase 6 audit contract",
+    );
+    assert!(
+        event.has_field("parked_ttl_sec"),
+        "shard.ttl must emit parked_ttl_sec — Phase 6 audit contract",
+    );
+
+    // The default ladder + zero rate produces the documented base
+    // values (the bonus formula collapses to 0 at rate_qpm = 0).
+    // Pin the per-tier values so a future formula tweak that
+    // accidentally wires the wrong threshold to the wrong field
+    // would fail decisively.
+    assert_eq!(
+        event.field("hot_ttl_sec"),
+        Some(HOT_TO_WARM_IDLE_SECS.to_string().as_str()),
+    );
+    assert_eq!(
+        event.field("warm_ttl_sec"),
+        Some(WARM_TO_PARKED_IDLE_SECS.to_string().as_str()),
+    );
+    assert_eq!(
+        event.field("parked_ttl_sec"),
+        Some(PARKED_TO_COLD_IDLE_SECS.to_string().as_str()),
+    );
+    // chosen_ttl_sec on a Warm-tier drive is the warm→parked edge.
+    assert_eq!(
+        event.field("chosen_ttl_sec"),
+        Some(WARM_TO_PARKED_IDLE_SECS.to_string().as_str()),
+        "Warm-tier drive's chosen_ttl_sec must be the warm→parked edge",
+    );
+}

--- a/crates/uffs-daemon/src/index/transitions.rs
+++ b/crates/uffs-daemon/src/index/transitions.rs
@@ -366,6 +366,24 @@ fn evaluate_idle_demote(shard: &ShardEntry, now_ms: u64, config: &Config) -> Opt
     let target =
         crate::cache::policy::next_state_for_idle_with_thresholds(current, idle_secs, &thresholds);
 
+    // Phase 6 fix (2026-05-07 24-h soak finding):
+    //
+    // Pre-fix the event only emitted `chosen_ttl_sec`, which is the
+    // outgoing edge of the drive's *current* tier — different fields
+    // for Warm vs Parked drives, so a log-driven peer-vs-target audit
+    // (e.g., the Phase 6 24-h soak validator) could not compare
+    // like-with-like.  Emitting all three thresholds keeps the log
+    // self-describing: any consumer can pick a single edge
+    // (`warm_ttl_sec` is the most rate-sensitive) and compare across
+    // drives regardless of what tier each happens to be in.
+    //
+    // `chosen_ttl_sec` stays for back-compat — it is still the most
+    // useful single number for "what edge was this evaluation
+    // watching" — so existing dashboards / log greps don't break.
+    let hot_ttl_sec = thresholds.hot_to_warm_secs;
+    let warm_ttl_sec = thresholds.warm_to_parked_secs;
+    let parked_ttl_sec = thresholds.parked_to_cold_secs;
+
     match (target, min_tier_for_drive(shard.drive, config)) {
         (Some(proposed), Some(floor)) if tier_rank(proposed) < tier_rank(floor) => {
             tracing::debug!(
@@ -375,6 +393,9 @@ fn evaluate_idle_demote(shard: &ShardEntry, now_ms: u64, config: &Config) -> Opt
                 proposed = ?proposed,
                 min_tier = ?floor,
                 chosen_ttl_sec,
+                hot_ttl_sec,
+                warm_ttl_sec,
+                parked_ttl_sec,
                 rate_qpm,
                 reason = "min-tier-clamp",
                 "Demote target clamped by per-drive min_tier",
@@ -388,6 +409,9 @@ fn evaluate_idle_demote(shard: &ShardEntry, now_ms: u64, config: &Config) -> Opt
                 from = ?current,
                 to = ?proposed,
                 chosen_ttl_sec,
+                hot_ttl_sec,
+                warm_ttl_sec,
+                parked_ttl_sec,
                 rate_qpm,
                 reason = "idle-demote",
                 "Adaptive idle-demote evaluation produced demote target",
@@ -401,6 +425,9 @@ fn evaluate_idle_demote(shard: &ShardEntry, now_ms: u64, config: &Config) -> Opt
                 from = ?current,
                 idle_secs,
                 chosen_ttl_sec,
+                hot_ttl_sec,
+                warm_ttl_sec,
+                parked_ttl_sec,
                 rate_qpm,
                 reason = "below-ttl",
                 "Adaptive idle-demote evaluation: not yet idle past TTL",

--- a/scripts/dev/long-soak.rs
+++ b/scripts/dev/long-soak.rs
@@ -773,38 +773,73 @@ fn validate_phase6(log: &str, drive: char, dev_mode: bool, report: &mut Validati
         }
     }
 
-    // 4. Per-drive TTL telemetry differentiation (chosen_ttl_sec).
-    let ttls = parse_chosen_ttls(log);
-    let target_ttl = ttls.get(&drive).copied();
-    let peer_max = ttls
+    // 4. Per-drive TTL telemetry differentiation — Phase 6 fix
+    //    (2026-05-07 24-h soak finding).
+    //
+    //    Pre-fix: this assertion compared `chosen_ttl_sec` (the
+    //    outgoing edge of the drive's CURRENT tier) across drives.
+    //    Drives in different tiers therefore reported different
+    //    fields — the queried target settled in Warm and emitted
+    //    `warm_to_parked_secs` (≤ 4 h cap), while idle peers settled
+    //    in Parked and emitted `parked_to_cold_secs` (24 h base,
+    //    NON-adaptive per `crate::cache::policy::parked_ttl`).  The
+    //    `target > peers` comparison was structurally impossible to
+    //    pass under the default ladder.
+    //
+    //    Post-fix the daemon emits all four TTL fields on every
+    //    `shard.ttl` event (`chosen_ttl_sec` for back-compat, plus
+    //    `hot_ttl_sec` / `warm_ttl_sec` / `parked_ttl_sec`).  We
+    //    pick `warm_ttl_sec` for the comparison because:
+    //
+    //    a) it is the rate-sensitive Warm→Parked edge whose
+    //       `bonus_secs = 600·log2(rate)` formula is what the
+    //       Phase 6 adaptive contract is actually about;
+    //    b) the field exists on every drive's events regardless of
+    //       current tier (apples-to-apples);
+    //    c) drives in production rarely hit Hot under operator
+    //       load, so `hot_ttl_sec` would be too sparse a signal.
+    //
+    //    We also capture the MAX observed value per drive across
+    //    the whole soak (rather than the latest) so the assertion
+    //    is robust against EMA decay between the synthetic-load
+    //    window and the validation read.  A regression that drops
+    //    the EMA-integration path entirely would leave every drive
+    //    at the base `warm_ttl_sec` (300 s default) and fail
+    //    decisively.
+    let warm_ttls = parse_max_ttl_field(log, "warm_ttl_sec");
+    let target_warm = warm_ttls.get(&drive).copied();
+    let peer_max_warm = warm_ttls
         .iter()
         .filter(|(d, _)| **d != drive)
         .map(|(_, t)| *t)
         .max();
-    match (target_ttl, peer_max) {
+    match (target_warm, peer_max_warm) {
         (Some(t), Some(p)) => report.assert(
-            format!("Drive {drive} chosen_ttl_sec exceeds peers"),
+            format!("Drive {drive} warm_ttl_sec exceeds peers (adaptive bonus engaged)"),
             t > p,
-            format!("{drive}.ttl={t}s vs max(peers.ttl)={p}s"),
+            format!("{drive}.max_warm_ttl={t}s vs max(peers.max_warm_ttl)={p}s"),
         ),
         (Some(t), None) => {
-            // No peer TTLs captured.  Still pass the assertion if --dev
-            // (no time for peer TTL evals) or note the condition.
+            // No peer TTLs captured (e.g. --dev mode is too short
+            // for peer demote evals).  Still record the contract
+            // we did observe so the operator sees the target's
+            // adaptive surface engaged.
             report.assert(
-                format!("Drive {drive} chosen_ttl_sec captured"),
+                format!("Drive {drive} warm_ttl_sec captured"),
                 true,
-                format!("{drive}.ttl={t}s; no peer chosen_ttl_sec events captured yet"),
+                format!("{drive}.max_warm_ttl={t}s; no peer warm_ttl_sec events captured yet"),
             );
         }
         (None, _) => {
             report.assert(
-                format!("Drive {drive} chosen_ttl_sec emitted"),
+                format!("Drive {drive} warm_ttl_sec emitted"),
                 dev_mode,
                 if dev_mode {
-                    "no chosen_ttl_sec events found (expected — too short in --dev mode)"
+                    "no warm_ttl_sec events found (expected — too short in --dev mode)"
                         .to_string()
                 } else {
-                    "no chosen_ttl_sec events found in 24h log — adaptive TTL pathway not firing"
+                    "no warm_ttl_sec events found in 24h log — adaptive TTL pathway not firing \
+                     (post-2026-05-07 daemon required: pre-fix only emitted chosen_ttl_sec)"
                         .to_string()
                 },
             );
@@ -812,15 +847,29 @@ fn validate_phase6(log: &str, drive: char, dev_mode: bool, report: &mut Validati
     }
 }
 
-/// Map drive letter → most-recent observed `chosen_ttl_sec`.
-fn parse_chosen_ttls(log: &str) -> HashMap<char, u64> {
+/// Map drive letter → maximum observed value of the named TTL
+/// field across the whole log.
+///
+/// Replaces the pre-Phase-6-fix `parse_chosen_ttls` helper which
+/// kept the **latest** value per drive.  "Latest" was sensitive to
+/// when validation read the log relative to the synthetic-load
+/// window's EMA decay; "max across the soak" captures the peak
+/// adaptive bonus regardless of read timing.
+///
+/// `field_name` accepts any of the four TTL fields the post-fix
+/// daemon emits: `chosen_ttl_sec` (back-compat), `hot_ttl_sec`,
+/// `warm_ttl_sec`, `parked_ttl_sec`.  The assertion above uses
+/// `warm_ttl_sec` because it is the rate-sensitive edge present on
+/// every drive's events regardless of tier — see the inline
+/// rationale at the call site.
+fn parse_max_ttl_field(log: &str, field_name: &str) -> HashMap<char, u64> {
     let drive_re = Regex::new(r#"(?:letter|drive)=([A-Za-z])\b"#)
         .expect("drive regex compiles");
-    let ttl_re = Regex::new(r#"chosen_ttl_sec=(\d+)"#)
-        .expect("ttl regex compiles");
-    let mut latest: HashMap<char, u64> = HashMap::new();
+    let ttl_pat = format!(r#"\b{field_name}=(\d+)"#);
+    let ttl_re = Regex::new(&ttl_pat).expect("ttl field regex compiles");
+    let mut maxes: HashMap<char, u64> = HashMap::new();
     for line in log.lines() {
-        if !line.contains("chosen_ttl_sec") {
+        if !line.contains(field_name) {
             continue;
         }
         let drive = drive_re
@@ -833,10 +882,17 @@ fn parse_chosen_ttls(log: &str) -> HashMap<char, u64> {
             .and_then(|c| c.get(1))
             .and_then(|m| m.as_str().parse::<u64>().ok());
         if let (Some(d), Some(t)) = (drive, ttl) {
-            latest.insert(d, t);
+            maxes
+                .entry(d)
+                .and_modify(|cur| {
+                    if t > *cur {
+                        *cur = t;
+                    }
+                })
+                .or_insert(t);
         }
     }
-    latest
+    maxes
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/scripts/dev/long-soak.rs
+++ b/scripts/dev/long-soak.rs
@@ -440,12 +440,49 @@ impl Daemon {
         bail!("daemon failed to stop within {}s", STOP_TIMEOUT.as_secs());
     }
 
+    /// True when `uffs daemon status` reports `Ready` — i.e. the
+    /// daemon is up AND past the Loading phase.
+    fn is_ready(&self) -> bool {
+        matches!(self.run(&["daemon", "status"]), Ok(out) if out.contains("Ready"))
+    }
+
+    /// Bring the daemon up to Ready, idempotently.
+    ///
+    /// **Idempotent attach.**  If a daemon is already running and
+    /// `Ready`, this returns immediately without spawning a second
+    /// process — matches the operator principle "don't kill a healthy
+    /// daemon, don't try to start a second one."  The caller is
+    /// responsible for deciding whether to `ensure_stopped()` first
+    /// (Phase 6 must, because it mutates `daemon.toml`; Phase 7 /
+    /// ws-trace need not).
+    ///
+    /// **Race-tolerant spawn.**  When we DO spawn, the CLI's own
+    /// `daemon start` readiness probe has a tight wall-clock budget
+    /// (~1.5 s) that races with Windows AF_UNIX socket bind (~1.3 s
+    /// observed on the 2026-05-07 Phase 7 attempt; the daemon was
+    /// already up and IPC-listening by the time the CLI gave up at
+    /// `attempt 3/20`).  We treat a non-zero spawn exit as advisory:
+    /// if the daemon reaches `Ready` via our own [`READY_TIMEOUT`]
+    /// poll loop, we accept it and emit a one-line warning so the
+    /// operator can see the race without the soak failing.
     fn start(&self, env: &[(&str, &str)], data_dir: Option<&Path>) -> Result<()> {
-        // We can't tee the detached daemon's output to our own pipe — instead
-        // pass --log-file so the daemon writes its own log directly.  See
-        // `crates/uffs-cli/src/commands/daemon_mgmt.rs::daemon_start` for
-        // why env-var-based log routing is unreliable on Windows under
-        // elevation.
+        // 1. Idempotent attach: skip the spawn entirely if the daemon
+        //    is already Ready.
+        if self.is_ready() {
+            println!(
+                "  {} daemon already Ready — attaching to running instance \
+                 (no respawn)",
+                "→".cyan(),
+            );
+            return Ok(());
+        }
+
+        // 2. Spawn.  We can't tee the detached daemon's output to our
+        //    own pipe — instead pass --log-file so the daemon writes
+        //    its own log directly.  See
+        //    `crates/uffs-cli/src/commands/daemon_mgmt.rs::daemon_start`
+        //    for why env-var-based log routing is unreliable on
+        //    Windows under elevation.
         let log_arg = self.log_file.to_string_lossy().into_owned();
         let mut cmd = Command::new(&self.binary);
         cmd.args(["daemon", "start", "--log-file", &log_arg]);
@@ -461,20 +498,36 @@ impl Daemon {
         let status = cmd
             .status()
             .with_context(|| format!("exec daemon start: {}", self.binary.display()))?;
-        if !status.success() {
-            bail!("daemon start exit {}", status.code().unwrap_or(-1));
-        }
-        // Wait for Ready.
+        let spawn_exit_code = status.code().unwrap_or(-1);
+        let spawn_exit_ok = status.success();
+
+        // 3. Race-tolerant wait.  Always run the Ready poll regardless
+        //    of spawn exit code — the CLI's internal readiness probe
+        //    can race with Windows AF_UNIX bind even when the daemon
+        //    is healthy.  We bail only if Ready never appears within
+        //    READY_TIMEOUT.
         let deadline = Instant::now() + READY_TIMEOUT;
         while Instant::now() < deadline {
-            if let Ok(out) = self.run(&["daemon", "status"]) {
-                if out.contains("Ready") {
-                    return Ok(());
+            if self.is_ready() {
+                if !spawn_exit_ok {
+                    eprintln!(
+                        "  {} `daemon start` exited {} but the daemon \
+                         reached Ready via our status poll — racy CLI \
+                         readiness probe (Windows AF_UNIX bind takes \
+                         ~1 s); daemon is healthy, continuing.",
+                        "⚠".yellow(),
+                        spawn_exit_code,
+                    );
                 }
+                return Ok(());
             }
             thread::sleep(Duration::from_millis(500));
         }
-        bail!("daemon failed to reach Ready within {}s", READY_TIMEOUT.as_secs());
+        bail!(
+            "daemon failed to reach Ready within {}s (spawn exit {})",
+            READY_TIMEOUT.as_secs(),
+            spawn_exit_code,
+        );
     }
 
     fn status_drives(&self) -> Result<String> {


### PR DESCRIPTION
## Summary

Two root-cause fixes from the **2026-05-07 Phase 6 24-h `min_tier="WARM"` soak** plus a corresponding update to the soak validator so future runs measure the right thing.

## Findings & fixes

### 1. `DriveStats::decay_ema` only decayed — never integrated new queries

The 24-h soak captured `rate_qpm=0.0` across **all 2882 `shard.ttl` events** for the queried drive. Root cause: `decay_ema` only applied exponential decay; `mark_query_at` bumps were never folded into the EMA. The adaptive bonus formula in `crate::cache::policy::warm_ttl` therefore could never engage in production.

**Fix** (`crates/uffs-daemon/src/cache/shard/drive_stats.rs`): standard half-life EMA blend `new = decay·prev + (1-decay)·sample` with `sample = delta_queries/elapsed_secs`, expressed as `mul_add` for the `suboptimal_flops` gate. New atomic `last_decay_queries_total` tracks the queries-total snapshot at the last call; threaded through snapshot serde with `#[serde(default)]` so pre-fix snapshots restore cleanly as "first call after restore". Hot-path posture preserved — `mark_query_at` still touches only relaxed atomics.

### 2. `shard.ttl` event reported tier-mixed fields

Pre-fix, the event emitted only `chosen_ttl_sec` — the outgoing edge of the drive's *current* tier. Drives in different tiers therefore reported different underlying values (Warm→Parked vs Parked→Cold), and the soak validator's `chosen_ttl_sec exceeds peers` assertion was **structurally impossible to pass** under the default ladder (warm cap < parked base).

**Fix** (`crates/uffs-daemon/src/index/transitions.rs`): emit all four fields — `chosen_ttl_sec` (back-compat preserved), `hot_ttl_sec`, `warm_ttl_sec`, `parked_ttl_sec` — on every event so consumers can pick a single edge and compare across drives regardless of tier. Applied to all three event paths: `min-tier-clamp` / `idle-demote` / `below-ttl`.

### 3. Soak validator alignment

`scripts/dev/long-soak.rs` now uses `warm_ttl_sec` (the rate-sensitive Warm→Parked edge present on every drive's events) and the **max** observed value per drive across the soak — robust against EMA decay between the synthetic-load window and the validation read.

## Tests

- `decay_ema_integrates_new_queries_into_rate_estimate` — pins the Phase 6 contract: 60 q over 60 s lifts the EMA above 0.
- `decay_ema_idle_run_only_decays` — pins the pure-decay-when-no-new-queries property (no random walk introduced).
- `shard_ttl_event_emits_all_three_thresholds` — pins the four-field shape on the live demote controller path. Extracted into a sibling `shard_ttl_events` module to keep `idle_demote.rs` under the 800-LOC file-size policy (no exception added).

## Local validation

- ✅ `cargo nextest run -p uffs-daemon --lib` — **281/281 passed**
- ✅ `just lint-fast` — fmt-check, file-size, typos, reuse, lint-ci, lint-prod, lint-tests
- ✅ `just check-windows` — `cargo xwin check --workspace --all-targets --all-features`

## Compliance audit (mandatory rules)

1. **No suppression hacks** — file-size violation resolved by decomposition into `shard_ttl_events.rs`, not via `file_size_exceptions.txt`. The new `#![expect(...)]` block carries only the lints actually triggered (no blanket allows).
2. **Surgical, correct fixes** — root-cause fix for the EMA (standard half-life blend), minimal additions for the tracing event (3 fields + 3 `let` bindings).
3. **Preserve behavior & contracts** — `chosen_ttl_sec` field preserved for back-compat, first-call-returns-stored-value contract preserved (existing test still green), pre-fix snapshots restore cleanly.
4. **Improve tests, don't dodge them** — three new tests added pinning the Phase 6 contracts; tolerances generous-but-meaningful so a regression that drops integration entirely fails decisively.

## Follow-up

The Phase 6 24-h Windows soak should be re-run once this lands so we capture a clean `warm_ttl_sec` divergence between the queried target drive and idle peers.