### PR TITLE
refactor(uffs-mft): retire vestigial `zstd` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ uffs-polars = { path = "crates/uffs-polars", version = "0.5.94" }
 uffs-security = { path = "crates/uffs-security", version = "0.5.94" }
 uffs-text = { path = "crates/uffs-text", version = "0.5.94" }
 uffs-time = { path = "crates/uffs-time", version = "0.5.94" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.94", features = ["zstd"] }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.94" }
 uffs-format = { path = "crates/uffs-format", version = "0.5.94" }
 uffs-core = { path = "crates/uffs-core", version = "0.5.94" }
 uffs-client = { path = "crates/uffs-client", version = "0.5.94" }

--- a/crates/uffs-mft/Cargo.toml
+++ b/crates/uffs-mft/Cargo.toml
@@ -60,7 +60,7 @@ smallvec.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 rayon.workspace = true
-zstd = { workspace = true, optional = true }
+zstd.workspace = true
 
 # CLI (for uffs_mft binary)
 clap.workspace = true
@@ -104,7 +104,3 @@ harness = false
 
 [lints]
 workspace = true
-
-[features]
-default = ["zstd"]
-zstd = ["dep:zstd"]

--- a/crates/uffs-mft/benches/mft_read.rs
+++ b/crates/uffs-mft/benches/mft_read.rs
@@ -52,8 +52,6 @@ use uffs_text as _;
 #[cfg(windows)]
 use windows as _;
 use zerocopy as _;
-
-#[cfg(feature = "zstd")]
 extern crate zstd as _;
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/uffs-mft/src/cache.rs
+++ b/crates/uffs-mft/src/cache.rs
@@ -51,7 +51,6 @@ pub use cache_dataframe::load_or_build_dataframe_cached;
 /// policy.
 #[path = "cache_compress.rs"]
 mod cache_compress;
-#[cfg(feature = "zstd")]
 pub use cache_compress::{
     compress_encrypt_write, compress_encrypt_write_streaming, compress_zstd_mt, new_zstd_mt_encoder,
 };
@@ -360,7 +359,6 @@ pub fn save_to_cache(
 /// Returns an error only if serialization or directory creation fails.
 /// Background compression/encryption/write errors are logged but not
 /// propagated (best-effort save).
-#[cfg(feature = "zstd")]
 pub fn save_to_cache_background(
     index: &MftIndex,
     drive: char,

--- a/crates/uffs-mft/src/cache_compress.rs
+++ b/crates/uffs-mft/src/cache_compress.rs
@@ -18,7 +18,6 @@ use crate::index::usize_to_f64;
 /// # Errors
 ///
 /// Returns an I/O error if compression fails.
-#[cfg(feature = "zstd")]
 pub fn compress_zstd_mt(data: &[u8], level: i32) -> std::io::Result<Vec<u8>> {
     let mut encoder = zstd::Encoder::new(Vec::new(), level)?;
     let workers_usize = std::thread::available_parallelism().map_or(4, |n| n.get().min(8));
@@ -36,7 +35,6 @@ pub fn compress_zstd_mt(data: &[u8], level: i32) -> std::io::Result<Vec<u8>> {
 /// # Errors
 ///
 /// Returns an I/O error if encoder initialisation fails.
-#[cfg(feature = "zstd")]
 pub fn new_zstd_mt_encoder(level: i32) -> std::io::Result<zstd::Encoder<'static, Vec<u8>>> {
     let mut encoder = zstd::Encoder::new(Vec::new(), level)?;
     let workers_usize = std::thread::available_parallelism().map_or(4, |n| n.get().min(8));
@@ -54,7 +52,6 @@ pub fn new_zstd_mt_encoder(level: i32) -> std::io::Result<zstd::Encoder<'static,
 /// # Errors
 ///
 /// Returns an I/O error if compression, encryption, or file writing fails.
-#[cfg(feature = "zstd")]
 pub fn compress_encrypt_write_streaming<F>(
     write_fn: F,
     path: &Path,
@@ -117,7 +114,6 @@ where
 ///
 /// Returns an I/O error if any step fails. Since this is typically called
 /// from a background thread, callers should log but not propagate errors.
-#[cfg(feature = "zstd")]
 pub fn compress_encrypt_write(
     serialized: Vec<u8>,
     path: &Path,

--- a/crates/uffs-mft/src/main.rs
+++ b/crates/uffs-mft/src/main.rs
@@ -75,8 +75,6 @@ use uffs_polars as _;
 use uffs_security as _;
 use uffs_text as _;
 use zerocopy as _;
-// Optional dependencies
-#[cfg(feature = "zstd")]
 use zstd as _;
 // Benchmark dependencies (used by bench/bench-all commands on Windows)
 #[cfg(not(windows))]

--- a/crates/uffs-mft/src/raw/mod.rs
+++ b/crates/uffs-mft/src/raw/mod.rs
@@ -257,19 +257,11 @@ fn prepare_write_data<'a>(
 ) -> Result<(u32, u64, alloc::borrow::Cow<'a, [u8]>)> {
     use alloc::borrow::Cow;
 
-    #[cfg(feature = "zstd")]
     if options.compress {
         let compressed = zstd::encode_all(data, options.compression_level)
             .map_err(|err| MftError::Io(std::io::Error::other(err)))?;
         let compressed_size = compressed.len() as u64;
         return Ok((FLAG_COMPRESSED, compressed_size, Cow::Owned(compressed)));
-    }
-
-    #[cfg(not(feature = "zstd"))]
-    if options.compress {
-        return Err(MftError::InvalidData(
-            "zstd feature not enabled for compression".into(),
-        ));
     }
 
     Ok((0_u32, 0_u64, Cow::Borrowed(data)))
@@ -404,17 +396,8 @@ pub fn load_raw_mft<P: AsRef<Path>>(path: P, options: &LoadRawOptions) -> Result
 
         // Decompress if needed
         let data = if header.is_compressed() {
-            #[cfg(feature = "zstd")]
-            {
-                zstd::decode_all(&*compressed_data)
-                    .map_err(|err| MftError::Io(std::io::Error::other(err)))?
-            }
-            #[cfg(not(feature = "zstd"))]
-            {
-                return Err(MftError::InvalidData(
-                    "zstd feature not enabled for decompression".into(),
-                ));
-            }
+            zstd::decode_all(&*compressed_data)
+                .map_err(|err| MftError::Io(std::io::Error::other(err)))?
         } else {
             compressed_data
         };

--- a/crates/uffs-mft/src/raw/streaming_writer.rs
+++ b/crates/uffs-mft/src/raw/streaming_writer.rs
@@ -40,15 +40,11 @@ pub struct StreamingRawMftWriter {
     bytes_written: u64,
     /// Whether compression is enabled.
     compress: bool,
-    /// Compression level (if compressing).
-    #[expect(dead_code, reason = "used only when zstd feature is enabled")]
-    compression_level: i32,
     /// Volume letter (e.g., 'C', 'D').
     volume_letter: char,
     /// Whether raw compatibility mode is enabled (no header).
     raw_compat: bool,
     /// Zstd encoder (if compressing).
-    #[cfg(feature = "zstd")]
     encoder: Option<zstd::stream::Encoder<'static, BufWriter<File>>>,
 }
 
@@ -81,10 +77,8 @@ impl StreamingRawMftWriter {
                 record_size,
                 bytes_written: 0,
                 compress: false, // Raw compat mode doesn't support compression
-                compression_level: options.compression_level,
                 volume_letter: options.volume_letter,
                 raw_compat: true,
-                #[cfg(feature = "zstd")]
                 encoder: None,
             });
         }
@@ -101,7 +95,6 @@ impl StreamingRawMftWriter {
         };
         writer.write_all(&placeholder_header.to_bytes())?;
 
-        #[cfg(feature = "zstd")]
         if options.compress {
             // For compressed output, we need to use a zstd encoder
             // Flush the header first, then create encoder for the data portion
@@ -126,7 +119,6 @@ impl StreamingRawMftWriter {
                 record_size,
                 bytes_written: 0,
                 compress: true,
-                compression_level: options.compression_level,
                 volume_letter: options.volume_letter,
                 raw_compat: false,
                 encoder: Some(encoder),
@@ -139,10 +131,8 @@ impl StreamingRawMftWriter {
             record_size,
             bytes_written: 0,
             compress: options.compress,
-            compression_level: options.compression_level,
             volume_letter: options.volume_letter,
             raw_compat: false,
-            #[cfg(feature = "zstd")]
             encoder: None,
         })
     }
@@ -157,7 +147,6 @@ impl StreamingRawMftWriter {
     ///
     /// Returns an error if writing fails.
     pub fn write_chunk(&mut self, data: &[u8]) -> Result<()> {
-        #[cfg(feature = "zstd")]
         if let Some(ref mut encoder) = self.encoder {
             encoder
                 .write_all(data)
@@ -200,7 +189,6 @@ impl StreamingRawMftWriter {
             });
         }
 
-        #[cfg(feature = "zstd")]
         let compressed_size = if let Some(encoder) = self.encoder.take() {
             let mut zstd_writer = encoder
                 .finish()
@@ -215,9 +203,6 @@ impl StreamingRawMftWriter {
         } else {
             0
         };
-
-        #[cfg(not(feature = "zstd"))]
-        let compressed_size = 0_u64;
 
         // Create final header
         let header = RawMftHeader {
@@ -246,7 +231,6 @@ impl StreamingRawMftWriter {
 
         // For compressed files, reopen the file and update the header
         // The zstd encoder has already closed the file, so we reopen it
-        #[cfg(feature = "zstd")]
         if self.compress {
             use std::fs::OpenOptions;
 

--- a/crates/uffs-mft/src/raw/tests.rs
+++ b/crates/uffs-mft/src/raw/tests.rs
@@ -85,7 +85,6 @@ fn save_load_uncompressed() -> TestResult {
     Ok(())
 }
 
-#[cfg(feature = "zstd")]
 #[test]
 fn save_load_compressed() -> TestResult {
     let temp_dir = std::env::temp_dir();

--- a/crates/uffs-mft/src/raw_iocp.rs
+++ b/crates/uffs-mft/src/raw_iocp.rs
@@ -362,7 +362,6 @@ impl IocpCaptureWriter {
         }
 
         // Write chunk data (optionally compressed)
-        #[cfg(feature = "zstd")]
         if self.compress {
             let mut encoder = zstd::stream::Encoder::new(&mut writer, self.compression_level)?;
             for (_, data) in &self.chunks {
@@ -373,11 +372,6 @@ impl IocpCaptureWriter {
             for (_, data) in &self.chunks {
                 writer.write_all(data)?;
             }
-        }
-
-        #[cfg(not(feature = "zstd"))]
-        for (_, data) in &self.chunks {
-            writer.write_all(data)?;
         }
 
         writer.flush()?;
@@ -455,20 +449,11 @@ pub fn load_iocp_capture<P: AsRef<Path>>(file_path: P) -> Result<IocpCaptureData
     drop(reader); // release file handle early
 
     let data = if header.is_compressed() {
-        #[cfg(feature = "zstd")]
-        {
-            let mut data = Vec::with_capacity(crate::index::frs_to_usize(header.total_data_size));
-            let cursor = std::io::Cursor::new(&compressed);
-            let mut decoder = zstd::stream::Decoder::new(cursor)?;
-            decoder.read_to_end(&mut data)?;
-            data
-        }
-        #[cfg(not(feature = "zstd"))]
-        {
-            return Err(MftError::InvalidData(
-                "IOCP capture is compressed but zstd feature is disabled".into(),
-            ));
-        }
+        let mut data = Vec::with_capacity(crate::index::frs_to_usize(header.total_data_size));
+        let cursor = std::io::Cursor::new(&compressed);
+        let mut decoder = zstd::stream::Decoder::new(cursor)?;
+        decoder.read_to_end(&mut data)?;
+        data
     } else {
         compressed
     };

--- a/docs/architecture/release-automation-plan.md
+++ b/docs/architecture/release-automation-plan.md
@@ -1697,17 +1697,28 @@ Known feature flags in the workspace (as of this plan):
 
 | Crate | Feature | Purpose | Default? |
 |---|---|---|---|
-| `uffs-mft` | `zstd` | zstd compression for archived MFT records | Yes (per workspace dep in root `Cargo.toml`) |
-| `uffs-client` | `async` | Async client API (tokio) | No — sync path is default |
+| `uffs-client` | `async` | Async client API (tokio) | Yes — `uffs-cli` overrides with `default-features = false` to drop tokio from the hot-path binary |
+| `uffs-mcp` | `streamable-http` | HTTP gateway transport (axum + tower + rmcp HTTP transport).  Required by the `uffs-mcp-http` binary | Yes |
+| `uffs-cli` | `mcp-http-probe` | Active `/status` probe for the HTTP MCP gateway in `system-status` output | No (off by default to keep the CLI binary lean) |
 
-For each feature flag, the crate should have a brief docs paragraph:
+> **2026-05-12**: the `uffs-mft.zstd` feature was retired.  The flag was
+> declared optional with `default = ["zstd"]` but every workspace
+> consumer pinned `features = ["zstd"]` and recent code paths added
+> uses of `zstd::` / `crate::cache::compress_zstd_mt` without
+> `#[cfg(feature = "zstd")]` gating.  `cargo hack --workspace
+> --each-feature` surfaced three un-gated sites; the rest of the
+> codebase carried ~26 cfg-gates that never fired in practice.  The
+> feature was promoted to a hard dependency to match reality.  See PR
+> on the `refactor/uffs-mft-retire-vestigial-zstd-feature` branch.
+
+For each remaining feature flag, the crate should have a brief docs paragraph:
 
 ```rust
 //! ## Feature flags
 //!
-//! - `zstd` (default): enables zstd compression of archived MFT
-//!   records.  Disabling reduces binary size by ~200KB but requires
-//!   external decompression for archives.
+//! - `async` (default): enables the tokio-based `UffsClient`.
+//!   Disabling drops the tokio dependency and `ws2_32.dll` (Windows)
+//!   from the call-site binary.
 ```
 
 Audit once in R6.  Add rustdoc-level feature docs to each crate


### PR DESCRIPTION
## Summary

Promote `zstd` from an optional feature to a hard dependency in
`uffs-mft`.  The flag was declared `default = ["zstd"]` and gated
via `#[cfg(feature = "zstd")]` at ~26 sites, but `cargo hack
--workspace --each-feature` (run locally 2026-05-12 as part of the
R3 tooling audit) surfaced that `--no-default-features` failed
hard with three errors:

| Site | Error | Cause |
|---|---|---|
| `src/lib.rs:164` | E0432 unresolved imports | Re-exports `compress_zstd_mt`, `compress_encrypt_write`, `save_to_cache_background` without a `#[cfg(feature = "zstd")]` guard.  The targets are themselves gated. |
| `src/index/storage/file_io.rs:57` | E0425 cannot find function | `MftIndex::save_to_file` calls `crate::cache::compress_zstd_mt(...)` unconditionally. |
| `src/index/storage/file_io.rs:178` | E0433 cannot find crate `zstd` | `MftIndex::load_from_file` calls `zstd::decode_all(...)` unconditionally. |

## Decision: Path B (retire the option)

Two options were considered:

- **Path A — Honour the option**: add `#[cfg(feature = "zstd")]`
  guards at the three failing sites plus `#[cfg(not(feature =
  "zstd"))]` error branches.  Adds ~30 LOC of conditional code.
  Future code must keep new sites cfg-gated.

- **Path B — Retire the option (this PR)**: make `zstd` a hard
  dependency.  Every workspace consumer already pins
  `features = ["zstd"]` on the `uffs-mft` workspace dep (root
  `Cargo.toml:103` before this PR), and the daemon's compressed-
  encrypted cache format is fundamental to the runtime.  There is
  no realistic deployment with zstd off.  Delete the `[features]`
  block, drop `optional = true`, delete all ~26 `#[cfg(feature =
  "zstd")]` attrs (their gated code becomes unconditional) and the
  ~5 `#[cfg(not(feature = "zstd"))]` blocks (dead code).

Path B reduces code by **~52 LOC net** and aligns intent with
reality.  Verified empirically that **no current workspace consumer
ever set `default-features = false`** on `uffs-mft`.

## Changes

**Manifests** (3 files):
- `Cargo.toml`: drop `features = ["zstd"]` from the `uffs-mft`
  workspace dep — the feature no longer exists.
- `crates/uffs-mft/Cargo.toml`: `zstd = { workspace = true,
  optional = true }` → `zstd.workspace = true`; delete `[features]`
  block.

**Source-side cfg-gate removals** (8 files, ~26 attrs + ~5 dead
blocks):
- `src/cache.rs` (2 attrs)
- `src/cache_compress.rs` (4 attrs)
- `src/main.rs` (1 attr)
- `src/raw/mod.rs` (2 attrs + 2 dead `cfg(not(...))` blocks)
- `src/raw/streaming_writer.rs` (7 attrs + 1 dead `cfg(not(...))`
  block + drops the unused `compression_level` struct field that
  was set during construction but never read via `self.`; it
  carried a misleading `#[expect(dead_code, reason = "used only
  when zstd feature is enabled")]` whose reason was inaccurate
  even before this PR)
- `src/raw/tests.rs` (1 attr)
- `src/raw_iocp.rs` (2 attrs + 2 dead `cfg(not(...))` blocks)
- `benches/mft_read.rs` (1 attr)

**Docs**:
- `docs/architecture/release-automation-plan.md` §5.3 feature-flag
  inventory: drop the `uffs-mft.zstd` row; add the previously-
  missing `uffs-mcp.streamable-http` and `uffs-cli.mcp-http-probe`
  rows.  Added a 2026-05-12 callout explaining the retire-the-
  vestige decision.

## Verification

| Check | Result |
|---|---|
| `cargo check --workspace --all-targets --all-features --locked` | clean |
| `cargo hack --workspace --exclude uffs-polars --each-feature --keep-going check --all-targets --locked` | **24/24 invocations pass** (was 23/24 with one hard fail before this PR) |
| `just lint-pre-push` (21/21 gates) | green in 48 s warm |

The `--each-feature` matrix on `uffs-mft` post-this-PR has zero
features to iterate (the `[features]` block is gone), so cargo-hack
just runs `uffs-mft` once normally and moves on.  The other
feature-bearing crates (`uffs-client`, `uffs-mcp`, `uffs-cli`) all
pass cleanly with their feature permutations.

`uffs-polars` continues to be excluded because of the chrono pin
issue documented in the R5 rollback deviation row (separate
upstream-blocked problem; unrelated to this PR).

## Non-goals

- **No behavioural change** — every code path that ran before this
  PR still runs.  The only "behaviour change" is that
  `uffs-mft --no-default-features` used to fail to compile and now
  builds cleanly (because the feature is gone; there is nothing to
  opt out of).
- **No new public API** — the re-exports at `lib.rs:164` were
  already declared `pub` behind the cfg gate.  Dropping the gate
  doesn't expose new symbols; consumers that built with the default
  feature already saw them.
- **No CI gate addition** — the cargo-hack gate in `tier-2.yml`
  lands as a **separate PR** immediately after this one merges.
  With this PR's fix in place, that gate passes cleanly and becomes
  the mechanism preventing this class of regression for
  `uffs-client` / `uffs-mcp` / `uffs-cli`.

## Audit context

This is the precursor PR for the R3-02 tooling addition (cargo-hack
`--each-feature` in `tier-2.yml`).  The audit-task workflow:

1. Surveyed every gate / tool in our pipelines.
2. Identified `cargo-hack` as a true addition (zero overlap with
   existing checks; we currently only test `--all-features`).
3. Probed locally; surfaced this `uffs-mft` regression.
4. Chose Path B over Path A based on consumer-pin analysis.
5. **This PR** fixes the regression.
6. **Next PR** lands cargo-hack in Tier 2 (now passes cleanly).

Refs: PR #174 (cargo-machete pre-push gate — sibling R3 work).  No
issue link — surfaced during the audit, not from external report.