### PR TITLE
chore: release v0.5.93 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -578,7 +578,7 @@ L1 zigbuild) now ✅; §8 acceptance items all checked.
   into a red required check rather than the documented advisory
   warning.
 
-## [0.5.92] - 2026-05-08
+## [0.5.93] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -587,7 +587,7 @@ L1 zigbuild) now ✅; §8 acceptance items all checked.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.92`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.93`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "clap",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "chrono",
  "itoa",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "clap",
@@ -4492,7 +4492,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "clap",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "axum",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4560,14 +4560,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4582,14 +4582,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.92"
+version = "0.5.93"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.92"
+version = "0.5.93"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires
@@ -96,14 +96,14 @@ categories = ["filesystem", "command-line-utilities"]
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.92" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.92" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.92" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.92" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.92", features = ["zstd"] }
-uffs-format = { path = "crates/uffs-format", version = "0.5.92" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.92" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.92" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.93" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.93" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.93" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.93" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.93", features = ["zstd"] }
+uffs-format = { path = "crates/uffs-format", version = "0.5.93" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.93" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.93" }
 # NOTE: no `uffs-diag` workspace dependency alias on purpose.
 # It is a top-level diagnostic/tool crate, not a shared runtime dependency.
 


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.93**.  Binaries + GitHub Release v0.5.93 are already live (step 09).  This PR routes the corresponding commit through branch-protection rules.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

Local `main` had this commit with a different SHA before squash rewrote it onto main; recover with `git fetch origin && git reset --hard origin/main`.