### PR TITLE
chore(lint): apply clippy::redundant_test_prefix — 363 test renames (R2-05)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -55,8 +55,9 @@ store-failure-output = true
 # Usage: cargo nextest run --profile pre-push-smoke --locked
 #
 # Selection is a denylist expressed in nextest's filterset language:
-#   - Exclude the validation suite (`test_validate_*`) — heavy integration,
-#     runs in the CI `ci` profile.
+#   - Exclude the validation suite (`validate_*`) — heavy integration,
+#     runs in the CI `ci` profile.  (Pre-2026-05 these were named
+#     `test_validate_*`; renamed workspace-wide for clippy::redundant_test_prefix.)
 #   - Exclude the entire `uffs-client` package — its shmem tests serialise
 #     globally via `threads-required = num-cpus` and would dominate wall-time.
 #   - Everything else: unit tests across all remaining crates.
@@ -79,7 +80,7 @@ status-level = "fail"
 final-status-level = "flaky"
 
 default-filter = """
-    not test(/^test_validate/)
+    not test(/^validate/)
   & not package(uffs-client)
 """
 
@@ -103,7 +104,7 @@ final-status-level = "all"
 # ---------------------------------------------------------------------------
 # Integration / validation tests are heavyweight (disk I/O, large DataFrames).
 [[profile.default.overrides]]
-filter = 'test(/^test_validate/)'
+filter = 'test(/^validate/)'
 threads-required = 2
 slow-timeout = { period = "300s", terminate-after = 2 }
 

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -231,10 +231,10 @@ jobs:
           # compressed raw test uses foreign-function calls that Miri does not support.
           # --locked per §2.8 so miri evaluates the same resolved crate
           # graph as the rest of the workspace.
-          cargo miri test --locked -p uffs-mft raw::tests::test_header_roundtrip -- --exact
-          cargo miri test --locked -p uffs-mft raw::tests::test_load_header_only -- --exact
-          cargo miri test --locked -p uffs-mft raw::tests::test_save_load_uncompressed -- --exact
-          cargo miri test --locked -p uffs-mft raw::tests::test_raw_compat_mode -- --exact
+          cargo miri test --locked -p uffs-mft raw::tests::header_roundtrip -- --exact
+          cargo miri test --locked -p uffs-mft raw::tests::load_header_only -- --exact
+          cargo miri test --locked -p uffs-mft raw::tests::save_load_uncompressed -- --exact
+          cargo miri test --locked -p uffs-mft raw::tests::raw_compat_mode -- --exact
 
   tier-2-summary:
     name: Tier 2 / Summary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -509,6 +509,7 @@ std_instead_of_core = "deny"  # Use core when std not needed
 
 # ───── Testing hygiene ─────
 tests_outside_test_module = "deny" # Keep tests in test modules
+redundant_test_prefix = "deny"     # `fn test_foo` redundant inside `mod tests` — bare `fn foo`
 
 # ───── Unused / dead code ─────
 unused_async = "deny"       # Remove unused async

--- a/crates/uffs-cli/src/commands/output/output_tests.rs
+++ b/crates/uffs-cli/src/commands/output/output_tests.rs
@@ -81,7 +81,7 @@ fn large_sample_rows() -> Vec<serde_json::Value> {
 // ===================================================================
 
 #[test]
-fn test_write_native_csv_uses_columns_without_legacy_footer() -> TestResult {
+fn write_native_csv_uses_columns_without_legacy_footer() -> TestResult {
     let path = temp_output_path("csv");
     let rows = sample_rows();
 
@@ -109,7 +109,7 @@ fn test_write_native_csv_uses_columns_without_legacy_footer() -> TestResult {
 }
 
 #[test]
-fn test_write_native_custom_file_appends_legacy_drive_footer() -> TestResult {
+fn write_native_custom_file_appends_legacy_drive_footer() -> TestResult {
     let path = temp_output_path("txt");
     let rows = sample_rows();
 
@@ -147,7 +147,7 @@ fn test_write_native_custom_file_appends_legacy_drive_footer() -> TestResult {
 }
 
 #[test]
-fn test_write_native_json_file_has_no_footer() -> TestResult {
+fn write_native_json_file_has_no_footer() -> TestResult {
     let path = temp_output_path("json");
     let rows = sample_rows();
 
@@ -180,7 +180,7 @@ fn test_write_native_json_file_has_no_footer() -> TestResult {
 // ===================================================================
 
 #[test]
-fn test_legacy_footer_includes_fast_scan_message_for_full_scan_pattern() -> TestResult {
+fn legacy_footer_includes_fast_scan_message_for_full_scan_pattern() -> TestResult {
     let path = temp_output_path("txt");
     let rows = sample_rows();
 
@@ -209,7 +209,7 @@ fn test_legacy_footer_includes_fast_scan_message_for_full_scan_pattern() -> Test
 }
 
 #[test]
-fn test_legacy_footer_includes_fast_scan_for_transformed_pattern() -> TestResult {
+fn legacy_footer_includes_fast_scan_for_transformed_pattern() -> TestResult {
     let path = temp_output_path("txt");
     let rows = sample_rows();
 
@@ -238,7 +238,7 @@ fn test_legacy_footer_includes_fast_scan_for_transformed_pattern() -> TestResult
 }
 
 #[test]
-fn test_legacy_footer_omits_fast_scan_for_real_regex_pattern() -> TestResult {
+fn legacy_footer_omits_fast_scan_for_real_regex_pattern() -> TestResult {
     let path = temp_output_path("txt");
     let rows = sample_rows();
 
@@ -267,7 +267,7 @@ fn test_legacy_footer_omits_fast_scan_for_real_regex_pattern() -> TestResult {
 }
 
 #[test]
-fn test_legacy_footer_omits_fast_scan_message_when_many_results() -> TestResult {
+fn legacy_footer_omits_fast_scan_message_when_many_results() -> TestResult {
     let path = temp_output_path("txt");
     let rows = large_sample_rows();
 

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -646,14 +646,14 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_drive_letter_accepts_letter_colon_and_whitespace_variants() {
+    fn parse_drive_letter_accepts_letter_colon_and_whitespace_variants() {
         assert_eq!(parse_drive_letter("c"), Ok('C'));
         assert_eq!(parse_drive_letter("C:"), Ok('C'));
         assert_eq!(parse_drive_letter(" d: "), Ok('D'));
     }
 
     #[test]
-    fn test_parse_drive_letter_rejects_invalid_values() {
+    fn parse_drive_letter_rejects_invalid_values() {
         parse_drive_letter("").unwrap_err();
         parse_drive_letter("12").unwrap_err();
         parse_drive_letter("1:").unwrap_err();
@@ -661,7 +661,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_cli_args_basic_search() {
+    fn from_cli_args_basic_search() {
         let args: Vec<String> = [
             "*.rs",
             "--drive",
@@ -688,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_cli_args_sugar_begins_with() {
+    fn from_cli_args_sugar_begins_with() {
         let args: Vec<String> = ["--begins-with", "report"]
             .iter()
             .map(ToString::to_string)
@@ -698,7 +698,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_cli_args_sugar_between() {
+    fn from_cli_args_sugar_between() {
         let args: Vec<String> = ["*", "--between", "2026-01-01,2026-03-31"]
             .iter()
             .map(ToString::to_string)

--- a/crates/uffs-cli/tests/cli_integration.rs
+++ b/crates/uffs-cli/tests/cli_integration.rs
@@ -71,7 +71,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_args_prints_top_level_help() {
+    fn no_args_prints_top_level_help() {
         assert_success("no_args_help", &[], &[
             "uffs - Ultra Fast File Search",
             "USAGE:",
@@ -79,7 +79,7 @@ mod tests {
     }
 
     #[test]
-    fn test_help_flag_prints_examples() {
+    fn help_flag_prints_examples() {
         assert_success("help_flag", &["--help"], &[
             "Search is the default action",
             "uffs '*.txt'",
@@ -87,7 +87,7 @@ mod tests {
     }
 
     #[test]
-    fn test_version_flag_prints_binary_version() {
+    fn version_flag_prints_binary_version() {
         assert_success("version_flag", &["--version"], &[
             "uffs",
             env!("CARGO_PKG_VERSION"),
@@ -104,7 +104,7 @@ mod tests {
     // Stats subcommand validation is still client-side.
 
     #[test]
-    fn test_stats_rejects_non_numeric_top() {
+    fn stats_rejects_non_numeric_top() {
         assert_failure(
             "stats_invalid_top",
             &["stats", "saved.parquet", "--top", "abc"],
@@ -118,7 +118,7 @@ mod tests {
     // We keep smoke tests that don't require a running daemon.
 
     #[test]
-    fn test_name_only_accepts_plain_literal() {
+    fn name_only_accepts_plain_literal() {
         // Should not error with "--name-only cannot be used with path
         // patterns". The command will fail because no daemon is running,
         // but the validation error should not appear.
@@ -136,7 +136,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name_only_accepts_glob_pattern() {
+    fn name_only_accepts_glob_pattern() {
         let output = run_cli("name_only_glob", &[
             "*.txt",
             "--name-only",
@@ -151,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name_only_accepts_regex_with_backslash_escapes() {
+    fn name_only_accepts_regex_with_backslash_escapes() {
         let output = run_cli("name_only_regex", &[
             r">.*\.(jpg|png)",
             "--name-only",

--- a/crates/uffs-core/src/compiled_pattern/tests.rs
+++ b/crates/uffs-core/src/compiled_pattern/tests.rs
@@ -13,49 +13,49 @@ type TestResult = Result<(), Box<dyn core::error::Error>>;
 // ============================================================================
 
 #[test]
-fn test_classify_any() {
+fn classify_any() {
     assert!(matches!(classify_glob("*"), GlobKind::Any));
 }
 
 #[test]
-fn test_classify_exact() {
+fn classify_exact() {
     let kind = classify_glob("readme.txt");
     assert!(matches!(kind, GlobKind::Exact(val) if val == "readme.txt"));
 }
 
 #[test]
-fn test_classify_prefix() {
+fn classify_prefix() {
     let kind = classify_glob("foo*");
     assert!(matches!(kind, GlobKind::Prefix(val) if val == "foo"));
 }
 
 #[test]
-fn test_classify_suffix() {
+fn classify_suffix() {
     let kind = classify_glob("*bar");
     assert!(matches!(kind, GlobKind::Suffix(val) if val == "bar"));
 }
 
 #[test]
-fn test_classify_extension() {
+fn classify_extension() {
     let kind = classify_glob("*.txt");
     assert!(matches!(kind, GlobKind::Extension(val) if val == "txt"));
 }
 
 #[test]
-fn test_classify_extension_multi_part() {
+fn classify_extension_multi_part() {
     // *.tar.gz should be Suffix, not Extension (has multiple dots)
     let kind = classify_glob("*.tar.gz");
     assert!(matches!(kind, GlobKind::Suffix(val) if val == ".tar.gz"));
 }
 
 #[test]
-fn test_classify_contains() {
+fn classify_contains() {
     let kind = classify_glob("*needle*");
     assert!(matches!(kind, GlobKind::Contains(val) if val == "needle"));
 }
 
 #[test]
-fn test_classify_prefix_suffix() {
+fn classify_prefix_suffix() {
     let kind = classify_glob("foo*bar");
     assert!(
         matches!(kind, GlobKind::PrefixSuffix { prefix, suffix } if prefix == "foo" && suffix == "bar")
@@ -63,7 +63,7 @@ fn test_classify_prefix_suffix() {
 }
 
 #[test]
-fn test_classify_prefix_suffix_with_extension() {
+fn classify_prefix_suffix_with_extension() {
     let kind = classify_glob("foo*.txt");
     assert!(
         matches!(kind, GlobKind::PrefixSuffix { prefix, suffix } if prefix == "foo" && suffix == ".txt")
@@ -71,25 +71,25 @@ fn test_classify_prefix_suffix_with_extension() {
 }
 
 #[test]
-fn test_classify_complex_question_mark() {
+fn classify_complex_question_mark() {
     let kind = classify_glob("file?.txt");
     assert!(matches!(kind, GlobKind::Complex(_)));
 }
 
 #[test]
-fn test_classify_complex_bracket() {
+fn classify_complex_bracket() {
     let kind = classify_glob("[abc]*");
     assert!(matches!(kind, GlobKind::Complex(_)));
 }
 
 #[test]
-fn test_classify_complex_double_star() {
+fn classify_complex_double_star() {
     let kind = classify_glob("**/*.rs");
     assert!(matches!(kind, GlobKind::Complex(_)));
 }
 
 #[test]
-fn test_classify_complex_multiple_stars() {
+fn classify_complex_multiple_stars() {
     let kind = classify_glob("a*b*c");
     assert!(matches!(kind, GlobKind::Complex(_)));
 }
@@ -99,7 +99,7 @@ fn test_classify_complex_multiple_stars() {
 // ============================================================================
 
 #[test]
-fn test_compile_literal() -> TestResult {
+fn compile_literal() -> TestResult {
     let parsed = ParsedPattern::parse("readme")?;
     let compiled = compile_pattern(&parsed)?;
     assert!(matches!(compiled, CompiledPattern::Contains(val) if val == "readme"));
@@ -107,7 +107,7 @@ fn test_compile_literal() -> TestResult {
 }
 
 #[test]
-fn test_compile_glob_any() -> TestResult {
+fn compile_glob_any() -> TestResult {
     let parsed = ParsedPattern::parse("*")?;
     let compiled = compile_pattern(&parsed)?;
     assert!(matches!(compiled, CompiledPattern::Any));
@@ -115,7 +115,7 @@ fn test_compile_glob_any() -> TestResult {
 }
 
 #[test]
-fn test_compile_glob_prefix() -> TestResult {
+fn compile_glob_prefix() -> TestResult {
     let parsed = ParsedPattern::parse("foo*")?;
     let compiled = compile_pattern(&parsed)?;
     assert!(matches!(compiled, CompiledPattern::Prefix(val) if val == "foo"));
@@ -123,7 +123,7 @@ fn test_compile_glob_prefix() -> TestResult {
 }
 
 #[test]
-fn test_compile_glob_suffix() -> TestResult {
+fn compile_glob_suffix() -> TestResult {
     let parsed = ParsedPattern::parse("*bar")?;
     let compiled = compile_pattern(&parsed)?;
     assert!(matches!(compiled, CompiledPattern::Suffix(val) if val == "bar"));
@@ -131,7 +131,7 @@ fn test_compile_glob_suffix() -> TestResult {
 }
 
 #[test]
-fn test_compile_glob_extension() -> TestResult {
+fn compile_glob_extension() -> TestResult {
     let parsed = ParsedPattern::parse("*.txt")?;
     let compiled = compile_pattern(&parsed)?;
     // Extension becomes Suffix with the dot
@@ -140,7 +140,7 @@ fn test_compile_glob_extension() -> TestResult {
 }
 
 #[test]
-fn test_compile_glob_contains() -> TestResult {
+fn compile_glob_contains() -> TestResult {
     let parsed = ParsedPattern::parse("*needle*")?;
     let compiled = compile_pattern(&parsed)?;
     assert!(matches!(compiled, CompiledPattern::Contains(val) if val == "needle"));
@@ -148,7 +148,7 @@ fn test_compile_glob_contains() -> TestResult {
 }
 
 #[test]
-fn test_compile_glob_prefix_suffix() -> TestResult {
+fn compile_glob_prefix_suffix() -> TestResult {
     let parsed = ParsedPattern::parse("foo*bar")?;
     let compiled = compile_pattern(&parsed)?;
     assert!(
@@ -158,7 +158,7 @@ fn test_compile_glob_prefix_suffix() -> TestResult {
 }
 
 #[test]
-fn test_compile_glob_complex() -> TestResult {
+fn compile_glob_complex() -> TestResult {
     let parsed = ParsedPattern::parse("file?.txt")?;
     let compiled = compile_pattern(&parsed)?;
     assert!(matches!(compiled, CompiledPattern::Regex {
@@ -169,7 +169,7 @@ fn test_compile_glob_complex() -> TestResult {
 }
 
 #[test]
-fn test_compile_regex() -> TestResult {
+fn compile_regex() -> TestResult {
     let parsed = ParsedPattern::parse(r">.*\.log$")?;
     let compiled = compile_pattern(&parsed)?;
     assert!(matches!(compiled, CompiledPattern::Regex {
@@ -180,7 +180,7 @@ fn test_compile_regex() -> TestResult {
 }
 
 #[test]
-fn test_compile_exact_no_wildcards() -> TestResult {
+fn compile_exact_no_wildcards() -> TestResult {
     let parsed = ParsedPattern::parse("README.md")?;
     // This is detected as Literal by ParsedPattern, so becomes Contains
     let compiled = compile_pattern(&parsed)?;
@@ -193,7 +193,7 @@ fn test_compile_exact_no_wildcards() -> TestResult {
 // ============================================================================
 
 #[test]
-fn test_to_expr_any() {
+fn to_expr_any() {
     let pattern = CompiledPattern::Any;
     let expr = pattern.to_expr("name", true);
     // Should produce lit(true)
@@ -202,7 +202,7 @@ fn test_to_expr_any() {
 }
 
 #[test]
-fn test_to_expr_exact() {
+fn to_expr_exact() {
     let pattern = CompiledPattern::Exact("README.md".to_owned());
     let expr = pattern.to_expr("name", true);
     let expr_str = format!("{expr:?}");
@@ -214,7 +214,7 @@ fn test_to_expr_exact() {
 }
 
 #[test]
-fn test_to_expr_prefix() {
+fn to_expr_prefix() {
     let pattern = CompiledPattern::Prefix("foo".to_owned());
     let expr = pattern.to_expr("name", true);
     let expr_str = format!("{expr:?}");
@@ -225,7 +225,7 @@ fn test_to_expr_prefix() {
 }
 
 #[test]
-fn test_to_expr_suffix() {
+fn to_expr_suffix() {
     let pattern = CompiledPattern::Suffix(".txt".to_owned());
     let expr = pattern.to_expr("name", true);
     let expr_str = format!("{expr:?}");
@@ -236,7 +236,7 @@ fn test_to_expr_suffix() {
 }
 
 #[test]
-fn test_to_expr_contains() {
+fn to_expr_contains() {
     let pattern = CompiledPattern::Contains("needle".to_owned());
     let expr = pattern.to_expr("name", true);
     let expr_str = format!("{expr:?}");
@@ -247,7 +247,7 @@ fn test_to_expr_contains() {
 }
 
 #[test]
-fn test_to_expr_prefix_suffix() {
+fn to_expr_prefix_suffix() {
     let pattern = CompiledPattern::PrefixSuffix {
         prefix: "foo".to_owned(),
         suffix: "bar".to_owned(),
@@ -261,7 +261,7 @@ fn test_to_expr_prefix_suffix() {
 }
 
 #[test]
-fn test_to_expr_exact_set() {
+fn to_expr_exact_set() {
     let pattern = CompiledPattern::ExactSet(vec!["README.md".to_owned(), "LICENSE".to_owned()]);
     let expr = pattern.to_expr("name", true);
     let expr_str = format!("{expr:?}");
@@ -272,7 +272,7 @@ fn test_to_expr_exact_set() {
 }
 
 #[test]
-fn test_to_expr_contains_any() {
+fn to_expr_contains_any() {
     let pattern = CompiledPattern::ContainsAny(vec!["foo".to_owned(), "bar".to_owned()]);
     let expr = pattern.to_expr("name", true);
     let expr_str = format!("{expr:?}");
@@ -283,7 +283,7 @@ fn test_to_expr_contains_any() {
 }
 
 #[test]
-fn test_to_expr_suffix_set() {
+fn to_expr_suffix_set() {
     let pattern = CompiledPattern::SuffixSet(vec![".txt".to_owned(), ".md".to_owned()]);
     let expr = pattern.to_expr("name", true);
     let expr_str = format!("{expr:?}");
@@ -294,7 +294,7 @@ fn test_to_expr_suffix_set() {
 }
 
 #[test]
-fn test_to_expr_regex() {
+fn to_expr_regex() {
     let pattern = CompiledPattern::Regex {
         pattern: r".*\.log$".to_owned(),
         anchored: false,
@@ -308,7 +308,7 @@ fn test_to_expr_regex() {
 }
 
 #[test]
-fn test_to_expr_case_insensitive() {
+fn to_expr_case_insensitive() {
     let pattern = CompiledPattern::Suffix(".TXT".to_owned());
     let expr = pattern.to_expr("name", false);
     let expr_str = format!("{expr:?}");
@@ -320,7 +320,7 @@ fn test_to_expr_case_insensitive() {
 }
 
 #[test]
-fn test_to_expr_suffix_set_empty() {
+fn to_expr_suffix_set_empty() {
     let pattern = CompiledPattern::SuffixSet(vec![]);
     let expr = pattern.to_expr("name", true);
     let expr_str = format!("{expr:?}");
@@ -336,7 +336,7 @@ fn test_to_expr_suffix_set_empty() {
 // ============================================================================
 
 #[test]
-fn test_suffix_case_insensitive_integration() -> TestResult {
+fn suffix_case_insensitive_integration() -> TestResult {
     use uffs_polars::{Column, DataFrame, IntoLazy as _};
 
     // Create test DataFrame with various filenames
@@ -368,7 +368,7 @@ fn test_suffix_case_insensitive_integration() -> TestResult {
 }
 
 #[test]
-fn test_suffix_case_sensitive_integration() -> TestResult {
+fn suffix_case_sensitive_integration() -> TestResult {
     use uffs_polars::{Column, DataFrame, IntoLazy as _};
 
     let input_names = vec![
@@ -400,7 +400,7 @@ fn test_suffix_case_sensitive_integration() -> TestResult {
 }
 
 #[test]
-fn test_dollar_prefix_files_matched() -> TestResult {
+fn dollar_prefix_files_matched() -> TestResult {
     use uffs_polars::{Column, DataFrame, IntoLazy as _};
 
     let input_names = vec![
@@ -444,7 +444,7 @@ fn test_dollar_prefix_files_matched() -> TestResult {
 }
 
 #[test]
-fn test_null_values_not_filtered() -> TestResult {
+fn null_values_not_filtered() -> TestResult {
     use uffs_polars::{Column, DataFrame, IntoLazy as _};
 
     // Create test DataFrame with null values

--- a/crates/uffs-core/src/export.rs
+++ b/crates/uffs-core/src/export.rs
@@ -64,7 +64,7 @@ mod tests {
     }
 
     #[test]
-    fn test_export_table() -> TestResult {
+    fn export_table_works() -> TestResult {
         let df = create_test_df()?;
         let mut output = Vec::new();
         export_table(&df, &mut output)?;
@@ -75,7 +75,7 @@ mod tests {
     }
 
     #[test]
-    fn test_export_json() -> TestResult {
+    fn export_json_works() -> TestResult {
         let df = create_test_df()?;
         let mut output = Vec::new();
         export_json(&df, &mut output)?;
@@ -85,7 +85,7 @@ mod tests {
     }
 
     #[test]
-    fn test_export_csv() -> TestResult {
+    fn export_csv_works() -> TestResult {
         let df = create_test_df()?;
         let mut output = Vec::new();
         export_csv(&df, &mut output)?;

--- a/crates/uffs-core/src/extensions/tests.rs
+++ b/crates/uffs-core/src/extensions/tests.rs
@@ -9,7 +9,7 @@ use super::*;
 type TestResult = core::result::Result<(), Box<dyn core::error::Error>>;
 
 #[test]
-fn test_parse_single_extension() {
+fn parse_single_extension() {
     let filter = ExtensionFilter::parse("jpg").unwrap();
     assert!(filter.matches("photo.jpg"));
     assert!(filter.matches("PHOTO.JPG"));
@@ -17,7 +17,7 @@ fn test_parse_single_extension() {
 }
 
 #[test]
-fn test_parse_multiple_extensions() {
+fn parse_multiple_extensions() {
     let filter = ExtensionFilter::parse("jpg,png,gif").unwrap();
     assert!(filter.matches("photo.jpg"));
     assert!(filter.matches("image.png"));
@@ -26,14 +26,14 @@ fn test_parse_multiple_extensions() {
 }
 
 #[test]
-fn test_parse_with_dots() {
+fn parse_with_dots() {
     let filter = ExtensionFilter::parse(".jpg,.png").unwrap();
     assert!(filter.matches("photo.jpg"));
     assert!(filter.matches("image.png"));
 }
 
 #[test]
-fn test_pictures_collection() {
+fn pictures_collection() {
     let filter = ExtensionFilter::parse("pictures").unwrap();
     assert!(filter.matches("photo.jpg"));
     assert!(filter.matches("image.png"));
@@ -42,7 +42,7 @@ fn test_pictures_collection() {
 }
 
 #[test]
-fn test_documents_collection() {
+fn documents_collection() {
     let filter = ExtensionFilter::parse("documents").unwrap();
     assert!(filter.matches("report.pdf"));
     assert!(filter.matches("letter.docx"));
@@ -51,7 +51,7 @@ fn test_documents_collection() {
 }
 
 #[test]
-fn test_mixed_collection_and_extensions() {
+fn mixed_collection_and_extensions() {
     let filter = ExtensionFilter::parse("pictures,mp4,pdf").unwrap();
     assert!(filter.matches("photo.jpg"));
     assert!(filter.matches("video.mp4"));
@@ -60,13 +60,13 @@ fn test_mixed_collection_and_extensions() {
 }
 
 #[test]
-fn test_empty_error() {
+fn empty_error() {
     ExtensionFilter::parse("").unwrap_err();
     ExtensionFilter::parse("   ").unwrap_err();
 }
 
 #[test]
-fn test_to_regex() {
+fn to_regex() {
     let filter = ExtensionFilter::parse("jpg,png").unwrap();
     let regex = filter.to_regex();
     assert!(regex.contains("jpg"));
@@ -76,7 +76,7 @@ fn test_to_regex() {
 }
 
 #[test]
-fn test_no_extension_file() {
+fn no_extension_file() {
     let filter = ExtensionFilter::parse("txt").unwrap();
     assert!(!filter.matches("README"));
     assert!(!filter.matches("Makefile"));
@@ -102,7 +102,7 @@ fn create_ext_test_df() -> DataFrame {
 }
 
 #[test]
-fn test_extension_index_build() -> TestResult {
+fn extension_index_build() -> TestResult {
     let df = create_ext_test_df();
     let index = ExtensionIndex::build(&df)?;
 
@@ -112,7 +112,7 @@ fn test_extension_index_build() -> TestResult {
 }
 
 #[test]
-fn test_extension_index_get() -> TestResult {
+fn extension_index_get() -> TestResult {
     let df = create_ext_test_df();
     let index = ExtensionIndex::build(&df)?;
 
@@ -131,7 +131,7 @@ fn test_extension_index_get() -> TestResult {
 }
 
 #[test]
-fn test_extension_index_case_insensitive() -> TestResult {
+fn extension_index_case_insensitive() -> TestResult {
     let df = create_ext_test_df();
     let index = ExtensionIndex::build(&df)?;
 
@@ -143,7 +143,7 @@ fn test_extension_index_case_insensitive() -> TestResult {
 }
 
 #[test]
-fn test_extension_index_stats() -> TestResult {
+fn extension_index_stats() -> TestResult {
     let df = create_ext_test_df();
     let index = ExtensionIndex::build(&df)?;
 
@@ -156,7 +156,7 @@ fn test_extension_index_stats() -> TestResult {
 }
 
 #[test]
-fn test_extension_index_hidden_files() -> TestResult {
+fn extension_index_hidden_files() -> TestResult {
     let df = DataFrame::new_infer_height(vec![
         Column::new("frs".into(), &[1_u64, 2, 3]),
         Column::new("name".into(), &[".gitignore", ".bashrc", "file.txt"]),
@@ -176,7 +176,7 @@ fn test_extension_index_hidden_files() -> TestResult {
 // =========================================================================
 
 #[test]
-fn test_add_ext_column() -> TestResult {
+fn add_ext_column_works() -> TestResult {
     let df = DataFrame::new_infer_height(vec![
         Column::new("frs".into(), &[1_u64, 2, 3, 4, 5]),
         Column::new("name".into(), &[
@@ -205,7 +205,7 @@ fn test_add_ext_column() -> TestResult {
 }
 
 #[test]
-fn test_has_ext_column() -> TestResult {
+fn has_ext_column_works() -> TestResult {
     let df_without = DataFrame::new_infer_height(vec![
         Column::new("frs".into(), &[1_u64]),
         Column::new("name".into(), &["file.txt"]),
@@ -220,7 +220,7 @@ fn test_has_ext_column() -> TestResult {
 }
 
 #[test]
-fn test_ext_expr_lowercase() -> TestResult {
+fn ext_expr_lowercase() -> TestResult {
     let df = DataFrame::new_infer_height(vec![
         Column::new("frs".into(), &[1_u64, 2]),
         Column::new("name".into(), &["Photo.JPG", "Document.TXT"]),

--- a/crates/uffs-core/src/glob.rs
+++ b/crates/uffs-core/src/glob.rs
@@ -98,42 +98,42 @@ mod tests {
     type TestResult = core::result::Result<(), Box<dyn core::error::Error>>;
 
     #[test]
-    fn test_simple_extension() -> TestResult {
+    fn simple_extension() -> TestResult {
         let regex = glob_to_regex("*.rs")?;
         assert_eq!(regex, "^[^/\\\\]*\\.rs$");
         Ok(())
     }
 
     #[test]
-    fn test_double_star() -> TestResult {
+    fn double_star() -> TestResult {
         let regex = glob_to_regex("**/*.rs")?;
         assert_eq!(regex, "^.*/[^/\\\\]*\\.rs$");
         Ok(())
     }
 
     #[test]
-    fn test_question_mark() -> TestResult {
+    fn question_mark() -> TestResult {
         let regex = glob_to_regex("file?.txt")?;
         assert_eq!(regex, "^file[^/\\\\]\\.txt$");
         Ok(())
     }
 
     #[test]
-    fn test_character_class() -> TestResult {
+    fn character_class() -> TestResult {
         let regex = glob_to_regex("[abc].txt")?;
         assert_eq!(regex, "^[abc]\\.txt$");
         Ok(())
     }
 
     #[test]
-    fn test_negated_class() -> TestResult {
+    fn negated_class() -> TestResult {
         let regex = glob_to_regex("[!abc].txt")?;
         assert_eq!(regex, "^[^abc]\\.txt$");
         Ok(())
     }
 
     #[test]
-    fn test_unclosed_bracket() {
+    fn unclosed_bracket() {
         let result = glob_to_regex("[abc");
         result.unwrap_err();
     }

--- a/crates/uffs-core/src/index_search/tests.rs
+++ b/crates/uffs-core/src/index_search/tests.rs
@@ -115,14 +115,14 @@ fn build_index_query_fixture() -> Result<MftIndex, TestError> {
 }
 
 #[test]
-fn test_pattern_any() {
+fn pattern_any() {
     let pattern = compile_index_pattern("*").unwrap();
     assert!(pattern.matches("anything", true, fold()));
     assert!(pattern.matches("", true, fold()));
 }
 
 #[test]
-fn test_pattern_exact() {
+fn pattern_exact() {
     let pattern = compile_index_pattern("foo.txt").unwrap();
     assert!(pattern.matches("foo.txt", true, fold()));
     assert!(!pattern.matches("FOO.TXT", true, fold()));
@@ -131,7 +131,7 @@ fn test_pattern_exact() {
 }
 
 #[test]
-fn test_pattern_prefix() {
+fn pattern_prefix() {
     let pattern = compile_index_pattern("foo*").unwrap();
     assert!(pattern.matches("foo", true, fold()));
     assert!(pattern.matches("foobar", true, fold()));
@@ -140,7 +140,7 @@ fn test_pattern_prefix() {
 }
 
 #[test]
-fn test_pattern_suffix() {
+fn pattern_suffix() {
     let pattern = compile_index_pattern("*.txt").unwrap();
     assert!(pattern.matches("foo.txt", true, fold()));
     assert!(pattern.matches(".txt", true, fold()));
@@ -149,7 +149,7 @@ fn test_pattern_suffix() {
 }
 
 #[test]
-fn test_pattern_contains() {
+fn pattern_contains() {
     let pattern = compile_index_pattern("*needle*").unwrap();
     assert!(pattern.matches("needle", true, fold()));
     assert!(pattern.matches("haystackneedlehaystack", true, fold()));
@@ -158,7 +158,7 @@ fn test_pattern_contains() {
 }
 
 #[test]
-fn test_pattern_prefix_suffix() {
+fn pattern_prefix_suffix() {
     let pattern = compile_index_pattern("foo*bar").unwrap();
     assert!(pattern.matches("foobar", true, fold()));
     assert!(pattern.matches("foo123bar", true, fold()));
@@ -167,7 +167,7 @@ fn test_pattern_prefix_suffix() {
 }
 
 #[test]
-fn test_extensions() {
+fn extensions() {
     let pattern = compile_extensions(&["rs", "toml"]);
     assert!(pattern.matches("main.rs", true, fold()));
     assert!(pattern.matches("Cargo.toml", true, fold()));
@@ -176,7 +176,7 @@ fn test_extensions() {
 }
 
 #[test]
-fn test_extension_index_integration() {
+fn extension_index_integration() {
     let mut index = MftIndex::new('C');
     let root_name_offset = index.add_name(".");
     let root = index.get_or_create(ROOT_FRS);
@@ -226,7 +226,7 @@ fn test_extension_index_integration() {
 }
 
 #[test]
-fn test_index_query_count_applies_record_filters() -> TestResult {
+fn index_query_count_applies_record_filters() -> TestResult {
     let index = build_index_query_fixture()?;
 
     assert_eq!(
@@ -239,7 +239,7 @@ fn test_index_query_count_applies_record_filters() -> TestResult {
 }
 
 #[test]
-fn test_index_query_collect_respects_name_and_stream_expansion_toggles() -> TestResult {
+fn index_query_collect_respects_name_and_stream_expansion_toggles() -> TestResult {
     let index = build_index_query_fixture()?;
 
     let expanded = IndexQuery::new(&index)
@@ -316,7 +316,7 @@ fn test_index_query_collect_respects_name_and_stream_expansion_toggles() -> Test
 }
 
 #[test]
-fn test_index_query_collect_resolves_paths_for_hard_links_and_ads() -> TestResult {
+fn index_query_collect_resolves_paths_for_hard_links_and_ads() -> TestResult {
     let index = build_index_query_fixture()?;
 
     let results = IndexQuery::new(&index)
@@ -339,7 +339,7 @@ fn test_index_query_collect_resolves_paths_for_hard_links_and_ads() -> TestResul
 }
 
 #[test]
-fn test_index_query_collect_any_pattern_matches_full_scan_results() -> TestResult {
+fn index_query_collect_any_pattern_matches_full_scan_results() -> TestResult {
     let index = build_index_query_fixture()?;
 
     let mut no_pattern: Vec<_> = IndexQuery::new(&index)
@@ -365,7 +365,7 @@ fn test_index_query_collect_any_pattern_matches_full_scan_results() -> TestResul
 }
 
 #[test]
-fn test_query_mode_from_str() {
+fn query_mode_from_str() {
     assert_eq!(QueryMode::from_str_opt("auto"), Some(QueryMode::Auto));
     assert_eq!(QueryMode::from_str_opt("hybrid"), Some(QueryMode::Auto));
     assert_eq!(
@@ -389,14 +389,14 @@ fn test_query_mode_from_str() {
 }
 
 #[test]
-fn test_query_mode_display() {
+fn query_mode_display() {
     assert_eq!(QueryMode::Auto.to_string(), "auto");
     assert_eq!(QueryMode::ForceIndex.to_string(), "index");
     assert_eq!(QueryMode::ForceDataFrame.to_string(), "dataframe");
 }
 
 #[test]
-fn test_query_features_requires_dataframe() {
+fn query_features_requires_dataframe() {
     let empty = QueryFeatures::empty();
     assert!(!empty.requires_dataframe());
 
@@ -418,7 +418,7 @@ fn test_query_features_requires_dataframe() {
 }
 
 #[test]
-fn test_analyze_pattern_complexity() {
+fn analyze_pattern_complexity_works() {
     let any = compile_index_pattern("*").unwrap();
     assert_eq!(analyze_pattern_complexity(&any), QueryComplexity::Simple);
 
@@ -437,7 +437,7 @@ fn test_analyze_pattern_complexity() {
 // =========================================================================
 
 #[test]
-fn test_or_first_match() {
+fn or_first_match() {
     let parsed = crate::pattern::ParsedPattern::parse("*.txt|*.log").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
     assert!(
@@ -447,7 +447,7 @@ fn test_or_first_match() {
 }
 
 #[test]
-fn test_or_second_match() {
+fn or_second_match() {
     let parsed = crate::pattern::ParsedPattern::parse("*.txt|*.log").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
     assert!(
@@ -457,7 +457,7 @@ fn test_or_second_match() {
 }
 
 #[test]
-fn test_or_no_match() {
+fn or_no_match() {
     let parsed = crate::pattern::ParsedPattern::parse("*.txt|*.log").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
     assert!(
@@ -467,7 +467,7 @@ fn test_or_no_match() {
 }
 
 #[test]
-fn test_or_both_match() {
+fn or_both_match() {
     let parsed = crate::pattern::ParsedPattern::parse("foo*|*bar").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
     assert!(
@@ -477,7 +477,7 @@ fn test_or_both_match() {
 }
 
 #[test]
-fn test_or_multi_alternatives() {
+fn or_multi_alternatives() {
     let parsed = crate::pattern::ParsedPattern::parse("nice|cool|awesome").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
     assert!(
@@ -491,7 +491,7 @@ fn test_or_multi_alternatives() {
 }
 
 #[test]
-fn test_or_pattern_is_simple_complexity() {
+fn or_pattern_is_simple_complexity() {
     let parsed = crate::pattern::ParsedPattern::parse("*.txt|*.log").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
     assert_eq!(
@@ -505,7 +505,7 @@ fn test_or_pattern_is_simple_complexity() {
 // =========================================================================
 
 #[test]
-fn test_case_insensitive_default() {
+fn case_insensitive_default() {
     let pattern = compile_index_pattern("nice").unwrap();
     assert!(
         pattern.matches("Nice", false, fold()),
@@ -514,7 +514,7 @@ fn test_case_insensitive_default() {
 }
 
 #[test]
-fn test_case_insensitive_upper() {
+fn case_insensitive_upper() {
     let pattern = compile_index_pattern("nice").unwrap();
     assert!(
         pattern.matches("NICE", false, fold()),
@@ -523,7 +523,7 @@ fn test_case_insensitive_upper() {
 }
 
 #[test]
-fn test_case_sensitive_mismatch() {
+fn case_sensitive_mismatch() {
     let pattern = compile_index_pattern("nice").unwrap();
     assert!(
         !pattern.matches("Nice", true, fold()),
@@ -532,7 +532,7 @@ fn test_case_sensitive_mismatch() {
 }
 
 #[test]
-fn test_case_sensitive_exact() {
+fn case_sensitive_exact() {
     let pattern = compile_index_pattern("nice").unwrap();
     assert!(
         pattern.matches("nice", true, fold()),
@@ -541,7 +541,7 @@ fn test_case_sensitive_exact() {
 }
 
 #[test]
-fn test_case_insensitive_glob_suffix() {
+fn case_insensitive_glob_suffix() {
     let pattern = compile_index_pattern("*.TXT").unwrap();
     assert!(
         pattern.matches("file.txt", false, fold()),
@@ -550,7 +550,7 @@ fn test_case_insensitive_glob_suffix() {
 }
 
 #[test]
-fn test_case_sensitive_glob_suffix() {
+fn case_sensitive_glob_suffix() {
     let pattern = compile_index_pattern("*.TXT").unwrap();
     assert!(
         !pattern.matches("file.txt", true, fold()),
@@ -563,7 +563,7 @@ fn test_case_sensitive_glob_suffix() {
 // =========================================================================
 
 #[test]
-fn test_literal_substring_match() {
+fn literal_substring_match() {
     // Literal patterns go through compile_parsed_pattern which converts to Contains
     let parsed = crate::pattern::ParsedPattern::parse("nice").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
@@ -582,7 +582,7 @@ fn test_literal_substring_match() {
 }
 
 #[test]
-fn test_literal_no_substring_match() {
+fn literal_no_substring_match() {
     let parsed = crate::pattern::ParsedPattern::parse("nice").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
     assert!(
@@ -596,7 +596,7 @@ fn test_literal_no_substring_match() {
 // =========================================================================
 
 #[test]
-fn test_any_matches_everything() {
+fn any_matches_everything() {
     let pattern = compile_index_pattern("*").unwrap();
     assert!(pattern.matches("anything.txt", false, fold()));
     assert!(pattern.matches("", false, fold()));
@@ -604,7 +604,7 @@ fn test_any_matches_everything() {
 }
 
 #[test]
-fn test_prefix_match() {
+fn prefix_match() {
     let pattern = compile_index_pattern("foo*").unwrap();
     assert!(pattern.matches("foobar", false, fold()));
     assert!(pattern.matches("FOO", false, fold()));
@@ -612,7 +612,7 @@ fn test_prefix_match() {
 }
 
 #[test]
-fn test_suffix_match() {
+fn suffix_match() {
     let pattern = compile_index_pattern("*.rs").unwrap();
     assert!(pattern.matches("main.rs", false, fold()));
     assert!(pattern.matches("MAIN.RS", false, fold()));
@@ -620,7 +620,7 @@ fn test_suffix_match() {
 }
 
 #[test]
-fn test_contains_match() {
+fn contains_match() {
     let pattern = compile_index_pattern("*needle*").unwrap();
     assert!(pattern.matches("hayneedlehay", false, fold()));
     assert!(pattern.matches("NEEDLE", false, fold()));
@@ -628,7 +628,7 @@ fn test_contains_match() {
 }
 
 #[test]
-fn test_regex_match() {
+fn regex_match() {
     let parsed = crate::pattern::ParsedPattern::parse(r">file\d+\.txt").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
     assert!(pattern.matches("file123.txt", false, fold()));
@@ -644,7 +644,7 @@ fn test_regex_match() {
 // =========================================================================
 
 #[test]
-fn test_regex_rejects_extension_appearing_mid_filename() {
+fn regex_rejects_extension_appearing_mid_filename() {
     // "icon.png.vir" should NOT match — the file ends with .vir, not .png
     let parsed = crate::pattern::ParsedPattern::parse(r">.*\.(jpg|png|heic)").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
@@ -655,7 +655,7 @@ fn test_regex_rejects_extension_appearing_mid_filename() {
 }
 
 #[test]
-fn test_regex_rejects_ads_entries() {
+fn regex_rejects_ads_entries() {
     // ADS entries like "photo.png:com.dropbox.attrs" should NOT match
     let parsed = crate::pattern::ParsedPattern::parse(r">.*\.(jpg|png|heic)").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
@@ -666,7 +666,7 @@ fn test_regex_rejects_ads_entries() {
 }
 
 #[test]
-fn test_regex_matches_correct_extensions() {
+fn regex_matches_correct_extensions() {
     let parsed = crate::pattern::ParsedPattern::parse(r">.*\.(jpg|png|heic)").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
 
@@ -681,7 +681,7 @@ fn test_regex_matches_correct_extensions() {
 }
 
 #[test]
-fn test_regex_with_explicit_dollar_anchor_not_doubled() {
+fn regex_with_explicit_dollar_anchor_not_doubled() {
     // If the user already wrote $, we should not double it
     let parsed = crate::pattern::ParsedPattern::parse(r">.*\.txt$").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
@@ -691,7 +691,7 @@ fn test_regex_with_explicit_dollar_anchor_not_doubled() {
 }
 
 #[test]
-fn test_regex_single_extension() {
+fn regex_single_extension() {
     let parsed = crate::pattern::ParsedPattern::parse(r">.*\.txt").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
 
@@ -702,7 +702,7 @@ fn test_regex_single_extension() {
 }
 
 #[test]
-fn test_regex_path_prefix_with_extension() {
+fn regex_path_prefix_with_extension() {
     // Regex with path prefix: only match .jpg files under C:\Users
     let parsed = crate::pattern::ParsedPattern::parse(r">C:\\Users\\.*\.(jpg|png|heic)").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
@@ -720,7 +720,7 @@ fn test_regex_path_prefix_with_extension() {
 }
 
 #[test]
-fn test_regex_digit_pattern_still_anchored() {
+fn regex_digit_pattern_still_anchored() {
     // Non-extension regex should also be end-anchored
     let parsed = crate::pattern::ParsedPattern::parse(r">file\d+\.txt").unwrap();
     let pattern = compile_parsed_pattern(&parsed).unwrap();
@@ -731,7 +731,7 @@ fn test_regex_digit_pattern_still_anchored() {
 }
 
 #[test]
-fn test_invalid_regex_returns_error() {
+fn invalid_regex_returns_error() {
     let parsed = crate::pattern::ParsedPattern::parse(">[invalid(regex");
     assert!(
         parsed.is_ok(),

--- a/crates/uffs-core/src/output/tests.rs
+++ b/crates/uffs-core/src/output/tests.rs
@@ -8,7 +8,7 @@ use uffs_polars::{Column, DataFrame};
 use super::*;
 
 #[test]
-fn test_parse_column() {
+fn parse_column() {
     assert_eq!(OutputColumn::parse("path"), Some(OutputColumn::Path));
     assert_eq!(OutputColumn::parse("PATH"), Some(OutputColumn::Path));
     assert_eq!(OutputColumn::parse("size"), Some(OutputColumn::Size));
@@ -16,13 +16,13 @@ fn test_parse_column() {
 }
 
 #[test]
-fn test_parse_columns_all() {
+fn parse_columns_all() {
     assert!(OutputConfig::parse_columns("all").is_none());
     assert!(OutputConfig::parse_columns("ALL").is_none());
 }
 
 #[test]
-fn test_parse_columns_list() {
+fn parse_columns_list() {
     let cols = OutputConfig::parse_columns("path,name,size").expect("should parse");
     assert_eq!(cols.len(), 3);
     assert_eq!(cols.first(), Some(&OutputColumn::Path));
@@ -31,7 +31,7 @@ fn test_parse_columns_list() {
 }
 
 #[test]
-fn test_parse_columns_with_spaces() {
+fn parse_columns_with_spaces() {
     // "Name,Size,Path Only" — the exact failing case from CLI validation test 22
     let cols = OutputConfig::parse_columns("Name,Size,Path Only").expect("should parse");
     assert_eq!(cols.len(), 3);
@@ -41,7 +41,7 @@ fn test_parse_columns_with_spaces() {
 }
 
 #[test]
-fn test_parse_columns_size_on_disk() {
+fn parse_columns_size_on_disk() {
     let cols =
         OutputConfig::parse_columns("Name,Size on Disk,Directory Flag").expect("should parse");
     assert_eq!(cols.len(), 3);
@@ -51,7 +51,7 @@ fn test_parse_columns_size_on_disk() {
 }
 
 #[test]
-fn test_parse_separator_special() {
+fn parse_separator_special() {
     // Original values
     assert_eq!(OutputConfig::parse_separator("TAB"), "\t");
     assert_eq!(OutputConfig::parse_separator("tab"), "\t");
@@ -67,7 +67,7 @@ fn test_parse_separator_special() {
 }
 
 #[test]
-fn test_parse_column_aliases() {
+fn parse_column_aliases() {
     // Short aliases for legacy compatibility
     assert_eq!(OutputColumn::parse("r"), Some(OutputColumn::ReadOnly));
     assert_eq!(OutputColumn::parse("a"), Some(OutputColumn::Archive));
@@ -125,7 +125,7 @@ fn test_parse_column_aliases() {
 }
 
 #[test]
-fn test_output_config_builder() {
+fn output_config_builder() {
     let config = OutputConfig::new()
         .with_columns("path,name")
         .with_separator(";")
@@ -143,14 +143,14 @@ fn test_output_config_builder() {
 }
 
 #[test]
-fn test_df_column_mapping() {
+fn df_column_mapping() {
     assert_eq!(OutputColumn::Path.df_column(), "path");
     assert_eq!(OutputColumn::SizeOnDisk.df_column(), "allocated_size");
     assert_eq!(OutputColumn::AttributeValue.df_column(), "flags");
 }
 
 #[test]
-fn test_display_name() {
+fn display_name() {
     assert_eq!(OutputColumn::Path.display_name(), "Path");
     assert_eq!(OutputColumn::SizeOnDisk.display_name(), "Size on Disk");
     assert_eq!(
@@ -160,7 +160,7 @@ fn test_display_name() {
 }
 
 #[test]
-fn test_needs_descendants() {
+fn needs_descendants() {
     let config_no_desc = OutputConfig::new().with_columns("path,name,size");
     assert!(!config_no_desc.needs_descendants());
 
@@ -173,7 +173,7 @@ fn test_needs_descendants() {
 }
 
 #[test]
-fn test_add_descendants_column() {
+fn add_descendants_column_works() {
     // Create a test DataFrame with directory structure:
     // root (5) -> Users (100) -> john (101) -> file.txt (102)
     //                         -> Documents (103) -> doc.pdf (104)
@@ -211,7 +211,7 @@ fn test_add_descendants_column() {
 }
 
 #[test]
-fn test_write_preserves_header_spacing_and_missing_column_defaults() {
+fn write_preserves_header_spacing_and_missing_column_defaults() {
     let df = DataFrame::new_infer_height(vec![
         Column::new("path".into(), &["C:\\Temp\\file.txt"]),
         Column::new("name".into(), &["file.txt"]),
@@ -236,7 +236,7 @@ fn test_write_preserves_header_spacing_and_missing_column_defaults() {
 }
 
 #[test]
-fn test_write_preserves_null_and_boolean_value_formatting() {
+fn write_preserves_null_and_boolean_value_formatting() {
     let df = DataFrame::new_infer_height(vec![
         Column::new("name".into(), &[Some("alpha"), None, Some("beta")]),
         Column::new("size".into(), &[Some(42_u64), None, Some(0_u64)]),
@@ -261,7 +261,7 @@ fn test_write_preserves_null_and_boolean_value_formatting() {
 }
 
 #[test]
-fn test_parity_compat_directory_formatting() {
+fn parity_compat_directory_formatting() {
     use crate::search::backend::DisplayRow;
 
     let file_row = DisplayRow::new(
@@ -370,7 +370,7 @@ fn test_parity_compat_directory_formatting() {
 /// backslash in parity mode. Root's path is already `G:\` — appending `\` would
 /// produce `G:\\` which mismatches the legacy baseline.
 #[test]
-fn test_parity_root_no_double_trailing_backslash() {
+fn parity_root_no_double_trailing_backslash() {
     use crate::search::backend::DisplayRow;
 
     let root_row = DisplayRow::new(
@@ -565,7 +565,7 @@ fn write_display_rows_emits_name_length_and_path_length() {
 /// someone re-introduces the Unix-micros interpretation, this renders
 /// as `8225-01-17` or similar and the test fails immediately.
 #[test]
-fn test_write_datetime_column_formats_filetime_as_2026() {
+fn write_datetime_column_formats_filetime_as_2026() {
     use uffs_polars::{DataType, IntoColumn as _, NamedFrom as _, Series, TimeUnit};
 
     // 2026-01-20 00:00:00 UTC as raw FILETIME.
@@ -672,7 +672,7 @@ fn write_display_rows_parallel_matches_sequential() {
 /// Zero FILETIME is the NTFS sentinel for "unset" — the formatter must
 /// emit an empty field, never decompose to `1601-01-01`.
 #[test]
-fn test_write_datetime_column_zero_filetime_is_empty() {
+fn write_datetime_column_zero_filetime_is_empty() {
     use uffs_polars::{DataType, IntoColumn as _, NamedFrom as _, Series, TimeUnit};
 
     let ts_column = Series::new("modified".into(), vec![0_i64])

--- a/crates/uffs-core/src/path_resolver/tests.rs
+++ b/crates/uffs-core/src/path_resolver/tests.rs
@@ -25,7 +25,7 @@ fn create_test_df() -> Result<DataFrame, uffs_polars::PolarsError> {
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[test]
-fn test_resolve_path() -> TestResult {
+fn resolve_path() -> TestResult {
     let df = create_test_df()?;
     let mut resolver = PathResolver::build(&df, 'C')?;
 
@@ -35,7 +35,7 @@ fn test_resolve_path() -> TestResult {
 }
 
 #[test]
-fn test_path_caching() -> TestResult {
+fn path_caching() -> TestResult {
     let df = create_test_df()?;
     let mut resolver = PathResolver::build(&df, 'C')?;
 
@@ -53,7 +53,7 @@ fn test_path_caching() -> TestResult {
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[test]
-fn test_fast_resolve_path() -> TestResult {
+fn fast_resolve_path() -> TestResult {
     let df = create_test_df()?;
     let resolver = FastPathResolver::build(&df, 'C')?;
 
@@ -63,7 +63,7 @@ fn test_fast_resolve_path() -> TestResult {
 }
 
 #[test]
-fn test_fast_resolve_root() -> TestResult {
+fn fast_resolve_root() -> TestResult {
     let df = create_test_df()?;
     let resolver = FastPathResolver::build(&df, 'C')?;
 
@@ -74,7 +74,7 @@ fn test_fast_resolve_root() -> TestResult {
 }
 
 #[test]
-fn test_fast_resolve_cached() -> TestResult {
+fn fast_resolve_cached() -> TestResult {
     let df = create_test_df()?;
     let mut resolver = FastPathResolver::build(&df, 'C')?;
 
@@ -93,7 +93,7 @@ fn test_fast_resolve_cached() -> TestResult {
 }
 
 #[test]
-fn test_fast_resolve_missing_frs() -> TestResult {
+fn fast_resolve_missing_frs() -> TestResult {
     let df = create_test_df()?;
     let resolver = FastPathResolver::build(&df, 'C')?;
 
@@ -104,7 +104,7 @@ fn test_fast_resolve_missing_frs() -> TestResult {
 }
 
 #[test]
-fn test_fast_add_path_column() -> TestResult {
+fn fast_add_path_column() -> TestResult {
     let df = create_test_df()?;
     let mut resolver = FastPathResolver::build(&df, 'C')?;
 
@@ -120,7 +120,7 @@ fn test_fast_add_path_column() -> TestResult {
 }
 
 #[test]
-fn test_fast_resolver_stats() -> TestResult {
+fn fast_resolver_stats() -> TestResult {
     let df = create_test_df()?;
     let resolver = FastPathResolver::build(&df, 'C')?;
 
@@ -136,7 +136,7 @@ fn test_fast_resolver_stats() -> TestResult {
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[test]
-fn test_name_arena() {
+fn name_arena() {
     let mut arena = NameArena::with_capacity(100);
 
     let (off1, len1) = arena.add("hello");
@@ -148,7 +148,7 @@ fn test_name_arena() {
 }
 
 #[test]
-fn test_name_arena_empty() {
+fn name_arena_empty() {
     let arena = NameArena::with_capacity(100);
     assert!(arena.is_empty());
     assert_eq!(arena.len(), 0);
@@ -159,7 +159,7 @@ fn test_name_arena_empty() {
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[test]
-fn test_fast_add_path_column_parallel() -> TestResult {
+fn fast_add_path_column_parallel() -> TestResult {
     let df = create_test_df()?;
     let resolver = FastPathResolver::build(&df, 'C')?;
 
@@ -178,7 +178,7 @@ fn test_fast_add_path_column_parallel() -> TestResult {
 }
 
 #[test]
-fn test_fast_add_path_column_auto() -> TestResult {
+fn fast_add_path_column_auto() -> TestResult {
     let df = create_test_df()?;
     let mut resolver = FastPathResolver::build(&df, 'C')?;
 
@@ -194,7 +194,7 @@ fn test_fast_add_path_column_auto() -> TestResult {
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[test]
-fn test_add_path_only_column() -> TestResult {
+fn add_path_only_column_works() -> TestResult {
     // Create a DataFrame with path column
     let df = DataFrame::new_infer_height(vec![Column::new("path".into(), &[
         "G:\\",

--- a/crates/uffs-core/src/pattern.rs
+++ b/crates/uffs-core/src/pattern.rs
@@ -190,7 +190,7 @@ mod tests {
     type TestResult = core::result::Result<(), Box<dyn core::error::Error>>;
 
     #[test]
-    fn test_simple_glob_pattern() -> TestResult {
+    fn simple_glob_pattern() -> TestResult {
         let parsed = ParsedPattern::parse("*.txt")?;
         assert_eq!(parsed.drive(), None);
         assert_eq!(parsed.pattern(), "*.txt");
@@ -199,7 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn test_drive_prefix_lowercase() -> TestResult {
+    fn drive_prefix_lowercase() -> TestResult {
         let parsed = ParsedPattern::parse("c:/pro*")?;
         assert_eq!(parsed.drive(), Some('C'));
         assert_eq!(parsed.pattern(), "/pro*");
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn test_drive_prefix_uppercase() -> TestResult {
+    fn drive_prefix_uppercase() -> TestResult {
         let parsed = ParsedPattern::parse("D:\\Users\\*")?;
         assert_eq!(parsed.drive(), Some('D'));
         assert_eq!(parsed.pattern(), "\\Users\\*");
@@ -217,7 +217,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_drive_with_leading_slash() -> TestResult {
+    fn no_drive_with_leading_slash() -> TestResult {
         let parsed = ParsedPattern::parse("/pro*.txt")?;
         assert_eq!(parsed.drive(), None);
         assert_eq!(parsed.pattern(), "/pro*.txt");
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn test_regex_pattern() -> TestResult {
+    fn regex_pattern() -> TestResult {
         let parsed = ParsedPattern::parse(r">C:\\Temp.*\.txt")?;
         assert_eq!(parsed.drive(), Some('C'));
         assert_eq!(parsed.pattern_type(), PatternType::Regex);
@@ -235,7 +235,7 @@ mod tests {
     }
 
     #[test]
-    fn test_regex_pattern_with_quotes() -> TestResult {
+    fn regex_pattern_with_quotes() -> TestResult {
         let parsed = ParsedPattern::parse(r#">"C:\\Temp.*""#)?;
         assert_eq!(parsed.pattern_type(), PatternType::Regex);
         assert_eq!(parsed.drive(), Some('C'));
@@ -243,7 +243,7 @@ mod tests {
     }
 
     #[test]
-    fn test_literal_pattern() -> TestResult {
+    fn literal_pattern() -> TestResult {
         let parsed = ParsedPattern::parse("readme")?;
         assert_eq!(parsed.drive(), None);
         assert_eq!(parsed.pattern(), "readme");
@@ -252,19 +252,19 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_pattern_error() {
+    fn empty_pattern_error() {
         let result = ParsedPattern::parse("");
         result.unwrap_err();
     }
 
     #[test]
-    fn test_whitespace_only_error() {
+    fn whitespace_only_error() {
         let result = ParsedPattern::parse("   ");
         result.unwrap_err();
     }
 
     #[test]
-    fn test_to_regex_glob() -> TestResult {
+    fn to_regex_glob() -> TestResult {
         let parsed = ParsedPattern::parse("*.rs")?;
         let regex = parsed.to_regex()?;
         assert!(regex.starts_with('^'));
@@ -273,7 +273,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_regex_literal() -> TestResult {
+    fn to_regex_literal() -> TestResult {
         let parsed = ParsedPattern::parse("main")?;
         let regex = parsed.to_regex()?;
         assert!(regex.contains("main"));
@@ -282,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn test_case_sensitivity() -> TestResult {
+    fn case_sensitivity() -> TestResult {
         let parsed = ParsedPattern::parse("*.txt")?.with_case_sensitive(true);
         assert!(parsed.is_case_sensitive());
 
@@ -292,14 +292,14 @@ mod tests {
     }
 
     #[test]
-    fn test_drive_override() -> TestResult {
+    fn drive_override() -> TestResult {
         let parsed = ParsedPattern::parse("*.txt")?.with_drive(Some('E'));
         assert_eq!(parsed.drive(), Some('E'));
         Ok(())
     }
 
     #[test]
-    fn test_double_star_glob() -> TestResult {
+    fn double_star_glob() -> TestResult {
         let parsed = ParsedPattern::parse("**\\Users\\**")?;
         assert_eq!(parsed.pattern_type(), PatternType::Glob);
         assert!(parsed.pattern().contains("**"));
@@ -307,14 +307,14 @@ mod tests {
     }
 
     #[test]
-    fn test_question_mark_glob() -> TestResult {
+    fn question_mark_glob() -> TestResult {
         let parsed = ParsedPattern::parse("file?.txt")?;
         assert_eq!(parsed.pattern_type(), PatternType::Glob);
         Ok(())
     }
 
     #[test]
-    fn test_bracket_glob() -> TestResult {
+    fn bracket_glob() -> TestResult {
         let parsed = ParsedPattern::parse("[abc].txt")?;
         assert_eq!(parsed.pattern_type(), PatternType::Glob);
         Ok(())
@@ -325,7 +325,7 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_backslash_path_detection() -> TestResult {
+    fn backslash_path_detection() -> TestResult {
         let parsed = ParsedPattern::parse("\\Users\\*")?;
         assert!(
             parsed.is_path_pattern(),
@@ -335,7 +335,7 @@ mod tests {
     }
 
     #[test]
-    fn test_forward_slash_path_detection() -> TestResult {
+    fn forward_slash_path_detection() -> TestResult {
         let parsed = ParsedPattern::parse("Users/foo/*")?;
         assert!(
             parsed.is_path_pattern(),
@@ -345,7 +345,7 @@ mod tests {
     }
 
     #[test]
-    fn test_literal_always_path_aware() -> TestResult {
+    fn literal_always_path_aware() -> TestResult {
         let parsed = ParsedPattern::parse("nice")?;
         assert_eq!(parsed.pattern_type(), PatternType::Literal);
         assert!(
@@ -356,7 +356,7 @@ mod tests {
     }
 
     #[test]
-    fn test_simple_glob_not_path_aware() -> TestResult {
+    fn simple_glob_not_path_aware() -> TestResult {
         let parsed = ParsedPattern::parse("*.txt")?;
         assert!(
             !parsed.is_path_pattern(),
@@ -366,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn test_glob_with_backslash_is_path_aware() -> TestResult {
+    fn glob_with_backslash_is_path_aware() -> TestResult {
         let parsed = ParsedPattern::parse("**\\Users\\**\\AppData\\**")?;
         assert!(
             parsed.is_path_pattern(),
@@ -376,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn test_leading_slash_not_path_aware() -> TestResult {
+    fn leading_slash_not_path_aware() -> TestResult {
         // Leading slash is a glob prefix, not a path separator between components
         let parsed = ParsedPattern::parse("/pro*")?;
         assert!(
@@ -387,7 +387,7 @@ mod tests {
     }
 
     #[test]
-    fn test_drive_prefix_with_path() -> TestResult {
+    fn drive_prefix_with_path() -> TestResult {
         let parsed = ParsedPattern::parse("C:\\Windows\\*")?;
         assert_eq!(parsed.drive(), Some('C'));
         assert!(
@@ -398,7 +398,7 @@ mod tests {
     }
 
     #[test]
-    fn test_regex_with_path_separators() -> TestResult {
+    fn regex_with_path_separators() -> TestResult {
         let parsed = ParsedPattern::parse(r">C:\\TemP.*\.txt")?;
         assert_eq!(parsed.pattern_type(), PatternType::Regex);
         assert!(
@@ -413,7 +413,7 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_forward_slash_normalized_in_path_pattern() -> TestResult {
+    fn forward_slash_normalized_in_path_pattern() -> TestResult {
         let parsed = ParsedPattern::parse("Users/foo/bar/*")?;
         assert!(
             parsed.pattern().contains('\\'),
@@ -427,7 +427,7 @@ mod tests {
     }
 
     #[test]
-    fn test_forward_slash_not_normalized_in_non_path_glob() -> TestResult {
+    fn forward_slash_not_normalized_in_non_path_glob() -> TestResult {
         // /pro* has leading slash only — not path-aware, no normalization
         let parsed = ParsedPattern::parse("/pro*")?;
         assert_eq!(

--- a/crates/uffs-core/src/query/tests.rs
+++ b/crates/uffs-core/src/query/tests.rs
@@ -21,7 +21,7 @@ fn create_test_df() -> core::result::Result<DataFrame, uffs_polars::PolarsError>
 }
 
 #[test]
-fn test_files_only() -> TestResult {
+fn files_only() -> TestResult {
     let df = create_test_df()?;
     let result = MftQuery::new(df).files_only().collect()?;
     assert_eq!(result.height(), 2); // file.txt and main.rs
@@ -29,7 +29,7 @@ fn test_files_only() -> TestResult {
 }
 
 #[test]
-fn test_directories_only() -> TestResult {
+fn directories_only() -> TestResult {
     let df = create_test_df()?;
     let result = MftQuery::new(df).directories_only().collect()?;
     assert_eq!(result.height(), 2); // root and src
@@ -37,7 +37,7 @@ fn test_directories_only() -> TestResult {
 }
 
 #[test]
-fn test_min_size() -> TestResult {
+fn min_size() -> TestResult {
     let df = create_test_df()?;
     let result = MftQuery::new(df).min_size(1500).collect()?;
     assert_eq!(result.height(), 1); // only main.rs (2048)
@@ -45,7 +45,7 @@ fn test_min_size() -> TestResult {
 }
 
 #[test]
-fn test_limit() -> TestResult {
+fn limit() -> TestResult {
     let df = create_test_df()?;
     let result = MftQuery::new(df).limit(2).collect()?;
     assert_eq!(result.height(), 2);
@@ -53,7 +53,7 @@ fn test_limit() -> TestResult {
 }
 
 #[test]
-fn test_chained_filters() -> TestResult {
+fn chained_filters() -> TestResult {
     let df = create_test_df()?;
     let result = MftQuery::new(df)
         .files_only()
@@ -94,7 +94,7 @@ fn create_pattern_test_df() -> core::result::Result<DataFrame, uffs_polars::Pola
 }
 
 #[test]
-fn test_pattern_suffix() -> TestResult {
+fn pattern_suffix() -> TestResult {
     use crate::pattern::ParsedPattern;
 
     let df = create_pattern_test_df()?;
@@ -106,7 +106,7 @@ fn test_pattern_suffix() -> TestResult {
 }
 
 #[test]
-fn test_pattern_prefix() -> TestResult {
+fn pattern_prefix() -> TestResult {
     use crate::pattern::ParsedPattern;
 
     let df = create_pattern_test_df()?;
@@ -118,7 +118,7 @@ fn test_pattern_prefix() -> TestResult {
 }
 
 #[test]
-fn test_pattern_contains() -> TestResult {
+fn pattern_contains() -> TestResult {
     use crate::pattern::ParsedPattern;
 
     let df = create_pattern_test_df()?;
@@ -130,7 +130,7 @@ fn test_pattern_contains() -> TestResult {
 }
 
 #[test]
-fn test_extension_filter_optimized() -> TestResult {
+fn extension_filter_optimized() -> TestResult {
     let df = create_pattern_test_df()?;
     let filter = crate::extensions::ExtensionFilter::parse("rs,txt")?;
     let result = MftQuery::new(df).extension_filter(&filter).collect()?;
@@ -140,7 +140,7 @@ fn test_extension_filter_optimized() -> TestResult {
 }
 
 #[test]
-fn test_extension_filter_fast() -> TestResult {
+fn extension_filter_fast() -> TestResult {
     let df = create_pattern_test_df()?;
     let df_with_ext = crate::extensions::add_ext_column(df)?;
     let filter = crate::extensions::ExtensionFilter::parse("rs,txt")?;
@@ -153,7 +153,7 @@ fn test_extension_filter_fast() -> TestResult {
 }
 
 #[test]
-fn test_extension_filter_single() -> TestResult {
+fn extension_filter_single() -> TestResult {
     let df = create_pattern_test_df()?;
     let filter = crate::extensions::ExtensionFilter::parse("jpg")?;
     let result = MftQuery::new(df).extension_filter(&filter).collect()?;
@@ -163,7 +163,7 @@ fn test_extension_filter_single() -> TestResult {
 }
 
 #[test]
-fn test_max_size() -> TestResult {
+fn max_size() -> TestResult {
     let df = create_test_df()?;
     let result = MftQuery::new(df).max_size(1500).collect()?;
     // Should include: root (0), file.txt (1024), src (0) = 3 items
@@ -172,7 +172,7 @@ fn test_max_size() -> TestResult {
 }
 
 #[test]
-fn test_sort_by_size_descending() -> TestResult {
+fn sort_by_size_descending() -> TestResult {
     let df = create_test_df()?;
     let result = MftQuery::new(df)
         .files_only()
@@ -186,7 +186,7 @@ fn test_sort_by_size_descending() -> TestResult {
 }
 
 #[test]
-fn test_sort_by_size_ascending() -> TestResult {
+fn sort_by_size_ascending() -> TestResult {
     let df = create_test_df()?;
     let result = MftQuery::new(df)
         .files_only()
@@ -200,7 +200,7 @@ fn test_sort_by_size_ascending() -> TestResult {
 }
 
 #[test]
-fn test_hide_system() -> TestResult {
+fn hide_system() -> TestResult {
     // Create df with NTFS system files ($ prefix and low FRS)
     let df = DataFrame::new_infer_height(vec![
         Column::new("frs".into(), &[0_u64, 5, 16, 100]),
@@ -219,7 +219,7 @@ fn test_hide_system() -> TestResult {
 }
 
 #[test]
-fn test_query_mode_from_str() {
+fn query_mode_from_str() {
     use crate::index_search::QueryMode;
     assert!(matches!(
         QueryMode::from_str_opt("auto"),
@@ -237,7 +237,7 @@ fn test_query_mode_from_str() {
 }
 
 #[test]
-fn test_empty_dataframe() -> TestResult {
+fn empty_dataframe() -> TestResult {
     let df = DataFrame::new_infer_height(vec![
         Column::new("frs".into(), Vec::<u64>::new()),
         Column::new("name".into(), Vec::<&str>::new()),
@@ -253,7 +253,7 @@ fn test_empty_dataframe() -> TestResult {
 }
 
 #[test]
-fn test_combined_size_filters() -> TestResult {
+fn combined_size_filters() -> TestResult {
     let df = create_test_df()?;
     let result = MftQuery::new(df).min_size(500).max_size(1500).collect()?;
     // Should include file.txt (1024) only

--- a/crates/uffs-core/src/tree/tests.rs
+++ b/crates/uffs-core/src/tree/tests.rs
@@ -30,7 +30,7 @@ fn create_test_df() -> DataFrame {
 }
 
 #[test]
-fn test_tree_column_parse() {
+fn tree_column_parse() {
     assert_eq!(
         TreeColumn::parse("descendants"),
         Some(TreeColumn::Descendants)
@@ -46,7 +46,7 @@ fn test_tree_column_parse() {
 }
 
 #[test]
-fn test_tree_index_from_dataframe() {
+fn tree_index_from_dataframe() {
     let df = create_test_df();
     let tree = TreeIndex::from_dataframe(&df).unwrap();
 
@@ -58,7 +58,7 @@ fn test_tree_index_from_dataframe() {
 }
 
 #[test]
-fn test_descendants_count() {
+fn descendants_count() {
     let df = create_test_df();
     let mut tree = TreeIndex::from_dataframe(&df).unwrap();
 
@@ -75,7 +75,7 @@ fn test_descendants_count() {
 }
 
 #[test]
-fn test_treesize() {
+fn treesize() {
     let df = create_test_df();
     let mut tree = TreeIndex::from_dataframe(&df).unwrap();
 
@@ -92,7 +92,7 @@ fn test_treesize() {
 }
 
 #[test]
-fn test_tree_allocated() {
+fn tree_allocated() {
     let df = create_test_df();
     let mut tree = TreeIndex::from_dataframe(&df).unwrap();
 
@@ -103,7 +103,7 @@ fn test_tree_allocated() {
 }
 
 #[test]
-fn test_bulkiness() {
+fn bulkiness() {
     let df = create_test_df();
     let mut tree = TreeIndex::from_dataframe(&df).unwrap();
 
@@ -129,7 +129,7 @@ fn test_bulkiness() {
 }
 
 #[test]
-fn test_bulkiness_with_many_small_files() {
+fn bulkiness_with_many_small_files() {
     // Create a directory with many small files to test bulkiness filtering
     // parent (frs=1) with 10 small files (100 bytes each) and 1 large file (10000
     // bytes)
@@ -163,7 +163,7 @@ fn test_bulkiness_with_many_small_files() {
 }
 
 #[test]
-fn test_add_tree_columns() {
+fn add_tree_columns_works() {
     let df = create_test_df();
     let result = add_tree_columns(&df, &[TreeColumn::Descendants, TreeColumn::TreeSize]).unwrap();
 
@@ -178,7 +178,7 @@ fn test_add_tree_columns() {
 }
 
 #[test]
-fn test_add_tree_columns_empty() {
+fn add_tree_columns_empty() {
     let df = create_test_df();
     let result = add_tree_columns(&df, &[]).unwrap();
 
@@ -187,7 +187,7 @@ fn test_add_tree_columns_empty() {
 }
 
 #[test]
-fn test_memoization() {
+fn memoization() {
     let df = create_test_df();
     let mut tree = TreeIndex::from_dataframe(&df).unwrap();
 

--- a/crates/uffs-daemon/tests/ipc_integration.rs
+++ b/crates/uffs-daemon/tests/ipc_integration.rs
@@ -179,7 +179,7 @@ mod unix_tests {
     /// D2/D3 integration tests — all run against one daemon instance.
     #[test]
     #[ignore = "requires pre-built daemon binary — run with --ignored"]
-    fn test_daemon_ipc_all_methods() {
+    fn daemon_ipc_all_methods() {
         let exe = daemon_exe();
         let Some(mut daemon) = start_daemon(&exe, &[]) else {
             return;
@@ -281,7 +281,7 @@ mod unix_tests {
     /// search.
     #[test]
     #[ignore = "requires pre-built daemon binary — run with --ignored"]
-    fn test_real_data_search() {
+    fn real_data_search() {
         let exe = daemon_exe();
         let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
@@ -372,7 +372,7 @@ mod unix_tests {
     /// D3.5.4: Benchmark — measure client round-trip latency (target <15ms).
     #[test]
     #[ignore = "requires pre-built daemon binary — run with --ignored"]
-    fn test_benchmark_round_trip_latency() {
+    fn benchmark_round_trip_latency() {
         let exe = daemon_exe();
         let Some(mut daemon) = start_daemon(&exe, &[]) else {
             return;
@@ -433,7 +433,7 @@ mod unix_tests {
     /// D2.7.4: Concurrent clients — 3 connections, interleaved queries.
     #[test]
     #[ignore = "requires pre-built daemon binary — run with --ignored"]
-    fn test_concurrent_clients() {
+    fn concurrent_clients() {
         let exe = daemon_exe();
         let Some(mut daemon) = start_daemon(&exe, &[]) else {
             return;

--- a/crates/uffs-mcp/tests/mcp_protocol.rs
+++ b/crates/uffs-mcp/tests/mcp_protocol.rs
@@ -62,7 +62,7 @@ async fn setup_client() -> rmcp::service::RunningService<rmcp::RoleClient, impl 
 // ── tools/list ──────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn test_mcp_tools_list() {
+async fn mcp_tools_list() {
     let client = setup_client().await;
     let tools = client.list_tools(None).await.unwrap();
 
@@ -82,7 +82,7 @@ async fn test_mcp_tools_list() {
 // ── resources/list ──────────────────────────────────────────────────
 
 #[tokio::test]
-async fn test_mcp_resources_list() {
+async fn mcp_resources_list() {
     let client = setup_client().await;
     let resources = client.list_resources(None).await.unwrap();
 
@@ -118,7 +118,7 @@ fn extract_text(rc: &rmcp::model::ResourceContents) -> &str {
 }
 
 #[tokio::test]
-async fn test_mcp_read_schema_fields() {
+async fn mcp_read_schema_fields() {
     let client = setup_client().await;
     let result = client
         .read_resource(rmcp::model::ReadResourceRequestParams::new(
@@ -142,7 +142,7 @@ async fn test_mcp_read_schema_fields() {
 }
 
 #[tokio::test]
-async fn test_mcp_read_schema_search() {
+async fn mcp_read_schema_search() {
     let client = setup_client().await;
     let result = client
         .read_resource(rmcp::model::ReadResourceRequestParams::new(
@@ -163,7 +163,7 @@ async fn test_mcp_read_schema_search() {
 }
 
 #[tokio::test]
-async fn test_mcp_read_aggregate_presets() {
+async fn mcp_read_aggregate_presets() {
     let client = setup_client().await;
     let result = client
         .read_resource(rmcp::model::ReadResourceRequestParams::new(
@@ -187,7 +187,7 @@ async fn test_mcp_read_aggregate_presets() {
 // ── resources/templates ──────────────────────────────────────────────
 
 #[tokio::test]
-async fn test_mcp_resource_templates_list() {
+async fn mcp_resource_templates_list() {
     let client = setup_client().await;
     let templates = client.list_resource_templates(None).await.unwrap();
 
@@ -212,7 +212,7 @@ async fn test_mcp_resource_templates_list() {
 // ── prompts/list ────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn test_mcp_prompts_list() {
+async fn mcp_prompts_list() {
     let client = setup_client().await;
     let prompts = client.list_prompts(None).await.unwrap();
 
@@ -233,7 +233,7 @@ async fn test_mcp_prompts_list() {
 // ── get_prompt ──────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn test_mcp_get_prompt_find_large_files() {
+async fn mcp_get_prompt_find_large_files() {
     let client = setup_client().await;
 
     let result = client
@@ -253,7 +253,7 @@ async fn test_mcp_get_prompt_find_large_files() {
 }
 
 #[tokio::test]
-async fn test_mcp_get_prompt_unknown_returns_error() {
+async fn mcp_get_prompt_unknown_returns_error() {
     let client = setup_client().await;
 
     let result = client
@@ -268,7 +268,7 @@ async fn test_mcp_get_prompt_unknown_returns_error() {
 // ── call_tool with unknown name ─────────────────────────────────────
 
 #[tokio::test]
-async fn test_mcp_call_unknown_tool_returns_error() {
+async fn mcp_call_unknown_tool_returns_error() {
     let client = setup_client().await;
 
     let result = client
@@ -305,7 +305,7 @@ async fn test_mcp_call_unknown_tool_returns_error() {
 /// }
 /// ```
 #[test]
-fn test_claude_desktop_config_example() {
+fn claude_desktop_config_example() {
     // This is a documentation test — verifies the config JSON is valid
     let config = r#"{
         "mcpServers": {
@@ -333,7 +333,7 @@ fn test_claude_desktop_config_example() {
 /// }
 /// ```
 #[test]
-fn test_cursor_windsurf_config_example() {
+fn cursor_windsurf_config_example() {
     let config = r#"{
         "uffs": {
             "command": "uffs-mcp"

--- a/crates/uffs-mft/src/commands/load.rs
+++ b/crates/uffs-mft/src/commands/load.rs
@@ -732,13 +732,13 @@ mod tests {
     use super::required_output_path;
 
     #[test]
-    fn test_required_output_path_accepts_validated_path() {
+    fn required_output_path_accepts_validated_path() {
         let path = Path::new("out.parquet");
         assert_eq!(required_output_path(Some(path)).ok(), Some(path));
     }
 
     #[test]
-    fn test_required_output_path_rejects_missing_output() {
+    fn required_output_path_rejects_missing_output() {
         let missing_output_error = required_output_path(None).err();
         assert!(matches!(
             missing_output_error,

--- a/crates/uffs-mft/src/flags.rs
+++ b/crates/uffs-mft/src/flags.rs
@@ -150,14 +150,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_directory_flag() {
+    fn directory_flag() {
         let flags = FileFlags::DIRECTORY;
         assert!(flags.is_directory());
         assert!(!flags.is_file());
     }
 
     #[test]
-    fn test_combined_flags() {
+    fn combined_flags() {
         let flags = FileFlags::HIDDEN | FileFlags::SYSTEM | FileFlags::DIRECTORY;
         assert!(flags.is_directory());
         assert!(flags.is_hidden());
@@ -166,7 +166,7 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_flags() {
+    fn raw_flags() {
         assert_eq!(raw_flags::DIRECTORY, 0x0010);
         assert_eq!(raw_flags::HIDDEN, 0x0002);
     }

--- a/crates/uffs-mft/src/index/tests_children.rs
+++ b/crates/uffs-mft/src/index/tests_children.rs
@@ -6,7 +6,7 @@
 use super::*;
 
 #[test]
-fn test_sort_directory_children_basic() {
+fn sort_directory_children_basic() {
     let mut index = MftIndex::new('C');
 
     // Create a directory (FRS 100)
@@ -76,7 +76,7 @@ fn test_sort_directory_children_basic() {
 }
 
 #[test]
-fn test_sort_directory_children_empty() {
+fn sort_directory_children_empty() {
     let mut index = MftIndex::new('C');
 
     // Create a directory with no children
@@ -93,7 +93,7 @@ fn test_sort_directory_children_empty() {
 }
 
 #[test]
-fn test_sort_directory_children_single_child() {
+fn sort_directory_children_single_child() {
     let mut index = MftIndex::new('C');
 
     // Create a directory with one child
@@ -134,7 +134,7 @@ fn test_sort_directory_children_single_child() {
 }
 
 #[test]
-fn test_sort_directory_children_performance() {
+fn sort_directory_children_performance() {
     use std::time::Instant;
 
     let mut index = MftIndex::new('C');

--- a/crates/uffs-mft/src/index/tests_core.rs
+++ b/crates/uffs-mft/src/index/tests_core.rs
@@ -8,7 +8,7 @@ use core::mem::size_of;
 use super::*;
 
 #[test]
-fn test_standard_info_flags() {
+fn standard_info_flags() {
     let mut info = StandardInfo::default();
     assert!(!info.is_directory());
 
@@ -20,7 +20,7 @@ fn test_standard_info_flags() {
 }
 
 #[test]
-fn test_file_record_size() {
+fn file_record_size() {
     // Verify compact size - should be reasonably compact (<= 240 bytes)
     // Version 4 added: sequence_number (2), namespace (1), reserved (1),
     // fn_created/modified/accessed/mft_changed (4 × 8 = 32) = 36 bytes extra
@@ -36,7 +36,7 @@ fn test_file_record_size() {
 }
 
 #[test]
-fn test_index_basic_operations() {
+fn index_basic_operations() {
     let mut index = MftIndex::new('C');
 
     // Add a record
@@ -53,13 +53,13 @@ fn test_index_basic_operations() {
 }
 
 #[test]
-fn test_index_name_ref_size() {
+fn index_name_ref_size() {
     // Verify IndexNameRef is exactly 8 bytes (no padding)
     assert_eq!(size_of::<IndexNameRef>(), 8);
 }
 
 #[test]
-fn test_index_name_ref_bit_packing() {
+fn index_name_ref_bit_packing() {
     // Test bit-packing correctness
     let name_ref = IndexNameRef::new(100, 255, true, 1234);
 
@@ -76,7 +76,7 @@ fn test_index_name_ref_bit_packing() {
 }
 
 #[test]
-fn test_names_buffer() {
+fn names_buffer() {
     let mut index = MftIndex::new('C');
 
     let offset1 = index.add_name("test.txt");
@@ -90,7 +90,7 @@ fn test_names_buffer() {
 }
 
 #[test]
-fn test_cmp_ascii_case_insensitive() {
+fn cmp_ascii_case_insensitive_works() {
     use core::cmp::Ordering;
 
     // Equal strings (different case)

--- a/crates/uffs-mft/src/index/tests_extensions.rs
+++ b/crates/uffs-mft/src/index/tests_extensions.rs
@@ -6,7 +6,7 @@
 use super::*;
 
 #[test]
-fn test_extension_table_interning() {
+fn extension_table_interning() {
     let mut table = ExtensionTable::new();
 
     // Test empty extension
@@ -38,7 +38,7 @@ fn test_extension_table_interning() {
 }
 
 #[test]
-fn test_extension_table_record_file() {
+fn extension_table_record_file() {
     let mut table = ExtensionTable::new();
 
     let txt_id = table.intern("txt");
@@ -61,7 +61,7 @@ fn test_extension_table_record_file() {
 }
 
 #[test]
-fn test_intern_extension() {
+fn intern_extension() {
     let mut index = MftIndex::new('C');
 
     // Test basic extension extraction
@@ -78,7 +78,7 @@ fn test_intern_extension() {
     clippy::indexing_slicing,
     reason = "test code with known valid indices"
 )]
-fn test_extension_table_serialization() {
+fn extension_table_serialization() {
     // Create an index with some extensions
     let mut index = MftIndex::new('C');
 
@@ -153,7 +153,7 @@ fn test_extension_table_serialization() {
 }
 
 #[test]
-fn test_extension_index_build() {
+fn extension_index_build() {
     let mut index = MftIndex::new('C');
 
     // Add files with different extensions
@@ -233,7 +233,7 @@ fn test_extension_index_build() {
     clippy::indexing_slicing,
     reason = "test code with known valid indices"
 )]
-fn test_extension_index_with_hard_links() {
+fn extension_index_with_hard_links() {
     let mut index = MftIndex::new('C');
 
     // Create a file with multiple hard links with different extensions
@@ -286,7 +286,7 @@ fn test_extension_index_with_hard_links() {
 }
 
 #[test]
-fn test_extension_index_empty() {
+fn extension_index_empty() {
     let mut index = MftIndex::new('C');
 
     // Build on empty index
@@ -307,7 +307,7 @@ fn test_extension_index_empty() {
 }
 
 #[test]
-fn test_size_bucket_assignment() {
+fn size_bucket_assignment() {
     // Test bucket boundaries
     assert_eq!(MftStats::size_bucket(0), 0); // 0 bytes → bucket 0
     assert_eq!(MftStats::size_bucket(512), 0); // 512 bytes → bucket 0
@@ -343,7 +343,7 @@ fn test_size_bucket_assignment() {
     clippy::indexing_slicing,
     reason = "test code with known valid indices"
 )]
-fn test_extension_table_top_by_bytes() {
+fn extension_table_top_by_bytes() {
     let mut index = MftIndex::new('C');
 
     // Add files with different extensions and sizes
@@ -398,7 +398,7 @@ fn test_extension_table_top_by_bytes() {
     clippy::indexing_slicing,
     reason = "test code with known valid indices"
 )]
-fn test_extension_table_top_by_count() {
+fn extension_table_top_by_count() {
     let mut index = MftIndex::new('C');
 
     // Add files with different extensions
@@ -446,7 +446,7 @@ fn test_extension_table_top_by_count() {
 }
 
 #[test]
-fn test_byte_tracking_accuracy() {
+fn byte_tracking_accuracy() {
     let mut index = MftIndex::new('C');
 
     // Add files with different sizes and attributes
@@ -534,7 +534,7 @@ fn test_byte_tracking_accuracy() {
 }
 
 #[test]
-fn test_extension_index_performance() {
+fn extension_index_performance() {
     use std::time::Instant;
 
     let mut index = MftIndex::new('C');

--- a/crates/uffs-mft/src/index/tests_merge.rs
+++ b/crates/uffs-mft/src/index/tests_merge.rs
@@ -9,7 +9,7 @@ use super::*;
 /// Test that extension records processed before base records in the same
 /// fragment preserve extension names.
 #[test]
-fn test_extension_before_base_in_same_fragment() {
+fn extension_before_base_in_same_fragment() {
     let mut fragment = MftIndexFragment::with_capacity(10);
 
     let name2_ref = push_fragment_name(&mut fragment, "name2.txt");
@@ -87,7 +87,7 @@ fn test_extension_before_base_in_same_fragment() {
 /// Test that cross-fragment merge correctly handles extension-only
 /// placeholders.
 #[test]
-fn test_cross_fragment_merge_extension_placeholder() {
+fn cross_fragment_merge_extension_placeholder() {
     let mut fragment_a = MftIndexFragment::with_capacity(10);
     let ext_name_ref = push_fragment_name(&mut fragment_a, "hardlink.txt");
 
@@ -128,7 +128,7 @@ fn test_cross_fragment_merge_extension_placeholder() {
 
 /// Test that cross-fragment merge keeps all extension names.
 #[test]
-fn test_cross_fragment_merge_multiple_extension_names() {
+fn cross_fragment_merge_multiple_extension_names() {
     let mut fragment_a = MftIndexFragment::with_capacity(10);
     let ext_hardlink_b = push_fragment_name(&mut fragment_a, "hardlink_b.txt");
     let ext_hardlink_c = push_fragment_name(&mut fragment_a, "hardlink_c.txt");
@@ -176,7 +176,7 @@ fn test_cross_fragment_merge_multiple_extension_names() {
 
 /// Test that cross-fragment merge works when the base record comes first.
 #[test]
-fn test_cross_fragment_merge_base_first() {
+fn cross_fragment_merge_base_first() {
     let mut fragment_a = MftIndexFragment::with_capacity(10);
     let base_original = push_fragment_name(&mut fragment_a, "original_a.txt");
 
@@ -225,7 +225,7 @@ fn test_cross_fragment_merge_base_first() {
 /// Test that `rebuild_children_from_names()` rebuilds child lists from parent
 /// references.
 #[test]
-fn test_rebuild_children_from_names_basic() {
+fn rebuild_children_from_names_basic() {
     let mut index = MftIndex::new('C');
 
     let root_frs = 5_u64;
@@ -280,7 +280,7 @@ fn test_rebuild_children_from_names_basic() {
 
 /// Test that `rebuild_children_from_names()` handles hard links correctly.
 #[test]
-fn test_rebuild_children_from_names_hardlinks() {
+fn rebuild_children_from_names_hardlinks() {
     let mut index = MftIndex::new('C');
 
     let dir1_frs = 100_u64;
@@ -339,7 +339,7 @@ fn test_rebuild_children_from_names_hardlinks() {
 
 /// Test that `rebuild_children_from_names()` skips self-referencing root.
 #[test]
-fn test_rebuild_children_from_names_skips_root_self_reference() {
+fn rebuild_children_from_names_skips_root_self_reference() {
     let mut index = MftIndex::new('C');
 
     let root_frs = 5_u64;
@@ -359,7 +359,7 @@ fn test_rebuild_children_from_names_skips_root_self_reference() {
 
 /// Test that tree metrics correctly handles empty directories.
 #[test]
-fn test_tree_metrics_empty_directory_descendants() {
+fn tree_metrics_empty_directory_descendants() {
     let mut index = MftIndex::new('C');
 
     let root_frs = 5_u64;
@@ -386,7 +386,7 @@ fn test_tree_metrics_empty_directory_descendants() {
 
 /// Test that tree metrics correctly handles directories with internal streams.
 #[test]
-fn test_tree_metrics_internal_streams_two_channel() {
+fn tree_metrics_internal_streams_two_channel() {
     let mut index = MftIndex::new('C');
 
     let root_frs = 5_u64;

--- a/crates/uffs-mft/src/index/tests_perf.rs
+++ b/crates/uffs-mft/src/index/tests_perf.rs
@@ -6,7 +6,7 @@
 use super::*;
 
 #[test]
-fn test_display_stats() {
+fn display_stats() {
     // Create a simple index with some files
     let mut index = MftIndex::new('C');
 
@@ -49,7 +49,7 @@ fn test_display_stats() {
     clippy::indexing_slicing,
     reason = "test code with known valid indices"
 )]
-fn test_extension_index_query_performance() {
+fn extension_index_query_performance() {
     use std::time::Instant;
 
     // Create index with 10K files across 10 extensions
@@ -110,7 +110,7 @@ fn test_extension_index_query_performance() {
 /// Run with: `cargo test --release -- test_full_postprocessing_performance
 /// --nocapture`
 #[test]
-fn test_full_postprocessing_performance() {
+fn full_postprocessing_performance() {
     use std::time::Instant;
 
     // Create a realistic index with 100K files

--- a/crates/uffs-mft/src/index/tests_storage.rs
+++ b/crates/uffs-mft/src/index/tests_storage.rs
@@ -18,7 +18,7 @@ fn write_u64(bytes: &mut [u8], offset: usize, value: u64) {
 }
 
 #[test]
-fn test_deserialize_rejects_record_count_that_is_too_large() {
+fn deserialize_rejects_record_count_that_is_too_large() {
     let mut data = empty_serialized_index();
     write_u64(&mut data, RECORD_COUNT_OFFSET, u64::MAX);
 
@@ -29,7 +29,7 @@ fn test_deserialize_rejects_record_count_that_is_too_large() {
 }
 
 #[test]
-fn test_deserialize_rejects_names_size_beyond_remaining_bytes() {
+fn deserialize_rejects_names_size_beyond_remaining_bytes() {
     let mut data = empty_serialized_index();
     // Use a size larger than remaining bytes after header+frs_to_idx+records.
     write_u64(&mut data, NAMES_SIZE_OFFSET, 9999);
@@ -41,7 +41,7 @@ fn test_deserialize_rejects_names_size_beyond_remaining_bytes() {
 }
 
 #[test]
-fn test_deserialize_rejects_links_count_beyond_remaining_bytes() {
+fn deserialize_rejects_links_count_beyond_remaining_bytes() {
     let mut data = empty_serialized_index();
     write_u64(&mut data, LINKS_COUNT_OFFSET, 1);
 

--- a/crates/uffs-mft/src/index/tests_tree.rs
+++ b/crates/uffs-mft/src/index/tests_tree.rs
@@ -6,7 +6,7 @@
 use super::*;
 
 #[test]
-fn test_compute_tree_metrics_simple() {
+fn compute_tree_metrics_simple() {
     let mut index = MftIndex::new('C');
 
     // Create a simple tree:
@@ -110,7 +110,7 @@ fn test_compute_tree_metrics_simple() {
 }
 
 #[test]
-fn test_compute_tree_metrics_deep_tree() {
+fn compute_tree_metrics_deep_tree() {
     let mut index = MftIndex::new('C');
 
     // Create a deep tree:
@@ -202,7 +202,7 @@ fn test_compute_tree_metrics_deep_tree() {
 }
 
 #[test]
-fn test_compute_tree_metrics_empty() {
+fn compute_tree_metrics_empty() {
     let mut index = MftIndex::new('C');
 
     // Empty index should not crash
@@ -212,7 +212,7 @@ fn test_compute_tree_metrics_empty() {
 }
 
 #[test]
-fn test_compute_tree_metrics_performance() {
+fn compute_tree_metrics_performance() {
     use std::time::Instant;
 
     let mut index = MftIndex::new('C');

--- a/crates/uffs-mft/src/io/aligned_buffer.rs
+++ b/crates/uffs-mft/src/io/aligned_buffer.rs
@@ -87,7 +87,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_aligned_buffer() {
+    fn aligned_buffer() {
         let buffer = AlignedBuffer::new(1024);
         assert_eq!(buffer.len(), 1024);
 
@@ -96,7 +96,7 @@ mod tests {
     }
 
     #[test]
-    fn test_aligned_buffer_write() {
+    fn aligned_buffer_write() {
         let mut buffer = AlignedBuffer::new(512);
         buffer.as_mut_slice()[0] = 0x42;
         assert_eq!(buffer.as_slice()[0], 0x42);

--- a/crates/uffs-mft/src/io/chunking.rs
+++ b/crates/uffs-mft/src/io/chunking.rs
@@ -591,7 +591,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_merge_adjacent_chunks_contiguous() {
+    fn merge_adjacent_chunks_contiguous() {
         let chunks = vec![
             ReadChunk {
                 disk_offset: 0,
@@ -617,7 +617,7 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_adjacent_chunks_non_contiguous_disk() {
+    fn merge_adjacent_chunks_non_contiguous_disk() {
         let chunks = vec![
             ReadChunk {
                 disk_offset: 1_000_000_000,
@@ -648,7 +648,7 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_adjacent_chunks_gap_too_large() {
+    fn merge_adjacent_chunks_gap_too_large() {
         let chunks = vec![
             ReadChunk {
                 disk_offset: 0,

--- a/crates/uffs-mft/src/io/extent_map.rs
+++ b/crates/uffs-mft/src/io/extent_map.rs
@@ -235,7 +235,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_extent_map_contiguous() {
+    fn extent_map_contiguous() {
         let map = MftExtentMap::contiguous(100, 1024 * 1024, 4096, 1024);
 
         assert_eq!(map.physical_offset(0), Some(409_600));
@@ -244,7 +244,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extent_map_fragmented() {
+    fn extent_map_fragmented() {
         let extents = vec![
             MftExtent {
                 vcn: 0,

--- a/crates/uffs-mft/src/io/readers/parallel/tests.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/tests.rs
@@ -10,7 +10,7 @@
 use super::*;
 
 #[test]
-fn test_parallel_mft_reader_uses_optimal_chunk_size() {
+fn parallel_mft_reader_uses_optimal_chunk_size() {
     use crate::platform::DriveType;
 
     let extent_map = MftExtentMap::contiguous(100, 1024 * 1024, 4096, 1024);
@@ -49,7 +49,7 @@ fn test_parallel_mft_reader_uses_optimal_chunk_size() {
 }
 
 #[test]
-fn test_drive_type_stored_in_reader() {
+fn drive_type_stored_in_reader() {
     use crate::platform::DriveType;
 
     let extent_map = MftExtentMap::contiguous(100, 1024 * 1024, 4096, 1024);
@@ -69,7 +69,7 @@ fn test_drive_type_stored_in_reader() {
 }
 
 #[test]
-fn test_optimal_defaults_when_none_passed() {
+fn optimal_defaults_when_none_passed() {
     use crate::platform::DriveType;
 
     fn resolve_concurrency(user_value: Option<usize>, drive_type: DriveType) -> usize {
@@ -100,7 +100,7 @@ fn test_optimal_defaults_when_none_passed() {
 }
 
 #[test]
-fn test_parallel_parsing_auto_detection() {
+fn parallel_parsing_auto_detection() {
     use crate::platform::DriveType;
 
     fn resolve_parallel_parse(user_value: Option<bool>, drive_type: DriveType) -> bool {

--- a/crates/uffs-mft/src/io/readers/parallel/tests_chaos.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/tests_chaos.rs
@@ -444,7 +444,7 @@ mod chaos_integration_tests {
         reason = "end-to-end chaos determinism test: load MFT, run 5 chaos iterations, \
                   hash sorted output, compare SHA — must remain a single cohesive test"
     )]
-    fn test_chaos_order_d_drive() {
+    fn chaos_order_d_drive() {
         use std::fs::File;
         use std::io::{BufRead as _, BufReader};
         const EXPECTED_SORTED_SHA: &str =
@@ -616,7 +616,7 @@ mod chaos_integration_tests {
     /// Tests reverse-order parsing (simpler chaos strategy).
     #[test]
     #[ignore = "requires offline MFT (set UFFS_MFT_TEST_FILE or UFFS_MFT_TEST_DIR)"]
-    fn test_reverse_order_d_drive() {
+    fn reverse_order_d_drive() {
         let _ = tracing_subscriber::fmt()
             .with_max_level(tracing::Level::INFO)
             .with_test_writer()
@@ -650,7 +650,7 @@ mod chaos_integration_tests {
     /// Tests interleaved chunk order (controlled chaos).
     #[test]
     #[ignore = "requires offline MFT (set UFFS_MFT_TEST_FILE or UFFS_MFT_TEST_DIR)"]
-    fn test_interleaved_order_d_drive() {
+    fn interleaved_order_d_drive() {
         let _ = tracing_subscriber::fmt()
             .with_max_level(tracing::Level::INFO)
             .with_test_writer()

--- a/crates/uffs-mft/src/io/readers/pipelined.rs
+++ b/crates/uffs-mft/src/io/readers/pipelined.rs
@@ -579,7 +579,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_pipelined_reader_creation() {
+    fn pipelined_reader_creation() {
         // Expected chunk sizes must track `DriveType::optimal_chunk_size`
         // in `crates/uffs-mft/src/platform/system.rs`.  The previous
         // hardcoded `64 * 1024` was stale from an early prototype; the

--- a/crates/uffs-mft/src/main.rs
+++ b/crates/uffs-mft/src/main.rs
@@ -191,7 +191,7 @@ mod tests {
     use super::{classify_binary_task_error, ctrl_c_listener_error, shutdown_requested_error};
 
     #[tokio::test]
-    async fn test_classify_binary_task_error_maps_cancelled_joins() {
+    async fn classify_binary_task_error_maps_cancelled_joins() {
         let handle = tokio::spawn(async {
             core::future::pending::<()>().await;
         });
@@ -212,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shutdown_requested_error_is_cancelled() {
+    fn shutdown_requested_error_is_cancelled() {
         let error = shutdown_requested_error("uffs_mft");
 
         assert!(matches!(error, uffs_mft::MftError::Cancelled {
@@ -222,7 +222,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ctrl_c_listener_error_is_wait_failed() {
+    fn ctrl_c_listener_error_is_wait_failed() {
         let error =
             ctrl_c_listener_error("uffs_mft", &std::io::Error::other("listener unavailable"));
 

--- a/crates/uffs-mft/src/ntfs/tests.rs
+++ b/crates/uffs-mft/src/ntfs/tests.rs
@@ -29,14 +29,14 @@ fn write_i64_le(buffer: &mut [u8], offset: usize, value: i64) {
 // zero-dep `uffs-time` crate.  See `crates/uffs-time/src/lib.rs::tests`.
 
 #[test]
-fn test_file_reference_extraction() {
+fn file_reference_extraction() {
     let file_ref: u64 = (7_u64 << 48) | 0x3039;
     assert_eq!(file_reference_to_frs(file_ref), 12345);
     assert_eq!(file_reference_to_sequence(file_ref), 7);
 }
 
 #[test]
-fn test_attribute_type_from_u32() {
+fn attribute_type_from_u32() {
     assert_eq!(
         AttributeType::from_u32(0x10),
         Some(AttributeType::StandardInformation)
@@ -51,7 +51,7 @@ fn test_attribute_type_from_u32() {
 }
 
 #[test]
-fn test_file_record_flags() {
+fn file_record_flags() {
     let header = FileRecordSegmentHeader {
         multi_sector_header: MultiSectorHeader {
             magic: FILE_RECORD_MAGIC,
@@ -77,7 +77,7 @@ fn test_file_record_flags() {
 }
 
 #[test]
-fn test_fixup_file_record_applies_usa_from_safe_header_decode() {
+fn fixup_file_record_applies_usa_from_safe_header_decode() {
     let mut record = vec![0_u8; 1024];
     let usa_offset = 0x30;
     let check_value = 0xABCD;
@@ -105,7 +105,7 @@ fn test_fixup_file_record_applies_usa_from_safe_header_decode() {
 }
 
 #[test]
-fn test_attribute_iterator_reads_resident_attribute_value() {
+fn attribute_iterator_reads_resident_attribute_value() {
     let mut record = vec![0_u8; 96];
     let record_len = crate::len_to_u32(record.len());
     let first_attribute_offset = size_of::<FileRecordSegmentHeader>();
@@ -151,7 +151,7 @@ fn test_attribute_iterator_reads_resident_attribute_value() {
 }
 
 #[test]
-fn test_non_resident_attribute_helpers_decode_mapping_pairs() {
+fn non_resident_attribute_helpers_decode_mapping_pairs() {
     let mut attr =
         vec![0_u8; size_of::<AttributeRecordHeader>() + size_of::<NonResidentAttributeData>() + 4];
     let attr_len = crate::len_to_u32(attr.len());

--- a/crates/uffs-mft/src/parse/direct_index_extension_tests.rs
+++ b/crates/uffs-mft/src/parse/direct_index_extension_tests.rs
@@ -53,7 +53,7 @@ fn merge_dir_index(
 }
 
 #[test]
-fn test_dir_index_extension_before_base_snapshot_restore() {
+fn dir_index_extension_before_base_snapshot_restore() {
     // Scenario: IOCP delivers extension record before base record
     // Extension has dir_index_size=4096, base has dir_index_size=8192
     // Result should be cumulative: 4096 + 8192 = 12288
@@ -94,7 +94,7 @@ fn test_dir_index_extension_before_base_snapshot_restore() {
 }
 
 #[test]
-fn test_dir_index_base_before_extension_snapshot_restore() {
+fn dir_index_base_before_extension_snapshot_restore() {
     // Scenario: Base record arrives before extension (normal case)
     // Base has dir_index_size=8192, extension has dir_index_size=4096
     // Result should be cumulative: 8192 + 4096 = 12288
@@ -121,7 +121,7 @@ fn test_dir_index_base_before_extension_snapshot_restore() {
 }
 
 #[test]
-fn test_dir_index_multiple_extensions_snapshot_restore() {
+fn dir_index_multiple_extensions_snapshot_restore() {
     // Scenario: Multiple extension records all arrive before base
     // All should accumulate properly using saturating_add
 
@@ -154,7 +154,7 @@ fn test_dir_index_multiple_extensions_snapshot_restore() {
 }
 
 #[test]
-fn test_dir_index_zero_extension_values() {
+fn dir_index_zero_extension_values() {
     // Scenario: Extension has zero dir_index (branch not taken in actual code,
     // but verify the logic handles it correctly)
 
@@ -178,7 +178,7 @@ fn test_dir_index_zero_extension_values() {
 }
 
 #[test]
-fn test_dir_index_saturating_add_no_overflow() {
+fn dir_index_saturating_add_no_overflow() {
     // Verify saturating_add prevents overflow
 
     let mut index = MftIndex::new('C');
@@ -204,7 +204,7 @@ fn test_dir_index_saturating_add_no_overflow() {
 }
 
 #[test]
-fn test_dir_index_regression_old_unconditional_add_bug() {
+fn dir_index_regression_old_unconditional_add_bug() {
     // This test demonstrates the bug that was fixed
     // OLD CODE (buggy): Always used += , losing data when extension arrives first
     // NEW CODE (correct): Uses snapshot/restore pattern

--- a/crates/uffs-mft/src/parse/tests.rs
+++ b/crates/uffs-mft/src/parse/tests.rs
@@ -159,7 +159,7 @@ fn create_test_record_with_attributes(
 }
 
 #[test]
-fn test_apply_fixup_valid_record() {
+fn apply_fixup_valid_record() {
     let mut data = create_test_record(5, true, false);
 
     // Before fixup, sector ends have check value
@@ -175,7 +175,7 @@ fn test_apply_fixup_valid_record() {
 }
 
 #[test]
-fn test_apply_fixup_invalid_magic() {
+fn apply_fixup_invalid_magic() {
     let mut data = vec![0_u8; 1024];
     data[0..4].copy_from_slice(b"BAAD"); // Invalid magic
 
@@ -184,7 +184,7 @@ fn test_apply_fixup_invalid_magic() {
 }
 
 #[test]
-fn test_apply_fixup_buffer_too_small() {
+fn apply_fixup_buffer_too_small() {
     let mut data = vec![0_u8; 10]; // Too small for header
 
     let result = apply_fixup(&mut data);
@@ -192,7 +192,7 @@ fn test_apply_fixup_buffer_too_small() {
 }
 
 #[test]
-fn test_apply_fixup_corrupted_check_value() {
+fn apply_fixup_corrupted_check_value() {
     let mut data = create_test_record(5, true, false);
 
     // Corrupt the check value at first sector end
@@ -203,7 +203,7 @@ fn test_apply_fixup_corrupted_check_value() {
 }
 
 #[test]
-fn test_apply_fixup_valid_record_on_unaligned_slice() {
+fn apply_fixup_valid_record_on_unaligned_slice() {
     let record = create_test_record(5, true, false);
     let mut storage = vec![0_u8; record.len() + 1];
     storage[1..].copy_from_slice(&record);
@@ -215,7 +215,7 @@ fn test_apply_fixup_valid_record_on_unaligned_slice() {
 }
 
 #[test]
-fn test_parse_standard_info_full_reads_unaligned_v30_payload() {
+fn parse_standard_info_full_reads_unaligned_v30_payload() {
     let attr_offset = 1_usize;
     let value_offset = 24_u16;
     let si_offset = attr_offset + usize::from(value_offset);
@@ -251,7 +251,7 @@ fn test_parse_standard_info_full_reads_unaligned_v30_payload() {
 }
 
 #[test]
-fn test_parse_file_name_full_reads_unaligned_payload() {
+fn parse_file_name_full_reads_unaligned_payload() {
     let attr_offset = 1_usize;
     let value_offset = 24_u16;
     let fn_offset = attr_offset + usize::from(value_offset);
@@ -298,7 +298,7 @@ fn test_parse_file_name_full_reads_unaligned_payload() {
 }
 
 #[test]
-fn test_parse_record_forensic_reads_unaligned_record_slice() {
+fn parse_record_forensic_reads_unaligned_record_slice() {
     let record = create_test_record(5, true, false);
     let mut storage = vec![0_u8; record.len() + 1];
     storage[1..].copy_from_slice(&record);
@@ -314,7 +314,7 @@ fn test_parse_record_forensic_reads_unaligned_record_slice() {
 }
 
 #[test]
-fn test_parse_record_forensic_reads_unaligned_extension_record_slice() {
+fn parse_record_forensic_reads_unaligned_extension_record_slice() {
     let extension_frs = 88_u64;
     let base_frs = 77_u64;
     let base_file_reference = (9_u64 << 48_u32) | base_frs;
@@ -353,7 +353,7 @@ fn test_parse_record_forensic_reads_unaligned_extension_record_slice() {
 }
 
 #[test]
-fn test_parse_record_forensic_reads_unaligned_resident_reparse_tag() {
+fn parse_record_forensic_reads_unaligned_resident_reparse_tag() {
     let frs = 91_u64;
     let reparse_attr = create_resident_attribute(
         AttributeType::ReparsePoint,
@@ -377,7 +377,7 @@ fn test_parse_record_forensic_reads_unaligned_resident_reparse_tag() {
 }
 
 #[test]
-fn test_create_placeholder_record() {
+fn create_placeholder_record_works() {
     let record = create_placeholder_record(12345);
 
     assert_eq!(record.frs, 12345);
@@ -390,7 +390,7 @@ fn test_create_placeholder_record() {
 }
 
 #[test]
-fn test_parse_result_variants() {
+fn parse_result_variants() {
     // Test ParseResult enum
     let base = ParseResult::Base(create_placeholder_record(1));
     assert!(matches!(base, ParseResult::Base(_)));
@@ -410,7 +410,7 @@ fn test_parse_result_variants() {
 }
 
 #[test]
-fn test_parse_options_default() {
+fn parse_options_default() {
     let opts = ParseOptions::default();
     assert!(!opts.include_deleted);
     assert!(!opts.include_corrupt);
@@ -418,7 +418,7 @@ fn test_parse_options_default() {
 }
 
 #[test]
-fn test_parse_options_forensic() {
+fn parse_options_forensic() {
     let opts = ParseOptions::FORENSIC;
     assert!(opts.include_deleted);
     assert!(opts.include_corrupt);
@@ -427,7 +427,7 @@ fn test_parse_options_forensic() {
 }
 
 #[test]
-fn test_parsed_record_default() {
+fn parsed_record_default() {
     let record = ParsedRecord::default();
     assert_eq!(record.frs, 0);
     assert_eq!(record.sequence_number, 0);
@@ -438,14 +438,14 @@ fn test_parsed_record_default() {
 }
 
 #[test]
-fn test_add_missing_parent_placeholders_empty() {
+fn add_missing_parent_placeholders_empty() {
     let mut records: Vec<ParsedRecord> = Vec::new();
     let added = add_missing_parent_placeholders_to_vec(&mut records);
     assert_eq!(added, 0);
 }
 
 #[test]
-fn test_add_missing_parent_placeholders_no_missing() {
+fn add_missing_parent_placeholders_no_missing() {
     let mut records = vec![
         {
             let mut r = create_placeholder_record(5);
@@ -464,7 +464,7 @@ fn test_add_missing_parent_placeholders_no_missing() {
 }
 
 #[test]
-fn test_add_missing_parent_placeholders_with_missing() {
+fn add_missing_parent_placeholders_with_missing() {
     let mut records = vec![{
         let mut r = create_placeholder_record(100);
         r.parent_frs = 50; // References non-existent parent
@@ -555,7 +555,7 @@ mod proptest_tests {
 /// Test that extension records with `$FILE_NAME` are properly merged into
 /// base records that have no `$FILE_NAME` attribute.
 #[test]
-fn test_extension_merge_with_empty_base_name() {
+fn extension_merge_with_empty_base_name() {
     // Simulate the case where base record has no $FILE_NAME
     // and extension record has the $FILE_NAME
 
@@ -632,7 +632,7 @@ fn test_extension_merge_with_empty_base_name() {
 /// Test that extension records are merged even when processed before base
 /// record
 #[test]
-fn test_extension_before_base_merge() {
+fn extension_before_base_merge() {
     let mut record_merger = MftRecordMerger::with_capacity(10);
 
     // Add extension record FIRST (before base record)

--- a/crates/uffs-mft/src/platform.rs
+++ b/crates/uffs-mft/src/platform.rs
@@ -53,13 +53,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_volume_root_path() {
+    fn volume_root_path_works() {
         assert_eq!(volume_root_path('c'), PathBuf::from("C:\\"));
         assert_eq!(volume_root_path('D'), PathBuf::from("D:\\"));
     }
 
     #[test]
-    fn test_is_elevated() {
+    fn is_elevated_works() {
         // Just verify it doesn't panic.  Bind with `_unused` so the must_use
         // result is consumed without us losing the annotation; the prefix
         // signals "intentionally unused" without triggering
@@ -68,7 +68,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nvme_optimal_settings() {
+    fn nvme_optimal_settings() {
         let drive_type = DriveType::Nvme;
 
         assert_eq!(drive_type.optimal_concurrency(), 32);
@@ -80,7 +80,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ssd_optimal_settings() {
+    fn ssd_optimal_settings() {
         let drive_type = DriveType::Ssd;
 
         assert_eq!(drive_type.optimal_concurrency(), 8);
@@ -92,7 +92,7 @@ mod tests {
     }
 
     #[test]
-    fn test_hdd_optimal_settings() {
+    fn hdd_optimal_settings() {
         let drive_type = DriveType::Hdd;
 
         assert_eq!(drive_type.optimal_concurrency(), 4);
@@ -104,7 +104,7 @@ mod tests {
     }
 
     #[test]
-    fn test_hdd_extent_aware_concurrency() {
+    fn hdd_extent_aware_concurrency() {
         assert_eq!(DriveType::optimal_concurrency_for_hdd(62), 2);
         assert_eq!(DriveType::optimal_concurrency_for_hdd(100), 2);
         assert_eq!(DriveType::optimal_concurrency_for_hdd(51), 2);
@@ -120,7 +120,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unknown_optimal_settings() {
+    fn unknown_optimal_settings() {
         let drive_type = DriveType::Unknown;
 
         assert_eq!(drive_type.optimal_concurrency(), 4);
@@ -132,7 +132,7 @@ mod tests {
     }
 
     #[test]
-    fn test_optimal_settings_are_reasonable() {
+    fn optimal_settings_are_reasonable() {
         let nvme = DriveType::Nvme;
         let ssd = DriveType::Ssd;
         let hdd = DriveType::Hdd;

--- a/crates/uffs-mft/src/raw/tests.rs
+++ b/crates/uffs-mft/src/raw/tests.rs
@@ -8,7 +8,7 @@ use super::*;
 type TestResult = core::result::Result<(), Box<dyn core::error::Error>>;
 
 #[test]
-fn test_header_roundtrip() -> TestResult {
+fn header_roundtrip() -> TestResult {
     let header = RawMftHeader {
         version: VERSION,
         flags: FLAG_COMPRESSED,
@@ -35,7 +35,7 @@ fn test_header_roundtrip() -> TestResult {
 }
 
 #[test]
-fn test_header_invalid_magic() {
+fn header_invalid_magic() {
     let mut bytes = [0_u8; HEADER_SIZE];
     bytes[0..8].copy_from_slice(b"INVALID!");
 
@@ -48,7 +48,7 @@ fn test_header_invalid_magic() {
     clippy::indexing_slicing,
     reason = "test code with known valid indices"
 )]
-fn test_save_load_uncompressed() -> TestResult {
+fn save_load_uncompressed() -> TestResult {
     let temp_dir = std::env::temp_dir();
     let path = temp_dir.join("test_mft_uncompressed.raw");
 
@@ -87,7 +87,7 @@ fn test_save_load_uncompressed() -> TestResult {
 
 #[cfg(feature = "zstd")]
 #[test]
-fn test_save_load_compressed() -> TestResult {
+fn save_load_compressed() -> TestResult {
     let temp_dir = std::env::temp_dir();
     let path = temp_dir.join("test_mft_compressed.raw");
 
@@ -118,7 +118,7 @@ fn test_save_load_compressed() -> TestResult {
 }
 
 #[test]
-fn test_load_header_only() -> TestResult {
+fn load_header_only() -> TestResult {
     let temp_dir = std::env::temp_dir();
     let path = temp_dir.join("test_mft_header_only.raw");
 
@@ -147,7 +147,7 @@ fn test_load_header_only() -> TestResult {
     clippy::indexing_slicing,
     reason = "test code with known valid indices"
 )]
-fn test_iter_records() {
+fn iter_records() {
     let header = RawMftHeader {
         version: VERSION,
         flags: 0,
@@ -169,7 +169,7 @@ fn test_iter_records() {
 }
 
 #[test]
-fn test_volume_letter_preserved() -> TestResult {
+fn volume_letter_preserved() -> TestResult {
     let temp_dir = std::env::temp_dir();
     let path = temp_dir.join("test_mft_volume_letter.raw");
 
@@ -198,7 +198,7 @@ fn test_volume_letter_preserved() -> TestResult {
     clippy::indexing_slicing,
     reason = "test code with known valid indices"
 )]
-fn test_raw_compat_mode() -> TestResult {
+fn raw_compat_mode() -> TestResult {
     let temp_dir = std::env::temp_dir();
     let path = temp_dir.join("test_mft_raw_compat.raw");
 
@@ -238,7 +238,7 @@ fn test_raw_compat_mode() -> TestResult {
     clippy::indexing_slicing,
     reason = "test code with known valid indices"
 )]
-fn test_load_raw_ntfs_format() -> TestResult {
+fn load_raw_ntfs_format() -> TestResult {
     let temp_dir = std::env::temp_dir();
     let path = temp_dir.join("test_mft_raw_ntfs.raw");
 

--- a/crates/uffs-mft/src/reader.rs
+++ b/crates/uffs-mft/src/reader.rs
@@ -526,7 +526,7 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
-    fn test_open_valid_volume() {
+    fn open_valid_volume() {
         let result = MftReader::open('C');
         // This will fail without admin privileges, but should not panic
         assert!(result.is_ok() || matches!(result, Err(MftError::InsufficientPrivileges)));
@@ -534,13 +534,13 @@ mod tests {
 
     #[test]
     #[cfg(not(windows))]
-    fn test_platform_not_supported() {
+    fn platform_not_supported() {
         let result = MftReader::open('C');
         assert!(matches!(result, Err(MftError::PlatformNotSupported)));
     }
 
     #[test]
-    fn test_progress_percentage() {
+    fn progress_percentage() {
         let progress = MftProgress {
             records_read: 50,
             total_records: Some(100),
@@ -551,7 +551,7 @@ mod tests {
     }
 
     #[test]
-    fn test_progress_speed() {
+    fn progress_speed() {
         let progress = MftProgress {
             records_read: 1000,
             total_records: None,
@@ -562,20 +562,20 @@ mod tests {
     }
 
     #[test]
-    fn test_multi_drive_reader_new() {
+    fn multi_drive_reader_new() {
         let reader = MultiDriveMftReader::new(vec!['c', 'd', 'e']);
         assert_eq!(reader.drives(), &['C', 'D', 'E']);
     }
 
     #[test]
-    fn test_multi_drive_reader_empty() {
+    fn multi_drive_reader_empty() {
         let reader = MultiDriveMftReader::new(vec![]);
         assert!(reader.drives().is_empty());
     }
 
     #[tokio::test]
     #[cfg(not(windows))]
-    async fn test_multi_drive_platform_not_supported() {
+    async fn multi_drive_platform_not_supported() {
         let reader = MultiDriveMftReader::new(vec!['C', 'D']);
         let result = reader.read_all().await;
         assert!(matches!(result, Err(MftError::PlatformNotSupported)));
@@ -583,7 +583,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg(not(windows))]
-    async fn test_multi_drive_index_platform_not_supported() {
+    async fn multi_drive_index_platform_not_supported() {
         let reader = MultiDriveMftReader::new(vec!['C', 'D']);
         let result = reader.read_all_index().await;
         assert!(matches!(result, Err(MftError::PlatformNotSupported)));
@@ -591,7 +591,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg(not(windows))]
-    async fn test_multi_drive_index_cached_platform_not_supported() {
+    async fn multi_drive_index_cached_platform_not_supported() {
         let reader = MultiDriveMftReader::new(vec!['C', 'D']);
         let result = reader.read_all_index_cached(3600).await;
         assert!(matches!(result, Err(MftError::PlatformNotSupported)));
@@ -605,7 +605,7 @@ mod tests {
     /// allowing the I/O layer to use optimal settings based on drive type.
     #[test]
     #[cfg(windows)]
-    fn test_mft_reader_uses_none_defaults() {
+    fn mft_reader_uses_none_defaults() {
         // This test requires admin privileges, so we check if we can open
         let reader = match MftReader::open('C') {
             Ok(opened) => opened,
@@ -638,7 +638,7 @@ mod tests {
     /// Test that `MftReader` builder methods correctly set values
     #[test]
     #[cfg(windows)]
-    fn test_mft_reader_builder_overrides() {
+    fn mft_reader_builder_overrides() {
         let reader = match MftReader::open('C') {
             Ok(opened) => opened,
             Err(MftError::InsufficientPrivileges) => return,
@@ -662,7 +662,7 @@ mod tests {
     /// Test that `MftReadMode::Auto` is the default
     #[test]
     #[cfg(windows)]
-    fn test_mft_reader_default_mode_is_auto() {
+    fn mft_reader_default_mode_is_auto() {
         let reader = match MftReader::open('C') {
             Ok(opened) => opened,
             Err(MftError::InsufficientPrivileges) => return,
@@ -679,7 +679,7 @@ mod tests {
     /// Test that all boolean defaults are set for optimal performance
     #[test]
     #[cfg(windows)]
-    fn test_mft_reader_boolean_defaults() {
+    fn mft_reader_boolean_defaults() {
         let reader = match MftReader::open('C') {
             Ok(opened) => opened,
             Err(MftError::InsufficientPrivileges) => return,

--- a/crates/uffs-mft/src/tree_metrics.rs
+++ b/crates/uffs-mft/src/tree_metrics.rs
@@ -588,7 +588,7 @@ mod tests {
     /// The formula is: `delta(v, i, n) = floor(v*(i+1)/n) - floor(v*i/n)`
     /// This ensures the sum of all deltas equals the original value exactly.
     #[test]
-    fn test_delta_sum_equals_original() {
+    fn delta_sum_equals_original() {
         let test_cases: &[(u64, u32)] = &[
             (0, 1),
             (1, 1),
@@ -616,7 +616,7 @@ mod tests {
 
     /// Tests specific delta values to ensure reference parity.
     #[test]
-    fn test_delta_specific_values() {
+    fn delta_specific_values() {
         assert_eq!(delta(5, 0, 2), 2, "First link of 5/2 should get 2");
         assert_eq!(delta(5, 1, 2), 3, "Second link of 5/2 should get 3");
 
@@ -638,7 +638,7 @@ mod tests {
 
     /// Tests the `compute_name_info` helper function.
     #[test]
-    fn test_compute_name_info_helper() {
+    fn compute_name_info_helper() {
         assert_eq!(
             compute_name_info(0, 2),
             1,
@@ -675,7 +675,7 @@ mod tests {
     /// Tests that the combined transformation + delta gives correct
     /// distribution.
     #[test]
-    fn test_transformed_delta_distribution() {
+    fn transformed_delta_distribution() {
         let value: u64 = 5;
         let name_count: u32 = 2;
 
@@ -693,7 +693,7 @@ mod tests {
 
     /// Tests edge cases for the delta function.
     #[test]
-    fn test_delta_edge_cases() {
+    fn delta_edge_cases() {
         assert_eq!(delta(100, 0, 1), 100);
         assert_eq!(delta(0, 0, 2), 0);
         assert_eq!(delta(0, 1, 2), 0);

--- a/crates/uffs-time/src/lib.rs
+++ b/crates/uffs-time/src/lib.rs
@@ -108,14 +108,14 @@ mod tests {
     };
 
     #[test]
-    fn test_filetime_conversion() {
+    fn filetime_conversion() {
         let filetime: i64 = 133_485_408_000_000_000;
         let unix_micros = filetime_to_unix_micros(filetime);
         assert_eq!(unix_micros, 1_704_067_200_000_000);
     }
 
     #[test]
-    fn test_filetime_to_calendar_post_1970() {
+    fn filetime_to_calendar_post_1970() {
         // 2024-01-01 00:00:00 UTC
         let filetime: i64 = 133_485_408_000_000_000;
         let cal = filetime_to_calendar(filetime);
@@ -123,7 +123,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_to_calendar_pre_1970() {
+    fn filetime_to_calendar_pre_1970() {
         // 1959-12-02 03:45:50 UTC — the exact case from the parity baseline.
         // From Dec 2, 1959 00:00:00 to Jan 1, 1970 00:00:00:
         //   1960-1969 = 10 years = 7*365 + 3*366 = 3653 days
@@ -137,7 +137,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_to_calendar_zero_is_none() {
+    fn filetime_to_calendar_zero_is_none() {
         assert_eq!(filetime_to_calendar(0), None);
     }
 
@@ -146,19 +146,19 @@ mod tests {
     // ═══════════════════════════════════════════════════════════════════════
 
     #[test]
-    fn test_filetime_to_unix_micros_zero_returns_zero() {
+    fn filetime_to_unix_micros_zero_returns_zero() {
         // FILETIME 0 means "unset" — must map to 0, not a 1601 date.
         assert_eq!(filetime_to_unix_micros(0), 0);
     }
 
     #[test]
-    fn test_filetime_to_unix_micros_unix_epoch() {
+    fn filetime_to_unix_micros_unix_epoch() {
         // FILETIME at the exact Unix epoch (1970-01-01 00:00:00).
         assert_eq!(filetime_to_unix_micros(FILETIME_UNIX_DIFF), 0);
     }
 
     #[test]
-    fn test_filetime_to_unix_micros_pre_1970() {
+    fn filetime_to_unix_micros_pre_1970() {
         // 1960-01-01 00:00:00 — 10 years before Unix epoch.
         // Leap years 1960,1964,1968 → 3*366 + 7*365 = 3653 days.
         let ft_1960 = FILETIME_UNIX_DIFF - 3653 * 86400 * FILETIME_TICKS_PER_SECOND;
@@ -168,7 +168,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_to_unix_micros_filetime_epoch() {
+    fn filetime_to_unix_micros_filetime_epoch() {
         // FILETIME = 1 (one 100ns tick after 1601-01-01 00:00:00).
         // Should produce a large negative Unix µs (roughly -11644473600 seconds).
         let us = filetime_to_unix_micros(1);
@@ -179,7 +179,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_to_unix_micros_y2k() {
+    fn filetime_to_unix_micros_y2k() {
         // 2000-01-01 00:00:00 — 30 years, well-known reference.
         let expected_us: i64 = 946_684_800_000_000;
         let ft = FILETIME_UNIX_DIFF + expected_us * FILETIME_TICKS_PER_MICROSECOND;
@@ -187,7 +187,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_to_unix_micros_roundtrip_with_calendar() {
+    fn filetime_to_unix_micros_roundtrip_with_calendar() {
         // Verify that filetime → unix_micros and filetime → calendar agree.
         let ft_2024: i64 = 133_485_408_000_000_000; // 2024-01-01 00:00:00
         let us = filetime_to_unix_micros(ft_2024);
@@ -204,7 +204,7 @@ mod tests {
     // ═══════════════════════════════════════════════════════════════════════
 
     #[test]
-    fn test_filetime_to_calendar_leap_day_2000() {
+    fn filetime_to_calendar_leap_day_2000() {
         // 2000-02-29 12:00:00 — Feb 29 in a century leap year.
         let unix_secs: i64 = 951_825_600; // 2000-02-29 12:00:00 UTC
         let ft = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
@@ -212,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_to_calendar_leap_day_2024() {
+    fn filetime_to_calendar_leap_day_2024() {
         // 2024-02-29 23:59:59 — last second of a leap day.
         let unix_secs: i64 = 1_709_251_199; // 2024-02-29 23:59:59 UTC
         let ft = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
@@ -220,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_to_calendar_non_leap_1900() {
+    fn filetime_to_calendar_non_leap_1900() {
         // 1900-02-28 — 1900 is NOT a leap year (divisible by 100 but not 400).
         let unix_secs: i64 = -2_203_977_600; // 1900-02-28 00:00:00 UTC
         let ft = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
@@ -228,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_to_calendar_year_boundary() {
+    fn filetime_to_calendar_year_boundary() {
         // 1999-12-31 23:59:59 → 2000-01-01 00:00:00 boundary
         let ft_dec31 = (946_684_799_i64) * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
         let ft_jan01 = (946_684_800_i64) * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
@@ -240,14 +240,14 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_to_calendar_filetime_epoch_itself() {
+    fn filetime_to_calendar_filetime_epoch_itself() {
         // FILETIME = 1 tick → 1601-01-01 00:00:00 (essentially).
         let cal = filetime_to_calendar(1);
         assert_eq!(cal, Some((1601, 1, 1, 0, 0, 0)));
     }
 
     #[test]
-    fn test_filetime_to_calendar_midnight_exact() {
+    fn filetime_to_calendar_midnight_exact() {
         // Exactly midnight — time components must all be zero.
         let ft = 86400_i64 * FILETIME_TICKS_PER_SECOND; // day 1 since 1601
         let cal = filetime_to_calendar(ft);
@@ -261,13 +261,13 @@ mod tests {
     // ═══════════════════════════════════════════════════════════════════════
 
     #[test]
-    fn test_filetime_with_tz_bias_zero_no_change() {
+    fn filetime_with_tz_bias_zero_no_change() {
         let ft: i64 = 133_485_408_000_000_000;
         assert_eq!(filetime_with_tz_bias(ft, 0), ft);
     }
 
     #[test]
-    fn test_filetime_with_tz_bias_positive_east() {
+    fn filetime_with_tz_bias_positive_east() {
         // UTC+5 (e.g. Yekaterinburg) — 5 hours ahead.
         let ft: i64 = 133_485_408_000_000_000; // 2024-01-01 00:00:00 UTC
         let biased = filetime_with_tz_bias(ft, 5 * 3600);
@@ -276,7 +276,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_with_tz_bias_negative_west() {
+    fn filetime_with_tz_bias_negative_west() {
         // UTC-8 (US Pacific) — 8 hours behind.
         let ft: i64 = 133_485_408_000_000_000; // 2024-01-01 00:00:00 UTC
         let biased = filetime_with_tz_bias(ft, -8 * 3600);
@@ -290,7 +290,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_with_tz_bias_half_hour() {
+    fn filetime_with_tz_bias_half_hour() {
         // UTC+5:30 (India) — non-integer hour offset.
         let ft: i64 = 133_485_408_000_000_000; // 2024-01-01 00:00:00 UTC
         let biased = filetime_with_tz_bias(ft, 5 * 3600 + 1800);
@@ -303,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filetime_with_tz_bias_symmetric_round_trip() {
+    fn filetime_with_tz_bias_symmetric_round_trip() {
         // Reversing a bias must recover the original FILETIME exactly.
         let base = FILETIME_UNIX_DIFF;
         let shifted = filetime_with_tz_bias(base, 3600);


### PR DESCRIPTION
## Summary

Removes the redundant `test_` prefix from every `#[test]`-annotated function across the workspace, per `clippy::redundant_test_prefix` (R2-05 in `CLIPPY_POSTURE.md` §11).

**Mechanical, declaration-site-only renames.** Zero source-body changes, zero new `#[allow]` / `#[expect]`, zero behaviour change. 1,516 / 1,516 tests still pass.

## Scope

- **363 function renames across 36 source files** (35 macOS-visible + Windows-only platform tests reached via `cargo xwin`).
- Lint promoted from implicit `pedantic` warn to explicit `deny` after sweep was clean.

## How

`cargo clippy --fix` does **not** auto-apply this lint (suggestion isn't `MachineApplicable`). Approach:

1. Run `cargo clippy --message-format=json` to get structured `(file, line, old_name, suggested_new_name)` triples.
2. Rewrite **only the declaration line** (`fn test_<x>(` -> `fn <new>(`).
3. Repeat against the Windows target via `cargo xwin clippy` to pick up `cfg(windows)`-gated tests invisible on macOS.
4. Run `cargo check --workspace` -> clean (no in-file or cross-crate callers broke).
5. Run `cargo nextest --profile pre-push-smoke` -> 1,516 / 1,516 pass.
6. Update external references that name tests explicitly (see below).
7. Promote to `deny`.

## Collision handling

Three sites in `uffs-core/src/export.rs` would have collided with the public function under test (`fn test_export_table` -> would clash with `pub fn export_table`). Clippy itself emits a `_works` disambiguator for these:

| Before | After |
|---|---|
| `test_export_table` | `export_table_works` |
| `test_export_json` | `export_json_works` |
| `test_export_csv` | `export_csv_works` |

The apply script extracts both old and new names directly from the JSON diagnostic (not derived) so collision cases land correctly.

## External references updated in this PR

| File | Reason |
|---|---|
| `.github/workflows/tier-2.yml` (lines 234-237) | 4 hard-coded miri test names with `--exact`; without updating, the miri job would silently pass with 0 tests. |
| `.config/nextest.toml` (3 sites) | `test(/^test_validate/)` filtersets forward-updated to `test(/^validate/)` to preserve intent; today these match zero tests in either form. |

## Config delta

### `Cargo.toml [workspace.lints.clippy]`

```toml
# ───── Testing hygiene ─────
tests_outside_test_module = "deny"
redundant_test_prefix = "deny"     # NEW: `fn test_foo` redundant inside `mod tests` — bare `fn foo`
```

## Verification

| Gate | Result |
|------|--------|
| `cargo check --workspace --all-targets --all-features` | clean (no internal callers broken) |
| `just lint-prod` | green |
| `just lint-tests` | green |
| `just lint-ci` (`--all-targets -D warnings`) | green |
| `just lint-ci-windows` (`cargo xwin`, `x86_64-pc-windows-msvc`) | green |
| `just lint-ci-linux-zig` (`cargo zigbuild`, `x86_64-unknown-linux-gnu`) | green |
| `cargo doc --workspace --all-features --no-deps` | **0 warnings** |
| `cargo nextest run --profile pre-push-smoke --locked` | **1516 / 1516 pass** |
| `just lint-pre-push` (full 20-gate bundle) | green (85 s) |

## Rule audit

1. **No suppression hacks** — `git diff -- '*.rs' | rg '#\[(allow\|expect)'` returns 0 lines. Source bodies untouched.
2. **Surgical, idiomatic** — `git diff --stat`: 391 insertions / 389 deletions across 42 files. Test-file deltas are exactly +1/-1 per renamed fn declaration; the +2 net is the `Cargo.toml` lint line + the new `nextest.toml` comment.
3. **Preserve behavior & contracts** — observable test names *do* change (test reports, IDE panels). The change *removes noise* and is consistent with clippy guidance; no API impact. The two scripts that hard-coded test names (`tier-2.yml`, `nextest.toml`) are updated in-PR.
4. **Improve tests, don't dodge them** — every renamed test still runs: 1,516 / 1,516 pre-push-smoke pass. Names are now strictly more descriptive (the `test_` prefix conveyed nothing inside `mod tests`).

## Follow-ups

- **R2-04 `field_scoped_visibility_modifiers`** — 44 hits, design discussion needed; stays in `CLIPPY_POSTURE.md` §11 Roadmap. Not declined.
