### PR TITLE
refactor(api): Phase 3b — field privacy / non_exhaustive / sealed-trait decisions (closes #190, #222)

### DIFF
--- a/crates/uffs-client/src/connect.rs
+++ b/crates/uffs-client/src/connect.rs
@@ -32,6 +32,23 @@ use crate::protocol::{RpcRequest, SearchParams};
 /// Uses boxed async I/O so the same struct works with Unix domain sockets
 /// (macOS/Linux) and named pipes (Windows) without generics leaking into
 /// the public API.
+///
+/// # Field discipline (Phase 3b §3.4)
+///
+/// All fields are **private**; the only way to construct a
+/// `UffsClient` is via one of the connection entry points
+/// ([`Self::connect`], [`Self::connect_with_args`], or — for tests —
+/// the `pub(crate)` `from_parts` / `from_parts_for_test`).  This
+/// protects two non-trivial invariants:
+///
+/// - The `reader` / `writer` halves both belong to the same IPC endpoint (a
+///   mismatched pair would silently corrupt RPCs).
+/// - `next_id` starts at `1` and is monotonically incremented by
+///   `Self::next_request_id`, preserving JSON-RPC's correlation guarantee.
+///
+/// # `#[non_exhaustive]` decision (Phase 3b §3.6)
+///
+/// **N/A** — no `pub` fields means future fields slot in transparently.
 pub struct UffsClient {
     /// Buffered reader for the IPC connection.
     reader: BufReader<Box<dyn tokio::io::AsyncRead + Unpin + Send>>,

--- a/crates/uffs-client/src/connect_sync.rs
+++ b/crates/uffs-client/src/connect_sync.rs
@@ -16,14 +16,16 @@
 
 use std::io::{BufRead as _, BufReader, Read, Write};
 
-use crate::daemon_ctl::{find_daemon_exe, pid_file_path, socket_path};
-use crate::daemon_spawn::{ElevationPolicy, resolve_elevation_policy, spawn_daemon};
+use crate::connect_sync_autostart::auto_start_daemon;
+use crate::daemon_ctl::{pid_file_path, socket_path};
+use crate::daemon_spawn::{ElevationPolicy, resolve_elevation_policy};
 use crate::error::ClientError;
 use crate::protocol::response::DaemonStatus;
 
 /// Synchronous thin client for the UFFS daemon.
 ///
-/// One request, one response, no event loop.
+/// One request, one response, no event loop.  Phase 3b decisions:
+/// see [`crate::connect::UffsClient`] (`deadline_guard` is sync-only).
 pub struct UffsClientSync {
     /// Buffered reader for the IPC socket.
     reader: BufReader<Box<dyn Read + Send>>,
@@ -689,111 +691,6 @@ impl Drop for DisarmOnDrop<'_> {
     }
 }
 
-// ── Auto-start daemon ───────────────────────────────────────────────
-
-/// Spawn the daemon binary if not already running.
-///
-/// Returns:
-/// * `Ok(Some(handle))` when this call spawned a fresh daemon — the handle lets
-///   the caller's retry loop poll for unexpected early exit.
-/// * `Ok(None)` when an existing daemon was already alive and no spawn
-///   happened, so there is nothing to poll.
-fn auto_start_daemon(
-    spawn_args: &[String],
-    policy: ElevationPolicy,
-) -> Result<Option<crate::daemon_child::DaemonChildHandle>, ClientError> {
-    let pid_path = pid_file_path();
-
-    // Check if daemon is already alive via PID file.
-    if pid_path.exists()
-        && crate::daemon_ctl::parse_pid_file(&pid_path)
-            .is_some_and(|(pid, _ts, _hash, _nonce)| is_process_alive(pid))
-    {
-        return Ok(None);
-    }
-    if pid_path.exists() {
-        // Stale PID file — clean up.
-        drop(std::fs::remove_file(&pid_path));
-        let sock = socket_path();
-        drop(std::fs::remove_file(&sock));
-    }
-
-    let daemon_exe = find_daemon_exe();
-    let str_args: Vec<&str> = spawn_args.iter().map(String::as_str).collect();
-    let handle = spawn_daemon(&daemon_exe, &str_args, policy)?;
-    Ok(Some(handle))
-}
-
-/// Check if a process is alive **and** is actually a `uffsd` daemon.
-///
-/// A bare `kill(pid, 0)` / `tasklist` check is insufficient because the OS
-/// can recycle PIDs.  A stale PID file whose PID was reused by an unrelated
-/// process would make us think the daemon is running, so we'd skip the spawn
-/// and then fail to connect (the socket never appears).
-///
-/// On **macOS** we use `ps -p <pid> -o comm=` to verify the process name.
-/// On **Linux** we read `/proc/<pid>/comm`.
-/// On **Windows** we check `tasklist` output for `uffsd`.
-fn is_process_alive(pid: u32) -> bool {
-    #[cfg(unix)]
-    {
-        // Cheap signal-zero check.  Unix PIDs fit in i32 by spec, so the
-        // saturating `try_from` fallback is unreachable in practice.
-        let pid_i32 = i32::try_from(pid).unwrap_or(i32::MAX);
-        // SAFETY: kill(pid, 0) only checks if a signal *could* be sent
-        // to the given PID — it does not actually deliver any signal.
-        // The pid comes from our own PID file (trusted input).
-        #[expect(unsafe_code, reason = "kill(pid, 0) is a safe existence check")]
-        let alive = unsafe { libc::kill(pid_i32, 0) } == 0;
-        if !alive {
-            return false;
-        }
-
-        // Process exists — verify it is actually uffsd.
-        is_daemon_process(pid)
-    }
-    #[cfg(not(unix))]
-    {
-        // Windows: `tasklist` filtered to our PID.
-        std::process::Command::new("tasklist")
-            .args(["/FI", &format!("PID eq {pid}"), "/NH"])
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
-            .output()
-            .is_ok_and(|output| {
-                let text = String::from_utf8_lossy(&output.stdout);
-                // tasklist prints  "uffsd.exe  <PID> ..." when the process matches.
-                // Verify both the PID and the executable name.
-                text.contains(&pid.to_string()) && text.contains("uffsd")
-            })
-    }
-}
-
-/// Verify that the process with `pid` is actually a `uffsd` daemon.
-#[cfg(unix)]
-fn is_daemon_process(pid: u32) -> bool {
-    // Linux: read /proc/<pid>/comm (fastest, no fork).
-    #[cfg(target_os = "linux")]
-    {
-        let comm_path = format!("/proc/{pid}/comm");
-        if let Ok(comm) = std::fs::read_to_string(&comm_path) {
-            return comm.trim() == "uffsd";
-        }
-    }
-
-    // macOS / fallback: use `ps -p <pid> -o comm=`.
-    std::process::Command::new("ps")
-        .args(["-p", &pid.to_string(), "-o", "comm="])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .is_ok_and(|output| {
-            let comm = String::from_utf8_lossy(&output.stdout);
-            // `ps -o comm=` prints the executable path or basename.
-            // Match if any path component is "uffsd".
-            comm.trim()
-                .rsplit('/')
-                .next()
-                .is_some_and(|name| name == "uffsd")
-        })
-}
+// Auto-start daemon helpers (`auto_start_daemon`, `is_process_alive`,
+// `is_daemon_process`) live in the sibling [`crate::connect_sync_autostart`]
+// module to keep this file under the 800-LOC policy ceiling.

--- a/crates/uffs-client/src/connect_sync_autostart.rs
+++ b/crates/uffs-client/src/connect_sync_autostart.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Auto-start daemon helpers for [`crate::connect_sync::UffsClientSync`].
+//!
+//! Extracted from `connect_sync.rs` to keep that file under the workspace
+//! 800-LOC policy ceiling.  The three helpers below are tightly coupled to
+//! one another (PID-file freshness → process liveness → daemon-identity
+//! verification) and only invoked by the sync client's reconnect loop.
+
+use crate::daemon_ctl::{find_daemon_exe, pid_file_path, socket_path};
+use crate::daemon_spawn::{ElevationPolicy, spawn_daemon};
+use crate::error::ClientError;
+
+/// Spawn the daemon binary if not already running.
+///
+/// Returns:
+/// * `Ok(Some(handle))` when this call spawned a fresh daemon — the handle lets
+///   the caller's retry loop poll for unexpected early exit.
+/// * `Ok(None)` when an existing daemon was already alive and no spawn
+///   happened, so there is nothing to poll.
+///
+/// # Errors
+///
+/// Propagates spawn failures from [`spawn_daemon`].
+pub(crate) fn auto_start_daemon(
+    spawn_args: &[String],
+    policy: ElevationPolicy,
+) -> Result<Option<crate::daemon_child::DaemonChildHandle>, ClientError> {
+    let pid_path = pid_file_path();
+
+    // Check if daemon is already alive via PID file.
+    if pid_path.exists()
+        && crate::daemon_ctl::parse_pid_file(&pid_path)
+            .is_some_and(|(pid, _ts, _hash, _nonce)| is_process_alive(pid))
+    {
+        return Ok(None);
+    }
+    if pid_path.exists() {
+        // Stale PID file — clean up.
+        drop(std::fs::remove_file(&pid_path));
+        let sock = socket_path();
+        drop(std::fs::remove_file(&sock));
+    }
+
+    let daemon_exe = find_daemon_exe();
+    let str_args: Vec<&str> = spawn_args.iter().map(String::as_str).collect();
+    let handle = spawn_daemon(&daemon_exe, &str_args, policy)?;
+    Ok(Some(handle))
+}
+
+/// Check if a process is alive **and** is actually a `uffsd` daemon.
+///
+/// A bare `kill(pid, 0)` / `tasklist` check is insufficient because the OS
+/// can recycle PIDs.  A stale PID file whose PID was reused by an unrelated
+/// process would make us think the daemon is running, so we'd skip the spawn
+/// and then fail to connect (the socket never appears).
+///
+/// On **macOS** we use `ps -p <pid> -o comm=` to verify the process name.
+/// On **Linux** we read `/proc/<pid>/comm`.
+/// On **Windows** we check `tasklist` output for `uffsd`.
+fn is_process_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        // Cheap signal-zero check.  Unix PIDs fit in i32 by spec, so the
+        // saturating `try_from` fallback is unreachable in practice.
+        let pid_i32 = i32::try_from(pid).unwrap_or(i32::MAX);
+        // SAFETY: kill(pid, 0) only checks if a signal *could* be sent
+        // to the given PID — it does not actually deliver any signal.
+        // The pid comes from our own PID file (trusted input).
+        #[expect(unsafe_code, reason = "kill(pid, 0) is a safe existence check")]
+        let alive = unsafe { libc::kill(pid_i32, 0) } == 0;
+        if !alive {
+            return false;
+        }
+
+        // Process exists — verify it is actually uffsd.
+        is_daemon_process(pid)
+    }
+    #[cfg(not(unix))]
+    {
+        // Windows: `tasklist` filtered to our PID.
+        std::process::Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .is_ok_and(|output| {
+                let text = String::from_utf8_lossy(&output.stdout);
+                // tasklist prints  "uffsd.exe  <PID> ..." when the process matches.
+                // Verify both the PID and the executable name.
+                text.contains(&pid.to_string()) && text.contains("uffsd")
+            })
+    }
+}
+
+/// Verify that the process with `pid` is actually a `uffsd` daemon.
+#[cfg(unix)]
+fn is_daemon_process(pid: u32) -> bool {
+    // Linux: read /proc/<pid>/comm (fastest, no fork).
+    #[cfg(target_os = "linux")]
+    {
+        let comm_path = format!("/proc/{pid}/comm");
+        if let Ok(comm) = std::fs::read_to_string(&comm_path) {
+            return comm.trim() == "uffsd";
+        }
+    }
+
+    // macOS / fallback: use `ps -p <pid> -o comm=`.
+    std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "comm="])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .is_ok_and(|output| {
+            let comm = String::from_utf8_lossy(&output.stdout);
+            // `ps -o comm=` prints the executable path or basename.
+            // Match if any path component is "uffsd".
+            comm.trim()
+                .rsplit('/')
+                .next()
+                .is_some_and(|name| name == "uffsd")
+        })
+}

--- a/crates/uffs-client/src/error.rs
+++ b/crates/uffs-client/src/error.rs
@@ -4,6 +4,19 @@
 //! Client error types.
 
 /// Errors that can occur when communicating with the daemon.
+///
+/// # `#[non_exhaustive]` decision (Phase 3b §3.6)
+///
+/// **Applied.**  The playbook explicitly calls error enums out as
+/// canonical `#[non_exhaustive]` candidates, and the practical cost
+/// here is zero: every external consumer in this workspace either
+/// uses `if let Some(ClientError::Variant { … }) = …` (which is
+/// already non-exhaustive by nature) or struct-literal-constructs a
+/// specific variant (which `#[non_exhaustive]` on the **enum** does
+/// not forbid — only on individual variants).  This unblocks adding
+/// new error variants without a major-version bump once `uffs-client`
+/// publishes.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
     /// Failed to connect to the daemon socket.

--- a/crates/uffs-client/src/lib.rs
+++ b/crates/uffs-client/src/lib.rs
@@ -13,6 +13,26 @@
 //! let results = client.search("*.rs").await?;
 //! let drives = client.drives().await?;
 //! ```
+//!
+//! ## API hygiene policy (Phase 3b §3.4 / §3.6 / §3.7)
+//!
+//! - **`protocol::*` wire DTOs / wire enums** — `pub` fields **are** the
+//!   contract (`serde` JSON keys 1:1; §3.4).  Kept exhaustive (§3.6): monorepo
+//!   deploys daemon + client together (no skew scenario), hundreds of
+//!   struct-literal construction sites, and the wire enums
+//!   (`SearchPredicateOp`, `SearchPayload`, `DaemonStatus`, …) are dispatch
+//!   enums where exhaustive `match` is the compile-time safety net.  Revisit
+//!   when this crate publishes externally.
+//! - **`schema::*` field-metadata DTOs / enums** — same field-discipline
+//!   reasoning as `protocol`; closed type-code enums by definition.
+//! - **`UffsClient` / `UffsClientSync`** — fields private, smart constructors
+//!   protect reader/writer pairing and `next_id` monotonicity invariants; sync
+//!   sibling adds the Windows `deadline_guard` watchdog-already-spawned
+//!   invariant.  See the focused decision record on `connect::UffsClient`.
+//! - **`ClientError`** — `#[non_exhaustive]` applied (the lone API attribute
+//!   change in Phase 3b); safe under both external usage patterns in
+//!   `uffs-cli`.
+//! - **§3.7** N/A — no `pub trait` declarations in this crate.
 
 // Suppress unused crate warnings for deps used in sub-modules
 use serde as _;
@@ -45,6 +65,10 @@ mod connect_logging;
 #[cfg(feature = "async")]
 mod connect_platform;
 pub mod connect_sync;
+/// Auto-start daemon helpers (`auto_start_daemon`, `is_process_alive`,
+/// `is_daemon_process`) — split off `connect_sync` to keep that file
+/// under the 800-LOC policy ceiling.
+pub(crate) mod connect_sync_autostart;
 /// Platform-specific `platform_connect` impls and the `rpc_deadline` helper.
 ///
 /// Split `impl` blocks live on [`connect_sync::UffsClientSync`];

--- a/crates/uffs-client/src/mcp_pid.rs
+++ b/crates/uffs-client/src/mcp_pid.rs
@@ -86,6 +86,22 @@ pub fn remove_mcp_pid_file() {
 }
 
 /// Parsed MCP server PID file.
+///
+/// # Field discipline (Phase 3b §3.4)
+///
+/// All fields are `pub` because this is a **parsed-data DTO** returned
+/// by [`parse_mcp_pid_file_full`] — callers read fields directly to
+/// render `uffs mcp status` output and to decide whether the running
+/// MCP server matches the requested transport / data sources.  No
+/// invariants are protected (the parse function is the validator).
+///
+/// # `#[non_exhaustive]` decision (Phase 3b §3.6)
+///
+/// **Kept exhaustive.**  The PID-file shape evolves only in lockstep
+/// with the writer functions ([`write_mcp_pid_file_with_transport`],
+/// [`write_mcp_pid_file_full`]) in this same module — there is no
+/// scenario where an external consumer reads a future version of the
+/// file that has fields the current `McpPidInfo` cannot represent.
 #[derive(Debug, Clone)]
 pub struct McpPidInfo {
     /// Process ID.

--- a/crates/uffs-client/src/protocol/aggregate_wire.rs
+++ b/crates/uffs-client/src/protocol/aggregate_wire.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Aggregation wire types — JSON-serialisable mirror of
+//! `uffs_core::aggregate::spec::AggregateSpec` and its result family.
+//!
+//! Extracted from `protocol/mod.rs` to keep that file under the workspace
+//! 800-LOC policy ceiling.  Re-exported from [`super`] so existing
+//! `uffs_client::protocol::AggregateSpecWire` import paths keep working.
+
+use serde::{Deserialize, Serialize};
+
+/// Wire format for a single aggregation specification.
+///
+/// This is the JSON-serializable form of
+/// `uffs_core::aggregate::spec::AggregateSpec`. It uses tagged-enum style for
+/// `kind` to make JSON schemas self-describing.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AggregateSpecWire {
+    /// The aggregation kind (e.g. `"count"`, `"terms"`, `"stats"`).
+    pub kind: String,
+    /// Optional label for this aggregation in the output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Field to aggregate on (required for most kinds except `"count"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    /// Maximum groups for terms aggregation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top: Option<u16>,
+    /// Bucket interval for histogram aggregation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interval: Option<u64>,
+    /// Calendar interval for date histogram (e.g. `"month"`, `"day"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calendar: Option<String>,
+    /// Range boundaries for range aggregation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub boundaries: Vec<u64>,
+    /// Metrics to compute per bucket/group.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub metrics: Vec<String>,
+    /// Preset name (when `kind` is `"preset"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preset: Option<String>,
+    /// Number of sample rows (top-hits) to attach per bucket.
+    /// `None` or absent means no samples.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample: Option<u8>,
+    /// Sort field for sample rows (e.g. `"size"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_sort: Option<String>,
+    /// Sort direction for sample rows.  `true` = descending (largest first).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sample_desc: Option<bool>,
+    /// Duplicate verification mode: `"first_bytes"`, `"sha256"`, or
+    /// absent/`"none"`.
+    ///
+    /// Only meaningful when `kind` is `"duplicates"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verify: Option<String>,
+    /// Byte count for `verify=first_bytes` mode (default: 4096).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verify_bytes: Option<u32>,
+}
+
+/// Wire format for an aggregate result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AggregateResultWire {
+    /// Label for this result.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// The result kind (mirrors the spec kind).
+    pub kind: String,
+    /// Field name (if applicable).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    /// Scalar value (for count/missing/distinct).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<u64>,
+    /// Scalar statistics (for stats kind).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stats: Option<StatsWire>,
+    /// Bucket rows (for `terms`/`histogram`/`date_histogram`/`range`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub buckets: Vec<BucketWire>,
+    /// Count of records beyond top-N (for terms).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub other_count: Option<u64>,
+    /// Total groups before truncation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_groups: Option<usize>,
+    /// Cursor token for the next page of buckets.
+    ///
+    /// Present only when the request included `page_size` and more
+    /// buckets remain beyond the current page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+    /// Whether the bucket values are exact (not approximate).
+    ///
+    /// `true` for all current implementations — reserved for future
+    /// sampling-based approximation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exact: Option<bool>,
+    /// Whether the result contains all distinct values.
+    ///
+    /// `true` when every group fits within `top` (i.e. `other_count == 0`).
+    /// `false` when the result was truncated and `other_count > 0`.
+    /// Absent for non-bucket results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub values_complete: Option<bool>,
+}
+
+/// Wire format for scalar statistics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatsWire {
+    /// Record count.
+    pub count: u64,
+    /// Sum of values.
+    pub sum: u64,
+    /// Minimum value.
+    pub min: u64,
+    /// Maximum value.
+    pub max: u64,
+    /// Average value.
+    pub avg: f64,
+    /// Waste bytes.
+    pub waste_bytes: u64,
+    /// Waste percentage.
+    pub waste_pct: f64,
+}
+
+/// Wire format for a single bucket row.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BucketWire {
+    /// Bucket key (display string).
+    pub key: String,
+    /// Record count in this bucket.
+    pub count: u64,
+    /// Total bytes in this bucket.
+    pub total_bytes: u64,
+    /// Total allocated bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_allocated: Option<u64>,
+    /// Average file size.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg_size: Option<f64>,
+    /// Share of total count (percentage).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub share_count: Option<f64>,
+    /// Share of total bytes (percentage).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub share_bytes: Option<f64>,
+    /// Sample rows (top-hits) — representative records from this bucket.
+    /// Empty when no `sample` was requested in the spec.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sample_rows: Vec<SampleRowWire>,
+    /// Drill-down predicates for re-querying this bucket's records.
+    /// Includes both the original query predicates and the bucket key.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub drilldown: Vec<DrilldownWire>,
+    /// Nested sub-aggregation bucket results (populated by nested rollups).
+    ///
+    /// When a rollup spec has a `sub` aggregation, each top-level bucket
+    /// contains the sub-aggregation's buckets here.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sub_buckets: Vec<Self>,
+    /// Whether this duplicate group has been content-verified.
+    ///
+    /// Only present for `kind="duplicates"` results with `verify != "none"`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub verified: bool,
+}
+
+/// Wire format for a sample row (top-hit) within a bucket.
+///
+/// Each entry represents one record from the bucket, projected onto a
+/// set of display fields (e.g. `name`, `size`, `modified`).  The daemon
+/// populates this from `uffs_core::aggregate::SampleRow` during
+/// `BucketRow → BucketWire` conversion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SampleRowWire {
+    /// Projected fields as key-value pairs (e.g. `"name" → "foo.rs"`).
+    pub fields: std::collections::HashMap<String, String>,
+    /// Sort key used for ordering (e.g. file size).  Absent when the
+    /// sample was collected without an explicit sort.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sort_key: Option<i64>,
+}
+
+/// Wire format for a drill-down predicate.
+///
+/// A client can re-issue a row-level search using the predicates
+/// attached to a bucket to retrieve the records behind it.  The
+/// `value` is a [`serde_json::Value`] so it naturally maps to JSON
+/// without an extra enum on the wire.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DrilldownWire {
+    /// Canonical field name (e.g. `"extension"`, `"drive"`, `"type"`).
+    pub field: String,
+    /// Comparison operator (e.g. `"eq"`, `"gte"`, `"in"`).
+    pub op: String,
+    /// Predicate value — string, number, or boolean.
+    pub value: serde_json::Value,
+}

--- a/crates/uffs-client/src/protocol/mod.rs
+++ b/crates/uffs-client/src/protocol/mod.rs
@@ -5,7 +5,12 @@
 //!
 //! These types define the wire format for IPC communication. Both
 //! `uffsd` (daemon) and `uffs` (CLI) both depend on this module.
+//!
+//! Phase 3b API-hygiene decisions for this module live at the crate
+//! root (see `crates/uffs-client/src/lib.rs`) since they are
+//! workspace-wide policy, not type-specific records.
 
+pub mod aggregate_wire;
 pub mod cli_args;
 mod cli_args_helpers;
 pub mod response;
@@ -15,6 +20,9 @@ pub mod search_params;
 #[cfg(test)]
 mod tests;
 
+pub use aggregate_wire::{
+    AggregateResultWire, AggregateSpecWire, BucketWire, DrilldownWire, SampleRowWire, StatsWire,
+};
 use serde::{Deserialize, Serialize};
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -590,200 +598,6 @@ impl Default for SearchParams {
     }
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// Aggregation wire types
-// ────────────────────────────────────────────────────────────────────────────
-
-/// Wire format for a single aggregation specification.
-///
-/// This is the JSON-serializable form of
-/// `uffs_core::aggregate::spec::AggregateSpec`. It uses tagged-enum style for
-/// `kind` to make JSON schemas self-describing.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct AggregateSpecWire {
-    /// The aggregation kind (e.g. `"count"`, `"terms"`, `"stats"`).
-    pub kind: String,
-    /// Optional label for this aggregation in the output.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
-    /// Field to aggregate on (required for most kinds except `"count"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub field: Option<String>,
-    /// Maximum groups for terms aggregation.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub top: Option<u16>,
-    /// Bucket interval for histogram aggregation.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub interval: Option<u64>,
-    /// Calendar interval for date histogram (e.g. `"month"`, `"day"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub calendar: Option<String>,
-    /// Range boundaries for range aggregation.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub boundaries: Vec<u64>,
-    /// Metrics to compute per bucket/group.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub metrics: Vec<String>,
-    /// Preset name (when `kind` is `"preset"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub preset: Option<String>,
-    /// Number of sample rows (top-hits) to attach per bucket.
-    /// `None` or absent means no samples.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sample: Option<u8>,
-    /// Sort field for sample rows (e.g. `"size"`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sample_sort: Option<String>,
-    /// Sort direction for sample rows.  `true` = descending (largest first).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sample_desc: Option<bool>,
-    /// Duplicate verification mode: `"first_bytes"`, `"sha256"`, or
-    /// absent/`"none"`.
-    ///
-    /// Only meaningful when `kind` is `"duplicates"`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub verify: Option<String>,
-    /// Byte count for `verify=first_bytes` mode (default: 4096).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub verify_bytes: Option<u32>,
-}
-
-/// Wire format for an aggregate result.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AggregateResultWire {
-    /// Label for this result.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
-    /// The result kind (mirrors the spec kind).
-    pub kind: String,
-    /// Field name (if applicable).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub field: Option<String>,
-    /// Scalar value (for count/missing/distinct).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<u64>,
-    /// Scalar statistics (for stats kind).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stats: Option<StatsWire>,
-    /// Bucket rows (for `terms`/`histogram`/`date_histogram`/`range`).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub buckets: Vec<BucketWire>,
-    /// Count of records beyond top-N (for terms).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub other_count: Option<u64>,
-    /// Total groups before truncation.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_groups: Option<usize>,
-    /// Cursor token for the next page of buckets.
-    ///
-    /// Present only when the request included `page_size` and more
-    /// buckets remain beyond the current page.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<String>,
-    /// Whether the bucket values are exact (not approximate).
-    ///
-    /// `true` for all current implementations — reserved for future
-    /// sampling-based approximation.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub exact: Option<bool>,
-    /// Whether the result contains all distinct values.
-    ///
-    /// `true` when every group fits within `top` (i.e. `other_count == 0`).
-    /// `false` when the result was truncated and `other_count > 0`.
-    /// Absent for non-bucket results.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub values_complete: Option<bool>,
-}
-
-/// Wire format for scalar statistics.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StatsWire {
-    /// Record count.
-    pub count: u64,
-    /// Sum of values.
-    pub sum: u64,
-    /// Minimum value.
-    pub min: u64,
-    /// Maximum value.
-    pub max: u64,
-    /// Average value.
-    pub avg: f64,
-    /// Waste bytes.
-    pub waste_bytes: u64,
-    /// Waste percentage.
-    pub waste_pct: f64,
-}
-
-/// Wire format for a single bucket row.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct BucketWire {
-    /// Bucket key (display string).
-    pub key: String,
-    /// Record count in this bucket.
-    pub count: u64,
-    /// Total bytes in this bucket.
-    pub total_bytes: u64,
-    /// Total allocated bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_allocated: Option<u64>,
-    /// Average file size.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub avg_size: Option<f64>,
-    /// Share of total count (percentage).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub share_count: Option<f64>,
-    /// Share of total bytes (percentage).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub share_bytes: Option<f64>,
-    /// Sample rows (top-hits) — representative records from this bucket.
-    /// Empty when no `sample` was requested in the spec.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub sample_rows: Vec<SampleRowWire>,
-    /// Drill-down predicates for re-querying this bucket's records.
-    /// Includes both the original query predicates and the bucket key.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub drilldown: Vec<DrilldownWire>,
-    /// Nested sub-aggregation bucket results (populated by nested rollups).
-    ///
-    /// When a rollup spec has a `sub` aggregation, each top-level bucket
-    /// contains the sub-aggregation's buckets here.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub sub_buckets: Vec<Self>,
-    /// Whether this duplicate group has been content-verified.
-    ///
-    /// Only present for `kind="duplicates"` results with `verify != "none"`.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub verified: bool,
-}
-
-/// Wire format for a sample row (top-hit) within a bucket.
-///
-/// Each entry represents one record from the bucket, projected onto a
-/// set of display fields (e.g. `name`, `size`, `modified`).  The daemon
-/// populates this from `uffs_core::aggregate::SampleRow` during
-/// `BucketRow → BucketWire` conversion.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SampleRowWire {
-    /// Projected fields as key-value pairs (e.g. `"name" → "foo.rs"`).
-    pub fields: std::collections::HashMap<String, String>,
-    /// Sort key used for ordering (e.g. file size).  Absent when the
-    /// sample was collected without an explicit sort.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sort_key: Option<i64>,
-}
-
-/// Wire format for a drill-down predicate.
-///
-/// A client can re-issue a row-level search using the predicates
-/// attached to a bucket to retrieve the records behind it.  The
-/// `value` is a [`serde_json::Value`] so it naturally maps to JSON
-/// without an extra enum on the wire.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DrilldownWire {
-    /// Canonical field name (e.g. `"extension"`, `"drive"`, `"type"`).
-    pub field: String,
-    /// Comparison operator (e.g. `"eq"`, `"gte"`, `"in"`).
-    pub op: String,
-    /// Predicate value — string, number, or boolean.
-    pub value: serde_json::Value,
-}
+// Aggregation wire types live in the sibling [`aggregate_wire`] module and are
+// re-exported at the top of this file.  Split off to keep `mod.rs` under the
+// 800-LOC policy ceiling.

--- a/crates/uffs-client/src/schema/mod.rs
+++ b/crates/uffs-client/src/schema/mod.rs
@@ -7,6 +7,29 @@
 //! columns, their types, aliases, display names, and aggregation capabilities.
 //! These are pure value types with zero polars dependency, suitable for use
 //! in both the thin CLI and the daemon.
+//!
+//! # Field / `#[non_exhaustive]` policy (Phase 3b §3.4 / §3.6)
+//!
+//! Every `pub struct` here (`FieldMeta`, `AggregateMeta`) is a
+//! **schema-metadata DTO** with `pub` fields by design — callers
+//! struct-literal-construct one entry per `FieldId` variant in
+//! `field_metadata::FIELD_META`.  Adding `#[non_exhaustive]` would
+//! force ~40 entries to be rewritten through a builder.
+//!
+//! Every `pub enum` here (`FieldId`, `Cardinality`, `FieldType`,
+//! `FieldAccess`, `SortDirection`) is **exhaustively matched** at
+//! hundreds of consumer sites — the exhaustiveness check is the
+//! compile-time guarantee that every field has display logic, every
+//! type has aggregation rules, every direction has a sort
+//! implementation, etc.  This is the playbook §3.6 "state-machine /
+//! dispatch enum" exception to applying `#[non_exhaustive]`.
+//!
+//! **Verdict:** Kept exhaustive workspace-wide; revisit when
+//! `uffs-client::schema` is split into an externally-publishable
+//! crate (today blocked by Polars dep on `FieldId` consumers in
+//! `uffs-core`).
+//!
+//! No `pub trait` declarations here, so §3.7 is **N/A**.
 
 pub mod field_metadata;
 #[cfg(test)]

--- a/crates/uffs-client/src/stdout_kind.rs
+++ b/crates/uffs-client/src/stdout_kind.rs
@@ -25,6 +25,17 @@
 //! per CLI invocation.
 
 /// Classification of the process's standard output destination.
+///
+/// # `#[non_exhaustive]` decision (Phase 3b §3.6)
+///
+/// **Kept exhaustive.**  The CLI's NUL-short-circuit / TTY-batching /
+/// pipe-default dispatch in [`crate::shmem::write_search_results`]
+/// and the daemon-side fast-path selector both `match` exhaustively
+/// over this enum — the compile-time exhaustiveness check is the
+/// safety net that guarantees every newly-added stdout destination
+/// (e.g. a future shared-memory transport) gets explicit handling at
+/// both call sites.  This is the playbook §3.6 "state-machine /
+/// dispatch enum" exception.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StdoutKind {
     /// Interactive terminal / console (TTY).

--- a/crates/uffs-core/src/aggregate/verify.rs
+++ b/crates/uffs-core/src/aggregate/verify.rs
@@ -30,6 +30,20 @@ use super::spec::DuplicateVerify;
 /// Each member in a [`DuplicateGroup`] is identified by `(record_idx,
 /// drive_ordinal)`. The implementor resolves this to a file path and reads the
 /// requested bytes.
+///
+/// # Sealed-trait decision (Phase 3b §3.7)
+///
+/// **Kept open** (not sealed).  This trait is a deliberate
+/// dependency-injection seam: the daemon supplies a production
+/// reader that resolves `(record_idx, drive_ordinal)` against the
+/// live `MftIndex` + drive registry, and the test suite supplies an
+/// in-memory mock reader.  Sealing the trait would force the mock
+/// implementations to live inside `uffs-core` (or behind a feature
+/// flag), undermining the test-isolation rationale that motivated
+/// the abstraction in the first place.  External crates may
+/// implement `FileReader` to plug in alternate I/O strategies
+/// (e.g. async readers, network-backed readers) without changes to
+/// `uffs-core`.
 pub trait FileReader {
     /// Read the first `count` bytes of the file identified by `(record_idx,
     /// drive_ordinal)`.

--- a/crates/uffs-core/src/lib.rs
+++ b/crates/uffs-core/src/lib.rs
@@ -39,6 +39,54 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! ## API hygiene policy (Phase 3b §3.4 / §3.6 / §3.7)
+//!
+//! `uffs-core` is the query-engine and aggregation crate (Layer 3
+//! per `docs/architecture/crate-graph.md`), consumed exclusively by
+//! `uffs-daemon`.  Its public surface — 69 `pub struct`, 35 `pub enum`,
+//! 1 `pub trait` — falls into four uniform categories with shared
+//! decisions:
+//!
+//! 1. **Aggregation specs & results** (`aggregate::spec::*`,
+//!    `aggregate::buckets::*`, `aggregate::duplicates::*`,
+//!    `aggregate::finalize::*`, `aggregate::accumulators::*`): builder-style
+//!    `pub`-field DTOs that the daemon constructs from incoming JSON wire
+//!    input.  Hundreds of struct-literal construction sites in handler /
+//!    facet-values / aggregate paths; a `#[non_exhaustive]` migration would
+//!    require introducing a typed builder for every spec type for marginal
+//!    benefit while the crate is Polars-blocked from publishing.  **Kept
+//!    exhaustive.**
+//!
+//! 2. **Search backend value types** (`search::backend::DisplayRow`,
+//!    `search::backend::DriveScopedRows`, `search::field::*`): canonical row
+//!    representations that the formatter and the daemon hold in memory.  `pub`
+//!    fields are the contract that `uffs-format::FormatRow` ↔ `DisplayRow` and
+//!    the parallel-writer fast path depend on.  **Kept exhaustive.**
+//!
+//! 3. **Compact-cache headers** (`compact::*`, `compact_cache::*`,
+//!    `compact_loader::*`, `compact_storage::*`): on-disk format contracts
+//!    paralleling the NTFS zerocopy types in `uffs-mft`. Field layout **is**
+//!    the cache file format; `pub` fields are non-negotiable.  **Kept
+//!    exhaustive.**
+//!
+//! 4. **Pattern / trigram / bloom / index-search** types: search- pipeline data
+//!    structures with `pub` constructor results. Same migration-cost rationale;
+//!    **kept exhaustive**.
+//!
+//! The 35 `pub enum` declarations are **state-machine / dispatch
+//! enums** (`FieldId`, `AggregateOp`, `BucketKind`, `SortDirection`,
+//! pattern AST nodes, etc.) consumed by hundreds of exhaustive `match`
+//! arms across `uffs-daemon`.  The compile-time exhaustiveness check
+//! is the safety net guaranteeing every variant has handling logic at
+//! every dispatch site — the playbook §3.6 "keep exhaustive" rule.
+//! **Kept exhaustive.**
+//!
+//! The single `pub trait` — [`aggregate::verify::FileReader`] — is
+//! the **dependency-injection point** between the daemon's real file
+//! reader and the test-side mock reader.  External impls are by
+//! design.  Sealing would defeat the trait's purpose.  **Kept open**
+//! (see the type-level decision record on `FileReader` itself).
 
 #![forbid(unsafe_code)]
 #![warn(clippy::all, clippy::pedantic)]

--- a/crates/uffs-format/src/column.rs
+++ b/crates/uffs-format/src/column.rs
@@ -20,6 +20,16 @@ use serde::{Deserialize, Serialize};
 ///
 /// 1:1 with `uffs_core::search::field::FieldId::ALL` — every variant
 /// here has an equally-named counterpart in core.
+///
+/// # `#[non_exhaustive]` decision (Phase 3b §3.6)
+///
+/// **Kept exhaustive.**  The exhaustive `match` in
+/// `uffs_core::output::display_rows::write_display_row_columns` is the
+/// compile-time safety net that guarantees every variant has display
+/// logic.  Marking this `#[non_exhaustive]` would force a wildcard
+/// arm (or `unreachable!()`), eliminating that guarantee.  When a new
+/// column is added, the missing-arm compile error in that match site
+/// is the desired feedback loop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OutputColumn {

--- a/crates/uffs-format/src/config.rs
+++ b/crates/uffs-format/src/config.rs
@@ -16,6 +16,26 @@ use crate::column::{OutputColumn, PARITY_COLUMN_ORDER};
 /// double-quote quote character, header row on, positive / negative
 /// boolean rendered as `"1"` / `"0"`).  The TZ offset defaults to the
 /// host's local timezone, matching the pre-unification CLI behaviour.
+///
+/// # Field discipline (Phase 3b §3.4)
+///
+/// All fields are `pub` because this is a **configuration DTO**:
+/// callers fill in the knobs they care about and rely on
+/// [`Default::default`] for the rest.  The builder methods
+/// ([`Self::with_columns`], [`Self::with_separator`], etc.) layer
+/// fluent ergonomics on top but never claim sole-constructor status.
+///
+/// # `#[non_exhaustive]` decision (Phase 3b §3.6)
+///
+/// **Kept exhaustive** for now.  Two workspace-internal call sites
+/// (`uffs_daemon::handler_blob::core_config_to_format` and
+/// `uffs_core::output::tests_format_parity`) struct-literal-construct
+/// this type; both live in the same monorepo and can be updated
+/// atomically.  When `uffs-format` graduates from its Polars-blocked
+/// state and becomes externally publishable
+/// (`docs/architecture/crate-graph.md` §5), revisit and add
+/// `#[non_exhaustive]` plus typed builder methods for the fields that
+/// today only have string-parsing builders.
 #[derive(Debug, Clone)]
 pub struct OutputConfig {
     /// Columns to output.

--- a/crates/uffs-format/src/footer.rs
+++ b/crates/uffs-format/src/footer.rs
@@ -35,6 +35,22 @@ use std::io::{self, Write};
 /// `uffs-daemon::handler` (fast path) can share the exact same struct.
 /// Borrowed slices / strs keep the type free of allocations — the
 /// footer writer only reads, never takes ownership.
+///
+/// # Field discipline (Phase 3b §3.4)
+///
+/// All three fields are `pub` because they are **required positional
+/// inputs** to [`write_legacy_drive_footer`].  A builder pattern would
+/// add lifetime-parameter friction (`DriveFooterContextBuilder<'a>`)
+/// without changing the required-vs-optional nature of any field.
+///
+/// # `#[non_exhaustive]` decision (Phase 3b §3.6)
+///
+/// **Kept exhaustive.**  This is a borrowed-data DTO whose three
+/// fields are all required arguments to the writer; future growth
+/// would mean a new required argument (which is a breaking change
+/// regardless of `#[non_exhaustive]`).  Both call sites
+/// (`uffs_cli::commands::output::parity::write_legacy_drive_footer`
+/// and `uffs_daemon::handler_blob`) live in the same workspace.
 #[derive(Debug, Clone, Copy)]
 pub struct DriveFooterContext<'a> {
     /// Drive letters the search targeted (e.g. `['C', 'D']`).  When

--- a/crates/uffs-format/src/row.rs
+++ b/crates/uffs-format/src/row.rs
@@ -23,6 +23,24 @@
 /// Every accessor must return in O(1) and without allocation — the
 /// formatter calls these per row on the hot path and the parallel
 /// writer relies on them being cheap enough to inline.
+///
+/// # Sealed-trait decision (Phase 3b §3.7)
+///
+/// **Kept open** (not sealed).  Two distinct crates impl this trait:
+///
+/// - `uffs_core::search::backend::DisplayRow` — the daemon's in-memory row
+///   (filename stored as an offset slice into `path` to avoid a per-row
+///   allocation).
+/// - `uffs_client::protocol::response::SearchRow` — the wire type the CLI
+///   receives over IPC (filename stored as a standalone `String` because the
+///   JSON wire format serialises it that way).
+///
+/// Sealing would prevent either of those impls or force both row
+/// types into `uffs-format`, which would invert the dependency
+/// direction codified in `docs/architecture/crate-graph.md`.  The
+/// trait deliberately stays open so consumers can plug their own row
+/// representation if they ever need to (e.g. a future Parquet-shaped
+/// row backend that avoids the JSON allocation entirely).
 pub trait FormatRow {
     /// Drive letter (e.g. `'C'`).
     fn drive(&self) -> char;

--- a/crates/uffs-mcp/src/handler/mod.rs
+++ b/crates/uffs-mcp/src/handler/mod.rs
@@ -74,6 +74,21 @@ enum ClientSlot {
 }
 
 /// The UFFS MCP server — wraps a daemon client and dispatches MCP requests.
+///
+/// # Field discipline (Phase 3b §3.4)
+///
+/// All fields are **private**; construction goes through one of
+/// [`Self::new`], [`Self::new_lazy`], [`Self::new_unconnected`], or
+/// the `pub(crate)` `Self::new_lazy_with_stats`.  This preserves
+/// the invariant that every server instance has a `ClientSlot`, a
+/// fresh `last_activity` epoch, and an `McpStats` shared handle —
+/// none of which a caller should be poking at directly.
+///
+/// # `#[non_exhaustive]` decision (Phase 3b §3.6)
+///
+/// **N/A** — no `pub` fields means there is nothing for callers to
+/// match exhaustively or struct-literal-construct from outside the
+/// crate.  Future fields slot in without any API impact.
 pub struct UffsMcpServer {
     /// Daemon connection strategy (active with `spawn_args`, or none).
     slot: ClientSlot,

--- a/crates/uffs-mcp/src/http.rs
+++ b/crates/uffs-mcp/src/http.rs
@@ -51,6 +51,21 @@ pub(crate) struct AppState {
 }
 
 /// Configuration for the HTTP gateway.
+///
+/// # Field discipline (Phase 3b §3.4)
+///
+/// All three fields are `pub` because this is a **configuration DTO**.
+/// `bind_addr` is a required parameter (no default that makes sense);
+/// `auth_token` is genuinely optional; `daemon_spawn_args` is a
+/// forwarded vector with no invariants to protect.
+///
+/// # `#[non_exhaustive]` decision (Phase 3b §3.6)
+///
+/// **Kept exhaustive.**  Same rationale as [`crate::McpConfig`] —
+/// `uffs-mcp` is a bin-dominant internal app and the construction
+/// sites all live in this crate's bins (`src/main.rs`,
+/// `src/bin/http_gateway.rs`) plus the test module below.  Revisit
+/// when / if `uffs-mcp` exposes an embedding API.
 pub struct HttpGatewayConfig {
     /// TCP bind address (e.g. `127.0.0.1:8080`).
     pub bind_addr: core::net::SocketAddr,

--- a/crates/uffs-mcp/src/lib.rs
+++ b/crates/uffs-mcp/src/lib.rs
@@ -152,6 +152,23 @@ use tracing::info;
 // ── Configuration ───────────────────────────────────────────────────
 
 /// Configuration for the MCP server.
+///
+/// # Field discipline (Phase 3b §3.4)
+///
+/// Both fields are `pub` because this is a **configuration DTO**.
+/// `daemon_spawn_args` is a forwarded `Vec<String>` (no invariants to
+/// protect); `idle_timeout_secs == 0` is the documented sentinel for
+/// "no timeout" and is validated at the call site, not in a setter.
+///
+/// # `#[non_exhaustive]` decision (Phase 3b §3.6)
+///
+/// **Kept exhaustive.**  `uffs-mcp` is a bin-dominant internal app
+/// (Layer 4 in `docs/architecture/crate-graph.md`), not externally
+/// consumed; the only struct-literal construction lives in this
+/// crate's own bin (`src/main.rs`) and tests.  If `uffs-mcp` ever
+/// publishes a library facade for embedding the MCP server in
+/// external apps, revisit and add `#[non_exhaustive]` plus an
+/// `McpConfigBuilder`.
 #[derive(Debug, Clone)]
 pub struct McpConfig {
     /// Extra CLI args forwarded to `uffs daemon run` when auto-starting

--- a/crates/uffs-mft/src/lib.rs
+++ b/crates/uffs-mft/src/lib.rs
@@ -46,6 +46,49 @@
 //! | `modified`   | `Datetime[μs]` | Modification timestamp         |
 //! | `accessed`   | `Datetime[μs]` | Access timestamp               |
 //! | `flags`      | `UInt16`       | Bit-packed attributes          |
+//!
+//! ## API hygiene policy (Phase 3b §3.4 / §3.6 / §3.7)
+//!
+//! The vast majority of `pub struct` declarations in this crate fall
+//! into one of three categories, each with a **uniform decision**:
+//!
+//! 1. **NTFS on-disk zerocopy types** (`#[repr(C, packed)]` +
+//!    `#[derive(FromBytes, Immutable, KnownLayout)]`): `MultiSectorHeader`,
+//!    `AttributeRecordHeader`, `ResidentAttributeData`,
+//!    `NonResidentAttributeData`, `FileRecordSegmentHeader`, `IndexHeader`,
+//!    `IndexRoot`, `StandardInformation`, `FileNameAttribute`,
+//!    `ExtendedStandardInfo`, `AttributeListEntry`, `ReparsePointHeader`,
+//!    `ReparseMountPointBuffer`, `NtfsBootSector`, IOCP capture headers, etc.
+//!    The field layout **is** the NTFS specification (or the IOCP capture file
+//!    contract); `pub` fields are non-negotiable.  `#[non_exhaustive]` would
+//!    forbid the very `MyHeader { … }` literals that the zerocopy decoder
+//!    helpers build by hand.  **Kept exhaustive.**
+//!
+//! 2. **Index / record DTOs** (`MftIndex`, `FileRecord`, `ChildInfo`,
+//!    `LinkInfo`, `SizeInfo`, `StandardInfo`, `IndexStreamInfo`,
+//!    `IndexNameRef`, `UsnApplyStats`, `IndexBuildTiming`, `ParseResult`,
+//!    `ParsedColumns`, `ParsedRecord`, `ReadChunk`, `RawMftHeader`,
+//!    `RawMftData`, etc.):  read-mostly value types consumed by `uffs-core` and
+//!    `uffs-daemon`.  Hundreds of struct-literal construction sites;
+//!    `#[non_exhaustive]` would require migrating each to a builder for
+//!    marginal benefit while the crate is Polars-blocked from publishing.
+//!    **Kept exhaustive.**
+//!
+//! 3. **Configuration option structs** (`LoadRawOptions`, `SaveRawOptions`,
+//!    `IocpCaptureOptions`):  `pub` fields are config knobs with
+//!    `Default::default()`; struct-literal construction is the natural API.
+//!    **Kept exhaustive** for the same migration-cost reason; revisit when the
+//!    crate publishes.
+//!
+//! The few `pub enum` declarations (`AttributeType`, `ReparseTag`,
+//! `DriveType`, `FileFlags`, etc.) are **closed type-code enums**
+//! defined by the NTFS specification — new variants only appear when
+//! Microsoft extends NTFS — and **state-machine / dispatch enums**
+//! that consumers exhaustively match.  Either category falls under
+//! the playbook §3.6 "keep exhaustive" rule.  **Kept exhaustive.**
+//!
+//! No `pub trait` declarations live in this crate, so the
+//! sealed-trait decision (§3.7) is **N/A**.
 
 #![warn(clippy::all, clippy::pedantic)]
 #![expect(


### PR DESCRIPTION
# Phase 3b — API hygiene

Continuation of the Phase 3 refactoring playbook.  Phase 3a (#221) curated module layout and removed dead code; this PR (Phase 3b) systematically audits and applies decisions for **field discipline**, **`#[must_use]` opportunities**, **`#[non_exhaustive]`**, and **sealed traits** across the five audit-target crates.

## Strategy: per-scope decision records, not per-item

Quantifying the audit load (84 + 69 = 153 structs; 10 + 35 = 45 enums in `uffs-mft` + `uffs-core` alone) made it clear per-item records would produce ~200 nearly-identical doc-comment blocks.  Execution therefore landed:

- **Crate-level policy** in `uffs-mft::lib.rs`, `uffs-core::lib.rs`, and `uffs-client::lib.rs`.
- **Type-level records** for genuine exceptions (`UffsClient` / `UffsClientSync` / `UffsMcpServer` private-field success stories; `FormatRow` + `FileReader` sealed-trait kept-open decisions).

## §3.4 outcome (per-crate)

| Crate | Decision strategy |
|---|---|
| `uffs-format` | 4 type records: `OutputConfig`, `DriveFooterContext` (pub fields = config / borrowed-data DTO); `OutputColumn` (exhaustive enum dispatch); `FormatRow` (sealed = open). |
| `uffs-mcp` | 3 type records: `McpConfig` + `HttpGatewayConfig` (pub fields = config DTO); `UffsMcpServer` (private fields + smart constructor). |
| `uffs-client` | Crate-level policy covering protocol DTOs, schema metadata, `UffsClient` / `UffsClientSync`, and `ClientError`. |
| `uffs-mft` | Crate-level policy covering 3 categories: NTFS zerocopy types (`#[repr(C, packed)]` + `FromBytes`), index / record DTOs, config option structs. |
| `uffs-core` | Crate-level policy covering 4 categories: aggregate specs/results, search backend value types, compact-cache headers, pattern / trigram / bloom data structures. |

## §3.5 outcome

779 `#[must_use]` attrs already present across the 5 audit crates.  Sub-phase audits visited every constructor / builder finalizer / validation result / getter and found **no missing candidates**.  Recorded "no fresh candidates" outcome.

## §3.6 outcome

**`ClientError`** (in `uffs-client::error`) is the **single new `#[non_exhaustive]` annotation** in Phase 3b.  Verified safe — both external consumers in `uffs-cli` use `if let Some(ClientError::X { … }) = …` or variant construction `ClientError::DaemonNeedsElevation { … }` (the enum-level `#[non_exhaustive]` doesn't forbid construction of `Variant { … }`).

All other enums kept exhaustive: closed type-code enums by NTFS spec (`uffs-mft`), state-machine / dispatch enums consumed by 100s of exhaustive `match` arms (`uffs-core`, `uffs-client::protocol`, `uffs-client::schema`), and config DTOs (`uffs-format`, `uffs-mcp`).

## §3.7 outcome

| Trait | Decision | Rationale |
|---|---|---|
| `uffs_format::FormatRow` | Kept open | Cross-crate impls: `uffs_client::protocol::response::SearchRow` (wire type) + `uffs_core::search::backend::DisplayRow` (in-memory daemon row).  Sealing would force both into `uffs-format` and invert the dependency graph. |
| `uffs_core::aggregate::verify::FileReader` | Kept open | Deliberate DI seam between the daemon's production reader and the test mock reader.  Sealing defeats the trait's purpose. |

## File splits (LOC discipline)

Two files were marginally over the 800-LOC policy threshold after doc additions and were split into cohesive siblings:

- **`connect_sync.rs` (800 → 696 LOC)**: `auto_start_daemon` / `is_process_alive` / `is_daemon_process` extracted to new sibling `connect_sync_autostart.rs`.  Cluster is tightly coupled (PID-file freshness → process liveness → daemon-identity verification) and only invoked by the sync client's reconnect loop.
- **`protocol/mod.rs` (793 → 603 LOC)**: aggregate wire DTOs (`AggregateSpecWire` / `AggregateResultWire` / `StatsWire` / `BucketWire` / `SampleRowWire` / `DrilldownWire`) extracted to new sibling `protocol/aggregate_wire.rs` and re-exported so existing `uffs_client::protocol::AggregateSpecWire` import paths keep working.

## Strict-lint posture

Honoured throughout:

- Zero new `#[allow(...)]` directives.
- No lint-disable flags.
- No `#[cfg(...)]` dead-code workarounds.
- Two intra-doc-link adjustments to replace private-item links with plain code spans (surgical, in-place).

## Verification

- `cargo check --workspace --all-targets`: 0 warnings
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`: 0 errors
- `cargo nextest run --workspace`: **1,710 / 1,710 pass**, 14 skipped
- File-size policy gate: green (no new `MISSING_EXCEPTION`)
- `just lint-prod` (CI gate): green

## Diff stats

`20 files changed, +668 / -308 net`.

Closes #190 (Phase 3 umbrella).
Closes #222 (Phase 3b follow-up).