### PR TITLE
fix(ci): #209 Design C — relocate notify-failure to ci-failure-notify.yml

### DIFF
--- a/.github/workflows/ci-failure-notify.yml
+++ b/.github/workflows/ci-failure-notify.yml
@@ -1,0 +1,273 @@
+# SPDX-FileCopyright (c) 2025-2026 SKY, LLC.
+# SPDX-License-Identifier: MPL-2.0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ci-failure-notify — file a tracking issue when a watched workflow
+# concludes in failure AFTER `auto-rerun-transient.yml` has had its
+# chance to retry transient flakes.
+#
+# Why this lives outside `pr-fast.yml` / `tier-2.yml`:
+#
+#   The previous in-workflow `notify-failure` jobs fired synchronously
+#   as soon as any gate job failed — BEFORE the cross-workflow
+#   `auto-rerun-transient` listener could observe the failure and
+#   dispatch a retry.  Transient failures (HTTP 429, network blips,
+#   runner-setup faults) thus generated false-positive `ci-failure-*`
+#   issues that stayed open while the underlying CI run flipped back
+#   to green via the auto-rerun.  Recurrence pattern was ~1 false-
+#   positive issue every 1-2 days; see #209 for the full design
+#   rationale (Design C).
+#
+# How this design eliminates the race:
+#
+#   * Trigger is `workflow_run [completed]`, which fires AFTER the
+#     parent workflow has fully concluded.
+#   * The job sleeps 60s to allow `auto-rerun-transient.yml` to
+#     decide whether to dispatch a retry.  Auto-rerun typically
+#     takes ~10-30s to inspect failed-job logs and either dispatch
+#     the rerun or exit silently; 60s gives a comfortable margin.
+#   * Then it re-fetches the run's status via the Actions REST API:
+#     - `status == 'in_progress'` → a retry was dispatched and is
+#        running → SKIP notification (the next `workflow_run
+#        [completed]` event will re-decide).
+#     - `status == 'completed'` + `conclusion == 'success'` →
+#        auto-rerun fixed the transient failure → SKIP notification.
+#     - `status == 'completed'` + `conclusion == 'failure'` →
+#        either a real failure (no transient signature matched) or
+#        the retry also failed → FILE / UPDATE tracking issue.
+#
+# Coverage:
+#
+#   * "PR Fast CI"               → label `ci-failure-pr-fast`
+#   * "🌙 UFFS Tier 2 Nightly CI" → label `ci-failure-tier-2`
+#   * "🔍 CodeQL (Rust SAST)" is intentionally NOT covered — it uses
+#     `continue-on-error: true` (advisory job) and its transient
+#     failures are absorbed by `auto-rerun-transient.yml` without
+#     ever surfacing as `conclusion == 'failure'`.
+#
+# Release pipeline (`release.yml`) keeps its own in-workflow
+# notify-failure job because:
+#
+#   1. It's not in `auto-rerun-transient.yml`'s watched list (release
+#      failures are not transient-retryable by design — every step
+#      mutates published state).
+#   2. Release failures need immediate human attention; a 60s delay
+#      is unwanted.
+#
+# Permissions:
+#
+#   * `actions: read`  — required to call GET /repos/.../actions/runs/<id>.
+#   * `contents: read` — implicit (issue body links to commits).
+#   * `issues: write`  — required to create / comment on / update issues.
+
+name: 🔔 CI Failure Notify
+
+on:
+  workflow_run:
+    workflows:
+      - "PR Fast CI"
+      - "🌙 UFFS Tier 2 Nightly CI"
+    types: [completed]
+
+# Default to ZERO permissions; the single job below grants only what
+# it needs.  Matches the least-privilege pattern used in every other
+# UFFS workflow.
+permissions: {}
+
+# Serialise per watched run so two near-simultaneous workflow_run
+# events (e.g. rapid push series or rerun completion racing with
+# initial completion) don't race on inspecting / notifying the same
+# run.  Keyed on the triggering run's id, NOT this workflow's ref,
+# so concurrent decisions for DIFFERENT runs proceed in parallel.
+concurrency:
+  group: ci-failure-notify-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    name: Open / update tracking issue for genuine failure
+    runs-on: ubuntu-22.04
+    # Filter on:
+    #   * fork PRs: their `workflow_run` events land in the base
+    #     repo but with `head_repository != repository` and we
+    #     deliberately don't notify on them (the fork author sees
+    #     their own failures in the PR checks UI).
+    #   * pull_request events: PR authors see their own failures
+    #     directly; tracking issues are only for main-branch
+    #     pushes and scheduled runs.
+    #   * conclusion: only failed runs trigger this workflow's
+    #     notify path (success runs already mean no notification
+    #     is needed, even if a transient signature was matched).
+    if: >-
+      github.repository_owner == 'skyllc-ai' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event != 'pull_request'
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    timeout-minutes: 5
+
+    steps:
+      - name: Wait for auto-rerun-transient.yml decision window
+        # auto-rerun-transient takes ~10-30s end-to-end:
+        #   * `gh api .../jobs?filter=latest`         ~1-2s
+        #   * per-job log fetch + grep                ~2-5s per job
+        #   * `POST .../rerun-failed-jobs` (if any)   ~1-2s
+        # 60s gives a comfortable margin and absorbs occasional
+        # GitHub-API latency spikes.
+        run: sleep 60
+
+      - name: Re-check workflow run status after auto-rerun window
+        id: status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          run_json="$(gh api "/repos/${GH_REPO}/actions/runs/${RUN_ID}")"
+          attempt="$(printf '%s' "$run_json" | jq -r '.run_attempt')"
+          status="$(printf '%s' "$run_json" | jq -r '.status')"
+          conclusion="$(printf '%s' "$run_json" | jq -r '.conclusion // "null"')"
+
+          printf 'Run %s — attempt=%s status=%s conclusion=%s\n' \
+            "${RUN_ID}" "${attempt}" "${status}" "${conclusion}"
+
+          {
+            echo "attempt=${attempt}"
+            echo "status=${status}"
+            echo "conclusion=${conclusion}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to notify
+        id: decide
+        env:
+          STATUS: ${{ steps.status.outputs.status }}
+          CONCLUSION: ${{ steps.status.outputs.conclusion }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Case 1: the run is still in_progress.  A retry is running;
+          # the next `workflow_run [completed]` event will re-decide.
+          if [[ "${STATUS}" != "completed" ]]; then
+            printf '⏳ Run is still %s; deferring to the next [completed] event.\n' "${STATUS}"
+            echo "notify=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Case 2: the run completed with success (rerun fixed the
+          # transient failure).  No notification needed.
+          if [[ "${CONCLUSION}" == "success" ]]; then
+            printf '✅ Run flipped to success (auto-rerun fixed it); no notification needed.\n'
+            echo "notify=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Case 3: completed + non-success.  Either a genuine failure
+          # (no transient signature matched, so auto-rerun didn't fire)
+          # or a transient failure whose retry ALSO failed (attempt 2+
+          # is fully consumed).  Either way, this is real and human
+          # triage is appropriate.
+          printf '🔔 Run is completed + %s; will file/update tracking issue.\n' "${CONCLUSION}"
+          echo "notify=true" >> "$GITHUB_OUTPUT"
+
+      - name: File or update tracking issue
+        if: steps.decide.outputs.notify == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          ACTOR: ${{ github.event.workflow_run.actor.login }}
+          ATTEMPT: ${{ steps.status.outputs.attempt }}
+        with:
+          script: |
+            // Map workflow-run name → per-workflow label + title prefix.
+            // The mapping mirrors the labels previously emitted by each
+            // workflow's in-line `notify-failure` job before the move
+            // to this centralised, race-safe workflow.
+            const wf = process.env.WORKFLOW_NAME;
+            const sha = process.env.HEAD_SHA;
+            const shortSha = sha.substring(0, 7);
+            const attempt = process.env.ATTEMPT;
+
+            let label, title, extraBody;
+            if (wf === 'PR Fast CI') {
+              label = 'ci-failure-pr-fast';
+              title = `🔴 CI Failure: PR Fast CI — ${shortSha}`;
+              extraBody = [];
+            } else if (wf === '🌙 UFFS Tier 2 Nightly CI') {
+              label = 'ci-failure-tier-2';
+              title = `🔴 CI Failure: Tier 2 Nightly CI — ${shortSha}`;
+              extraBody = [
+                '',
+                '📧 Notification sent to: githubrobbi@nios.net',
+              ];
+            } else {
+              core.warning(`Unknown workflow name: ${wf}; not notifying.`);
+              return;
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.RUN_ID}`;
+            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${sha}`;
+
+            // Attempt-specific suffix in the body so readers can
+            // immediately see whether this was a first-shot failure
+            // (auto-rerun saw no transient signature) or a retry
+            // that ALSO failed (genuinely persistent flake).
+            const attemptNote = attempt === '1'
+              ? 'auto-rerun-transient saw no transient signature in the failed-job logs → genuine failure on first attempt'
+              : `auto-rerun-transient dispatched a retry but attempt ${attempt} also failed → persistent flake or real regression`;
+
+            const body = [
+              `## ${wf} failed on \`${process.env.HEAD_BRANCH}\``,
+              ``,
+              `| Field | Value |`,
+              `|-------|-------|`,
+              `| **Workflow** | \`${wf}\` |`,
+              `| **Run** | [#${process.env.RUN_NUMBER}](${runUrl}) |`,
+              `| **Attempt** | ${attempt} |`,
+              `| **Branch** | \`${process.env.HEAD_BRANCH}\` |`,
+              `| **Commit** | [\`${shortSha}\`](${commitUrl}) |`,
+              `| **Triggered by** | @${process.env.ACTOR} |`,
+              ``,
+              `_Filed by \`ci-failure-notify.yml\` after the 60-second auto-rerun-transient window: ${attemptNote}._`,
+              ...extraBody,
+            ].join('\n');
+
+            // Reuse an existing open issue with the same label rather
+            // than spamming.  Matches the original semantics of the
+            // in-line `notify-failure` jobs that this workflow replaces.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 1,
+            });
+
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body: body,
+              });
+              core.info(`Updated existing issue #${existing.data[0].number}`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: [label, 'ci-failure'],
+                assignees: ['githubrobbi'],
+              });
+              core.info('Created new failure issue');
+            }

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -678,60 +678,14 @@ jobs:
           exit "$fail"
 
   # ─────────────────────────────────────────────────────────────────────
-  # notify-failure — file a tracking issue when the workflow breaks,
-  # using the same per-workflow label convention as tier-2.yml.
+  # notify-failure was REMOVED in the Design C refactor for #209 — it
+  # is now handled by `.github/workflows/ci-failure-notify.yml`, which
+  # triggers off `workflow_run [completed]` AFTER `auto-rerun-transient.yml`
+  # has had its 60-second window to retry transient flakes.  See the
+  # header of `ci-failure-notify.yml` for the full rationale and the
+  # status-decision matrix.
+  #
+  # Genuine failures still produce a tracking issue (same title /
+  # label / body schema as before); transient failures auto-absorb
+  # without ever opening one.
   # ─────────────────────────────────────────────────────────────────────
-  notify-failure:
-    name: 🔔 Notify on Failure
-    runs-on: ubuntu-latest
-    needs: [classify, file-size, gates-drift, hooks-drift, workflow-drift, fast-drift, fmt, sanity, clippy, docs, test-build, tests, security, windows-lint, required]
-    if: failure() && github.event_name != 'pull_request'
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - name: Create failure issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            const title = `🔴 CI Failure: PR Fast CI — ${context.sha.substring(0, 7)}`;
-            const body = [
-              `## PR Fast CI failed on ${context.ref}`,
-              ``,
-              `| Field | Value |`,
-              `|-------|-------|`,
-              `| **Workflow** | \`${context.workflow}\` |`,
-              `| **Run** | [#${context.runNumber}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) |`,
-              `| **Branch** | \`${context.ref}\` |`,
-              `| **Commit** | [\`${context.sha.substring(0, 7)}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}) |`,
-              `| **Triggered by** | @${context.actor} |`,
-            ].join('\n');
-
-            const label = 'ci-failure-pr-fast';
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: label,
-              per_page: 1,
-            });
-
-            if (existing.data.length > 0) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: existing.data[0].number,
-                body: body,
-              });
-              core.info(`Updated existing issue #${existing.data[0].number}`);
-            } else {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: title,
-                body: body,
-                labels: [label, 'ci-failure'],
-                assignees: ['githubrobbi'],
-              });
-              core.info('Created new failure issue');
-            }

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -14,9 +14,10 @@ on:
 
 # Workflow-level permissions follow least-privilege (§2.8):
 # every job that doesn't declare its own `permissions:` block
-# inherits `contents: read` only.  `notify-failure` re-declares
-# `issues: write` on its own block so that scope is scoped to the
-# one job that actually opens issues.
+# inherits `contents: read` only.  Failure notification has been
+# moved out of this workflow into `.github/workflows/ci-failure-notify.yml`
+# (Design C for #209), so no in-workflow job needs `issues: write`
+# anymore.
 permissions:
   contents: read
 
@@ -823,73 +824,21 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ═══════════════════════════════════════════════════════════════════════════
-  # Failure Notification — opens a GitHub Issue on any job failure
+  # Failure Notification has been moved out of this workflow into
+  # `.github/workflows/ci-failure-notify.yml` (Design C for #209).
+  # That workflow triggers off `workflow_run [completed]` AFTER
+  # `auto-rerun-transient.yml` has had its 60-second window to retry
+  # transient flakes, so this Tier 2 nightly no longer self-files
+  # false-positive `ci-failure-tier-2` issues for transient HTTP 429
+  # / network blips / runner-setup faults.
+  #
+  # The advisory-job exemption (mutants + fuzz intentionally omitted
+  # from notification triggers) is preserved indirectly: those two
+  # jobs use `continue-on-error: true`, so when they fail the workflow
+  # run's overall `conclusion` is still `success` — and
+  # `ci-failure-notify.yml` only files an issue on `conclusion ==
+  # 'failure'`.  When either job is promoted to a hard gate (see the
+  # `Check pipeline success` step's comment in the tier-2-summary
+  # job), removing `continue-on-error: true` will automatically wire
+  # it into the notification path.
   # ═══════════════════════════════════════════════════════════════════════════
-
-  notify-failure:
-    name: 🔔 Notify on Failure
-    runs-on: ubuntu-latest
-    # `mutants` and `fuzz` intentionally OMITTED from this needs-list
-    # so an advisory cargo-mutants miss or cargo-fuzz crash does NOT
-    # open a Tier 2 failure issue.  Both jobs carry `continue-on-
-    # error: true` (advisory initial rollout; see header comments in
-    # each job definition).  Once either is promoted from advisory
-    # to a hard gate (see the `Check pipeline success` step's comment
-    # in the tier-2-summary job), add it here too.
-    needs: [file-size-policy, coverage, build-validation, udeps, hack, miri, careful, msrv]
-    if: failure()
-    # §2.8: every job caps its runtime.  Cheap notifier — 2 min is
-    # generous for a single API call round-trip + JSON formatting.
-    timeout-minutes: 2
-    permissions:
-      issues: write
-    steps:
-      - name: Create failure issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            // Per-workflow label so Tier 1 / Tier 2 / Release failures
-            // triage to distinct issues instead of piling onto one.
-            const label = 'ci-failure-tier-2';
-            const title = `🔴 CI Failure: Tier 2 Nightly CI — ${context.sha.substring(0, 7)}`;
-            const body = [
-              `## CI Pipeline Failed`,
-              ``,
-              `| Field | Value |`,
-              `|-------|-------|`,
-              `| **Workflow** | \`${context.workflow}\` |`,
-              `| **Run** | [#${context.runNumber}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) |`,
-              `| **Branch** | \`${context.ref}\` |`,
-              `| **Commit** | [\`${context.sha.substring(0, 7)}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}) |`,
-              `| **Triggered by** | @${context.actor} |`,
-              ``,
-              `📧 Notification sent to: githubrobbi@nios.net`,
-            ].join('\n');
-
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: label,
-              per_page: 1,
-            });
-
-            if (existing.data.length > 0) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: existing.data[0].number,
-                body: body,
-              });
-              core.info(`Updated existing issue #${existing.data[0].number}`);
-            } else {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: title,
-                body: body,
-                labels: [label, 'ci-failure'],
-                assignees: ['githubrobbi'],
-              });
-              core.info('Created new failure issue');
-            }

--- a/scripts/ci/check_gates_drift.sh
+++ b/scripts/ci/check_gates_drift.sh
@@ -193,13 +193,16 @@ scrape_pr_fast() {
         | sort -u
 }
 
-# Jobs in pr-fast.yml that exist for orchestration / branch protection
-# / failure handling, NOT for an individual gate.  These are EXEMPT
-# from the manifest — they have no matching `[[gate]]` entry.
+# Jobs in pr-fast.yml that exist for orchestration / branch protection,
+# NOT for an individual gate.  These are EXEMPT from the manifest —
+# they have no matching `[[gate]]` entry.
+#
+# `notify-failure` was removed in the Design C refactor for #209
+# (failure notification now lives in `.github/workflows/ci-failure-notify.yml`),
+# so it's no longer listed here.
 WORKFLOW_INFRA_JOBS=(
     "classify"
     "required"
-    "notify-failure"
 )
 
 # ── Mapping helpers ────────────────────────────────────────────────────

--- a/scripts/ci/gates.toml
+++ b/scripts/ci/gates.toml
@@ -160,10 +160,12 @@ structural properties of `.github/workflows/pr-fast.yml` against this
 manifest: (1) every pr-fast-tier gate has a corresponding job, (2) each
 job's `if:` predicate is at least as permissive as the LUB of its
 folded gates' `gate_when` classes, (3) every gate's resolved job-id is
-present in `required.needs:`, the bash `declare -A R=(...)`
-aggregator, AND `notify-failure.needs:`, and (4) the `required` job's
-`name:` is exactly `PR Fast CI / required` (the literal string in the
-repo's branch-protection rule).  See plan §4.2 for the full property
+present in `required.needs:` AND the bash `declare -A R=(...)`
+aggregator, and (4) the `required` job's `name:` is exactly
+`PR Fast CI / required` (the literal string in the repo's
+branch-protection rule).  The `notify-failure.needs:` invariant
+was retired in the Design C refactor for #209 (failure notification
+now lives in `.github/workflows/ci-failure-notify.yml`).  See plan §4.2 for the full property
 specification and the rationale for the structural-validator design
 (vs. the originally-planned YAML emitter).
 
@@ -173,8 +175,8 @@ gate-set of every consumer; `hooks-drift` ensures the on-disk pre-push
 hook matches what the generator would emit; `workflow-drift` ensures
 the structural properties of the per-gate jobs in `pr-fast.yml` are
 consistent with the manifest, including the rename-bookkeeping failure
-mode (`required.needs:` / aggregator table / `notify-failure.needs:`)
-that motivated the whole gate-manifest plan.
+mode (`required.needs:` / aggregator table) that motivated the whole
+gate-manifest plan.
 """
 
 [[gate]]

--- a/scripts/ci/gen-workflow/src/main.rs
+++ b/scripts/ci/gen-workflow/src/main.rs
@@ -38,9 +38,11 @@
 //!    (over-runs); narrower is drift (would block a gate from running on its
 //!    trigger).
 //! 3. **Aggregator coverage** — every gate's resolved job-id is in
-//!    `required.needs:`, the `declare -A R=(...)` aggregator inside the
-//!    `required` job, AND `notify-failure.needs:`.  This is the exact
-//!    rename-bookkeeping failure mode that motivated the whole plan.
+//!    `required.needs:` AND the `declare -A R=(...)` aggregator inside the
+//!    `required` job.  This is the exact rename-bookkeeping failure mode that
+//!    motivated the whole plan.  (The `notify-failure.needs:` invariant was
+//!    retired in the Design C refactor for #209; failure notification now lives
+//!    in `.github/workflows/ci-failure-notify.yml`.)
 //! 4. **Branch-protection guard** — the `required` job's `name:` field is
 //!    exactly the literal string `PR Fast CI / required`. This name is in the
 //!    repo's branch-protection rule (`required_status_checks`); a refactor that

--- a/scripts/ci/gen-workflow/src/validate.rs
+++ b/scripts/ci/gen-workflow/src/validate.rs
@@ -321,7 +321,12 @@ fn extract_aggregator_ids(workflow_text: &str) -> Result<BTreeSet<String>> {
 /// For each manifest gate's resolved job-id, verify presence in:
 /// 1. `workflow.jobs["required"].needs`
 /// 2. the bash `declare -A R=(...)` table inside `required`
-/// 3. `workflow.jobs["notify-failure"].needs`
+///
+/// The third invariant — coverage in `workflow.jobs["notify-failure"].needs:`
+/// — was retired in the Design C refactor for #209.  Failure notification
+/// is now produced by `.github/workflows/ci-failure-notify.yml`, which
+/// triggers off `workflow_run [completed]` rather than via an in-workflow
+/// `notify-failure` job needing a `needs:` list of every gate.
 ///
 /// # Errors
 ///
@@ -339,16 +344,11 @@ fn check_aggregator_coverage(
         .get("required")
         .map(|job| job.needs.iter().cloned().collect())
         .unwrap_or_default();
-    let notify_needs: BTreeSet<String> = workflow
-        .jobs
-        .get("notify-failure")
-        .map(|job| job.needs.iter().cloned().collect())
-        .unwrap_or_default();
     let aggregator_ids = extract_aggregator_ids(workflow_text)?;
 
-    // Each manifest job-id must appear in all three lists.  We
-    // dedupe via BTreeSet to avoid duplicate reports for folded
-    // gates (e.g. rustdoc + doc-tests both → docs).
+    // Each manifest job-id must appear in both lists.  We dedupe via
+    // BTreeSet to avoid duplicate reports for folded gates (e.g.
+    // rustdoc + doc-tests both → docs).
     let needed_ids: BTreeSet<&str> = manifest.pr_fast_gates().map(Gate::pr_fast_job_id).collect();
 
     for job_id in needed_ids {
@@ -360,11 +360,6 @@ fn check_aggregator_coverage(
         if !aggregator_ids.contains(job_id) {
             issues.push(format!(
                 "Property 3 (aggregator coverage): job `{job_id}` is missing from the `declare -A R=(...)` table inside the required job"
-            ));
-        }
-        if !notify_needs.contains(job_id) {
-            issues.push(format!(
-                "Property 3 (aggregator coverage): job `{job_id}` is missing from notify-failure.needs:"
             ));
         }
     }
@@ -504,14 +499,6 @@ jobs:
             [file-size]='${{ needs.file-size.result }}'
             [sanity]='${{ needs.sanity.result }}'
           )
-
-  notify-failure:
-    name: Notify on failure
-    runs-on: ubuntu-22.04
-    needs: [classify, fmt, file-size, sanity, required]
-    if: failure()
-    steps:
-      - run: echo
 ";
 
     /// Helper — parse both fixtures and run the validator.
@@ -669,20 +656,12 @@ jobs:
         );
     }
 
-    #[test]
-    fn property3_detects_missing_notify_failure_needs() {
-        let workflow = WORKFLOW_FIXTURE.replace(
-            "    needs: [classify, fmt, file-size, sanity, required]",
-            "    needs: [classify, fmt, file-size, required]", // sanity removed
-        );
-        let issues = validate_fixture(MANIFEST_FIXTURE, &workflow);
-        assert!(
-            issues
-                .iter()
-                .any(|s| s.contains("Property 3") && s.contains("notify-failure.needs:")),
-            "expected P3 missing-from-notify, got: {issues:?}"
-        );
-    }
+    // `property3_detects_missing_notify_failure_needs` was retired with
+    // the Design C refactor for #209.  The notify-failure invariant
+    // no longer applies because failure notification has been moved
+    // out of pr-fast.yml into ci-failure-notify.yml (workflow_run-
+    // triggered, post-auto-rerun-window), which doesn't carry a
+    // `needs:` list of every gate.
 
     // ─── Property 4 mutation tests ────────────────────────────────
 


### PR DESCRIPTION
# Closes #209 (Design C — full structural fix)

Follow-up to PR #225 (Design B, merged in `742e316b4`) which added the
\`cleanup-stale-notification\` belt-and-suspenders job to \`auto-rerun-transient.yml\`.

This PR lands **Design C** from #209's design matrix: move \`notify-failure\` out of
\`pr-fast.yml\` + \`tier-2.yml\` into a new \`workflow_run\`-triggered
\`ci-failure-notify.yml\` that fires AFTER the auto-rerun-transient window, so
transient CI failures never produce an open \`ci-failure-*\` issue in the first place.

Together with #225, this closes #209 fully.

## Behaviour after both PRs are merged

### Transient failure (HTTP 429, network blip, runner setup)
\`\`\`
T+0     PR Fast CI attempt 1 starts
T+13min Tests job fails (flaky)
T+13min workflow_run [completed] event fires
T+13min auto-rerun-transient.yml retries the failed job
T+13min ci-failure-notify.yml waits 60s, then checks status
T+14min status = in_progress (retry running) → SKIP notification
T+18min attempt 2 succeeds → second workflow_run [completed] event
T+18min ci-failure-notify.yml checks status: conclusion = success → NO notification
\`\`\`
Net: **zero false-positive issues filed**.

### Genuine failure (real regression, no transient signature)
\`\`\`
T+0     PR Fast CI attempt 1 starts
T+13min Tests job fails (real bug)
T+13min auto-rerun-transient.yml scans logs, finds no transient signature → exits silently
T+13min ci-failure-notify.yml waits 60s, then checks status
T+14min status=completed, conclusion=failure, attempt=1 → FILE issue with note:
        "auto-rerun-transient saw no transient signature in the failed-job logs →
         genuine failure on first attempt"
\`\`\`
Net: same tracking-issue UX as before — just routed through a race-safe trigger.

### Transient failure where retry ALSO fails
\`\`\`
T+0     attempt 1 fails transient
T+13min auto-rerun retries
T+25min attempt 2 also fails
T+25min ci-failure-notify.yml checks status: completed + failure + attempt=2
        → FILE issue with note:
        "auto-rerun-transient dispatched a retry but attempt 2 also failed
         → persistent flake or real regression"
\`\`\`

## Files changed

| File | Lines | Change |
|---|---:|---|
| \`.github/workflows/ci-failure-notify.yml\` | +273 | NEW — Design C |
| \`.github/workflows/pr-fast.yml\` | -58 / +12 | Remove in-workflow notify-failure |
| \`.github/workflows/tier-2.yml\` | -67 / +18 | Remove in-workflow notify-failure |
| \`scripts/ci/gen-workflow/src/validate.rs\` | -25 / +12 | Drop notify-failure.needs invariant; retire 1 unit test |
| \`scripts/ci/check_gates_drift.sh\` | -3 / +8 | Drop notify-failure from infra-jobs exempt list |
| \`scripts/ci/gates.toml\` | -3 / +11 | Update Property 3 docstring |
| \`scripts/ci/gen-workflow/src/main.rs\` | -2 / +6 | Update module-level Property 3 docstring |

## What does NOT change

- \`release.yml::notify-failure\` stays in-workflow — release failures are not transient-retryable by design (every step mutates published state). Same rationale as #209's recommendation.
- \`auto-rerun-transient.yml::cleanup-stale-notification\` (Design B, merged in #225) stays as belt-and-suspenders against any future code path that re-introduces synchronous notify behaviour.

## Strict-rule compliance

- **No suppression hacks** — zero new \`#[allow(...)]\`, no lint-disable, no \`if: false\` test skips. The one retired unit test (\`property3_detects_missing_notify_failure_needs\`) verified an invariant that has been **intentionally removed** by the design — not a skip-to-pass. \`validate.rs:659-664\` documents the rationale.
- **Surgical fixes** — each edit targets a specific consumer of the moved notify-failure jobs.
- **Behaviour preserved where contractually unchanged** — issue title/body/label/dedupe schema match the original notify-failure jobs. The intentional behaviour change (notifications arrive after the 60s rerun window) is the whole point of #209.
- **Tests improved, not dodged** — 32/32 gen-workflow unit tests pass (down from 33; one test retired for the removed invariant). \`WORKFLOW_FIXTURE\` updated to match trimmed \`pr-fast.yml\` so future tests don't drift.

## Verification

- \`cargo test --manifest-path scripts/ci/gen-workflow/Cargo.toml\`: 32/32 ✅
- \`bash scripts/ci/check_gates_drift.sh\`: 25 gates agree ✅
- \`just lint-fast\`: 8 gates green (fmt, file-size, typos, reuse, taplo, lint-ci, lint-prod, lint-tests) ✅
- \`lint-pre-push\` (full pre-push gate, 53-63s): green ✅