### PR TITLE
chore(release): v0.5.95 + machete gate hotfix

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -553,7 +553,17 @@ jobs:
         # output is reproducible on both surfaces.  pr-fast bundles
         # into this `security` job (same `code_changed` predicate as
         # the deny + vet pair) to keep the job graph narrow.
-        run: cargo machete --skip-target-dir
+        #
+        # Invocation form: `cargo-machete` (direct binary) rather
+        # than `cargo machete` (cargo subcommand dispatch).  cargo
+        # 1.97-nightly + cargo-machete v0.9.1 interact badly when
+        # invoked via the cargo subcommand wrapper — cargo passes
+        # the subcommand name `machete` as argv[1], and cargo-
+        # machete's gumdrop CLI parser treats it as a positional
+        # path and stops parsing flags (so `--skip-target-dir` lands
+        # as a second path).  See `scripts/ci/gates.toml::machete`
+        # for the full reproduction notes.
+        run: cargo-machete --skip-target-dir
 
   # ─────────────────────────────────────────────────────────────────────
   # windows-lint — native Windows clippy gate on `windows-latest`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -578,7 +578,7 @@ L1 zigbuild) now ✅; §8 acceptance items all checked.
   into a red required check rather than the documented advisory
   warning.
 
-## [0.5.94] - 2026-05-08
+## [0.5.95] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -587,7 +587,7 @@ L1 zigbuild) now ✅; §8 acceptance items all checked.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.94`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.95`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "clap",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "chrono",
  "itoa",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "clap",
@@ -4492,7 +4492,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "clap",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "axum",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4560,14 +4560,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4582,14 +4582,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.94"
+version = "0.5.95"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.94"
+version = "0.5.95"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires
@@ -96,14 +96,14 @@ categories = ["filesystem", "command-line-utilities"]
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.94" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.94" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.94" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.94" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.94" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.94" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.94" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.94" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.95" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.95" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.95" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.95" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.95" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.95" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.95" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.95" }
 # NOTE: no `uffs-diag` workspace dependency alias on purpose.
 # It is a top-level diagnostic/tool crate, not a shared runtime dependency.
 

--- a/just/analysis_ci.just
+++ b/just/analysis_ci.just
@@ -44,6 +44,6 @@ machete:
     #!/usr/bin/env bash
     printf "\033[0;34m🔪 Checking for unused dependencies...\033[0m\n"
     if ! command -v cargo-machete >/dev/null 2>&1; then printf "\033[1;33m⚠️  cargo-machete not installed. Run 'just setup' first.\033[0m\n"; exit 1; fi
-    cargo machete --skip-target-dir
+    cargo-machete --skip-target-dir
     printf "\033[0;32m✅ Dependency check complete!\033[0m\n"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -30,7 +30,7 @@
 # CI pipeline will auto-refresh on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed — use that flag (or plain `just ship`) while the upstream regression
 # persists.
-channel = "nightly-2026-05-09"
+channel = "nightly-2026-05-12"
 
 # Specify components that should always be available
 components = [

--- a/scripts/ci/gates.toml
+++ b/scripts/ci/gates.toml
@@ -518,7 +518,7 @@ the gate is hard on `main`.  pr-fast bundles this into the existing
 [[gate]]
 id = "machete"
 label = "cargo-machete unused-dep check"
-command = ["cargo", "machete", "--skip-target-dir"]
+command = ["cargo-machete", "--skip-target-dir"]
 tiers = ["pre-push", "pr-fast"]
 gate_when = "code_changed"
 hard = true
@@ -548,6 +548,22 @@ HARD-FAIL with install hint when missing (`cargo install
 cargo-machete` or `cargo binstall cargo-machete`; ~3 MB binary,
 sub-second build via binstall).  pr-fast bundles into the existing
 `security` job alongside `vet` + `deny` + `vet-audit-discipline`.
+
+Invocation form: `cargo-machete` (direct binary) rather than
+`cargo machete` (cargo subcommand dispatch).  Background: cargo
+1.97-nightly + cargo-machete v0.9.1 interact badly when invoked
+via the cargo subcommand wrapper — cargo passes the subcommand
+name `machete` as argv[1], and cargo-machete's gumdrop CLI parser
+treats that leading positional as a path and stops parsing flags
+(so `--skip-target-dir` lands as a second path).  The failure mode
+is silent under `cargo machete --skip-target-dir` in a developer
+terminal (works fine via shell PATH resolution) but reproduces in
+the git pre-push hook context, breaking `just ship-fresh` on the
+2026-05-12 release attempt of v0.5.95.  Direct binary invocation
+bypasses the cargo dispatch entirely — argv becomes
+`["cargo-machete", "--skip-target-dir"]` and `--skip-target-dir`
+is correctly recognised as a flag.  Both forms work in normal
+terminals; the direct form is the form that always works.
 """
 
 [[gate]]

--- a/scripts/hooks/_lint_pre_push.sh
+++ b/scripts/hooks/_lint_pre_push.sh
@@ -224,7 +224,7 @@ if (( DEP_CHANGED )); then
     spawn_bg "vet" cargo vet check --locked
 fi
 spawn_bg "vet-audit-discipline" bash scripts/ci/check_vet_audit_discipline.sh pre-push
-spawn_bg "machete" cargo machete --skip-target-dir
+spawn_bg "machete" cargo-machete --skip-target-dir
 command -v typos >/dev/null 2>&1 && spawn_bg "typos" typos .
 command -v reuse >/dev/null 2>&1 && spawn_bg "reuse" reuse lint --quiet
 


### PR DESCRIPTION
## Summary

Release PR for **v0.5.95** — bundled with an **inline hotfix** to the machete CI gate that blocked the original push (root-cause + reproduction notes below).

## Commits in this PR

\`\`\`
f7c33d962 fix(ci): machete gate — use direct binary form to avoid cargo nightly arg-passing bug
f1762b015 chore: development v0.5.95 - comprehensive testing complete [auto-commit]
\`\`\`

(Will be squashed at merge per repo policy.)

## Commit 1 — \`f1762b015\` (clean version bump)

Pure version-bump commit from \`just ship-fresh\`:

| File | Change |
|---|---|
| \`CHANGELOG.md\` | v0.5.94 → v0.5.95 header |
| \`Cargo.toml\` | workspace version v0.5.94 → v0.5.95 |
| \`Cargo.lock\` | regenerated for the new workspace version |
| \`rust-toolchain.toml\` | dated-nightly cadence bump |

## Commit 2 — \`f7c33d962\` (machete gate hotfix)

### Root cause

\`cargo machete --skip-target-dir\` is **broken** under cargo 1.97-nightly + cargo-machete v0.9.1. cargo passes the subcommand name \`machete\` as argv[1] to the cargo-machete binary, and cargo-machete's gumdrop CLI parser treats that leading positional as a path and stops parsing flags, so \`--skip-target-dir\` lands as a **second positional path**. Result:

\`\`\`
Analyzing dependencies of crates in machete,--skip-target-dir...
Error: Errors when walking over directories:
machete: IO error for operation on machete: No such file or directory
--skip-target-dir: IO error for operation on --skip-target-dir: ...
\`\`\`

The failure is **silent** under \`cargo machete --skip-target-dir\` in a developer terminal (works fine via shell PATH resolution) but **reproduces deterministically in the git pre-push hook context**.

### Why bundled with this release

Surfaced on 2026-05-12 during \`just ship-fresh\` for v0.5.95 itself — the release pipeline got as far as committing v0.5.95 to main, then the release-branch push was rejected by the pre-push hook. Choosing to land the fix as a second commit on top of the version bump (rather than amend / reset / separate PR) per Option C of the triage decision.

### Fix

Direct binary invocation (\`cargo-machete --skip-target-dir\`) bypasses the cargo subcommand dispatch entirely. argv becomes \`["cargo-machete", "--skip-target-dir"]\`, \`--skip-target-dir\` is correctly recognised as a flag, and the binary scans cwd with target-dir skip enabled.

### Files

| File | Change |
|---|---|
| \`scripts/ci/gates.toml::machete\` | \`command\` updated; full reproduction notes + rationale added so a future maintainer doesn't revert to the cargo-subcommand form |
| \`.github/workflows/pr-fast.yml\` | \`security\` job's machete step updated with in-file pointer back to gates.toml for canonical write-up |
| \`just/analysis_ci.just::machete\` | local on-demand analyzer recipe matched |
| \`scripts/hooks/_lint_pre_push.sh\` | auto-regenerated from gates.toml via \`just gen-hooks\` |

### Why not file an upstream cargo-machete patch instead

That's the proper upstream fix and worth doing separately, but the release pipeline cannot wait for an external release cycle. The gate manifest pins the invocation form we control; the gates.toml notes carry a clear "direct binary form, not cargo subcommand" contract so a future cargo-machete release fixing this won't lure a maintainer back to the broken form.

## Verification

- \`just lint-pre-push\` (22/22 gates incl. machete + windows-lint): **green** in 260 s on the fix-only run.
- Push pre-push hook re-ran on this exact branch: **green** in 50 s with full bucket-2 cache hits.

## Auto-merge

Auto-merge will be armed (squash) once this PR opens.