### PR TITLE
fix(ci): close #209 fully — Design B (belt-and-suspenders) + Design C (relocate notify-failure)

### DIFF
--- a/.github/workflows/auto-rerun-transient.yml
+++ b/.github/workflows/auto-rerun-transient.yml
@@ -102,9 +102,16 @@ jobs:
     # already-retried runs.  The fork check is a belt-and-suspenders
     # measure — `rerun-failed-jobs` would 404 anyway, but failing
     # silently is cheaper than logging the rejection.
+    #
+    # We also gate on `conclusion == 'failure'` so this job is a
+    # strict no-op on the second `workflow_run` event the rerun
+    # itself fires (which has `conclusion = success` when the retry
+    # works).  That second event is consumed by `cleanup-stale-
+    # notification` below.
     if: >-
       github.repository_owner == 'skyllc-ai' &&
-      github.event.workflow_run.run_attempt < 2
+      github.event.workflow_run.run_attempt < 2 &&
+      github.event.workflow_run.conclusion == 'failure'
     permissions:
       actions: write
       contents: read
@@ -239,3 +246,109 @@ jobs:
             "/repos/${GH_REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs"
 
           printf '✅ Rerun dispatched.  See the workflow run page for the new attempt.\n'
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # cleanup-stale-notification — close auto-filed CI-failure issues whose
+  # underlying workflow run flipped back to green after a successful rerun.
+  #
+  # Why this exists:
+  #   The watched workflows (PR Fast CI, Tier 2 Nightly) embed their own
+  #   `notify-failure` job which fires inside the workflow run as soon as
+  #   any gate job fails — well before this `auto-rerun-transient`
+  #   workflow even sees the `workflow_run [completed]` event.  Property 3
+  #   of `gen-workflow/src/validate.rs` requires every gate to list
+  #   `notify-failure.needs:`, so we cannot simply delete those in-workflow
+  #   notifiers without restructuring the gates manifest.
+  #
+  #   Net effect: a transient failure briefly produces an open `ci-failure-*`
+  #   issue.  When the rerun (dispatched by the `rerun` job above) succeeds
+  #   and flips the run's conclusion to `success`, GitHub fires a second
+  #   `workflow_run [completed]` event with `run_attempt >= 2` and
+  #   `conclusion == 'success'`.  This job consumes that event and closes
+  #   the now-stale issue with a comment pointing at the green rerun.
+  #
+  #   The match key is the short SHA in the auto-filed issue's title
+  #   (`🔴 CI Failure: ... — <short_sha>`) compared against the
+  #   workflow_run's `head_sha`.  Per-workflow labels (`ci-failure-pr-fast`,
+  #   `ci-failure-tier-2`) make this O(1) issue-list scan.
+  #
+  # Genuine (non-transient) failures stay open because the `rerun` job
+  # finds no transient signature and never dispatches a retry, so the
+  # second `workflow_run` event with `conclusion == 'success'` never fires.
+  cleanup-stale-notification:
+    name: Close stale ci-failure issue after successful rerun
+    runs-on: ubuntu-22.04
+    if: >-
+      github.repository_owner == 'skyllc-ai' &&
+      github.event.workflow_run.run_attempt >= 2 &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      issues: write
+      contents: read
+    timeout-minutes: 3
+
+    steps:
+      - name: Close auto-filed issue if title matches this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          SERVER_URL: ${{ github.server_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          short_sha="${HEAD_SHA:0:7}"
+
+          # Map watched-workflow name → per-workflow ci-failure label.
+          # The mapping mirrors the labels emitted by each workflow's
+          # `notify-failure` job (see `pr-fast.yml`, `tier-2.yml`).
+          # CodeQL is intentionally absent — its workflow has no
+          # `notify-failure` job (advisory / `continue-on-error`).
+          case "${WORKFLOW_NAME}" in
+            "PR Fast CI")
+              label="ci-failure-pr-fast"
+              ;;
+            "🌙 UFFS Tier 2 Nightly CI")
+              label="ci-failure-tier-2"
+              ;;
+            *)
+              printf 'ℹ️  No notification-cleanup policy for workflow: %s\n' "${WORKFLOW_NAME}"
+              exit 0
+              ;;
+          esac
+
+          printf '🧹 Looking for stale `%s` issues whose title ends in `— %s` ...\n' \
+            "${label}" "${short_sha}"
+
+          # List open issues with the right label.  We filter client-side
+          # by title-suffix match against the short SHA — the search API's
+          # `in:title` qualifier matches anywhere in the title, but the
+          # short SHA is the title's literal suffix in every auto-filed
+          # notification, so an exact suffix match is more precise.
+          mapfile -t issue_nums < <(
+            gh issue list --repo "${GH_REPO}" \
+              --label "${label}" \
+              --state open \
+              --json number,title \
+              --jq ".[] | select(.title | endswith(\"— ${short_sha}\")) | .number"
+          )
+
+          if [[ "${#issue_nums[@]}" -eq 0 ]]; then
+            printf '✅ No stale `%s` issues found for commit %s.\n' "${label}" "${short_sha}"
+            exit 0
+          fi
+
+          rerun_url="${SERVER_URL}/${GH_REPO}/actions/runs/${RUN_ID}"
+
+          for n in "${issue_nums[@]}"; do
+            printf '   • closing issue #%s\n' "${n}"
+            gh issue close "${n}" \
+              --repo "${GH_REPO}" \
+              --comment "Auto-closed: the originally-failed CI run for commit \`${short_sha}\` was retried by the auto-rerun-transient workflow and **succeeded** — the failure was transient (HTTP 429 / network / runner setup). See the green [rerun](${rerun_url}). No code regression."
+          done
+
+          printf '✅ Closed %d stale `%s` issue(s) for commit %s.\n' \
+            "${#issue_nums[@]}" "${label}" "${short_sha}"


### PR DESCRIPTION
# Closes #209 (Design B + Design C)

Closes the pre-existing #209 triage of the auto-rerun-transient race condition.  Two commits land the full design space:

| Commit | Design | Scope |
|---|---|---|
| `33302ab3b` | **Design B** — belt-and-suspenders | Adds `cleanup-stale-notification` job to `auto-rerun-transient.yml` that auto-closes `ci-failure-*` issues when the rerun succeeds. |
| `114df6fe2` | **Design C** — structural fix | Moves `notify-failure` out of `pr-fast.yml` + `tier-2.yml` into a new `workflow_run`-triggered `ci-failure-notify.yml` that fires AFTER the auto-rerun-transient window.  Updates the `gen-workflow` validator + `check_gates_drift.sh` + `gates.toml` accordingly. |

## Why both?

#209's design matrix explicitly called Design B "belt-and-suspenders ... covers the case where a notify-failure issue was created before this refactor lands".  After Design C, transient failures never produce an issue in the first place — but the Design B cleanup remains as a defense-in-depth guard against any future code path that re-introduces synchronous notify behavior.

## Bug background

Three false-positive `ci-failure-pr-fast` issues in three days (#169, #206, #223), all caused by:

```
T+0     PR Fast CI attempt 1 starts
T+13min Tests job fails (flaky)
T+13min notify-failure fires synchronously → creates ci-failure-pr-fast issue ❌
T+13min workflow_run event fires
T+13min auto-rerun-transient.yml matches transient signature → calls rerun-failed-jobs
T+18min attempt 2 succeeds ✅
        (no automatic close-out — stale issue stays open)
```

After this PR:

```
T+0     PR Fast CI attempt 1 starts
T+13min Tests job fails (flaky)
T+13min workflow_run [completed] event fires
T+13min auto-rerun-transient.yml retries the failed job
T+13min ci-failure-notify.yml waits 60s, then checks status
T+14min status = in_progress (retry running) → skip notification
T+18min attempt 2 succeeds → second workflow_run [completed] event
T+18min auto-rerun-transient.yml::cleanup-stale-notification skips (no issue to close)
T+18min ci-failure-notify.yml checks status: conclusion = success → no notification
```

Net: **no issue ever opened** for the transient failure.

For a GENUINE failure (no transient signature → auto-rerun doesn't retry → attempt stays at 1, conclusion stays at failure):

```
T+0     PR Fast CI attempt 1 starts
T+13min Tests job fails (real regression)
T+13min auto-rerun-transient.yml scans logs, finds no transient signature → exits silently
T+13min ci-failure-notify.yml waits 60s, then checks status
T+14min status=completed, conclusion=failure, attempt=1 → file issue with note
        "auto-rerun-transient saw no transient signature in the failed-job logs →
         genuine failure on first attempt"
```

Same tracking-issue UX as before — just routed through a race-safe trigger.

## Files changed

| File | Lines | Change |
|---|---:|---|
| `.github/workflows/ci-failure-notify.yml` | +273 | NEW — Design C |
| `.github/workflows/auto-rerun-transient.yml` | +114 / -1 | Design B cleanup job (prev commit) |
| `.github/workflows/pr-fast.yml` | -58 / +12 | Removed in-workflow notify-failure |
| `.github/workflows/tier-2.yml` | -67 / +18 | Removed in-workflow notify-failure |
| `scripts/ci/gen-workflow/src/validate.rs` | -25 / +12 | Drop notify-failure.needs invariant + retire one unit test |
| `scripts/ci/check_gates_drift.sh` | -3 / +8 | Drop notify-failure from infra-jobs exempt list |
| `scripts/ci/gates.toml` | -3 / +11 | Update Property 3 docstring |
| `scripts/ci/gen-workflow/src/main.rs` | -2 / +6 | Update Property 3 module docstring |

## Strict-rule compliance

- **No suppression hacks** — zero new `#[allow(...)]`, no lint-disable, no `if: false` test skips.  The one retired unit test (`property3_detects_missing_notify_failure_needs`) verified an invariant that has been *intentionally removed* by the design — not a skip-to-pass.  Comment in `validate.rs:659-664` documents the rationale.
- **Surgical fixes** — each edit targets a specific consumer of the moved notify-failure jobs.  No incidental refactoring.
- **Behavior preserved where contractually unchanged** — issue title/body/label/dedupe schema match the original notify-failure jobs.  The intentional behavior change (notifications arrive after the 60-second rerun window) is the whole point of #209.
- **Tests improved, not dodged** — 32/32 gen-workflow unit tests pass (down from 33; the retired test was for a removed invariant).  Strengthened `WORKFLOW_FIXTURE` to match the trimmed `pr-fast.yml` so future tests don't drift.

## Verification

* `cargo test --manifest-path scripts/ci/gen-workflow/Cargo.toml`: 32/32 ✅
* `./scripts/ci/gen-workflow/target/debug/gen-workflow --check --verbose`: 4 properties green ✅
* `bash scripts/ci/check_gates_drift.sh`: 25 gates agree ✅
* `just lint-fast`: 8 gates green (fmt, file-size, typos, reuse, taplo, lint-ci, lint-prod, lint-tests) ✅