### PR TITLE
feat(ci): cargo-machete as a hard gate at pre-push + pr-fast (R3-01)

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -485,11 +485,16 @@ jobs:
       - run: cargo nextest run --workspace --all-features --lib --tests --profile ci --locked
 
   # ─────────────────────────────────────────────────────────────────────
-  # security — cargo-deny + cargo-vet.  Re-runs vet here (also runs in
-  # sanity when dep changed) because external observers (branch
-  # protection history, search tooling, audit trails) expect a
-  # distinct "Security" check in the check-runs list.  Cheap on warm
-  # cache (~10 s).
+  # security — cargo-deny + cargo-vet + cargo-vet audit-discipline +
+  # cargo-machete.  Bundles every supply-chain-hygiene check into a
+  # single Linux job.  Re-runs `vet` here (also runs in `sanity` when
+  # dep changed) because external observers (branch protection
+  # history, search tooling, audit trails) expect a distinct "Security"
+  # check in the check-runs list.  Display name kept stable as
+  # "Security (deny + vet)" to preserve historical check-run identity
+  # across additions to the job (audit-discipline landed in PR #172,
+  # cargo-machete in this PR — both bundled without renaming).
+  # Cheap on warm cache (~10 s wall).
   # ─────────────────────────────────────────────────────────────────────
   security:
     name: Security (deny + vet)
@@ -516,7 +521,7 @@ jobs:
 
       - uses: taiki-e/install-action@dfc84ffb7254b048a0a843316ff5a2714dcdc7bd # v2
         with:
-          tool: cargo-deny,cargo-vet
+          tool: cargo-deny,cargo-vet,cargo-machete
 
       - name: cargo deny check
         # cargo-deny does not accept --locked; it reads Cargo.lock directly.
@@ -536,6 +541,19 @@ jobs:
         # bypass: CI is hard on `main`.
         if: needs.classify.outputs.dep == 'true'
         run: bash scripts/ci/check_vet_audit_discipline.sh ci
+
+      - name: cargo-machete unused-dep check
+        # Fast (~1 s) AST-based unused-dependency detector.  Complements
+        # `cargo-udeps` in Tier 2 weekly (which actually compiles to
+        # detect, more accurate but multi-minute, nightly-only).
+        # cargo-machete catches the common case — a `[dependencies]`
+        # entry whose crate is no longer `use`d anywhere — at PR time
+        # instead of a week later.  `--skip-target-dir` mirrors the
+        # local `just/analysis_ci.just::machete` recipe so identical
+        # output is reproducible on both surfaces.  pr-fast bundles
+        # into this `security` job (same `code_changed` predicate as
+        # the deny + vet pair) to keep the job graph narrow.
+        run: cargo machete --skip-target-dir
 
   # ─────────────────────────────────────────────────────────────────────
   # windows-lint — native Windows clippy gate on `windows-latest`.

--- a/docs/architecture/dev-flow.md
+++ b/docs/architecture/dev-flow.md
@@ -150,6 +150,7 @@ and `.github/workflows/tier-2.yml` (all as of commit `185ed8825`).
 | rustdoc `-Dwarnings` | — | ✅ | ✅ | — |
 | `cargo deny check` | — | ✅ | ✅ | — |
 | **`cargo vet check --locked`** | — | **❌** | ✅ | — |
+| `cargo machete` (unused-dep static check) | — | ✅ | ✅ | — |
 | test COMPILE (`nextest --no-run`) | — | ✅ | ✅ (test-build) | — |
 | test EXECUTE (`nextest run`) | — | **❌** | ✅ | via coverage |
 | **`cargo test --doc`** | — | **❌** | ✅ | — |
@@ -244,17 +245,27 @@ as actual tests) is CI-only at `ci.yml:268`.
 
 **Fix**: Add a mandatory gate `doc-tests` alongside `rustdoc`.
 
-### 4.4 GAP 4 — unused-dependency detection is weekly-only (🟢 LOW)
+### 4.4 GAP 4 — unused-dependency detection is weekly-only (✅ CLOSED 2026-05-12)
 
-**Evidence**: `cargo udeps` runs only in `tier-2.yml:166-191`.  A PR that
-removes the last use of a workspace dep accumulates cruft until the next
-Monday's Tier 2 run.
+**Original evidence**: `cargo udeps` runs only in `tier-2.yml:166-191`.
+A PR that removes the last use of a workspace dep accumulated cruft
+until the next Monday's Tier 2 run.
 
-**Fast alternative**: `cargo machete` is 5–10× faster than `cargo-udeps`
-(static analysis vs rebuild-with-RUSTC_WRAPPER).  Already in
-`dev.just:118`'s `update-tools` tool list.
+**Resolution**: `cargo machete` (sub-second AST-based unused-dep
+detector — static-analysis sibling of `cargo-udeps`, no nightly
+required) promoted to a **hard gate at pre-push + pr-fast** via
+`scripts/ci/gates.toml [[gate]] id = "machete"` and the
+`pr-fast.yml::security` job's step list.  Added to
+`just install-dev-tools` so contributors onboard with the binary
+required by the gate.  See
+[CLIPPY_POSTURE.md §12 entry for 2026-05-12 `cargo-machete`](../dev/architecture/code_clean/CLIPPY_POSTURE.md#12--decisions-log)
+for the full decision-log record.
 
-**Recommendation**: Add `cargo machete` as an optional pre-push gate.
+`cargo-udeps` stays at Tier 2 weekly as the authoritative
+compile-driven check — it catches deps used only behind `#[cfg]`
+gates that machete's static grep misses.  The two are complementary,
+not redundant: machete is the fast inner-loop check, udeps is the
+thorough weekly sweep.
 
 ### 4.5 GAP 5 — CodeQL is intentionally CI-only (🟢 LEAVE)
 

--- a/docs/architecture/security/supply-chain-posture.md
+++ b/docs/architecture/security/supply-chain-posture.md
@@ -6,7 +6,19 @@
 Status as of **2026-05-12** · Maintainer: `@githubrobbi` · Review cadence: monthly
 
 **Changelog**:
-- 2026-05-12 — **Four-layer cargo-vet audit-discipline policy** (this PR).
+- 2026-05-12 — **`cargo-machete` promoted to pre-push + pr-fast hard gate**.
+  Sub-second AST-based unused-dependency detector, complementary to the
+  existing weekly `cargo-udeps` check (compile-driven, nightly-only,
+  multi-minute).  Closes `dev-flow.md §4.4 GAP 4` — unused-dep
+  detection was previously weekly-only.  Wired via `[[gate]] id =
+  "machete"` in `scripts/ci/gates.toml`, regenerated `_lint_pre_push.sh`,
+  and bundled into `pr-fast.yml`'s existing `security` job step list
+  (display name kept stable to preserve check-run history).  Added to
+  `just install-dev-tools` so contributors onboard with the binary
+  required by the gate.  Workspace was clean against `cargo machete
+  --skip-target-dir` at adoption.  See CLIPPY_POSTURE.md §12 entry for
+  2026-05-12 `cargo-machete` for the full decision-log record.
+- 2026-05-12 — **Four-layer cargo-vet audit-discipline policy** (PR #172).
   Closes the lazy-bump anti-pattern PR #166 introduced and PR #170
   manually undid.  Four defenses now compose to make `cargo vet
   regenerate exemptions` the wrong-by-default answer to a patch-bump
@@ -93,6 +105,8 @@ control lands or a deferred item is promoted.
 | Lockfile pinning | Committed `Cargo.lock` | Every resolved crate-version frozen across devs / CI / releases | Always | **Yes** — `cargo vet check --locked` would fail any drift |
 | Audit trail | `cargo-vet check --locked` | Every resolved crate-version must have import / own audit / exemption | Every PR | **Yes** — `pr-fast.yml` security job |
 | Audit discipline | `scripts/ci/check_vet_audit_discipline.sh` | Every exemption version-bump must have a matching delta audit AND a `Vet-Reviewed-Diff:` commit trailer | Every push touching `supply-chain/config.toml` | **Yes** — pre-push hook + `pr-fast.yml::security` |
+| Unused-dep hygiene (static) | `cargo-machete` | Every `[dependencies]` / `[dev-dependencies]` / `[build-dependencies]` entry must be `use`d somewhere in the workspace | Every code-changed push / PR | **Yes** — pre-push hook + `pr-fast.yml::security` (Tier R3-01, landed 2026-05-12) |
+| Unused-dep hygiene (compiled) | `cargo-udeps` | Same scope as machete but compiles to detect — catches `#[cfg]`-gated false-negatives machete's grep misses | Weekly | **Yes** (advisory) — `tier-2.yml::udeps` |
 | Import refresh | `cargo-vet-refresh.yml` | Weekly `cargo vet regenerate imports` → PR | Mondays 08:00 UTC | GitHub schedules |
 | Structural audit | `cargo-geiger` via `just geiger` | unsafe / build.rs / proc-macro footprint | On-demand (monthly) | No |
 | Semantic SAST | `codeql.yml` (Rust, public preview) | Dataflow-based bug patterns (path / SQL / regex injection, crypto misuse, unvalidated redirects) | PR + Tuesdays 06:30 UTC | Informational (not a required gate yet) |

--- a/just/test.just
+++ b/just/test.just
@@ -341,7 +341,7 @@ taplo-fmt *ARGS:
 install-dev-tools:
     #!/usr/bin/env bash
     set -euo pipefail
-    printf "\033[0;34m📦 Installing dev tools (typos-cli, taplo-cli, cargo-xwin)...\033[0m\n"
+    printf "\033[0;34m📦 Installing dev tools (typos-cli, taplo-cli, cargo-machete, cargo-xwin)...\033[0m\n"
     if ! command -v typos >/dev/null 2>&1; then
         cargo install --locked typos-cli
     else
@@ -351,6 +351,17 @@ install-dev-tools:
         cargo install --locked taplo-cli
     else
         printf "   \033[0;32m✓\033[0m taplo already installed\n"
+    fi
+    # cargo-machete is required by the pre-push / pr-fast `machete` gate
+    # (Tier R3 of `docs/dev/architecture/code_clean/CLIPPY_POSTURE.md`).
+    # Sub-second AST-based unused-dependency detector — complements
+    # cargo-udeps (Tier 2 weekly, multi-minute, nightly-only) with a
+    # cheap pre-push check that catches the common case before PR opens.
+    # ~3 MB binary; binstall takes <5 s when cargo-binstall is present.
+    if ! command -v cargo-machete >/dev/null 2>&1; then
+        cargo install --locked cargo-machete
+    else
+        printf "   \033[0;32m✓\033[0m cargo-machete already installed\n"
     fi
     # cargo-xwin is required by the pre-commit / pre-push `lint-ci-windows`
     # gate (Phase W5.6).  Optional on Windows hosts (where `cargo clippy`

--- a/scripts/ci/gates.toml
+++ b/scripts/ci/gates.toml
@@ -516,6 +516,41 @@ the gate is hard on `main`.  pr-fast bundles this into the existing
 """
 
 [[gate]]
+id = "machete"
+label = "cargo-machete unused-dep check"
+command = ["cargo", "machete", "--skip-target-dir"]
+tiers = ["pre-push", "pr-fast"]
+gate_when = "code_changed"
+hard = true
+tool = "cargo-machete"
+expected_runtime_secs = 1
+bucket = "bg"
+order = 47
+consumer_names = { "pr-fast" = "security" }
+notes = """
+Fast AST-based unused-dependency detector.  Greps source for
+`use <crate>` / `<crate>::path` patterns and cross-references the
+`[dependencies]` / `[dev-dependencies]` / `[build-dependencies]`
+sections in every workspace `Cargo.toml`.
+
+Complementary to `cargo-udeps` (Tier 2 weekly) which actually
+compiles the workspace to detect unused deps — `udeps` is more
+accurate (catches deps used only behind `#[cfg]` that machete's
+static grep misses) but multi-minute and nightly-only.  machete
+runs sub-second on stable, fits the pre-push budget cleanly.
+
+Gate fires on any code change (rust / dep / infra) because either
+class can flip machete's verdict: removing the last `use foo` from
+a `.rs` file or adding `foo = "..."` to a `Cargo.toml` without a
+consumer both produce a new finding.
+
+HARD-FAIL with install hint when missing (`cargo install
+cargo-machete` or `cargo binstall cargo-machete`; ~3 MB binary,
+sub-second build via binstall).  pr-fast bundles into the existing
+`security` job alongside `vet` + `deny` + `vet-audit-discipline`.
+"""
+
+[[gate]]
 id = "deny"
 label = "cargo deny check"
 command = ["cargo", "deny", "check", "--hide-inclusion-graph"]

--- a/scripts/hooks/_lint_pre_push.sh
+++ b/scripts/hooks/_lint_pre_push.sh
@@ -224,6 +224,7 @@ if (( DEP_CHANGED )); then
     spawn_bg "vet" cargo vet check --locked
 fi
 spawn_bg "vet-audit-discipline" bash scripts/ci/check_vet_audit_discipline.sh pre-push
+spawn_bg "machete" cargo machete --skip-target-dir
 command -v typos >/dev/null 2>&1 && spawn_bg "typos" typos .
 command -v reuse >/dev/null 2>&1 && spawn_bg "reuse" reuse lint --quiet
 


### PR DESCRIPTION
## Summary

Promotes `cargo-machete` from a maintainer-only `just analysis_ci.just`
recipe to a load-bearing CI gate.  Closes
[`dev-flow.md §4.4 GAP 4`](../blob/chore/cargo-machete-pre-push-gate/docs/architecture/dev-flow.md#44-gap-4--unused-dependency-detection-is-weekly-only--closed-2026-05-12)
("unused-dependency detection is weekly-only") — `cargo-udeps` only
ran in `tier-2.yml::udeps` (weekly cron, multi-minute, nightly-only),
so a PR that removed the last `use` of a workspace dep accumulated
cruft until the following Monday.

`cargo-machete` is the static-analysis sibling of `cargo-udeps`:
sub-second AST-based detector, stable toolchain, no compile.
**Complementary, not redundant** — machete catches the common case
(`[dependencies]` entry with no remaining `use` in the workspace)
at PR time; udeps stays at Tier 2 as the authoritative
compile-driven sweep that catches `#[cfg]`-gated false-negatives
machete's grep misses.

## Audit context

This is the first PR of a five-PR sequence implementing Tier R3
(Tooling / CI additions) from `CLIPPY_POSTURE.md`, prioritized by an
end-to-end pipeline audit:

| # | Tool | Verdict | Status |
|---|---|---|---|
| **A** | `cargo-machete` (pre-push gate) | TRUE addition, low overlap with `cargo-udeps` | **This PR** |
| B | `cargo-hack --each-feature` (Tier 2) | TRUE addition, zero overlap | Pending |
| C | `cargo-careful` (Tier 2) | TRUE addition, complements miri | Pending |
| D | `cargo-mutants` (Tier 2, scoped to `uffs-security`) | TRUE addition, no overlap | Pending |
| E | `cargo-semver-checks` (`crates-io-dry-run.yml`) | TRUE addition (discovered during audit) | Pending |

Audit also verified that `cargo-audit` and `cargo-outdated` (as
gates) would be **redundant** (cargo-deny covers RustSec advisories;
Dependabot covers outdated bumps) and are NOT being added.

## Wiring

| File | Change |
|---|---|
| `scripts/ci/gates.toml` | New `[[gate]] id = "machete"`, `gate_when = "code_changed"`, `bucket = "bg"`, hard, order 47 |
| `scripts/hooks/_lint_pre_push.sh` | Regenerated via `just gen-hooks`; +1 line (`spawn_bg "machete" cargo machete --skip-target-dir`) |
| `.github/workflows/pr-fast.yml::security` job | `taiki-e/install-action` tool list extended; new `cargo-machete` step.  Display name kept as `Security (deny + vet)` to preserve check-run history (precedent from PR #172 audit-discipline bundling) |
| `just/test.just install-dev-tools` | `cargo-machete` added to canonical onboarding recipe |
| `docs/architecture/dev-flow.md §3.2` | Gate matrix row added (T2 ✅, T3 ✅) |
| `docs/architecture/dev-flow.md §4.4` | GAP 4 marked ✅ CLOSED with resolution narrative |
| `docs/architecture/security/supply-chain-posture.md` | Two new rows in Layered Defences (static / compiled unused-dep hygiene); changelog entry |

## Verification

Workspace was clean against `cargo machete --skip-target-dir` at
adoption.  Local pre-push gate suite (22/22 green, 49s):

```
🚦 lint-pre-push — workspace parallel gate
  ✅ [1] fmt / file-size / gates-drift / hooks-drift / workflow-drift
  ✅ [1] fast-drift / commit-subjects / vet / vet-audit-discipline
  ✅ [1] machete / typos / reuse
  ✅ [2] cargo-check / lint-ci / lint-prod / lint-tests / rustdoc
  ✅ [2] doc-tests / tests / smoke / deny / lint-ci-windows
✅ lint-pre-push passed (49s)
```

Drift detectors all green; manifest now counts **25 gates** (was 24).
The classify job during this push correctly identified `infra=1,
code=1` (`gates.toml`, `pr-fast.yml`, `just/test.just`, hook regen
all match the `infra` regex), so Bucket 2 ran.  `machete` ran in
Bucket 1 and reported clean.

## Non-goals

- **No code change** — pure CI hygiene.
- **No display-name change** to the `Security` job — bundling
  precedent from PR #172 (audit-discipline) preserved.
- **No `cargo-udeps` removal** — the two tools are kept side-by-side
  as fast inner-loop (machete) + thorough weekly sweep (udeps).
- **No new required-check** — bundled into the existing
  `Security (deny + vet)` required check via the `security` job.

Refs: Tier R3-01 of `CLIPPY_POSTURE.md` (the maintainer-local
`docs/dev/` doc); next in the sequence is **PR B**: `cargo-hack
--each-feature` in `tier-2.yml`.