### PR TITLE
docs(cargo): correct stale clippy threshold comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,9 +306,9 @@ unnecessary_safety_comment = "deny"    # Accurate safety comments
 missing_errors_doc = "deny"                        # Document error conditions
 missing_panics_doc = "deny"                        # Document panic conditions
 missing_safety_doc = "deny"                        # Document safety requirements
-cognitive_complexity = "deny"                      # Keep functions simple (threshold=30 in clippy.toml)
-too_many_lines = "deny"                            # Keep functions short (threshold=150 in clippy.toml)
-type_complexity = "deny"                           # Keep types simple (threshold=300 in clippy.toml)
+cognitive_complexity = "deny"                      # Keep functions simple (default threshold=25; violations get scoped #[expect])
+too_many_lines = "deny"                            # Keep functions short (default threshold=100; violations get scoped #[expect])
+type_complexity = "deny"                           # Keep types simple (default threshold=250; violations get scoped #[expect])
 large_enum_variant = "deny"                        # Optimize enum memory usage
 large_stack_arrays = "deny"                        # Avoid large stack allocations
 large_types_passed_by_value = "deny"               # Pass large types by reference


### PR DESCRIPTION
## Summary

Three inline comments in `Cargo.toml [workspace.lints.clippy]` claimed `clippy.toml` thresholds that were never actually set there.  This PR aligns the comments with the live config.

## The drift

| Line | Old comment claim | Reality (`clippy.toml`) |
|---|---|---|
| `Cargo.toml:309` | `# threshold=30 in clippy.toml`  | unset — Clippy default `25` |
| `Cargo.toml:310` | `# threshold=150 in clippy.toml` | unset — Clippy default `100` |
| `Cargo.toml:311` | `# threshold=300 in clippy.toml` | unset — Clippy default `250` |

The values `30 / 150 / 300` were never written to `clippy.toml` — they appear to be a stale plan from before Phase 2D of the [Lint Consolidation Roadmap](https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/docs/dev/architecture/code_clean/2026_04_03_lint_consolidation_roadmap.md), when the project briefly considered blanket-raising the thresholds and instead landed on a **scoped-`#[expect]`-per-violation** policy.

This drift was previously surfaced when the dev-notes posture doc was rewritten on 2026-05-11 — the doc was corrected (its §12 Decisions Log records the fix) but `Cargo.toml`'s inline comments were not updated in the same commit, violating the project's _"doc and config land together"_ rule.

## What this PR changes

```diff
-cognitive_complexity = "deny"                      # Keep functions simple (threshold=30 in clippy.toml)
-too_many_lines = "deny"                            # Keep functions short (threshold=150 in clippy.toml)
-type_complexity = "deny"                           # Keep types simple (threshold=300 in clippy.toml)
+cognitive_complexity = "deny"                      # Keep functions simple (default threshold=25; violations get scoped #[expect])
+too_many_lines = "deny"                            # Keep functions short (default threshold=100; violations get scoped #[expect])
+type_complexity = "deny"                           # Keep types simple (default threshold=250; violations get scoped #[expect])
```

The new comments encode two facts a future maintainer needs to know at the deny site:

1. **No threshold override exists** — Clippy's defaults are in effect.
2. **Violations are handled with scoped `#[expect(lint, reason = "...")]`** — not by raising the ceiling.  This is the canonical UFFS pattern (~37 scoped `#[expect(clippy::cognitive_complexity)]` sites across the workspace, all NTFS attribute dispatchers / request routers / parser orchestrators).

## What this PR does NOT change

- `clippy.toml` — untouched.
- `[workspace.lints]` levels — untouched.
- The actual `#[expect]` inventory — untouched.

## Verification

```
$ cargo metadata --format-version=1 --no-deps >/dev/null   # parses
$ cargo vet check --locked                                  # unchanged
Vetting Succeeded (134 fully audited, 4 partially audited, 375 exempted)
```

`pre-push` ran the full local gate (`lint-pre-push.sh`): `reuse`, `taplo`, `vet-fmt`, `cargo-check`, `lint-ci`, `lint-prod`, `lint-tests`, `rustdoc`, `doc-tests`, `tests`, `smoke`, `deny`, `lint-ci-windows` — all green.

## Net diff

```
 Cargo.toml | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

## Rule audit

1. **No suppression hacks** — comment fix only; no lint added, raised, lowered, or suppressed.
2. **Surgical, idiomatic** — three-line change, no whitespace churn.
3. **Preserve behavior** — `cargo metadata` parses; `cargo vet` unchanged; thresholds were already at defaults so no compile-time behavior shift.
4. **Improve tests** — n/a (comment fix). Removes a documentation footgun that a future maintainer could have followed into a real config bump.
