### PR TITLE
chore(ci): restore auto-tag-release.yml to re-enable automatic binary builds

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# Auto-Tag Release — the bridge between `just ship` and `release.yml`.
+#
+# When a commit lands on `main` that changes the `[workspace.package]`
+# `version` in `Cargo.toml`, this workflow invokes `release.yml` via
+# `workflow_dispatch` with the new version and commit SHA.  `release.yml`
+# itself creates + pushes the `vX.Y.Z` tag and publishes the release.
+#
+# Why NOT push the tag from here:
+#
+#   `release.yml`'s `workflow_dispatch` path has a guard that fails if
+#   the tag already exists (release.yml:101-108) and a later step that
+#   creates + pushes the tag itself (release.yml:491-499).  Delegating
+#   tag creation to `release.yml` makes it the single source of truth
+#   for "did this version ship" — a tag on origin means a release was
+#   built successfully, nothing weaker.
+#
+# Why the explicit `gh workflow run` invocation:
+#
+#   The default `GITHUB_TOKEN` is prevented from triggering downstream
+#   workflow runs (infinite-loop guard), so relying on the tag push to
+#   fire `release.yml`'s `push: tags: v*` trigger would require a PAT.
+#   Instead we explicitly invoke `release.yml` via `workflow_dispatch`,
+#   which the default token IS permitted to do (actions: write).
+#   Developers pushing tags manually still hit the normal `push: tags:
+#   v*` trigger — both paths remain supported.
+#
+# This workflow completes the hands-off release flow:
+#
+#   just ship  -->  opens release/vX.Y.Z PR  -->  auto-merge on CI green
+#                                                       |
+#                                                       v
+#                                              auto-tag-release.yml
+#                                                       |
+#                                                       v
+#                                              release.yml (build + publish)
+
+name: "🏷️ Auto-Tag Release"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+  workflow_dispatch:
+    # Manual re-trigger.  When dispatched (with no inputs), replays
+    # the HEAD-vs-HEAD~1 version diff logic against current main.
+    # Useful if `release.yml` has been fixed after a failed run and
+    # the same version-bump commit should be retried.  The
+    # idempotency guard (tag already on origin) handles double-fire
+    # races automatically.
+
+permissions:
+  # Read commit history (for the HEAD vs HEAD~1 version diff).
+  contents: read
+  # Invoke `release.yml` via `gh workflow run`.
+  actions: write
+
+concurrency:
+  # Serialise auto-tag attempts.  Two version bumps landing in quick
+  # succession is rare but possible; queue them so the second sees the
+  # first's release workflow already running (or tag already on origin)
+  # and becomes a no-op skip.
+  group: auto-tag-release
+  cancel-in-progress: false
+
+jobs:
+  maybe-tag:
+    name: "🏷️ Tag if workspace version bumped"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Belt-and-suspenders loop guard.  This workflow doesn't modify
+    # Cargo.toml or push tags, so nothing it does could re-trigger
+    # itself anyway, but skip bot-authored pushes defensively.
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - name: Checkout (fetch HEAD + HEAD~1 for version diff)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+          # Default GITHUB_TOKEN authenticates the checkout.  We no
+          # longer push anything from this workflow (release.yml
+          # pushes the tag itself), so credential persistence is
+          # optional; keep it on for any future git reads.
+          persist-credentials: true
+
+      - name: Extract current and previous workspace versions
+        id: versions
+        shell: bash
+        run: |
+          extract_version() {
+            # Read the `version = "..."` line from the [workspace.package]
+            # section of the given Cargo.toml content (stdin).
+            awk '/^\[workspace\.package\]/{flag=1; next} flag && /^version/{print; exit}' \
+              | cut -d'"' -f2
+          }
+
+          new=$(extract_version < Cargo.toml)
+          old=$(git show HEAD~1:Cargo.toml 2>/dev/null | extract_version || true)
+
+          echo "Current:  ${new:-<not found>}"
+          echo "Previous: ${old:-<not found>}"
+
+          printf 'new=%s\n' "$new" >> "$GITHUB_OUTPUT"
+          printf 'old=%s\n' "${old:-}" >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to invoke release.yml
+        id: plan
+        shell: bash
+        env:
+          NEW_VERSION: ${{ steps.versions.outputs.new }}
+          OLD_VERSION: ${{ steps.versions.outputs.old }}
+        run: |
+          if [[ -z "$NEW_VERSION" ]]; then
+            echo "::notice::No [workspace.package].version found in Cargo.toml — nothing to do."
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$NEW_VERSION" == "$OLD_VERSION" ]]; then
+            echo "::notice::Workspace version unchanged ($NEW_VERSION) — nothing to do."
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          tag="v$NEW_VERSION"
+
+          # Idempotency: if the tag already exists on origin, a release
+          # has already been produced for this version.  Skip silently
+          # (supports `just ship` replays on a branch that was already
+          # auto-merged).
+          if git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "::notice::Tag $tag already exists on origin — release already shipped, skipping."
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Will invoke release.yml for $tag (commit ${{ github.sha }})"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger release.yml via workflow_dispatch
+        if: steps.plan.outputs.tag != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.plan.outputs.tag }}
+          SHA: ${{ github.sha }}
+        run: |
+          # Explicit workflow_dispatch invocation.  `release.yml` itself
+          # creates + pushes the vX.Y.Z tag after a successful build
+          # (release.yml:491-499), so we do NOT push the tag here —
+          # that would collide with release.yml's own tag-exists guard
+          # (release.yml:101-108) and abort the run.
+          #
+          # The version + commit_sha inputs match release.yml's
+          # workflow_dispatch schema exactly.
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f version="$TAG" \
+            -f commit_sha="$SHA" \
+            -f triggered_by="auto-tag-release[sha:${SHA:0:7}]"
+
+          echo "::notice::Invoked release.yml for $TAG (commit ${SHA:0:7})"
+          echo ""
+          echo "Watch: gh run list --repo ${{ github.repository }} --workflow=release.yml --limit 1"


### PR DESCRIPTION
## Problem

After PR #153 (R5 — retire bespoke version-bump tooling) deleted `auto-tag-release.yml`, the automatic binary build pipeline was broken. While the manual version-bump flow via `just ship` continues to work, binaries are no longer built automatically when version bumps land on `main`.

## Solution

Restore `auto-tag-release.yml` from commit `779c14fb1^` (the commit immediately before deletion). This workflow serves as the **bridge** between the manual version-bump flow and the binary-build pipeline.

## How It Works

```
Developer: just ship
    ↓
Version bump PR → merge to main
    ↓
auto-tag-release.yml detects Cargo.toml version change
    ↓
Triggers release.yml via workflow_dispatch
    ↓
release.yml builds binaries + creates tag + publishes release
```

## What This Restores

- ✅ Automatic binary builds after version bump merges
- ✅ Idempotent tag detection (skips if tag already exists)
- ✅ Manual retry capability (`gh workflow run auto-tag-release.yml`)
- ✅ Serialized execution (no race conditions)

## What This Does NOT Change

- ✅ Manual version-bump flow (`just ship`) remains unchanged
- ✅ `release-plz.yml` stays dormant (polars/chrono conflict)
- ✅ `release.yml` unchanged (still builds all 3 platforms)

## Compatibility

- Works with existing `release.yml` (uses `workflow_dispatch` trigger)
- No changes needed to `just ship` or any other tooling
- Branch protection rules honored (this is a PR, not direct push)

## Testing

All pre-push checks passed:
- ✅ fmt, typos, reuse, file-size
- ✅ gates-drift, hooks-drift, workflow-drift
- ✅ cargo-check, clippy (prod + tests), rustdoc
- ✅ doc-tests, tests, smoke
- ✅ Windows CI lint

## References

- Original workflow: commit `779c14fb1^` before deletion
- Deletion PR: #153 (R5 — retire bespoke version-bump tooling)
- Related: PR #158 (revert R5 — restore manual version bump)
- Example successful run: v0.5.92 (manually triggered yesterday)
