### PR TITLE
refactor(cast-cleanup): eliminate all file-level cast blankets + 80 % per-line reduction

### DIFF
--- a/crates/uffs-cli/src/commands.rs
+++ b/crates/uffs-cli/src/commands.rs
@@ -76,6 +76,12 @@ fn format_number(num: u64) -> String {
 }
 
 /// Format file size in human-readable format.
+///
+/// Boundary thresholds are typed as `u64` to compare against the input
+/// without a cast; the human-readable divisors are typed as `f64`
+/// directly so the only remaining f64 conversion is the input byte
+/// count via [`u64_to_display_f64`] (which carries the single
+/// `cast_precision_loss` justification this function needs).
 #[expect(
     clippy::float_arithmetic,
     reason = "division for human-readable size formatting"
@@ -85,42 +91,34 @@ fn format_size(bytes: u64) -> String {
     const MB: u64 = KB * 1024;
     const GB: u64 = MB * 1024;
     const TB: u64 = GB * 1024;
+    const KB_F: f64 = 1024.0_f64;
+    const MB_F: f64 = KB_F * 1024.0_f64;
+    const GB_F: f64 = MB_F * 1024.0_f64;
+    const TB_F: f64 = GB_F * 1024.0_f64;
 
-    // Precision loss acceptable — display-only formatting where ±1 byte is fine.
-    #[expect(
-        clippy::cast_precision_loss,
-        reason = "display-only human-readable formatting"
-    )]
-    let bytes_f64 = bytes as f64;
+    let bytes_f64 = u64_to_display_f64(bytes);
     if bytes >= TB {
-        #[expect(
-            clippy::cast_precision_loss,
-            reason = "display-only human-readable formatting"
-        )]
-        let divisor = TB as f64;
-        format!("{:.2} TB", bytes_f64 / divisor)
+        format!("{:.2} TB", bytes_f64 / TB_F)
     } else if bytes >= GB {
-        #[expect(
-            clippy::cast_precision_loss,
-            reason = "display-only human-readable formatting"
-        )]
-        let divisor = GB as f64;
-        format!("{:.2} GB", bytes_f64 / divisor)
+        format!("{:.2} GB", bytes_f64 / GB_F)
     } else if bytes >= MB {
-        #[expect(
-            clippy::cast_precision_loss,
-            reason = "display-only human-readable formatting"
-        )]
-        let divisor = MB as f64;
-        format!("{:.2} MB", bytes_f64 / divisor)
+        format!("{:.2} MB", bytes_f64 / MB_F)
     } else if bytes >= KB {
-        #[expect(
-            clippy::cast_precision_loss,
-            reason = "display-only human-readable formatting"
-        )]
-        let divisor = KB as f64;
-        format!("{:.2} KB", bytes_f64 / divisor)
+        format!("{:.2} KB", bytes_f64 / KB_F)
     } else {
         format!("{bytes} B")
     }
+}
+
+/// Lossy `u64 -> f64` conversion for human-readable telemetry output.
+///
+/// Values above `2^53` lose low bits, which is acceptable for the
+/// `{:.2}` MB/GB/TB display format used by `format_size`.
+#[inline]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "display-only `format!(\"{:.2} ...\")` byte counts; ±1 byte rounding is invisible at MB resolution"
+)]
+const fn u64_to_display_f64(value: u64) -> f64 {
+    value as f64
 }

--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -402,16 +402,7 @@ fn daemon_stats() -> Result<()> {
         // Aggregate cache observability.  Hit-rate is computed on
         // demand to avoid a division-by-zero for cold daemons.
         let lookups = stats.agg_cache_hits.saturating_add(stats.agg_cache_misses);
-        #[expect(
-            clippy::float_arithmetic,
-            clippy::cast_precision_loss,
-            reason = "hit-rate display is best-effort approximate"
-        )]
-        let hit_rate = if lookups > 0 {
-            (stats.agg_cache_hits as f64 / lookups as f64) * 100.0_f64
-        } else {
-            0.0_f64
-        };
+        let hit_rate = compute_hit_rate_percent(stats.agg_cache_hits, lookups);
         println!(
             "Agg cache:         {} hits / {} misses ({:.1}% hit-rate, {} entries)",
             stats.agg_cache_hits, stats.agg_cache_misses, hit_rate, stats.agg_cache_entries,
@@ -420,6 +411,25 @@ fn daemon_stats() -> Result<()> {
         println!("Daemon is not running.");
     }
     Ok(())
+}
+
+/// Compute aggregate-cache hit-rate as a percentage for daemon status display.
+///
+/// Returns `0.0` when no lookups have occurred, avoiding a division by
+/// zero on cold daemons.  The `cast_precision_loss` expect is justified
+/// for telemetry display: well over `2^53` cache lookups would be
+/// required to lose a single bit of precision, and the output is
+/// rendered with `{:.1}` so single-bit differences are invisible.
+#[expect(
+    clippy::float_arithmetic,
+    clippy::cast_precision_loss,
+    reason = "telemetry hit-rate percent; rendered with `{:.1}` so precision loss is invisible"
+)]
+fn compute_hit_rate_percent(hits: u64, lookups: u64) -> f64 {
+    if lookups == 0 {
+        return 0.0_f64;
+    }
+    (hits as f64 / lookups as f64) * 100.0_f64
 }
 
 /// `uffs daemon stop` — graceful shutdown via RPC.

--- a/crates/uffs-cli/src/commands/output/mod.rs
+++ b/crates/uffs-cli/src/commands/output/mod.rs
@@ -34,13 +34,14 @@ fn vi(row: &Value, key: &str) -> i64 {
 }
 
 /// Get u32 field (clamped to `u32::MAX` on overflow).
+///
+/// NTFS file attributes (`FILE_ATTRIBUTE_*`) are documented as `u32` by
+/// Microsoft, so the saturating `try_from` fallback is unreachable for
+/// well-formed daemon responses; it nevertheless replaces the previous
+/// truncating `as u32` to keep the conversion idiomatic and lint-free.
 fn vu32(row: &Value, key: &str) -> u32 {
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "flags are stored as u32 in NTFS — overflow is not possible in practice"
-    )]
-    let val = row.get(key).and_then(Value::as_u64).unwrap_or(0) as u32;
-    val
+    let raw = row.get(key).and_then(Value::as_u64).unwrap_or(0);
+    u32::try_from(raw).unwrap_or(u32::MAX)
 }
 
 /// Get bool field.

--- a/crates/uffs-client/src/connect_sync.rs
+++ b/crates/uffs-client/src/connect_sync.rs
@@ -737,9 +737,9 @@ fn auto_start_daemon(
 fn is_process_alive(pid: u32) -> bool {
     #[cfg(unix)]
     {
-        // First, cheap signal-zero check.
-        #[expect(clippy::cast_possible_wrap, reason = "Unix PIDs are always < 2^31")]
-        let pid_i32 = pid as i32;
+        // Cheap signal-zero check.  Unix PIDs fit in i32 by spec, so the
+        // saturating `try_from` fallback is unreachable in practice.
+        let pid_i32 = i32::try_from(pid).unwrap_or(i32::MAX);
         // SAFETY: kill(pid, 0) only checks if a signal *could* be sent
         // to the given PID — it does not actually deliver any signal.
         // The pid comes from our own PID file (trusted input).

--- a/crates/uffs-client/src/daemon_child.rs
+++ b/crates/uffs-client/src/daemon_child.rs
@@ -205,11 +205,12 @@ fn try_wait_windows(
     #[expect(unsafe_code, reason = "Win32 GetExitCodeProcess FFI")]
     let got_code = unsafe { GetExitCodeProcess(handle, &raw mut exit_code) };
     got_code.map_err(|err| std::io::Error::other(err.to_string()))?;
-    #[expect(
-        clippy::cast_possible_wrap,
-        reason = "Windows exit codes are u32 in the API but semantically i32"
-    )]
-    let signed = exit_code as i32;
+    // Windows exit codes are documented as `u32` by `GetExitCodeProcess`
+    // but the historical Unix-style return type is `i32` (high bit
+    // signals an exception code).  `u32::cast_signed` is the
+    // documented exact-bit-pattern reinterpret that preserves both
+    // representations without triggering `clippy::cast_possible_wrap`.
+    let signed = exit_code.cast_signed();
     Ok(Some(signed))
 }
 

--- a/crates/uffs-client/src/format.rs
+++ b/crates/uffs-client/src/format.rs
@@ -170,13 +170,10 @@ mod platform_tz {
             return 0; // fallback to UTC
         }
 
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "tm_gmtoff is at most ±50400 (±14h), fits i32"
-        )]
-        {
-            tm_buf.tm_gmtoff as i32
-        }
+        // `tm_gmtoff` is at most ±50400 (±14h) by POSIX timezone spec,
+        // so the saturating `try_from` fallbacks are unreachable.  This
+        // replaces the previous truncating `as i32` cast.
+        i32::try_from(tm_buf.tm_gmtoff).unwrap_or(0)
     }
 }
 

--- a/crates/uffs-client/src/format.rs
+++ b/crates/uffs-client/src/format.rs
@@ -34,26 +34,23 @@ pub fn format_number_commas(num: u64) -> String {
 /// - >= 1 TB: `123.45 TB`
 #[must_use]
 #[expect(
-    clippy::cast_precision_loss,
-    reason = "precision loss acceptable for display"
-)]
-#[expect(
     clippy::float_arithmetic,
     reason = "floating-point arithmetic required for human-readable byte formatting"
 )]
 pub fn format_bytes(bytes: u64) -> String {
+    let bytes_f64 = u64_to_f64(bytes);
     if bytes < 1024 {
         format!("{bytes:>4} B")
     } else if bytes < 1024 * 1024 {
-        format!("{:>7.2} KB", bytes as f64 / 1024.0)
+        format!("{:>7.2} KB", bytes_f64 / 1024.0)
     } else if bytes < 1024 * 1024 * 1024 {
-        format!("{:>7.2} MB", bytes as f64 / (1024.0 * 1024.0))
+        format!("{:>7.2} MB", bytes_f64 / (1024.0 * 1024.0))
     } else if bytes < 1024 * 1024 * 1024 * 1024 {
-        format!("{:>7.2} GB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
+        format!("{:>7.2} GB", bytes_f64 / (1024.0 * 1024.0 * 1024.0))
     } else {
         format!(
             "{:>7.2} TB",
-            bytes as f64 / (1024.0 * 1024.0 * 1024.0 * 1024.0)
+            bytes_f64 / (1024.0 * 1024.0 * 1024.0 * 1024.0)
         )
     }
 }

--- a/crates/uffs-client/src/protocol/response.rs
+++ b/crates/uffs-client/src/protocol/response.rs
@@ -629,14 +629,16 @@ impl RpcErrorResponse {
 // ────────────────────────────────────────────────────────────────────────────
 
 /// Format a byte count as human-readable size (e.g. "1.23 MB").
+///
+/// Routes the `u64 -> f64` conversion through [`crate::format::u64_to_f64`]
+/// so this function no longer needs a local `cast_precision_loss` expect.
 #[must_use]
 #[expect(
     clippy::float_arithmetic,
     reason = "floating-point division is intentional for human-readable size formatting"
 )]
 pub fn format_size(bytes: u64) -> String {
-    #[expect(clippy::cast_precision_loss, reason = "u64→f64 acceptable for display")]
-    let bytes_f64 = bytes as f64;
+    let bytes_f64 = crate::format::u64_to_f64(bytes);
     if bytes < 1024 {
         format!("{bytes} B")
     } else if bytes < 1024 * 1024 {

--- a/crates/uffs-client/src/protocol/response.rs
+++ b/crates/uffs-client/src/protocol/response.rs
@@ -653,12 +653,12 @@ pub fn format_size(bytes: u64) -> String {
 /// Format a raw FILETIME timestamp as `YYYY-MM-DD HH:MM`.
 ///
 /// Decomposes the FILETIME directly — no intermediate Unix conversion.
+/// Every `as u32` narrowing in the Hinnant algorithm goes through
+/// `u32::try_from(...).unwrap_or(...)`; the algorithm's intermediate
+/// values are bounded (`hour` ∈ `[0, 23]`, `minute` ∈ `[0, 59]`,
+/// `doe` ∈ `[0, 146_096]`) so the saturating fallbacks are unreachable
+/// for any valid FILETIME.
 #[must_use]
-#[expect(
-    clippy::cast_sign_loss,
-    clippy::cast_possible_truncation,
-    reason = "Hinnant algorithm: intermediate values are bounded for valid dates"
-)]
 pub fn format_time(filetime: i64) -> String {
     const TICKS_PER_SECOND: i64 = 10_000_000; // 100-ns intervals per second
     if filetime == 0 {
@@ -667,14 +667,14 @@ pub fn format_time(filetime: i64) -> String {
     let total_secs = filetime / TICKS_PER_SECOND;
     let days_since_1601 = total_secs.div_euclid(86400);
     let day_secs = total_secs.rem_euclid(86400);
-    let hour = (day_secs / 3600) as u32;
-    let minute = ((day_secs % 3600) / 60) as u32;
+    let hour = u32::try_from(day_secs / 3600).unwrap_or(0);
+    let minute = u32::try_from((day_secs % 3600) / 60).unwrap_or(0);
 
     // Hinnant civil_from_days:
     // 719468 (0000-03-01→1970-01-01) − 134774 (1601-01-01→1970-01-01) = 584694
     let z = days_since_1601 + 584_694;
     let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
-    let doe = (z - era * 146_097) as u32;
+    let doe = u32::try_from(z - era * 146_097).unwrap_or(0);
     let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
     let y = i64::from(yoe) + era * 400;
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);

--- a/crates/uffs-core/src/bloom.rs
+++ b/crates/uffs-core/src/bloom.rs
@@ -134,38 +134,31 @@ impl Bloom {
 
         // m / n = -ln(p) / ln(2)^2
         let ln2 = core::f64::consts::LN_2;
-        #[expect(
-            clippy::cast_precision_loss,
-            reason = "n_items > 1<<53 would mean a multi-petabyte bloom; not a real \
-                      use case for filesystem-name filters"
-        )]
-        let n_as_float = n_items as f64;
+        // `usize -> f64` precision-loss cast routed through the
+        // centralized `uffs_mft::usize_to_f64` helper.  `n_items >
+        // 1<<53` would mean a multi-petabyte bloom, which is not a
+        // real filesystem-name-filter use case.
+        let n_as_float = uffs_mft::usize_to_f64(n_items);
         let bits_per_element = -target_fpr.ln() / (ln2 * ln2);
         let nbits_as_float = (n_as_float * bits_per_element).ceil();
 
         // Round up to next multiple of 64 so the bit-packed Vec<u64>
         // has whole-word alignment.  Saturate to u64::MAX on overflow
-        // (a 16-EB bloom is well outside any realistic call site).
-        #[expect(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            reason = "nbits_as_float is non-negative and bounded by ceil(n * 30) for \
-                      reasonable inputs; the f64-to-u64 cast is the standard \
-                      conversion clippy permits via `#[expect]`"
-        )]
-        let nbits_raw = nbits_as_float as u64;
+        // (a 16-EB bloom is well outside any realistic call site);
+        // `uffs_mft::f64_to_u64` carries the single documented
+        // `cast_possible_truncation` / `cast_sign_loss` /
+        // `cast_precision_loss` triplet.
+        let nbits_raw = uffs_mft::f64_to_u64(nbits_as_float);
         let aligned_nbits = nbits_raw.div_ceil(64).saturating_mul(64).max(64);
 
-        // k = (m / n) * ln(2), clamped to [1, 32].  The clamp protects
-        // the u8 cast and matches the tiering-plan §6.2 envelope.
+        // k = (m / n) * ln(2), clamped to [1, 32].  The clamp bounds
+        // the value into u8 range; we go through u64 first via the
+        // centralized `f64_to_u64` helper so the only remaining
+        // narrowing is the saturating `u8::try_from` (which is
+        // lint-free).
         let k_as_float = (bits_per_element * ln2).round();
-        #[expect(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            reason = "k_as_float is in [1.0, 32.0] after clamp; the f64-to-u8 cast \
-                      is well-defined (the clamp bounds the value into u8 range)"
-        )]
-        let k_clamped = k_as_float.clamp(1.0_f64, 32.0_f64) as u8;
+        let k_clamped_f64 = k_as_float.clamp(1.0_f64, 32.0_f64);
+        let k_clamped = u8::try_from(uffs_mft::f64_to_u64(k_clamped_f64)).unwrap_or(32_u8);
 
         Self::with_size_and_k(aligned_nbits, k_clamped)
     }
@@ -308,18 +301,15 @@ impl Bloom {
         if n_inserted == 0 || self.nbits == 0 {
             return 0.0_f64;
         }
-        #[expect(
-            clippy::cast_precision_loss,
-            reason = "n_inserted up to 2^53 is representable exactly in f64; beyond \
-                      that the FPR estimate is already saturated near 1.0 anyway"
-        )]
-        let n_as_float = n_inserted as f64;
-        #[expect(
-            clippy::cast_precision_loss,
-            reason = "see above; nbits up to 2^53 is exact, beyond that the bloom is \
-                      petabyte-scale and FPR is dominated by k, not m"
-        )]
-        let m_as_float = self.nbits as f64;
+        // Both `usize -> f64` and `u64 -> f64` conversions go through
+        // the centralized `uffs_mft::{usize_to_f64, u64_to_f64}`
+        // helpers (each of which carries a single documented
+        // `cast_precision_loss` expect).  Beyond the 2^53 representable
+        // range, the FPR estimate is already saturated near 1.0 and
+        // dominated by `k_hashes`, so the precision loss is invisible
+        // to callers.
+        let n_as_float = uffs_mft::usize_to_f64(n_inserted);
+        let m_as_float = uffs_mft::u64_to_f64(self.nbits);
         let k_as_float = f64::from(self.k_hashes);
         let inner = 1.0_f64 - (-k_as_float * n_as_float / m_as_float).exp();
         inner.powf(k_as_float)

--- a/crates/uffs-core/src/compact_cache.rs
+++ b/crates/uffs-core/src/compact_cache.rs
@@ -480,12 +480,12 @@ pub fn serialize_compact_to_writer<W: io::Write>(
 }
 
 /// Write a `usize` as little-endian `u32` to a writer.
+///
+/// Record/name counts fit in u32 for any realistic MFT (NTFS caps at
+/// ~4 G entries per volume), so the saturating `try_from` fallback is
+/// unreachable in practice and replaces the previous truncating cast.
 fn write_u32<W: io::Write>(writer: &mut W, val: usize) -> io::Result<()> {
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "record/name counts fit in u32 for any realistic MFT"
-    )]
-    let val_u32 = val as u32;
+    let val_u32 = u32::try_from(val).unwrap_or(u32::MAX);
     writer.write_all(&val_u32.to_le_bytes())
 }
 

--- a/crates/uffs-core/src/path_trie.rs
+++ b/crates/uffs-core/src/path_trie.rs
@@ -63,6 +63,7 @@
 use core::mem::size_of;
 
 use rustc_hash::FxHashMap;
+use uffs_mft::len_to_u32;
 
 use crate::compact::CompactRecord;
 
@@ -142,37 +143,28 @@ impl PathTrie {
         let mut nodes: Vec<TrieNode> = Vec::with_capacity(dir_count_estimate);
         let mut trie_names: Vec<u8> = Vec::with_capacity(dir_count_estimate * 16);
 
+        // Every `usize -> u32` conversion below uses the centralized
+        // `len_to_u32` helper (which saturates at `u32::MAX`), so the
+        // call sites stay free of `cast_possible_truncation` expects.
+        // The saturating fallback is unreachable for any realistic NTFS
+        // MFT: records.len() and nodes.len() are bounded by the NTFS
+        // ~4 G entries-per-volume cap, and trie_names.len() is bounded
+        // by the sum of u16 name_len fields across directories.
         for (record_idx_usize, record) in records.iter().enumerate() {
             if !record.is_directory() {
                 continue;
             }
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "records.len() ≤ u32::MAX by NTFS MFT layout (max ~4 G \
-                          entries per volume); the index fits u32 by construction"
-            )]
-            let record_idx = record_idx_usize as u32;
+            let record_idx = len_to_u32(record_idx_usize);
 
             // Slice the basename out of the shared name buffer.
             let name_start = record.name_offset as usize;
             let name_end = name_start + record.name_len as usize;
             let basename = names.get(name_start..name_end).unwrap_or(&[]);
 
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "trie_names.len() growth is bounded by sum of u16 name_len \
-                          across directories; an entire-drive trie's names buffer \
-                          stays under 4 GB by an enormous margin"
-            )]
-            let trie_name_offset = trie_names.len() as u32;
+            let trie_name_offset = len_to_u32(trie_names.len());
             trie_names.extend_from_slice(basename);
 
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "nodes.len() ≤ records.len() ≤ u32::MAX by the same NTFS \
-                          MFT bound"
-            )]
-            let trie_idx = nodes.len() as u32;
+            let trie_idx = len_to_u32(nodes.len());
             record_to_trie.insert(record_idx, trie_idx);
 
             // Stash the *record-side* parent_idx temporarily; pass 2
@@ -286,11 +278,7 @@ impl PathTrie {
         let mut roots: Vec<u32> = Vec::new();
         for (idx, node) in self.nodes.iter().enumerate() {
             if node.parent_idx == NO_PARENT {
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "nodes.len() ≤ u32::MAX by the same MFT bound as build"
-                )]
-                let trie_idx = idx as u32;
+                let trie_idx = len_to_u32(idx);
                 roots.push(trie_idx);
             }
         }
@@ -473,11 +461,7 @@ fn build_children_csr(nodes: &[TrieNode]) -> (Vec<u32>, Vec<u32>) {
         let Some(target) = indices.get_mut(*pos_slot as usize) else {
             continue;
         };
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "nodes.len() ≤ u32::MAX (build precondition)"
-        )]
-        let child_idx = idx_usize as u32;
+        let child_idx = len_to_u32(idx_usize);
         *target = child_idx;
         *pos_slot += 1;
     }
@@ -593,17 +577,11 @@ mod tests {
         let mut expected_dir_names: Vec<String> = Vec::with_capacity(1000);
         for i in 0_u32..1000 {
             let name = format!("dir{i}");
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "names.len() in the test stays well under u32::MAX"
-            )]
-            let off = names.len() as u32;
+            // Test fixture sizes are statically bounded, so the
+            // saturating `try_from` fallbacks are unreachable.
+            let off = len_to_u32(names.len());
             names.extend_from_slice(name.as_bytes());
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "name.len() ≤ 'dir' + 3 digits = 6 bytes"
-            )]
-            let len = name.len() as u16;
+            let len = uffs_mft::len_to_u16(name.len());
             records.push(make_record(off, len, 0, true));
             expected_dir_names.push(name);
         }
@@ -622,11 +600,9 @@ mod tests {
         for (offset, expected_name) in expected_dir_names.iter().enumerate() {
             let segs: [&[u8]; 2] = [b"C", expected_name.as_bytes()];
             let found = trie.lookup_path(&segs).expect("lookup_path missed");
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "offset < 1000 fits u32 trivially"
-            )]
-            let expected_idx = offset as u32 + 1;
+            // offset < 1000 fits u32 trivially; saturating fallback is
+            // unreachable.
+            let expected_idx = len_to_u32(offset) + 1;
             assert_eq!(found, expected_idx);
         }
     }

--- a/crates/uffs-core/src/search/filters/time_parsing.rs
+++ b/crates/uffs-core/src/search/filters/time_parsing.rs
@@ -331,15 +331,13 @@ fn parse_named_time_range(name: &str, now_ft: i64, is_newer: bool) -> Option<i64
 /// Convert days since FILETIME epoch (1601-01-01) to (year, month, day).
 ///
 /// Uses the Hinnant algorithm. 1601-01-01 = day 584389 since 0000-03-01.
-#[expect(
-    clippy::cast_sign_loss,
-    clippy::cast_possible_truncation,
-    reason = "Hinnant algorithm: intermediate values are bounded for valid dates"
-)]
 fn days_to_ymd_1601(days_since_1601: i64) -> (i64, i64, i64) {
     let z = days_since_1601 + 584_694; // days since 0000-03-01
     let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
-    let doe = (z - era * 146_097) as u32;
+    // `z - era * 146_097` is bounded by the era division to
+    // `[0, 146_096]`; `try_from` is the lint-free way to narrow it
+    // to u32 (saturating fallback is unreachable in practice).
+    let doe = u32::try_from(z - era * 146_097).unwrap_or(0);
     let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
     let y = i64::from(yoe) + era * 400;
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
@@ -369,11 +367,6 @@ const fn days_in_month(year: i64, month: i64) -> i64 {
 /// Convert (year, month, day) to days since FILETIME epoch (1601-01-01).
 ///
 /// Inverse of `days_to_ymd_1601`.
-#[expect(
-    clippy::cast_sign_loss,
-    clippy::cast_possible_truncation,
-    reason = "Hinnant algorithm: intermediate values are bounded for valid dates"
-)]
 fn ymd_to_days_1601(year: i64, month: i64, day: i64) -> i64 {
     // Shift to March-based year for the Hinnant inverse algorithm.
     let (adj_year, adj_month) = if month <= 2 {
@@ -386,8 +379,15 @@ fn ymd_to_days_1601(year: i64, month: i64, day: i64) -> i64 {
     } else {
         adj_year - 399
     }) / 400;
-    let yoe = (adj_year - era * 400) as u32;
-    let doy = (153 * adj_month as u32 + 2) / 5 + day as u32 - 1;
+    // All three narrowings below are bounded by the algorithm:
+    // `adj_year - era * 400` lives in `[0, 399]`, `adj_month` in
+    // `[0, 11]`, and `day` in `[1, 31]`.  `try_from` is the lint-free
+    // narrowing pattern; the saturating fallback is unreachable for
+    // any valid civil date.
+    let yoe = u32::try_from(adj_year - era * 400).unwrap_or(0);
+    let adj_month_u32 = u32::try_from(adj_month).unwrap_or(0);
+    let day_u32 = u32::try_from(day).unwrap_or(1);
+    let doy = (153 * adj_month_u32 + 2) / 5 + day_u32 - 1;
     let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
     let days = i64::from(doe) + era * 146_097;
     days - 584_694 // convert from 0000-03-01 epoch to 1601-01-01 epoch

--- a/crates/uffs-core/src/search/query/numeric_top_n.rs
+++ b/crates/uffs-core/src/search/query/numeric_top_n.rs
@@ -32,45 +32,38 @@ const RESOLVE_CHUNK_SIZE: usize = 4096;
 /// inside the per-drive scan.  Moved out of the scan closure so the
 /// drive loop can be parallelised without duplicating the 100-line
 /// `match` across each branch.
-#[expect(clippy::cast_possible_wrap, reason = "file sizes within i64 range")]
 fn extract_sort_key(rec: &CompactRecord, sort_column: FieldId, drive: &DriveCompactIndex) -> i64 {
     let drive_fold = drive.fold;
+    // All `u64 -> i64` conversions below use `u64::cast_signed` (stable
+    // since Rust 1.87) to document the exact-bit-pattern reinterpret
+    // without needing a `cast_possible_wrap` expect.  Real NTFS file /
+    // tree sizes never approach `i64::MAX`, so the high-bit flip is
+    // unreachable in practice.
     match sort_column {
-        FieldId::Size => rec.size as i64,
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "allocated sizes within i64 range"
-        )]
-        FieldId::SizeOnDisk => rec.allocated as i64,
+        FieldId::Size => rec.size.cast_signed(),
+        FieldId::SizeOnDisk => rec.allocated.cast_signed(),
         FieldId::Created => rec.created,
         FieldId::Accessed => rec.accessed,
         FieldId::Descendants => i64::from(rec.descendants),
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "allocated values are expected within i64 range"
-        )]
         FieldId::TreeAllocated => {
             if rec.is_directory() {
-                rec.tree_allocated as i64
+                rec.tree_allocated.cast_signed()
             } else {
-                rec.allocated as i64
+                rec.allocated.cast_signed()
             }
         }
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "scaled bulkiness metric is expected within i64 range"
-        )]
-        FieldId::Bulkiness => bulkiness_for_record(rec) as i64,
+        FieldId::Bulkiness => bulkiness_for_record(rec).cast_signed(),
         FieldId::Extension | FieldId::Type => i64::from(rec.extension_id),
         FieldId::Name => {
             let name = rec.name(&drive.names);
             let mut key = [0_u8; 8];
             for (dst, ch) in key.iter_mut().zip(name.chars()) {
                 let folded = drive_fold.fold_char(ch);
-                #[expect(clippy::cast_possible_truncation, reason = "sort key prefix")]
-                {
-                    *dst = folded as u8;
-                }
+                // Sort-key prefix: the low byte of the folded u16 is the
+                // canonical 8-byte name-prefix; `to_be_bytes()[1]` is the
+                // lint-free way to take it (vs `folded as u8` which would
+                // trigger `clippy::cast_possible_truncation`).
+                *dst = folded.to_be_bytes()[1];
             }
             i64::from_be_bytes(key)
         }
@@ -80,22 +73,15 @@ fn extract_sort_key(rec: &CompactRecord, sort_column: FieldId, drive: &DriveComp
             key[0] = u8::try_from(u32::from(drive.letter)).unwrap_or(b'?');
             for (dst, ch) in key[1..].iter_mut().zip(name.chars()) {
                 let folded = drive_fold.fold_char(ch);
-                #[expect(clippy::cast_possible_truncation, reason = "sort key prefix")]
-                {
-                    *dst = folded as u8;
-                }
+                *dst = folded.to_be_bytes()[1];
             }
             i64::from_be_bytes(key)
         }
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "treesize values within i64 range"
-        )]
         FieldId::TreeSize => {
             if rec.is_directory() {
-                rec.treesize as i64
+                rec.treesize.cast_signed()
             } else {
-                rec.size as i64
+                rec.size.cast_signed()
             }
         }
         // Boolean attribute flags: extract the individual bit as 0/1.

--- a/crates/uffs-core/src/search/query_tests.rs
+++ b/crates/uffs-core/src/search/query_tests.rs
@@ -1241,14 +1241,10 @@ fn build_modified_gradient_drive(letter: char, base_frs: u64, count: usize) -> D
         rec.stdinfo.flags = 0x20;
         // Monotonic timestamps: ensures Modified-DESC order is
         // fully determined by FRS, independent of drive order or
-        // rayon scheduling.
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "small test-only FRS values stay well inside i64"
-        )]
-        {
-            rec.stdinfo.modified = frs as i64;
-        }
+        // rayon scheduling.  `u64::cast_signed` is the Rust 1.87
+        // exact-bit-pattern reinterpret; small test-only FRS values
+        // stay well inside i64 so the high bit never flips.
+        rec.stdinfo.modified = frs.cast_signed();
     }
     let (drive, _, _) = build_compact_index(letter, &idx);
     drive

--- a/crates/uffs-daemon/src/cache/policy.rs
+++ b/crates/uffs-daemon/src/cache/policy.rs
@@ -259,7 +259,6 @@ pub(crate) struct TierThresholds {
 #[must_use]
 #[expect(
     clippy::float_arithmetic,
-    clippy::cast_precision_loss,
     reason = "TTL formula uses log2 + multiply + clamp on a non-negative \
               rate; precision loss bounded by `Duration::from_secs_f64` \
               and the explicit `cap` ceiling."
@@ -267,8 +266,11 @@ pub(crate) struct TierThresholds {
 pub(crate) fn hot_ttl(rate_ema_qpm: f64, base_secs: u64, cap_secs: u64) -> Duration {
     const HOT_BONUS_COEF_SECS: f64 = 60.0;
     let bonus_secs = HOT_BONUS_COEF_SECS * rate_ema_qpm.log2().max(0.0);
-    let total_secs = (base_secs as f64) + bonus_secs;
-    let capped_secs = total_secs.min(cap_secs as f64).max(base_secs as f64);
+    // All `u64 -> f64` conversions go through `uffs_mft::u64_to_f64`
+    // (centralized `cast_precision_loss` expect at the helper site).
+    let base_f64 = uffs_mft::u64_to_f64(base_secs);
+    let total_secs = base_f64 + bonus_secs;
+    let capped_secs = total_secs.min(uffs_mft::u64_to_f64(cap_secs)).max(base_f64);
     Duration::from_secs_f64(capped_secs)
 }
 
@@ -289,7 +291,6 @@ pub(crate) fn hot_ttl(rate_ema_qpm: f64, base_secs: u64, cap_secs: u64) -> Durat
 #[must_use]
 #[expect(
     clippy::float_arithmetic,
-    clippy::cast_precision_loss,
     reason = "TTL formula uses log2 + multiply + clamp on a non-negative \
               rate; precision loss bounded by `Duration::from_secs_f64` \
               and the explicit `cap` ceiling."
@@ -297,8 +298,9 @@ pub(crate) fn hot_ttl(rate_ema_qpm: f64, base_secs: u64, cap_secs: u64) -> Durat
 pub(crate) fn warm_ttl(rate_ema_qpm: f64, base_secs: u64, cap_secs: u64) -> Duration {
     const WARM_BONUS_COEF_SECS: f64 = 600.0;
     let bonus_secs = WARM_BONUS_COEF_SECS * rate_ema_qpm.log2().max(0.0);
-    let total_secs = (base_secs as f64) + bonus_secs;
-    let capped_secs = total_secs.min(cap_secs as f64).max(base_secs as f64);
+    let base_f64 = uffs_mft::u64_to_f64(base_secs);
+    let total_secs = base_f64 + bonus_secs;
+    let capped_secs = total_secs.min(uffs_mft::u64_to_f64(cap_secs)).max(base_f64);
     Duration::from_secs_f64(capped_secs)
 }
 

--- a/crates/uffs-daemon/src/cache/shard/drive_stats.rs
+++ b/crates/uffs-daemon/src/cache/shard/drive_stats.rs
@@ -282,9 +282,6 @@ impl DriveStats {
     /// happens once per controller tick (every 30 s) inside
     /// `decay_ema`, so the search dispatch path remains branch-free.
     #[expect(
-        clippy::cast_precision_loss,
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
         clippy::float_arithmetic,
         reason = "EMA arithmetic is intentionally floating-point and lossy; \
                   the values cast through u64 are fixed-point µ/s representations \
@@ -300,32 +297,37 @@ impl DriveStats {
             .last_decay_queries_total
             .swap(cur_queries, Ordering::Relaxed);
         let prev_ema_fixed = self.rate_ema_micro_per_s.load(Ordering::Relaxed);
+        // All `u64 -> f64` / `f64 -> u64` conversions below go through
+        // the centralized `uffs_mft::{u64_to_f64, f64_to_u64}` helpers
+        // (each of which carries the single documented
+        // `cast_precision_loss` / `cast_possible_truncation` /
+        // `cast_sign_loss` triplet).
         if prev_ms == 0 {
             // First call after construction: no elapsed window to
             // compute a rate sample over.  Initialise the
             // tracking pair (already done by the swaps above) and
             // return the stored EMA as-is.
-            return prev_ema_fixed as f64 / 1.0e6;
+            return uffs_mft::u64_to_f64(prev_ema_fixed) / 1.0e6_f64;
         }
         let elapsed_ms = now_ms.saturating_sub(prev_ms);
         // Half-life formula factored as `decay = exp(-half_lives · ln 2)`.
-        let half_lives = elapsed_ms as f64 / HALF_LIFE_MS as f64;
+        let half_lives = uffs_mft::u64_to_f64(elapsed_ms) / uffs_mft::u64_to_f64(HALF_LIFE_MS);
         let decay = (-half_lives * core::f64::consts::LN_2).exp();
-        let prev_ema = prev_ema_fixed as f64 / 1.0e6_f64;
+        let prev_ema = uffs_mft::u64_to_f64(prev_ema_fixed) / 1.0e6_f64;
         // Per-second rate over the elapsed window.  Floor the
         // denominator at 1 ms so very-fast successive ticks (a
         // status_drives RPC racing the demote tick on a hot drive)
         // don't divide by zero or produce a kHz-scale rate spike.
-        let elapsed_secs = (elapsed_ms.max(1) as f64) / 1000.0_f64;
+        let elapsed_secs = uffs_mft::u64_to_f64(elapsed_ms.max(1)) / 1000.0_f64;
         let delta_queries = cur_queries.saturating_sub(prev_queries);
-        let sample_rate = (delta_queries as f64) / elapsed_secs;
+        let sample_rate = uffs_mft::u64_to_f64(delta_queries) / elapsed_secs;
         // EMA blend: new = decay · prev + (1 - decay) · sample.
         // Express as a fused multiply-add (`mul_add`) so clippy's
         // `suboptimal_flops` pedantic gate is satisfied and the
         // arithmetic is also marginally more accurate (single
         // rounding instead of two).
         let new_ema = decay.mul_add(prev_ema, (1.0_f64 - decay) * sample_rate);
-        let new_fixed = (new_ema * 1.0e6_f64) as u64;
+        let new_fixed = uffs_mft::f64_to_u64(new_ema * 1.0e6_f64);
         self.rate_ema_micro_per_s
             .store(new_fixed, Ordering::Relaxed);
         new_ema
@@ -361,14 +363,13 @@ impl DriveStats {
 /// helper.
 #[cfg(test)]
 #[expect(
-    clippy::cast_precision_loss,
     clippy::float_arithmetic,
     reason = "test-only EMA read: float divide on a fixed-point store; \
               the precision loss is tolerated by the rate-estimator \
               semantics."
 )]
 pub(crate) fn drive_stats_ema_value(stats: &DriveStats) -> f64 {
-    stats.rate_ema_micro_per_s.load(Ordering::Relaxed) as f64 / 1.0e6
+    uffs_mft::u64_to_f64(stats.rate_ema_micro_per_s.load(Ordering::Relaxed)) / 1.0e6_f64
 }
 
 /// Serializable snapshot of a [`DriveStats`].

--- a/crates/uffs-daemon/src/ipc.rs
+++ b/crates/uffs-daemon/src/ipc.rs
@@ -128,12 +128,13 @@ impl IpcServer {
             uid: 0,
             gid: 0,
         };
-        // ucred is 12 bytes (3 × i32), always fits in socklen_t (u32).
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "size_of::<ucred>() is 12, which fits in u32 socklen_t"
-        )]
-        let mut len = size_of::<libc::ucred>() as libc::socklen_t;
+        // `ucred` is 12 bytes (3 × i32) on every supported platform, so
+        // `try_from` is the lossless, lint-free conversion to
+        // `socklen_t` (u32 on Linux, u32 on macOS); the saturating
+        // fallback exists only to satisfy the type-system contract and
+        // is unreachable in practice.
+        let mut len =
+            libc::socklen_t::try_from(size_of::<libc::ucred>()).unwrap_or(libc::socklen_t::MAX);
 
         // SAFETY: `getsockopt` with `SO_PEERCRED` reads the ucred struct for
         // the peer of a Unix domain socket.  We pass a valid fd and correctly

--- a/crates/uffs-diag/src/bin/analyze_diff.rs
+++ b/crates/uffs-diag/src/bin/analyze_diff.rs
@@ -496,11 +496,11 @@ fn main() -> Result<()> {
     println!("  - Match rate (no ADS): {match_rate_no_ads:.2}%");
 
     println!("\nLikely Issues:");
-    #[expect(
-        clippy::cast_possible_wrap,
-        reason = "ADS counts are small enough that i64 wrapping cannot occur"
-    )]
-    let ads_diff = reference_ads_count as i64 - rust_ads_count as i64;
+    // ADS counts are small enough that `i64::try_from` is infallible in
+    // practice; the saturating fallback is unreachable.
+    let ref_i64 = i64::try_from(reference_ads_count).unwrap_or(i64::MAX);
+    let rust_i64 = i64::try_from(rust_ads_count).unwrap_or(i64::MAX);
+    let ads_diff = ref_i64 - rust_i64;
     println!(
         "  1. ADS entries: {reference_ads_count} in reference output, {rust_ads_count} in Rust (diff: {ads_diff})"
     );

--- a/crates/uffs-diag/src/bin/compare_scan_parity.rs
+++ b/crates/uffs-diag/src/bin/compare_scan_parity.rs
@@ -257,13 +257,12 @@ fn compare_numeric_field(
                 stats.exact_matches += 1;
             } else {
                 stats.mismatches += 1;
-                // u64→i64 wrapping_sub for signed difference; .unsigned_abs() recovers
-                // magnitude
-                #[expect(
-                    clippy::cast_possible_wrap,
-                    reason = "u64→i64 for signed diff of file sizes"
-                )]
-                let diff = uffs_mft::u64_to_f64((c as i64).wrapping_sub(r as i64).unsigned_abs());
+                // `u64::abs_diff` returns the unsigned magnitude
+                // `|c - r|` directly, replacing the previous
+                // `wrapping_sub(...).unsigned_abs()` chain (which
+                // required a `cast_possible_wrap` expect on every
+                // `as i64` cast).
+                let diff = uffs_mft::u64_to_f64(c.abs_diff(r));
                 stats.sum_abs_diff += diff;
                 if diff > stats.max_abs_diff {
                     stats.max_abs_diff = diff;
@@ -648,13 +647,12 @@ fn print_results(results: &ComparisonResults) {
         format_num(results.reference_total_rows)
     );
     println!("  Rust rows:  {:>12}", format_num(results.rust_total_rows));
-    // usize→i64 wrapping_sub: row counts are well within i64 range for any
-    // practical MFT
-    #[expect(
-        clippy::cast_possible_wrap,
-        reason = "usize→i64 for signed row count diff"
-    )]
-    let diff = (results.rust_total_rows as i64).wrapping_sub(results.reference_total_rows as i64);
+    // Row counts are well within `i64::MAX` for any practical MFT;
+    // `i64::try_from` is the lint-free way to compute the signed
+    // difference without a `cast_possible_wrap` expect.
+    let rust_i64 = i64::try_from(results.rust_total_rows).unwrap_or(i64::MAX);
+    let ref_i64 = i64::try_from(results.reference_total_rows).unwrap_or(i64::MAX);
+    let diff = rust_i64.wrapping_sub(ref_i64);
     println!("  Difference: {:>+12}", diff);
 
     println!("\n🔗 PATH MATCHING");
@@ -800,12 +798,11 @@ fn write_markdown_report(results: &ComparisonResults, path: &Path) -> Result<()>
         format_num(results.reference_total_rows)
     )?;
     writeln!(f, "| Rust rows | {} |", format_num(results.rust_total_rows))?;
-    // usize→i64 wrapping_sub: row counts within i64 range
-    #[expect(
-        clippy::cast_possible_wrap,
-        reason = "usize→i64 for signed row count diff"
-    )]
-    let diff = (results.rust_total_rows as i64).wrapping_sub(results.reference_total_rows as i64);
+    // Row counts within `i64::MAX` — see `print_summary` for the
+    // identical `i64::try_from` rationale.
+    let rust_i64 = i64::try_from(results.rust_total_rows).unwrap_or(i64::MAX);
+    let ref_i64 = i64::try_from(results.reference_total_rows).unwrap_or(i64::MAX);
+    let diff = rust_i64.wrapping_sub(ref_i64);
     writeln!(f, "| Difference | {:+} |", diff)?;
     writeln!(f)?;
 

--- a/crates/uffs-mft/benches/mft_read.rs
+++ b/crates/uffs-mft/benches/mft_read.rs
@@ -82,10 +82,6 @@ mod windows_benches {
         clippy::shadow_reuse,
         reason = "criterion `bench_with_input(... |b, &input| ...)` deliberately re-binds the input ref inside the closure; the shadow is part of the closure's destructuring contract"
     )]
-    #![expect(
-        clippy::cast_possible_wrap,
-        reason = "synthetic test data: `i as i64` produces deterministic counter columns; bench inputs are bounded (<= 1_000_000) so wrap cannot occur"
-    )]
 
     use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group};
     use uffs_mft::{AlignedBuffer, ParsedColumns};
@@ -133,17 +129,23 @@ mod windows_benches {
         let mut cols = ParsedColumns::with_capacity(count);
 
         for i in 0..count {
-            cols.frs.push(i as u64);
-            cols.parent_frs
-                .push(if i > 0 { (i / 10) as u64 } else { 5 });
+            let row_frs = uffs_mft::usize_to_u64(i);
+            // Synthetic bench inputs are bounded (<= 1_000_000) so the
+            // `try_from` fallback is unreachable in practice; the typed
+            // conversion avoids the `cast_possible_wrap` blanket and the
+            // unwrap mirrors criterion's bounded-input convention.
+            let row_offset_i64 = i64::try_from(i).unwrap_or(i64::MAX);
+            cols.frs.push(row_frs);
+            cols.parent_frs.push(if i > 0 { row_frs / 10 } else { 5 });
             cols.name.push(format!("file_{i}.txt"));
-            cols.size.push((i * 1024) as u64);
+            cols.size.push(row_frs * 1024);
             cols.allocated_size
-                .push(((i * 1024).div_ceil(4096) * 4096) as u64);
-            cols.created.push(1_700_000_000_000_i64 + i as i64);
-            cols.modified.push(1_700_000_000_000_i64 + i as i64);
-            cols.accessed.push(1_700_000_000_000_i64 + i as i64);
-            cols.mft_changed.push(1_700_000_000_000_i64 + i as i64);
+                .push((row_frs * 1024).div_ceil(4096) * 4096);
+            cols.created.push(1_700_000_000_000_i64 + row_offset_i64);
+            cols.modified.push(1_700_000_000_000_i64 + row_offset_i64);
+            cols.accessed.push(1_700_000_000_000_i64 + row_offset_i64);
+            cols.mft_changed
+                .push(1_700_000_000_000_i64 + row_offset_i64);
             cols.is_directory.push(i % 10 == 0);
             cols.name_count.push(1);
             cols.stream_count.push(1);

--- a/crates/uffs-mft/src/commands/windows/bench.rs
+++ b/crates/uffs-mft/src/commands/windows/bench.rs
@@ -13,11 +13,8 @@
 )]
 #![expect(
     clippy::float_arithmetic,
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
     clippy::default_numeric_fallback,
-    reason = "throughput rates (MB/s, rec/s) are computed from integer counters into f64 for human-readable display"
+    reason = "throughput rates (MB/s, rec/s) divide f64 helpers for human-readable display"
 )]
 #![expect(
     clippy::min_ident_chars,
@@ -32,6 +29,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context as _, Result};
 use tracing::{info, warn};
+use uffs_mft::{f64_to_u64, millis_to_u64, u32_as_usize, u64_to_f64, usize_to_f64, usize_to_u64};
 
 use super::shared::pause_between_benchmark_runs;
 use crate::display::format_number_commas;
@@ -78,7 +76,7 @@ pub(crate) async fn cmd_bench(
         .with_mode(mode)
         .with_merge_extensions(full);
 
-    let mut results: Vec<BenchmarkResult> = Vec::with_capacity(runs as usize);
+    let mut results: Vec<BenchmarkResult> = Vec::with_capacity(u32_as_usize(runs));
 
     for run in 1..=runs {
         if !json && runs > 1 {
@@ -142,7 +140,7 @@ fn average_results(results: &[uffs_mft::BenchmarkResult]) -> Result<uffs_mft::Be
     let Some(first) = results.first() else {
         anyhow::bail!("no benchmark results were collected");
     };
-    let n = results.len() as u64;
+    let n = usize_to_u64(results.len());
 
     let avg_timings = uffs_mft::PhaseTimings {
         open_ms: results.iter().map(|r| r.timings.open_ms).sum::<u64>() / n,
@@ -164,9 +162,9 @@ fn average_results(results: &[uffs_mft::BenchmarkResult]) -> Result<uffs_mft::Be
     };
 
     let avg_throughput: f64 =
-        results.iter().map(|r| r.throughput_mb_s).sum::<f64>() / results.len() as f64;
+        results.iter().map(|r| r.throughput_mb_s).sum::<f64>() / usize_to_f64(results.len());
     let avg_records_per_sec: f64 =
-        results.iter().map(|r| r.records_per_sec).sum::<f64>() / results.len() as f64;
+        results.iter().map(|r| r.records_per_sec).sum::<f64>() / usize_to_f64(results.len());
 
     Ok(uffs_mft::BenchmarkResult {
         timings: avg_timings,
@@ -202,7 +200,7 @@ fn print_benchmark_result(result: &uffs_mft::BenchmarkResult, runs: u32) {
         format_number_commas(c.total_records)
     );
     if let Some(in_use) = c.in_use_records {
-        let skip_pct = (in_use as f64 / c.total_records as f64).mul_add(-100.0, 100.0);
+        let skip_pct = (u64_to_f64(in_use) / u64_to_f64(c.total_records)).mul_add(-100.0, 100.0);
         println!(
             "   In-Use Records:   {} ({:.1}% skipped)",
             format_number_commas(in_use),
@@ -250,12 +248,12 @@ fn print_benchmark_result(result: &uffs_mft::BenchmarkResult, runs: u32) {
     println!("🚀 THROUGHPUT");
     println!(
         "   Records/sec:      {}",
-        format_number_commas(result.records_per_sec as u64)
+        format_number_commas(f64_to_u64(result.records_per_sec))
     );
     println!("   MB/sec:           {:.1}", result.throughput_mb_s);
     println!(
         "   Records Parsed:   {}",
-        format_number_commas(result.records_parsed as u64)
+        format_number_commas(usize_to_u64(result.records_parsed))
     );
     println!();
 
@@ -409,7 +407,7 @@ pub(crate) async fn cmd_bench_all(
                 println!("  ✅ Drive {drive}:");
                 println!(
                     "     Records:     {}",
-                    format_number_commas(result.records_parsed as u64)
+                    format_number_commas(usize_to_u64(result.records_parsed))
                 );
                 println!("     Total time:  {} ms", result.timings.total_ms);
                 println!("     Throughput:  {:.1} MB/s", result.throughput_mb_s);
@@ -425,7 +423,7 @@ pub(crate) async fn cmd_bench_all(
         }
     }
 
-    let total_time_ms = total_start.elapsed().as_millis() as u64;
+    let total_time_ms = millis_to_u64(total_start.elapsed().as_millis());
 
     // Build full report
     let report = FullBenchmarkReport {
@@ -457,7 +455,7 @@ pub(crate) async fn cmd_bench_all(
     println!(
         "  ⏱️  Total time:         {} ms ({:.1} sec)",
         total_time_ms,
-        total_time_ms as f64 / 1000.0
+        u64_to_f64(total_time_ms) / 1000.0
     );
     println!("  📄 Results saved to:   {}", output_path.display());
     println!();
@@ -489,7 +487,7 @@ async fn benchmark_single_drive(
         .with_context(|| format!("Failed to open drive {drive}:"))?
         .with_merge_extensions(full);
 
-    let mut results: Vec<uffs_mft::BenchmarkResult> = Vec::with_capacity(runs as usize);
+    let mut results: Vec<uffs_mft::BenchmarkResult> = Vec::with_capacity(u32_as_usize(runs));
 
     for run in 1..=runs {
         if runs > 1 {

--- a/crates/uffs-mft/src/commands/windows/benchmark_index.rs
+++ b/crates/uffs-mft/src/commands/windows/benchmark_index.rs
@@ -19,11 +19,8 @@
 )]
 #![expect(
     clippy::float_arithmetic,
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
     clippy::default_numeric_fallback,
-    reason = "throughput rates (MB/s, rec/s) are computed from integer counters into f64 for human-readable display"
+    reason = "throughput rates (MB/s, rec/s) divide f64 helpers for human-readable display"
 )]
 #![expect(
     clippy::min_ident_chars,
@@ -40,7 +37,7 @@
 
 use anyhow::{Context as _, Result};
 use tracing::warn;
-use uffs_mft::MftReader;
+use uffs_mft::{MftReader, bytes_to_mb_f64, f64_to_u64, millis_to_u64, u64_to_f64, usize_to_u64};
 
 /// Converts a byte to a printable ASCII character or '.' for non-printable.
 #[cfg(windows)]
@@ -97,19 +94,19 @@ pub(crate) async fn cmd_benchmark_index(drive: char) -> Result<()> {
         .with_context(|| format!("Failed to read MFT from {drive_upper}:"))?;
 
     let elapsed = start_time.elapsed();
-    let elapsed_ms = elapsed.as_millis() as u64;
+    let elapsed_ms = millis_to_u64(elapsed.as_millis());
     let elapsed_secs = elapsed.as_secs_f64();
 
     // =========================================================================
     // Calculate statistics from DataFrame
     // =========================================================================
-    let total_entries = df.height() as u64;
+    let total_entries = usize_to_u64(df.height());
 
     // Count files vs directories using the is_directory column
     let is_dir_col = df.column("is_directory").ok().and_then(|c| c.bool().ok());
 
     let (files_count, dirs_count) = is_dir_col.map_or((total_entries, 0), |col| {
-        let dirs: u64 = col.into_iter().filter(|v| v.unwrap_or(false)).count() as u64;
+        let dirs = usize_to_u64(col.into_iter().filter(|v| v.unwrap_or(false)).count());
         let files = total_entries.saturating_sub(dirs);
         (files, dirs)
     });
@@ -128,19 +125,19 @@ pub(crate) async fn cmd_benchmark_index(drive: char) -> Result<()> {
     // Print benchmark results using the historical layout
     // =========================================================================
     let mft_read_speed = if elapsed_secs > 0.0 {
-        (mft_size as f64 / (1024.0 * 1024.0)) / elapsed_secs
+        bytes_to_mb_f64(mft_size) / elapsed_secs
     } else {
         0.0
     };
 
     let records_per_sec = if elapsed_secs > 0.0 {
-        (mft_capacity as f64 / elapsed_secs) as u64
+        f64_to_u64(u64_to_f64(mft_capacity) / elapsed_secs)
     } else {
         0
     };
 
     let entries_per_sec = if elapsed_secs > 0.0 {
-        (total_entries as f64 / elapsed_secs) as u64
+        f64_to_u64(u64_to_f64(total_entries) / elapsed_secs)
     } else {
         0
     };
@@ -333,16 +330,16 @@ pub(crate) async fn cmd_benchmark_index_lean(
         .with_context(|| format!("Failed to read MFT from {drive_upper}:"))?;
 
     let elapsed = start_time.elapsed();
-    let elapsed_ms = elapsed.as_millis() as u64;
+    let elapsed_ms = millis_to_u64(elapsed.as_millis());
     let elapsed_secs = elapsed.as_secs_f64();
 
     // =========================================================================
     // Calculate statistics from MftIndex
     // =========================================================================
-    let total_entries = index.records.len() as u64;
+    let total_entries = usize_to_u64(index.records.len());
 
     // Count files vs directories
-    let dirs_count = index.records.iter().filter(|r| r.is_directory()).count() as u64;
+    let dirs_count = usize_to_u64(index.records.iter().filter(|r| r.is_directory()).count());
     let files_count = total_entries.saturating_sub(dirs_count);
 
     // =========================================================================
@@ -402,19 +399,19 @@ pub(crate) async fn cmd_benchmark_index_lean(
     // Print Benchmark Results
     // =========================================================================
     let mft_read_speed = if elapsed_secs > 0.0 {
-        (mft_size as f64 / (1024.0 * 1024.0)) / elapsed_secs
+        bytes_to_mb_f64(mft_size) / elapsed_secs
     } else {
         0.0
     };
 
     let records_per_sec = if elapsed_secs > 0.0 {
-        (mft_capacity as f64 / elapsed_secs) as u64
+        f64_to_u64(u64_to_f64(mft_capacity) / elapsed_secs)
     } else {
         0
     };
 
     let entries_per_sec = if elapsed_secs > 0.0 {
-        (total_entries as f64 / elapsed_secs) as u64
+        f64_to_u64(u64_to_f64(total_entries) / elapsed_secs)
     } else {
         0
     };
@@ -506,7 +503,7 @@ pub(crate) async fn cmd_benchmark_tree(
                 .with_context(|| format!("Failed to read MFT from {drive_upper}:"))?
         }
     };
-    let load_ms = load_start.elapsed().as_millis() as u64;
+    let load_ms = millis_to_u64(load_start.elapsed().as_millis());
     println!("Index loaded in {load_ms} ms");
     println!();
 
@@ -536,7 +533,7 @@ pub(crate) async fn cmd_benchmark_tree(
         // Time the tree metrics computation
         let tree_start = Instant::now();
         index.compute_tree_metrics();
-        let tree_ms = tree_start.elapsed().as_millis() as u64;
+        let tree_ms = millis_to_u64(tree_start.elapsed().as_millis());
         times_ms.push(tree_ms);
 
         println!("  Iteration {}: {} ms", i + 1, tree_ms);
@@ -547,7 +544,7 @@ pub(crate) async fn cmd_benchmark_tree(
     let max_ms = *times_ms.iter().max().unwrap_or(&0);
     let sum_ms: u64 = times_ms.iter().sum();
     let avg_ms = if iterations > 0 {
-        sum_ms / iterations as u64
+        sum_ms / usize_to_u64(iterations)
     } else {
         0
     };
@@ -574,7 +571,7 @@ pub(crate) async fn cmd_benchmark_tree(
     println!();
 
     // Calculate throughput
-    let entries_per_sec = (total_entries as u64 * 1000)
+    let entries_per_sec = (usize_to_u64(total_entries) * 1000)
         .checked_div(avg_ms)
         .unwrap_or(0);
 
@@ -671,7 +668,7 @@ pub(crate) async fn cmd_benchmark_multi_volume(drives: Vec<char>) -> Result<()> 
             drive,
             drive_type,
             total_records,
-            mft_size as f64 / (1024.0 * 1024.0)
+            bytes_to_mb_f64(mft_size)
         );
 
         let state = prepare_volume_state(drive, overlapped_handle, extent_map, bitmap, drive_type);
@@ -718,9 +715,9 @@ pub(crate) async fn cmd_benchmark_multi_volume(drives: Vec<char>) -> Result<()> 
     for index in &indices {
         let files = index.records.iter().filter(|r| !r.is_directory()).count();
         let dirs = index.records.iter().filter(|r| r.is_directory()).count();
-        total_records += index.len() as u64;
-        total_files += files as u64;
-        total_dirs += dirs as u64;
+        total_records += usize_to_u64(index.len());
+        total_files += usize_to_u64(files);
+        total_dirs += usize_to_u64(dirs);
 
         println!(
             "  {}: {} records ({} files, {} dirs)",

--- a/crates/uffs-mft/src/commands/windows/benchmark_mft.rs
+++ b/crates/uffs-mft/src/commands/windows/benchmark_mft.rs
@@ -13,12 +13,8 @@
 )]
 #![expect(
     clippy::float_arithmetic,
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
-    clippy::cast_possible_wrap,
     clippy::default_numeric_fallback,
-    reason = "byte / rate calculations convert integer counters into f64 for human-readable display; LCN/byte-offset casts are bounded by NTFS volume size"
+    reason = "byte / rate calculations divide f64 helpers for human-readable MB/s display"
 )]
 #![expect(
     clippy::redundant_type_annotations,
@@ -38,6 +34,7 @@
 )]
 
 use anyhow::{Context as _, Result};
+use uffs_mft::{bytes_to_mb_f64, frs_to_usize, millis_to_u64, u32_as_usize, usize_to_u64};
 
 use crate::display::char_or_dot;
 
@@ -116,7 +113,7 @@ pub(crate) async fn cmd_benchmark_mft(drive: char) -> Result<()> {
     // Benchmark: Read MFT with 1MB synchronous reads
     // =========================================================================
     const BUFFER_SIZE: usize = 1024 * 1024; // 1 MB buffer (matches the reference benchmark layout)
-    let sector_size = vol_data.bytes_per_sector as usize;
+    let sector_size = u32_as_usize(vol_data.bytes_per_sector);
     let bytes_per_cluster = vol_data.bytes_per_cluster;
 
     // Allocate sector-aligned buffer (AlignedBuffer uses SECTOR_SIZE internally)
@@ -140,8 +137,17 @@ pub(crate) async fn cmd_benchmark_mft(drive: char) -> Result<()> {
             continue;
         }
 
-        // Calculate byte offset and size for this extent
-        let extent_byte_offset = (extent.lcn as u64) * u64::from(bytes_per_cluster);
+        // Calculate byte offset and size for this extent.
+        //
+        // NTFS exposes `LcnPosition` (extent LCN) as `i64` on the FFI side
+        // even though valid extents are non-negative; the sign-loss cast
+        // here is bounded by upstream extent-map validation.
+        #[expect(
+            clippy::cast_sign_loss,
+            reason = "NTFS extents come from MftExtentMap which rejects negative LCNs upstream"
+        )]
+        let lcn_u64 = extent.lcn as u64;
+        let extent_byte_offset = lcn_u64 * u64::from(bytes_per_cluster);
         let extent_byte_size = extent.cluster_count * u64::from(bytes_per_cluster);
 
         // Don't read beyond MFT valid data length
@@ -152,13 +158,22 @@ pub(crate) async fn cmd_benchmark_mft(drive: char) -> Result<()> {
             break;
         }
 
-        // Seek to extent start
+        // Seek to extent start.
+        //
+        // Win32 `SetFilePointerEx` takes the offset as `i64`; NTFS volume
+        // sizes never exceed `i64::MAX`, so the wrap below cannot occur in
+        // practice — the per-site `cast_possible_wrap` expect documents
+        // that contract.
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "SetFilePointerEx accepts i64; NTFS volume offsets never exceed i64::MAX"
+        )]
+        let signed_offset = extent_byte_offset as i64;
         // SAFETY: `raw_handle` is a live volume handle owned by `vol_data`'s
-        // `VolumeHandle` and `extent_byte_offset` is bounded by the MFT extent
+        // `VolumeHandle` and `signed_offset` is bounded by the MFT extent
         // returned by Windows; the cast to `i64` is safe because volume sizes
         // never exceed `i64::MAX`.
-        let seek_result =
-            unsafe { SetFilePointerEx(raw_handle, extent_byte_offset as i64, None, FILE_BEGIN) };
+        let seek_result = unsafe { SetFilePointerEx(raw_handle, signed_offset, None, FILE_BEGIN) };
         if seek_result.is_err() {
             anyhow::bail!(
                 "Failed to seek to offset {} for extent at LCN {}",
@@ -170,7 +185,7 @@ pub(crate) async fn cmd_benchmark_mft(drive: char) -> Result<()> {
         // Read extent in 1MB chunks
         let mut extent_offset: u64 = 0;
         while extent_offset < extent_bytes_to_read {
-            let chunk_size = ((extent_bytes_to_read - extent_offset) as usize).min(BUFFER_SIZE);
+            let chunk_size = frs_to_usize(extent_bytes_to_read - extent_offset).min(BUFFER_SIZE);
             // Round up to sector boundary for FILE_FLAG_NO_BUFFERING
             let aligned_chunk_size = chunk_size.div_ceil(sector_size) * sector_size;
 
@@ -207,12 +222,12 @@ pub(crate) async fn cmd_benchmark_mft(drive: char) -> Result<()> {
             }
 
             // Update last 4 bytes (always keep the most recent)
-            let actual_bytes = (bytes_read as usize).min(chunk_size);
+            let actual_bytes = u32_as_usize(bytes_read).min(chunk_size);
             if actual_bytes >= 4 {
                 last_4_bytes.copy_from_slice(&buf_slice[actual_bytes - 4..actual_bytes]);
             }
 
-            total_bytes_read += actual_bytes as u64;
+            total_bytes_read += usize_to_u64(actual_bytes);
             extent_offset += u64::from(bytes_read);
 
             // Stop if we've read enough
@@ -228,12 +243,12 @@ pub(crate) async fn cmd_benchmark_mft(drive: char) -> Result<()> {
 
     // Stop timing
     let elapsed = start_time.elapsed();
-    let elapsed_ms = elapsed.as_millis() as u64;
+    let elapsed_ms = millis_to_u64(elapsed.as_millis());
     let elapsed_secs = elapsed.as_secs_f64();
 
     // Calculate throughput
     let read_speed_mb_s = if elapsed_secs > 0.0 {
-        (total_bytes_read as f64 / (1024.0 * 1024.0)) / elapsed_secs
+        bytes_to_mb_f64(total_bytes_read) / elapsed_secs
     } else {
         0.0
     };

--- a/crates/uffs-mft/src/commands/windows/benchmark_mft.rs
+++ b/crates/uffs-mft/src/commands/windows/benchmark_mft.rs
@@ -139,14 +139,13 @@ pub(crate) async fn cmd_benchmark_mft(drive: char) -> Result<()> {
 
         // Calculate byte offset and size for this extent.
         //
-        // NTFS exposes `LcnPosition` (extent LCN) as `i64` on the FFI side
-        // even though valid extents are non-negative; the sign-loss cast
-        // here is bounded by upstream extent-map validation.
-        #[expect(
-            clippy::cast_sign_loss,
-            reason = "NTFS extents come from MftExtentMap which rejects negative LCNs upstream"
-        )]
-        let lcn_u64 = extent.lcn as u64;
+        // NTFS exposes `LcnPosition` (extent LCN) as `i64` on the FFI
+        // side even though valid extents are non-negative.  The
+        // `extent.lcn < 0` guard above filters sparse extents, so
+        // `i64::cast_unsigned` is the documented exact-bit-pattern
+        // reinterpret (Rust 1.87 stable) without a `cast_sign_loss`
+        // expect.
+        let lcn_u64 = extent.lcn.cast_unsigned();
         let extent_byte_offset = lcn_u64 * u64::from(bytes_per_cluster);
         let extent_byte_size = extent.cluster_count * u64::from(bytes_per_cluster);
 

--- a/crates/uffs-mft/src/commands/windows/benchmark_mft.rs
+++ b/crates/uffs-mft/src/commands/windows/benchmark_mft.rs
@@ -160,15 +160,12 @@ pub(crate) async fn cmd_benchmark_mft(drive: char) -> Result<()> {
 
         // Seek to extent start.
         //
-        // Win32 `SetFilePointerEx` takes the offset as `i64`; NTFS volume
-        // sizes never exceed `i64::MAX`, so the wrap below cannot occur in
-        // practice — the per-site `cast_possible_wrap` expect documents
-        // that contract.
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "SetFilePointerEx accepts i64; NTFS volume offsets never exceed i64::MAX"
-        )]
-        let signed_offset = extent_byte_offset as i64;
+        // Win32 `SetFilePointerEx` takes the offset as `i64`.  NTFS
+        // volume sizes never exceed `i64::MAX`, so the same bit pattern
+        // represents both unsigned (NTFS) and signed (Win32) views;
+        // `u64::cast_signed` documents that reinterpret without needing
+        // a `cast_possible_wrap` expect.
+        let signed_offset = extent_byte_offset.cast_signed();
         // SAFETY: `raw_handle` is a live volume handle owned by `vol_data`'s
         // `VolumeHandle` and `signed_offset` is bounded by the MFT extent
         // returned by Windows; the cast to `i64` is safe because volume sizes

--- a/crates/uffs-mft/src/commands/windows/bitmap_diag.rs
+++ b/crates/uffs-mft/src/commands/windows/bitmap_diag.rs
@@ -13,7 +13,6 @@
 )]
 #![expect(
     clippy::float_arithmetic,
-    clippy::cast_precision_loss,
     clippy::default_numeric_fallback,
     reason = "percent / fraction calculations convert integer counters into f64 for human-readable display"
 )]
@@ -31,6 +30,7 @@
 )]
 
 use anyhow::{Context as _, Result};
+use uffs_mft::{bytes_to_mb_f64, u64_to_f64, usize_to_f64, usize_to_u64};
 
 // ============================================================================
 // Bitmap Diagnostic Command
@@ -61,7 +61,7 @@ pub(crate) async fn cmd_bitmap_diag(drive: char, show_samples: bool) -> Result<(
     println!(
         "   MFT valid data length: {} bytes ({:.2} MB)",
         mft_size,
-        mft_size as f64 / 1024.0 / 1024.0
+        bytes_to_mb_f64(mft_size)
     );
     println!("   Bytes per record: {record_size}");
     println!("   Total records (from size): {total_records_from_size}");
@@ -76,7 +76,8 @@ pub(crate) async fn cmd_bitmap_diag(drive: char, show_samples: bool) -> Result<(
             let bitmap_record_count = bitmap.record_count();
             let in_use_count = bitmap.count_in_use();
             let free_count = bitmap_record_count.saturating_sub(in_use_count);
-            let utilization = (in_use_count as f64 / bitmap_record_count as f64) * 100.0;
+            let utilization =
+                (usize_to_f64(in_use_count) / usize_to_f64(bitmap_record_count)) * 100.0;
 
             println!("   ✅ Bitmap retrieved successfully");
             println!("   Bitmap size: {bitmap_bytes} bytes");
@@ -97,17 +98,17 @@ pub(crate) async fn cmd_bitmap_diag(drive: char, show_samples: bool) -> Result<(
             println!(
                 "   Bytes with all bits set (0xFF): {} ({:.1}%)",
                 all_ff_bytes,
-                (all_ff_bytes as f64 / bitmap_bytes as f64) * 100.0
+                (usize_to_f64(all_ff_bytes) / usize_to_f64(bitmap_bytes)) * 100.0
             );
             println!(
                 "   Bytes with no bits set (0x00): {} ({:.1}%)",
                 all_00_bytes,
-                (all_00_bytes as f64 / bitmap_bytes as f64) * 100.0
+                (usize_to_f64(all_00_bytes) / usize_to_f64(bitmap_bytes)) * 100.0
             );
             println!(
                 "   Mixed bytes: {} ({:.1}%)",
                 mixed_bytes,
-                (mixed_bytes as f64 / bitmap_bytes as f64) * 100.0
+                (usize_to_f64(mixed_bytes) / usize_to_f64(bitmap_bytes)) * 100.0
             );
             println!();
 
@@ -122,7 +123,7 @@ pub(crate) async fn cmd_bitmap_diag(drive: char, show_samples: bool) -> Result<(
                 println!(
                     "   ✅ Bitmap shows {} free records ({:.1}% free)",
                     free_count,
-                    (free_count as f64 / bitmap_record_count as f64) * 100.0
+                    (usize_to_f64(free_count) / usize_to_f64(bitmap_record_count)) * 100.0
                 );
             }
             println!();
@@ -181,7 +182,7 @@ pub(crate) async fn cmd_bitmap_diag(drive: char, show_samples: bool) -> Result<(
                 println!("   Checking records {}-{}:", mid, mid + 15);
                 print!("   ");
                 for frs in mid..(mid + 16).min(bitmap_record_count) {
-                    let in_use = bitmap.is_record_in_use(frs as u64);
+                    let in_use = bitmap.is_record_in_use(usize_to_u64(frs));
                     print!("{}: {} ", frs, if in_use { "✓" } else { "✗" });
                 }
                 println!();
@@ -195,7 +196,7 @@ pub(crate) async fn cmd_bitmap_diag(drive: char, show_samples: bool) -> Result<(
                 );
                 print!("   ");
                 for frs in last_start..bitmap_record_count {
-                    let in_use = bitmap.is_record_in_use(frs as u64);
+                    let in_use = bitmap.is_record_in_use(usize_to_u64(frs));
                     print!("{}: {} ", frs, if in_use { "✓" } else { "✗" });
                 }
                 println!();
@@ -224,7 +225,7 @@ pub(crate) async fn cmd_bitmap_diag(drive: char, show_samples: bool) -> Result<(
                     skip_end,
                     skipped,
                     range_size,
-                    (skipped as f64 / range_size as f64) * 100.0
+                    (u64_to_f64(skipped) / u64_to_f64(range_size)) * 100.0
                 );
             }
             println!();

--- a/crates/uffs-mft/src/commands/windows/incremental.rs
+++ b/crates/uffs-mft/src/commands/windows/incremental.rs
@@ -23,9 +23,7 @@
 )]
 #![expect(
     clippy::float_arithmetic,
-    clippy::cast_precision_loss,
-    clippy::default_numeric_fallback,
-    reason = "byte/rate calculations convert integer counters into f64 for human-readable display"
+    reason = "byte/rate calculations divide f64 helpers for human-readable MB / MB/s display"
 )]
 #![expect(
     clippy::min_ident_chars,
@@ -39,6 +37,7 @@
 use std::path::Path;
 
 use anyhow::Result;
+use uffs_mft::{bytes_to_mb_f64, u64_to_f64, usize_to_u64};
 
 use crate::display::format_number;
 
@@ -88,7 +87,7 @@ pub(crate) async fn cmd_index_save(drive: char, output: &Path) -> Result<()> {
     println!(
         "✅ Saved to {}: {:.1} MB in {:.3}s",
         output.display(),
-        file_size as f64 / (1024.0 * 1024.0),
+        bytes_to_mb_f64(file_size),
         save_time.as_secs_f64()
     );
 
@@ -132,14 +131,11 @@ pub(crate) async fn cmd_index_load(input: &Path) -> Result<()> {
     println!("  Children:         {}", header.children_count);
     println!();
     println!("=== Performance ===");
-    println!(
-        "  File Size:        {:.1} MB",
-        file_size as f64 / (1024.0 * 1024.0)
-    );
+    println!("  File Size:        {:.1} MB", bytes_to_mb_f64(file_size));
     println!("  Load Time:        {:.3}s", load_time.as_secs_f64());
     println!(
         "  Throughput:       {:.1} MB/s",
-        (file_size as f64 / (1024.0 * 1024.0)) / load_time.as_secs_f64()
+        bytes_to_mb_f64(file_size) / load_time.as_secs_f64()
     );
 
     // Count files vs directories
@@ -294,7 +290,7 @@ pub(crate) async fn cmd_cache_get(drive: char, force: bool, ttl: Option<u64>) ->
     println!(
         "💾 Cached to: {} ({:.1} MB)",
         cache_path.display(),
-        file_size as f64 / (1024.0 * 1024.0)
+        bytes_to_mb_f64(file_size)
     );
 
     if usn_journal_id != 0 {
@@ -590,7 +586,7 @@ async fn do_full_index_build(drive: char) -> Result<()> {
     println!(
         "💾 Cached to: {} ({:.1} MB)",
         cache_path.display(),
-        file_size as f64 / (1024.0 * 1024.0)
+        bytes_to_mb_f64(file_size)
     );
 
     if usn_journal_id != 0 {
@@ -679,18 +675,18 @@ pub(crate) async fn cmd_index_all(
     let mut total_entries = 0_u64;
 
     for index in &indices {
-        let files = index.file_count() as u64;
-        let dirs = index.dir_count() as u64;
+        let files = usize_to_u64(index.file_count());
+        let dirs = usize_to_u64(index.dir_count());
         total_files += files;
         total_dirs += dirs;
-        total_entries += index.len() as u64;
+        total_entries += usize_to_u64(index.len());
 
         println!(
             "  {}:  {:>10} files  {:>8} dirs  {:>10} total",
             index.volume,
             format_number(files),
             format_number(dirs),
-            format_number(index.len() as u64),
+            format_number(usize_to_u64(index.len())),
         );
     }
 
@@ -706,7 +702,7 @@ pub(crate) async fn cmd_index_all(
 
     // Performance stats
     let elapsed_secs = read_time.as_secs_f64();
-    let entries_per_sec = total_entries as f64 / elapsed_secs;
+    let entries_per_sec = u64_to_f64(total_entries) / elapsed_secs;
 
     println!("=== Performance ===");
     println!("Time: {elapsed_secs:.3}s");

--- a/crates/uffs-mft/src/commands/windows/info.rs
+++ b/crates/uffs-mft/src/commands/windows/info.rs
@@ -13,7 +13,6 @@
 )]
 #![expect(
     clippy::float_arithmetic,
-    clippy::cast_precision_loss,
     clippy::default_numeric_fallback,
     reason = "byte/percent calculations convert integer counters into f64 for human-readable display"
 )]
@@ -30,7 +29,7 @@
 
 use anyhow::{Context as _, Result};
 use tracing::info;
-use uffs_mft::MftReader;
+use uffs_mft::{MftReader, bytes_to_mb_f64, u64_to_f64, usize_to_u64};
 
 use super::shared::drive_type_label;
 use crate::display::{format_bytes, format_duration, format_number_commas, truncate_string};
@@ -73,17 +72,18 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
     // Calculate derived metrics
     let record_count =
         vol_data.mft_valid_data_length / u64::from(vol_data.bytes_per_file_record_segment);
-    let mft_size_mb = vol_data.mft_valid_data_length as f64 / (1024.0 * 1024.0);
+    let mft_size_mb = bytes_to_mb_f64(vol_data.mft_valid_data_length);
     let volume_size_bytes = vol_data.total_clusters * u64::from(vol_data.bytes_per_cluster);
-    let volume_size_gb = volume_size_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    let volume_size_gb = u64_to_f64(volume_size_bytes) / (1024.0_f64 * 1024.0_f64 * 1024.0_f64);
     let free_space_bytes = vol_data.free_clusters * u64::from(vol_data.bytes_per_cluster);
     let used_space_bytes = volume_size_bytes.saturating_sub(free_space_bytes);
     let free_percentage = if volume_size_bytes > 0 {
-        (free_space_bytes as f64 / volume_size_bytes as f64) * 100.0
+        (u64_to_f64(free_space_bytes) / u64_to_f64(volume_size_bytes)) * 100.0
     } else {
         0.0
     };
-    let mft_percentage = (vol_data.mft_valid_data_length as f64 / volume_size_bytes as f64) * 100.0;
+    let mft_percentage =
+        (u64_to_f64(vol_data.mft_valid_data_length) / u64_to_f64(volume_size_bytes)) * 100.0;
 
     // Log detailed metrics
     info!(
@@ -151,9 +151,9 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
     let mut free_records = 0_u64;
     let mut utilization = 0.0_f64;
     if let Ok(bitmap) = handle.get_mft_bitmap() {
-        in_use_records = bitmap.count_in_use() as u64;
+        in_use_records = usize_to_u64(bitmap.count_in_use());
         free_records = record_count.saturating_sub(in_use_records);
-        utilization = (in_use_records as f64 / record_count as f64) * 100.0;
+        utilization = (u64_to_f64(in_use_records) / u64_to_f64(record_count)) * 100.0;
 
         info!(
             drive = %drive_upper,
@@ -281,7 +281,7 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
             .ok()
             .and_then(|c| c.bool().ok())
             .map_or(0, |b| u64::from(b.sum().unwrap_or(0)));
-        let file_count = total_parsed as u64 - dir_count;
+        let file_count = usize_to_u64(total_parsed) - dir_count;
 
         // Helper closure to count bool columns
         let count_bool = |name: &str| -> u64 {
@@ -374,7 +374,7 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
 
         let slack_space = total_allocated_size.saturating_sub(total_file_size);
         let slack_percentage = if total_allocated_size > 0 {
-            (slack_space as f64 / total_allocated_size as f64) * 100.0
+            (u64_to_f64(slack_space) / u64_to_f64(total_allocated_size)) * 100.0
         } else {
             0.0
         };
@@ -382,7 +382,7 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
         println!("📊 FILE SYSTEM STATISTICS");
         println!(
             "  Parsed records:       {}",
-            format_number_commas(total_parsed as u64)
+            format_number_commas(usize_to_u64(total_parsed))
         );
         println!(
             "  Directories:          {}",
@@ -596,7 +596,7 @@ pub(crate) async fn cmd_drives() -> Result<()> {
                 let free_space = vol_data.free_clusters * u64::from(vol_data.bytes_per_cluster);
                 let used_space = total_size.saturating_sub(free_space);
                 let used_pct = if total_size > 0 {
-                    (used_space as f64 / total_size as f64) * 100.0
+                    (u64_to_f64(used_space) / u64_to_f64(total_size)) * 100.0
                 } else {
                     0.0
                 };
@@ -675,7 +675,7 @@ pub(crate) async fn cmd_drives() -> Result<()> {
         let total_mft: u64 = drive_infos.iter().map(|d| d.mft_size).sum();
         let total_records: u64 = drive_infos.iter().map(|d| d.mft_records).sum();
         let total_used_pct = if total_size > 0 {
-            (total_used as f64 / total_size as f64) * 100.0
+            (u64_to_f64(total_used) / u64_to_f64(total_size)) * 100.0
         } else {
             0.0
         };

--- a/crates/uffs-mft/src/commands/windows/read.rs
+++ b/crates/uffs-mft/src/commands/windows/read.rs
@@ -4,20 +4,17 @@
 //! Live MFT read/export command handlers.
 //!
 //! These commands print human-readable progress to stdout and convert
-//! `usize` byte counters into `f64` for MB/s rate display; the lint
-//! exemptions below capture those CLI-specific patterns.
-#![expect(
-    clippy::float_arithmetic,
-    clippy::cast_precision_loss,
-    clippy::default_numeric_fallback,
-    reason = "byte / rate calculations convert integer counters into f64 for human-readable display"
-)]
+//! `usize` byte counters into `f64` for MB/s rate display.  The integer
+//! to `f64` conversions go through the `bytes_to_mb_f64` / `u64_to_f64`
+//! helpers (which carry their own targeted `cast_precision_loss` expects)
+//! and the float arithmetic for display rates carries scoped expects at
+//! the use site.
 
 use std::path::PathBuf;
 
 use anyhow::{Context as _, Result};
 use tracing::{info, warn};
-use uffs_mft::MftReader;
+use uffs_mft::{MftReader, bytes_to_mb_f64, usize_to_f64};
 
 use crate::display::{format_bytes, format_duration, format_number_commas};
 use crate::progress::spinner;
@@ -60,7 +57,7 @@ pub(crate) async fn cmd_read(
     let file_size = save_dataframe_with_logging(&mut df, &output)?;
 
     let total_elapsed = start_time.elapsed();
-    let file_size_mb = file_size as f64 / (1024.0 * 1024.0);
+    let file_size_mb = bytes_to_mb_f64(file_size);
     info!(
         drive = %drive_upper,
         records = record_count,
@@ -71,7 +68,7 @@ pub(crate) async fn cmd_read(
 
     pb.finish_with_message(format!(
         "✅ Exported {} records to {} ({}) in {}",
-        format_number_commas(record_count as u64),
+        format_number_commas(uffs_mft::usize_to_u64(record_count)),
         output.display(),
         format_bytes(file_size),
         format_duration(total_elapsed)
@@ -161,10 +158,15 @@ fn read_records_with_logging(reader: &MftReader) -> Result<(uffs_polars::DataFra
 
     let record_count = df.height();
     let read_elapsed = read_start.elapsed();
-    let records_per_sec = if read_elapsed.as_secs_f64() > 0.0 {
-        record_count as f64 / read_elapsed.as_secs_f64()
+    let records_per_sec = if read_elapsed.as_secs_f64() > 0.0_f64 {
+        #[expect(
+            clippy::float_arithmetic,
+            reason = "display-only records-per-second rate"
+        )]
+        let rate = usize_to_f64(record_count) / read_elapsed.as_secs_f64();
+        rate
     } else {
-        0.0
+        0.0_f64
     };
 
     info!(
@@ -192,7 +194,7 @@ fn save_dataframe_with_logging(
     MftReader::save_parquet(df, output).with_context(|| "Failed to save Parquet")?;
 
     let file_size = std::fs::metadata(output).map_or(0, |metadata| metadata.len());
-    let file_size_mb = file_size as f64 / (1024.0 * 1024.0);
+    let file_size_mb = bytes_to_mb_f64(file_size);
     info!(
         output = %output.display(),
         file_size_mb = format!("{:.2}", file_size_mb),

--- a/crates/uffs-mft/src/commands/windows/save.rs
+++ b/crates/uffs-mft/src/commands/windows/save.rs
@@ -259,16 +259,9 @@ async fn cmd_save_iocp(
         compression_level,
         volume_letter: drive_upper,
         // IOCP concurrency is bounded by the CLI parser (max 255); the
-        // narrowing cast is documented at the use site rather than via a
-        // module blanket.
-        concurrency: {
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "CLI parser bounds `concurrency` to 0..=255 before reaching this path"
-            )]
-            let value = concurrency as u8;
-            value
-        },
+        // saturating `try_from` fallback is unreachable for valid CLI
+        // input and replaces the previous truncating `as u8` cast.
+        concurrency: u8::try_from(concurrency).unwrap_or(u8::MAX),
         reserved_allocated_bytes: reserved_alloc,
     };
 

--- a/crates/uffs-mft/src/commands/windows/save.rs
+++ b/crates/uffs-mft/src/commands/windows/save.rs
@@ -15,10 +15,8 @@
 )]
 #![expect(
     clippy::float_arithmetic,
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
     clippy::default_numeric_fallback,
-    reason = "byte / utilization calculations convert integer counters into f64 for human-readable display"
+    reason = "byte / utilization calculations divide f64 helpers for human-readable percentage display"
 )]
 #![expect(
     clippy::min_ident_chars,
@@ -50,6 +48,7 @@ use std::path::Path;
 
 use anyhow::{Context as _, Result};
 use tracing::info;
+use uffs_mft::{u64_to_f64, usize_to_u64};
 
 use super::shared::drive_type_label;
 use crate::display::{clean_path_for_display, format_bytes, format_duration, format_number_commas};
@@ -116,8 +115,8 @@ pub(crate) async fn cmd_save(
     // Bitmap analysis
     let (in_use_records, utilization) =
         handle.get_mft_bitmap().map_or((0_u64, 0.0_f64), |bitmap| {
-            let in_use = bitmap.count_in_use() as u64;
-            let pct = (in_use as f64 / record_count as f64) * 100.0;
+            let in_use = usize_to_u64(bitmap.count_in_use());
+            let pct = (u64_to_f64(in_use) / u64_to_f64(record_count)) * 100.0;
             (in_use, pct)
         });
     let free_records = record_count.saturating_sub(in_use_records);
@@ -187,9 +186,8 @@ pub(crate) async fn cmd_save(
             clippy::float_arithmetic,
             reason = "floating-point needed for compression ratio calculation"
         )]
-        let ratio = uffs_mft::u64_to_f64(header.compressed_size)
-            / uffs_mft::u64_to_f64(header.original_size)
-            * 100.0_f64;
+        let ratio =
+            u64_to_f64(header.compressed_size) / u64_to_f64(header.original_size) * 100.0_f64;
         println!("  Compression ratio:    {ratio:.1}%");
         #[expect(
             clippy::float_arithmetic,
@@ -260,7 +258,17 @@ async fn cmd_save_iocp(
         compress,
         compression_level,
         volume_letter: drive_upper,
-        concurrency: concurrency as u8,
+        // IOCP concurrency is bounded by the CLI parser (max 255); the
+        // narrowing cast is documented at the use site rather than via a
+        // module blanket.
+        concurrency: {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "CLI parser bounds `concurrency` to 0..=255 before reaching this path"
+            )]
+            let value = concurrency as u8;
+            value
+        },
         reserved_allocated_bytes: reserved_alloc,
     };
 
@@ -367,7 +375,7 @@ async fn cmd_save_upcase(drive: char, output: &Path) -> Result<()> {
     println!("💾 $UpCase table saved");
     println!(
         "  Size:   {} ({} entries)",
-        format_bytes(upcase::UPCASE_SIZE_BYTES as u64),
+        format_bytes(usize_to_u64(upcase::UPCASE_SIZE_BYTES)),
         format_number_commas(65_536)
     );
     println!("  NTFS:   {}.{}", header.ntfs_major, header.ntfs_minor);

--- a/crates/uffs-mft/src/commands/windows/usn.rs
+++ b/crates/uffs-mft/src/commands/windows/usn.rs
@@ -18,17 +18,12 @@
     reason = "intentional user-facing CLI USN journal output: stdout for primary output, stderr for journal-unavailable diagnostics"
 )]
 #![expect(
-    clippy::float_arithmetic,
-    clippy::cast_precision_loss,
-    clippy::default_numeric_fallback,
-    reason = "byte/MB conversion of USN journal sizes uses f64 for human-readable display"
-)]
-#![expect(
     clippy::min_ident_chars,
     reason = "short identifiers used for printf-style indices in CLI output"
 )]
 
 use anyhow::Result;
+use uffs_mft::bytes_to_mb_f64;
 
 use crate::display::format_usn_reason;
 
@@ -50,11 +45,11 @@ pub(crate) async fn cmd_usn_info(drive: char) -> Result<()> {
             println!("  Max USN:          {}", info.max_usn);
             println!(
                 "  Max Size:         {:.1} MB",
-                info.max_size as f64 / (1024.0 * 1024.0)
+                bytes_to_mb_f64(info.max_size)
             );
             println!(
                 "  Alloc Delta:      {:.1} MB",
-                info.allocation_delta as f64 / (1024.0 * 1024.0)
+                bytes_to_mb_f64(info.allocation_delta)
             );
             println!();
             println!(

--- a/crates/uffs-mft/src/index.rs
+++ b/crates/uffs-mft/src/index.rs
@@ -54,7 +54,8 @@ pub(crate) use self::types::cmp_ascii_case_insensitive;
 pub use self::types::{
     FileRecord, IndexNameRef, IndexStreamInfo, InternalStreamInfo, LinkInfo, NO_ENTRY, ROOT_FRS,
     SizeInfo, bytes_to_mb_f64, f64_to_u64, f64_to_usize, frs_to_usize, len_to_u16, len_to_u32,
-    micros_to_i64, nonneg_to_u64, u32_as_usize, u32_to_f64, u64_to_f64, usize_to_f64,
+    micros_to_i64, millis_to_u64, nanos_to_u64, nonneg_to_u64, u32_as_usize, u32_to_f64,
+    u64_to_f64, usize_to_f64, usize_to_u64,
 };
 pub use self::usn::UsnApplyStats;
 

--- a/crates/uffs-mft/src/index/types.rs
+++ b/crates/uffs-mft/src/index/types.rs
@@ -96,6 +96,37 @@ pub fn micros_to_i64(us: u128) -> i64 {
     i64::try_from(us).unwrap_or(i64::MAX)
 }
 
+/// Convert a `u128` nanosecond count (e.g. from `Duration::as_nanos()`) to
+/// `u64`.
+///
+/// Saturates at `u64::MAX` (~584 years of nanoseconds) instead of truncating.
+/// Used wherever per-phase elapsed time is reported as a `u64` ns counter.
+#[inline]
+#[must_use]
+pub fn nanos_to_u64(ns: u128) -> u64 {
+    u64::try_from(ns).unwrap_or(u64::MAX)
+}
+
+/// Convert a `u128` millisecond count (e.g. from `Duration::as_millis()`) to
+/// `u64`.
+///
+/// Saturates at `u64::MAX` (~584 million years) instead of truncating.
+#[inline]
+#[must_use]
+pub fn millis_to_u64(ms: u128) -> u64 {
+    u64::try_from(ms).unwrap_or(u64::MAX)
+}
+
+/// Convert a `usize` to `u64`.
+///
+/// On every supported target (`usize` ≤ 64 bits) this is a lossless widening.
+/// On hypothetical >64-bit targets it saturates at `u64::MAX`.
+#[inline]
+#[must_use]
+pub fn usize_to_u64(val: usize) -> u64 {
+    u64::try_from(val).unwrap_or(u64::MAX)
+}
+
 /// Convert bytes (`u64`) to megabytes as `f64` for display purposes.
 ///
 /// Precision loss beyond 2^53 bytes (~8 PB) is acceptable for human display.

--- a/crates/uffs-mft/src/index/types.rs
+++ b/crates/uffs-mft/src/index/types.rs
@@ -79,9 +79,10 @@ pub const fn u32_as_usize(val: u32) -> usize {
 #[must_use]
 pub const fn nonneg_to_u64(val: i64) -> u64 {
     if val > 0 {
-        #[expect(clippy::cast_sign_loss, reason = "val > 0 guard makes this lossless")]
-        let result = val as u64;
-        result
+        // `val > 0` guard makes the reinterpret lossless;
+        // `i64::cast_unsigned` is the stable Rust 1.87 exact-bit-pattern
+        // converter that does not require a `cast_sign_loss` expect.
+        val.cast_unsigned()
     } else {
         0
     }

--- a/crates/uffs-mft/src/io.rs
+++ b/crates/uffs-mft/src/io.rs
@@ -13,7 +13,7 @@
 //! Available on all platforms for offline MFT processing (chaos mode, testing).
 //! Live MFT access via HANDLE is Windows-only and gated per-function.
 
-pub use crate::ntfs::SECTOR_SIZE;
+pub use crate::ntfs::{SECTOR_SIZE, SECTOR_SIZE_U64};
 
 mod aligned_buffer;
 mod chunking;

--- a/crates/uffs-mft/src/io/readers/basic.rs
+++ b/crates/uffs-mft/src/io/readers/basic.rs
@@ -3,14 +3,10 @@
 
 //! Basic record and batch readers.
 //!
-//! **Module-scoped cast justification:** `as usize` casts here convert NTFS
-//! disk offsets / read sizes (`u64`) and record sizes (`u32`) into `usize` for
-//! buffer slicing.  `usize` is ≥ 32 bits on every supported target; the u64
-//! values are physically bounded by the volume size (≤ 2⁶⁴ bytes).
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size casts are lossless on supported 32/64-bit targets"
-)]
+//! All `as`-style integer conversions in this module use the typed helpers
+//! (`u32_as_usize`, `frs_to_usize`) and the `SECTOR_SIZE_U64` constant so the
+//! NTFS disk-offset / record-size casts retain their domain bounds without a
+//! module-level lint suppression.
 
 use super::prelude::*;
 
@@ -50,7 +46,7 @@ impl MftRecordReader {
         );
 
         // Allocate buffer for one record (rounded up to sector boundary)
-        let buffer_size = (record_size as usize).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
+        let buffer_size = u32_as_usize(record_size).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
         let buffer = AlignedBuffer::new(buffer_size);
 
         Self {
@@ -72,7 +68,7 @@ impl MftRecordReader {
         let record_size = extent_map.bytes_per_record;
 
         // Allocate buffer for one record (rounded up to sector boundary)
-        let buffer_size = (record_size as usize).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
+        let buffer_size = u32_as_usize(record_size).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
         let buffer = AlignedBuffer::new(buffer_size);
 
         Self {
@@ -122,8 +118,8 @@ impl MftRecordReader {
                 })?;
 
         // Align to sector boundary
-        let aligned_offset = (record_offset / SECTOR_SIZE as u64) * SECTOR_SIZE as u64;
-        let offset_within_sector = (record_offset - aligned_offset) as usize;
+        let aligned_offset = (record_offset / SECTOR_SIZE_U64) * SECTOR_SIZE_U64;
+        let offset_within_sector = frs_to_usize(record_offset - aligned_offset);
 
         // Seek to the aligned offset
         let mut new_position = 0_i64;
@@ -151,7 +147,7 @@ impl MftRecordReader {
             )
         }?;
 
-        if (bytes_read as usize) < self.record_size as usize + offset_within_sector {
+        if u32_as_usize(bytes_read) < u32_as_usize(self.record_size) + offset_within_sector {
             return Err(MftError::RecordRead {
                 frs,
                 reason: format!(
@@ -164,7 +160,7 @@ impl MftRecordReader {
         // Return the record data (accounting for sector alignment offset)
         self.buffer
             .as_slice()
-            .get(offset_within_sector..offset_within_sector + self.record_size as usize)
+            .get(offset_within_sector..offset_within_sector + u32_as_usize(self.record_size))
             .ok_or_else(|| MftError::RecordRead {
                 frs,
                 reason: format!(
@@ -238,7 +234,7 @@ impl BatchMftReader {
         let record_size = extent_map.bytes_per_record;
 
         // Round block size to cluster boundary
-        let cluster_size = bytes_per_cluster as usize;
+        let cluster_size = u32_as_usize(bytes_per_cluster);
         let read_block_size = block_size.div_ceil(cluster_size) * cluster_size;
 
         let buffer = AlignedBuffer::new(read_block_size);
@@ -255,7 +251,7 @@ impl BatchMftReader {
     /// Returns the number of records that fit in one read block.
     #[must_use]
     pub const fn records_per_block(&self) -> usize {
-        self.read_block_size / self.record_size as usize
+        self.read_block_size / u32_as_usize(self.record_size)
     }
 
     /// Returns the extent map.
@@ -304,9 +300,9 @@ impl BatchMftReader {
 
         // Calculate how many records we can read
         let total_records = self.extent_map.total_records();
-        let max_records = (total_records - start_frs) as usize;
+        let max_records = frs_to_usize(total_records - start_frs);
         let records_to_read = max_records.min(self.records_per_block());
-        let bytes_to_read = records_to_read * self.record_size as usize;
+        let bytes_to_read = records_to_read * u32_as_usize(self.record_size);
 
         // Seek to the aligned offset
         let mut new_position = 0_i64;
@@ -336,14 +332,14 @@ impl BatchMftReader {
         unsafe { ReadFile(handle, Some(read_slice), Some(&raw mut bytes_read), None) }?;
 
         // Calculate offset within buffer for the first record
-        let offset_in_buffer = (start_offset - aligned_offset) as usize;
-        let usable_bytes = (bytes_read as usize).saturating_sub(offset_in_buffer);
-        let records_read = usable_bytes / self.record_size as usize;
+        let offset_in_buffer = frs_to_usize(start_offset - aligned_offset);
+        let usable_bytes = u32_as_usize(bytes_read).saturating_sub(offset_in_buffer);
+        let records_read = usable_bytes / u32_as_usize(self.record_size);
 
         let batch = self
             .buffer
             .as_slice()
-            .get(offset_in_buffer..offset_in_buffer + records_read * self.record_size as usize)
+            .get(offset_in_buffer..offset_in_buffer + records_read * u32_as_usize(self.record_size))
             .ok_or_else(|| {
                 MftError::Io(std::io::Error::new(
                     std::io::ErrorKind::UnexpectedEof,
@@ -365,7 +361,7 @@ impl BatchMftReader {
     /// The record data slice, or `None` if the index is out of bounds.
     #[must_use]
     pub fn extract_record<'a>(&self, batch_buffer: &'a [u8], index: usize) -> Option<&'a [u8]> {
-        let record_size = self.record_size as usize;
+        let record_size = u32_as_usize(self.record_size);
         let start = index * record_size;
         let end = start + record_size;
         batch_buffer.get(start..end)

--- a/crates/uffs-mft/src/io/readers/iocp/mod.rs
+++ b/crates/uffs-mft/src/io/readers/iocp/mod.rs
@@ -14,7 +14,7 @@
 /// The module name `prelude` is exempt from `clippy::wildcard_imports`.
 mod prelude {
     pub(super) use super::super::prelude::*;
-    pub(super) use super::shared::{IoCompletionPort, OverlappedRead};
+    pub(super) use super::shared::{IoCompletionPort, OverlappedRead, set_overlapped_offset};
 }
 
 mod multi_volume;
@@ -23,4 +23,5 @@ mod shared;
 
 pub use multi_volume::{MultiVolumeIoOp, MultiVolumeIocpReader, VolumeState, prepare_volume_state};
 pub use reader::IocpMftReader;
+pub(crate) use shared::set_overlapped_offset;
 pub use shared::{IoCompletionPort, OverlappedRead};

--- a/crates/uffs-mft/src/io/readers/iocp/multi_volume.rs
+++ b/crates/uffs-mft/src/io/readers/iocp/multi_volume.rs
@@ -2,15 +2,6 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Multi-volume IOCP reader.
-//!
-//! **Module-scoped cast justification:** `as usize` / `as u32` casts convert
-//! NTFS disk offsets (`u64`) and record sizes (`u32`) into `usize` / `u32`
-//! respectively.  `usize` ≥ 32 bits on every supported target; NTFS disk
-//! offsets are physically bounded by the volume size (≤ 2⁶⁴ bytes).
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size casts are lossless on supported 32/64-bit targets"
-)]
 
 use super::prelude::*;
 
@@ -110,7 +101,7 @@ impl MultiVolumeIocpReader {
     pub fn read_all_volumes(&mut self) -> Result<Vec<crate::index::MftIndex>> {
         use core::pin::Pin;
 
-        use windows::Win32::Foundation::{ERROR_IO_PENDING, GetLastError, HANDLE};
+        use windows::Win32::Foundation::{ERROR_IO_PENDING, GetLastError};
         use windows::Win32::Storage::FileSystem::ReadFile;
         use windows::Win32::System::IO::GetQueuedCompletionStatus;
 
@@ -121,10 +112,9 @@ impl MultiVolumeIocpReader {
             op: MultiVolumeIoOp,
         }
 
-        let record_size = self
-            .volumes
-            .first()
-            .map_or(1024_usize, |vol| vol.extent_map.bytes_per_record as usize);
+        let record_size = self.volumes.first().map_or(1024_usize, |vol| {
+            u32_as_usize(vol.extent_map.bytes_per_record)
+        });
 
         // Create single IOCP for all volumes
         let iocp = IoCompletionPort::new(0)?;
@@ -174,20 +164,11 @@ impl MultiVolumeIocpReader {
                         .unwrap_or_else(|| AlignedBuffer::new(vol.io_chunk_size));
 
                     let mut in_flight_op = Box::pin(InFlightOp {
-                        overlapped: windows::Win32::System::IO::OVERLAPPED {
-                            Anonymous: windows::Win32::System::IO::OVERLAPPED_0 {
-                                Anonymous: windows::Win32::System::IO::OVERLAPPED_0_0 {
-                                    Offset: (op.disk_offset & 0xFFFF_FFFF) as u32,
-                                    OffsetHigh: (op.disk_offset >> 32) as u32,
-                                },
-                            },
-                            hEvent: HANDLE::default(),
-                            Internal: 0,
-                            InternalHigh: 0,
-                        },
+                        overlapped: windows::Win32::System::IO::OVERLAPPED::default(),
                         buffer,
                         op: op.clone(),
                     });
+                    set_overlapped_offset(&mut in_flight_op.overlapped, op.disk_offset);
 
                     let overlapped_ptr = core::ptr::addr_of_mut!(in_flight_op.overlapped);
                     let buffer_ptr = in_flight_op.buffer.as_mut_slice().as_mut_ptr();
@@ -311,7 +292,7 @@ impl MultiVolumeIocpReader {
             let Some(buffer_slice) = completed_op
                 .buffer
                 .as_slice()
-                .get(..bytes_transferred as usize)
+                .get(..u32_as_usize(bytes_transferred))
             else {
                 // Unreachable: bytes_transferred ≤ allocated buffer size.
                 return Err(MftError::Io(std::io::Error::new(
@@ -319,7 +300,7 @@ impl MultiVolumeIocpReader {
                     "multi-volume completion reported more bytes than buffer size",
                 )));
             };
-            let records_in_buffer = bytes_transferred as usize / record_size;
+            let records_in_buffer = u32_as_usize(bytes_transferred) / record_size;
             let start_frs = completed_op.op.start_frs;
 
             for (current_frs, record_idx) in (start_frs..).zip(0..records_in_buffer) {
@@ -345,20 +326,11 @@ impl MultiVolumeIocpReader {
                     .unwrap_or_else(|| AlignedBuffer::new(vol.io_chunk_size));
 
                 let mut new_in_flight = Box::pin(InFlightOp {
-                    overlapped: windows::Win32::System::IO::OVERLAPPED {
-                        Anonymous: windows::Win32::System::IO::OVERLAPPED_0 {
-                            Anonymous: windows::Win32::System::IO::OVERLAPPED_0_0 {
-                                Offset: (next_op.disk_offset & 0xFFFF_FFFF) as u32,
-                                OffsetHigh: (next_op.disk_offset >> 32) as u32,
-                            },
-                        },
-                        hEvent: HANDLE::default(),
-                        Internal: 0,
-                        InternalHigh: 0,
-                    },
+                    overlapped: windows::Win32::System::IO::OVERLAPPED::default(),
                     buffer,
                     op: next_op.clone(),
                 });
+                set_overlapped_offset(&mut new_in_flight.overlapped, next_op.disk_offset);
 
                 let next_overlapped_ptr = core::ptr::addr_of_mut!(new_in_flight.overlapped);
                 let buffer_ptr = new_in_flight.buffer.as_mut_slice().as_mut_ptr();
@@ -448,8 +420,8 @@ pub fn prepare_volume_state(
     bitmap: Option<crate::platform::MftBitmap>,
     drive_type: crate::platform::DriveType,
 ) -> VolumeState {
-    let record_size = extent_map.bytes_per_record as usize;
-    let total_records = extent_map.total_records() as usize;
+    let record_size = u32_as_usize(extent_map.bytes_per_record);
+    let total_records = frs_to_usize(extent_map.total_records());
     // For HDD, use extent-aware concurrency (fragmentation affects optimal value)
     let max_concurrency = if matches!(drive_type, crate::platform::DriveType::Hdd) {
         crate::platform::DriveType::optimal_concurrency_for_hdd(extent_map.extent_count())
@@ -466,20 +438,21 @@ pub fn prepare_volume_state(
     let mut io_queue = alloc::collections::VecDeque::new();
 
     for chunk in &sorted_chunks {
-        let skip_begin_bytes = chunk.skip_begin as usize * record_size;
+        let skip_begin_bytes = frs_to_usize(chunk.skip_begin) * record_size;
         let effective_records = chunk.record_count - chunk.skip_begin - chunk.skip_end;
         if effective_records == 0 {
             continue;
         }
 
-        let chunk_bytes = effective_records as usize * record_size;
+        let chunk_bytes = frs_to_usize(effective_records) * record_size;
         let mut offset_within_chunk = 0_usize;
         let mut frs_offset = 0_u64;
 
         while offset_within_chunk < chunk_bytes {
             let io_size = core::cmp::min(io_chunk_size, chunk_bytes - offset_within_chunk);
-            let disk_offset =
-                chunk.disk_offset + skip_begin_bytes as u64 + offset_within_chunk as u64;
+            let disk_offset = chunk.disk_offset
+                + usize_to_u64(skip_begin_bytes)
+                + usize_to_u64(offset_within_chunk);
 
             io_queue.push_back(MultiVolumeIoOp {
                 disk_offset,
@@ -488,7 +461,7 @@ pub fn prepare_volume_state(
             });
 
             offset_within_chunk += io_size;
-            frs_offset += (io_size / record_size) as u64;
+            frs_offset += usize_to_u64(io_size / record_size);
         }
     }
 

--- a/crates/uffs-mft/src/io/readers/iocp/reader.rs
+++ b/crates/uffs-mft/src/io/readers/iocp/reader.rs
@@ -2,15 +2,6 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Single-volume IOCP reader.
-//!
-//! **Module-scoped cast justification:** `as usize` / `as u32` casts convert
-//! NTFS disk offsets (`u64`) and record sizes (`u32`) into `usize` / `u32`
-//! respectively.  `usize` ≥ 32 bits on every supported target; NTFS disk
-//! offsets are physically bounded by the volume size (≤ 2⁶⁴ bytes).
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size casts are lossless on supported 32/64-bit targets"
-)]
 
 use super::prelude::*;
 
@@ -125,7 +116,7 @@ impl IocpMftReader {
             .sum();
 
         let estimated_records = self.bitmap.as_ref().map_or_else(
-            || self.extent_map.total_records() as usize,
+            || frs_to_usize(self.extent_map.total_records()),
             crate::platform::MftBitmap::count_in_use,
         );
 
@@ -144,11 +135,13 @@ impl IocpMftReader {
         let mut all_results: Vec<ParseResult> = Vec::with_capacity(estimated_records);
         let mut bytes_read_total: u64 = 0;
 
-        let max_chunk_size = chunks
-            .iter()
-            .map(|chunk| chunk.record_count * u64::from(record_size))
-            .max()
-            .unwrap_or(self.chunk_size as u64) as usize;
+        let max_chunk_size = frs_to_usize(
+            chunks
+                .iter()
+                .map(|chunk| chunk.record_count * u64::from(record_size))
+                .max()
+                .unwrap_or_else(|| usize_to_u64(self.chunk_size)),
+        );
 
         // Sort chunks by disk_offset (LCN order) to minimise seek time on HDD.
         let mut sorted_chunks: Vec<ReadChunk> = chunks;
@@ -238,7 +231,7 @@ impl IocpMftReader {
         // SAFETY: the `Pin<Box<_>>` is still pinned in this scope; we only
         // project a mutable reference without moving the allocation.
         let op_mut = unsafe { op.as_mut().get_unchecked_mut() };
-        op_mut.bytes_read = bytes_transferred as usize;
+        op_mut.bytes_read = u32_as_usize(bytes_transferred);
 
         let results = parse_buffer_zero_copy_inner(
             op_mut.buffer.as_mut_slice(),
@@ -348,9 +341,10 @@ unsafe fn iocp_issue_replacement_read(
     use windows::Win32::Storage::FileSystem::ReadFile;
 
     let read_size = chunk.record_count * u64::from(record_size);
-    let aligned_offset = (chunk.disk_offset / SECTOR_SIZE as u64) * SECTOR_SIZE as u64;
-    let offset_adjustment = (chunk.disk_offset - aligned_offset) as usize;
-    let aligned_size = (read_size as usize + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
+    let aligned_offset = (chunk.disk_offset / SECTOR_SIZE_U64) * SECTOR_SIZE_U64;
+    let offset_adjustment = frs_to_usize(chunk.disk_offset - aligned_offset);
+    let aligned_size =
+        (frs_to_usize(read_size) + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
 
     if buffer.len() < aligned_size {
         buffer = AlignedBuffer::new(aligned_size);

--- a/crates/uffs-mft/src/io/readers/iocp/shared.rs
+++ b/crates/uffs-mft/src/io/readers/iocp/shared.rs
@@ -2,16 +2,31 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Shared IOCP primitives.
-//!
-//! **Module-scoped cast justification:** `as u32` cast here converts the
-//! u64 overlapped offset low bits to u32 per Win32 OVERLAPPED struct layout;
-//! the high 32 bits are stored separately in `OffsetHigh`.
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "Win32 OVERLAPPED low-32 / high-32 offset split is the documented struct layout"
-)]
 
 use super::super::prelude::{AlignedBuffer, HANDLE, MftError, ReadChunk, Result};
+
+/// Write a `u64` byte offset into a Win32 `OVERLAPPED` struct's
+/// `Offset` / `OffsetHigh` fields.
+///
+/// The Win32 `OVERLAPPED` ABI splits the 64-bit file offset into a
+/// low-half `u32` (`Offset`) and a high-half `u32` (`OffsetHigh`).  The
+/// low-half narrowing cast is intentional and exact — it reproduces the
+/// bit pattern of the original `u64` byte-for-byte across the two
+/// fields.  The high-half cast is provably lossless because the right
+/// shift by 32 guarantees the value fits in `u32`.
+pub(crate) const fn set_overlapped_offset(
+    overlapped: &mut windows::Win32::System::IO::OVERLAPPED,
+    offset: u64,
+) {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Win32 OVERLAPPED ABI: the canonical low-half is the lower 32 bits of the u64 offset"
+    )]
+    let low = offset as u32;
+    let high = (offset >> 32_u32) as u32;
+    overlapped.Anonymous.Anonymous.Offset = low;
+    overlapped.Anonymous.Anonymous.OffsetHigh = high;
+}
 
 /// I/O Completion Port wrapper for Windows async I/O.
 ///
@@ -141,8 +156,7 @@ impl OverlappedRead {
 
     /// Sets the file offset for the overlapped read.
     pub const fn set_offset(&mut self, offset: u64) {
-        self.overlapped.Anonymous.Anonymous.Offset = offset as u32;
-        self.overlapped.Anonymous.Anonymous.OffsetHigh = (offset >> 32_u32) as u32;
+        set_overlapped_offset(&mut self.overlapped, offset);
     }
 
     /// Gets a mutable pointer to the OVERLAPPED structure.

--- a/crates/uffs-mft/src/io/readers/mft_file.rs
+++ b/crates/uffs-mft/src/io/readers/mft_file.rs
@@ -7,16 +7,13 @@
 //! byte `record_size` → FRS 1, etc.
 
 #![cfg(windows)]
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS record-size / byte-offset casts are lossless on supported 32/64-bit targets"
-)]
 
 use tracing::{debug, info, warn};
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::Storage::FileSystem::{FILE_BEGIN, ReadFile, SetFilePointerEx};
 
 use crate::error::Result;
+use crate::index::{frs_to_usize, u32_as_usize, usize_to_u64};
 use crate::io::AlignedBuffer;
 use crate::parse::{MftRecordMerger, ParsedRecord, apply_fixup, parse_record_full};
 
@@ -48,7 +45,7 @@ pub(crate) fn read_mft_from_file_handle(
     record_size: u32,
     total_records: u64,
 ) -> Result<Vec<ParsedRecord>> {
-    let record_size_usize = record_size as usize;
+    let record_size_usize = u32_as_usize(record_size);
     let total_bytes = total_records * u64::from(record_size);
     let chunk_records = MFT_FILE_CHUNK_SIZE / record_size_usize;
     let chunk_bytes = chunk_records * record_size_usize;
@@ -60,7 +57,7 @@ pub(crate) fn read_mft_from_file_handle(
         "📖 Starting $MFT file-based read (write-protect fallback)"
     );
 
-    let mut merger = MftRecordMerger::with_capacity(total_records as usize);
+    let mut merger = MftRecordMerger::with_capacity(frs_to_usize(total_records));
     let mut buffer = AlignedBuffer::new(chunk_bytes + 512); // pad for alignment
     let mut file_offset: u64 = 0;
     let mut frs: u64 = 0;
@@ -75,7 +72,7 @@ pub(crate) fn read_mft_from_file_handle(
 
     while frs < total_records {
         let remaining = total_records - frs;
-        let records_this_chunk = remaining.min(chunk_records as u64) as usize;
+        let records_this_chunk = frs_to_usize(remaining.min(usize_to_u64(chunk_records)));
         let read_size = records_this_chunk * record_size_usize;
 
         if buffer.len() < read_size {
@@ -97,9 +94,9 @@ pub(crate) fn read_mft_from_file_handle(
             &mut merger,
         );
 
-        frs += actual_records as u64;
-        file_offset += actual_bytes as u64;
-        bytes_read_total += actual_bytes as u64;
+        frs += usize_to_u64(actual_records);
+        file_offset += usize_to_u64(actual_bytes);
+        bytes_read_total += usize_to_u64(actual_bytes);
         chunks_read += 1;
 
         if actual_bytes < read_size {
@@ -176,7 +173,7 @@ unsafe fn read_one_chunk(
         ));
     }
 
-    Ok(bytes_read as usize)
+    Ok(u32_as_usize(bytes_read))
 }
 
 /// Apply NTFS fixup to each record slice in `buffer` and feed the parsed
@@ -197,7 +194,7 @@ fn parse_chunk_records(
             break;
         };
         if apply_fixup(record_slice) {
-            merger.add_result(parse_record_full(record_slice, base_frs + i as u64));
+            merger.add_result(parse_record_full(record_slice, base_frs + usize_to_u64(i)));
         }
     }
 }

--- a/crates/uffs-mft/src/io/readers/mod.rs
+++ b/crates/uffs-mft/src/io/readers/mod.rs
@@ -25,10 +25,14 @@ mod prelude {
     pub(super) use windows::Win32::Storage::FileSystem::{FILE_BEGIN, ReadFile, SetFilePointerEx};
 
     pub(super) use super::zero_copy::parse_buffer_zero_copy_inner;
+    pub(super) use crate::index::{
+        frs_to_usize, millis_to_u64, nanos_to_u64, u32_as_usize, usize_to_u64,
+    };
     pub(super) use crate::io::{
         AlignedBuffer, MftExtentMap, MftRecordMerger, ParseResult, ParsedColumns, ParsedRecord,
-        ReadChunk, SECTOR_SIZE, apply_fixup, generate_precise_read_chunks, generate_read_chunks,
-        parse_record, parse_record_full, parse_record_zero_alloc, process_record,
+        ReadChunk, SECTOR_SIZE, SECTOR_SIZE_U64, apply_fixup, generate_precise_read_chunks,
+        generate_read_chunks, parse_record, parse_record_full, parse_record_zero_alloc,
+        process_record,
     };
     pub(super) use crate::platform::VolumeHandle;
     pub(super) use crate::{MftError, Result};

--- a/crates/uffs-mft/src/io/readers/parallel/bulk.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/bulk.rs
@@ -6,10 +6,6 @@
 //! Windows-only: requires HANDLE.
 
 #![cfg(windows)]
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size casts are lossless on supported 32/64-bit targets"
-)]
 
 use super::prelude::*;
 
@@ -61,8 +57,8 @@ impl ParallelMftReader {
     where
         F: Fn(u64, u64),
     {
-        let record_size = self.extent_map.bytes_per_record as usize;
-        let total_records = self.extent_map.total_records() as usize;
+        let record_size = u32_as_usize(self.extent_map.bytes_per_record);
+        let total_records = frs_to_usize(self.extent_map.total_records());
         let total_bytes = total_records * record_size;
 
         info!(
@@ -171,10 +167,10 @@ impl ParallelMftReader {
                 let records_in_chunk = chunk.len() / record_size;
 
                 for i in 0..records_in_chunk {
-                    let frs = start_frs + i;
+                    let frs = usize_to_u64(start_frs + i);
 
                     if let Some(bm) = bitmap_ref
-                        && !bm.is_record_in_use(frs as u64)
+                        && !bm.is_record_in_use(frs)
                     {
                         skipped += 1;
                         processed += 1;
@@ -192,7 +188,7 @@ impl ParallelMftReader {
                         continue;
                     }
 
-                    let result = parse_record_full(record_slice, frs as u64);
+                    let result = parse_record_full(record_slice, frs);
                     if matches!(result, ParseResult::Skip) {
                         skipped += 1;
                     } else {
@@ -252,10 +248,10 @@ impl ParallelMftReader {
                 let records_in_chunk = chunk.len() / record_size;
 
                 for i in 0..records_in_chunk {
-                    let frs = start_frs + i;
+                    let frs = usize_to_u64(start_frs + i);
 
                     if let Some(bm) = bitmap_ref
-                        && !bm.is_record_in_use(frs as u64)
+                        && !bm.is_record_in_use(frs)
                     {
                         skipped += 1;
                         processed += 1;
@@ -273,7 +269,7 @@ impl ParallelMftReader {
                         continue;
                     }
 
-                    if let Some(record) = parse_record(record_slice, frs as u64) {
+                    if let Some(record) = parse_record(record_slice, frs) {
                         records.push(record);
                     } else {
                         skipped += 1;
@@ -320,17 +316,18 @@ fn plan_bulk_chunks(
     let mut sorted_chunks = generate_read_chunks(extent_map, bitmap, chunk_size);
     sorted_chunks.sort_by_key(|chunk| chunk.disk_offset);
 
+    let record_size_u64 = usize_to_u64(record_size);
     let bytes_to_read: u64 = sorted_chunks
         .iter()
         .map(|chunk| {
             let effective_records = chunk.record_count - chunk.skip_begin - chunk.skip_end;
-            effective_records * record_size as u64
+            effective_records * record_size_u64
         })
         .sum();
 
     let total_mb = total_bytes / (1024 * 1024);
     let read_mb = bytes_to_read / (1024 * 1024);
-    let savings_pct = 100 - (bytes_to_read * 100 / total_bytes as u64);
+    let savings_pct = 100 - (bytes_to_read * 100 / usize_to_u64(total_bytes));
 
     info!(
         chunks = sorted_chunks.len(),
@@ -365,16 +362,16 @@ where
     let mut bytes_read_total: u64 = 0;
 
     for chunk in sorted_chunks {
-        let skip_begin_bytes = chunk.skip_begin as usize * record_size;
+        let skip_begin_bytes = frs_to_usize(chunk.skip_begin) * record_size;
         let effective_records = chunk.record_count - chunk.skip_begin - chunk.skip_end;
 
         if effective_records == 0 {
             continue;
         }
 
-        let effective_bytes = effective_records as usize * record_size;
-        let disk_offset = chunk.disk_offset + skip_begin_bytes as u64;
-        let buffer_offset = chunk.start_frs as usize * record_size + skip_begin_bytes;
+        let effective_bytes = frs_to_usize(effective_records) * record_size;
+        let disk_offset = chunk.disk_offset + usize_to_u64(skip_begin_bytes);
+        let buffer_offset = frs_to_usize(chunk.start_frs) * record_size + skip_begin_bytes;
 
         let mut new_pos: i64 = 0;
         // SAFETY: `handle` is live and `new_pos` is valid writable storage

--- a/crates/uffs-mft/src/io/readers/parallel/bulk_iocp.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/bulk_iocp.rs
@@ -24,7 +24,7 @@ struct BulkOverlappedRead {
 /// provided by the kernel itself, which is the only invariant the
 /// wrapper relies on.
 #[derive(Clone, Copy)]
-struct SendHandle(isize);
+struct SendHandle(usize);
 #[expect(
     unsafe_code,
     reason = "FFI: copies a kernel IOCP handle value; thread-safety is provided by the kernel."
@@ -424,11 +424,7 @@ fn drain_bulk_iocp_completions(
     // pointer address via `expose_provenance` / `with_exposed_provenance_mut`,
     // wrapped in `SendHandle` so the kernel-managed pointer satisfies `Send` /
     // `Sync`.  The orchestrator owns the IoCompletionPort for the full drain.
-    #[expect(
-        clippy::cast_possible_wrap,
-        reason = "Win32 HANDLE address fits in isize on every supported 64-bit target"
-    )]
-    let iocp_handle_raw = SendHandle(iocp.raw_handle().0.expose_provenance() as isize);
+    let iocp_handle_raw = SendHandle(iocp.raw_handle().0.expose_provenance());
 
     let mut workers = Vec::with_capacity(num_workers);
     for _ in 0..num_workers {
@@ -441,12 +437,8 @@ fn drain_bulk_iocp_completions(
         workers.push(std::thread::spawn(move || {
             // `iocp_handle_raw` was constructed from a live IOCP handle
             // owned by the orchestrator and outlives every worker.
-            #[expect(
-                clippy::cast_sign_loss,
-                reason = "isize -> usize round-trip preserves the original Win32 HANDLE address"
-            )]
             let iocp_handle = HANDLE(core::ptr::with_exposed_provenance_mut::<core::ffi::c_void>(
-                handle_raw.0 as usize,
+                handle_raw.0,
             ));
             bulk_iocp_drain_loop(iocp_handle, pending, &bytes_read, &completed_count, &error);
         }));
@@ -461,14 +453,11 @@ fn drain_bulk_iocp_completions(
 
     let error_code = error_flag.load(Ordering::Acquire);
     if error_code != 0 {
-        // The atomic stored a `WIN32_ERROR` (`u32`); reinterpret the same
-        // bit pattern as `i32` for `from_raw_os_error`.
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "Win32 error code stored as u32; from_raw_os_error takes i32 with matching bit pattern"
-        )]
+        // The atomic stored a `WIN32_ERROR` (`u32`); `u32::cast_signed`
+        // reinterprets the same bit pattern as `i32` for
+        // `from_raw_os_error` without a `cast_possible_wrap` expect.
         return Err(MftError::Io(std::io::Error::from_raw_os_error(
-            error_code as i32,
+            error_code.cast_signed(),
         )));
     }
 

--- a/crates/uffs-mft/src/io/readers/parallel/bulk_iocp.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/bulk_iocp.rs
@@ -2,15 +2,6 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Bulk IOCP reader path for `ParallelMftReader`.
-//!
-//! **Module-scoped cast justification:** `as usize` / `as u32` casts convert
-//! NTFS disk offsets (`u64`) and record sizes (`u32`) into `usize` / `u32`
-//! respectively.  `usize` ≥ 32 bits on every supported target; NTFS disk
-//! offsets are physically bounded by the volume size (≤ 2⁶⁴ bytes).
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size casts are lossless on supported 32/64-bit targets"
-)]
 
 use core::sync::atomic::AtomicUsize;
 
@@ -76,8 +67,8 @@ impl ParallelMftReader {
     where
         F: Fn(u64, u64),
     {
-        let record_size = self.extent_map.bytes_per_record as usize;
-        let total_records = self.extent_map.total_records() as usize;
+        let record_size = u32_as_usize(self.extent_map.bytes_per_record);
+        let total_records = frs_to_usize(self.extent_map.total_records());
         let total_bytes = total_records * record_size;
 
         info!(
@@ -235,16 +226,17 @@ fn plan_bulk_iocp_chunks(
     let mut sorted_chunks: Vec<ReadChunk> = generate_read_chunks(extent_map, bitmap, chunk_size);
     sorted_chunks.sort_by_key(|chunk| chunk.disk_offset);
 
+    let record_size_u64 = usize_to_u64(record_size);
     let bytes_to_read: u64 = sorted_chunks
         .iter()
         .map(|chunk| {
             let effective_records = chunk.record_count - chunk.skip_begin - chunk.skip_end;
-            effective_records * record_size as u64
+            effective_records * record_size_u64
         })
         .sum();
 
     let savings_pct = if total_bytes > 0 {
-        100 - (bytes_to_read * 100 / total_bytes as u64)
+        100 - (bytes_to_read * 100 / usize_to_u64(total_bytes))
     } else {
         0
     };
@@ -302,25 +294,25 @@ unsafe fn queue_bulk_iocp_reads(
         reason = "OVERLAPPED structs must be kept alive until IOCP completes; this Vec is the lifetime owner"
     )]
     let mut operations: Vec<Pin<Box<BulkOverlappedRead>>> =
-        Vec::with_capacity((bytes_to_read as usize / io_chunk_size) + sorted_chunks.len());
+        Vec::with_capacity((frs_to_usize(bytes_to_read) / io_chunk_size) + sorted_chunks.len());
     let mut pending_count = 0_usize;
 
     for chunk in sorted_chunks {
-        let skip_begin_bytes = chunk.skip_begin as usize * record_size;
+        let skip_begin_bytes = frs_to_usize(chunk.skip_begin) * record_size;
         let effective_records = chunk.record_count - chunk.skip_begin - chunk.skip_end;
         if effective_records == 0 {
             continue;
         }
 
-        let effective_bytes = effective_records as usize * record_size;
-        let chunk_disk_offset = chunk.disk_offset + skip_begin_bytes as u64;
-        let chunk_buffer_offset = chunk.start_frs as usize * record_size + skip_begin_bytes;
+        let effective_bytes = frs_to_usize(effective_records) * record_size;
+        let chunk_disk_offset = chunk.disk_offset + usize_to_u64(skip_begin_bytes);
+        let chunk_buffer_offset = frs_to_usize(chunk.start_frs) * record_size + skip_begin_bytes;
 
         let mut offset_within_chunk = 0_usize;
         while offset_within_chunk < effective_bytes {
             let remaining = effective_bytes - offset_within_chunk;
             let io_size = remaining.min(io_chunk_size);
-            let disk_offset = chunk_disk_offset + offset_within_chunk as u64;
+            let disk_offset = chunk_disk_offset + usize_to_u64(offset_within_chunk);
             let buffer_offset = chunk_buffer_offset + offset_within_chunk;
 
             // SAFETY: caller holds the live overlapped handle; `mft_buffer`
@@ -369,8 +361,7 @@ unsafe fn queue_one_bulk_read(
         overlapped: unsafe { core::mem::zeroed() },
     });
 
-    op.overlapped.Anonymous.Anonymous.Offset = (disk_offset & 0xFFFF_FFFF) as u32;
-    op.overlapped.Anonymous.Anonymous.OffsetHigh = (disk_offset >> 32_u32) as u32;
+    set_overlapped_offset(&mut op.overlapped, disk_offset);
 
     // SAFETY: `buffer_offset` is computed from `chunk.start_frs *
     // record_size` and was bounded by upstream chunk validation to stay
@@ -424,9 +415,20 @@ fn drain_bulk_iocp_completions(
 
     let bytes_read_total = Arc::new(AtomicU64::new(0));
     let completed = Arc::new(AtomicUsize::new(0));
-    let error_flag = Arc::new(AtomicUsize::new(0));
+    // Win32 error codes are `u32`; storing as `AtomicU32` keeps the i32
+    // reinterpret for `from_raw_os_error` an exact bit-pattern cast.
+    let error_flag: Arc<core::sync::atomic::AtomicU32> =
+        Arc::new(core::sync::atomic::AtomicU32::new(0));
 
-    let iocp_handle_raw = SendHandle(iocp.raw_handle().0 as isize);
+    // The IOCP HANDLE is `!Send`; ferry it across worker boundaries as the raw
+    // pointer address via `expose_provenance` / `with_exposed_provenance_mut`,
+    // wrapped in `SendHandle` so the kernel-managed pointer satisfies `Send` /
+    // `Sync`.  The orchestrator owns the IoCompletionPort for the full drain.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "Win32 HANDLE address fits in isize on every supported 64-bit target"
+    )]
+    let iocp_handle_raw = SendHandle(iocp.raw_handle().0.expose_provenance() as isize);
 
     let mut workers = Vec::with_capacity(num_workers);
     for _ in 0..num_workers {
@@ -439,7 +441,13 @@ fn drain_bulk_iocp_completions(
         workers.push(std::thread::spawn(move || {
             // `iocp_handle_raw` was constructed from a live IOCP handle
             // owned by the orchestrator and outlives every worker.
-            let iocp_handle = HANDLE(handle_raw.0 as *mut core::ffi::c_void);
+            #[expect(
+                clippy::cast_sign_loss,
+                reason = "isize -> usize round-trip preserves the original Win32 HANDLE address"
+            )]
+            let iocp_handle = HANDLE(core::ptr::with_exposed_provenance_mut::<core::ffi::c_void>(
+                handle_raw.0 as usize,
+            ));
             bulk_iocp_drain_loop(iocp_handle, pending, &bytes_read, &completed_count, &error);
         }));
     }
@@ -457,7 +465,7 @@ fn drain_bulk_iocp_completions(
         // bit pattern as `i32` for `from_raw_os_error`.
         #[expect(
             clippy::cast_possible_wrap,
-            reason = "Win32 error code stored as u32; from_raw_os_error takes i32"
+            reason = "Win32 error code stored as u32; from_raw_os_error takes i32 with matching bit pattern"
         )]
         return Err(MftError::Io(std::io::Error::from_raw_os_error(
             error_code as i32,
@@ -481,7 +489,7 @@ fn bulk_iocp_drain_loop(
     pending: usize,
     bytes_read: &Arc<AtomicU64>,
     completed_count: &Arc<AtomicUsize>,
-    error: &Arc<AtomicUsize>,
+    error: &Arc<core::sync::atomic::AtomicU32>,
 ) {
     use windows::Win32::Foundation::GetLastError;
     use windows::Win32::System::IO::GetQueuedCompletionStatus;
@@ -528,7 +536,7 @@ fn bulk_iocp_drain_loop(
             continue;
         }
 
-        error.store(last_error.0 as usize, Ordering::Release);
+        error.store(last_error.0, Ordering::Release);
         break;
     }
 }
@@ -606,10 +614,10 @@ fn parse_bulk_chunk_to_results(
     let records_in_chunk = chunk.len() / record_size;
 
     for i in 0..records_in_chunk {
-        let frs = start_frs + i;
+        let frs = usize_to_u64(start_frs + i);
 
         if let Some(bm) = bitmap
-            && !bm.is_record_in_use(frs as u64)
+            && !bm.is_record_in_use(frs)
         {
             continue;
         }
@@ -623,7 +631,7 @@ fn parse_bulk_chunk_to_results(
             continue;
         }
 
-        let parsed = parse_record_full(record_slice, frs as u64);
+        let parsed = parse_record_full(record_slice, frs);
         if !matches!(parsed, ParseResult::Skip) {
             results.push(parsed);
         }
@@ -645,10 +653,10 @@ fn parse_bulk_chunk_to_records(
     let records_in_chunk = chunk.len() / record_size;
 
     for i in 0..records_in_chunk {
-        let frs = start_frs + i;
+        let frs = usize_to_u64(start_frs + i);
 
         if let Some(bm) = bitmap
-            && !bm.is_record_in_use(frs as u64)
+            && !bm.is_record_in_use(frs)
         {
             continue;
         }
@@ -662,7 +670,7 @@ fn parse_bulk_chunk_to_records(
             continue;
         }
 
-        if let Some(record) = parse_record(record_slice, frs as u64) {
+        if let Some(record) = parse_record(record_slice, frs) {
             records.push(record);
         }
     }

--- a/crates/uffs-mft/src/io/readers/parallel/chunk.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/chunk.rs
@@ -6,10 +6,6 @@
 //! Windows-only: requires HANDLE.
 
 #![cfg(windows)]
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size casts are lossless on supported 32/64-bit targets"
-)]
 
 use super::prelude::*;
 
@@ -36,10 +32,10 @@ impl ParallelMftReader {
         let read_size = chunk.record_count * u64::from(record_size);
 
         // Align to sector boundary
-        let aligned_offset = (chunk.disk_offset / SECTOR_SIZE as u64) * SECTOR_SIZE as u64;
-        let offset_adjustment = (chunk.disk_offset - aligned_offset) as usize;
+        let aligned_offset = (chunk.disk_offset / SECTOR_SIZE_U64) * SECTOR_SIZE_U64;
+        let offset_adjustment = frs_to_usize(chunk.disk_offset - aligned_offset);
         let aligned_size =
-            (read_size as usize + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
+            (frs_to_usize(read_size) + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
 
         // M1 8.4: Reuse buffer, only reallocate if needed
         let mut buffer = self.buffer.borrow_mut();
@@ -74,7 +70,7 @@ impl ParallelMftReader {
         unsafe { ReadFile(handle, Some(read_slice), Some(&raw mut bytes_read), None) }?;
 
         // Extract the actual data (accounting for alignment offset)
-        let actual_size = (bytes_read as usize).saturating_sub(offset_adjustment);
+        let actual_size = u32_as_usize(bytes_read).saturating_sub(offset_adjustment);
         let data = buffer
             .as_slice()
             .get(offset_adjustment..offset_adjustment + actual_size)

--- a/crates/uffs-mft/src/io/readers/parallel/columns.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/columns.rs
@@ -6,10 +6,6 @@
 //! Windows-only: requires HANDLE.
 
 #![cfg(windows)]
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size casts are lossless on supported 32/64-bit targets"
-)]
 
 use super::prelude::*;
 
@@ -133,7 +129,7 @@ impl ParallelMftReader {
         info!(num_chunks = chunks.len(), "Generated read chunks");
 
         let estimated_records = self.bitmap.as_ref().map_or_else(
-            || self.extent_map.total_records() as usize,
+            || frs_to_usize(self.extent_map.total_records()),
             crate::platform::MftBitmap::count_in_use,
         );
         info!(estimated_records, "Estimated record count");
@@ -205,7 +201,7 @@ impl ParallelMftReader {
             match self.read_chunk(handle, &chunk, record_size) {
                 Ok(data) => {
                     consecutive_failures = 0;
-                    total_bytes_read += data.len() as u64;
+                    total_bytes_read += usize_to_u64(data.len());
                     if let Some(cb) = progress_callback {
                         cb(total_bytes_read, total_bytes_to_read);
                     }
@@ -249,9 +245,9 @@ impl ParallelMftReader {
         let combined = chunk_data
             .par_iter()
             .fold(ChunkStats::default, |mut acc, (chunk, data)| {
-                let record_size_bytes = record_size as usize;
-                let skip_begin = chunk.skip_begin as usize;
-                let effective_count = chunk.effective_record_count() as usize;
+                let record_size_bytes = u32_as_usize(record_size);
+                let skip_begin = frs_to_usize(chunk.skip_begin);
+                let effective_count = frs_to_usize(chunk.effective_record_count());
 
                 acc.results.reserve(effective_count);
 
@@ -261,7 +257,7 @@ impl ParallelMftReader {
                         break;
                     };
 
-                    let frs = chunk.start_frs + skip_begin as u64 + i as u64;
+                    let frs = chunk.start_frs + usize_to_u64(skip_begin) + usize_to_u64(i);
 
                     let result = parse_record_zero_alloc(record_data, frs);
                     if matches!(result, ParseResult::Skip) {
@@ -321,9 +317,9 @@ impl ParallelMftReader {
                     ..Default::default()
                 },
                 |mut acc, (chunk, data)| {
-                    let record_size_bytes = record_size as usize;
-                    let skip_begin = chunk.skip_begin as usize;
-                    let effective_count = chunk.effective_record_count() as usize;
+                    let record_size_bytes = u32_as_usize(record_size);
+                    let skip_begin = frs_to_usize(chunk.skip_begin);
+                    let effective_count = frs_to_usize(chunk.effective_record_count());
 
                     acc.columns.reserve(effective_count);
 
@@ -333,7 +329,7 @@ impl ParallelMftReader {
                             break;
                         };
 
-                        let frs = chunk.start_frs + skip_begin as u64 + i as u64;
+                        let frs = chunk.start_frs + usize_to_u64(skip_begin) + usize_to_u64(i);
 
                         match parse_record_zero_alloc(record_data, frs) {
                             ParseResult::Base(record) => {

--- a/crates/uffs-mft/src/io/readers/parallel/mod.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/mod.rs
@@ -2,27 +2,15 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Parallel reader implementations and strategy entrypoints.
-//!
-//! **Module-scoped cast justification:** `as usize` / `as u32` casts convert
-//! NTFS disk offsets (`u64`) and record sizes (`u32`) into `usize` / `u32`
-//! for buffer slicing.  `usize` ≥ 32 bits on every supported target; NTFS
-//! disk offsets are physically bounded by the volume size (≤ 2⁶⁴ bytes).
-#![cfg_attr(
-    windows,
-    expect(
-        clippy::cast_possible_truncation,
-        reason = "NTFS disk-offset / record-size casts are lossless on supported 32/64-bit targets"
-    )
-)]
 
 /// Re-exports the readers-wide prelude plus parallel-only items
-/// (`IoCompletionPort`, `ParallelMftReader`, `ReadParseTiming`) so that
-/// parallel's child reader paths can write `impl ParallelMftReader` and
-/// reference the timing struct directly. The module name `prelude` is
-/// exempt from `clippy::wildcard_imports`.
+/// (`IoCompletionPort`, `set_overlapped_offset`, `ParallelMftReader`,
+/// `ReadParseTiming`) so that parallel's child reader paths can write
+/// `impl ParallelMftReader` and reference the timing struct directly.
+/// The module name `prelude` is exempt from `clippy::wildcard_imports`.
 #[cfg(windows)]
 mod prelude {
-    pub(super) use super::super::iocp::IoCompletionPort;
+    pub(super) use super::super::iocp::{IoCompletionPort, set_overlapped_offset};
     pub(super) use super::super::prelude::*;
     pub(super) use super::{ParallelMftReader, ReadParseTiming};
 }
@@ -392,7 +380,7 @@ impl ParallelMftReader {
         info!(num_chunks = chunks.len(), "Generated read chunks");
 
         let estimated_records = self.bitmap.as_ref().map_or_else(
-            || self.extent_map.total_records() as usize,
+            || frs_to_usize(self.extent_map.total_records()),
             crate::platform::MftBitmap::count_in_use,
         );
         info!(estimated_records, "Estimated record count");
@@ -429,9 +417,9 @@ impl ParallelMftReader {
         let combined = chunk_data
             .par_iter_mut()
             .fold(ChunkStats::default, |mut acc, (chunk, data)| {
-                let record_size_bytes = record_size as usize;
-                let skip_begin = chunk.skip_begin as usize;
-                let effective_count = chunk.effective_record_count() as usize;
+                let record_size_bytes = u32_as_usize(record_size);
+                let skip_begin = frs_to_usize(chunk.skip_begin);
+                let effective_count = frs_to_usize(chunk.effective_record_count());
 
                 if chunk.skip_begin > 0 || chunk.skip_end > 0 {
                     debug!(
@@ -453,7 +441,7 @@ impl ParallelMftReader {
                         break;
                     };
 
-                    let frs = chunk.start_frs + skip_begin as u64 + i as u64;
+                    let frs = chunk.start_frs + usize_to_u64(skip_begin) + usize_to_u64(i);
 
                     if !apply_fixup(record_slice) {
                         acc.skipped += 1;
@@ -508,9 +496,9 @@ impl ParallelMftReader {
         let combined = chunk_data
             .par_iter_mut()
             .fold(LegacyStats::default, |mut acc, (chunk, data)| {
-                let record_size_bytes = record_size as usize;
-                let skip_begin = chunk.skip_begin as usize;
-                let effective_count = chunk.effective_record_count() as usize;
+                let record_size_bytes = u32_as_usize(record_size);
+                let skip_begin = frs_to_usize(chunk.skip_begin);
+                let effective_count = frs_to_usize(chunk.effective_record_count());
 
                 acc.records.reserve(effective_count);
 
@@ -521,7 +509,7 @@ impl ParallelMftReader {
                         break;
                     };
 
-                    let frs = chunk.start_frs + skip_begin as u64 + i as u64;
+                    let frs = chunk.start_frs + usize_to_u64(skip_begin) + usize_to_u64(i);
 
                     if !apply_fixup(record_slice) {
                         acc.skipped += 1;

--- a/crates/uffs-mft/src/io/readers/parallel/sliding_window.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/sliding_window.rs
@@ -2,16 +2,6 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Sliding-window IOCP reader path.
-//!
-//! **Module-scoped cast justification:** `as usize` / `as u32` casts convert
-//! NTFS disk offsets (`u64`) and record sizes (`u32`) into `usize` / `u32`
-//! for buffer slicing and Win32 `OVERLAPPED` high/low offset split.  `usize`
-//! ≥ 32 bits on every supported target; NTFS disk offsets are physically
-//! bounded by the volume size (≤ 2⁶⁴ bytes).
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size / OVERLAPPED offset-split casts are lossless"
-)]
 
 use super::prelude::*;
 
@@ -72,8 +62,8 @@ impl ParallelMftReader {
             op: IoOp,
         }
 
-        let record_size = self.extent_map.bytes_per_record as usize;
-        let total_records = self.extent_map.total_records() as usize;
+        let record_size = u32_as_usize(self.extent_map.bytes_per_record);
+        let total_records = frs_to_usize(self.extent_map.total_records());
         let total_bytes = total_records * record_size;
 
         // Use adaptive concurrency and I/O size based on drive type (M2 optimization)
@@ -116,7 +106,7 @@ impl ParallelMftReader {
         let mut total_skipped_records = 0_u64;
 
         for chunk in &sorted_chunks {
-            let skip_begin_bytes = chunk.skip_begin as usize * record_size;
+            let skip_begin_bytes = frs_to_usize(chunk.skip_begin) * record_size;
             let effective_records = chunk.record_count - chunk.skip_begin - chunk.skip_end;
 
             // Log chunks with non-zero skips
@@ -144,13 +134,14 @@ impl ParallelMftReader {
                 continue;
             }
 
-            let chunk_bytes = effective_records as usize * record_size;
+            let chunk_bytes = frs_to_usize(effective_records) * record_size;
             let mut offset_within_chunk = 0_usize;
 
             while offset_within_chunk < chunk_bytes {
                 let io_size = core::cmp::min(io_chunk_size, chunk_bytes - offset_within_chunk);
-                let disk_offset =
-                    chunk.disk_offset + skip_begin_bytes as u64 + offset_within_chunk as u64;
+                let disk_offset = chunk.disk_offset
+                    + usize_to_u64(skip_begin_bytes)
+                    + usize_to_u64(offset_within_chunk);
 
                 io_ops.push_back(IoOp {
                     disk_offset,
@@ -225,8 +216,7 @@ impl ParallelMftReader {
                 // SAFETY: The pinned allocation remains in place while the I/O is in
                 // flight; this only projects a mutable reference without moving it.
                 let op_mut = unsafe { in_flight_op.as_mut().get_unchecked_mut() };
-                op_mut.overlapped.Anonymous.Anonymous.Offset = offset as u32;
-                op_mut.overlapped.Anonymous.Anonymous.OffsetHigh = (offset >> 32_u32) as u32;
+                set_overlapped_offset(&mut op_mut.overlapped, offset);
 
                 // Issue read
                 let overlapped_ptr = &raw mut op_mut.overlapped;
@@ -319,7 +309,10 @@ impl ParallelMftReader {
 
                 // Copy data to final buffer
                 let dest_offset = op_mut.op.buffer_offset;
-                let Some(src_slice) = op_mut.buffer.as_slice().get(..bytes_transferred as usize)
+                let Some(src_slice) = op_mut
+                    .buffer
+                    .as_slice()
+                    .get(..u32_as_usize(bytes_transferred))
                 else {
                     return Err(MftError::Io(std::io::Error::new(
                         std::io::ErrorKind::UnexpectedEof,
@@ -328,7 +321,7 @@ impl ParallelMftReader {
                 };
                 let Some(dest_slice) = mft_buffer
                     .as_mut_slice()
-                    .get_mut(dest_offset..dest_offset + bytes_transferred as usize)
+                    .get_mut(dest_offset..dest_offset + u32_as_usize(bytes_transferred))
                 else {
                     return Err(MftError::Io(std::io::Error::new(
                         std::io::ErrorKind::UnexpectedEof,
@@ -366,9 +359,7 @@ impl ParallelMftReader {
                     // SAFETY: The pinned allocation remains in place while the I/O
                     // is in flight; this only projects a mutable reference.
                     let new_op_mut = unsafe { new_in_flight.as_mut().get_unchecked_mut() };
-                    new_op_mut.overlapped.Anonymous.Anonymous.Offset = offset as u32;
-                    new_op_mut.overlapped.Anonymous.Anonymous.OffsetHigh =
-                        (offset >> 32_u32) as u32;
+                    set_overlapped_offset(&mut new_op_mut.overlapped, offset);
 
                     let new_overlapped_ptr = &raw mut new_op_mut.overlapped;
                     let read_size = new_op_mut.op.size;
@@ -445,10 +436,10 @@ impl ParallelMftReader {
                     let records_in_chunk = chunk.len() / record_size;
 
                     for i in 0..records_in_chunk {
-                        let frs = start_frs + i;
+                        let frs = usize_to_u64(start_frs + i);
 
                         if let Some(bm) = bitmap_ref
-                            && !bm.is_record_in_use(frs as u64)
+                            && !bm.is_record_in_use(frs)
                         {
                             skipped += 1;
                             processed += 1;
@@ -466,7 +457,7 @@ impl ParallelMftReader {
                             continue;
                         }
 
-                        let parsed = parse_record_full(record_slice, frs as u64);
+                        let parsed = parse_record_full(record_slice, frs);
                         match &parsed {
                             ParseResult::Skip => skipped += 1,
                             ParseResult::Base(_) | ParseResult::Extension(_) => {
@@ -507,10 +498,10 @@ impl ParallelMftReader {
                     let records_in_chunk = chunk.len() / record_size;
 
                     for i in 0..records_in_chunk {
-                        let frs = start_frs + i;
+                        let frs = usize_to_u64(start_frs + i);
 
                         if let Some(bm) = bitmap_ref
-                            && !bm.is_record_in_use(frs as u64)
+                            && !bm.is_record_in_use(frs)
                         {
                             skipped += 1;
                             processed += 1;
@@ -528,7 +519,7 @@ impl ParallelMftReader {
                             continue;
                         }
 
-                        if let Some(record) = parse_record(record_slice, frs as u64) {
+                        if let Some(record) = parse_record(record_slice, frs) {
                             records.push(record);
                         } else {
                             skipped += 1;

--- a/crates/uffs-mft/src/io/readers/parallel/timing.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/timing.rs
@@ -6,19 +6,6 @@
 //! Windows-only: requires HANDLE.
 
 #![cfg(windows)]
-// Module-scoped pedantic allows with prose justification.  All
-// `cast_possible_truncation` hits in this file fall into two domain-bounded
-// categories:
-//   1. `Duration::as_nanos() as u64` — 584 years of nanoseconds fit in u64; timing values measured
-//      here are sub-second in practice.
-//   2. `u32 / u64 -> usize` for on-disk NTFS record counts and byte offsets — usize is ≥ 32 bits on
-//      every supported target, and u64 values come from the NTFS MFT which is physically bounded by
-//      the disk size (≤ 2⁶⁴ bytes but practically always < 2⁶⁴ records).
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "timing (u128 ns -> u64) and NTFS record-count (u32/u64 -> usize) casts are \
-              provably lossless given the domain bounds; see module header"
-)]
 
 use super::prelude::*;
 
@@ -83,7 +70,7 @@ impl ParallelMftReader {
         info!(num_chunks = chunks.len(), "Generated read chunks");
 
         let estimated_records = self.bitmap.as_ref().map_or_else(
-            || self.extent_map.total_records() as usize,
+            || frs_to_usize(self.extent_map.total_records()),
             crate::platform::MftBitmap::count_in_use,
         );
         let record_size = self.extent_map.bytes_per_record;
@@ -98,7 +85,7 @@ impl ParallelMftReader {
             self.parse_legacy_timed(&mut chunk_data, record_size)
         };
 
-        let wall_ns = wall_start.elapsed().as_nanos() as u64;
+        let wall_ns = nanos_to_u64(wall_start.elapsed().as_nanos());
         let timing = ReadParseTiming {
             io_ns,
             parse_ns,
@@ -156,7 +143,7 @@ impl ParallelMftReader {
                 }
             }
         }
-        let io_ns = io_start.elapsed().as_nanos() as u64;
+        let io_ns = nanos_to_u64(io_start.elapsed().as_nanos());
 
         info!(
             chunks_read = chunk_data.len(),
@@ -188,9 +175,9 @@ impl ParallelMftReader {
         let combined = chunk_data
             .par_iter_mut()
             .fold(ChunkStats::default, |mut acc, (chunk, data)| {
-                let record_size_bytes = record_size as usize;
-                let skip_begin = chunk.skip_begin as usize;
-                let effective_count = chunk.effective_record_count() as usize;
+                let record_size_bytes = u32_as_usize(record_size);
+                let skip_begin = frs_to_usize(chunk.skip_begin);
+                let effective_count = frs_to_usize(chunk.effective_record_count());
 
                 acc.results.reserve(effective_count);
 
@@ -201,7 +188,7 @@ impl ParallelMftReader {
                         break;
                     };
 
-                    let frs = chunk.start_frs + skip_begin as u64 + i as u64;
+                    let frs = chunk.start_frs + usize_to_u64(skip_begin) + usize_to_u64(i);
 
                     if !apply_fixup(record_slice) {
                         acc.skipped += 1;
@@ -231,7 +218,7 @@ impl ParallelMftReader {
         self.skipped_records
             .fetch_add(combined.skipped, Ordering::Relaxed);
 
-        let parse_ns = parse_start.elapsed().as_nanos() as u64;
+        let parse_ns = nanos_to_u64(parse_start.elapsed().as_nanos());
         info!(
             parse_results = combined.results.len(),
             parse_ms = parse_ns / 1_000_000,
@@ -244,7 +231,7 @@ impl ParallelMftReader {
             merger.add_result(result);
         }
         let records = merger.merge();
-        let merge_ns = merge_start.elapsed().as_nanos() as u64;
+        let merge_ns = nanos_to_u64(merge_start.elapsed().as_nanos());
 
         info!(
             records = records.len(),
@@ -275,9 +262,9 @@ impl ParallelMftReader {
         let combined = chunk_data
             .par_iter_mut()
             .fold(LegacyStats::default, |mut acc, (chunk, data)| {
-                let record_size_bytes = record_size as usize;
-                let skip_begin = chunk.skip_begin as usize;
-                let effective_count = chunk.effective_record_count() as usize;
+                let record_size_bytes = u32_as_usize(record_size);
+                let skip_begin = frs_to_usize(chunk.skip_begin);
+                let effective_count = frs_to_usize(chunk.effective_record_count());
 
                 acc.records.reserve(effective_count);
 
@@ -288,7 +275,7 @@ impl ParallelMftReader {
                         break;
                     };
 
-                    let frs = chunk.start_frs + skip_begin as u64 + i as u64;
+                    let frs = chunk.start_frs + usize_to_u64(skip_begin) + usize_to_u64(i);
 
                     if !apply_fixup(record_slice) {
                         acc.skipped += 1;
@@ -316,7 +303,7 @@ impl ParallelMftReader {
         self.skipped_records
             .fetch_add(combined.skipped, Ordering::Relaxed);
 
-        let parse_ns = parse_start.elapsed().as_nanos() as u64;
+        let parse_ns = nanos_to_u64(parse_start.elapsed().as_nanos());
         info!(
             records = combined.records.len(),
             parse_ms = parse_ns / 1_000_000,

--- a/crates/uffs-mft/src/io/readers/parallel/to_index.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/to_index.rs
@@ -6,15 +6,6 @@
 //! Windows-only: requires IOCP and HANDLE.
 
 #![cfg(windows)]
-// Module-scoped cast justification: `as usize` / `as u32` casts convert
-// NTFS disk offsets (u64) and record sizes (u32) into usize / u32 for buffer
-// slicing and Win32 OVERLAPPED high/low offset split.  usize ≥ 32 bits on
-// every supported target; NTFS disk offsets are physically bounded by the
-// volume size (≤ 2⁶⁴ bytes).
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size / OVERLAPPED offset-split casts are lossless"
-)]
 
 use super::prelude::*;
 
@@ -131,8 +122,8 @@ impl ParallelMftReader {
         }
 
         debug!("[PARITY_TRACE] to_index.rs: read_all_sliding_window_iocp_to_index ENTER");
-        let record_size = self.extent_map.bytes_per_record as usize;
-        let total_records = self.extent_map.total_records() as usize;
+        let record_size = u32_as_usize(self.extent_map.bytes_per_record);
+        let total_records = frs_to_usize(self.extent_map.total_records());
         debug!(
             record_size,
             total_records, "[PARITY_TRACE] to_index.rs: config"
@@ -195,19 +186,19 @@ impl ParallelMftReader {
         let mut io_ops: VecDeque<IoOp> = VecDeque::new();
 
         for chunk in &sorted_chunks {
-            let skip_begin_bytes = chunk.skip_begin as usize * record_size;
+            let skip_begin_bytes = frs_to_usize(chunk.skip_begin) * record_size;
             let effective_records = chunk.record_count - chunk.skip_begin - chunk.skip_end;
             if effective_records == 0 {
                 continue;
             }
 
-            let chunk_bytes = effective_records as usize * record_size;
+            let chunk_bytes = frs_to_usize(effective_records) * record_size;
 
             if use_direct_chunk_io {
                 // NVMe/SSD: Use chunk directly as one I/O operation (no splitting)
                 // This minimizes syscall overhead since there's no seek penalty
                 io_ops.push_back(IoOp {
-                    disk_offset: chunk.disk_offset + skip_begin_bytes as u64,
+                    disk_offset: chunk.disk_offset + usize_to_u64(skip_begin_bytes),
                     size: chunk_bytes,
                     start_frs: chunk.start_frs + chunk.skip_begin,
                 });
@@ -219,8 +210,9 @@ impl ParallelMftReader {
                 while offset_within_chunk < chunk_bytes {
                     let io_size = core::cmp::min(io_chunk_size, chunk_bytes - offset_within_chunk);
                     let records_in_io = io_size / record_size;
-                    let disk_offset =
-                        chunk.disk_offset + skip_begin_bytes as u64 + offset_within_chunk as u64;
+                    let disk_offset = chunk.disk_offset
+                        + usize_to_u64(skip_begin_bytes)
+                        + usize_to_u64(offset_within_chunk);
 
                     io_ops.push_back(IoOp {
                         disk_offset,
@@ -229,7 +221,7 @@ impl ParallelMftReader {
                     });
 
                     offset_within_chunk += io_size;
-                    frs_offset += records_in_io as u64;
+                    frs_offset += usize_to_u64(records_in_io);
                 }
             }
         }
@@ -238,13 +230,13 @@ impl ParallelMftReader {
         let (estimated_records, max_frs) = self.bitmap.as_ref().map_or_else(
             || {
                 // No bitmap: use total records as both count and max FRS
-                (total_records, total_records.saturating_sub(1) as u64)
+                (total_records, usize_to_u64(total_records.saturating_sub(1)))
             },
             |bitmap| (bitmap.count_in_use(), bitmap.max_frs_in_use()),
         );
 
         // Calculate total bytes to read and max I/O size for buffer allocation
-        let total_bytes_to_read: u64 = io_ops.iter().map(|op| op.size as u64).sum();
+        let total_bytes_to_read: u64 = io_ops.iter().map(|op| usize_to_u64(op.size)).sum();
         let max_io_size = io_ops
             .iter()
             .map(|op| op.size)
@@ -302,8 +294,7 @@ impl ParallelMftReader {
                 // SAFETY: The pinned allocation remains in place while the I/O is in
                 // flight; this only projects a mutable reference without moving it.
                 let op_mut = unsafe { in_flight_op.as_mut().get_unchecked_mut() };
-                op_mut.overlapped.Anonymous.Anonymous.Offset = offset as u32;
-                op_mut.overlapped.Anonymous.Anonymous.OffsetHigh = (offset >> 32_u32) as u32;
+                set_overlapped_offset(&mut op_mut.overlapped, offset);
 
                 let overlapped_ptr = &raw mut op_mut.overlapped;
                 let read_size = op_mut.op.size;
@@ -373,7 +364,7 @@ impl ParallelMftReader {
                 )
             };
 
-            total_wait_time_ns += wait_start.elapsed().as_nanos() as u64;
+            total_wait_time_ns += nanos_to_u64(wait_start.elapsed().as_nanos());
 
             if result.is_err() {
                 // SAFETY: `GetLastError` reads the calling thread's last-error slot
@@ -440,7 +431,7 @@ impl ParallelMftReader {
                 let Some(buffer_slice) = op_mut
                     .buffer
                     .as_mut_slice()
-                    .get_mut(..bytes_transferred as usize)
+                    .get_mut(..u32_as_usize(bytes_transferred))
                 else {
                     // Unreachable: completion bytes_transferred ≤ allocated buffer size.
                     return Err(MftError::Io(std::io::Error::new(
@@ -448,10 +439,10 @@ impl ParallelMftReader {
                         "to-index completion reported more bytes than buffer size",
                     )));
                 };
-                let records_in_buffer = bytes_transferred as usize / record_size;
+                let records_in_buffer = u32_as_usize(bytes_transferred) / record_size;
 
                 for i in 0..records_in_buffer {
-                    let frs = op_mut.op.start_frs + i as u64;
+                    let frs = op_mut.op.start_frs + usize_to_u64(i);
                     let offset = i * record_size;
 
                     // Check bitmap
@@ -498,7 +489,7 @@ impl ParallelMftReader {
                     }
                 }
 
-                total_parse_time_ns += parse_start.elapsed().as_nanos() as u64;
+                total_parse_time_ns += nanos_to_u64(parse_start.elapsed().as_nanos());
 
                 bytes_read_total += u64::from(bytes_transferred);
                 completed_count += 1;
@@ -526,9 +517,7 @@ impl ParallelMftReader {
                     // SAFETY: The pinned allocation remains in place while the I/O
                     // is in flight; this only projects a mutable reference.
                     let new_op_mut = unsafe { new_in_flight.as_mut().get_unchecked_mut() };
-                    new_op_mut.overlapped.Anonymous.Anonymous.Offset = offset as u32;
-                    new_op_mut.overlapped.Anonymous.Anonymous.OffsetHigh =
-                        (offset >> 32_u32) as u32;
+                    set_overlapped_offset(&mut new_op_mut.overlapped, offset);
 
                     let new_overlapped_ptr = &raw mut new_op_mut.overlapped;
                     let read_size = new_op_mut.op.size;
@@ -568,7 +557,7 @@ impl ParallelMftReader {
             }
         }
 
-        let total_ms = read_start.elapsed().as_millis() as u64;
+        let total_ms = millis_to_u64(read_start.elapsed().as_millis());
         let wait_ms = total_wait_time_ns / 1_000_000;
         let parse_ms = total_parse_time_ns / 1_000_000;
 

--- a/crates/uffs-mft/src/io/readers/parallel/to_index_parallel.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/to_index_parallel.rs
@@ -2,16 +2,6 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Parallel direct-to-index reader path.
-//!
-//! **Module-scoped cast justification:** `as usize` / `as u32` casts convert
-//! NTFS disk offsets (`u64`) and record sizes (`u32`) into `usize` / `u32`
-//! for buffer slicing and Win32 `OVERLAPPED` high/low offset split.  `usize`
-//! ≥ 32 bits on every supported target; NTFS disk offsets are physically
-//! bounded by the volume size (≤ 2⁶⁴ bytes).
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size / OVERLAPPED offset-split casts are lossless"
-)]
 
 use super::prelude::*;
 
@@ -122,8 +112,8 @@ impl ParallelMftReader {
 
         use crate::index::MftIndex;
 
-        let record_size = self.extent_map.bytes_per_record as usize;
-        let total_records = self.extent_map.total_records() as usize;
+        let record_size = u32_as_usize(self.extent_map.bytes_per_record);
+        let total_records = frs_to_usize(self.extent_map.total_records());
 
         // Use provided values or adaptive defaults
         // For HDD, use extent-aware concurrency (fragmentation affects optimal value)
@@ -199,19 +189,19 @@ impl ParallelMftReader {
         let mut io_ops: VecDeque<IoOp> = VecDeque::new();
 
         for chunk in &sorted_chunks {
-            let skip_begin_bytes = chunk.skip_begin as usize * record_size;
+            let skip_begin_bytes = frs_to_usize(chunk.skip_begin) * record_size;
             let effective_records = chunk.record_count - chunk.skip_begin - chunk.skip_end;
             if effective_records == 0 {
                 continue;
             }
 
-            let chunk_bytes = effective_records as usize * record_size;
+            let chunk_bytes = frs_to_usize(effective_records) * record_size;
 
             if use_direct_chunk_io {
                 // NVMe/SSD: Use chunk directly as one I/O operation (no splitting)
                 // This minimizes syscall overhead since there's no seek penalty
                 io_ops.push_back(IoOp {
-                    disk_offset: chunk.disk_offset + skip_begin_bytes as u64,
+                    disk_offset: chunk.disk_offset + usize_to_u64(skip_begin_bytes),
                     size: chunk_bytes,
                     start_frs: chunk.start_frs + chunk.skip_begin,
                 });
@@ -223,8 +213,9 @@ impl ParallelMftReader {
                 while offset_within_chunk < chunk_bytes {
                     let io_size = core::cmp::min(io_chunk_size, chunk_bytes - offset_within_chunk);
                     let records_in_io = io_size / record_size;
-                    let disk_offset =
-                        chunk.disk_offset + skip_begin_bytes as u64 + offset_within_chunk as u64;
+                    let disk_offset = chunk.disk_offset
+                        + usize_to_u64(skip_begin_bytes)
+                        + usize_to_u64(offset_within_chunk);
 
                     io_ops.push_back(IoOp {
                         disk_offset,
@@ -233,7 +224,7 @@ impl ParallelMftReader {
                     });
 
                     offset_within_chunk += io_size;
-                    frs_offset += records_in_io as u64;
+                    frs_offset += usize_to_u64(records_in_io);
                 }
             }
         }
@@ -245,7 +236,7 @@ impl ParallelMftReader {
             .map_or(total_records, crate::platform::MftBitmap::count_in_use);
 
         // Calculate total bytes to read and max I/O size for buffer allocation
-        let total_bytes_to_read: u64 = io_ops.iter().map(|op| op.size as u64).sum();
+        let total_bytes_to_read: u64 = io_ops.iter().map(|op| usize_to_u64(op.size)).sum();
         let max_io_size = io_ops
             .iter()
             .map(|op| op.size)
@@ -290,7 +281,7 @@ impl ParallelMftReader {
                 // Use `mut buffer` to apply fixup in-place (zero-copy optimization)
                 while let Ok(Some((mut buffer, start_frs, record_count))) = worker_rx.recv() {
                     for i in 0..record_count {
-                        let frs = start_frs + i as u64;
+                        let frs = start_frs + usize_to_u64(i);
 
                         // Check bitmap
                         if let Some(bm) = &worker_bitmap
@@ -374,8 +365,7 @@ impl ParallelMftReader {
                 // SAFETY: The pinned allocation remains in place while the I/O is in
                 // flight; this only projects a mutable reference without moving it.
                 let op_mut = unsafe { in_flight_op.as_mut().get_unchecked_mut() };
-                op_mut.overlapped.Anonymous.Anonymous.Offset = offset as u32;
-                op_mut.overlapped.Anonymous.Anonymous.OffsetHigh = (offset >> 32_u32) as u32;
+                set_overlapped_offset(&mut op_mut.overlapped, offset);
 
                 let overlapped_ptr = &raw mut op_mut.overlapped;
                 let read_size = op_mut.op.size;
@@ -464,7 +454,10 @@ impl ParallelMftReader {
                 let op_mut = unsafe { completed_op.as_mut().get_unchecked_mut() };
 
                 // Send buffer to workers (copy the data)
-                let Some(buffer_slice) = op_mut.buffer.as_slice().get(..bytes_transferred as usize)
+                let Some(buffer_slice) = op_mut
+                    .buffer
+                    .as_slice()
+                    .get(..u32_as_usize(bytes_transferred))
                 else {
                     // Unreachable: bytes_transferred ≤ allocated buffer size.
                     drop(tx);
@@ -475,7 +468,7 @@ impl ParallelMftReader {
                 };
                 let buffer_data = buffer_slice.to_vec();
                 let start_frs = op_mut.op.start_frs;
-                let record_count = bytes_transferred as usize / record_size;
+                let record_count = u32_as_usize(bytes_transferred) / record_size;
 
                 if tx
                     .send(Some((buffer_data, start_frs, record_count)))
@@ -510,9 +503,7 @@ impl ParallelMftReader {
                     // SAFETY: The pinned allocation remains in place while the I/O
                     // is in flight; this only projects a mutable reference.
                     let new_op_mut = unsafe { new_in_flight.as_mut().get_unchecked_mut() };
-                    new_op_mut.overlapped.Anonymous.Anonymous.Offset = offset as u32;
-                    new_op_mut.overlapped.Anonymous.Anonymous.OffsetHigh =
-                        (offset >> 32_u32) as u32;
+                    set_overlapped_offset(&mut new_op_mut.overlapped, offset);
 
                     let new_overlapped_ptr = &raw mut new_op_mut.overlapped;
                     let read_size = new_op_mut.op.size;

--- a/crates/uffs-mft/src/io/readers/pipelined.rs
+++ b/crates/uffs-mft/src/io/readers/pipelined.rs
@@ -2,15 +2,6 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Pipelined reader implementation.
-//!
-//! **Module-scoped cast justification:** `as usize` casts here convert NTFS
-//! disk offsets / read sizes (`u64`) and record sizes (`u32`) into `usize` for
-//! buffer slicing.  `usize` is ≥ 32 bits on every supported target; the u64
-//! values are physically bounded by the volume size (≤ 2⁶⁴ bytes).
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size casts are lossless on supported 32/64-bit targets"
-)]
 
 use super::prelude::*;
 
@@ -126,7 +117,7 @@ impl PipelinedMftReader {
             .sum();
 
         let estimated_records = self.bitmap.as_ref().map_or_else(
-            || self.extent_map.total_records() as usize,
+            || frs_to_usize(self.extent_map.total_records()),
             crate::platform::MftBitmap::count_in_use,
         );
 
@@ -142,7 +133,7 @@ impl PipelinedMftReader {
             .iter()
             .map(|chunk| chunk.record_count * u64::from(record_size))
             .max()
-            .unwrap_or(self.chunk_size as u64) as usize;
+            .map_or(self.chunk_size, frs_to_usize);
 
         let (reader_handle, rx) = spawn_pipelined_reader(
             handle,
@@ -168,7 +159,7 @@ impl PipelinedMftReader {
                 record_size: chunk_record_size,
             } = read_buffer;
 
-            bytes_read_total += bytes_read as u64;
+            bytes_read_total += usize_to_u64(bytes_read);
             parse_buffer_into_merger(
                 buffer.as_mut_slice(),
                 bytes_read,
@@ -287,7 +278,7 @@ impl PipelinedMftReader {
             .sum();
 
         let estimated_records = self.bitmap.as_ref().map_or_else(
-            || self.extent_map.total_records() as usize,
+            || frs_to_usize(self.extent_map.total_records()),
             crate::platform::MftBitmap::count_in_use,
         );
 
@@ -304,7 +295,7 @@ impl PipelinedMftReader {
             .iter()
             .map(|chunk| chunk.record_count * u64::from(record_size))
             .max()
-            .unwrap_or(self.chunk_size as u64) as usize;
+            .map_or(self.chunk_size, frs_to_usize);
 
         Some(PipelinedReadPlan {
             chunks,
@@ -363,7 +354,7 @@ where
 
     while let Ok(result) = rx.recv() {
         let read_buffer = result?;
-        bytes_read_total += read_buffer.bytes_read as u64;
+        bytes_read_total += usize_to_u64(read_buffer.bytes_read);
         all_buffers.push(read_buffer);
 
         if let Some(ref mut cb) = progress_callback {
@@ -421,9 +412,10 @@ fn read_chunk_into_buffer_static(
     let read_size = chunk.record_count * u64::from(record_size);
 
     // Align to sector boundary
-    let aligned_offset = (chunk.disk_offset / SECTOR_SIZE as u64) * SECTOR_SIZE as u64;
-    let offset_adjustment = (chunk.disk_offset - aligned_offset) as usize;
-    let aligned_size = (read_size as usize + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
+    let aligned_offset = (chunk.disk_offset / SECTOR_SIZE_U64) * SECTOR_SIZE_U64;
+    let offset_adjustment = frs_to_usize(chunk.disk_offset - aligned_offset);
+    let aligned_size =
+        (frs_to_usize(read_size) + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
 
     // Resize buffer if needed
     if buffer.len() < aligned_size {
@@ -465,7 +457,7 @@ fn read_chunk_into_buffer_static(
         return Err(MftError::Io(std::io::Error::last_os_error()));
     }
 
-    Ok(bytes_read as usize)
+    Ok(u32_as_usize(bytes_read))
 }
 
 /// Spawn the pipelined reader thread.
@@ -494,7 +486,11 @@ fn spawn_pipelined_reader(
     // `HANDLE` is not `Send`; ferry the raw pointer as `usize` and rebuild on
     // the worker side.  The pointer remains valid because the orchestrator
     // owns the underlying `VolumeHandle` for the duration of this call.
-    let handle_raw = handle.0 as usize;
+    // SAFETY-NOTE: handle.0 is `*mut c_void`; we serialise it as `usize` purely
+    // for cross-thread transport because `HANDLE` is `!Send`. The pointer is
+    // reconstructed on the worker thread and the underlying handle remains
+    // owned by the orchestrator for the full lifetime of this call.
+    let handle_raw = handle.0.expose_provenance();
 
     let join = thread::spawn(move || {
         let thread_handle = HANDLE(handle_raw as *mut core::ffi::c_void);
@@ -546,9 +542,9 @@ fn parse_buffer_into_merger(
     merge_extensions: bool,
     merger: &mut MftRecordMerger,
 ) {
-    let skip_begin = chunk.skip_begin as usize;
-    let effective_count = chunk.effective_record_count() as usize;
-    let record_size_usize = chunk_record_size as usize;
+    let skip_begin = frs_to_usize(chunk.skip_begin);
+    let effective_count = frs_to_usize(chunk.effective_record_count());
+    let record_size_usize = u32_as_usize(chunk_record_size);
 
     for i in 0..effective_count {
         let offset = (skip_begin + i) * record_size_usize;
@@ -560,7 +556,7 @@ fn parse_buffer_into_merger(
             break;
         }
 
-        let frs = chunk.start_frs + skip_begin as u64 + i as u64;
+        let frs = chunk.start_frs + usize_to_u64(skip_begin) + usize_to_u64(i);
 
         if !apply_fixup(record_slice) {
             continue;

--- a/crates/uffs-mft/src/io/readers/prefetch.rs
+++ b/crates/uffs-mft/src/io/readers/prefetch.rs
@@ -2,15 +2,6 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Prefetch reader implementation.
-//!
-//! **Module-scoped cast justification:** `as usize` casts here convert NTFS
-//! disk offsets / read sizes (`u64`) and record sizes (`u32`) into `usize` for
-//! buffer slicing.  `usize` is ≥ 32 bits on every supported target; the u64
-//! values are physically bounded by the volume size (≤ 2⁶⁴ bytes).
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size casts are lossless on supported 32/64-bit targets"
-)]
 
 use super::prelude::*;
 
@@ -89,7 +80,7 @@ impl PrefetchMftReader {
 
         // Estimate capacity
         let estimated_records = self.bitmap.as_ref().map_or_else(
-            || self.extent_map.total_records() as usize,
+            || frs_to_usize(self.extent_map.total_records()),
             crate::platform::MftBitmap::count_in_use,
         );
 
@@ -105,11 +96,13 @@ impl PrefetchMftReader {
         let mut bytes_read_total: u64 = 0;
 
         // Pre-allocate two buffers for double-buffering
-        let max_chunk_size = chunks
-            .iter()
-            .map(|chunk| chunk.record_count * u64::from(record_size))
-            .max()
-            .unwrap_or(self.chunk_size as u64) as usize;
+        let max_chunk_size = frs_to_usize(
+            chunks
+                .iter()
+                .map(|chunk| chunk.record_count * u64::from(record_size))
+                .max()
+                .unwrap_or_else(|| usize_to_u64(self.chunk_size)),
+        );
 
         let mut buffer_a = AlignedBuffer::new(max_chunk_size + SECTOR_SIZE);
         let mut buffer_b = AlignedBuffer::new(max_chunk_size + SECTOR_SIZE);
@@ -125,12 +118,12 @@ impl PrefetchMftReader {
             };
 
             let bytes_read = Self::read_chunk_into_buffer(handle, &chunk, record_size, buffer)?;
-            bytes_read_total += bytes_read as u64;
+            bytes_read_total += usize_to_u64(bytes_read);
 
             // Process records from buffer using zero-copy in-place fixup
-            let skip_begin = chunk.skip_begin as usize;
-            let effective_count = chunk.effective_record_count() as usize;
-            let record_size_usize = record_size as usize;
+            let skip_begin = frs_to_usize(chunk.skip_begin);
+            let effective_count = frs_to_usize(chunk.effective_record_count());
+            let record_size_usize = u32_as_usize(record_size);
             let buffer_slice = buffer.as_mut_slice();
 
             for i in 0..effective_count {
@@ -144,7 +137,7 @@ impl PrefetchMftReader {
                     break;
                 };
 
-                let frs = chunk.start_frs + skip_begin as u64 + i as u64;
+                let frs = chunk.start_frs + usize_to_u64(skip_begin) + usize_to_u64(i);
 
                 // Apply fixup in-place on the shared buffer (zero-copy)
                 if !apply_fixup(record_slice) {
@@ -194,10 +187,10 @@ impl PrefetchMftReader {
         let read_size = chunk.record_count * u64::from(record_size);
 
         // Align to sector boundary
-        let aligned_offset = (chunk.disk_offset / SECTOR_SIZE as u64) * SECTOR_SIZE as u64;
-        let offset_adjustment = (chunk.disk_offset - aligned_offset) as usize;
+        let aligned_offset = (chunk.disk_offset / SECTOR_SIZE_U64) * SECTOR_SIZE_U64;
+        let offset_adjustment = frs_to_usize(chunk.disk_offset - aligned_offset);
         let aligned_size =
-            (read_size as usize + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
+            (frs_to_usize(read_size) + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
 
         // Resize buffer if needed
         if buffer.len() < aligned_size {
@@ -230,6 +223,6 @@ impl PrefetchMftReader {
         // out-parameter.
         unsafe { ReadFile(handle, Some(read_slice), Some(&raw mut bytes_read), None) }?;
 
-        Ok(bytes_read as usize)
+        Ok(u32_as_usize(bytes_read))
     }
 }

--- a/crates/uffs-mft/src/io/readers/streaming.rs
+++ b/crates/uffs-mft/src/io/readers/streaming.rs
@@ -2,15 +2,6 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Streaming reader implementation.
-//!
-//! **Module-scoped cast justification:** `as usize` casts here convert NTFS
-//! disk offsets / read sizes (`u64`) and record sizes (`u32`) into `usize` for
-//! buffer slicing.  `usize` is ≥ 32 bits on every supported target; the u64
-//! values are physically bounded by the volume size (≤ 2⁶⁴ bytes).
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS disk-offset / record-size casts are lossless on supported 32/64-bit targets"
-)]
 
 use super::prelude::*;
 
@@ -86,7 +77,7 @@ impl StreamingMftReader {
 
         // Estimate capacity
         let estimated_records = self.bitmap.as_ref().map_or_else(
-            || self.extent_map.total_records() as usize,
+            || frs_to_usize(self.extent_map.total_records()),
             crate::platform::MftBitmap::count_in_use,
         );
 
@@ -103,12 +94,12 @@ impl StreamingMftReader {
         for chunk in chunks {
             // Read chunk into reusable buffer
             let bytes_read = self.read_chunk_into_buffer(handle, &chunk, record_size)?;
-            bytes_read_total += bytes_read as u64;
+            bytes_read_total += usize_to_u64(bytes_read);
 
             // Process records from buffer using zero-copy in-place fixup
-            let skip_begin = chunk.skip_begin as usize;
-            let effective_count = chunk.effective_record_count() as usize;
-            let record_size_usize = record_size as usize;
+            let skip_begin = frs_to_usize(chunk.skip_begin);
+            let effective_count = frs_to_usize(chunk.effective_record_count());
+            let record_size_usize = u32_as_usize(record_size);
             let buffer_slice = self.buffer.as_mut_slice();
 
             for i in 0..effective_count {
@@ -122,7 +113,7 @@ impl StreamingMftReader {
                     break;
                 };
 
-                let frs = chunk.start_frs + skip_begin as u64 + i as u64;
+                let frs = chunk.start_frs + usize_to_u64(skip_begin) + usize_to_u64(i);
 
                 // Apply fixup in-place on the shared buffer (zero-copy)
                 if !apply_fixup(record_slice) {
@@ -172,10 +163,10 @@ impl StreamingMftReader {
         let read_size = chunk.record_count * u64::from(record_size);
 
         // Align to sector boundary
-        let aligned_offset = (chunk.disk_offset / SECTOR_SIZE as u64) * SECTOR_SIZE as u64;
-        let offset_adjustment = (chunk.disk_offset - aligned_offset) as usize;
+        let aligned_offset = (chunk.disk_offset / SECTOR_SIZE_U64) * SECTOR_SIZE_U64;
+        let offset_adjustment = frs_to_usize(chunk.disk_offset - aligned_offset);
         let aligned_size =
-            (read_size as usize + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
+            (frs_to_usize(read_size) + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
 
         // Resize buffer if needed
         if self.buffer.len() < aligned_size {
@@ -208,6 +199,6 @@ impl StreamingMftReader {
         // out-parameter.
         unsafe { ReadFile(handle, Some(read_slice), Some(&raw mut bytes_read), None) }?;
 
-        Ok(bytes_read as usize)
+        Ok(u32_as_usize(bytes_read))
     }
 }

--- a/crates/uffs-mft/src/io/readers/zero_copy.rs
+++ b/crates/uffs-mft/src/io/readers/zero_copy.rs
@@ -2,14 +2,6 @@
 // Copyright (c) 2025-2026 SKY, LLC.
 
 //! Shared zero-copy buffer parsing helpers.
-//!
-//! **Module-scoped cast justification:** `as usize` casts here convert NTFS
-//! on-disk record sizes (`u32`) into `usize` for buffer slicing.  `usize` is
-//! ≥ 32 bits on every supported target.
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "NTFS record-size (u32 -> usize) casts are lossless on supported 32/64-bit targets"
-)]
 
 use super::prelude::*;
 
@@ -23,9 +15,9 @@ pub(super) fn parse_buffer_zero_copy_inner(
     record_size: u32,
     merge_extensions: bool,
 ) -> Vec<ParseResult> {
-    let skip_begin = chunk.skip_begin as usize;
-    let effective_count = chunk.effective_record_count() as usize;
-    let record_size_usize = record_size as usize;
+    let skip_begin = frs_to_usize(chunk.skip_begin);
+    let effective_count = frs_to_usize(chunk.effective_record_count());
+    let record_size_usize = u32_as_usize(record_size);
     let start_frs = chunk.start_frs;
 
     let mut results = Vec::with_capacity(effective_count);
@@ -36,7 +28,7 @@ pub(super) fn parse_buffer_zero_copy_inner(
             break;
         }
 
-        let frs = start_frs + skip_begin as u64 + i as u64;
+        let frs = start_frs + usize_to_u64(skip_begin) + usize_to_u64(i);
 
         let Some(record_slice) = buffer_slice.get_mut(offset..offset + record_size_usize) else {
             break;

--- a/crates/uffs-mft/src/lib.rs
+++ b/crates/uffs-mft/src/lib.rs
@@ -172,8 +172,8 @@ pub use flags::FileFlags;
 pub use index::{
     ChildInfo, FileRecord, IndexBuildTiming, IndexNameRef, IndexStreamInfo, LinkInfo, MftIndex,
     NO_ENTRY, ROOT_FRS, SizeInfo, StandardInfo, UsnApplyStats, bytes_to_mb_f64, f64_to_u64,
-    f64_to_usize, frs_to_usize, len_to_u16, len_to_u32, micros_to_i64, nonneg_to_u64, u32_as_usize,
-    u32_to_f64, u64_to_f64, usize_to_f64,
+    f64_to_usize, frs_to_usize, len_to_u16, len_to_u32, micros_to_i64, millis_to_u64, nanos_to_u64,
+    nonneg_to_u64, u32_as_usize, u32_to_f64, u64_to_f64, usize_to_f64, usize_to_u64,
 };
 // Re-export I/O types for advanced usage
 #[cfg(windows)]

--- a/crates/uffs-mft/src/ntfs/mod.rs
+++ b/crates/uffs-mft/src/ntfs/mod.rs
@@ -39,7 +39,7 @@ pub use self::metadata::{
 pub use self::records::{
     AttributeIterator, AttributeRecordHeader, AttributeRef, AttributeType, FILE_RECORD_MAGIC,
     FileRecordFlags, FileRecordSegmentHeader, INDX_RECORD_MAGIC, MultiSectorHeader,
-    NonResidentAttributeData, ResidentAttributeData, SECTOR_SIZE, apply_usa_fixup,
+    NonResidentAttributeData, ResidentAttributeData, SECTOR_SIZE, SECTOR_SIZE_U64, apply_usa_fixup,
     fixup_file_record,
 };
 

--- a/crates/uffs-mft/src/ntfs/records.rs
+++ b/crates/uffs-mft/src/ntfs/records.rs
@@ -18,6 +18,13 @@ pub const INDX_RECORD_MAGIC: u32 = 0x5844_4E49;
 /// Sector size (standard for NTFS).
 pub const SECTOR_SIZE: usize = 512;
 
+/// Sector size as `u64` for byte-offset arithmetic.
+///
+/// NTFS disk offsets are tracked as `u64`; aliasing the same compile-time
+/// constant in the wider integer type avoids `as u64` truncation casts at
+/// every alignment site without introducing runtime conversion.
+pub const SECTOR_SIZE_U64: u64 = 512;
+
 /// Multi-sector header present at the start of FILE and INDX records.
 ///
 /// Contains the Update Sequence Array (USA) used for sector-level

--- a/crates/uffs-mft/src/platform.rs
+++ b/crates/uffs-mft/src/platform.rs
@@ -30,6 +30,8 @@ pub use extents::MftExtent;
 pub use system::DriveType;
 // is_volume_read_only is available on all platforms (stub on non-Windows)
 pub use system::is_volume_read_only;
+#[cfg(windows)]
+pub(crate) use system::u32_size_of;
 // System memory query — available on all platforms
 pub use system::{SystemMemory, query_system_memory};
 #[cfg(windows)]

--- a/crates/uffs-mft/src/platform/system.rs
+++ b/crates/uffs-mft/src/platform/system.rs
@@ -9,11 +9,15 @@ use core::mem::size_of;
 /// Narrow u32 size-of helper for Win32 FFI sizing parameters.
 ///
 /// Every struct passed here is a small fixed-size Win32 type
-/// (`TOKEN_ELEVATION`, `MEMORYSTATUSEX`, `StoragePropertyQuery`, etc.) whose
-/// size is provably well under `u32::MAX`.  A saturating cast keeps the
-/// function total without introducing an `#[expect]` per call site.
+/// (`TOKEN_ELEVATION`, `MEMORYSTATUSEX`, `StoragePropertyQuery`,
+/// `UsnJournalDataV0`, etc.) whose size is provably well under
+/// `u32::MAX`.  A saturating cast keeps the function total without
+/// introducing an `#[expect]` per call site.
+///
+/// `pub(crate)` so the matching Win32 FFI const sites in `usn` can
+/// reuse the single centralized expect rather than declaring their own.
 #[cfg(windows)]
-const fn u32_size_of<T>() -> u32 {
+pub(crate) const fn u32_size_of<T>() -> u32 {
     // Saturating truncation: Win32 structs are always < u32::MAX bytes, so this
     // branch is unreachable in practice.
     if size_of::<T>() > u32::MAX as usize {
@@ -27,6 +31,7 @@ const fn u32_size_of<T>() -> u32 {
         size
     }
 }
+
 #[cfg(windows)]
 use std::path::{Path, PathBuf};
 

--- a/crates/uffs-mft/src/platform/volume.rs
+++ b/crates/uffs-mft/src/platform/volume.rs
@@ -214,13 +214,11 @@ impl VolumeHandle {
         let handle = match create_result {
             Ok(handle) => handle,
             Err(err) => {
-                // err.code().0 is an i32 holding an HRESULT; reinterpret as u32
-                // to compare against Win32 error codes (documented as u32).
-                #[expect(
-                    clippy::cast_sign_loss,
-                    reason = "HRESULT bit-pattern reinterpret for documented u32 error constants"
-                )]
-                let code_unsigned = err.code().0 as u32;
+                // `err.code().0` is an `i32` holding an HRESULT bit
+                // pattern; `i32::cast_unsigned` reinterprets the same
+                // bits as `u32` for comparison against documented Win32
+                // error constants (which Microsoft publishes as u32).
+                let code_unsigned = err.code().0.cast_unsigned();
                 if code_unsigned == 0x8007_0005 {
                     return Err(MftError::InsufficientPrivileges);
                 }
@@ -277,32 +275,30 @@ impl VolumeHandle {
         // (not available in NTFS_VOLUME_DATA_BUFFER).  Default to 0; callers
         // should use `query_ntfs_version()` if they need the actual version.
         //
-        // Every `i64 -> u64` cast below reinterprets an on-disk NTFS count
-        // (sector / cluster / LCN / length).  These fields are documented
-        // non-negative by the NTFS on-disk format and Microsoft's
-        // NTFS_VOLUME_DATA_BUFFER MSDN page, so the bit-level reinterpret is
-        // the correct and lossless conversion.
-        #[expect(
-            clippy::cast_sign_loss,
-            reason = "NTFS_VOLUME_DATA_BUFFER LARGE_INTEGER fields are non-negative by on-disk format spec"
-        )]
+        // Every `i64 -> u64` reinterpret below comes from an on-disk
+        // NTFS count (sector / cluster / LCN / length) that the NTFS
+        // on-disk format and Microsoft's `NTFS_VOLUME_DATA_BUFFER` MSDN
+        // page document as non-negative.  `i64::cast_unsigned` /
+        // `u64::cast_unsigned` are the stable Rust 1.87
+        // exact-bit-pattern converters that replace the previous
+        // `cast_sign_loss` expect.
         let volume_data = NtfsVolumeData {
-            volume_serial_number: buffer.VolumeSerialNumber as u64,
+            volume_serial_number: buffer.VolumeSerialNumber.cast_unsigned(),
             ntfs_major_version: 0,
             ntfs_minor_version: 0,
-            number_of_sectors: buffer.NumberSectors as u64,
-            total_clusters: buffer.TotalClusters as u64,
-            free_clusters: buffer.FreeClusters as u64,
-            total_reserved: buffer.TotalReserved as u64,
+            number_of_sectors: buffer.NumberSectors.cast_unsigned(),
+            total_clusters: buffer.TotalClusters.cast_unsigned(),
+            free_clusters: buffer.FreeClusters.cast_unsigned(),
+            total_reserved: buffer.TotalReserved.cast_unsigned(),
             bytes_per_sector: buffer.BytesPerSector,
             bytes_per_cluster: buffer.BytesPerCluster,
             bytes_per_file_record_segment: buffer.BytesPerFileRecordSegment,
             clusters_per_file_record_segment: buffer.ClustersPerFileRecordSegment,
-            mft_valid_data_length: buffer.MftValidDataLength as u64,
-            mft_start_lcn: buffer.MftStartLcn as u64,
-            mft2_start_lcn: buffer.Mft2StartLcn as u64,
-            mft_zone_start: buffer.MftZoneStart as u64,
-            mft_zone_end: buffer.MftZoneEnd as u64,
+            mft_valid_data_length: buffer.MftValidDataLength.cast_unsigned(),
+            mft_start_lcn: buffer.MftStartLcn.cast_unsigned(),
+            mft2_start_lcn: buffer.Mft2StartLcn.cast_unsigned(),
+            mft_zone_start: buffer.MftZoneStart.cast_unsigned(),
+            mft_zone_end: buffer.MftZoneEnd.cast_unsigned(),
         };
         Ok(volume_data)
     }

--- a/crates/uffs-mft/src/platform/volume.rs
+++ b/crates/uffs-mft/src/platform/volume.rs
@@ -23,6 +23,7 @@ use zerocopy::FromBytes as _;
 use super::bitmap::MftBitmap;
 use super::extents::{MftExtent, get_retrieval_pointers};
 use crate::error::{MftError, Result};
+use crate::index::{frs_to_usize, u32_as_usize};
 use crate::ntfs::NtfsBootSector;
 
 /// `FILE_READ_DATA` access right (0x0001) - required to read data from a
@@ -599,14 +600,6 @@ impl VolumeHandle {
         clippy::unnecessary_wraps,
         reason = "every failure branch returns `Ok(MftBitmap::new_all_valid(...))` (graceful fallback); the `Result<_>` signature documents the fallible Win32 call surface and aligns with `get_mft_bitmap` / `get_mft_bitmap_verbose` callers"
     )]
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "buffer / file-size arithmetic targets x86_64 Windows where `usize == u64`; bitmap is bounded by NTFS cluster_count * bytes_per_cluster which never exceeds `usize::MAX` on 64-bit pointers"
-    )]
-    #[expect(
-        clippy::cast_sign_loss,
-        reason = "`file_size` and `bytes_read` are returned by `GetFileSizeEx` / `ReadFile` and are never negative for the bitmap MFT record; the cast is documented at each use"
-    )]
     fn get_mft_bitmap_internal(&self, verbose: bool) -> Result<MftBitmap> {
         use windows::Win32::Storage::FileSystem::{
             FILE_BEGIN, GetFileSizeEx, ReadFile, SYNCHRONIZE, SetFilePointerEx,
@@ -650,9 +643,9 @@ impl VolumeHandle {
                         "CreateFileW for MFT bitmap failed; falling back to all-valid bitmap"
                     );
                 }
-                return Ok(MftBitmap::new_all_valid(
-                    self.estimated_record_count() as usize
-                ));
+                return Ok(MftBitmap::new_all_valid(frs_to_usize(
+                    self.estimated_record_count(),
+                )));
             }
         };
 
@@ -670,9 +663,9 @@ impl VolumeHandle {
                         "GetFileSizeEx for MFT bitmap failed; falling back to all-valid bitmap"
                     );
                 }
-                return Ok(MftBitmap::new_all_valid(
-                    self.estimated_record_count() as usize
-                ));
+                return Ok(MftBitmap::new_all_valid(frs_to_usize(
+                    self.estimated_record_count(),
+                )));
             }
         }
 
@@ -711,9 +704,9 @@ impl VolumeHandle {
                         "get_retrieval_pointers returned no MFT bitmap extents; falling back to all-valid bitmap"
                     );
                 }
-                return Ok(MftBitmap::new_all_valid(
-                    self.estimated_record_count() as usize
-                ));
+                return Ok(MftBitmap::new_all_valid(frs_to_usize(
+                    self.estimated_record_count(),
+                )));
             }
             Err(err) => {
                 if verbose {
@@ -723,15 +716,15 @@ impl VolumeHandle {
                         "get_retrieval_pointers for MFT bitmap failed; falling back to all-valid bitmap"
                     );
                 }
-                return Ok(MftBitmap::new_all_valid(
-                    self.estimated_record_count() as usize
-                ));
+                return Ok(MftBitmap::new_all_valid(frs_to_usize(
+                    self.estimated_record_count(),
+                )));
             }
         };
 
         let bytes_per_cluster = self.volume_data.bytes_per_cluster;
         let total_clusters: u64 = extents.iter().map(|ext| ext.cluster_count).sum();
-        let aligned_size = (total_clusters * u64::from(bytes_per_cluster)) as usize;
+        let aligned_size = frs_to_usize(total_clusters * u64::from(bytes_per_cluster));
         let mut buffer = vec![0_u8; aligned_size];
         let mut buffer_offset = 0_usize;
 
@@ -747,7 +740,7 @@ impl VolumeHandle {
 
         for (i, extent) in extents.iter().enumerate() {
             let byte_offset = extent.lcn * i64::from(bytes_per_cluster);
-            let extent_bytes = (extent.cluster_count * u64::from(bytes_per_cluster)) as usize;
+            let extent_bytes = frs_to_usize(extent.cluster_count * u64::from(bytes_per_cluster));
 
             if extent_bytes == 0 {
                 continue;
@@ -782,9 +775,9 @@ impl VolumeHandle {
                             "SetFilePointerEx for MFT bitmap extent failed; falling back to all-valid bitmap"
                         );
                     }
-                    return Ok(MftBitmap::new_all_valid(
-                        self.estimated_record_count() as usize
-                    ));
+                    return Ok(MftBitmap::new_all_valid(frs_to_usize(
+                        self.estimated_record_count(),
+                    )));
                 }
             }
 
@@ -801,9 +794,9 @@ impl VolumeHandle {
                         "MFT bitmap extent exceeds buffer size; falling back to all-valid bitmap"
                     );
                 }
-                return Ok(MftBitmap::new_all_valid(
-                    self.estimated_record_count() as usize
-                ));
+                return Ok(MftBitmap::new_all_valid(frs_to_usize(
+                    self.estimated_record_count(),
+                )));
             };
             // SAFETY: `self.handle` is a live volume handle, the slice points to
             // a contiguous writable region of `extent_bytes`, and `bytes_read`
@@ -824,16 +817,16 @@ impl VolumeHandle {
                             "ReadFile for MFT bitmap extent failed; falling back to all-valid bitmap"
                         );
                     }
-                    return Ok(MftBitmap::new_all_valid(
-                        self.estimated_record_count() as usize
-                    ));
+                    return Ok(MftBitmap::new_all_valid(frs_to_usize(
+                        self.estimated_record_count(),
+                    )));
                 }
             }
 
             if verbose && i < 3 {
                 tracing::info!(volume = %self.volume, extent_index = i, bytes_read, "Read MFT bitmap extent bytes");
                 if i == 0 && bytes_read > 0 {
-                    let sample_end = buffer_offset + 32.min(bytes_read as usize);
+                    let sample_end = buffer_offset + 32.min(u32_as_usize(bytes_read));
                     let sample: Vec<String> = buffer
                         .get(buffer_offset..sample_end)
                         .unwrap_or(&[])
@@ -849,7 +842,7 @@ impl VolumeHandle {
                 }
             }
 
-            buffer_offset += bytes_read as usize;
+            buffer_offset += u32_as_usize(bytes_read);
         }
 
         if verbose {
@@ -859,18 +852,19 @@ impl VolumeHandle {
                 file_size,
                 "Completed MFT bitmap read; truncating to reported file size"
             );
+            let file_size_usize = usize::try_from(file_size).unwrap_or(0);
             let all_ff = buffer
                 .iter()
-                .take(file_size as usize)
+                .take(file_size_usize)
                 .all(|&byte| byte == 0xFF);
             let all_00 = buffer
                 .iter()
-                .take(file_size as usize)
+                .take(file_size_usize)
                 .all(|&byte| byte == 0x00);
             tracing::info!(volume = %self.volume, all_ff, all_00, "Computed MFT bitmap byte-pattern summary");
         }
 
-        buffer.truncate(file_size as usize);
+        buffer.truncate(usize::try_from(file_size).unwrap_or(0));
         Ok(MftBitmap::from_bytes(buffer))
     }
 }

--- a/crates/uffs-mft/src/reader/persistence_capture.rs
+++ b/crates/uffs-mft/src/reader/persistence_capture.rs
@@ -7,18 +7,10 @@
 //! Both functions are `impl MftReader` methods that require a live volume
 //! handle.
 //!
-//! **Module-scoped cast justification:** All `as usize` casts in this file
-//! convert NTFS disk offsets / read sizes (`u64`) into `usize` indices for
-//! buffer slicing.  On every supported target `usize ≥ 64 bits`, so these
-//! conversions are lossless.  The underlying values are also physically bounded
-//! by the volume size (`u64`) which is the only addressable range.
-#![cfg_attr(
-    windows,
-    expect(
-        clippy::cast_possible_truncation,
-        reason = "NTFS disk-offset / read-size (u64 -> usize) casts are lossless on supported 64-bit targets"
-    )
-)]
+//! All `as usize` casts in this file go through the centralized
+//! `frs_to_usize` / `u32_as_usize` / `usize_to_u64` helpers so the NTFS
+//! disk-offset and record-size domain invariants stay encoded at the call
+//! site instead of in a module-scoped lint suppression.
 
 #[cfg(windows)]
 use std::path::Path;
@@ -30,6 +22,8 @@ use tracing::{debug, info};
 use super::MftReader;
 #[cfg(windows)]
 use crate::error::{MftError, Result};
+#[cfg(windows)]
+use crate::index::frs_to_usize;
 
 #[cfg(windows)]
 impl MftReader {
@@ -79,7 +73,7 @@ impl MftReader {
 
         let mut writer = StreamingRawMftWriter::new(path, record_size, options)?;
         let (tx, rx): (Sender<Vec<u8>>, Receiver<Vec<u8>>) = bounded(2);
-        let handle_ptr = vol_handle.raw_handle().0 as usize;
+        let handle_ptr = vol_handle.raw_handle().0.expose_provenance();
         let record_size_copy = record_size;
 
         let reader_handle = thread::spawn(move || -> Result<()> {
@@ -141,7 +135,7 @@ impl MftReader {
 
         let vol_handle = self.require_handle()?;
         let record_size = vol_handle.file_record_size();
-        let concurrency = options.concurrency as usize;
+        let concurrency = usize::from(options.concurrency);
 
         let (chunks, chunk_size) = plan_iocp_capture_chunks(vol_handle, self.volume, record_size);
         let num_chunks = chunks.len();
@@ -178,7 +172,7 @@ impl MftReader {
             .iter()
             .map(|chunk| chunk.record_count * u64::from(record_size))
             .max()
-            .unwrap_or(chunk_size as u64) as usize;
+            .map_or(chunk_size, frs_to_usize);
 
         // Don't sort chunks - we want to capture IOCP completion order
         let mut pending_chunks: VecDeque<crate::io::ReadChunk> = chunks.into_iter().collect();
@@ -424,17 +418,17 @@ fn record_completed_chunk(
     record_size: u32,
     writer: &mut crate::raw_iocp::IocpCaptureWriter,
 ) -> Result<()> {
-    use crate::io::SECTOR_SIZE;
+    use crate::io::SECTOR_SIZE_U64;
 
     let chunk = &op.chunk;
     let read_size = chunk.record_count * u64::from(record_size);
-    let aligned_offset = (chunk.disk_offset / SECTOR_SIZE as u64) * SECTOR_SIZE as u64;
-    let offset_adjustment = (chunk.disk_offset - aligned_offset) as usize;
+    let aligned_offset = (chunk.disk_offset / SECTOR_SIZE_U64) * SECTOR_SIZE_U64;
+    let offset_adjustment = frs_to_usize(chunk.disk_offset - aligned_offset);
 
     let data = op
         .buffer
         .as_slice()
-        .get(offset_adjustment..offset_adjustment + read_size as usize)
+        .get(offset_adjustment..offset_adjustment + frs_to_usize(read_size))
         .ok_or_else(|| {
             MftError::Io(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
@@ -483,18 +477,19 @@ unsafe fn issue_overlapped_read(
     use windows::Win32::Foundation::{ERROR_IO_PENDING, GetLastError};
     use windows::Win32::Storage::FileSystem::ReadFile;
 
-    use crate::io::{AlignedBuffer, OverlappedRead, SECTOR_SIZE};
+    use crate::io::{AlignedBuffer, OverlappedRead, SECTOR_SIZE, SECTOR_SIZE_U64};
 
     let buffer = AlignedBuffer::new(buffer_size);
     let mut op: Pin<Box<OverlappedRead>> =
         Box::pin(OverlappedRead::new(buffer, chunk, record_size, slot_idx));
 
-    let aligned_offset = (op.chunk.disk_offset / SECTOR_SIZE as u64) * SECTOR_SIZE as u64;
+    let aligned_offset = (op.chunk.disk_offset / SECTOR_SIZE_U64) * SECTOR_SIZE_U64;
     op.set_offset(aligned_offset);
 
     let read_size = op.chunk.record_count * u64::from(record_size);
-    let offset_adjustment = (op.chunk.disk_offset - aligned_offset) as usize;
-    let aligned_size = (read_size as usize + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
+    let offset_adjustment = frs_to_usize(op.chunk.disk_offset - aligned_offset);
+    let aligned_size =
+        (frs_to_usize(read_size) + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
 
     // SAFETY: `op` is a pinned Box with this thread as the sole writer; the
     // overlapped raw pointer is consumed before the second mutable reborrow.
@@ -547,17 +542,22 @@ fn streaming_capture_read_loop(
     use windows::Win32::Foundation::HANDLE;
     use windows::Win32::Storage::FileSystem::{FILE_BEGIN, ReadFile, SetFilePointerEx};
 
-    use crate::io::{AlignedBuffer, SECTOR_SIZE};
+    use crate::io::{AlignedBuffer, SECTOR_SIZE, SECTOR_SIZE_U64};
 
-    let handle = HANDLE(handle_ptr as *mut core::ffi::c_void);
+    // `handle_ptr` was produced by `expose_provenance()` on the original
+    // `HANDLE`'s raw pointer; round-trip via `with_exposed_provenance_mut`
+    // to recover the Win32 handle on the worker thread.
+    let handle = HANDLE(core::ptr::with_exposed_provenance_mut::<core::ffi::c_void>(
+        handle_ptr,
+    ));
     let mut buffer = AlignedBuffer::new(chunk_size + SECTOR_SIZE);
 
     for chunk in chunks {
         let read_size = chunk.record_count * u64::from(record_size);
-        let aligned_offset = (chunk.disk_offset / SECTOR_SIZE as u64) * SECTOR_SIZE as u64;
-        let offset_adjustment = (chunk.disk_offset - aligned_offset) as usize;
+        let aligned_offset = (chunk.disk_offset / SECTOR_SIZE_U64) * SECTOR_SIZE_U64;
+        let offset_adjustment = frs_to_usize(chunk.disk_offset - aligned_offset);
         let aligned_size =
-            (read_size as usize + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
+            (frs_to_usize(read_size) + offset_adjustment).div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
 
         if buffer.len() < aligned_size {
             buffer = AlignedBuffer::new(aligned_size);
@@ -595,7 +595,7 @@ fn streaming_capture_read_loop(
             return Err(MftError::Io(std::io::Error::last_os_error()));
         }
 
-        let actual_size = read_size as usize;
+        let actual_size = frs_to_usize(read_size);
         let data_slice = buffer
             .as_slice()
             .get(offset_adjustment..offset_adjustment + actual_size)

--- a/crates/uffs-mft/src/usn.rs
+++ b/crates/uffs-mft/src/usn.rs
@@ -219,7 +219,6 @@ pub use windows_impl::{query_usn_journal, read_targeted_frs_records, read_usn_jo
     reason = "FFI: Windows API calls (CreateFileW, DeviceIoControl, CloseHandle)"
 )]
 mod windows_impl {
-    use core::mem::size_of;
     use core::ptr;
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt as _;
@@ -235,6 +234,7 @@ mod windows_impl {
     use zerocopy::{FromBytes, Immutable, KnownLayout};
 
     use super::{UsnJournalInfo, UsnRecord};
+    use crate::platform::u32_size_of;
 
     /// Mirror of the Win32 `USN_JOURNAL_DATA_V0` struct populated by
     /// `FSCTL_QUERY_USN_JOURNAL`.  Field order and layout match the
@@ -310,17 +310,14 @@ mod windows_impl {
     }
 
     /// Size of a `UsnJournalDataV0` in bytes — always fits in `u32`.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "`UsnJournalDataV0` is a fixed-layout C struct of 56 bytes; the cast is compile-time bounded and required for the Win32 ioctl size argument"
-    )]
-    const USN_JOURNAL_DATA_V0_SIZE: u32 = size_of::<UsnJournalDataV0>() as u32;
+    ///
+    /// Routes the `usize -> u32` narrowing through the centralized
+    /// `u32_size_of` helper so the `cast_possible_truncation` expect
+    /// lives at one site (next to the Win32 FFI-sizing comment) rather
+    /// than at every Win32 ioctl const that needs the same bound.
+    const USN_JOURNAL_DATA_V0_SIZE: u32 = u32_size_of::<UsnJournalDataV0>();
     /// Size of a `ReadUsnJournalDataV0` in bytes — always fits in `u32`.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "`ReadUsnJournalDataV0` is a fixed-layout C struct of 40 bytes; the cast is compile-time bounded and required for the Win32 ioctl size argument"
-    )]
-    const READ_USN_JOURNAL_DATA_V0_SIZE: u32 = size_of::<ReadUsnJournalDataV0>() as u32;
+    const READ_USN_JOURNAL_DATA_V0_SIZE: u32 = u32_size_of::<ReadUsnJournalDataV0>();
 
     /// Open a `\\.\X:` volume handle with read access for USN-journal ioctls.
     fn open_volume_handle(volume: char) -> Result<HANDLE, std::io::Error> {

--- a/crates/uffs-text/src/case_fold.rs
+++ b/crates/uffs-text/src/case_fold.rs
@@ -94,18 +94,13 @@ impl CaseFold {
             let fallback = u16::try_from(cp).unwrap_or(0);
             self.table.get(cp as usize).copied().unwrap_or(fallback)
         } else {
-            // Non-BMP — no uppercase mapping; truncate to u16 is intentional:
-            // callers comparing two non-BMP chars will get the same low 16 bits
-            // for identical chars and almost certainly different bits for
-            // different chars. Full correctness for supplementary planes is
-            // deferred to i18n Phase 2.
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "non-BMP identity: only low 16 bits stored; acceptable for filename trigrams"
-            )]
-            {
-                cp as u16
-            }
+            // Non-BMP — no uppercase mapping; the documented behaviour
+            // is to keep only the low 16 bits as the trigram-bucket
+            // identity (full correctness for supplementary planes is
+            // deferred to i18n Phase 2).  `cp & 0xFFFF` is provably in
+            // u16 range, so the saturating `try_from` fallback is
+            // unreachable and the conversion is lint-free.
+            u16::try_from(cp & 0xFFFF).unwrap_or(0)
         }
     }
 


### PR DESCRIPTION
## Summary

13 surgical commits eliminating all file-level `#![expect(clippy::cast_*)]` blankets and ~80 % of per-line cast suppressions across the workspace.

| Metric | Before | After | Reduction |
|---|---|---|---|
| **File-level `#![expect(clippy::cast_*)]` blankets** | ~17 | **0** | **100 %** |
| **Per-line `#[expect(clippy::cast_*)]` attributes** | ~60 / 118 lint mentions | **12** / 20 mentions | **~80 %** |
| **Crates with zero cast suppressions** | 0 | **`uffs-daemon`, `uffs-diag`, `uffs-text`** | — |

## Bug-fixing discipline

- **No suppression hacks** — every removal is replaced with an idiomatic, lint-free alternative; no blanket `allow`, no disabled lints, no commented-out tests.
- **Surgical fixes** — minimal, focused edits at root cause (type choices, ownership, exact-bit-pattern reinterpret).
- **Behaviour preserved** — public API and observable behaviour unchanged; all changes carry regression tests where they touch semantics.
- **Tests strengthened, never dodged** — all 32 bloom, 17 cache::policy, 21 cache::shard, 18 uffs-text, 173 uffs-client, and 10 time_parsing tests pass after every commit.

## Techniques applied (in order of preference)

1. **`{u,i}NN::cast_signed` / `cast_unsigned`** (Rust 1.87 exact-bit-pattern reinterpret) for Win32 exit codes, IOCP errors, OVERLAPPED offsets, NTFS LCN, LARGE_INTEGER battery, numeric-top-N sort keys.
2. **`try_from(...).unwrap_or(saturating)`** with documented invariants for Hinnant calendar narrowings, Win32 PID, libc::ucred sizing, attribute flags, CLI concurrency, tm_gmtoff.
3. **Centralized helpers** (`len_to_u32`, `frs_to_usize`, `u32_as_usize`, `u32_size_of`, `bytes_to_mb_f64`, `u64_to_f64`, `usize_to_f64`, `f64_to_u64`).
4. **`u64::abs_diff`** for `|c − r|` magnitude in diag parity comparator.
5. **`u16::to_be_bytes()[1]`** for sort-key prefix low-byte extraction.
6. **Type refactors** — `SendHandle(usize)` instead of `isize`; `AtomicU32` instead of `AtomicUsize` for cross-thread Win32 error codes; `ptr::expose_provenance` / `with_exposed_provenance_mut` for cross-thread Win32 handles.

## Remaining 12 attrs — mathematically irreducible boundary

| Crate | Count | Where |
|---|---|---|
| `uffs-mft` | 6 | 5 centralized type-conversion helpers in `index/types.rs` + Win32 OVERLAPPED low-half + `u32_size_of` Win32 ioctl helper |
| `uffs-client` | 2 | `format::u64_to_f64` / `f64_to_u64` centralized helpers |
| `uffs-cli` | 2 | `u64_to_display_f64` + `compute_hit_rate_percent` display helpers |
| `uffs-core` | 1 | `Bloom::size_bytes` `const fn` (const-fn `try_from` not yet stable) |
| `uffs-time` | 1 | `filetime_to_calendar` `const fn` (const-fn `try_from` not yet stable) |

Each remaining attr is at a fundamental boundary: centralized helper (suppression *is* the documentation of intent), Win32 ABI calling convention, or `pub const fn` where `u32::try_from` is not yet const-stable.

## Verification

- `just lint-ci` clean on Linux — workspace clippy with `-D warnings`.
- `cargo xwin clippy --workspace --all-targets --all-features --target x86_64-pc-windows-msvc -- -D warnings` clean on Windows.
- All targeted unit-test suites green after every commit.

## Commits

```
86db42a48 refactor(cast-cleanup): replace Hinnant calendar cast expects with try_from / unwrap_or
f3eaee760 refactor(cast-cleanup): eliminate uffs-text non-BMP truncation + test FRS cast
1fdfffec5 refactor(cast-cleanup): route uffs-daemon EMA decay through u64_to_f64 / f64_to_u64
8b2274c7c refactor(cast-cleanup): route uffs-daemon TTL formulas through u64_to_f64 helper
0c2580383 refactor(cast-cleanup): route uffs-core bloom filter f64 sizing through centralized helpers
32741222c refactor(cast-cleanup): centralize Win32 size_of -> u32 cast via shared u32_size_of helper
d749a879b refactor(cast-cleanup): eliminate function-scoped cast expects in volume.rs + tm_gmtoff narrowing
380803210 refactor(cast-cleanup): route path_trie usize->u32 narrowings through len_to_u32 helper
6f2cada69 refactor(cast-cleanup): another 5 per-line cast suppressions removed via cast_signed / cast_unsigned
5c9eb4396 refactor(cast-cleanup): eliminate 12 more cast suppressions across uffs-{core,diag}
ce92438bc refactor(cast-cleanup): eliminate 14 more per-line cast suppressions across uffs-{cli,client,daemon,mft}
f3ce33584 refactor(uffs-mft): remove cast_* file-level blankets in commands/windows/* + persistence_capture + bench
b3e494647 refactor(uffs-mft): remove cast_* file-level blankets in io/readers/*
```
