### PR TITLE
fix(release): surface GitHub immutability conflict in pre-flight (closes #150)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,15 +119,42 @@ jobs:
           echo "🏷️ Tag: $VERSION"
           echo "🚀 Triggered by: ${{ inputs.triggered_by || 'tag-push' }}"
 
-      - name: Check if tag already exists (workflow_dispatch only)
+      - name: Check if tag or release already exists (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch'
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.validate.outputs.tag }}
         run: |
-          if git tag -l | grep -q "^${{ steps.validate.outputs.tag }}$"; then
-            echo "❌ Tag ${{ steps.validate.outputs.tag }} already exists"
+          # Guard 1 — git tag.  The release workflow creates the tag via
+          # action-gh-release's REST path; a colliding tag would be
+          # silently treated as "already created" and the build would
+          # publish over the existing one.
+          if git tag -l | grep -q "^${TAG}$"; then
+            echo "::error title=Tag ${TAG} already exists::A git tag for ${TAG} already exists.  Bump the version in Cargo.toml + CHANGELOG.md and re-dispatch."
             exit 1
           fi
-          echo "✅ Tag is available"
+
+          # Guard 2 — GitHub release row.  Since 2025-Q4 GitHub publishes
+          # releases as immutable by default.  When a release row exists
+          # for $TAG but the git tag has been rolled back (e.g. a previous
+          # release attempt failed AFTER the release was created but
+          # BEFORE artifacts uploaded, then the tag was manually deleted),
+          # action-gh-release tries to UPDATE the existing row's
+          # target_commitish and GitHub rejects with:
+          #
+          #   Validation Failed: target_commitish cannot be changed when
+          #   release is immutable
+          #
+          # The remedy is to bump the version, not to retry.  Surfacing
+          # that here gives a clear error instead of the cryptic one from
+          # action-gh-release.  See issue #150 / run 25549839464.
+          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error title=Release ${TAG} already published::A release for ${TAG} already exists on GitHub and is immutable.  GitHub does not allow re-publishing the same version.  Bump the version in Cargo.toml + CHANGELOG.md and re-dispatch."
+            exit 1
+          fi
+
+          echo "✅ Tag and release are both available for ${TAG}"
 
       - name: Validate commit_sha is ancestor of main (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch' && inputs.commit_sha != ''


### PR DESCRIPTION
## Summary

Closes #150.  Extends the existing `Check if tag already exists` step in `release.yml` so it ALSO detects an already-published GitHub release row.

Since 2025-Q4 GitHub publishes every release as **immutable** by default.  When `softprops/action-gh-release` finds an existing release for the candidate tag, it tries to UPDATE `target_commitish` — which GitHub now rejects with:

```
Validation Failed: target_commitish cannot be changed when release is immutable
```

That's exactly what hit v0.5.91 on 2026-05-08 (runs `25549839464`, `25551586203`, `25551688547`).  The author worked around it by bumping to v0.5.92 / v0.5.94 (both shipped fine — they were *new* tags) but the latent flaw stayed.

## Root cause sequence

1. Earlier v0.5.91 run created the release row via the REST API.
2. The run failed AFTER row creation but BEFORE artifact upload.
3. The git tag was rolled back manually.
4. Re-dispatching the workflow saw "no git tag" -> proceeded -> hit the immutable release row at the publish step -> died with the cryptic error.

The existing guard at line 122 only inspected `git tag -l`, so it couldn't catch step (4).

## Change

```diff
-      - name: Check if tag already exists (workflow_dispatch only)
+      - name: Check if tag or release already exists (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch'
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.validate.outputs.tag }}
         run: |
-          if git tag -l | grep -q "^${{ steps.validate.outputs.tag }}$"; then
-            echo "Tag already exists"
+          # Guard 1 - git tag (unchanged behaviour)
+          if git tag -l | grep -q "^${TAG}$"; then
+            echo "::error title=Tag ${TAG} already exists::Bump version + re-dispatch."
             exit 1
           fi
-          echo "Tag is available"
+
+          # Guard 2 - GitHub release row (NEW)
+          # See full rationale block in-file (issue #150 / run 25549839464)
+          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error title=Release ${TAG} already published::immutable; bump version."
+            exit 1
+          fi
+
+          echo "Tag and release both available for ${TAG}"
```

Both guards emit `::error title=...::` annotations that point at the **actual remedy** ("bump Cargo.toml + CHANGELOG.md and re-dispatch") instead of the cryptic GitHub validation error.

## Scope

- **+31 / -4 lines, one file:** `.github/workflows/release.yml`
- No source code, no test code, no Cargo manifests, no clippy config.
- No new dependencies - the `gh` CLI is already on every GitHub-hosted runner.

## Verification

| Gate | Result |
|------|--------|
| `actionlint .github/workflows/release.yml` | no new findings on edited lines 122-157 |
| `just workflow-drift` | green |
| `just typos` | green |
| `just reuse` (license header) | green |
| `just lint-pre-push` (full 20-gate bundle) | green (118 s) |

## Rule audit

1. **No suppression hacks** - workflow-level change; no `#[allow]`, no test skipping.
2. **Surgical, idiomatic** - extends the existing guard rather than duplicating it; uses the same step, same `if:` predicate, same shell, same env-var style.
3. **Preserve behavior** - when no release exists for `$TAG`, the step behaves identically to before.  The only newly-failing scenario is the one that was *already* failing downstream with a worse error.
4. **Improve tests** - the workflow gets a stronger invariant (no silent double-publish path).  No existing tests were touched.

## Follow-up

- Audit `auto-tag-release.yml` and `release-plz.yml` for the same flaw - **out of scope for this PR.**  Filing as a separate issue if the manual sweep finds anything.
