### PR TITLE
chore(ci): auto-rerun transient CI failures + advisory CodeQL (PR F)

### DIFF
--- a/.github/workflows/auto-rerun-transient.yml
+++ b/.github/workflows/auto-rerun-transient.yml
@@ -1,0 +1,241 @@
+# SPDX-FileCopyright (c) 2025-2026 SKY, LLC.
+# SPDX-License-Identifier: MPL-2.0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Auto-rerun transient CI failures
+#
+# Catches a class of failure that no per-step retry can fix: the
+# `Set up job` phase that runs BEFORE any user-controllable step.
+# When `codeload.github.com` rate-limits an action-tarball download
+# with a 429, the runner already exhausts its 3 built-in retries
+# (with exponential backoff) before our YAML gets a chance to run.
+# After that, the job is dead — the only way to recover is to
+# trigger a fresh run from outside.
+#
+# This workflow listens for `workflow_run` completion events on the
+# main CI workflows and, if it detects a failed job whose logs match
+# a transient-failure signature (429 / ECONNRESET / EAI_AGAIN /
+# context deadline exceeded / runner has lost contact / etc.), calls
+# the `rerun-failed-jobs` REST API to re-execute only the failed
+# jobs.  `run_attempt < 2` bounds this to exactly one retry per run
+# so a persistently-failing job cannot loop forever.
+#
+# Design notes:
+#
+#   * `workflow_run` is the only `on:` trigger that fires AFTER a
+#     workflow concludes and has the necessary permissions to
+#     rerun it.  It runs in the BASE repo's context (`secrets.
+#     GITHUB_TOKEN` has `actions: write`), so forks cannot abuse
+#     this — fork PRs that fail get inspected but the rerun call
+#     is rejected with 404 (the fork's run isn't in our repo's
+#     actions namespace), which we handle gracefully.
+#
+#   * `if: github.event.workflow_run.run_attempt < 2` is the loop-
+#     prevention guard.  Attempts are 1-indexed: the initial run is
+#     `run_attempt = 1`, the first rerun produces `run_attempt = 2`.
+#     We never fire on `run_attempt >= 2`, so each `workflow_run.id`
+#     gets at most one auto-rerun.  A persistent failure (e.g. real
+#     compile error) thus surfaces normally on the second attempt.
+#
+#   * We deliberately do NOT filter on `conclusion == 'failure'` —
+#     `codeql.yml` uses `continue-on-error: true` (informational
+#     job), so its 429-class failures produce `workflow_run.
+#     conclusion = success` even though the underlying job failed.
+#     Inspecting `jobs[*].conclusion == failure` catches both
+#     cases.
+#
+#   * Transient signatures are matched against the failed job's log
+#     via a single grep -E regex.  Patterns are conservative — only
+#     well-known infra-layer error strings (HTTP 429, TCP / DNS
+#     errors, runner crashes, disk-full).  Genuine compile or test
+#     failures don't match these strings and don't trigger a rerun.
+#
+#   * `gh api .../jobs/<id>/logs` returns a 302 to a signed S3 URL;
+#     `gh` follows the redirect transparently and prints the log
+#     text to stdout.  The job logs are deleted from the GH backend
+#     after 90 days, but we always rerun within seconds of failure,
+#     so the URL is always valid at this point.
+#
+# Permissions:
+#
+#   * `actions: write` — required to call POST
+#     /repos/.../actions/runs/<id>/rerun-failed-jobs.
+#   * `contents: read` — implicit (no repo content fetched).
+#
+# Cost / volume:
+#
+#   * Job runtime: ~10-30 s per failed run.  Only runs on failed
+#     runs of the three watched workflows.  Worst case: every PR
+#     gets one transient failure → +30 s overhead.  Typical case:
+#     near-zero overhead (transient failures are rare).
+
+name: 🔁 Auto-rerun transient CI failures
+
+on:
+  workflow_run:
+    workflows:
+      - "PR Fast CI"
+      - "🔍 CodeQL (Rust SAST)"
+      - "🌙 UFFS Tier 2 Nightly CI"
+    types: [completed]
+
+# Default to ZERO permissions; the single job below grants only what
+# it needs.  Matches the least-privilege pattern used in every other
+# UFFS workflow.
+permissions: {}
+
+# Serialise auto-rerun decisions per watched run so two near-
+# simultaneous workflow_run events (e.g. a rapid push series) don't
+# race on inspecting / rerunning the same run.  Keyed on the
+# triggering run's id, NOT this workflow's ref, so concurrent
+# auto-reruns of DIFFERENT failed runs proceed in parallel.
+concurrency:
+  group: auto-rerun-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  rerun:
+    name: Inspect and rerun failed jobs if transient
+    runs-on: ubuntu-22.04
+    # Skip on forks (their workflow_runs land in the base repo but
+    # don't carry a `pull_requests[]` we can authorise) and skip on
+    # already-retried runs.  The fork check is a belt-and-suspenders
+    # measure — `rerun-failed-jobs` would 404 anyway, but failing
+    # silently is cheaper than logging the rejection.
+    if: >-
+      github.repository_owner == 'skyllc-ai' &&
+      github.event.workflow_run.run_attempt < 2
+    permissions:
+      actions: write
+      contents: read
+    timeout-minutes: 5
+
+    steps:
+      - name: Inspect failed-job logs and rerun if transient
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          # Transient-failure signatures.  Extend conservatively —
+          # every pattern here will cause the failed job to retry,
+          # so over-matching wastes CI minutes.  Each token is a
+          # well-known infra-layer error string from one of:
+          #
+          #   - HTTP rate limiting / GH Actions runner setup:
+          #       `Too Many Requests`, `\b429\b`, `failed to
+          #       download`, `Failed to download archive`.
+          #   - TCP / DNS:
+          #       `ECONNRESET`, `Connection reset by peer`,
+          #       `EAI_AGAIN`, `unable to resolve host`,
+          #       `Network is unreachable`.
+          #   - Runner / step engine:
+          #       `runner has lost contact`, `The runner was
+          #       forced to stop`, `context deadline exceeded`.
+          #   - Disk / resource:
+          #       `No space left on device`.
+          #
+          # Genuine code failures (compile errors, test failures,
+          # clippy violations) do NOT match these — they produce
+          # distinct error strings (`error[E0`, `assertion failed`,
+          # `error: ...`, etc.) that we deliberately don't list.
+          TRANSIENT_PATTERN: 'Too Many Requests|\b429\b|failed to download|Failed to download archive|ECONNRESET|Connection reset by peer|EAI_AGAIN|unable to resolve host|Network is unreachable|runner has lost contact|The runner was forced to stop|context deadline exceeded|No space left on device'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          printf '🔍 Inspecting run %s (attempt %s) — workflow: %s\n' \
+            "${RUN_ID}" "${RUN_ATTEMPT}" "${WORKFLOW_NAME}"
+
+          # Fetch failed jobs in the latest attempt.  `filter=latest`
+          # restricts to the most-recent attempt's jobs (defensive —
+          # we already know run_attempt == 1, but explicit is safer).
+          mapfile -t failed_jobs < <(
+            gh api \
+              "/repos/${GH_REPO}/actions/runs/${RUN_ID}/jobs?filter=latest&per_page=100" \
+              --jq '.jobs[] | select(.conclusion == "failure") | "\(.id) \(.name)"'
+          )
+
+          if [[ "${#failed_jobs[@]}" -eq 0 ]]; then
+            printf '✅ No failed jobs in run %s; nothing to do.\n' "${RUN_ID}"
+            exit 0
+          fi
+
+          printf '   %d failed job(s) to inspect:\n' "${#failed_jobs[@]}"
+          for entry in "${failed_jobs[@]}"; do
+            printf '     · %s\n' "${entry}"
+          done
+
+          # For each failed job, fetch its log and grep for the
+          # transient pattern.  We accept the FIRST match — if ANY
+          # failed job in the run looks transient, rerun the whole
+          # set (the API only supports per-run rerun, not per-job).
+          # That's the right behaviour: re-executing already-passing
+          # jobs is wasteful, but rerun-failed-jobs only re-runs
+          # the ones that failed, so we get exactly-once retry of
+          # the actual transient failure.
+          found_transient=0
+          matched_job=""
+          matched_signature=""
+
+          for entry in "${failed_jobs[@]}"; do
+            job_id="${entry%% *}"
+            job_name="${entry#* }"
+
+            # `gh api .../logs` follows the 302 redirect and prints
+            # the log body.  If the log is gone (>90 days old, which
+            # can't happen here since we always run within seconds
+            # of failure), the API returns 410 and gh exits non-
+            # zero; the `|| true` keeps us going so a single missing
+            # log doesn't kill the whole inspection.
+            log_text="$(gh api "/repos/${GH_REPO}/actions/jobs/${job_id}/logs" 2>/dev/null || true)"
+
+            if [[ -z "${log_text}" ]]; then
+              printf '     ⚠️  could not fetch log for job %s (%s); skipping.\n' \
+                "${job_id}" "${job_name}"
+              continue
+            fi
+
+            # Grep the log for any transient pattern; first match
+            # wins.  -m1 stops after the first match per job for
+            # speed.  We pull the matched line so the workflow log
+            # records WHICH pattern fired (useful for debugging
+            # pattern coverage over time).
+            if matched_signature="$(printf '%s\n' "${log_text}" | grep -E -m1 "${TRANSIENT_PATTERN}" || true)" \
+               && [[ -n "${matched_signature}" ]]; then
+              printf '     🎯 transient signature in job %s (%s):\n' \
+                "${job_id}" "${job_name}"
+              printf '        %s\n' "$(printf '%s' "${matched_signature}" | head -c 200)"
+              matched_job="${job_name}"
+              found_transient=1
+              break
+            else
+              printf '     · no transient signature in job %s (%s).\n' \
+                "${job_id}" "${job_name}"
+            fi
+          done
+
+          if [[ "${found_transient}" != "1" ]]; then
+            printf '🚫 No transient signatures found in any failed-job log; not rerunning.\n'
+            printf '   This is the right outcome for genuine failures — they should\n'
+            printf '   stay red so a human can investigate.\n'
+            exit 0
+          fi
+
+          printf '\n🔁 Rerunning failed jobs in run %s (triggered by %s).\n' \
+            "${RUN_ID}" "${matched_job}"
+
+          # POST /repos/.../actions/runs/<id>/rerun-failed-jobs.
+          # Only the failed jobs re-execute; previously-passing jobs
+          # are left alone (their artifacts and conclusions are
+          # preserved).  The new attempt gets `run_attempt = 2`,
+          # which our `if:` guard above will reject — so even if the
+          # rerun also fails with a transient signature, we will not
+          # auto-rerun a second time.
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GH_REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs"
+
+          printf '✅ Rerun dispatched.  See the workflow run page for the new attempt.\n'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -95,6 +95,30 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-22.04
     timeout-minutes: 20
+    # CodeQL is informational-only on UFFS (Rust support is in public
+    # preview; we do not wire it into branch protection — see the
+    # header comment above for the rationale).  `continue-on-error:
+    # true` codifies that intent at the workflow-engine level:
+    #
+    #   * When the job fails — e.g. because `codeload.github.com`
+    #     returned 429s for the `github/codeql-action` tarball during
+    #     "Set up job", which is structurally un-retryable from inside
+    #     our steps — the workflow-level conclusion remains `success`.
+    #     The job itself still shows ❌ in the PR's check-runs panel
+    #     so genuine analysis failures stay visible (and the Security
+    #     tab continues to receive findings on green runs), but the
+    #     red badge no longer leaks into the workflow conclusion that
+    #     auto-merge / branch protection observe.
+    #
+    #   * Paired with `auto-rerun-transient.yml` (Layer B): that
+    #     watcher fires on every completed run regardless of conclusion
+    #     and reruns the failed jobs once if their logs match transient
+    #     signatures (429 / ECONNRESET / etc.).  So 429-class failures
+    #     are silently retried; only persistent failures stay red.
+    #
+    # Reference: 2026-05-12 PR F (this PR) — auto-rerun-transient
+    # workflow + this continue-on-error flag, landed together.
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/docs/architecture/dev-flow.md
+++ b/docs/architecture/dev-flow.md
@@ -274,6 +274,59 @@ downloading the CodeQL CLI + the Rust extractor (~400 MB).  Not worth it
 — clippy (`--pedantic --nursery --cargo`) plus weekly miri covers ~80% of
 what CodeQL would catch for this codebase.  This gate stays where it is.
 
+### 4.6 GAP 6 — Transient infra failures had no recovery path (✅ CLOSED 2026-05-12)
+
+**Original evidence**: GitHub Actions' "Set up job" phase downloads
+every `uses: <action>@<sha>` tarball from `codeload.github.com`
+before any of our YAML steps run.  When `codeload.github.com` rate-
+limits the runner's IP (HTTP 429 / `Too Many Requests`), the runner
+exhausts its 3 built-in retries (with 10 s and 12 s exponential
+backoff) and then fails the entire job.  No per-step retry action
+(`nick-fields/retry@v3` or similar) can help — the failure happens
+*before* any step gets a chance to execute.
+
+Observed on PR #175 (zstd retire-vestige) and PR #174 (cargo-machete)
+on 2026-05-12: CodeQL's "Set up job" 429'd while downloading the
+`github/codeql-action` tarball; the analyse job died.  Same
+infrastructure issue could hit pr-fast.yml or tier-2.yml and would
+appear as a "real" CI failure, blocking merge until a maintainer
+manually clicked "Re-run failed jobs".
+
+**Resolution**: Two-layer hardening landed in this PR:
+
+- **Layer A** — `continue-on-error: true` on `codeql.yml::analyze`.
+  Codifies the workflow's own docstring (which already said *"the
+  check is NOT wired into branch protection"*) at the workflow-
+  engine level.  CodeQL job failures still show as ❌ in the PR's
+  check-runs panel, but the workflow conclusion is `success` so
+  branch protection / auto-merge are not affected.
+
+- **Layer B** — new `auto-rerun-transient.yml` watcher.  Triggers
+  on `workflow_run` completion of the three main workflows
+  (`PR Fast CI`, `🔍 CodeQL (Rust SAST)`, `🌙 UFFS Tier 2 Nightly
+  CI`).  For each completed run with `run_attempt < 2` (loop
+  prevention), it inspects the logs of every failed job; if any
+  log matches a transient-infra regex (`429` / `ECONNRESET` /
+  `EAI_AGAIN` / `runner has lost contact` / `No space left on
+  device` / etc.) it calls `POST /actions/runs/<id>/rerun-failed-
+  jobs` to re-execute exactly the failed jobs once.  Persistent
+  failures (real compile / test errors) do not match the regex and
+  stay red.
+
+**Bounded retry**: `run_attempt < 2` enforces *exactly one*
+auto-rerun per run.  If the rerun also fails with a transient
+signature, the second attempt (`run_attempt = 2`) is *not*
+re-retried — a human investigates.  Worst-case overhead: ~30 s per
+transient failure, single-digit per week.
+
+**Policy classification** added by this PR:
+
+| Job kind | Branch protection | Failure visibility | Auto-rerun? |
+|---|---|---|---|
+| Required (pr-fast.yml `required` aggregator) | blocks merge | red ❌ until fixed | yes if transient |
+| Advisory (`continue-on-error: true`) | does not block | red ❌ on job, ✅ workflow | yes if transient |
+| Tier 2 weekly | does not block PRs | `ci-failure-tier-2` issue auto-opened | yes if transient |
+
 ---
 
 ## 5. Known Bugs in the Current Flow


### PR DESCRIPTION
## Summary

Two-layer hardening for the class of CI failure that no per-step
retry can fix: the `Set up job` phase that runs **before** any
YAML step.  When `codeload.github.com` rate-limits a runner's IP
(HTTP 429 / `Too Many Requests`) during the `uses: <action>@<sha>`
tarball download, the runner exhausts its 3 built-in retries (10 s
+ 12 s backoff) and the job dies — `nick-fields/retry@v3` and
similar **cannot help** because the failure happens before any
step gets to run.

Observed on PR #175 (zstd retire-vestige) and PR #174 (cargo-
machete) on 2026-05-12: CodeQL's `Set up job` 429'd while
downloading the `github/codeql-action` tarball; the analyse job
died with the 3-attempt exit message.  Same infra issue could hit
pr-fast.yml or tier-2.yml and would appear as a "real" CI failure,
blocking merge until a maintainer manually clicks **Re-run failed
jobs**.

## Layer A — `continue-on-error: true` on `codeql.yml::analyze`

The workflow's own header comment already classifies CodeQL as
informational-only.  This codifies that intent at the workflow-
engine level:

- Job failure → ❌ on the job in the PR's check-runs panel
  (genuine analysis failures stay visible).
- Workflow conclusion → ✅ `success` regardless (branch
  protection / auto-merge unaffected).
- Security tab continues to receive findings on green runs.

## Layer B — new `auto-rerun-transient.yml` watcher

Listens for `workflow_run` completion on the three main CI
workflows (`PR Fast CI`, `🔍 CodeQL (Rust SAST)`, `🌙 UFFS Tier 2
Nightly CI`).  For each run with `run_attempt < 2`:

1. `gh api .../runs/<id>/jobs?filter=latest --jq` → list of failed
   jobs.
2. For each failed job: `gh api .../jobs/<id>/logs` follows the 302
   to fetch the log body.
3. `grep -E -m1 "$TRANSIENT_PATTERN"` against the log.
4. If ANY failed job matches → POST `.../rerun-failed-jobs`.

The `TRANSIENT_PATTERN` is conservative and covers documented
infra-layer signatures only:

```
Too Many Requests | \b429\b | failed to download |
Failed to download archive | ECONNRESET |
Connection reset by peer | EAI_AGAIN |
unable to resolve host | Network is unreachable |
runner has lost contact | The runner was forced to stop |
context deadline exceeded | No space left on device
```

Compile / test / clippy failures produce error strings (`error[E0…]`,
`assertion failed`, etc.) that don't match — they correctly stay
red.

**Bounded retry**: `run_attempt < 2` enforces *exactly one*
auto-rerun per run.  A persistent transient failure surfaces
normally after one retry — no infinite loops.

## Policy classification (added to `dev-flow.md §4.6`)

| Job kind | Branch protection | Auto-rerun? |
|---|---|---|
| Required (pr-fast `required`) | blocks merge | yes if transient |
| Advisory (`continue-on-error: true`) | does not block | yes if transient |
| Tier 2 weekly | does not block PRs | yes if transient |

## Verification

YAML validated (`ruby -ryaml`).  `just lint-pre-push` (22/22 gates
including machete from PR #174): green in 49 s.  Drift detectors
(`gates-drift` / `hooks-drift` / `workflow-drift` / `fast-drift`):
all green.

`auto-rerun-transient.yml` itself is **not** in its own watched-
workflows list — no cascade risk if the watcher flakes.

## Cost

- **Per failed run**: ~10-30 s overhead (one short job).
- **Per typical week**: near-zero (transient failures are rare).
- **Worst case**: ~30 s × N transients/week.  Single-digit overhead
  even on a bad week of GitHub Actions infra weather.

## Non-goals

- **Not a perfect transient catcher** — pattern coverage is
  conservative.  Novel transient error strings won't match and will
  surface red.  `TRANSIENT_PATTERN` can be extended via follow-up
  PRs.
- **Not unconditional retry** — runs without a transient signature
  are never retried.
- **Not a replacement for fixing flaky tests** — if a flake produces
  non-transient strings, fix the flake.  Don't add it to
  `TRANSIENT_PATTERN`.

## Independence from the R3 sequence

This PR is orthogonal to PR #174 (cargo-machete), PR #175 (zstd
retire-vestige), and the pending PR B-gate / R3-03..05 tail.
Touches only `.github/workflows/codeql.yml` (1 logical edit),
`.github/workflows/auto-rerun-transient.yml` (new), and
`docs/architecture/dev-flow.md` (§4.6 added).  Lands in parallel.

Refs: PR #174 / PR #175 (where the 429 failure mode surfaced on
2026-05-12), `auto-rerun-transient.yml` header comment for the full
design rationale.