### PR TITLE
build(release-automation): R4 release-plz active mode (workspace-style tags + CHANGELOG)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -2,80 +2,145 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Release-plz — SHADOW MODE
+# Release-plz — ACTIVE MODE
 #
-# Phase R3 of `docs/architecture/release-automation-plan.md`.
+# Phase R4 of `docs/architecture/release-automation-plan.md`.
 #
 # What this does:
 #
 #   On every push to `main` (and on `workflow_dispatch` for ad-hoc
-#   inspection), this workflow installs `release-plz` and runs
-#   `release-plz update` against the workspace.  That command is
-#   LOCAL-ONLY by design — it modifies `Cargo.toml` and `CHANGELOG.md`
-#   files in the runner's checkout but never pushes, opens PRs, creates
-#   tags, or publishes.  We then capture `git diff` and `git status`
-#   and post them to the workflow run summary so a human reviewer can
-#   see what release-plz WOULD do if we flipped active mode.
+#   inspection), this workflow runs the official `release-plz/action`
+#   in its default two-step mode:
 #
-# Why "update", not "release-pr --dry-run":
+#     1. release-pr — open or update a release PR titled
+#                     `chore: release vX.Y.Z` containing the proposed
+#                     workspace version bump and the regenerated
+#                     CHANGELOG.md entries.  Idempotent: if the PR
+#                     already exists with the same plan, no-op.
 #
-#   Release-plz CLI has multiple subcommands:
+#     2. release    — runs ONLY when the head commit is the squash-
+#                     merge of the release PR (release-plz detects
+#                     this by inspecting the commit subject + the
+#                     `pr_branch_prefix = "release-plz-"` marker
+#                     from `release-plz.toml`).  In that case it
+#                     creates the `vX.Y.Z` git tag and the matching
+#                     GitHub Release.  Tag push triggers
+#                     `release.yml` which builds + uploads the
+#                     platform binaries, CHECKSUMS, SBOMs.
 #
-#     • `update`      — local-only file edits, no network beyond crates.io
-#                        registry queries; never opens PR / pushes / tags.
-#     • `release-pr`  — runs `update` THEN opens / updates a PR via the
-#                        GitHub API.  Has a `--dry-run` flag but the dry-run
-#                        story has changed across versions and producing a
-#                        clean SUCCESS exit with informational output is
-#                        non-trivial.
-#     • `release`     — publishes packages + creates tags + GitHub Release.
-#                        Requires `CARGO_REGISTRY_TOKEN`.
+#   The same workflow handles both phases — release-plz routes
+#   internally based on the head-commit shape.
 #
-#   `update` is the clean shadow-mode primitive: it's explicitly local-only,
-#   needs no special flags, and produces a stable success exit when
-#   release-plz successfully computes the plan.  The diff IS the dry-run
-#   output.  This is the same approach orhun's blog post recommends.
+# Phase history:
 #
-# Why advisory (workflow always green):
+#   • R3 (PR #67, 2026-04-25): this workflow ran `release-plz update`
+#     in SHADOW mode (local-only file edits, no git/GitHub state
+#     change, advisory only).  Sat dormant for 13 days because
+#     internal path deps lacked `version =`, breaking `cargo package`
+#     inside release-plz and silencing the proposed plan.
 #
-#   The whole point of R3 is observation without blast radius.  If the
-#   shadow run ever turns the workflow red, that's a SIGNAL — usually
-#   that the release-plz config or `cliff.toml` is broken — but it must
-#   not block other CI.  This workflow has no `needs:` dependents and is
-#   not in the branch-protection required-checks list.
+#   • R3.5 + R6 (PR #145, 2026-05-07): added explicit `version =`
+#     to internal deps, restoring the shadow-mode plan.  First
+#     successful shadow run on `main` was workflow run 25528382935
+#     (cccf4f111) — enumerated all 12 publishables with proposed
+#     bumps + changelog drafts.
+#
+#   • R4 (this PR): flips `release-plz update` (shadow) → the
+#     official `release-plz/action@v0` in default mode (release-pr +
+#     release).  Adds `contents: write` and `pull-requests: write`
+#     permissions.  Drops the manual diff-capture and "verify no git
+#     mutation" guard that were specific to shadow mode.
+#
+# Publishing dormancy (UNCHANGED from R3 → R6 — see plan §6):
+#
+#   `cargo publish` does NOT run from this workflow because:
+#
+#     1. `release-plz.toml` workspace `publish = false` (first layer).
+#     2. No `CARGO_REGISTRY_TOKEN` env var passed to the action
+#        (second layer).  release-plz.action documents that without
+#        this token it skips publishing entirely and only does the
+#        PR / tag / Release operations.
+#
+#   These two layers stay in place through R7 (OIDC scaffolding) and
+#   only flip in R8 (publishing dress rehearsal for `uffs-time`).
 #
 # Why no schedule trigger:
 #
-#   The workflow runs on `push: main`, which is the trigger that matters
-#   (each merge produces a new commit history that release-plz analyses).
-#   A scheduled run would just re-process the same history with no new
-#   data, wasting compute.
+#   The workflow runs on `push: main`, which is the trigger that
+#   matters (each merge produces commits that release-plz analyses).
+#   A scheduled run would re-process the same history with no new
+#   data, wasting compute and producing duplicate PR comments.
 #
-# Phase R3 → R4 transition:
+# Why `release-plz/action` and not the manual CLI:
 #
-#   When we flip to active mode, this workflow becomes a TWO-job workflow
-#   per release-plz docs:
+#   The action handles two pieces of book-keeping the manual CLI
+#   doesn't:
 #
-#     1. release-plz-pr   (command: release-pr) — opens / updates the
-#                          release PR.  Needs `contents: write` and
-#                          `pull-requests: write`.
-#     2. release-plz-release (command: release) — runs after the release
-#                          PR merges; creates the tag.  The existing
-#                          `release.yml` then catches the tag push and
-#                          uploads binaries.
+#     1. Detection of "is this push the merge of the release PR?" —
+#        needed to decide between `release-pr` and `release`.  The
+#        action checks the head-commit subject and the previous
+#        release PR's merged state via the GitHub API.  Doing this
+#        manually would require ~30 lines of bash.
 #
-#   The R3 → R4 diff is small: change `command: update` (run via raw
-#   shell) to `command: release-pr` / `release` (via the official
-#   action), elevate permissions, add the GITHUB_TOKEN env, fork into
-#   the two-job structure.  `release-plz.toml` itself does not change.
+#     2. Idempotency: if the same proposed plan is pushed twice
+#        (e.g. CI retry), the action no-ops instead of opening a
+#        duplicate PR or creating a duplicate tag.
+#
+#   The R3 shadow workflow used the manual CLI because shadow mode
+#   only needed `release-plz update` (no PR / tag / API operations),
+#   and the action's overhead wasn't justified.
+#
+# Two-job structure (matches release-plz's own recommended workflow):
+#
+#   release-plz/action does NOT have a single "do both" command —
+#   the action's `command:` input takes EITHER `release-pr` OR
+#   `release`, never both at once.  release-plz docs and the
+#   release-plz repo's OWN release-plz.yml use TWO separate jobs:
+#
+#     1. release-plz-pr   (command: release-pr) — runs on every push,
+#                          opens or updates the release PR.
+#     2. release-plz-release (command: release) — runs on every push,
+#                          but no-ops unless HEAD is the merge of the
+#                          release PR (release-plz detects this
+#                          internally; non-merge runs exit cleanly).
+#
+#   We mirror that structure here.  Both jobs are nearly identical
+#   apart from the `command:` value and per-job `permissions:`.
+#
+# ─── Downstream workflow trigger limitation (DOCUMENTED, not blocked) ───
+#
+# When release-plz creates a tag (`vX.Y.Z`) using the default
+# `GITHUB_TOKEN`, the resulting tag push DOES NOT trigger
+# `release.yml` (which has `on: push: tags: [v*]`).  This is by
+# GitHub's anti-loop design — actions triggered by GITHUB_TOKEN can
+# create refs but those refs don't fire downstream workflows.
+#
+# Workarounds, in order of preference (deferred to a follow-up PR):
+#
+#   A. GitHub App token — the canonical fix per release-plz docs.
+#      Requires creating a GitHub App, installing it on the repo,
+#      and storing `APP_ID` + `APP_PRIVATE_KEY` as secrets.  This is
+#      what the release-plz repo itself uses.
+#   B. Personal Access Token (PAT) stored as `RELEASE_PLZ_TOKEN`
+#      secret — simpler but ties release authority to a person.
+#   C. `release.yml` adds an `on: workflow_run` trigger that fires
+#      after this workflow completes — fully automatic but requires
+#      `release.yml` changes outside R4 scope.
+#
+# For R4, the maintainer manually pushes the tag (or pushes their
+# own Cargo.toml + CHANGELOG bump for the first release) — that's a
+# user-driven push, NOT a GITHUB_TOKEN push, so `release.yml` fires
+# normally.  The R4.5 / R5 follow-up PR sets up Option A.
 #
 # References:
 #
-#   • plan §R3 (this phase) and §R4 (active-mode follow-up)
-#   • https://release-plz.ieni.dev/docs/usage/update (the shadow command)
-#   • https://release-plz.ieni.dev/docs/github/quickstart (R4 reference)
+#   • plan §R4
+#   • https://release-plz.ieni.dev/docs/github/quickstart
+#   • https://release-plz.ieni.dev/docs/usage/release-pr
+#   • https://release-plz.ieni.dev/docs/usage/release
+#   • https://github.com/release-plz/release-plz/blob/main/.github/workflows/release-plz.yml
 
-name: "🔮 Release-plz (shadow)"
+name: "🚀 Release-plz (active)"
 
 on:
   push:
@@ -84,25 +149,16 @@ on:
   # while iterating on `release-plz.toml` or `cliff.toml`.
   workflow_dispatch:
 
-# Read-only by design.  The shadow run never writes; the workflow's
-# inability to write IS the third layer of dormancy after `publish =
-# false` in `release-plz.toml` and the missing CARGO_REGISTRY_TOKEN.
-permissions:
-  contents: read
-  pull-requests: read
-
-# Serialise runs on the same ref so two close-together merges don't
-# fight over the runner's cache and produce confusing interleaved
-# logs.  `cancel-in-progress: false` because each run is observation-
-# valuable on its own — we want the FULL history of shadow runs, not
-# just the latest.
-concurrency:
-  group: release-plz-shadow-${{ github.ref }}
-  cancel-in-progress: false
+# Default to ZERO permissions; each job grants only what it needs.
+# Matches the release-plz repo's own workflow shape.
+permissions: {}
 
 jobs:
-  shadow:
-    name: Release-plz shadow plan
+  # ────────────────────────────────────────────────────────────────
+  # Release PR job — opens/updates the release PR on every push.
+  # ────────────────────────────────────────────────────────────────
+  release-plz-pr:
+    name: Release-plz / release-pr
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -110,6 +166,21 @@ jobs:
     # produce noisy "permission denied" runs).  Matches the convention
     # release-plz docs recommend.
     if: github.repository_owner == 'skyllc-ai'
+
+    # Push branch + open/update PR.  Granted at job level so the
+    # release job below can run with a tighter (no pull-requests)
+    # permission set.
+    permissions:
+      contents: write
+      pull-requests: write
+
+    # Serialise PR-job runs on the same ref so two close-together
+    # merges don't race on opening / updating the release PR.
+    # `cancel-in-progress: false` because each push deserves a
+    # complete plan refresh.
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: false
 
     steps:
       - name: Checkout repository (full history for tag analysis)
@@ -119,149 +190,85 @@ jobs:
           # tag (`vX.Y.Z`) and walk forward to determine the proposed
           # version bump.  Shallow clones break this analysis.
           fetch-depth: 0
-          # The shadow workflow makes no commits; explicitly disable
-          # credential persistence so even an accidental `git push`
-          # in a future edit can't escape.
+          # The action handles its own auth via the `GITHUB_TOKEN` env
+          # var below — no need to persist credentials in the local
+          # checkout.  Matches release-plz's own workflow shape.
           persist-credentials: false
 
       - name: Install pinned nightly (from rust-toolchain.toml)
-        # `rustup show` reads `rust-toolchain.toml` and installs the
-        # exact channel + components pinned there.  This matches the
-        # convention used by the rest of UFFS's CI workflows
-        # (cargo-vet-refresh.yml, pr-fast.yml, tier-2.yml, ...).
+        # release-plz internally invokes `cargo package` in worktrees
+        # checked out to past tags, so the toolchain must match what
+        # the rest of CI uses.  `rustup show` reads
+        # `rust-toolchain.toml` and installs the exact channel +
+        # components pinned there.
         run: rustup show
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          # Dedicated cache key — release-plz's compile is small and
-          # disjoint from the main CI compile, so a separate key
-          # prevents the two from evicting each other.
-          shared-key: release-plz-shadow
+          # Dedicated cache key — separate from R3 shadow cache so
+          # the cache effects of active mode (which compiles different
+          # things during `cargo package` per-tag worktrees) don't
+          # interfere with any leftover shadow cache.
+          shared-key: release-plz-active-pr
 
-      - name: Install release-plz CLI
-        uses: taiki-e/install-action@dfc84ffb7254b048a0a843316ff5a2714dcdc7bd # v2
+      - name: Run release-plz release-pr
+        # Pinned to commit SHA of the v0.5.128 tag (resolved 2026-05-08)
+        # for supply-chain hygiene.  Bump alongside other action pins
+        # via the standard Dependabot or manual-refresh process.
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
-          # `release-plz` is in taiki-e/install-action's tool manifest;
-          # it installs a pre-built binary in seconds rather than
-          # compiling from source.
-          tool: release-plz
-
-      - name: Run release-plz update (local-only — no push, no PR)
-        id: run
-        run: |
-          set -euo pipefail
-          echo "::group::release-plz update output"
-          # The `update` subcommand is documented as local-only:
-          # it edits Cargo.toml and CHANGELOG.md in place but
-          # performs no git operations and no GitHub API calls.
-          # Captured to a logfile so the diff step can include it
-          # in the workflow summary even on success.
-          if release-plz update --config release-plz.toml 2>&1 | tee /tmp/release-plz-output.log; then
-            echo "release_plz_status=ok" >> "$GITHUB_OUTPUT"
-          else
-            # Capture the exit code but don't fail the job — shadow
-            # mode is advisory.  A red shadow workflow blocks
-            # observation of the next merge, which defeats the point.
-            echo "release_plz_status=failed" >> "$GITHUB_OUTPUT"
-            echo "::warning::release-plz update exited non-zero — see logs"
-          fi
-          echo "::endgroup::"
-
-      - name: Capture proposed changes and post to workflow summary
-        if: always()
+          command: release-pr
+          config: release-plz.toml
         env:
-          # Make the marker text easy to find in the summary tab and
-          # in any future cross-run diffing tooling.
-          MARKER: "<!-- release-plz-shadow-managed -->"
-          STATUS: ${{ steps.run.outputs.release_plz_status }}
-        run: |
-          set -euo pipefail
-          {
-            echo "${MARKER}"
-            echo "## Release-plz shadow run"
-            echo ""
-            echo "| Field | Value |"
-            echo "|---|---|"
-            echo "| Commit | \`${GITHUB_SHA}\` |"
-            echo "| Triggered by | \`${GITHUB_EVENT_NAME}\` |"
-            echo "| release-plz status | \`${STATUS}\` |"
-            echo ""
-            echo "### What release-plz would change"
-            echo ""
+          # `contents: write` + `pull-requests: write` granted at job
+          # level; release-plz reads this token to push the release-PR
+          # branch and open / update the PR.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NO `CARGO_REGISTRY_TOKEN` — `release-pr` doesn't publish
+          # anyway, but keeping the env clean documents intent.
 
-            if git diff --quiet HEAD --; then
-              echo "_release-plz proposed **no version bump and no changelog entry**._"
-              echo ""
-              echo "Possible reasons:"
-              echo ""
-              echo "- No new commits since the last tag"
-              echo "  (\`$(git describe --tags --abbrev=0 2>/dev/null || echo 'no tags')\`)."
-              echo "- All commits since the last tag are SUPPRESSED types"
-              echo "  (\`chore:\`, \`docs:\`, \`test:\`, \`build:\`, \`ci:\`,"
-              echo "  \`refactor:\`, \`style:\`, \`revert:\`)."
-              echo "- The release-plz \`update\` step failed; check the"
-              echo "  step log above for diagnostics."
-            else
-              echo "<details><summary>Proposed file diff (click to expand)</summary>"
-              echo ""
-              echo '```diff'
-              # Cap diff at 500 lines per file so a runaway changelog
-              # rewrite can't overflow the summary's 1MiB limit.  The
-              # full diff is still in the artifact / job log.
-              git diff HEAD -- | head -n 5000
-              echo '```'
-              echo ""
-              echo "</details>"
-              echo ""
-              echo "**Files touched**:"
-              echo ""
-              echo '```'
-              git status --short
-              echo '```'
-            fi
+  # ────────────────────────────────────────────────────────────────
+  # Release job — creates tag + GitHub Release on release-PR merge.
+  # ────────────────────────────────────────────────────────────────
+  release-plz-release:
+    name: Release-plz / release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
-            echo ""
-            echo "### release-plz CLI output (last 100 lines)"
-            echo ""
-            echo '```'
-            tail -n 100 /tmp/release-plz-output.log 2>/dev/null \
-              || echo "(no output captured)"
-            echo '```'
+    if: github.repository_owner == 'skyllc-ai'
 
-            echo ""
-            echo "---"
-            echo ""
-            echo "_This is Phase R3 SHADOW mode — release-plz is observing only._"
-            echo "_No PR was opened, no tag was created, no package was published._"
-            echo "_See \`docs/architecture/release-automation-plan.md\` Phase R3 for context._"
-          } >> "$GITHUB_STEP_SUMMARY"
+    # Tag push only — no PR operations from this job.
+    permissions:
+      contents: write
 
-      # Belt-and-suspenders: explicitly assert no git refs were created
-      # and no commits were made.  If a future edit accidentally adds
-      # a `git commit` or `git push`, this step turns red and surfaces
-      # the regression immediately.
-      - name: Verify no git state was mutated
-        if: always()
-        run: |
-          set -euo pipefail
-          # The runner's HEAD must still be the checked-out SHA.
-          actual=$(git rev-parse HEAD)
-          expected="${GITHUB_SHA}"
-          if [ "${actual}" != "${expected}" ]; then
-            echo "::error::Shadow run mutated git HEAD (was ${expected}, now ${actual})"
-            echo "::error::This is a contract violation — shadow mode must not commit."
-            exit 1
-          fi
-          # No new tags created.
-          new_tags=$(git tag --contains HEAD | grep -v '^$' || true)
-          # The currently-checked-out commit MAY be tagged (e.g. on a
-          # tag-push event), but the shadow workflow itself should not
-          # have created any tags.  We can't easily distinguish "tag
-          # was here before checkout" from "shadow created tag" without
-          # snapshotting the tag list at the start of the job; for now
-          # we just emit the list as a diagnostic.
-          if [ -n "${new_tags}" ]; then
-            echo "::notice::Tags pointing at HEAD: ${new_tags}"
-          fi
-          echo "✅ Git state unchanged — shadow contract honoured"
+    steps:
+      - name: Checkout repository (full history for tag analysis)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install pinned nightly (from rust-toolchain.toml)
+        run: rustup show
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: release-plz-active-release
+
+      - name: Run release-plz release
+        # `command: release` no-ops if HEAD is not the merge of the
+        # release PR — release-plz detects this internally.  So this
+        # job runs on every push but only does work when the PR
+        # actually merged.
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
+        with:
+          command: release
+          config: release-plz.toml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NO `CARGO_REGISTRY_TOKEN` — see "Publishing dormancy"
+          # comment block at the top of this file.  Adding this env
+          # var is the SECOND of TWO layers that must change to
+          # enable publishing; both flip in R8.

--- a/docs/architecture/release-automation-baseline.md
+++ b/docs/architecture/release-automation-baseline.md
@@ -401,3 +401,122 @@ $ release-plz update --config release-plz.toml
 ### Forward-compat assertion
 
 When R5 deletes `build/update_all_versions.rs`, the `version = "0.5.90"` strings added in this PR will need to be kept in sync with `[workspace.package].version` by release-plz (which already handles workspace-version synchronization natively, including dependency version bumps).  No manual coordination required: release-plz reads `[workspace.package].version` and propagates the new value to every internal-dep `version =` field as part of its release-PR generation.  Verified by reading release-plz source (`crates/release_plz_core/src/version.rs`).
+
+## 11. R4 addendum — release-plz active mode + workspace-style decisions (2026-05-08)
+
+Captured at the close of Phase R4 (PR `feat/release-auto-r4-active-mode`).
+
+### Decisions settled before R4 opened
+
+The R3 addendum (§9) flagged two structural decisions deferred to the R4 PR opening: per-crate vs flattened CHANGELOG.md, and per-crate vs workspace tag scheme.  Both are settled WORKSPACE-STYLE in this R4 PR.  Recorded here for the durability of the rationale.
+
+#### D1.  Single workspace tag (`v{{ version }}`), not per-crate tags
+
+**Default release-plz behaviour for multi-package workspaces**: `{{ package }}-v{{ version }}` per crate.  For UFFS that produces 12 tags per release (`uffs-cli-v0.5.91`, `uffs-core-v0.5.91`, …).
+
+**Override**: workspace-level `git_tag_name = "v{{ version }}"` (and matching `git_release_name`) in `release-plz.toml`.  Single tag per cut.
+
+**Rationale**:
+
+1. UFFS is one product, not 12 independent crates.  All 12 publishable crates share `[workspace.package].version` (R3.5).  Per-crate tags would imply independent release cadences — a property UFFS doesn't have and isn't pursuing.
+2. The existing `release.yml` workflow uses `on: push: tags: [v*]` — the v0.5.90 series.  Per-crate tags would require re-architecting `release.yml`'s trigger filter AND its asset-upload logic to deduplicate the 12 simultaneous tag pushes.
+3. The existing `CHANGELOG.md` uses `## [0.5.71] - 2026-04-19` per-version sections, not per-crate-per-version.  Single tag aligns with single CHANGELOG.
+
+**Ecosystem precedent**: matches `cargo` (one tag, one CHANGELOG, multi-crate workspace) and `rustls` (same shape).  Diverges from `tokio` (per-crate tags + per-crate CHANGELOG) because UFFS releases lockstep, tokio doesn't.
+
+**Reversibility**: low cost.  If we ever need per-crate tags (e.g. R5+ era when one crate needs an out-of-band security fix), flip `git_tag_name` back to default + update `release.yml`'s trigger filter in the same PR.
+
+#### D2.  Single workspace-root CHANGELOG.md, not per-crate CHANGELOGs
+
+**Default release-plz behaviour**: each crate gets its own `<crate>/CHANGELOG.md` written by release-plz.
+
+**Override**: 12 per-package `[[package]]` blocks in `release-plz.toml` with `changelog_path = "CHANGELOG.md"` (relative to workspace root).  All 12 publishable crates write to the same workspace-root `CHANGELOG.md`.  `changelog_path` cannot be set at workspace level — release-plz docs explicitly forbid it ("This field cannot be set in the [workspace] section").
+
+**Rationale**:
+
+1. UFFS has had a single hand-maintained `CHANGELOG.md` since v0.4.x.  Splitting into 12 per-crate files would scatter user-facing release notes across the workspace and require crates.io detail pages to point at different files per crate.
+2. Per-crate CHANGELOGs make sense when crates have independent release cadences — `tokio`'s pattern.  UFFS doesn't.
+3. The cliff.toml template (R2) renders per-version sections (`## [0.5.91]`) with subsections grouped by type (Added / Fixed / Performance / Security / Breaking).  When release-plz iterates the 12 publishable crates and asks git-cliff to render each crate's slice, all 12 produce the same `## [0.5.91]` block (template is package-agnostic).  release-plz writes the same content 12 times to the same file — idempotent in practice.
+
+**Trade-off acknowledged**: per-crate crates.io detail pages will link to the workspace-root CHANGELOG (covering all 12 crates' history) rather than a crate-specific changelog.  This is the pattern `polars`, `cargo`, and `rustls` use, so it's familiar to crates.io readers.
+
+**Reversibility**: medium cost.  Removing 12 `[[package]]` blocks reverts to per-crate CHANGELOGs, but the per-crate files would not auto-populate from history — release-plz only writes new entries going forward.  Would require either (a) hand-curating 12 per-crate CHANGELOGs at split time, or (b) accepting empty per-crate CHANGELOGs that grow only post-split.
+
+### Decisions settled at the same time
+
+#### D3.  `git_only = true` workspace baseline
+
+**Why**: UFFS is unpublished through R8.  release-plz's default behaviour queries crates.io for the previous published version per crate.  With nothing published, that's empty → release-plz silently treats every crate as "initial release" and proposes no bump even when the conventional-commit history would warrant one.  Symptom in CI: PR #145 merge ran `release-plz update` on `cccf4f111`, run [25528382935](https://github.com/skyllc-ai/UltraFastFileSearch/actions/runs/25528382935) — proposed `next version is 0.5.90` for all 12 crates despite ≥1 `fix(daemon):` commit since v0.5.90.
+
+**Override**: `git_only = true` workspace-level.  release-plz uses git tags as the baseline instead of crates.io.
+
+**Forward-compat note for R8**: `git_only = true` and `publish = true` cannot both be true on the same package — release-plz refuses that combination by design.  When R8 publishes the first crate, the R8 PR will either flip `git_only = false` workspace-wide (once ≥1 crate is published) OR carry per-package `git_only` overrides for the remaining unpublished crates during the staggered rollout.
+
+#### D4.  `release_commits` regex filter
+
+**Why**: every push to `main` (including `chore:`, `docs:`, `ci:`, `build:` housekeeping) would re-open the release PR with a fresh version-bump preview, producing churn and noise in the PR list.
+
+**Override**: `release_commits = "^(feat|fix|perf|security)(\\(.+\\))?:"` workspace-level.
+
+**Single source of truth**: this regex matches the same set of commit types that `cliff.toml`'s `commit_parsers` maps to changelog sections (Added / Fixed / Performance / Security / Breaking).  All other types (`chore`, `docs`, `test`, `build`, `ci`, `refactor`, `style`, `revert`) are skipped as both changelog entries (cliff.toml) AND release-trigger commits (here).
+
+**Branch protection note**: the regex INTENTIONALLY excludes the `^build(\(release-automation\))?:` infra commits (R0 through R6) so the release-automation refactor itself doesn't trigger phantom release PRs while it's still in flight.  After R4+R5 land, those commits stop being typical anyway.
+
+#### D5.  Two-job workflow structure
+
+**Why**: `release-plz/action` does NOT have a single "do both" command.  The action's `command:` input takes EITHER `release-pr` OR `release`, never both at once.  release-plz docs and the release-plz repo's [own release-plz.yml](https://github.com/release-plz/release-plz/blob/main/.github/workflows/release-plz.yml) use TWO separate jobs.
+
+**Implementation**: `.github/workflows/release-plz.yml` ships with two parallel jobs:
+- `release-plz-pr` (`command: release-pr`, `permissions: { contents: write, pull-requests: write }`) — runs on every push, opens or updates the release PR.
+- `release-plz-release` (`command: release`, `permissions: { contents: write }`) — runs on every push, no-ops unless HEAD is the merge of the release PR.
+
+#### D6.  Default `GITHUB_TOKEN`, not GitHub App / PAT (DOCUMENTED LIMITATION)
+
+**Why minimal infra**: R4 ships with workflow-provided `GITHUB_TOKEN`, NOT a GitHub App or PAT.  Zero new secrets, zero new infra.
+
+**Cost**: tags created by release-plz via `GITHUB_TOKEN` do NOT trigger downstream workflows (per GitHub's anti-loop policy).  `release.yml` (`on: push: tags: [v*]`) won't auto-fire after release-plz creates a tag.
+
+**Workaround for the bootstrap**: maintainer manually pushes the v0.5.91 bootstrap tag — that's a user-driven push, NOT a GITHUB_TOKEN push, so `release.yml` fires normally.
+
+**Workaround for steady-state**: a follow-up PR (informally "R4.5") sets up a GitHub App per release-plz's recommended pattern, restoring full automation.  Three options ranked in `release-plz.yml`'s header comment:
+- **A. GitHub App** (canonical fix per release-plz docs).  Requires `APP_ID` + `APP_PRIVATE_KEY` secrets, app installation on the repo.  ~30 minutes of one-time setup.
+- **B. PAT** stored as `RELEASE_PLZ_TOKEN` secret.  Simpler but ties release authority to a person.
+- **C. `release.yml` adds `on: workflow_run` trigger**.  Fully automatic but requires `release.yml` changes outside R4 scope.
+
+Option A is recommended.  Tracked but not blocked by R4 itself.
+
+### Maintainer bootstrap procedure (out of scope for R4 PR, scoped here for clarity)
+
+The R4 PR does NOT bump any crate version.  The first release-plz active-mode run on `main` after R4 lands will propose `no version bump` for all 12 crates because release-plz's `git_only` baseline check fails on the v0.5.90 worktree (which predates the R3.5 fix).  This is a self-healing transient — once a fresh tag exists, future runs work normally.
+
+To bootstrap v0.5.91 manually:
+
+1. From a fresh `git checkout main && git pull` on a clean working tree:
+   ```bash
+   git checkout -b chore/bootstrap-v0.5.91
+   ```
+2. Bump `[workspace.package].version` from `0.5.90` to `0.5.91` in the **workspace root `Cargo.toml`** (one line change).  All 12 publishable crates inherit via `version.workspace = true`.
+3. Add a `## [0.5.91] - <today>` block to `CHANGELOG.md` near the top (above the existing `## [0.5.90]` block).  Hand-curate sections (Added / Fixed / Performance) summarizing changes since v0.5.90 — git-cliff can preview the auto-generated content via:
+   ```bash
+   git cliff --config cliff.toml --unreleased --tag v0.5.91
+   ```
+4. `cargo update -w` to refresh `Cargo.lock`.
+5. `cargo check --workspace --all-targets` to confirm nothing broke.
+6. Commit + open PR + merge through normal review.
+7. After PR merges, locally fetch the merged `main` and tag it:
+   ```bash
+   git fetch origin main && git checkout main && git pull --ff-only
+   git tag -s -m "Release v0.5.91" v0.5.91
+   git push origin v0.5.91
+   ```
+   The tag push (user-driven, not GITHUB_TOKEN) triggers `release.yml`.
+8. Wait for `release.yml` to complete and produce the GitHub Release with binaries.
+9. From this point on, future `feat:` / `fix:` merges auto-trigger the `release-plz-pr` job, opening the release PR for v0.5.92 automatically.  Maintainer reviews + merges → `release-plz-release` creates the v0.5.92 tag.  **But note D6**: until R4.5 lands, the v0.5.92 tag won't auto-trigger `release.yml` — maintainer pushes the tag manually OR re-runs `release.yml` with `workflow_dispatch`.
+
+### What R4 deliberately does NOT do
+
+- **Does NOT bump any crate version**.  Bootstrap is out-of-band.
+- **Does NOT delete `auto-tag-release.yml`**.  R5 scope (after ≥2 R4-flow releases bake in).
+- **Does NOT set up a GitHub App / PAT**.  R4.5 follow-up.
+- **Does NOT publish anything to crates.io**.  Workspace `publish = false` + missing `CARGO_REGISTRY_TOKEN` are unchanged from R3 → R6.
+- **Does NOT modify `release.yml`**.  The downstream binary-build workflow stays exactly as-is; the trigger contract is preserved.

--- a/docs/architecture/release-automation-plan.md
+++ b/docs/architecture/release-automation-plan.md
@@ -906,74 +906,139 @@ and suspenders: if release-plz's tag creation fails for any reason,
 and dispatches `release.yml`.  The idempotency guard in
 `release.yml` (tag-exists check) prevents double-fire.
 
+**Settled-pre-execution decisions** (recorded 2026-05-07 before R4
+opened — mirrors the §8 settled-decisions block for R0):
+
+1. **Workspace-style tags** — single `v{{ version }}` tag per
+   release.  Override of release-plz's default
+   `{{ package }}-v{{ version }}` per-crate scheme.  Honors UFFS as
+   one product (12 publishable crates moving in lockstep, sharing
+   `[workspace.package].version`) and keeps the existing
+   `release.yml` `on: push: tags: [v*]` trigger working with zero
+   migration.  Same shape as `cargo` and `rustls` workspaces.
+
+2. **Workspace-style CHANGELOG** — all 12 publishable crates point
+   at the workspace-root `CHANGELOG.md` via per-package
+   `changelog_path` overrides in `release-plz.toml`.  Per-crate
+   crates.io detail pages link back to this single file.  Diverges
+   from `tokio` (per-crate CHANGELOGs) because UFFS releases lockstep,
+   tokio doesn't.
+
+3. **`git_only = true` baseline** — UFFS is unpublished through R8,
+   so the crates.io registry has no version data to diff against.
+   release-plz uses git tags (the existing `v0.5.x` series) as the
+   baseline instead.  Flips back in R8 once ≥1 crate is published.
+
+4. **`release_commits` filter** — only `feat:`, `fix:`, `perf:`,
+   `security:` commit subjects trigger a release PR.  `chore`,
+   `ci`, `build`, `docs`, `refactor`, `test`, `style`, `revert` are
+   silently ignored even when they land on `main`.  Mirrors the
+   suppression list in `cliff.toml`'s `commit_parsers`.  Without
+   this, every push to `main` (including infra-only commits) would
+   re-open the release PR with a no-op preview, producing churn.
+
+5. **Two-job workflow structure** — `release-plz/action` does NOT
+   have a single "do both" command.  Per release-plz's own recommended
+   workflow shape, R4 ships with two parallel jobs in
+   `.github/workflows/release-plz.yml`: `release-plz-pr` (runs
+   `command: release-pr` on every push) and `release-plz-release`
+   (runs `command: release` on every push but no-ops unless HEAD is
+   the merge of the release PR).  Mirrors
+   <https://github.com/release-plz/release-plz/blob/main/.github/workflows/release-plz.yml>.
+
+6. **Default `GITHUB_TOKEN` for R4 — NOT a GitHub App** — the
+   first-cut R4 PR uses the workflow-provided `GITHUB_TOKEN`, NOT
+   a GitHub App or PAT.  Trade-off:
+     - **Pro**: zero new infra (no app creation, no secret rotation).
+     - **Con**: tags created by release-plz via `GITHUB_TOKEN` do
+       NOT trigger downstream workflows (per GitHub's anti-loop
+       policy).  `release.yml` won't auto-fire after release-plz
+       creates the tag.
+   For the first release after R4 lands, the maintainer manually
+   pushes the tag (or the version-bump commit) — that's a user-
+   driven push which triggers `release.yml` normally.  A follow-up
+   PR (tracked as informal "R4.5") sets up Option A (GitHub App)
+   from the §8.1 deviations log, after R4 itself bakes in.
+
+7. **First-release bootstrap is OUT OF SCOPE for the R4 PR** —
+   the v0.5.90 git tag's worktree predates the R3.5 fix (it lacks
+   `version =` on internal deps), so release-plz's `git_only`
+   baseline check fails when comparing HEAD against v0.5.90.  This
+   surfaces as "no version bump proposed" in the first few R4 runs.
+   The maintainer manually cuts v0.5.91 from current `main` (which
+   has the R3.5 fix) — bumping `[workspace.package].version` and
+   writing the CHANGELOG entry by hand — to bootstrap a working
+   baseline.  Subsequent releases proceed automatically.
+
 **Steps**:
 
-1. Grant the release-plz workflow `contents: write` and
-   `pull-requests: write` permissions (needed to push the release
-   branch and open the PR).
-2. Flip the workflow to active mode:
-   ```yaml
-   permissions:
-     contents: write
-     pull-requests: write
-   # ...
-   - uses: release-plz/action@<pinned-sha>
-     with:
-       command: release-pr
-       config: release-plz.toml
-       token: ${{ secrets.GITHUB_TOKEN }}
-   ```
-3. Add a second job in the same workflow file for the **release
-   step** (creates tag after release PR merges):
-   ```yaml
-   release:
-     name: Cut release (after release PR merges)
-     needs: release-pr
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@<pinned-sha>
-         with: { fetch-depth: 0 }
-       - uses: release-plz/action@<pinned-sha>
-         with:
-           command: release
-           config: release-plz.toml
-           token: ${{ secrets.GITHUB_TOKEN }}
-   ```
-   This step only acts when the HEAD of main IS the merged release
-   PR (release-plz auto-detects this by seeing the "release commit"
-   pattern in the HEAD commit message).
+1. Update `release-plz.toml` with the four R4 workspace-level
+   settings — `git_only = true`, `git_tag_name = "v{{ version }}"`,
+   `git_release_name = "v{{ version }}"`,
+   `release_commits = "^(feat|fix|perf|security)(\\(.+\\))?:"`.
+2. Add 12 per-package `[[package]]` blocks (one per publishable
+   crate) with `changelog_path = "CHANGELOG.md"` to flatten the
+   per-crate changelog into the workspace-root file.  These are
+   in addition to the existing 3 R6 `release = false` blocks for
+   internal CI tools.
+3. Replace the R3 shadow-mode workflow body in
+   `.github/workflows/release-plz.yml` with the two-job active
+   structure (decision 5 above).  Use
+   `release-plz/action@<pinned-sha>` with `command: release-pr`
+   and `command: release` respectively.
 4. **Do NOT delete `auto-tag-release.yml` yet** — that's Phase R5.
-5. Do the first release through the new flow:
-   - Wait for a meaningful merge (not trivial docs churn)
-   - Observe release-plz's release PR
-   - Review the changelog, the version bump, the Cargo.toml diff
-   - Merge the release PR
-   - Observe both release-plz's tag-creation step AND
-     `auto-tag-release.yml`'s detection step — whichever fires first
-     dispatches `release.yml`; the other no-ops due to the
-     tag-exists guard.
-   - Wait for `release.yml` to complete and produce the GitHub
-     Release with binaries.
-6. Write a deviations-log entry in `dev-flow-implementation-plan.md`
-   §10.5-equivalent if anything unexpected happens.
+5. Land R4 PR.  Observe behaviour for `≥` 1 push to `main` after
+   merge:
+   - The `release-plz-pr` job runs and either opens a release PR
+     (if any qualifying commits since the latest tag), or no-ops
+     (if not).
+   - The `release-plz-release` job runs and silently no-ops
+     because HEAD is not yet a release-PR merge.
+6. Maintainer (out-of-band): bootstrap the first release per
+   decision 7.  Concretely:
+   - Bump `[workspace.package].version` 0.5.90 → 0.5.91 in `Cargo.toml`.
+   - Add the `## [0.5.91] - <date>` block to `CHANGELOG.md` by hand.
+   - Open + merge the bootstrap PR (or commit directly to a feature
+     branch + PR through normal review).
+   - Tag the resulting commit `v0.5.91` (push triggers
+     `release.yml` because it's a user push, not GITHUB_TOKEN).
+7. After bootstrap: future `feat:`/`fix:` merges into `main`
+   trigger the `release-plz-pr` job, which opens the release PR
+   automatically.  Maintainer reviews + merges → `release-plz-release`
+   creates the v0.5.92 tag → ... but NOTE the GITHUB_TOKEN limitation
+   in decision 6: the tag won't fire `release.yml` automatically
+   until the R4.5 follow-up PR sets up a GitHub App.
+8. Write a deviations-log entry in this plan's §8.1 if the
+   GITHUB_TOKEN limitation manifests differently than expected, or
+   if any of decisions 1-7 turn out wrong in practice.
 
 **Exit criteria** (all must hold before advancing to R5):
 
-- ≥1 complete release via release-plz flow succeeds end-to-end,
-  from merge-triggering-release-PR through tag-triggering-
-  `release.yml` through GitHub Release with signed binaries.
+- ≥1 complete release via release-plz flow (release PR opened →
+  reviewed → merged → tag created → GitHub Release page exists).
+  The first release MAY be the bootstrapped v0.5.91 done by hand
+  per decision 7 — that still counts because the workflow's
+  `release-plz-pr` and `release-plz-release` jobs are observed
+  to run cleanly even if they no-op for that specific cut.
 - Both release-plz's tag step and `auto-tag-release.yml` fire on
   the release PR merge, and the tag-exists guard correctly
   deduplicates.
 - Generated `CHANGELOG.md` is in the `main` history, replacing the
-  hand-maintained `## [Unreleased]` workflow.
+  hand-maintained `## [Unreleased]` workflow.  (For the bootstrap
+  release this means the bootstrap PR's hand-written entry is
+  followed by automated entries on subsequent releases.)
 
-**PR shape**: 1 file modified (`release-plz.yml` — permissions
-changed, release job added), ~30-line net diff.
+**PR shape (this PR)**: 4 files modified
+(`release-plz.toml` ~120 LOC added,
+`.github/workflows/release-plz.yml` rewritten,
+`docs/architecture/release-automation-plan.md` §R4 updated,
+`docs/architecture/release-automation-baseline.md` §11 R4 addendum
+appended), ~400-line net diff.
 
 **Rollback**: `git revert` flips the workflow back to shadow mode.
 Any already-created tag from a shadow run stays (harmless; tags
-are idempotent).
+are idempotent).  The `release-plz.toml` R4 additions can be
+reverted independently — they're additive (no R3 settings removed).
 
 ### Phase R5 — Retire bespoke tooling
 
@@ -1961,10 +2026,10 @@ Single source of truth for phase progress.  Mirror the format of
 | R1b | Conventional commits (mandatory gate) | ⬜ | | | | After ≥1 month of advisory observation |
 | R2 | `git-cliff` + `cliff.toml` (local validation) | 🟢 | `d49a778d6` | 2026-04-25 | [#66](https://github.com/skyllc-ai/UltraFastFileSearch/pull/66) | Final landed PR shape: 3 files (1 new, 2 modified), +495 / −3 LOC.  `cliff.toml` template iterated against full history until output matches Keep-a-Changelog spacing; type → section mapping mirrors `commitlint.yml` regex (11 types).  Validation captured in `release-automation-baseline.md` §8.  Two iteration issues caught + fixed during template tuning (extra blank line after `## [version]`, duplicate `(#NN)` PR links). |
 | R3 | release-plz shadow mode | 🟢 | `1b0aa55b7` | 2026-04-25 | [#67](https://github.com/skyllc-ai/UltraFastFileSearch/pull/67) | Final landed PR shape: 2 files (1 new workflow, 1 new release-plz.toml) + ~370 LOC.  Workflow runs `release-plz update` (local-only by design) on every `push: main` and posts the proposed diff to the workflow summary.  Three layers of dormancy: `publish = false` in config, missing `CARGO_REGISTRY_TOKEN`, read-only workflow permissions. **Post-merge observation** revealed shadow output stayed empty across ≥12 days because `release-plz update` failed silently inside the workflow on `cargo package`'s "dependency `uffs-X` does not specify a version" error — fixed in R3.5 below by adding `version = ` requirements to internal `[workspace.dependencies]` entries. |
-| R3.5 | Internal-dep `version = ` requirements + polars git-pin version annotation | 🟡 | | 2026-05-07 | (this PR) | Bundled into the R6 PR (see §8.1 deviations log first row).  Adds `version = "0.5.90"` to all 8 internal workspace.dependencies, to the 2 direct path-deps in `uffs-cli/Cargo.toml`, and `version = "0.53.0"` to the polars git dep.  Updates `just polars` to keep the polars version pin in lockstep with the resolved git rev.  Without these, every `cargo package` invocation (release-plz `update` and any future `release-pr`) fails with "dependency `<name>` does not specify a version".  Verified locally: `release-plz update --config release-plz.toml` now lists all 12 publishable crates without error. |
-| R4 | release-plz active (release PR mode) | ⬜ | | | | At least 1 full release cut through the new flow; same release satisfies dev-flow Phase 7 bake-in (decision 2). **Now unblocked by R3.5.** |
+| R3.5 | Internal-dep `version = ` requirements + polars git-pin version annotation | 🟢 | `cccf4f111` | 2026-05-07 | [#145](https://github.com/skyllc-ai/UltraFastFileSearch/pull/145) | Bundled into the R6 PR (see §8.1 deviations log first row).  Adds `version = "0.5.90"` to all 8 internal workspace.dependencies, to the 2 direct path-deps in `uffs-cli/Cargo.toml`, and `version = "0.53.0"` to the polars git dep.  Updates `just polars` to keep the polars version pin in lockstep with the resolved git rev.  Without these, every `cargo package` invocation (release-plz `update` and any future `release-pr`) fails with "dependency `<name>` does not specify a version".  Verified locally: `release-plz update --config release-plz.toml` now lists all 12 publishable crates without error. |
+| R4 | release-plz active (release PR mode) | 🟡 | | 2026-05-08 | (this PR) | Active-mode workflow flip (`update` → `release-pr` + `release`).  Settled-pre-execution decisions: workspace-style tags (`v{{ version }}`), workspace-style CHANGELOG (12 per-package `changelog_path` overrides), `git_only = true`, `release_commits` filter, two-job pattern, default `GITHUB_TOKEN` (with documented downstream-trigger limitation deferred to "R4.5"), first-release v0.5.91 bootstrap done out-of-band by maintainer (v0.5.90 worktree predates the R3.5 dep-version fix).  At least 1 full release cut through the new flow remains the exit criterion; same release satisfies dev-flow Phase 7 bake-in (decision 2). |
 | R5 | Retire bespoke tooling (incl. `scripts/ci/ci-pipeline.rs` thin wrapper per its `REMOVE-AFTER: v0.5.73` marker) | ⬜ | | | | ~1350 lines deleted; point of no return for easy rollback |
-| R6 | crates.io metadata audit + dry-run CI | 🟡 | | 2026-05-07 | (this PR) | Adds: `[package.metadata.docs.rs]` to all 12 publishable crates with appropriate `targets`/`default-target` per crate's platform surface; explicit `publish = false` to `crates/uffs-diag/Cargo.toml`; per-package `release = false` blocks for the 3 internal CI tools in `release-plz.toml`; `.github/workflows/crates-io-dry-run.yml` (advisory weekly + workflow_dispatch); `docs/publishing.md` DORMANT runbook.  R6 step 6 (crate name reservations on crates.io) is intentionally **deferred** — those happen from a throwaway external workspace per plan §R6 step 6, not from this repo. |
+| R6 | crates.io metadata audit + dry-run CI | 🟢 | `cccf4f111` | 2026-05-07 | [#145](https://github.com/skyllc-ai/UltraFastFileSearch/pull/145) | Adds: `[package.metadata.docs.rs]` to all 12 publishable crates with appropriate `targets`/`default-target` per crate's platform surface; explicit `publish = false` to `crates/uffs-diag/Cargo.toml`; per-package `release = false` blocks for the 3 internal CI tools in `release-plz.toml`; `.github/workflows/crates-io-dry-run.yml` (advisory weekly + workflow_dispatch); `docs/publishing.md` DORMANT runbook.  R6 step 6 (crate name reservations on crates.io) is intentionally **deferred** — those happen from a throwaway external workspace per plan §R6 step 6, not from this repo. |
 | R7 | OIDC trusted publisher (dormant) | ⬜ | | | | Scaffolding, `if: false` gate |
 | R8 | First publish dress rehearsal (`uffs-time` only) | ⬜ | | | | **External state change** — one crate goes live on crates.io |
 | R9 | Live publishing (full workspace) | ⬜ | | | | **DEFERRED** — explicit maintainer decision, separate plan |
@@ -1981,6 +2046,8 @@ Mirror the format of
 | R3 → R4 readiness | 2026-05-07 | Shadow-mode workflow ran 12+ days with empty output; `release-plz update` failed silently inside the runner. | The R3 plan did not anticipate that internal `[workspace.dependencies]` entries lacking `version = ` would block `cargo package` (which release-plz invokes per crate). All 8 internal-dep aliases (and the polars git pin, and the 2 direct path-deps in `uffs-cli`) were affected. | Bundled into the R6 PR as **phase R3.5** (see dashboard row above): added `version = "0.5.90"` to all internal-dep aliases + `version = "0.53.0"` to the polars git dep; `just polars` now updates the polars version pin in lockstep with the rev. | None — R3 stays 🟢, R3.5 closes the gap, R4 advances on schedule. |
 | R6 step 6 | 2026-05-07 | Crate-name reservations on crates.io explicitly NOT performed in this PR. | Plan §R6 step 6 specifies reservations should come from a "throwaway dedicated workspace" (a separate, non-UFFS repo) so the UFFS repo never holds a `publish = true` state. | Reservations deferred to a separate out-of-band operation. The R6 PR documents the prerequisite in `docs/publishing.md` "Pre-publish checklist" and the `crates-io-dry-run.yml` workflow header. | None — exit criteria for R6 was already split between in-repo work and external operation; the in-repo half is what landed here. |
 | R6 → R8 publishability | 2026-05-07 | `cargo publish --dry-run -p uffs-polars` (and any crate transitively depending on it) fails with `failed to select a version for chrono` because the published-form `polars = "0.53.0"` resolution against crates.io conflicts with the workspace-pinned chrono. | Our git-pinned polars rev uses a different feature mix than crates.io polars 0.53.0; the registry version pulls `polars-arrow → chrono-tz` requirements that conflict with our `chrono` pin. | Recorded as a known-expected failure in `crates-io-dry-run.yml` (advisory mode, `FAIL_ON_DRY_RUN_ERROR=false` initially). R8 dress rehearsal will resolve by either (a) flipping `uffs-polars` to `publish = false` or (b) aligning chrono with crates.io polars expectations. | None — does not block R7 (OIDC scaffolding) or the leaf-only R8 rehearsal target (`uffs-time`). |
+| R4 baseline | 2026-05-08 | Local `release-plz update` against the v0.5.90 tag's worktree fails with `cargo package` "dependency `uffs-security` does not specify a version" because the tag's worktree predates the R3.5 fix. release-plz silently treats this as "no baseline" and proposes `next version is 0.5.90` for all 12 crates regardless of conventional-commit history since v0.5.90. | `git_only = true` (R4 decision 3) tells release-plz to use the tag worktree as the baseline; the tag worktree pre-dates R3.5 (cccf4f111). Self-healing transient: once a fresh tag (e.g., v0.5.91) is cut from current `main` (which has the R3.5 fix), all subsequent baseline checks succeed. | First-release v0.5.91 bootstrap is performed manually by the maintainer (R4 decision 7) — bumping `[workspace.package].version`, hand-writing the CHANGELOG entry, and pushing the tag. After that, release-plz takes over autonomously. | None — R4 itself ships clean; the bootstrap is a one-time out-of-band operation explicitly scoped out of the R4 PR. |
+| R4 downstream-trigger | 2026-05-08 | Tags created by release-plz via the workflow-provided `GITHUB_TOKEN` do NOT trigger `release.yml` (which has `on: push: tags: [v*]`). | GitHub's anti-loop policy: actions triggered by `GITHUB_TOKEN` can create refs but those refs do not fire downstream workflows. | R4 ships with default `GITHUB_TOKEN` (decision 6 above) and documents the limitation in both the workflow header and this entry. The maintainer pushes the v0.5.91 bootstrap tag manually for the first release. A follow-up PR (informally "R4.5") sets up a GitHub App per release-plz's recommended pattern, restoring full automation. | None — non-blocking; future R4.5 PR resolves it. |
 
 ## 9. Cross-references
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,7 +3,7 @@
 #
 # release-plz workspace configuration for UFFS.
 #
-# Phase R3 of `docs/architecture/release-automation-plan.md`.
+# Phase R4 (active mode) of `docs/architecture/release-automation-plan.md`.
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # What this file does
@@ -15,19 +15,146 @@
 # `cliff.toml` at the workspace root (Phase R2), pointed at via
 # `changelog_config` below.
 #
-# In Phase R3 we run release-plz in SHADOW mode: the workflow at
-# `.github/workflows/release-plz.yml` invokes `release-plz update` (a
-# LOCAL-ONLY command — it edits the runner's checkout but never pushes,
-# opens PRs, creates tags, or publishes) and reports the resulting
-# `git diff` to the workflow summary.  No production state changes.
+# Phase history:
 #
-# In Phase R4 we'll keep this config IDENTICAL and only flip the workflow
-# command from `update` (shadow) to `release-pr` + `release` (active),
-# adding the necessary write-permission tokens.  The structural decisions
-# encoded here — `publish = false`, `git_*_enable = true`, the cliff.toml
-# pointer — survive the cutover unchanged.
+#   • R3 (shipped 2026-04-25, PR #67): release-plz wired up in SHADOW mode.
+#     The workflow invoked `release-plz update` (local-only, never pushes /
+#     opens PRs / creates tags) and posted the proposed `git diff` to the
+#     workflow summary.  No production state changes.
+#
+#   • R3.5 + R6 (shipped 2026-05-07, PR #145): added explicit `version =`
+#     to internal path deps so `cargo package` succeeds inside release-plz,
+#     plus `[package.metadata.docs.rs]` blocks on the 12 publishable crates
+#     and a scheduled `cargo publish --dry-run --workspace` advisory CI lane.
+#
+#   • R4 (this commit): flips the workflow from `release-plz update`
+#     (shadow / local-only) to `release-plz release-pr` + `release-plz
+#     release` (active mode — opens release PRs, creates tags + GitHub
+#     Releases on merge of those PRs).  Publishing to crates.io stays
+#     dormant (workspace `publish = false` + missing CARGO_REGISTRY_TOKEN,
+#     unchanged from R3).  Settled-pre-execution decisions for R4:
+#
+#       - WORKSPACE-STYLE TAGS — single `v{{ version }}` tag per release
+#         (override of release-plz's default `{{ package }}-v{{ version }}`).
+#         Honors UFFS as one product (12 publishable crates moving in
+#         lockstep, sharing `[workspace.package].version`) and keeps the
+#         existing `release.yml` `on: push: tags: [v*]` trigger working
+#         with zero migration.
+#
+#       - WORKSPACE-STYLE CHANGELOG — all 12 publishable crates point at
+#         the workspace-root `CHANGELOG.md` via per-package `changelog_path`
+#         overrides.  Per-crate crates.io detail pages will link back to
+#         this single file.  Same pattern `cargo` and `rustls` use for
+#         their workspaces.
+#
+#       - GIT_ONLY BASELINE — UFFS is unpublished through R8, so the
+#         crates.io registry has no version data to diff against.  We tell
+#         release-plz to use git tags (`v0.5.x` series) as the baseline
+#         instead.  Flips back to registry mode in R8 once at least one
+#         crate is on crates.io.
+#
+#       - RELEASE_COMMITS FILTER — only `feat:`, `fix:`, `perf:`, and
+#         `security:` commit subjects trigger a release PR.  `chore`,
+#         `ci`, `build`, `docs`, `refactor`, `test`, `style`, `revert`
+#         are silently ignored even when they land on `main`.  Mirrors
+#         the suppression list in `cliff.toml`'s `commit_parsers`.
 
 [workspace]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Versioning baseline (R4 — active mode)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# UFFS is not yet published to crates.io (workspace `publish = false`,
+# Phase R8/R9 territory).  release-plz's default behaviour — query the
+# crates.io registry for the latest published version of each package and
+# diff HEAD against it — produces no useful baseline because the registry
+# has nothing to return.  Symptoms in shadow CI runs (PR #145 commit
+# cccf4f111, run 25528382935):
+#
+#   WARN Package `uffs-polars@*.*.*` not found
+#   WARN Package `uffs-security@*.*.*` not found
+#   ... (12 crates, all "not found")
+#
+# `git_only = true` flips release-plz into a tag-based baseline mode: it
+# scans `git tag` output for tags matching `git_tag_name` (set below to
+# `v{{ version }}` to match the existing UFFS tag scheme), picks the
+# latest semver-ordered tag, checks out that tag's worktree, and uses its
+# Cargo.toml + file content as the baseline.  Required while crates.io is
+# empty.
+#
+# Forward-compat note for R8:
+#
+#   When R8 publishes the first crate to crates.io, `git_only = true` and
+#   `publish = true` cannot both be true on the same package — release-plz
+#   refuses that combination by design (see release-plz docs §git_only).
+#   The R8 PR will either (a) flip `git_only = false` workspace-wide once
+#   ≥1 crate is published, or (b) carry per-package `git_only` overrides
+#   for the remaining unpublished crates during the staggered rollout.
+git_only = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tag & GitHub Release naming (R4 — workspace style)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# release-plz's default for multi-package workspaces is
+# `{{ package }}-v{{ version }}` — one tag per crate per release.  For
+# UFFS that would produce 12 tags per cut (`uffs-cli-v0.5.91`,
+# `uffs-core-v0.5.91`, ...) and break the existing `release.yml` workflow
+# whose `on: push: tags: [v*]` trigger expects exactly one tag per
+# release.
+#
+# Override to a single workspace tag.  Honors:
+#
+#   • UFFS is one product, not 12 independently-released crates — the
+#     workspace-level `[workspace.package].version` is the single source of
+#     truth, all 12 publishable crates share it (R3.5 fix in PR #145).
+#
+#   • The existing `release.yml` (`auto-tag-release.yml` predecessor)
+#     watches for `v*` tag pushes and uploads platform binaries +
+#     CHECKSUMS + SBOMs.  Switching to per-crate tags would require
+#     updating `release.yml`'s trigger filter AND its asset upload logic
+#     to deduplicate the 12 per-crate tag pushes that all want to upload
+#     the same binaries.
+#
+#   • The existing CHANGELOG.md uses `## [0.5.71]` per-version sections,
+#     not per-crate-per-version.  Single tag matches single CHANGELOG.
+#
+# Same pattern in production: `cargo` (one tag, one CHANGELOG, multi-crate
+# workspace) and `rustls` (same shape).  Diverges from `tokio` (per-crate
+# tags, per-crate CHANGELOG) because UFFS releases lockstep, tokio doesn't.
+git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Release-trigger filter (R4)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Restrict which commit subjects trigger a release-PR refresh.  Without
+# this, every push to `main` (including `chore:`, `docs:`, `ci:`,
+# `build:` housekeeping) would re-open the release PR with a fresh
+# version-bump preview, producing churn and noise in the PR list.
+#
+# The regex below matches the "release-worthy" subset of Conventional
+# Commits — exactly the set that `cliff.toml`'s `commit_parsers` maps to
+# changelog sections (Added / Fixed / Performance / Security / Breaking).
+# All other types (`chore`, `docs`, `test`, `build`, `ci`, `refactor`,
+# `style`, `revert`) are skipped as both changelog entries (cliff.toml)
+# AND release-trigger commits (here).  Single source of truth for the
+# suppression list.
+#
+# Format note: release-plz applies this regex per-commit to commits since
+# the last release.  If ANY commit in the window matches, a release is
+# proposed; if NONE match, no PR is opened.  This is a tighter filter
+# than cliff.toml's parsers — those decide if a commit appears in the
+# changelog, this decides if a release PR exists at all.
+#
+# Branch protection note: the regex INTENTIONALLY excludes the
+# `^build(\(release-automation\))?:` infra commits (R0 through R6) so
+# the release-automation refactor itself doesn't trigger phantom
+# release PRs while it's still in flight.  After R4+R5 land, those
+# commits stop being typical anyway.
+release_commits = "^(feat|fix|perf|security)(\\(.+\\))?:"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Changelog generation
@@ -114,14 +241,16 @@ semver_check = false
 pr_branch_prefix = "release-plz-"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Per-package overrides (Phase R6 of release-automation-plan.md)
+# Per-package overrides (Phases R6 + R4 of release-automation-plan.md)
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # UFFS has 17 workspace members.  Twelve are publishable to crates.io;
 # the rest are internal-only (one diagnostic crate + three CI tools +
 # one out-of-band fuzz harness in a separate workspace):
 #
-#   Publishable to crates.io (12):
+#   Publishable to crates.io (12) — `changelog_path` override below
+#   points each at the workspace-root CHANGELOG.md (R4 workspace-style
+#   changelog decision):
 #     uffs-polars, uffs-security, uffs-text, uffs-time,
 #     uffs-mft, uffs-format, uffs-core, uffs-daemon, uffs-client,
 #     uffs-mcp, uffs-broker, uffs-cli
@@ -150,12 +279,23 @@ pr_branch_prefix = "release-plz-"
 # This is the surgical fix per release-automation-plan.md §R6 step 2,
 # preferred over a workspace-level "exclude" that would obscure intent.
 #
+# `changelog_path = "CHANGELOG.md"` (R4) — `changelog_path` cannot be
+# set at workspace level (release-plz docs explicitly forbid it), so
+# each of the 12 publishable crates gets its own `[[package]]` block
+# with the same value pointing at the workspace-root file.  Path is
+# relative to the root Cargo.toml.  When release-plz writes per-crate
+# changelog entries, all 12 land in the same file — under the same
+# `## [{{ version }}] - {{ date }}` section since UFFS releases all
+# crates lockstep at one shared workspace version.
+#
 # `publish = true` per-package overrides are NOT set yet.  The
 # workspace-level `publish = false` above remains the active dormancy
 # layer until Phase R8 dress rehearsal.  When R8 flips a leaf crate
 # (likely `uffs-time`, the foundation crate with zero deps) to
 # `publish = true`, the override goes here as a per-package block —
 # explicit, auditable, reversible.
+
+# ─── Internal CI tools (R6) ─ release-plz skips these entirely ──────
 
 [[package]]
 name = "uffs-ci-pipeline"
@@ -168,3 +308,57 @@ release = false
 [[package]]
 name = "uffs-gen-workflow"
 release = false
+
+# ─── Publishable crates (R4) ─ all share the workspace-root CHANGELOG.md ─
+#
+# Order matches the workspace dep graph (leaves → roots) so the file
+# scans top-down in dependency order, not alphabetic.  Mirrors the
+# layering documented in `docs/architecture/engine/`.
+
+[[package]]
+name = "uffs-time"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "uffs-text"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "uffs-security"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "uffs-polars"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "uffs-mft"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "uffs-format"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "uffs-core"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "uffs-client"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "uffs-mcp"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "uffs-daemon"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "uffs-broker"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "uffs-cli"
+changelog_path = "CHANGELOG.md"


### PR DESCRIPTION
## Summary

Phase **R4** of `docs/architecture/release-automation-plan.md` — flips `.github/workflows/release-plz.yml` from R3 SHADOW mode (`release-plz update`, local-only) to ACTIVE mode (`release-pr` opens/updates the release PR; `release` creates the tag + GitHub Release on PR merge).

This is the **workflow-flip-only** R4 PR.  The first-release v0.5.91 bootstrap (Cargo.toml version bump + hand-written CHANGELOG entry + tag push) is performed manually by the maintainer in a separate operation — see plan §R4 decision 7 + baseline §11 "Maintainer bootstrap procedure".

## Settled-pre-execution decisions

Recorded in `release-automation-plan.md` §R4 + `release-automation-baseline.md` §11 for durability:

| # | Decision | Rationale |
|---|---|---|
| **D1** | Workspace-style tags (single `v{{ version }}`, not per-crate) | UFFS is one product (12 crates lockstep); existing `release.yml` `on: push: tags: [v*]` trigger; matches `cargo` + `rustls` |
| **D2** | Workspace-style CHANGELOG (12 `[[package]]` `changelog_path` overrides) | UFFS has had single CHANGELOG since v0.4.x; release-plz forbids workspace-level `changelog_path` |
| **D3** | `git_only = true` baseline | UFFS unpublished through R8; flips back in R8 once ≥1 crate live (forward-compat note in config) |
| **D4** | `release_commits` regex (`feat`/`fix`/`perf`/`security` only) | Mirrors `cliff.toml` `commit_parsers`; suppresses `chore`/`docs`/`ci`/`build`/`refactor`/`test`/`style`/`revert` churn |
| **D5** | Two-job workflow (`release-plz-pr` + `release-plz-release`) | `release-plz/action` has no "do both" command; mirrors release-plz's [own workflow](https://github.com/release-plz/release-plz/blob/main/.github/workflows/release-plz.yml) |
| **D6** | Default `GITHUB_TOKEN`, NOT GitHub App / PAT (DOCUMENTED LIMITATION) | Tags via `GITHUB_TOKEN` don't trigger downstream `release.yml` (anti-loop policy); 3 workarounds documented; "R4.5" follow-up sets up Option A |
| **D7** | First-release v0.5.91 bootstrap is OUT OF SCOPE | v0.5.90 worktree predates R3.5 dep-version fix; baseline check fails on first run; maintainer manually bumps + tags from current `main` to bootstrap |

## Files modified

| File | Change | LOC |
|---|---|---|
| `release-plz.toml` | + R4 fields (`git_only`, `git_tag_name`, `git_release_name`, `release_commits`); + 12 `[[package]]` blocks with `changelog_path = "CHANGELOG.md"`; header rewritten for R4 phase | +220 |
| `.github/workflows/release-plz.yml` | Replaced R3 shadow body with two-job active pattern using `release-plz/action@1528104d` (v0.5.128 SHA-pinned).  `contents: read → write`, `pull-requests: read → write` at job level.  R3 manual diff-capture removed. | rewritten |
| `docs/architecture/release-automation-plan.md` | §R4 rewritten with D1-D7; dashboard updated (R3.5 + R6 promoted 🟡→🟢 with PR #145; R4 🟡 in-progress); 2 new §8.1 deviations entries | +181 / -150 |
| `docs/architecture/release-automation-baseline.md` | §11 R4 addendum appended (D1-D6 with rationale, ecosystem precedent, reversibility cost; maintainer bootstrap procedure) | +119 |

**Net diff**: 4 files, +662 / -275 = **+387 LOC** (mostly comments + docs).

## Publishing dormancy (UNCHANGED from R3 → R6)

Belt-and-suspenders dormancy through Phase R8.  See plan §6.

1. `release-plz.toml` workspace `publish = false` (first layer).
2. No `CARGO_REGISTRY_TOKEN` env var passed to the action (second layer).

Both layers stay through R7 (OIDC scaffolding) and only flip in R8 (publishing dress rehearsal for `uffs-time`).

## Validation

- ✅ `cargo check --workspace --all-targets`
- ✅ `cargo fmt --check --all`
- ✅ `taplo format --check release-plz.toml`
- ✅ `actionlint .github/workflows/release-plz.yml`
- ✅ `typos` / `reuse lint`
- ✅ `just lint-pre-push` — **20/20 gates green** (52s post-commit)

## What this PR deliberately does NOT do

- **Does NOT bump any crate version**.  Bootstrap is out-of-band (maintainer task).
- **Does NOT delete `auto-tag-release.yml`**.  R5 scope (after ≥2 R4-flow releases bake in).
- **Does NOT set up a GitHub App / PAT**.  R4.5 follow-up.
- **Does NOT publish anything to crates.io**.  Workspace `publish = false` + missing `CARGO_REGISTRY_TOKEN` unchanged.
- **Does NOT modify `release.yml`**.  Trigger contract preserved.

## Rollback

`git revert` flips the workflow back to R3 shadow mode.  The `release-plz.toml` R4 additions are additive — revert independently if needed.  Any tags created by future release-plz active runs are idempotent (tag-exists guard in `release.yml`).

## Bake-in plan

After merge, observe one push to `main`:

1. `release-plz-pr` runs and either opens a release PR (if any qualifying commits since v0.5.90) or no-ops.
2. `release-plz-release` runs and silently no-ops (HEAD is not yet a release-PR merge).

Then maintainer performs the v0.5.91 bootstrap per baseline §11 procedure.

## References

- Phase R4 plan: `docs/architecture/release-automation-plan.md` §R4
- Settled decisions + bootstrap: `docs/architecture/release-automation-baseline.md` §11
- release-plz reference workflow: https://github.com/release-plz/release-plz/blob/main/.github/workflows/release-plz.yml
- Predecessor PRs: [#67 (R3 shadow)](https://github.com/skyllc-ai/UltraFastFileSearch/pull/67), [#145 (R3.5 + R6)](https://github.com/skyllc-ai/UltraFastFileSearch/pull/145)