### PR TITLE
chore: release v0.5.91 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -578,7 +578,7 @@ L1 zigbuild) now ✅; §8 acceptance items all checked.
   into a red required check rather than the documented advisory
   warning.
 
-## [0.5.90] - 2026-04-25
+## [0.5.91] - 2026-04-25
 
 ### Fixed
 - **macOS arm64 release binaries SIGKILLed at launch** under macOS 26+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "clap",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "chrono",
  "itoa",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "clap",
@@ -4492,7 +4492,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "clap",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "axum",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4560,14 +4560,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4582,14 +4582,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.90"
+version = "0.5.91"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.90"
+version = "0.5.91"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires
@@ -96,14 +96,14 @@ categories = ["filesystem", "command-line-utilities"]
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.90" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.90" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.90" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.90" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.90", features = ["zstd"] }
-uffs-format = { path = "crates/uffs-format", version = "0.5.90" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.90" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.90" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.91" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.91" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.91" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.91" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.91", features = ["zstd"] }
+uffs-format = { path = "crates/uffs-format", version = "0.5.91" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.91" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.91" }
 # NOTE: no `uffs-diag` workspace dependency alias on purpose.
 # It is a top-level diagnostic/tool crate, not a shared runtime dependency.
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -30,7 +30,7 @@
 # CI pipeline will auto-refresh on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed — use that flag (or plain `just ship`) while the upstream regression
 # persists.
-channel = "nightly-2026-05-05"
+channel = "nightly-2026-05-08"
 
 # Specify components that should always be available
 components = [


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.91**.  Binaries + GitHub Release v0.5.91 are already live (step 09).  This PR routes the corresponding commit through branch-protection rules.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

Local `main` had this commit with a different SHA before squash rewrote it onto main; recover with `git fetch origin && git reset --hard origin/main`.