### PR TITLE
chore(lint): pin Clippy MSRV and add three restriction lints (R1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -417,6 +417,7 @@ mem_forget = "deny"                   # Avoid mem::forget
 missing_assert_message = "deny"       # Add messages to assertions
 missing_asserts_for_indexing = "deny" # Assert before indexing
 try_err = "deny"                      # Use ? instead of try!
+unused_result_ok = "deny"             # Don't call .ok() just to discard — use `_ = expr;`
 unwrap_in_result = "deny"             # No unwrap/expect inside Result-returning fns
 
 # ───── Memory & allocation ─────
@@ -500,6 +501,7 @@ print_stdout = "deny" # Use proper logging instead (clippy.toml allows in tests)
 use_debug = "deny"    # Avoid Debug in production
 
 # ───── Portability ─────
+host_endian_bytes = "deny"    # Forbid to_ne_bytes/from_ne_bytes — UFFS reads little-endian NTFS on hosts of varying endianness
 std_instead_of_alloc = "deny" # Use alloc when std not needed
 std_instead_of_core = "deny"  # Use core when std not needed
 
@@ -507,9 +509,10 @@ std_instead_of_core = "deny"  # Use core when std not needed
 tests_outside_test_module = "deny" # Keep tests in test modules
 
 # ───── Unused / dead code ─────
-unused_async = "deny"    # Remove unused async
-unused_peekable = "deny" # Remove unused peekable
-unused_rounding = "deny" # Remove unused rounding
+unused_async = "deny"       # Remove unused async
+unused_peekable = "deny"    # Remove unused peekable
+unused_rounding = "deny"    # Remove unused rounding
+unused_trait_names = "deny" # Drop `use Trait;` imports whose methods are never used through that import
 
 # ───── Exceptions ─────
 # External deps (polars, tokio ecosystem) pull transitive version conflicts

--- a/clippy.toml
+++ b/clippy.toml
@@ -12,6 +12,22 @@
 #     all welcome because a test that doesn't crash on failure is useless.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ── MSRV ─────────────────────────────────────────────────────────────────────
+# Pin Clippy's MSRV awareness to the workspace MSRV in [workspace.package]
+# (Cargo.toml).  Affects ~80 MSRV-aware lints — notably `incompatible_msrv`,
+# `manual_div_ceil`, `manual_hash_one`, `legacy_numeric_constants`,
+# `cloned_instead_of_copied`, `assigning_clones`, `manual_let_else`,
+# `option_if_let_else`, `cast_abs_to_unsigned`, `manual_repeat_n`.
+#
+# Setting it here (not just relying on the Cargo.toml fallback) ensures the
+# same lints fire under `cargo xwin clippy` and `cargo zigbuild clippy`,
+# which historically do not always pick up `rust-version` reliably.
+msrv = "1.91"
+
+# Apply MSRV-aware lints inside test code too — tests are real code that
+# also has to compile on the MSRV; we don't get a free pass there.
+check-incompatible-msrv-in-tests = true
+
 # ── Test code relaxations ────────────────────────────────────────────────────
 # These allow restriction lints to fire only in production code while letting
 # test code use idiomatic Rust test patterns (unwrap, expect, panic, dbg!).

--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -378,7 +378,7 @@ fn uninstall_service() -> anyhow::Result<()> {
 #[cfg(windows)]
 #[expect(unsafe_code, reason = "CreateNamedPipeW is an FFI call")]
 fn create_broker_pipe() -> anyhow::Result<windows::Win32::Foundation::HANDLE> {
-    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::ffi::OsStrExt as _;
 
     use windows::Win32::Storage::FileSystem::{FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_ACCESS_DUPLEX};
     use windows::Win32::System::Pipes::{

--- a/crates/uffs-cli/src/commands/daemon_load.rs
+++ b/crates/uffs-cli/src/commands/daemon_load.rs
@@ -18,7 +18,7 @@
 //! `fn` items in another rendering pass, and we want
 //! `--no-deps -- -D rustdoc::broken-intra-doc-links` to stay clean.
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use uffs_client::connect_sync::UffsClientSync;
 
 /// `uffs daemon load` — resolve `--mft-file` / `--data-dir` /

--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -3,7 +3,7 @@
 
 //! `uffs daemon {status|stop|kill|restart}` subcommand handlers.
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use uffs_client::connect_sync::UffsClientSync;
 use uffs_client::daemon_ctl::{pid_file_path, socket_path};
 use uffs_client::protocol::response::{DaemonStatus, DriveInfo, ShardTier};

--- a/crates/uffs-cli/src/commands/daemon_tiering.rs
+++ b/crates/uffs-cli/src/commands/daemon_tiering.rs
@@ -10,7 +10,7 @@
 //! (`status_drives` table) will land their CLI shims in this same
 //! file when the corresponding daemon RPCs come online.
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use uffs_client::connect_sync::UffsClientSync;
 use uffs_client::protocol::response::{
     DEFAULT_PRELOAD_PIN_MINUTES, DriveTierStatus, ForgetParams, HibernateParams, PreloadParams,

--- a/crates/uffs-cli/src/commands/mcp_mgmt/mod.rs
+++ b/crates/uffs-cli/src/commands/mcp_mgmt/mod.rs
@@ -7,7 +7,7 @@
 //! standalone `uffsmcp` binary.  This module simply exec's / spawns
 //! `uffsmcp` with the right arguments, keeping `uffs` thin.
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 
 /// Execute an MCP management action by forwarding raw args to `uffsmcp`.
 ///

--- a/crates/uffs-cli/src/commands/output/mod.rs
+++ b/crates/uffs-cli/src/commands/output/mod.rs
@@ -12,7 +12,7 @@ use core::time::Duration;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use parity::{write_legacy_drive_footer, write_parity};
 use serde_json::Value;
 

--- a/crates/uffs-cli/src/commands/output/parity.rs
+++ b/crates/uffs-cli/src/commands/output/parity.rs
@@ -180,7 +180,7 @@ fn write_parity_row(
 
 /// Append a `u64` value to a string buffer without allocation.
 fn push_u64(buf: &mut String, value: u64) {
-    use core::fmt::Write;
+    use core::fmt::Write as _;
     let _ok = write!(buf, "{value}");
 }
 
@@ -197,7 +197,7 @@ fn push_u64(buf: &mut String, value: u64) {
 /// Created/Modified/Accessed` combination that
 /// `RequestHandler::try_pack_csv_blob` now pre-formats (v0.5.64+).
 fn append_datetime_tz(buf: &mut String, filetime: i64, tz_offset_secs: i32) {
-    use core::fmt::Write;
+    use core::fmt::Write as _;
     let local_ft = uffs_time::filetime_with_tz_bias(filetime, tz_offset_secs);
     if let Some((year, month, day, hour, minute, second)) =
         uffs_time::filetime_to_calendar(local_ft)

--- a/crates/uffs-cli/src/commands/system_status.rs
+++ b/crates/uffs-cli/src/commands/system_status.rs
@@ -9,7 +9,7 @@
 //! - **MCP Stdio Sessions**: active `uffs mcp run` processes (one per AI host)
 
 #[cfg(feature = "mcp-http-probe")]
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use uffs_client::connect_sync::UffsClientSync;
 use uffs_client::protocol::response::{DaemonStatus, ShardTier};
 
@@ -491,14 +491,12 @@ fn resolve_parent_name(ppid: u32) -> Option<String> {
 /// build drops `ws2_32.dll` from the Windows CLI binary.
 #[cfg(feature = "mcp-http-probe")]
 fn http_get_json(bind: &str, port: u16, path: &str) -> Result<serde_json::Value> {
-    use std::io::{Read, Write};
+    use std::io::{Read as _, Write as _};
 
     let addr = format!("{bind}:{port}");
     let mut stream =
         std::net::TcpStream::connect(&addr).with_context(|| format!("connect to {addr}"))?;
-    stream
-        .set_read_timeout(Some(core::time::Duration::from_secs(5)))
-        .ok();
+    _ = stream.set_read_timeout(Some(core::time::Duration::from_secs(5)));
 
     let request = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
     stream.write_all(request.as_bytes())?;

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -14,7 +14,7 @@
     reason = "CLI entry point functions are called once from main"
 )]
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 #[cfg(test)]
 use assert_cmd as _;
 

--- a/crates/uffs-client/src/connect.rs
+++ b/crates/uffs-client/src/connect.rs
@@ -16,7 +16,7 @@
 
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
 
 use crate::connect_logging::{log_connect_attempt, log_connect_error, log_spawn_details};
 use crate::daemon_ctl::{

--- a/crates/uffs-client/src/connect_sync.rs
+++ b/crates/uffs-client/src/connect_sync.rs
@@ -14,7 +14,7 @@
 //! | macOS/Linux | `std::os::unix::net::UnixStream`                   |
 //! | Windows     | Named pipe via `std::fs::OpenOptions` (no Winsock) |
 
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead as _, BufReader, Read, Write};
 
 use crate::daemon_ctl::{find_daemon_exe, pid_file_path, socket_path};
 use crate::daemon_spawn::{ElevationPolicy, resolve_elevation_policy, spawn_daemon};

--- a/crates/uffs-client/src/daemon_ctl.rs
+++ b/crates/uffs-client/src/daemon_ctl.rs
@@ -186,7 +186,7 @@ pub fn verify_daemon_after_connect_strict_at(
 pub fn keepalive_send_blocking(sock_path: &std::path::Path) {
     #[cfg(unix)]
     {
-        use std::io::Write;
+        use std::io::Write as _;
         use std::os::unix::net::UnixStream;
         if let Ok(mut stream) = UnixStream::connect(sock_path) {
             let msg = r#"{"jsonrpc":"2.0","id":0,"method":"keepalive"}"#;
@@ -198,7 +198,7 @@ pub fn keepalive_send_blocking(sock_path: &std::path::Path) {
     #[cfg(windows)]
     {
         use std::fs::OpenOptions;
-        use std::io::Write;
+        use std::io::Write as _;
 
         // `sock_path` is unused on Windows — the pipe name is derived
         // from the current user's SID — but we keep the parameter for

--- a/crates/uffs-core/src/aggregate/cache.rs
+++ b/crates/uffs-core/src/aggregate/cache.rs
@@ -226,7 +226,7 @@ impl AggregateCache {
 /// This is a simple hash function for cache keying — not cryptographic.
 #[must_use]
 pub fn hash_specs(specs_key: &str) -> u64 {
-    use core::hash::{Hash, Hasher};
+    use core::hash::{Hash as _, Hasher as _};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     specs_key.hash(&mut hasher);
     hasher.finish()

--- a/crates/uffs-core/src/aggregate/duplicates.rs
+++ b/crates/uffs-core/src/aggregate/duplicates.rs
@@ -7,7 +7,7 @@
 //! candidate duplicate groups. Optionally verifies via first-bytes
 //! comparison or full SHA-256 hash.
 
-use core::hash::{Hash, Hasher};
+use core::hash::{Hash, Hasher as _};
 use std::collections::HashMap;
 
 use super::accumulators::StatsAccumulator;

--- a/crates/uffs-core/src/aggregate/verify.rs
+++ b/crates/uffs-core/src/aggregate/verify.rs
@@ -325,7 +325,7 @@ impl DuplicateVerifier {
     /// Reads the entire file for each member, computes SHA-256, and
     /// compares all hashes. All members must hash identically.
     fn verify_sha256(&mut self, group: &DuplicateGroup, reader: &dyn FileReader) -> VerifyOutcome {
-        use sha2::{Digest, Sha256};
+        use sha2::{Digest as _, Sha256};
 
         let mut reference_hash: Option<[u8; 32]> = None;
 

--- a/crates/uffs-core/src/bloom.rs
+++ b/crates/uffs-core/src/bloom.rs
@@ -52,7 +52,7 @@
 //! - [`Bloom::estimated_fpr`] — analytic FPR estimate for a given load factor;
 //!   used by tests and the `shard.bloom.decision` telemetry.
 
-use core::hash::Hasher;
+use core::hash::Hasher as _;
 
 use rustc_hash::FxHasher;
 

--- a/crates/uffs-core/src/compact_loader.rs
+++ b/crates/uffs-core/src/compact_loader.rs
@@ -356,7 +356,7 @@ fn load_mft_index_from_file(
 /// than being inlined.
 #[cfg(windows)]
 fn load_mft_index_live(drive_letter: char, no_cache: bool) -> anyhow::Result<MftIndex> {
-    use anyhow::Context;
+    use anyhow::Context as _;
 
     let read_index = async {
         let reader = uffs_mft::MftReader::open(drive_letter)

--- a/crates/uffs-core/src/compact_mmap.rs
+++ b/crates/uffs-core/src/compact_mmap.rs
@@ -55,7 +55,7 @@
 use alloc::sync::Arc;
 use core::mem::{align_of, size_of};
 use std::fs::File;
-use std::io::{self, Seek, SeekFrom, Write};
+use std::io::{self, Seek as _, SeekFrom, Write as _};
 
 use memmap2::Mmap;
 

--- a/crates/uffs-core/src/compact_mmap/tests.rs
+++ b/crates/uffs-core/src/compact_mmap/tests.rs
@@ -22,7 +22,7 @@ use alloc::sync::Arc;
 use core::mem::size_of;
 
 use tempfile::TempDir;
-use uffs_security::runtime_dir::{DefaultRuntimeDir, RuntimeDir, mmap_read_only};
+use uffs_security::runtime_dir::{DefaultRuntimeDir, RuntimeDir as _, mmap_read_only};
 
 use super::{PAGE_SIZE, RuntimeLayout, load_from_runtime, write_runtime_layout};
 use crate::compact::CompactRecord;

--- a/crates/uffs-core/src/compact_reader.rs
+++ b/crates/uffs-core/src/compact_reader.rs
@@ -9,7 +9,7 @@
 //! file without loading the entire `MftIndex`.
 
 use std::collections::HashMap;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{Read as _, Seek as _, SeekFrom};
 use std::path::{Path, PathBuf};
 
 /// Extra fields from a full `FileRecord` not present in `CompactRecord`.

--- a/crates/uffs-core/src/compiled_pattern/mod.rs
+++ b/crates/uffs-core/src/compiled_pattern/mod.rs
@@ -37,7 +37,7 @@
 mod glob;
 
 pub use glob::{GlobKind, classify_glob, compile_pattern};
-use uffs_polars::{Expr, NamedFrom, PlSmallStr, Series, col, lit};
+use uffs_polars::{Expr, NamedFrom as _, PlSmallStr, Series, col, lit};
 
 // ============================================================================
 // CompiledPattern - The Pattern IR

--- a/crates/uffs-core/src/compiled_pattern/tests.rs
+++ b/crates/uffs-core/src/compiled_pattern/tests.rs
@@ -337,7 +337,7 @@ fn test_to_expr_suffix_set_empty() {
 
 #[test]
 fn test_suffix_case_insensitive_integration() -> TestResult {
-    use uffs_polars::{Column, DataFrame, IntoLazy};
+    use uffs_polars::{Column, DataFrame, IntoLazy as _};
 
     // Create test DataFrame with various filenames
     let names = vec![
@@ -369,7 +369,7 @@ fn test_suffix_case_insensitive_integration() -> TestResult {
 
 #[test]
 fn test_suffix_case_sensitive_integration() -> TestResult {
-    use uffs_polars::{Column, DataFrame, IntoLazy};
+    use uffs_polars::{Column, DataFrame, IntoLazy as _};
 
     let input_names = vec![
         "file.TXT",
@@ -401,7 +401,7 @@ fn test_suffix_case_sensitive_integration() -> TestResult {
 
 #[test]
 fn test_dollar_prefix_files_matched() -> TestResult {
-    use uffs_polars::{Column, DataFrame, IntoLazy};
+    use uffs_polars::{Column, DataFrame, IntoLazy as _};
 
     let input_names = vec![
         "$MFT",
@@ -445,7 +445,7 @@ fn test_dollar_prefix_files_matched() -> TestResult {
 
 #[test]
 fn test_null_values_not_filtered() -> TestResult {
-    use uffs_polars::{Column, DataFrame, IntoLazy};
+    use uffs_polars::{Column, DataFrame, IntoLazy as _};
 
     // Create test DataFrame with null values
     let input_names: Vec<Option<&str>> = vec![

--- a/crates/uffs-core/src/export.rs
+++ b/crates/uffs-core/src/export.rs
@@ -7,7 +7,7 @@
 
 use std::io::Write;
 
-use uffs_polars::{DataFrame, SerWriter};
+use uffs_polars::{DataFrame, SerWriter as _};
 
 use crate::error::{CoreError, Result};
 

--- a/crates/uffs-core/src/extensions/mod.rs
+++ b/crates/uffs-core/src/extensions/mod.rs
@@ -28,7 +28,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use uffs_polars::{DataFrame, Expr, IntoLazy, col, lit};
+use uffs_polars::{DataFrame, Expr, IntoLazy as _, col, lit};
 
 use crate::error::Result;
 

--- a/crates/uffs-core/src/output/tests.rs
+++ b/crates/uffs-core/src/output/tests.rs
@@ -566,7 +566,7 @@ fn write_display_rows_emits_name_length_and_path_length() {
 /// as `8225-01-17` or similar and the test fails immediately.
 #[test]
 fn test_write_datetime_column_formats_filetime_as_2026() {
-    use uffs_polars::{DataType, IntoColumn, NamedFrom, Series, TimeUnit};
+    use uffs_polars::{DataType, IntoColumn as _, NamedFrom as _, Series, TimeUnit};
 
     // 2026-01-20 00:00:00 UTC as raw FILETIME.
     // Unix seconds: 1_768_867_200 (2026-01-20).  Convert to 100-ns ticks
@@ -673,7 +673,7 @@ fn write_display_rows_parallel_matches_sequential() {
 /// emit an empty field, never decompose to `1601-01-01`.
 #[test]
 fn test_write_datetime_column_zero_filetime_is_empty() {
-    use uffs_polars::{DataType, IntoColumn, NamedFrom, Series, TimeUnit};
+    use uffs_polars::{DataType, IntoColumn as _, NamedFrom as _, Series, TimeUnit};
 
     let ts_column = Series::new("modified".into(), vec![0_i64])
         .cast(&DataType::Datetime(TimeUnit::Microseconds, None))

--- a/crates/uffs-core/src/query/matching.rs
+++ b/crates/uffs-core/src/query/matching.rs
@@ -3,7 +3,7 @@
 
 //! Pattern, name, and extension matching for `MftQuery`.
 
-use uffs_polars::{Expr, NamedFrom, PlSmallStr, Series, col, lit};
+use uffs_polars::{Expr, NamedFrom as _, PlSmallStr, Series, col, lit};
 
 use super::MftQuery;
 use crate::compiled_pattern::compile_pattern;

--- a/crates/uffs-core/src/query/mod.rs
+++ b/crates/uffs-core/src/query/mod.rs
@@ -11,7 +11,7 @@ mod operations;
 
 use std::path::Path;
 
-use uffs_polars::{DataFrame, IntoLazy, LazyFrame};
+use uffs_polars::{DataFrame, IntoLazy as _, LazyFrame};
 
 use crate::error::Result;
 

--- a/crates/uffs-core/src/tree/mod.rs
+++ b/crates/uffs-core/src/tree/mod.rs
@@ -96,7 +96,7 @@ pub fn add_tree_columns(df: &DataFrame, columns: &[TreeColumn]) -> Result<DataFr
 /// Returns an error if required columns are missing or the transformation
 /// fails.
 pub fn apply_directory_treesize(df: &DataFrame) -> Result<DataFrame> {
-    use uffs_polars::{IntoLazy, col, lit, when};
+    use uffs_polars::{IntoLazy as _, col, lit, when};
 
     // Baseline-compatible output: apply treesize to ALL directories, including
     // reparse points. ADS entries keep the stream-specific size (not the

--- a/crates/uffs-daemon/src/broker_client.rs
+++ b/crates/uffs-daemon/src/broker_client.rs
@@ -25,7 +25,7 @@ const BROKER_PIPE_NAME: &str = r"\\.\pipe\uffs-broker";
 /// Check if the Access Broker is available (pipe exists).
 #[cfg(windows)]
 pub(crate) fn broker_available() -> bool {
-    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::ffi::OsStrExt as _;
 
     use windows::Win32::Storage::FileSystem::GetFileAttributesW;
     use windows::core::PCWSTR;
@@ -51,7 +51,7 @@ pub(crate) fn broker_available() -> bool {
 /// The handle is already duplicated into our process by the broker.
 #[cfg(windows)]
 pub(crate) fn request_volume_handle(drive_letter: char) -> anyhow::Result<u64> {
-    use std::io::{Read, Write};
+    use std::io::{Read as _, Write as _};
 
     // Connect to broker pipe
     let pipe_path = std::path::Path::new(BROKER_PIPE_NAME);

--- a/crates/uffs-daemon/src/index/aggregation.rs
+++ b/crates/uffs-daemon/src/index/aggregation.rs
@@ -67,7 +67,7 @@ impl FileReader for DaemonFileReader<'_> {
         drive_ordinal: u8,
         count: u32,
     ) -> std::io::Result<Vec<u8>> {
-        use std::io::Read;
+        use std::io::Read as _;
         let path = self
             .resolve_path(record_idx, drive_ordinal)
             .ok_or_else(|| {

--- a/crates/uffs-daemon/src/index/dispatch.rs
+++ b/crates/uffs-daemon/src/index/dispatch.rs
@@ -30,7 +30,7 @@
 
 use alloc::sync::Arc;
 
-use futures::{FutureExt, StreamExt};
+use futures::{FutureExt as _, StreamExt as _};
 
 use super::{InFlightLoad, InFlightPromotes, IndexManager};
 use crate::cache::unix_now_ms;

--- a/crates/uffs-daemon/src/index/search.rs
+++ b/crates/uffs-daemon/src/index/search.rs
@@ -12,7 +12,7 @@
 //! Search execution: query dispatch, profile construction, and drive info.
 
 use core::sync::atomic::Ordering;
-use std::io::Write;
+use std::io::Write as _;
 use std::time::Instant;
 
 use uffs_client::protocol::response::{

--- a/crates/uffs-daemon/src/ipc.rs
+++ b/crates/uffs-daemon/src/ipc.rs
@@ -9,7 +9,7 @@
 use alloc::sync::Arc;
 use std::path::PathBuf;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
 use uffs_client::protocol::{ERR_PARSE, RpcErrorResponse, RpcRequest};
 
 use crate::events::{EventReceiver, event_to_json_line};
@@ -72,7 +72,7 @@ impl IpcServer {
         reason = "security boundary — must stay separate"
     )]
     fn verify_peer_credentials(stream: &tokio::net::UnixStream) -> bool {
-        use std::os::unix::io::AsRawFd;
+        use std::os::unix::io::AsRawFd as _;
 
         let fd = stream.as_raw_fd();
 

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -953,7 +953,7 @@ pub(crate) fn spawn_pressure_subscriber(
 /// Returns `!` because both arms terminate the process.
 fn force_exit_with_watchdog() -> ! {
     tracing::info!("Spawning shutdown watchdog (5s grace period)");
-    std::thread::Builder::new()
+    _ = std::thread::Builder::new()
         .name("shutdown-watchdog".into())
         .spawn(|| {
             std::thread::sleep(core::time::Duration::from_secs(5));
@@ -972,8 +972,7 @@ fn force_exit_with_watchdog() -> ! {
             )]
             let _: () = eprintln!("[CATASTROPHE] {msg}");
             std::process::abort();
-        })
-        .ok(); // best-effort; if thread spawn fails, exit may still work
+        }); // best-effort; if thread spawn fails, exit may still work
 
     // Force-exit the process.  The Windows IPC server uses
     // `std::os::windows::net::UnixListener` with `spawn_blocking(accept)`

--- a/crates/uffs-daemon/src/lifecycle.rs
+++ b/crates/uffs-daemon/src/lifecycle.rs
@@ -613,12 +613,12 @@ impl LifecycleManager {
         reason = "nonce generation — clarity over inlining"
     )]
     fn generate_nonce() -> String {
-        use rand::Rng;
+        use rand::Rng as _;
         let mut nonce_bytes = [0_u8; 8];
         rand::rng().fill_bytes(&mut nonce_bytes);
         let mut nonce_str = String::with_capacity(16_usize);
         for byte in &nonce_bytes {
-            use core::fmt::Write;
+            use core::fmt::Write as _;
             let _ignore = write!(nonce_str, "{byte:02x}");
         }
         nonce_str

--- a/crates/uffs-daemon/tests/ipc_integration.rs
+++ b/crates/uffs-daemon/tests/ipc_integration.rs
@@ -55,7 +55,7 @@ use windows as _;
 #[cfg(unix)]
 mod unix_tests {
     use core::time::Duration;
-    use std::io::{BufRead, BufReader, Write};
+    use std::io::{BufRead as _, BufReader, Write as _};
     use std::os::unix::net::UnixStream;
     use std::path::PathBuf;
     use std::process::Command;

--- a/crates/uffs-diag/src/bin/analyze_diff.rs
+++ b/crates/uffs-diag/src/bin/analyze_diff.rs
@@ -63,8 +63,10 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::Path;
 
-use anyhow::{Context, Result};
-use uffs_polars::{Column, CsvReadOptions, DataFrame, IntoSeries, SerReader, StringChunked};
+use anyhow::{Context as _, Result};
+use uffs_polars::{
+    Column, CsvReadOptions, DataFrame, IntoSeries as _, SerReader as _, StringChunked,
+};
 
 /// Loads a CSV file into a Polars `DataFrame`.
 ///

--- a/crates/uffs-diag/src/bin/analyze_mft_parents.rs
+++ b/crates/uffs-diag/src/bin/analyze_mft_parents.rs
@@ -40,8 +40,8 @@ use std::collections::HashSet;
 use std::env;
 use std::path::Path;
 
-use anyhow::{Context, Result};
-use uffs_polars::{BooleanChunked, DataFrame, SerReader, UInt64Chunked};
+use anyhow::{Context as _, Result};
+use uffs_polars::{BooleanChunked, DataFrame, SerReader as _, UInt64Chunked};
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();

--- a/crates/uffs-diag/src/bin/compare_raw_mft.rs
+++ b/crates/uffs-diag/src/bin/compare_raw_mft.rs
@@ -28,11 +28,11 @@
 
 use std::env;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, Read as _};
 use std::path::Path;
 use std::time::Instant;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context as _, Result, bail};
 
 /// Header size in bytes (matches `uffs-mft::raw`).
 const HEADER_SIZE: usize = 64;

--- a/crates/uffs-diag/src/bin/compare_scan_parity.rs
+++ b/crates/uffs-diag/src/bin/compare_scan_parity.rs
@@ -74,13 +74,13 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::File;
-use std::io::Write;
+use std::io::Write as _;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use rayon::prelude::*;
 use uffs_diag::parity::stats::{ComparisonResults, FieldStats};
-use uffs_polars::{CsvReadOptions, DataFrame, SerReader, StringChunked};
+use uffs_polars::{CsvReadOptions, DataFrame, SerReader as _, StringChunked};
 
 // ============================================================================
 // Column Name Mappings (reference output <-> Rust)
@@ -241,7 +241,7 @@ fn get_bool_value(df: &DataFrame, col: &str, idx: usize) -> Option<bool> {
     })
 }
 
-use uffs_polars::IntoSeries;
+use uffs_polars::IntoSeries as _;
 
 /// Compare numeric field and update stats
 fn compare_numeric_field(

--- a/crates/uffs-diag/src/bin/cross_check_mft_reference.rs
+++ b/crates/uffs-diag/src/bin/cross_check_mft_reference.rs
@@ -35,10 +35,10 @@
 use std::env;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use uffs_polars::{
-    BooleanChunked, CsvParseOptions, CsvReadOptions, DataFrame, DataFrameJoinOps, DataType,
-    JoinArgs, JoinType, SerReader,
+    BooleanChunked, CsvParseOptions, CsvReadOptions, DataFrame, DataFrameJoinOps as _, DataType,
+    JoinArgs, JoinType, SerReader as _,
 };
 
 fn main() -> Result<()> {

--- a/crates/uffs-diag/src/bin/dump_mft_extents.rs
+++ b/crates/uffs-diag/src/bin/dump_mft_extents.rs
@@ -39,7 +39,7 @@
 use std::env;
 
 #[cfg(windows)]
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 #[cfg(windows)]
 use uffs_mft::{MftExtent, VolumeHandle};
 

--- a/crates/uffs-diag/src/bin/dump_mft_records.rs
+++ b/crates/uffs-diag/src/bin/dump_mft_records.rs
@@ -26,7 +26,7 @@
 use std::env;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use uffs_mft::parse::{MftRecordMerger, ParseResult, parse_record_full};
 use uffs_mft::raw::{LoadRawOptions, load_raw_mft};
 // This binary intentionally pulls in uffs_polars via the uffs-diag crate

--- a/crates/uffs-diag/src/bin/inspect_mft_record_flow.rs
+++ b/crates/uffs-diag/src/bin/inspect_mft_record_flow.rs
@@ -22,7 +22,7 @@
 use std::env;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use uffs_mft::{LoadRawOptions, RawMftData, load_raw_mft};
 
 /// Local copy of `FileRecordSegmentHeader` so this binary can run on

--- a/crates/uffs-diag/src/bin/scan_mft_magic.rs
+++ b/crates/uffs-diag/src/bin/scan_mft_magic.rs
@@ -25,7 +25,7 @@ use alloc::collections::BTreeMap;
 use std::env;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use uffs_mft::raw::{LoadRawOptions, load_raw_mft};
 
 /// Local copy of the NTFS multi-sector header so this tool can run on

--- a/crates/uffs-diag/src/bin/verify_iocp_capture.rs
+++ b/crates/uffs-diag/src/bin/verify_iocp_capture.rs
@@ -44,12 +44,12 @@
 )]
 
 use std::env;
-use std::io::Write;
+use std::io::Write as _;
 use std::path::Path;
 use std::time::Instant;
 
-use anyhow::{Context, Result};
-use sha2::{Digest, Sha256};
+use anyhow::{Context as _, Result};
+use sha2::{Digest as _, Sha256};
 use uffs_mft::raw::{LoadRawOptions, load_raw_mft};
 use uffs_mft::raw_iocp::load_iocp_capture;
 

--- a/crates/uffs-mcp/src/handler/mod.rs
+++ b/crates/uffs-mcp/src/handler/mod.rs
@@ -16,9 +16,9 @@ use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use rmcp::model::{
-    AnnotateAble, CallToolRequestParams, CallToolResult, GetPromptRequestParams, GetPromptResult,
-    Implementation, ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult,
-    ListToolsResult, PaginatedRequestParams, RawResource, RawResourceTemplate,
+    AnnotateAble as _, CallToolRequestParams, CallToolResult, GetPromptRequestParams,
+    GetPromptResult, Implementation, ListPromptsResult, ListResourceTemplatesResult,
+    ListResourcesResult, ListToolsResult, PaginatedRequestParams, RawResource, RawResourceTemplate,
     ReadResourceRequestParams, ReadResourceResult, ResourceContents, ServerCapabilities,
     ServerInfo,
 };

--- a/crates/uffs-mcp/src/http.rs
+++ b/crates/uffs-mcp/src/http.rs
@@ -215,7 +215,7 @@ async fn shutdown_signal() {
 mod tests {
     use axum::body::Body;
     use axum::http::{Request, header};
-    use tower_service::Service;
+    use tower_service::Service as _;
 
     use super::*;
 

--- a/crates/uffs-mcp/src/lib.rs
+++ b/crates/uffs-mcp/src/lib.rs
@@ -136,8 +136,8 @@ pub mod tools;
 use core::sync::atomic::Ordering;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::Context;
-use rmcp::ServiceExt;
+use anyhow::Context as _;
+use rmcp::ServiceExt as _;
 #[cfg(feature = "streamable-http")]
 use tower_service as _;
 use tracing::info;

--- a/crates/uffs-mcp/src/main.rs
+++ b/crates/uffs-mcp/src/main.rs
@@ -30,7 +30,7 @@ use tracing_appender as _;
 
 mod process;
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use clap::{Parser, Subcommand};
 
 /// UFFS MCP server — bridges AI agents to the UFFS daemon via the

--- a/crates/uffs-mcp/src/process.rs
+++ b/crates/uffs-mcp/src/process.rs
@@ -125,7 +125,7 @@ pub(crate) fn kill_process_on_port(port: u16, skip_pid: u32) {
 
 /// Minimal HTTP GET — no external deps needed.
 pub(crate) async fn reqwest_lite_get(raw_url: &str) -> Result<String> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
     let stripped = raw_url.strip_prefix("http://").unwrap_or(raw_url);
     let (host_port, rel_path) = stripped.split_once('/').unwrap_or((stripped, ""));
     let abs_path = format!("/{rel_path}");

--- a/crates/uffs-mcp/src/text.rs
+++ b/crates/uffs-mcp/src/text.rs
@@ -6,7 +6,7 @@
 //! These formatters produce compact summaries alongside structured JSON,
 //! giving LLMs context without requiring them to parse raw data.
 
-use core::fmt::Write;
+use core::fmt::Write as _;
 
 /// Format aggregate results as a compact human-readable summary.
 #[must_use]
@@ -19,31 +19,29 @@ pub fn format_aggregate_summary(results: &[uffs_client::protocol::AggregateResul
         match result.kind.as_str() {
             "count" => {
                 let val = result.value.unwrap_or(0);
-                writeln!(out, "• {label}: {val}").ok();
+                _ = writeln!(out, "• {label}: {val}");
             }
             "missing" => {
                 let val = result.value.unwrap_or(0);
-                writeln!(out, "• {label}: {val} records with missing value").ok();
+                _ = writeln!(out, "• {label}: {val} records with missing value");
             }
             "distinct" => {
                 let val = result.value.unwrap_or(0);
-                writeln!(out, "• {label}: {val} distinct values").ok();
+                _ = writeln!(out, "• {label}: {val} distinct values");
             }
             "stats" => {
                 if let Some(stats) = &result.stats {
-                    writeln!(
+                    _ = writeln!(
                         out,
                         "• {label}: count={} sum={} min={} max={} avg={:.1}",
                         stats.count, stats.sum, stats.min, stats.max, stats.avg
-                    )
-                    .ok();
+                    );
                     if stats.waste_bytes > 0 {
-                        writeln!(
+                        _ = writeln!(
                             out,
                             "  waste: {} bytes ({:.1}%)",
                             stats.waste_bytes, stats.waste_pct
-                        )
-                        .ok();
+                        );
                     }
                 }
             }
@@ -51,13 +49,12 @@ pub fn format_aggregate_summary(results: &[uffs_client::protocol::AggregateResul
                 format_bucket_summary(&mut out, label, result);
             }
             _ => {
-                writeln!(
+                _ = writeln!(
                     out,
                     "• {label}: (kind={}, {} buckets)",
                     result.kind,
                     result.buckets.len()
-                )
-                .ok();
+                );
             }
         }
     }
@@ -75,14 +72,13 @@ fn format_bucket_summary(
     label: &str,
     result: &uffs_client::protocol::AggregateResultWire,
 ) {
-    writeln!(out, "• {label} ({} buckets):", result.buckets.len()).ok();
+    _ = writeln!(out, "• {label} ({} buckets):", result.buckets.len());
     for bucket in result.buckets.iter().take(10) {
-        writeln!(
+        _ = writeln!(
             out,
             "    {:<30} count={:<8} bytes={}",
             bucket.key, bucket.count, bucket.total_bytes
-        )
-        .ok();
+        );
         // Sample rows (top-hits), max 3 per bucket.
         let max_samples = 3;
         for sr in bucket.sample_rows.iter().take(max_samples) {
@@ -92,42 +88,41 @@ fn format_bucket_summary(
                 .get("size")
                 .and_then(|val| val.parse::<u64>().ok())
                 .map_or(String::new(), |n| format!(" ({n} B)"));
-            writeln!(out, "      → {name}{size}").ok();
+            _ = writeln!(out, "      → {name}{size}");
         }
         let remaining = bucket.sample_rows.len().saturating_sub(max_samples);
         if remaining > 0 {
-            writeln!(out, "      ... and {remaining} more").ok();
+            _ = writeln!(out, "      ... and {remaining} more");
         }
         // Nested sub-aggregation buckets.
         for sub in bucket.sub_buckets.iter().take(5) {
-            writeln!(
+            _ = writeln!(
                 out,
                 "      ├─ {:<26} count={:<8} bytes={}",
                 sub.key, sub.count, sub.total_bytes
-            )
-            .ok();
+            );
         }
         let sub_rest = bucket.sub_buckets.len().saturating_sub(5);
         if sub_rest > 0 {
-            writeln!(out, "      ... and {sub_rest} more sub-buckets").ok();
+            _ = writeln!(out, "      ... and {sub_rest} more sub-buckets");
         }
     }
     if result.buckets.len() > 10 {
-        writeln!(out, "    ... and {} more", result.buckets.len() - 10).ok();
+        _ = writeln!(out, "    ... and {} more", result.buckets.len() - 10);
     }
     if let Some(other) = result.other_count
         && other > 0
     {
-        writeln!(out, "    (+ {other} in other groups)").ok();
+        _ = writeln!(out, "    (+ {other} in other groups)");
     }
     if result.values_complete == Some(false) {
-        writeln!(out, "    [truncated — not all values shown]").ok();
+        _ = writeln!(out, "    [truncated — not all values shown]");
     }
     if result.exact == Some(false) {
-        writeln!(out, "    [approximate — not all records scanned]").ok();
+        _ = writeln!(out, "    [approximate — not all records scanned]");
     }
     if let Some(cursor) = &result.next_cursor {
-        writeln!(out, "    [next_cursor: {cursor}]").ok();
+        _ = writeln!(out, "    [next_cursor: {cursor}]");
     }
 }
 

--- a/crates/uffs-mcp/src/tools/aggregate.rs
+++ b/crates/uffs-mcp/src/tools/aggregate.rs
@@ -3,7 +3,7 @@
 
 //! `uffs_aggregate` tool — server-side aggregation summaries.
 
-use core::fmt::Write;
+use core::fmt::Write as _;
 
 use rmcp::model::{CallToolResult, Content};
 use schemars::JsonSchema;
@@ -188,12 +188,11 @@ pub async fn run(
         let omitted = full_json_len.saturating_sub(truncated.len());
         let mut out = preamble;
         out.push_str(truncated);
-        write!(
+        _ = write!(
             out,
             "\n... (truncated — {omitted} of {full_json_len} chars omitted. \
              Use more specific pattern, type_filter, or drives to narrow results.)"
-        )
-        .ok();
+        );
         out.push_str(suffix);
         out
     };

--- a/crates/uffs-mcp/src/tools/drives.rs
+++ b/crates/uffs-mcp/src/tools/drives.rs
@@ -3,7 +3,7 @@
 
 //! `uffs_drives` tool — list all indexed NTFS drives.
 
-use core::fmt::Write;
+use core::fmt::Write as _;
 
 use rmcp::model::{CallToolResult, Content};
 use uffs_client::connect::UffsClient;
@@ -36,14 +36,13 @@ pub async fn run(client: &mut UffsClient) -> Result<CallToolResult, BridgeError>
     };
 
     let mut output = String::new();
-    write!(output, "Loaded {} drive(s):\n\n", response.drives.len()).ok();
+    _ = write!(output, "Loaded {} drive(s):\n\n", response.drives.len());
     for drive in &response.drives {
-        writeln!(
+        _ = writeln!(
             output,
             "  {}:  {:>10} records  ({})",
             drive.letter, drive.records, drive.source
-        )
-        .ok();
+        );
     }
 
     let mut result = CallToolResult::success(vec![Content::text(output)]);

--- a/crates/uffs-mcp/src/tools/search.rs
+++ b/crates/uffs-mcp/src/tools/search.rs
@@ -3,9 +3,9 @@
 
 //! `uffs_search` tool — file search across all indexed NTFS drives.
 
-use core::fmt::Write;
+use core::fmt::Write as _;
 
-use rmcp::model::{AnnotateAble, CallToolResult, Content, RawContent, RawResource};
+use rmcp::model::{AnnotateAble as _, CallToolResult, Content, RawContent, RawResource};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use uffs_client::connect::UffsClient;
@@ -499,14 +499,13 @@ struct FormatContext<'a> {
 fn format_text_output(ctx: &FormatContext<'_>) -> String {
     let mut output = String::new();
     if ctx.page_rows.is_empty() {
-        write!(
+        _ = write!(
             output,
             "0 matches ({} scanned in {}ms)\n\n",
             ctx.records_scanned, ctx.duration_ms,
-        )
-        .ok();
+        );
     } else {
-        write!(
+        _ = write!(
             output,
             "Showing {}-{} of {} matches ({} scanned in {}ms)\n\n",
             ctx.offset + 1,
@@ -514,11 +513,10 @@ fn format_text_output(ctx: &FormatContext<'_>) -> String {
             ctx.total_count,
             ctx.records_scanned,
             ctx.duration_ms,
-        )
-        .ok();
+        );
     }
     for warning in ctx.warnings {
-        writeln!(output, "⚠ {warning}").ok();
+        _ = writeln!(output, "⚠ {warning}");
     }
 
     if ctx.page_rows.is_empty() {
@@ -527,15 +525,15 @@ fn format_text_output(ctx: &FormatContext<'_>) -> String {
         // Build projection-aware markdown table.
         let header: Vec<&str> = ctx.projection.iter().map(|col| col_header(col)).collect();
         let separator: Vec<&str> = header.iter().map(|_| "------").collect();
-        writeln!(output, "| {} |", header.join(" | ")).ok();
-        writeln!(output, "| {} |", separator.join(" | ")).ok();
+        _ = writeln!(output, "| {} |", header.join(" | "));
+        _ = writeln!(output, "| {} |", separator.join(" | "));
         for row in ctx.page_rows {
             let cells: Vec<String> = ctx
                 .projection
                 .iter()
                 .map(|col| col_value(col, row))
                 .collect();
-            writeln!(output, "| {} |", cells.join(" | ")).ok();
+            _ = writeln!(output, "| {} |", cells.join(" | "));
         }
         if ctx.has_more {
             // When total matches vastly exceed the page limit, the agent
@@ -543,21 +541,19 @@ fn format_text_output(ctx: &FormatContext<'_>) -> String {
             // paging through hundreds of rows.
             let limit_u64 = u64::from(ctx.effective_limit);
             if ctx.total_count > limit_u64.saturating_mul(AGGREGATE_HINT_FACTOR) {
-                write!(
+                _ = write!(
                     output,
                     "\n⚠ {} total matches — far more than the {limit_u64}-row page. \
                      Consider using `uffs_aggregate` (e.g. preset `duplicates`, \
                      `by_extension`, `by_type`) to summarise large result sets \
                      instead of paging through them.\n",
                     ctx.total_count,
-                )
-                .ok();
+                );
             } else if let Some(cursor) = &ctx.next_cursor {
-                write!(
+                _ = write!(
                     output,
                     "\n(More results available. Pass `cursor: \"{cursor}\"` to fetch the next page.)\n",
-                )
-                .ok();
+                );
             }
         }
     }
@@ -633,7 +629,7 @@ pub fn percent_encode_path(path: &str) -> String {
                 // Percent-encode multi-byte UTF-8 chars byte-by-byte.
                 let mut buf = [0_u8; 4];
                 for byte in ch.encode_utf8(&mut buf).bytes() {
-                    write!(encoded, "%{byte:02X}").ok();
+                    _ = write!(encoded, "%{byte:02X}");
                 }
             }
         }

--- a/crates/uffs-mcp/tests/mcp_protocol.rs
+++ b/crates/uffs-mcp/tests/mcp_protocol.rs
@@ -28,7 +28,7 @@ use anyhow as _;
 use axum as _;
 use clap as _;
 use dirs_next as _;
-use rmcp::{ClientHandler, ServiceExt};
+use rmcp::{ClientHandler, ServiceExt as _};
 use schemars as _;
 use serde as _;
 use thiserror as _;

--- a/crates/uffs-mft/src/commands/load.rs
+++ b/crates/uffs-mft/src/commands/load.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 
 use crate::display::{clean_path_for_display, format_bytes, format_duration, format_number_commas};
 
@@ -468,7 +468,7 @@ pub(crate) fn cmd_load(
         "csv" => {
             use std::fs::File;
 
-            use uffs_polars::{CsvWriter, SerWriter};
+            use uffs_polars::{CsvWriter, SerWriter as _};
 
             let file = File::create(output)?;
             CsvWriter::new(file).finish(&mut df)?;
@@ -693,7 +693,7 @@ fn cmd_load_iocp(
                     MftReader::save_parquet(&mut df, output).context("Failed to save Parquet")?;
                 }
                 "csv" => {
-                    use uffs_polars::{CsvWriter, SerWriter};
+                    use uffs_polars::{CsvWriter, SerWriter as _};
                     let file = std::fs::File::create(output)?;
                     CsvWriter::new(file)
                         .finish(&mut df)

--- a/crates/uffs-mft/src/commands/windows/bench.rs
+++ b/crates/uffs-mft/src/commands/windows/bench.rs
@@ -30,7 +30,7 @@
 
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use tracing::{info, warn};
 
 use super::shared::pause_between_benchmark_runs;

--- a/crates/uffs-mft/src/commands/windows/benchmark_index.rs
+++ b/crates/uffs-mft/src/commands/windows/benchmark_index.rs
@@ -38,7 +38,7 @@
     reason = "benchmark commands are inherently linear: configure → run → format → print, kept in one place for readability"
 )]
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use tracing::warn;
 use uffs_mft::MftReader;
 
@@ -697,11 +697,11 @@ pub(crate) async fn cmd_benchmark_multi_volume(drives: Vec<char>) -> Result<()> 
     // Close overlapped handles
     for handle in handles {
         #[expect(unsafe_code, reason = "required for windows ffi call to CloseHandle")]
-        // SAFETY: each `handle` was returned by `open_overlapped_handle` above
-        // and not used after this point; `CloseHandle` is the documented
-        // counterpart for `CreateFileW`-derived volume handles.
-        unsafe {
-            windows::Win32::Foundation::CloseHandle(handle).ok();
+        {
+            // SAFETY: each `handle` was returned by `open_overlapped_handle` above
+            // and not used after this point; `CloseHandle` is the documented
+            // counterpart for `CreateFileW`-derived volume handles.
+            _ = unsafe { windows::Win32::Foundation::CloseHandle(handle) };
         }
     }
 

--- a/crates/uffs-mft/src/commands/windows/benchmark_mft.rs
+++ b/crates/uffs-mft/src/commands/windows/benchmark_mft.rs
@@ -37,7 +37,7 @@
     reason = "slices into the local 1\u{a0}MiB buffer; sizes are clamped via `min(BUFFER_SIZE)` and `min(chunk_size)` above"
 )]
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 
 use crate::display::char_or_dot;
 

--- a/crates/uffs-mft/src/commands/windows/bitmap_diag.rs
+++ b/crates/uffs-mft/src/commands/windows/bitmap_diag.rs
@@ -30,7 +30,7 @@
     reason = "small one-shot CLI bitmap summary; SIMD-accelerated `bytecount` would be overkill for an interactive diagnostic and would add a dependency"
 )]
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 
 // ============================================================================
 // Bitmap Diagnostic Command

--- a/crates/uffs-mft/src/commands/windows/info.rs
+++ b/crates/uffs-mft/src/commands/windows/info.rs
@@ -28,7 +28,7 @@
     reason = "info commands run a configure -> query -> format -> print pipeline that is most readable inline"
 )]
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use tracing::info;
 use uffs_mft::MftReader;
 
@@ -714,7 +714,7 @@ pub(crate) async fn cmd_drives() -> Result<()> {
 )]
 fn get_volume_label(drive: char) -> Option<String> {
     use std::ffi::OsString;
-    use std::os::windows::ffi::OsStringExt;
+    use std::os::windows::ffi::OsStringExt as _;
 
     use windows::Win32::Storage::FileSystem::GetVolumeInformationW;
     use windows::core::PCWSTR;

--- a/crates/uffs-mft/src/commands/windows/read.rs
+++ b/crates/uffs-mft/src/commands/windows/read.rs
@@ -15,7 +15,7 @@
 
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use tracing::{info, warn};
 use uffs_mft::MftReader;
 

--- a/crates/uffs-mft/src/commands/windows/save.rs
+++ b/crates/uffs-mft/src/commands/windows/save.rs
@@ -48,7 +48,7 @@
 
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use tracing::info;
 
 use super::shared::drive_type_label;

--- a/crates/uffs-mft/src/index/base.rs
+++ b/crates/uffs-mft/src/index/base.rs
@@ -493,7 +493,7 @@ impl MftIndex {
     #[expect(clippy::min_ident_chars, reason = "'n' for count is idiomatic")]
     #[expect(clippy::too_many_lines, reason = "stats display has many fields")]
     pub fn display_stats(&self) {
-        use std::io::Write;
+        use std::io::Write as _;
 
         use super::types::u64_to_f64;
 
@@ -534,84 +534,73 @@ impl MftIndex {
             result.chars().rev().collect()
         };
 
-        writeln!(out, "{sep}").ok();
-        writeln!(out, "                    ENHANCED MFT STATISTICS").ok();
-        writeln!(out, "{sep}\n").ok();
+        _ = writeln!(out, "{sep}");
+        _ = writeln!(out, "                    ENHANCED MFT STATISTICS");
+        _ = writeln!(out, "{sep}\n");
 
         // Basic counts
-        writeln!(out, "📊 RECORD COUNTS").ok();
-        writeln!(
+        _ = writeln!(out, "📊 RECORD COUNTS");
+        _ = writeln!(
             out,
             "  Total records:        {}",
             format_number(u64::from(self.stats.record_count))
-        )
-        .ok();
-        writeln!(
+        );
+        _ = writeln!(
             out,
             "  Directories:          {}",
             format_number(u64::from(self.stats.dir_count))
-        )
-        .ok();
-        writeln!(
+        );
+        _ = writeln!(
             out,
             "  Files:                {}\n",
             format_number(u64::from(self.stats.file_count))
-        )
-        .ok();
+        );
 
         // Byte counters
-        writeln!(out, "💾 SIZE METRICS").ok();
-        writeln!(
+        _ = writeln!(out, "💾 SIZE METRICS");
+        _ = writeln!(
             out,
             "  Total bytes:          {}",
             format_size(self.stats.total_bytes)
-        )
-        .ok();
-        writeln!(
+        );
+        _ = writeln!(
             out,
             "  Directory bytes:      {}",
             format_size(self.stats.dir_bytes)
-        )
-        .ok();
-        writeln!(
+        );
+        _ = writeln!(
             out,
             "  Hidden bytes:         {}",
             format_size(self.stats.hidden_bytes)
-        )
-        .ok();
-        writeln!(
+        );
+        _ = writeln!(
             out,
             "  System bytes:         {}",
             format_size(self.stats.system_bytes)
-        )
-        .ok();
-        writeln!(
+        );
+        _ = writeln!(
             out,
             "  Compressed bytes:     {}",
             format_size(self.stats.compressed_bytes)
-        )
-        .ok();
-        writeln!(
+        );
+        _ = writeln!(
             out,
             "  Encrypted bytes:      {}",
             format_size(self.stats.encrypted_bytes)
-        )
-        .ok();
-        writeln!(
+        );
+        _ = writeln!(
             out,
             "  Sparse bytes:         {}",
             format_size(self.stats.sparse_bytes)
-        )
-        .ok();
-        writeln!(
+        );
+        _ = writeln!(
             out,
             "  Reparse bytes:        {}\n",
             format_size(self.stats.reparse_bytes)
-        )
-        .ok();
+        );
 
         // Size distribution
-        writeln!(out, "📏 SIZE DISTRIBUTION").ok();
+        _ = writeln!(out, "📏 SIZE DISTRIBUTION");
         let bucket_names = [
             "0-1 KB",
             "1-10 KB",
@@ -627,56 +616,53 @@ impl MftIndex {
                 self.stats.size_bucket_counts.get(i),
                 self.stats.size_bucket_bytes.get(i),
             ) {
-                writeln!(
+                _ = writeln!(
                     out,
                     "  {:15} {:>10} files  ({:>10})",
                     name,
                     format_number(u64::from(count)),
                     format_size(bytes)
-                )
-                .ok();
+                );
             }
         }
-        writeln!(out).ok();
+        _ = writeln!(out);
 
         // Top extensions by count
-        writeln!(out, "🏆 TOP EXTENSIONS BY COUNT").ok();
+        _ = writeln!(out, "🏆 TOP EXTENSIONS BY COUNT");
         let top_by_count = self.extensions.top_by_count(10);
         if top_by_count.is_empty() {
-            writeln!(out, "  (no extensions)").ok();
+            _ = writeln!(out, "  (no extensions)");
         } else {
             for (_ext_id, ext, count, bytes) in &top_by_count {
-                writeln!(
+                _ = writeln!(
                     out,
                     "  {:15} {:>10} files  ({:>10})",
                     ext,
                     format_number(u64::from(*count)),
                     format_size(*bytes)
-                )
-                .ok();
+                );
             }
         }
-        writeln!(out).ok();
+        _ = writeln!(out);
 
         // Top extensions by bytes
-        writeln!(out, "🏆 TOP EXTENSIONS BY SIZE").ok();
+        _ = writeln!(out, "🏆 TOP EXTENSIONS BY SIZE");
         let top_by_bytes = self.extensions.top_by_bytes(10);
         if top_by_bytes.is_empty() {
-            writeln!(out, "  (no extensions)").ok();
+            _ = writeln!(out, "  (no extensions)");
         } else {
             for (_ext_id, ext, bytes, count) in &top_by_bytes {
-                writeln!(
+                _ = writeln!(
                     out,
                     "  {:15} {:>10} files  ({:>10})",
                     ext,
                     format_number(u64::from(*count)),
                     format_size(*bytes)
-                )
-                .ok();
+                );
             }
         }
 
-        writeln!(out, "\n{sep}").ok();
+        _ = writeln!(out, "\n{sep}");
     }
 
     /// Get the name string for a link.

--- a/crates/uffs-mft/src/index/dataframe.rs
+++ b/crates/uffs-mft/src/index/dataframe.rs
@@ -44,7 +44,7 @@ impl MftIndex {
         reason = "DataFrame construction has many columns"
     )]
     pub fn to_dataframe(&self) -> crate::Result<uffs_polars::DataFrame> {
-        use uffs_polars::{DataType, IntoColumn, NamedFrom, Series, TimeUnit};
+        use uffs_polars::{DataType, IntoColumn as _, NamedFrom as _, Series, TimeUnit};
         let n = self.records.len();
         // Pre-allocate all column vectors (35 columns in v5)
         let (mut frs, mut seq, mut lsn, mut parent, mut name, mut ns) = (

--- a/crates/uffs-mft/src/io/parser/fragment.rs
+++ b/crates/uffs-mft/src/io/parser/fragment.rs
@@ -7,7 +7,7 @@
 use core::mem::size_of;
 
 use smallvec::SmallVec;
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 #[expect(
     deprecated,

--- a/crates/uffs-mft/src/io/parser/fragment_extension.rs
+++ b/crates/uffs-mft/src/io/parser/fragment_extension.rs
@@ -7,7 +7,7 @@
 use core::mem::size_of;
 
 use smallvec::SmallVec;
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use crate::index::{
     ChildInfo, IndexNameRef, IndexStreamInfo, LinkInfo, NO_ENTRY, SizeInfo, frs_to_usize,

--- a/crates/uffs-mft/src/io/parser/index.rs
+++ b/crates/uffs-mft/src/io/parser/index.rs
@@ -28,7 +28,7 @@
 use core::mem::size_of;
 
 use smallvec::SmallVec;
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use super::index_extension::parse_extension_to_index;
 use crate::index::{len_to_u16, nonneg_to_u64, u32_as_usize};

--- a/crates/uffs-mft/src/io/parser/index_extension.rs
+++ b/crates/uffs-mft/src/io/parser/index_extension.rs
@@ -14,7 +14,7 @@
 use core::mem::size_of;
 
 use smallvec::SmallVec;
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use crate::index::{frs_to_usize, len_to_u16, len_to_u32, u32_as_usize};
 

--- a/crates/uffs-mft/src/io/parser/unified.rs
+++ b/crates/uffs-mft/src/io/parser/unified.rs
@@ -9,7 +9,7 @@
 
 use core::mem::size_of;
 
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use crate::index::{
     ChildInfo, IndexNameRef, IndexStreamInfo, InternalStreamInfo, MftIndex, NO_ENTRY, SizeInfo,

--- a/crates/uffs-mft/src/io/readers/iocp/shared.rs
+++ b/crates/uffs-mft/src/io/readers/iocp/shared.rs
@@ -94,7 +94,7 @@ impl Drop for IoCompletionPort {
         if !self.handle.is_invalid() {
             // SAFETY: `self.handle` was created by `CreateIoCompletionPort` and is
             // closed exactly once during drop after `is_invalid()` checked validity.
-            unsafe { CloseHandle(self.handle) }.ok();
+            _ = unsafe { CloseHandle(self.handle) };
         }
     }
 }

--- a/crates/uffs-mft/src/io/readers/parallel/tests_chaos.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/tests_chaos.rs
@@ -370,7 +370,7 @@ fn sorted_sha256(lines: &[String]) -> String {
 /// This matches `scripts/verify_parity.rs:1229-1236` exactly.
 #[cfg(test)]
 fn sha256_for_lines<'a>(lines: impl IntoIterator<Item = &'a str>) -> String {
-    use sha2::{Digest, Sha256};
+    use sha2::{Digest as _, Sha256};
     let mut hasher = Sha256::new();
     for line in lines {
         hasher.update(line.as_bytes());
@@ -446,7 +446,7 @@ mod chaos_integration_tests {
     )]
     fn test_chaos_order_d_drive() {
         use std::fs::File;
-        use std::io::{BufRead, BufReader};
+        use std::io::{BufRead as _, BufReader};
         const EXPECTED_SORTED_SHA: &str =
             "028356d4c9298ca8ef790229f4d4270ea29827ad155051e01181181fa34a531e";
 

--- a/crates/uffs-mft/src/io/readers/pipelined.rs
+++ b/crates/uffs-mft/src/io/readers/pipelined.rs
@@ -522,9 +522,9 @@ fn spawn_pipelined_reader(
                     warn!(error = %err, "Pipelined reader: chunk read failed");
                     // Forward the error and terminate; the consumer will
                     // surface it via `?` and the orchestrator returns Err.
-                    // `.ok()` discards the must_use Result without losing
-                    // the annotation if a receiver-disconnect happens here.
-                    tx.send(Err(err)).ok();
+                    // Discard the must_use Result if the receiver has already
+                    // disconnected — the error path is already terminal.
+                    _ = tx.send(Err(err));
                     break;
                 }
             }

--- a/crates/uffs-mft/src/logging.rs
+++ b/crates/uffs-mft/src/logging.rs
@@ -9,9 +9,9 @@ use std::path::PathBuf;
 use tracing_appender::non_blocking::NonBlocking;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::fmt::time::UtcTime;
-use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::registry::Registry;
-use tracing_subscriber::{EnvFilter, Layer};
+use tracing_subscriber::{EnvFilter, Layer as _};
 
 /// Initialize logging with terminal + file support.
 ///

--- a/crates/uffs-mft/src/main.rs
+++ b/crates/uffs-mft/src/main.rs
@@ -42,7 +42,7 @@
 use anyhow::Result;
 use bitflags as _;
 use bytemuck as _;
-use clap::Parser;
+use clap::Parser as _;
 // Dev-dependencies (used in benchmarks and tests only)
 #[cfg(test)]
 use criterion as _;

--- a/crates/uffs-mft/src/parse/attribute_helpers.rs
+++ b/crates/uffs-mft/src/parse/attribute_helpers.rs
@@ -3,7 +3,7 @@
 
 //! Helpers for parsing core NTFS attributes from MFT record bytes.
 
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use crate::index::nonneg_to_u64;
 use crate::ntfs::{ExtendedStandardInfo, NameInfo, StreamInfo};

--- a/crates/uffs-mft/src/parse/direct_index.rs
+++ b/crates/uffs-mft/src/parse/direct_index.rs
@@ -40,7 +40,7 @@
 use core::mem::size_of;
 
 use smallvec::SmallVec;
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use super::direct_index_extension::parse_extension_to_index;
 use super::index_helpers::{

--- a/crates/uffs-mft/src/parse/direct_index_extension.rs
+++ b/crates/uffs-mft/src/parse/direct_index_extension.rs
@@ -43,7 +43,7 @@
 use core::mem::size_of;
 
 use smallvec::SmallVec;
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use super::index_helpers::{add_link_to_index, add_stream_to_index};
 use crate::index::{frs_to_usize, len_to_u16, len_to_u32, nonneg_to_u64, u32_as_usize};

--- a/crates/uffs-mft/src/parse/fixup.rs
+++ b/crates/uffs-mft/src/parse/fixup.rs
@@ -5,7 +5,7 @@
 
 use core::mem::size_of;
 
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use crate::ntfs::{FILE_RECORD_MAGIC, MultiSectorHeader, SECTOR_SIZE};
 

--- a/crates/uffs-mft/src/parse/forensic.rs
+++ b/crates/uffs-mft/src/parse/forensic.rs
@@ -8,7 +8,7 @@ mod extension;
 
 use base::parse_base_record;
 use extension::parse_extension_record;
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use super::{ParseOptions, ParseResult, ParsedRecord};
 

--- a/crates/uffs-mft/src/parse/forensic/base.rs
+++ b/crates/uffs-mft/src/parse/forensic/base.rs
@@ -3,7 +3,7 @@
 
 //! Base-record forensic parsing after record-header validation.
 
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use super::super::{
     ParseResult, ParsedRecord, PrimaryNameTracker, parse_data_attribute_full, parse_file_name_full,

--- a/crates/uffs-mft/src/parse/forensic/extension.rs
+++ b/crates/uffs-mft/src/parse/forensic/extension.rs
@@ -3,7 +3,7 @@
 
 //! Extension-record forensic parsing for merge-oriented handling.
 
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use super::super::{
     ExtensionAttributes, ParseResult, parse_data_attribute_full, parse_file_name_full,

--- a/crates/uffs-mft/src/parse/full.rs
+++ b/crates/uffs-mft/src/parse/full.rs
@@ -4,7 +4,7 @@
 //! Standard MFT record parsing for base and extension records.
 
 use tracing::debug;
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use super::{
     ExtensionAttributes, ParseResult, ParsedRecord, PrimaryNameTracker, parse_data_attribute_full,

--- a/crates/uffs-mft/src/platform/volume.rs
+++ b/crates/uffs-mft/src/platform/volume.rs
@@ -18,7 +18,7 @@ use windows::Win32::Storage::FileSystem::{
 };
 use windows::Win32::System::Ioctl::{FSCTL_GET_NTFS_VOLUME_DATA, NTFS_VOLUME_DATA_BUFFER};
 use windows::core::PCWSTR;
-use zerocopy::FromBytes;
+use zerocopy::FromBytes as _;
 
 use super::bitmap::MftBitmap;
 use super::extents::{MftExtent, get_retrieval_pointers};
@@ -885,7 +885,7 @@ impl Drop for VolumeHandle {
         if !self.handle.is_invalid() {
             // SAFETY: `VolumeHandle` owns this valid handle and closes it once
             // during drop after all safe borrows have ended.
-            unsafe { CloseHandle(self.handle) }.ok();
+            _ = unsafe { CloseHandle(self.handle) };
         }
     }
 }
@@ -899,7 +899,7 @@ impl Drop for HandleGuard {
         if !self.0.is_invalid() {
             // SAFETY: `HandleGuard` exclusively owns this valid handle and drops
             // it exactly once when the guard is destroyed.
-            unsafe { CloseHandle(self.0) }.ok();
+            _ = unsafe { CloseHandle(self.0) };
         }
     }
 }
@@ -993,7 +993,7 @@ fn enable_privilege_with_token(token: HANDLE, luid: windows::Win32::Foundation::
     let result = unsafe { AdjustTokenPrivileges(token, false, Some(&raw const tp), 0, None, None) };
 
     // SAFETY: `token` was opened by the caller and is closed exactly once.
-    unsafe { CloseHandle(token) }.ok();
+    _ = unsafe { CloseHandle(token) };
 
     match result {
         Ok(()) => tracing::info!("✅ SeBackupPrivilege enabled"),
@@ -1009,7 +1009,7 @@ fn enable_privilege_with_token(token: HANDLE, luid: windows::Win32::Foundation::
 fn unsafe_close_token(token: HANDLE) {
     // SAFETY: caller passes a token returned from
     // `open_current_process_token` that has not yet been closed.
-    unsafe { CloseHandle(token) }.ok();
+    _ = unsafe { CloseHandle(token) };
 }
 
 #[cfg(test)]

--- a/crates/uffs-mft/src/raw/mod.rs
+++ b/crates/uffs-mft/src/raw/mod.rs
@@ -37,7 +37,7 @@
 //! analyzeMFT, MFT2CSV, and ntfstool.
 
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, BufWriter, Read as _, Write as _};
 use std::path::Path;
 
 use crate::error::{MftError, Result};
@@ -371,7 +371,7 @@ fn detect_record_size_from_first_record(data: &[u8]) -> u32 {
     reason = "path rebinding from P to &Path is idiomatic"
 )]
 pub fn load_raw_mft<P: AsRef<Path>>(path: P, options: &LoadRawOptions) -> Result<RawMftData> {
-    use std::io::{Seek, SeekFrom};
+    use std::io::{Seek as _, SeekFrom};
 
     let path = path.as_ref();
     let file = File::open(path)?;

--- a/crates/uffs-mft/src/raw/streaming_writer.rs
+++ b/crates/uffs-mft/src/raw/streaming_writer.rs
@@ -6,7 +6,7 @@
 //! Extracted from `raw.rs` to keep it under the 800 LOC threshold.
 
 use std::fs::File;
-use std::io::{BufWriter, Write};
+use std::io::{BufWriter, Write as _};
 use std::path::Path;
 
 use super::{FLAG_COMPRESSED, HEADER_SIZE, RawMftHeader, SaveRawOptions, VERSION};
@@ -180,7 +180,7 @@ impl StreamingRawMftWriter {
     ///
     /// Returns an error if flushing or seeking fails.
     pub fn finish(mut self) -> Result<RawMftHeader> {
-        use std::io::{Seek, SeekFrom};
+        use std::io::{Seek as _, SeekFrom};
 
         let original_size = self.bytes_written;
         let record_count = original_size / u64::from(self.record_size);

--- a/crates/uffs-mft/src/raw_iocp.rs
+++ b/crates/uffs-mft/src/raw_iocp.rs
@@ -48,7 +48,7 @@
 //! ```
 
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, BufWriter, Read as _, Write as _};
 use std::path::Path;
 
 use crate::error::{MftError, Result};

--- a/crates/uffs-mft/src/reader/dataframe_build.rs
+++ b/crates/uffs-mft/src/reader/dataframe_build.rs
@@ -145,7 +145,7 @@ impl MftReader {
         accessed_vec: Vec<i64>,
         flags_vec: Vec<u16>,
     ) -> Result<DataFrame> {
-        use uffs_polars::{DataType, IntoColumn, NamedFrom, Series, TimeUnit};
+        use uffs_polars::{DataType, IntoColumn as _, NamedFrom as _, Series, TimeUnit};
 
         let columns = vec![
             Series::new("frs".into(), frs_vec).into_column(),
@@ -206,7 +206,7 @@ impl MftReader {
         is_virtual_vec: Vec<bool>,
         flags_vec: Vec<u32>,
     ) -> Result<DataFrame> {
-        use uffs_polars::{DataType, IntoColumn, NamedFrom, Series, TimeUnit};
+        use uffs_polars::{DataType, IntoColumn as _, NamedFrom as _, Series, TimeUnit};
 
         let columns = vec![
             // Core identifiers
@@ -275,7 +275,7 @@ impl MftReader {
     pub(super) fn build_dataframe_from_columns(
         columns: crate::parse::ParsedColumns,
     ) -> Result<DataFrame> {
-        use uffs_polars::{DataType, IntoColumn, NamedFrom, Series, TimeUnit};
+        use uffs_polars::{DataType, IntoColumn as _, NamedFrom as _, Series, TimeUnit};
 
         let polars_columns = vec![
             // Core identifiers

--- a/crates/uffs-mft/src/reader/dataframe_read.rs
+++ b/crates/uffs-mft/src/reader/dataframe_read.rs
@@ -425,7 +425,7 @@ impl MftReader {
                 {
                     // SAFETY: `overlapped_handle` came from `open_overlapped_handle` and is
                     // closed exactly once here.
-                    unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) }.ok();
+                    _ = unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) };
                 };
 
                 result?
@@ -499,7 +499,7 @@ impl MftReader {
                 {
                     // SAFETY: `overlapped_handle` came from `open_overlapped_handle`, is
                     // no longer used after the read completes, and is closed exactly once.
-                    unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) }.ok();
+                    _ = unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) };
                 };
 
                 result?
@@ -545,7 +545,7 @@ impl MftReader {
                 {
                     // SAFETY: `overlapped_handle` came from `open_overlapped_handle`, is
                     // no longer used after the read completes, and is closed exactly once.
-                    unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) }.ok();
+                    _ = unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) };
                 };
 
                 result?
@@ -593,7 +593,7 @@ impl MftReader {
                 {
                     // SAFETY: `overlapped_handle` came from `open_overlapped_handle`, is
                     // no longer used after the read completes, and is closed exactly once.
-                    unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) }.ok();
+                    _ = unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) };
                 };
 
                 match result {

--- a/crates/uffs-mft/src/reader/index_read.rs
+++ b/crates/uffs-mft/src/reader/index_read.rs
@@ -537,7 +537,7 @@ impl MftReader {
                 {
                     // SAFETY: `overlapped_handle` was opened by `open_overlapped_handle`
                     // and is closed exactly once here.
-                    unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) }.ok();
+                    _ = unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) };
                 };
 
                 result?
@@ -614,7 +614,7 @@ impl MftReader {
                 {
                     // SAFETY: `overlapped_handle` came from `open_overlapped_handle`, is
                     // no longer used after the read completes, and is closed exactly once.
-                    unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) }.ok();
+                    _ = unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) };
                 };
 
                 result?
@@ -663,7 +663,7 @@ impl MftReader {
                 {
                     // SAFETY: `overlapped_handle` came from `open_overlapped_handle`, is
                     // no longer used after the read completes, and is closed exactly once.
-                    unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) }.ok();
+                    _ = unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) };
                 };
 
                 result?
@@ -693,7 +693,7 @@ impl MftReader {
                 {
                     // SAFETY: `overlapped_handle` came from `open_overlapped_handle`, is
                     // no longer used after the read completes, and is closed exactly once.
-                    unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) }.ok();
+                    _ = unsafe { windows::Win32::Foundation::CloseHandle(overlapped_handle) };
                 };
 
                 match result {
@@ -887,7 +887,7 @@ impl MftReader {
                 {
                     // SAFETY: `mft_handle` from `open_mft_read_handle`, closed
                     // exactly once after the read completes.
-                    unsafe { windows::Win32::Foundation::CloseHandle(mft_handle) }.ok();
+                    _ = unsafe { windows::Win32::Foundation::CloseHandle(mft_handle) };
                 };
                 return result;
             }
@@ -917,7 +917,7 @@ impl MftReader {
         {
             // SAFETY: `unbuf_handle` from `open_unbuffered_handle`, closed
             // exactly once after the read completes.
-            unsafe { windows::Win32::Foundation::CloseHandle(unbuf_handle) }.ok();
+            _ = unsafe { windows::Win32::Foundation::CloseHandle(unbuf_handle) };
         };
         result
     }

--- a/crates/uffs-mft/src/reader/multi_drive/dataframe.rs
+++ b/crates/uffs-mft/src/reader/multi_drive/dataframe.rs
@@ -6,7 +6,7 @@
 use alloc::sync::Arc;
 
 use tokio::task::JoinSet;
-use uffs_polars::{DataFrame, IntoLazy, col, lit};
+use uffs_polars::{DataFrame, IntoLazy as _, col, lit};
 
 use super::{DriveReadResult, MultiDriveMftReader, drive_reader_budget};
 use crate::error::{MftError, Result};

--- a/crates/uffs-mft/src/reader/persistence.rs
+++ b/crates/uffs-mft/src/reader/persistence.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 
-use uffs_polars::{DataFrame, ParquetReader, ParquetWriter, SerReader};
+use uffs_polars::{DataFrame, ParquetReader, ParquetWriter, SerReader as _};
 
 use super::MftReader;
 use crate::error::{MftError, Result};

--- a/crates/uffs-mft/src/reader/persistence_capture.rs
+++ b/crates/uffs-mft/src/reader/persistence_capture.rs
@@ -169,7 +169,7 @@ impl MftReader {
         let iocp = IoCompletionPort::new(0)?;
         if let Err(err) = iocp.associate(handle, 0) {
             // SAFETY: handle was successfully opened by open_overlapped_handle
-            unsafe { CloseHandle(handle) }.ok();
+            _ = unsafe { CloseHandle(handle) };
             return Err(err);
         }
 
@@ -198,7 +198,7 @@ impl MftReader {
             )
         } {
             // SAFETY: handle opened above, no further use.
-            unsafe { CloseHandle(handle) }.ok();
+            _ = unsafe { CloseHandle(handle) };
             return Err(err);
         }
 
@@ -213,7 +213,7 @@ impl MftReader {
                 Ok(None) => continue,
                 Err(err) => {
                     // SAFETY: handle opened above, no further use.
-                    unsafe { CloseHandle(handle) }.ok();
+                    _ = unsafe { CloseHandle(handle) };
                     return Err(err);
                 }
             };
@@ -231,7 +231,7 @@ impl MftReader {
                 }
                 Err(err) => {
                     // SAFETY: handle opened above, no further use.
-                    unsafe { CloseHandle(handle) }.ok();
+                    _ = unsafe { CloseHandle(handle) };
                     return Err(err);
                 }
             }
@@ -256,7 +256,7 @@ impl MftReader {
                     }
                     Err(err) => {
                         // SAFETY: handle opened above, no further use.
-                        unsafe { CloseHandle(handle) }.ok();
+                        _ = unsafe { CloseHandle(handle) };
                         return Err(err);
                     }
                 }
@@ -270,7 +270,7 @@ impl MftReader {
 
         // Close the overlapped handle before writing the file
         // SAFETY: handle was opened by open_overlapped_handle and is no longer needed
-        unsafe { CloseHandle(handle) }.ok();
+        _ = unsafe { CloseHandle(handle) };
 
         writer.write_to_file(path)
     }

--- a/crates/uffs-mft/src/usn.rs
+++ b/crates/uffs-mft/src/usn.rs
@@ -222,7 +222,7 @@ mod windows_impl {
     use core::mem::size_of;
     use core::ptr;
     use std::ffi::OsStr;
-    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::ffi::OsStrExt as _;
 
     use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, HANDLE, INVALID_HANDLE_VALUE};
     use windows::Win32::Storage::FileSystem::{
@@ -655,7 +655,7 @@ mod windows_impl {
     /// after statements in the caller — required by
     /// `clippy::items_after_statements`.
     fn scan_attribute_list_extensions(data: &[u8], base_frs: u64, out: &mut Vec<u64>) {
-        use zerocopy::FromBytes;
+        use zerocopy::FromBytes as _;
 
         use crate::ntfs::{
             AttributeListEntry, AttributeRecordHeader, AttributeType, FileRecordSegmentHeader,

--- a/crates/uffs-security/src/crypto.rs
+++ b/crates/uffs-security/src/crypto.rs
@@ -31,7 +31,7 @@
 use std::io;
 
 use aes_gcm::aead::generic_array::GenericArray;
-use aes_gcm::{AeadInPlace, Aes256Gcm, KeyInit, Nonce};
+use aes_gcm::{AeadInPlace as _, Aes256Gcm, KeyInit as _, Nonce};
 
 // ────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -111,7 +111,7 @@ pub fn detect_format(data: &[u8]) -> CacheFormat {
 ///
 /// Returns an error if encryption fails (should not happen with valid key).
 pub fn encrypt_cache(plaintext: &[u8], key: &[u8; 32]) -> io::Result<Vec<u8>> {
-    use rand::Rng;
+    use rand::Rng as _;
 
     let plaintext_len = plaintext.len() as u64; // usize→u64 lossless on 64-bit
 

--- a/crates/uffs-security/src/fs.rs
+++ b/crates/uffs-security/src/fs.rs
@@ -38,7 +38,7 @@ pub fn create_secure_dir(path: &Path) -> io::Result<()> {
 
     #[cfg(unix)]
     return {
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::PermissionsExt as _;
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
     };
 
@@ -65,7 +65,7 @@ pub fn create_secure_dir(path: &Path) -> io::Result<()> {
 pub fn set_file_permissions_owner_only(path: &Path) -> io::Result<()> {
     #[cfg(unix)]
     return {
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::PermissionsExt as _;
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
     };
 
@@ -129,7 +129,7 @@ fn win_clear_readonly(path: &Path) -> io::Result<()> {
 /// `OsStr`, and we only append a single null terminator.
 #[cfg(windows)]
 fn path_to_wide(path: &Path) -> Vec<u16> {
-    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::ffi::OsStrExt as _;
     path.as_os_str().encode_wide().chain(Some(0_u16)).collect()
 }
 
@@ -210,7 +210,7 @@ fn win_set_owner_only_acl(path: &Path) -> bool {
 ///
 /// Returns an error if writing, syncing, or renaming fails.
 pub fn atomic_write(path: &Path, data: &[u8]) -> io::Result<()> {
-    use std::io::Write;
+    use std::io::Write as _;
 
     let tmp_path = path.with_extension("uffs.tmp");
 
@@ -242,7 +242,7 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> io::Result<()> {
 ///
 /// Returns an error if overwriting, syncing, or removal fails.
 pub fn secure_remove(path: &Path) -> io::Result<()> {
-    use std::io::{Seek, SeekFrom, Write};
+    use std::io::{Seek as _, SeekFrom, Write as _};
 
     /// Size of the zero-fill buffer for secure wipe.
     const ZERO_BUF_SIZE: usize = 64 * 1024;
@@ -328,7 +328,7 @@ impl FileLock {
         kind: LockKind,
         timeout: core::time::Duration,
     ) -> io::Result<Self> {
-        use std::os::unix::io::AsRawFd;
+        use std::os::unix::io::AsRawFd as _;
 
         let file = std::fs::OpenOptions::new()
             .create(true)
@@ -390,7 +390,7 @@ impl FileLock {
         kind: LockKind,
         timeout: core::time::Duration,
     ) -> io::Result<Self> {
-        use std::os::windows::io::AsRawHandle;
+        use std::os::windows::io::AsRawHandle as _;
 
         /// Windows error code for lock contention.
         const ERROR_LOCK_VIOLATION: i32 = 33;

--- a/crates/uffs-security/src/keystore.rs
+++ b/crates/uffs-security/src/keystore.rs
@@ -71,7 +71,7 @@ pub fn get_cache_key() -> io::Result<[u8; KEY_SIZE]> {
 /// after multiple regeneration attempts).
 #[cfg(target_os = "macos")]
 fn keychain_key() -> io::Result<[u8; KEY_SIZE]> {
-    use rand::Rng;
+    use rand::Rng as _;
     use security_framework::passwords::{
         delete_generic_password, get_generic_password, set_generic_password,
     };
@@ -138,7 +138,7 @@ fn keychain_key() -> io::Result<[u8; KEY_SIZE]> {
 /// Returns an error if DPAPI access or file I/O fails.
 #[cfg(target_os = "windows")]
 pub fn get_cache_key() -> io::Result<[u8; KEY_SIZE]> {
-    use rand::Rng;
+    use rand::Rng as _;
     let key_path = dpapi_key_path()?;
 
     // Try to read and decrypt existing DPAPI blob
@@ -372,7 +372,7 @@ pub fn get_cache_key() -> io::Result<[u8; KEY_SIZE]> {
 /// Returns an error if filesystem access or key generation fails.
 #[cfg(not(target_os = "windows"))]
 fn file_based_key() -> io::Result<[u8; KEY_SIZE]> {
-    use rand::Rng;
+    use rand::Rng as _;
 
     let base = dirs_next::data_local_dir().ok_or_else(|| {
         io::Error::new(io::ErrorKind::NotFound, "cannot determine local data dir")

--- a/crates/uffs-security/src/runtime_dir.rs
+++ b/crates/uffs-security/src/runtime_dir.rs
@@ -276,7 +276,7 @@ fn parse_pid_dir_entry(entry_result: io::Result<std::fs::DirEntry>) -> Option<(P
 mod unix_impl {
     use std::fs::OpenOptions;
     use std::io;
-    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::fs::OpenOptionsExt as _;
     use std::path::Path;
 
     use super::{RuntimeDir, RuntimeFile, sweep_pid_directories};
@@ -363,8 +363,8 @@ mod windows_impl {
     use std::ffi::OsStr;
     use std::fs::File;
     use std::io;
-    use std::os::windows::ffi::OsStrExt;
-    use std::os::windows::io::FromRawHandle;
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::FromRawHandle as _;
     use std::path::Path;
 
     use windows::Win32::Foundation::CloseHandle;

--- a/crates/uffs-security/src/runtime_dir/tests.rs
+++ b/crates/uffs-security/src/runtime_dir/tests.rs
@@ -13,12 +13,12 @@
 //! * `mmap_read_only` round-trip covered against the real default impl on
 //!   whichever platform is running the test.
 
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 
 use tempfile::TempDir;
 
 use super::test_fake::TestRuntimeDir;
-use super::{DefaultRuntimeDir, RuntimeDir, mmap_read_only};
+use super::{DefaultRuntimeDir, RuntimeDir as _, mmap_read_only};
 
 // ─────────────────────────────────────────────────────────────────────
 // `create_owner_only` — happy path + duplicate-create rejection.
@@ -76,7 +76,7 @@ fn create_owner_only_rejects_existing_file() {
 #[cfg(unix)]
 #[test]
 fn create_owner_only_sets_0600_on_unix() {
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::PermissionsExt as _;
 
     let tmp = TempDir::new().expect("tempdir");
     let path = tmp.path().join("perms.live");


### PR DESCRIPTION
## Summary

Applies the four **R1** items from [`CLIPPY_POSTURE.md` §11 Roadmap](docs/dev/architecture/code_clean/CLIPPY_POSTURE.md) and drives every resulting violation to clean state across all three target surfaces — **no `#[allow]` introduced, no tests skipped or weakened, no behavioral / API changes**.

## What's in this PR

### Config — strict lint surface widens

| File | Change |
|------|--------|
| `clippy.toml` | `msrv = "1.91"` + `check-incompatible-msrv-in-tests = true` |
| `Cargo.toml [workspace.lints.clippy]` | `host_endian_bytes = "deny"`, `unused_result_ok = "deny"`, `unused_trait_names = "deny"` |

The `msrv` pin makes ~80 MSRV-aware Clippy lints fire reliably under `cargo clippy`, `cargo xwin clippy`, and `cargo zigbuild clippy` (they only honour `[workspace.package].rust-version` when also set explicitly in `clippy.toml`).

### Source — two idiomatic patterns, applied surgically

| Pattern | Sites | Why |
|---------|------:|-----|
| `expr.ok();` → `_ = expr;` | ~50 | The idiomatic discard satisfies *both* `unused_result_ok` (not `.ok()`) *and* `let_underscore_must_use` (not a `let` binding) without any `#[allow]`. |
| `use Trait;` → `use Trait as _;` | ~80 | Trait stays in scope for method resolution; only the redundant *name* binding is dropped. |

One small block-wrap in `crates/uffs-mft/src/commands/windows/benchmark_index.rs` so the existing `#[expect(unsafe_code, reason = "...")]` attaches reliably to the discarded unsafe expression (matches the working pattern already in `dataframe_read.rs` / `index_read.rs`).

### Doc — `CLIPPY_POSTURE.md` follows the config

- R1 moved from §11 (Roadmap) to **"Applied 2026-05-11"** with a roll-up.
- §4 bucket counts updated (Error+Safety 11→12, Portability 2→3, Unused/Dead-code 3→4; total ~95→~98).
- §7 `clippy.toml` table gains two `msrv` rows.
- §12 Decisions Log appended with **five** 2026-05-11 entries covering each lint and the `_ = expr;` discard convention.

## Verification

All four lint gates and the full pre-push bundle pass locally:

```
just lint-prod          ✅
just lint-tests         ✅
just lint-ci            ✅  (--all-targets -D warnings)
just lint-ci-windows    ✅  cargo xwin    → x86_64-pc-windows-msvc
just lint-ci-linux-zig  ✅  cargo zigbuild → x86_64-unknown-linux-gnu
just lint-pre-push      ✅  20/20 gates
```

Targeted `cargo nextest` of every affected module: **35/35 passing**.

## Rule-by-rule audit

1. **No suppression hacks** — zero new `#[allow]`, zero cfg-gated hiding, zero unjustified `#[expect]`.  The only attribute touched was an existing `#[expect(unsafe_code, reason = "...")]` whose scope was tightened to a `{ }` block; the reason string is preserved verbatim.
2. **Surgical, idiomatic fixes** — every transform is the minimal language-level construct that resolves the lint at the root: discard via `_ = …`, trait imports via `use … as _`.  No type changes, no ownership changes, no API surface changes.
3. **Preserve behavior & contracts** — `_ = expr;` and `expr.ok();` are semantically identical (both evaluate, both drop the result).  `use Trait as _;` leaves the trait fully available through method resolution; only nameable access is removed.  35/35 affected tests pass.
4. **Improve tests, don't dodge them** — no test deleted / skipped / `#[ignore]`-d, no `unwrap` / `expect` / `assert*` weakened.  Tests received the same `Trait as _` treatment as production code.
