### PR TITLE
chore(release): v0.5.92 (manual bootstrap; v0.5.91 immutable-release lockout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -578,9 +578,32 @@ L1 zigbuild) now ✅; §8 acceptance items all checked.
   into a red required check rather than the documented advisory
   warning.
 
-## [0.5.91] - 2026-04-25
+## [0.5.92] - 2026-05-08
+
+> **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
+> reached a published GitHub Release: the `release.yml` finalize step hit
+> a server-side `pre_receive Repository rule violations found ... Cannot
+> create ref due to creations being restricted` rejection, and after the
+> partial release was deleted, the tag name became permanently locked by
+> GitHub's *immutable releases* feature (the pre-receive hook refuses any
+> future ref creation under that name even after a clean delete).  The
+> public release sequence therefore jumps `v0.5.90 → v0.5.92`; all
+> intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed
+- **release-plz active-mode race with the bespoke `auto-tag-release.yml`
+  flow.**  Without `release_always = false`, the `release-plz release`
+  job ran on every push to `main` and competed with `auto-tag-release.yml`
+  to create the same `v*` tag, producing duplicate workflow runs and
+  occasional failed tag pushes during the R4 transition.  Setting
+  `release_always = false` in `release-plz.toml` gates tag creation
+  through `release-plz-*` PR merges only, so the bespoke flow remains
+  the sole tag source until R5 retires it.  See
+  `docs/architecture/release-automation-plan.md §R4` for the full
+  rationale and the deviations log entry "R4 release-job race".
+  (R4 active mode, PR #151)
+
+### Carried over from the unreleased v0.5.91
 - **macOS arm64 release binaries SIGKILLed at launch** under macOS 26+
   (`SIGKILL (Code Signature Invalid)` / `namespace=CODESIGNING` /
   `"Taskgated Invalid Signature"`).  `[profile.release].strip = "symbols"`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "clap",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "chrono",
  "itoa",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "clap",
@@ -4492,7 +4492,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "clap",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "axum",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4560,14 +4560,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4582,14 +4582,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.91"
+version = "0.5.92"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.91"
+version = "0.5.92"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires
@@ -96,14 +96,14 @@ categories = ["filesystem", "command-line-utilities"]
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.91" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.91" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.91" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.91" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.91", features = ["zstd"] }
-uffs-format = { path = "crates/uffs-format", version = "0.5.91" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.91" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.91" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.92" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.92" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.92" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.92" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.92", features = ["zstd"] }
+uffs-format = { path = "crates/uffs-format", version = "0.5.92" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.92" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.92" }
 # NOTE: no `uffs-diag` workspace dependency alias on purpose.
 # It is a top-level diagnostic/tool crate, not a shared runtime dependency.
 


### PR DESCRIPTION
## Summary

Manual workspace version bump **0.5.91 → 0.5.92** to recover from the v0.5.91 immutable-release lockout and unblock release-plz active-mode automation.

## Why this PR exists

v0.5.91 was prepared and tagged via the bespoke `auto-tag-release.yml` → `release.yml` chain on 2026-05-08, but the `release.yml` finalize step hit a server-side ruleset rejection:

\`\`\`
error finalizing release: HttpError: Validation Failed:
  pre_receive Repository rule violations found
  Cannot create ref due to creations being restricted
  tag_name was used by an immutable release
\`\`\`

After the partial release was deleted to recover, the **tag name itself became permanently locked** by GitHub's *immutable releases* feature — the pre-receive hook now refuses any future ref creation under \`v0.5.91\`, even though the release object is gone (verified twice via \`git push origin v0.5.91\` and via the REST API).

## Resolution

Skip v0.5.91 entirely.  Public release sequence jumps **\`v0.5.90\` → \`v0.5.92\`**.  All intended v0.5.91 changes are rolled forward; \`CHANGELOG.md\` carries a *Note on the v0.5.91 gap* explaining the discontinuity.

## What's in v0.5.92

- **Fixed** — release-plz active-mode race with the bespoke flow (\`release_always = false\`, PR #151).
- **Carried over from the unreleased v0.5.91** — macOS arm64 SIGKILL fix (\`release.yml\` re-codesign step), CI / commitlint robustness fixes.

See \`CHANGELOG.md\` v0.5.92 section for the full delta.

## Post-merge expectations

1. \`auto-tag-release.yml\` detects the version bump and pushes \`v0.5.92\` tag (fresh tag name, never burned).
2. \`release.yml\` fires on the tag push and builds 29 assets (1 CHECKSUMS + 13 SBOMs + 15 binaries).
3. \`release-plz\` now has a baseline tag (\`v0.5.92\`) whose worktree contains the R3.5 dep-version fix, so the \`release-plz-pr\` job can compute next-versions for v0.5.93+ via R4 active mode.
4. Phase R5 (retire bespoke tooling) becomes safe to schedule once we've observed at least one fully release-plz-driven cycle — likely v0.5.93.

## Validation

- \`taplo\` / file-size / typos / reuse / commit-subjects — green.
- Tier 1 pre-push (cargo-check / clippy lint-ci / lint-prod / lint-tests / rustdoc / doc-tests / tests / smoke / deny / lint-ci-windows) — green in 147s.
- No Cargo.lock drift beyond the bumped workspace versions.

## Rollback

Revert the merge commit; \`v0.5.92\` tag is fresh, so it can be deleted (no immutable-release lock unless we let \`release.yml\` finalise it).  Cargo.toml workspace version reverts to 0.5.91 (which is still locked, so a follow-up bump to 0.5.93 would be needed if a re-cut is required).