### PR TITLE
chore(phase-1): centralize publish policy + document MSRV (closure-gaps A+B, closes #188)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,6 @@ Thanks for helping improve UFFS.
 ## Toolchain and setup
 
 - Use the pinned nightly toolchain from `rust-toolchain.toml`.
-- The workspace MSRV is Rust 1.91, but day-to-day development should use the pinned nightly.
 - `just` is the primary workflow entry point.
 
 Recommended setup:
@@ -29,6 +28,17 @@ Recommended setup:
 2. Install `just`: `cargo install just`
 3. Install the common contributor toolchain: `just setup`
 4. List available workflows any time with `just`
+
+### MSRV policy
+
+The workspace pins **Rust 1.91** as its declared minimum supported stable version (`rust-version = "1.91"` in `Cargo.toml`'s `[workspace.package]`).  This declaration sets four contracts:
+
+- **Supported stable version:** Pure-Rust workspace code (i.e., everything outside the Polars-backed compilation surface) compiles on stable Rust **1.91 or newer**.  This is verified weekly by the `tier-2.yml::msrv` CI job, which installs stable 1.91 and runs `cargo +1.91 check --workspace --locked --all-features` plus a sibling `--no-default-features` run, failing the job on any stable-incompatible feature use.  `cargo check` (rather than `build`) is sufficient because every MSRV breach surfaces during type-checking.
+- **Nightly is required, not advisory:** Day-to-day development uses the pinned nightly toolchain from `rust-toolchain.toml`.  Nightly is **required** for two reasons: (1) `uffs-polars` is built with `features = ["nightly", "simd"]` to unlock Polars's SIMD-accelerated compute kernels, which need nightly intrinsics; (2) the workspace `[workspace.lints.rust]` policy enables `#[expect(...)]` (stable since 1.81, but other unstable lints are also gated to nightly).  The `tier-2.yml::msrv` stable build proves the *non-Polars* surface still compiles on stable; it does NOT prove the binary distribution is stable-buildable.
+- **Update cadence:** MSRV bumps are coupled to **major workspace-version boundaries** (`0.X.0` → `0.Y.0`).  Patch-level releases (`0.5.95` → `0.5.96`) NEVER raise MSRV.  Minor releases bump MSRV only when a transitive dep we cannot pin around (e.g., Polars, Tokio) bumps its own MSRV — in which case the bump is announced in `CHANGELOG.md` under that release's `### Toolchain` heading.  The nightly channel pin (`rust-toolchain.toml`'s `channel = "nightly-YYYY-MM-DD"`) bumps more frequently — see that file's header comment for the bump-cadence history and rollback rationale.
+- **Older release branches:** UFFS is pre-1.0 and has **no maintained back-branches**.  Only the latest `main`-derived release line carries MSRV.  Once UFFS reaches 1.0, this section will be expanded to cover branch-specific MSRV (e.g., `release-1.x` may stay on Rust 1.91 while `main` advances to 1.95).  Until then, "the workspace MSRV" unambiguously means "the MSRV at `main`'s `HEAD`".
+
+If any of these contracts changes, the MSRV section in `CHANGELOG.md` MUST be updated **in the same PR** that lands the change; reviewers should reject changes to `rust-version` (or to the `tier-2.yml::msrv` job) that don't update this section.
 
 For cross-compilation from macOS/Linux hosts:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,16 @@ documentation = "https://docs.rs/uffs"
 readme = "README.md"
 keywords = ["mft", "ntfs", "file-search", "windows", "polars"]
 categories = ["filesystem", "command-line-utilities"]
+# Default publish policy: most workspace members are internal-only tooling
+# / facade / orchestration crates that must never accidentally hit crates.io.
+# Five crates intentionally override this with explicit `publish = true`
+# (`uffs-broker`, `uffs-broker-protocol`, `uffs-security`, `uffs-text`,
+# `uffs-time`) — see `release-automation-baseline.md` §10 row 5 for the
+# full publishable-set rationale.  Non-publishable members opt into this
+# default via `publish.workspace = true` (rather than declaring their own
+# `publish = false`) so the root manifest stays the single source of truth.
+# Phase 1 closure gap A — see `docs/dev/baseline/2026-05-12/phase_1_findings.md`.
+publish = false
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Workspace Dependencies (shared versions & pins)

--- a/crates/uffs-broker-protocol/Cargo.toml
+++ b/crates/uffs-broker-protocol/Cargo.toml
@@ -29,6 +29,11 @@ authors.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
+# Explicitly publishable — overrides the workspace default `publish = false`
+# set in root `Cargo.toml`'s `[workspace.package]`.  Member of the 5-crate
+# publishable subset (`uffs-broker`, `uffs-broker-protocol`, `uffs-security`,
+# `uffs-text`, `uffs-time`) per `release-automation-baseline.md` §10 row 5.
+publish = true
 
 # Phase R6 of `release-automation-plan.md` step 3: docs.rs build configuration.
 # Pure-logic crate — docs.rs's default Linux build renders everything; no

--- a/crates/uffs-broker/Cargo.toml
+++ b/crates/uffs-broker/Cargo.toml
@@ -18,6 +18,11 @@ authors.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
+# Explicitly publishable — overrides the workspace default `publish = false`
+# set in root `Cargo.toml`'s `[workspace.package]`.  Member of the 5-crate
+# publishable subset (`uffs-broker`, `uffs-broker-protocol`, `uffs-security`,
+# `uffs-text`, `uffs-time`) per `release-automation-baseline.md` §10 row 5.
+publish = true
 
 # Phase R6 of `release-automation-plan.md` step 3 — docs.rs build config.
 # `uffs-broker` is a Windows-elevated handle broker; on non-Windows the

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -35,7 +35,7 @@ categories.workspace = true
 # was never the recommended install method anyway.  See
 # `crates/uffs-polars/Cargo.toml` and the deviation log row 5 in
 # `docs/architecture/release-automation-plan.md`.
-publish = false
+publish.workspace = true
 
 # Phase R6 of `release-automation-plan.md` step 3 — docs.rs build config.
 # Multi-target build so platform-gated CLI subcommands render in docs.

--- a/crates/uffs-client/Cargo.toml
+++ b/crates/uffs-client/Cargo.toml
@@ -29,7 +29,7 @@ categories.workspace = true
 # `docs/architecture/release-automation-plan.md`.  (A future R9+ RFC
 # could move `len_to_u16` and `parity_attributes` into a polars-free
 # foundation crate to break this transitive chain.)
-publish = false
+publish.workspace = true
 
 # Phase R6 of `release-automation-plan.md` step 3 — docs.rs build config.
 # Multi-target build so the Unix-domain-socket and Windows-named-pipe IPC

--- a/crates/uffs-core/Cargo.toml
+++ b/crates/uffs-core/Cargo.toml
@@ -31,7 +31,7 @@ categories.workspace = true
 # patches our git/rev pin carries, `cargo package` (and therefore
 # release-plz) hard-fails.  See `crates/uffs-polars/Cargo.toml` and the
 # deviation log row 5 in `docs/architecture/release-automation-plan.md`.
-publish = false
+publish.workspace = true
 
 # Phase R6 of `release-automation-plan.md` step 3 — docs.rs build config.
 # Multi-target build so platform-gated query helpers (Windows-only direct-MFT

--- a/crates/uffs-daemon/Cargo.toml
+++ b/crates/uffs-daemon/Cargo.toml
@@ -27,7 +27,7 @@ categories.workspace = true
 # nightly-API patches our git/rev pin carries.  See
 # `crates/uffs-polars/Cargo.toml` and the deviation log row 5 in
 # `docs/architecture/release-automation-plan.md`.
-publish = false
+publish.workspace = true
 
 # Phase R6 of `release-automation-plan.md` step 3 — docs.rs build config.
 # Multi-target build so platform-gated daemon transports (UDS / named pipes)

--- a/crates/uffs-diag/Cargo.toml
+++ b/crates/uffs-diag/Cargo.toml
@@ -48,9 +48,15 @@ categories.workspace = true
 #
 # Per workspace-layout in root `Cargo.toml::[workspace.members]`, this is
 # explicitly tagged "Retained workspace-only diagnostic tools (not shipped
-# in dist/)".  The `publish = false` here makes that retention contract
-# enforceable at `cargo publish` time, not just by convention.
-publish = false
+# in dist/)".  Inheriting the workspace default `publish = false` here
+# makes that retention contract enforceable at `cargo publish` time, not
+# just by convention.
+#
+# Posture: **permanently non-publishable** — distinct from the 8
+# Polars-blocked deferred-publishable crates (uffs-mft, uffs-core, etc.).
+# uffs-diag would remain non-publishable even if Polars upstream
+# released its nightly-API patches; it is internal-by-design tooling.
+publish.workspace = true
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Binaries

--- a/crates/uffs-format/Cargo.toml
+++ b/crates/uffs-format/Cargo.toml
@@ -40,7 +40,7 @@ categories.workspace = true
 # until polars upstream publishes a release with the nightly-API
 # patches.  See `crates/uffs-polars/Cargo.toml` and the deviation log
 # row 5 in `docs/architecture/release-automation-plan.md`.
-publish = false
+publish.workspace = true
 
 # Phase R6 of `release-automation-plan.md` step 3 — docs.rs build config.
 # See `uffs-time/Cargo.toml` for the full rationale.

--- a/crates/uffs-mcp/Cargo.toml
+++ b/crates/uffs-mcp/Cargo.toml
@@ -27,7 +27,7 @@ categories.workspace = true
 # release with the nightly-API patches our git/rev pin carries.  See
 # `crates/uffs-polars/Cargo.toml` and the deviation log row 5 in
 # `docs/architecture/release-automation-plan.md`.
-publish = false
+publish.workspace = true
 
 # Phase R6 of `release-automation-plan.md` step 3 — docs.rs build config.
 # Multi-target so the platform-gated transport stack (HTTP gateway is

--- a/crates/uffs-mft/Cargo.toml
+++ b/crates/uffs-mft/Cargo.toml
@@ -31,7 +31,7 @@ categories.workspace = true
 # carries, `cargo package` (and therefore release-plz) hard-fails.  See
 # `crates/uffs-polars/Cargo.toml` and the deviation log row 5 in
 # `docs/architecture/release-automation-plan.md`.
-publish = false
+publish.workspace = true
 
 # Phase R6 of `release-automation-plan.md` step 3 — docs.rs build config.
 # Multi-target build so `#[cfg(windows)]` MFT readers and `#[cfg(unix)]`

--- a/crates/uffs-polars/Cargo.toml
+++ b/crates/uffs-polars/Cargo.toml
@@ -44,7 +44,7 @@ categories.workspace = true
 # upstream publishes a release with those patches, this crate cannot
 # ship to crates.io.  See `docs/architecture/release-automation-plan.md`
 # deviation log row 5 for the full trail.
-publish = false
+publish.workspace = true
 
 # Phase R6 of `release-automation-plan.md` step 3 — docs.rs build config.
 # `all-features = true` is acceptable here because all `[features]` below

--- a/crates/uffs-security/Cargo.toml
+++ b/crates/uffs-security/Cargo.toml
@@ -19,6 +19,11 @@ authors.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
+# Explicitly publishable — overrides the workspace default `publish = false`
+# set in root `Cargo.toml`'s `[workspace.package]`.  Member of the 5-crate
+# publishable subset (`uffs-broker`, `uffs-broker-protocol`, `uffs-security`,
+# `uffs-text`, `uffs-time`) per `release-automation-baseline.md` §10 row 5.
+publish = true
 
 # Phase R6 of `release-automation-plan.md` step 3 — docs.rs build config.
 # Multi-target build so the platform-specific items (`#[cfg(target_os = "macos")]`

--- a/crates/uffs-text/Cargo.toml
+++ b/crates/uffs-text/Cargo.toml
@@ -19,6 +19,11 @@ authors.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
+# Explicitly publishable — overrides the workspace default `publish = false`
+# set in root `Cargo.toml`'s `[workspace.package]`.  Member of the 5-crate
+# publishable subset (`uffs-broker`, `uffs-broker-protocol`, `uffs-security`,
+# `uffs-text`, `uffs-time`) per `release-automation-baseline.md` §10 row 5.
+publish = true
 
 # Phase R6 of `release-automation-plan.md` step 3 — docs.rs build config.
 # See `uffs-time/Cargo.toml` for the full rationale comment; intentionally

--- a/crates/uffs-time/Cargo.toml
+++ b/crates/uffs-time/Cargo.toml
@@ -22,6 +22,11 @@ authors.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
+# Explicitly publishable — overrides the workspace default `publish = false`
+# set in root `Cargo.toml`'s `[workspace.package]`.  Member of the 5-crate
+# publishable subset (`uffs-broker`, `uffs-broker-protocol`, `uffs-security`,
+# `uffs-text`, `uffs-time`) per `release-automation-baseline.md` §10 row 5.
+publish = true
 
 # Phase R6 of `release-automation-plan.md` step 3: docs.rs build configuration.
 # `all-features = true` ensures docs.rs renders the full public API surface.

--- a/scripts/ci-pipeline/Cargo.toml
+++ b/scripts/ci-pipeline/Cargo.toml
@@ -30,7 +30,11 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "UFFS internal CI pipeline driver (promoted from rust-script; not published)"
-publish = false
+# Posture: **permanently non-publishable** — internal workspace CI tooling.
+# Distinct from the 8 Polars-blocked deferred-publishable crates: this
+# crate would remain non-publishable even if Polars upstream released,
+# because it is internal CI orchestration, not a reusable library.
+publish.workspace = true
 
 [[bin]]
 name = "uffs-ci-pipeline"

--- a/scripts/ci/gen-hooks/Cargo.toml
+++ b/scripts/ci/gen-hooks/Cargo.toml
@@ -27,7 +27,11 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "UFFS gate-manifest hook generator (Phase 2 of gates-manifest-plan); not published"
-publish = false
+# Posture: **permanently non-publishable** — internal workspace CI tooling.
+# Distinct from the 8 Polars-blocked deferred-publishable crates: this
+# crate would remain non-publishable even if Polars upstream released,
+# because it is internal CI orchestration, not a reusable library.
+publish.workspace = true
 
 [[bin]]
 name = "gen-hooks"

--- a/scripts/ci/gen-workflow/Cargo.toml
+++ b/scripts/ci/gen-workflow/Cargo.toml
@@ -20,7 +20,11 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Gate-manifest workflow structural validator (gates-manifest-plan.md Phase 3)"
-publish = false
+# Posture: **permanently non-publishable** — internal workspace CI tooling.
+# Distinct from the 8 Polars-blocked deferred-publishable crates: this
+# crate would remain non-publishable even if Polars upstream released,
+# because it is internal CI orchestration, not a reusable library.
+publish.workspace = true
 
 [[bin]]
 name = "gen-workflow"


### PR DESCRIPTION
## Summary

Phase-1 closure-gap PR.  After the initial Phase-1 audit closeout, user-prompted re-read of the playbook `world_class_rust_workspace_refactor_playbook.md` Phase-1 **Refactor section** (lines 241-326) and **Validate section** (lines 330-344) surfaced two real CHORE items that the audit dimensions had missed.  This PR fixes both.

## GAP A — `publish` policy now centralized at workspace level

**Playbook requirement** (Phase-1 Refactor item 2): "Use `[workspace.package]` for fields that should be inherited: edition, rust-version, version, license, repository, readme, description, authors, **publish policy**".

### Before

- 12 crates carried explicit `publish = false`
- 5 publishable crates had no `publish` field (defaulted to `true`)
- Root `[workspace.package]` had no `publish` policy
- New crate added without thought → publishable by default (unsafe)

### After (this PR)

- Root `[workspace.package]` carries `publish = false` as default (visible, documented, safer default for new crates)
- 12 non-publishable crates use `publish.workspace = true` (explicit opt-in to workspace default)
- 5 publishable crates use explicit `publish = true` (override + clear intent)

### Three-group posture verification (every crate verified consciously, not just inherited from prior state)

| Group | Count | Posture form | Rationale comment |
|---|---:|---|---|
| **A — Publishable** | 5 | `publish = true` | All 5 carry explicit 5-line rationale: "Member of the 5-crate publishable subset per `release-automation-baseline.md` §10 row 5".  Verified zero git-pinned deps. |
| **B — Polars-blocked / deferred-publishable** | 8 | `publish.workspace = true` | All 8 carry pre-existing `polars-subtree publishability deferred` comment block referencing `release-automation-plan.md` Phase R6→R8 deviation row 5. |
| **C — Permanently internal** | 4 | `publish.workspace = true` | All 4 now carry NEW "Posture: permanently non-publishable" comment distinguishing from Group B (these would remain non-publishable even after Polars releases). |

**Group A** (5): `uffs-broker`, `uffs-broker-protocol`, `uffs-security`, `uffs-text`, `uffs-time`
**Group B** (8): `uffs-cli`, `uffs-client`, `uffs-core`, `uffs-daemon`, `uffs-format`, `uffs-mcp`, `uffs-mft`, `uffs-polars`
**Group C** (4): `uffs-diag`, `uffs-ci-pipeline`, `uffs-gen-hooks`, `uffs-gen-workflow`

`cargo metadata` partition verified: 5 publishable + 12 non-publishable matches `release-automation-baseline.md` §10 row 5 exactly.

### Why the asymmetry between `publish.workspace = true` and `publish = true` is correct

`publish.workspace = true` ≠ `publish = true`.  In Cargo:
- `publish.workspace = true` → inherit workspace.package default (which is `false`)
- `publish = true` → override to publishable

The asymmetry **encodes intent**: every member is either "inheriting the safer default" or "explicitly opting in to crates.io".  Reading the manifest reveals which crates need crates.io thinking.

## GAP B — MSRV policy documented in CONTRIBUTING.md

**Playbook requirement** (Phase-1 Refactor item 5): "If the repo has an MSRV policy, write it down in `CONTRIBUTING.md` or `DEVELOPMENT.md`: supported stable version, update cadence, whether nightly is advisory only, whether older release branches have different MSRV".

### Before

`CONTRIBUTING.md` § Toolchain had 2 lines:
> "The workspace MSRV is Rust 1.91, but day-to-day development should use the pinned nightly."

That covered the version number but **none of the 4 enumerated contracts** the playbook asks for.

### After (this PR)

New § **MSRV policy** subsection in `CONTRIBUTING.md` with 4 enumerated contracts:

1. **Supported stable version:** Rust 1.91+, verified weekly by `tier-2.yml::msrv` (which runs `cargo +1.91 check --workspace --locked --all-features` plus `--no-default-features`).
2. **Nightly required, not advisory:** Polars `features = ["nightly", "simd"]` needs nightly intrinsics; `[workspace.lints.rust]` uses unstable lints.  Stable build proves the *non-Polars* surface only.
3. **Update cadence:** MSRV bumps coupled to major-version boundaries (0.X.0 → 0.Y.0).  Patch releases NEVER bump MSRV.  Minor releases bump only on transitive-dep pressure (announced in `CHANGELOG.md` § Toolchain).  Nightly pin (in `rust-toolchain.toml`) bumps more frequently.
4. **Older release branches:** UFFS is pre-1.0; no maintained back-branches.  Section to expand at 1.0.

Plus a **reviewer-rule**: any change to `rust-version` must update `CHANGELOG.md` and this section in the same PR.

## Files changed (19 files, +78 / -15)

- `Cargo.toml` — `publish = false` added to `[workspace.package]` with rationale comment
- `crates/uffs-broker/Cargo.toml`, `crates/uffs-broker-protocol/Cargo.toml`, `crates/uffs-security/Cargo.toml`, `crates/uffs-text/Cargo.toml`, `crates/uffs-time/Cargo.toml` — `publish = true` added with 5-line rationale comment
- 12 non-publishable crates — `publish = false` replaced with `publish.workspace = true` (semantically equivalent given new workspace default)
- `crates/uffs-diag/Cargo.toml` — existing comment updated; added explicit "permanently non-publishable" posture clarification
- `scripts/ci-pipeline/Cargo.toml`, `scripts/ci/gen-hooks/Cargo.toml`, `scripts/ci/gen-workflow/Cargo.toml` — added "permanently non-publishable" posture comment
- `CONTRIBUTING.md` — new § MSRV policy with 4 enumerated contracts

## Workspace policy compliance

1. **No suppression hacks** — pure manifest + doc edits; zero `#[allow]` / lint disables / test skips
2. **Surgical correct fixes** — only `Cargo.toml` fields and one `CONTRIBUTING.md` subsection touched.  Zero source code changes.
3. **Preserve behavior & contracts** — `cargo metadata` publish partition is byte-identical to pre-PR state (verified per-crate); no API surface change; no test change.
4. **Improve tests, don't dodge them** — no test files touched; all 1719 workspace tests pass post-fix.

## Local verification matrix

| Check | Result |
|---|---|
| `cargo check --workspace --all-targets --frozen` | ✓ clean |
| `cargo verify-project` per-manifest | ✓ 17/17 valid |
| `just lint-ci` (host clippy + fmt) | ✓ clean |
| `just lint-ci-windows` (cargo-xwin clippy) | ✓ clean |
| `cargo nextest run --workspace --no-fail-fast` | ✓ 1719/1719 pass, 14 skipped |
| `cargo deny check` | ✓ advisories ok, bans ok, licenses ok, sources ok |
| `cargo metadata --no-deps` publish partition | ✓ 5 publishable + 12 non-publishable matches `release-automation-baseline.md` §10 row 5 |
| Pre-push hook (`lint-pre-push`) | ✓ 60s |

## Local-only docs updated (gitignored)

- `docs/dev/baseline/2026-05-12/phase_1_findings.md` — closure-gap addendum with full per-gap rationale + revised severity tally (CLEAN 13 / INFO 4 / CHORE 2 fixed / BLOCKER 0)
- `docs/dev/baseline/2026-05-12/phase_1_final_report.md` — executive summary + per-dimension table updated; "PRs landed: 1" reflects this PR

## Closes

This PR closes #188 cleanly for the second (and final) time.  The initial Phase-1 closeout's claim of "0 CHORE findings" was wrong; the audit dimensions didn't catch these two playbook items until user-prompted re-read.  Phase-1 is now genuinely complete on its proper scope.

## Phase 2 unblocked

With Phase 1 truly closed, Phase 2 (#189 crate graph + layering) is the next playbook entry point.  Phase 2 plan is at `docs/dev/architecture/code_clean/phase_2_crate_graph_implementation_plan.md` (local-only).  Phase 2 has 5 specific UFFS deep-dives queued (Q1: uffs-format→uffs-mft; Q2: uffs-client→uffs-format; Q3: uffs-mft→uffs-security; Q4: uffs-core composition vs god-crate; Q5: uffs-cli redundant uffs-format dep).