### PR TITLE
fix(security): replace lazy vet exemption bumps from #166 with proper delta audits

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,6 +1,12 @@
 
 # cargo-vet audits file
 
+[[audits.assert_cmd]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-run"
+delta = "2.2.1 -> 2.2.2"
+notes = "Delta audit reviewed via cargo vet diff. Replaces the silent exemption bump from PR #166 (which was a supply-chain #[allow] — see docs/architecture/security/supply-chain-posture.md). Changes: (1) #[track_caller] attributes on assert/failure/success paths + replacement of `.unwrap_or_else(AssertError::panic)` chains with explicit `match` blocks so caller location is preserved through panic; (2) edition-2024 idiom updates (Self::Variant / Self {..}); (3) include-list path normalization in Cargo.toml (/build.rs etc.); (4) internal lints.clippy config tightening. No semantic changes to assertion logic, no new unsafe, no new network/FS access paths. assert_cmd is test-only (safe-to-run)."
+
 [[audits.colored]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -48,6 +54,12 @@ Delta audit (Apr 2026, v0.5.71):
   nightly-only cfg-gated feature flag addition; inert on stable toolchains.
   No runtime behavior change.
 - No unsafe additions, no API changes, no new ambient capabilities."""
+
+[[audits.tokio]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.52.2 -> 1.52.3"
+notes = "Delta audit reviewed via cargo vet diff. Replaces the silent exemption bump from PR #166 (which was a supply-chain #[allow]). Changes scoped to src/sync/mpsc/* and src/sync/rwlock.rs, implementing four documented upstream bug-fix PRs per tokio 1.52.3 release notes (May 2026): tokio#8062 fix mpsc len() underflow; tokio#8074 return TryRecvError::Empty from try_recv() when mpsc closed with outstanding permits; tokio#8075 notify receivers in mpsc OwnedPermit::release() by reusing non-owned Permit Drop impl; tokio#8076 reject RwLock::new max_readers==0 (prevents div-by-zero in semaphore fast path). Companion tests in tests/sync_mpsc.rs + tests/sync_rwlock.rs. No feature additions, no new unsafe, no public API signature changes."
 
 [[trusted.h2]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -147,7 +147,7 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.assert_cmd]]
-version = "2.2.2"
+version = "2.2.1"
 criteria = "safe-to-run"
 
 [[exemptions.async-channel]]
@@ -1179,7 +1179,7 @@ version = "1.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
-version = "1.52.3"
+version = "1.52.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-macros]]


### PR DESCRIPTION
## Summary

Replaces the silent vet exemption bumps from #166 with proper delta audits.

PR #166 (Dependabot patch group) bumped `assert_cmd 2.2.1 -> 2.2.2` and `tokio 1.52.2 -> 1.52.3`.  CI was unblocked by `cargo vet regenerate exemptions`, which widened both exemption entries from the old patch version to the new one **without any diff review** — the supply-chain equivalent of `#[allow]`.  By the time the proper audits were ready to push, #166 had already auto-merged.

## What this PR does

| | Before (on main from #166) | After (this PR) |
|---|---|---|
| `[[exemptions.assert_cmd]] version` | `2.2.2` | `2.2.1` (anchor) |
| `[[exemptions.tokio]] version` | `1.52.3` | `1.52.2` (anchor) |
| `[[audits.assert_cmd]]` | _absent_ | new — `delta = "2.2.1 -> 2.2.2"` with review notes |
| `[[audits.tokio]]` | _absent_ | new — `delta = "1.52.2 -> 1.52.3"` with review notes |

**Trust chain after merge:**

```
exemption @ 2.2.1   + audit @ 2.2.1 -> 2.2.2   ==> trusted @ 2.2.2
exemption @ 1.52.2  + audit @ 1.52.2 -> 1.52.3 ==> trusted @ 1.52.3
```

The exemption is the same width as it was *before* #166 — only the documented delta extends it to the new lockfile versions.  **Future patch bumps (2.2.3, 1.52.4, ...) will fail vet again until another delta audit lands** — no silent extension of trust.

## Diff review evidence

### `assert_cmd` 2.2.1 → 2.2.2

`cargo vet diff assert_cmd 2.2.1 2.2.2` shows four classes of change:

1. `#[track_caller]` attributes added on `assert/failure/success` paths + replacement of `.unwrap_or_else(AssertError::panic)` chains with explicit `match` blocks so the caller location survives the panic.
2. Edition-2024 idiom updates (`Self::Variant`, `Self { .. }`).
3. Manifest path-prefix normalization (`/build.rs` etc.).
4. Internal `[lints.clippy]` config tightening.

**No semantic changes** to assertion logic, no new `unsafe`, no new network/FS access paths.  `assert_cmd` is test-only (`safe-to-run`).

### `tokio` 1.52.2 → 1.52.3

`cargo vet diff tokio 1.52.2 1.52.3` is scoped to `src/sync/mpsc/*` and `src/sync/rwlock.rs`, implementing **four documented upstream bug-fix PRs** from the tokio 1.52.3 release notes (May 2026):

| PR | Bug |
|---|---|
| [tokio#8062](https://github.com/tokio-rs/tokio/pull/8062) | Fix underflow in mpsc channel `len()` |
| [tokio#8074](https://github.com/tokio-rs/tokio/pull/8074) | Return `TryRecvError::Empty` from `try_recv()` when mpsc is closed with outstanding permits |
| [tokio#8075](https://github.com/tokio-rs/tokio/pull/8075) | Notify receivers in mpsc `OwnedPermit::release()` by reusing the non-owned `Permit` Drop impl |
| [tokio#8076](https://github.com/tokio-rs/tokio/pull/8076) | Reject `RwLock::new(max_readers = 0)` (div-by-zero guard in semaphore fast path) |

Companion tests in `tests/sync_mpsc.rs` and `tests/sync_rwlock.rs`.  No feature additions, no new `unsafe`, no public API signature changes.

## Verification

```
$ cargo vet check --locked
Vetting Succeeded (134 fully audited, 4 partially audited, 375 exempted)
```

The `4 partially audited` count is up from `2` on main: the two new delta audits each contribute one partial-audit entry.

## Scope

- **+14 / -2 lines, two files:**
  - `supply-chain/audits.toml`  +12  (two new delta audit entries with full review notes)
  - `supply-chain/config.toml`   ±4  (exemption anchors restored from 2.2.2 → 2.2.1 and 1.52.3 → 1.52.2)
- No source code, no test code, no Cargo manifest/lock changes, no `imports.lock` changes.

## Rule audit

1. **No suppression hacks** — directly undoes the `#[allow]`-style exemption widening from #166.  The replacement is inspected delta audits whose review notes are themselves auditable artifacts.
2. **Surgical, idiomatic** — two `cargo vet certify` invocations + a 4-line edit to restore the anchor versions.  No tool bypass, no manual `audits.toml` hand-editing.
3. **Preserve behavior** — supply-chain only; no runtime impact.  Cargo.lock version trust is unchanged from #166's perspective, but now grounded in audit rather than blanket trust.
4. **Improve tests** — the delta audit notes serve as forensic checkpoints.  Any future maintainer can re-run `cargo vet diff assert_cmd 2.2.1 2.2.2` (or the tokio equivalent) and verify the notes still describe the diff accurately.

## Follow-up

A separate PR will add the **four-layer policy** that prevents future lazy exemption bumps from sneaking through CI:

1. **CI gate** — `Security (deny + vet)` step that fails any PR which bumps an exemption `version` without a paired `[[audits.<crate>]]` delta entry.
2. **`just vet-bump` wrapper** — interactive `cargo vet diff` + `cargo vet certify` in one command, surfaced as the fix in the CI error message.
3. **CODEOWNERS rule** — `/supply-chain/   @<security-reviewer>` so a specific reviewer signs off on all supply-chain mutations.
4. **Commit-trailer requirement** — `Vet-Reviewed-Diff: <upstream URL>` trailer enforced on commits touching `supply-chain/audits.toml`.

Discussed in the conversation that produced this PR.

Refs: #166 (the lazy bump this PR replaces).
