### PR TITLE
chore(release-automation): defer release-plz auto-trigger until polars upstream ships chrono-compat release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -2,9 +2,85 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Release-plz — ACTIVE MODE
+# Release-plz — DEFERRED (manual-only, 2026-05-08)
 #
-# Phase R4 of `docs/architecture/release-automation-plan.md`.
+# Phase R4 of `docs/architecture/release-automation-plan.md`, currently
+# dormant pending an upstream-polars compat release.  See the DEFERRAL
+# NOTICE below for the full root-cause and re-enable trail.
+#
+# ─── DEFERRAL NOTICE (2026-05-08) ───────────────────────────────────────
+#
+# The `push: branches: [main]` auto-trigger is commented out below.  The
+# workflow runs ONLY on `workflow_dispatch` (manual `gh workflow run`
+# from the maintainer).  Reason:
+#
+#   release-plz `git_only = true` mode hardcodes
+#       cargo package --allow-dirty --workspace
+#   in `release_plz_core/src/next_ver.rs::run_cargo_package` (verified
+#   on 2026-05-08 against release-plz v0.3.157, the version this
+#   workflow pins via the action).  That step packages EVERY workspace
+#   member regardless of `[[package]] release = false` or Cargo
+#   `publish = false` flags.  When it runs against `uffs-polars`,
+#   cargo strips the polars git rev for publish-form simulation,
+#   falls back to crates.io polars-arrow 0.53.0 which constrains
+#   `chrono <= 0.4.41`, and that conflicts with the workspace lock
+#   at `chrono 0.4.44` (transitively required by `chrono-tz 0.10.4`).
+#   The conflict has no Cargo-side resolution — verified failure on
+#   workflow run 25583934251 (commit d3a1adc1d, R6 → R8 Path A merged).
+#
+#   PR #155 (R6 → R8 Path A) flipped the polars-tainted subtree to
+#   `publish = false` + `release = false` thinking that would tell
+#   release-plz to skip them.  It does — for the *release* step (no
+#   PR / version bump / tag / changelog).  But it does NOT skip the
+#   `cargo package --workspace` step, which is hardcoded in
+#   release-plz's git_only-mode pipeline.
+#
+# Two structural fixes were investigated but not pursued:
+#
+#   (a) Move `crates/uffs-polars` from `[workspace] members` to
+#       `[workspace] exclude`.  Removes it from `cargo metadata
+#       --workspace`, which is what release-plz iterates.  But cargo
+#       treats excluded paths as standalone packages — `uffs-polars`
+#       can no longer inherit the 9 fields it gets via
+#       `.workspace = true` (version, edition, rust-version, license,
+#       repository, authors, readme, keywords, categories) plus
+#       `[lints] workspace = true`.  Inlining those values is a
+#       permanent maintenance burden until uffs-polars goes back to
+#       a member.  Rejected pending a clearer return-on-cost.
+#
+#   (b) Replace `release-plz/action` with a manual CLI invocation
+#       that wraps the cargo step ourselves.  Out of scope for the
+#       current release-automation refactor cycle (R5 just finished;
+#       R6/R7 already in flight).
+#
+# Until polars upstream ships a release that no longer needs the git
+# rev pin (i.e. the nightly-rust API regressions the rev was patching
+# land in a published version), this workflow stays manual-only and
+# version bumps continue via `just ship` — the existing manual flow
+# that has worked since v0.5.0.  The `just ship` flow:
+#
+#   1. uses the in-tree `build/update_all_versions.rs` driver to
+#      bump every Cargo.toml's `version =` field (or `version.workspace
+#      = true` consumers via the workspace.package.version source);
+#   2. regenerates CHANGELOG.md via `git cliff` (configured by
+#      `cliff.toml`);
+#   3. opens a `chore: release vX.Y.Z` PR by hand;
+#   4. once merged, the maintainer pushes a signed `vX.Y.Z` tag
+#      which fires `release.yml` to build + upload binaries.
+#
+# Re-enable when the chrono conflict goes away:
+#
+#   1. Verify `cargo package -p uffs-polars --allow-dirty` succeeds
+#      locally (it should once polars upstream ships).
+#   2. Uncomment the `push: branches: [main]` block below.
+#   3. Optionally reverse the `publish = false` flips in the polars-
+#      tainted subtree if R8 dress-rehearsal is ready (8 crates —
+#      see `docs/architecture/release-automation-plan.md` §8
+#      deviation log row "R6 → R8 publishability resolution").
+#   4. Rename this workflow back to "🚀 Release-plz (active)".
+#
+# Refs: PR #155 (R6→R8 Path A), workflow run 25583934251 (failure
+#       evidence), `release-automation-plan.md` §8 deviation log.
 #
 # What this does:
 #
@@ -174,13 +250,22 @@
 #   • https://release-plz.ieni.dev/docs/usage/release
 #   • https://github.com/release-plz/release-plz/blob/main/.github/workflows/release-plz.yml
 
-name: "🚀 Release-plz (active)"
+name: "💤 Release-plz (deferred — manual-only)"
 
 on:
-  push:
-    branches: [main]
-  # Allow ad-hoc inspection without waiting for a real merge.  Useful
-  # while iterating on `release-plz.toml` or `cliff.toml`.
+  # ─── push trigger DISABLED 2026-05-08 — see DEFERRAL NOTICE above ───
+  # Workflow run 25583934251 on commit d3a1adc1d (R6 → R8 Path A merged)
+  # confirmed that release-plz's hardcoded `cargo package --workspace`
+  # trips the polars-arrow chrono ≤0.4.41 vs workspace 0.4.44 conflict
+  # regardless of `release = false` / `publish = false` flags.  Until
+  # polars upstream ships a chrono-compatible release this workflow is
+  # manual-only.  Uncomment the `push:` block below to re-enable.
+  # push:
+  #   branches: [main]
+  # Manual `gh workflow run release-plz.yml` for the maintainer to spot-
+  # check what release-plz proposes (e.g. on a temporary branch where
+  # the polars rev is updated, ahead of formally re-enabling the push
+  # trigger).
   workflow_dispatch:
 
 # Default to ZERO permissions; each job grants only what it needs.


### PR DESCRIPTION
## Summary

Defers the release-plz auto-trigger until polars upstream ships a chrono-compatible release. PR #155's Path A (`publish = false` + `release = false` on the polars-tainted subtree) was correct in intent but addressed the wrong layer — it didn't stop release-plz from invoking `cargo package --workspace`, which trips the chrono conflict.

This PR makes the workflow `workflow_dispatch:`-only and renames it to `💤 Release-plz (deferred — manual-only)` so the dormant state is visible in the GitHub Actions UI. **Diff: 1 file, +93 / -8** (most of the +93 is the explanatory `DEFERRAL NOTICE` section in the YAML header).

## Root cause (verified, not guessed)

Reading `release-plz` v0.3.157's source on 2026-05-08 — `crates/release_plz_core/src/next_ver.rs::run_cargo_package`:

```rust
fn run_cargo_package(worktree: &GitWorkTree) -> anyhow::Result<()> {
    let worktree_path = to_utf8_path(worktree.path())?;
    let output = run_cargo(worktree_path, &["package", "--allow-dirty", "--workspace"])
        .context("run cargo package in worktree")?;
    ...
}
```

With its comment:

```rust
// In git_only mode we always package the whole workspace to make sure
// local path dependencies are materialized as local tarballs.
```

In `git_only = true` mode (which we use because UFFS isn't yet on crates.io), release-plz hardcodes `cargo package --allow-dirty --workspace` per package being processed. That step packages **every** workspace member regardless of `[[package]] release = false` or Cargo `publish = false` flags. When run against `uffs-polars`, cargo strips the polars git-rev pin for publish-form simulation, falls back to crates.io `polars-arrow 0.53.0` which constrains `chrono <= 0.4.41`, and that conflicts with the workspace lock at `chrono 0.4.44` (transitively required by `chrono-tz 0.10.4`).

**Failure evidence**: workflow run [25583934251](https://github.com/skyllc-ai/UltraFastFileSearch/actions/runs/25583934251) on commit `d3a1adc1d` (PR #155 merged into main).

## Why not Approach A (workspace-exclude `uffs-polars`)

Tested locally on a throwaway branch `fix/release-plz-workspace-exclude-uffs-polars`: moving `crates/uffs-polars` from `[workspace] members` to `[workspace] exclude` does remove it from `cargo metadata --workspace` (the iteration set release-plz uses) but cargo treats excluded paths as **standalone packages**. `uffs-polars`'s nine `.workspace = true` inheritances all break:

```
error inheriting `edition` from workspace root manifest's `workspace.package.edition`
Caused by: failed to find a workspace root
```

Inlining 9 fields (version, edition, rust-version, license, repository, authors, readme, keywords, categories) plus `[lints]` is a permanent maintenance burden — every workspace version bump would need a manual matching bump on `uffs-polars` until it rejoins the workspace. **Cost > benefit while UFFS isn't yet publishing to crates.io**, so rejected.

## Why not Approach D (replace release-plz/action with manual CLI)

The `release-plz/action`'s `action.yml` doesn't expose a `--package` whitelist input. Bypassing the action with a raw CLI invocation that wraps the cargo step would re-implement most of the action ourselves, which is out of scope for the current release-automation refactor cycle (R5 just landed; R6/R7 are in flight).

## What stays

- **PR #155's `publish = false` flips** on the eight polars-tainted crates remain — they correctly express that those crates can't ship to crates.io until the polars rev pin can be retired. This PR just acknowledges those flags don't make release-plz green.
- **PR #155's `release = false` entries** in `release-plz.toml` likewise stay — they correctly suppress release/PR/tag/changelog actions, which is the only thing that flag actually controls.
- The `release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128` pin and the rest of the workflow (jobs, permissions, downstream-trigger bridge) are untouched so re-enabling is a one-line uncomment of the `push:` block.

## Manual flow continues

Version bumps continue via `just ship` → `cargo run -q --release -p uffs-ci-pipeline -- ship` (defined in `just/workflow.just`). This has been the canonical manual mechanism since v0.5.0 and is unaffected by this PR.

The signed-tag escape hatch (`git tag -s vX.Y.Z && git push origin vX.Y.Z` → fires `release.yml` via `push: tags: [v*]`) is also unaffected.

## Re-enable trail (also captured inline in the YAML header)

1. Verify `cargo package -p uffs-polars --allow-dirty` succeeds locally — it should once polars upstream ships a chrono-compat release that no longer needs the git rev pin.
2. Uncomment the `push: branches: [main]` block in `.github/workflows/release-plz.yml`.
3. Optionally reverse the `publish = false` flips on the eight polars-tainted crates if R8 dress-rehearsal is ready.
4. Rename the workflow back to `🚀 Release-plz (active)`.

## Verification

```
$ python3 -c "<...regex parse on:>"
Active triggers (non-comment lines under on:):
  '  workflow_dispatch:'
```

Pre-push lints all green (102s, including `lint-ci-windows`).

## Stacking

This PR branches off `origin/main` directly. PR #156 (dead re-export cleanup in `uffs-core`) is independent and unaffected — they touch different files (#156 → `crates/uffs-core/src/lib.rs`; this PR → `.github/workflows/release-plz.yml`).

## Refs

- PR #155 — R6→R8 publishability resolution Path A (set up the `publish=false` flags this PR acknowledges as insufficient).
- Workflow run 25583934251 — failure evidence.
- `release_plz_core/src/next_ver.rs::run_cargo_package` (release-plz v0.3.157) — root-cause source.
- `docs/architecture/release-automation-plan.md` §8 deviation log row "R6 → R8 publishability resolution (Path A)" — the audit trail this PR extends.
- `just/workflow.just` `ship` recipe — the manual flow that keeps version bumps moving while release-plz is dormant.
