### PR TITLE
chore(ci): add manifest-inheritance drift-detector (closes #211)

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -287,6 +287,35 @@ jobs:
       - run: cargo run -q --release -p uffs-gen-hooks -- --target pre-commit --check
 
   # ─────────────────────────────────────────────────────────────────────
+  # manifest-drift — Phase 1 follow-up from
+  # `docs/dev/architecture/code_clean/phase_1_manifest_implementation_plan.md`
+  # (local-only) — issue #211.  Encodes the 15 Phase-1 manifest
+  # invariants as machine-checkable assertions and runs them against
+  # every member `Cargo.toml`.  Catches the drift class the manual
+  # Phase-1 audit can only detect on the annual cadence (a new crate
+  # landing without `[lints] workspace = true`, an `edition = "..."`
+  # override, a `[profile.*]` block in a member, etc).  Gated on
+  # `dep_changed` so docs-only PRs skip the audit.  Cache key shared
+  # with `sanity` per the sibling drift-detector pattern.
+  # ─────────────────────────────────────────────────────────────────────
+  manifest-drift:
+    name: Manifest inheritance drift
+    runs-on: ubuntu-22.04
+    needs: classify
+    if: needs.classify.outputs.dep == 'true'
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - run: rustup show
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: pr-fast-sanity
+          save-if: 'false'
+      - run: cargo run -q --release -p uffs-manifest-audit -- --check
+
+  # ─────────────────────────────────────────────────────────────────────
   # fmt — rustfmt check.  Gates on rust_changed (pure TOML / config /
   # docs edits don't need rustfmt).
   # ─────────────────────────────────────────────────────────────────────
@@ -628,6 +657,7 @@ jobs:
       - hooks-drift
       - workflow-drift
       - fast-drift
+      - manifest-drift
       - fmt
       - sanity
       - clippy
@@ -653,6 +683,7 @@ jobs:
             [hooks-drift]='${{ needs.hooks-drift.result }}'
             [workflow-drift]='${{ needs.workflow-drift.result }}'
             [fast-drift]='${{ needs.fast-drift.result }}'
+            [manifest-drift]='${{ needs.manifest-drift.result }}'
             [fmt]='${{ needs.fmt.result }}'
             [sanity]='${{ needs.sanity.result }}'
             [clippy]='${{ needs.clippy.result }}'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,9 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64",
@@ -3373,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4504,6 +4504,16 @@ dependencies = [
  "anyhow",
  "clap",
  "regex",
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "uffs-manifest-audit"
+version = "0.5.95"
+dependencies = [
+ "anyhow",
+ "clap",
  "serde",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,20 @@ members = [
   "crates/uffs-cli", # 🖥️  Command-line interface
   # NOTE: uffs-tui and uffs-gui have moved to the private uffs-products repo.
   # ── Tools ──
-  "crates/uffs-diag",        # 🔬 Retained workspace-only diagnostic tools (not shipped in dist/)
-  "scripts/ci-pipeline",     # 🛠️ Promoted CI pipeline driver (dev-flow-implementation-plan.md § 7)
-  "scripts/ci/gen-hooks",    # 🧬 Gate-manifest hook generator (gates-manifest-plan.md Phase 2)
-  "scripts/ci/gen-workflow", # 🧪 Gate-manifest workflow structural validator (gates-manifest-plan.md Phase 3)
+  "crates/uffs-diag",          # 🔬 Retained workspace-only diagnostic tools (not shipped in dist/)
+  "scripts/ci-pipeline",       # 🛠️ Promoted CI pipeline driver (dev-flow-implementation-plan.md § 7)
+  "scripts/ci/gen-hooks",      # 🧬 Gate-manifest hook generator (gates-manifest-plan.md Phase 2)
+  "scripts/ci/gen-workflow",   # 🧪 Gate-manifest workflow structural validator (gates-manifest-plan.md Phase 3)
+  "scripts/ci/manifest-audit", # 🧾 Workspace manifest-inheritance drift detector (phase-1 follow-up, #211)
 ]
+# Default-members policy: intentionally NOT set. `cargo build` /
+# `cargo test` at the workspace root default to ALL members above, which
+# is the right behaviour for a development workspace where every member
+# is a first-class part of the deliverable.  When a future contributor
+# adds a member that should be opt-in (e.g. a heavyweight bench harness),
+# define `default-members = [...]` explicitly and exclude the new
+# member.  Per Phase 1 manifest-audit invariant 3.11, this comment is
+# the documented-fallback case the drift-detector looks for.
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Workspace Package Metadata (inherited by all crates)
@@ -204,7 +213,7 @@ thiserror = "2.0.18"
 anyhow = "1.0.102"
 
 # ───── MCP (Model Context Protocol) ─────
-rmcp = { version = "1.6.0", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "1.7.0", features = ["server", "transport-io", "macros"] }
 schemars = "1.2.1"
 
 # ───── HTTP / Tower (for MCP Streamable HTTP gateway) ─────

--- a/scripts/ci/gates.toml
+++ b/scripts/ci/gates.toml
@@ -218,6 +218,48 @@ right place to catch the drift before it reaches the remote.
 """
 
 [[gate]]
+id = "manifest-drift"
+label = "Workspace manifest-inheritance drift detector (manifest-audit --check)"
+command = [
+  "cargo",
+  "run",
+  "-q",
+  "--release",
+  "-p",
+  "uffs-manifest-audit",
+  "--",
+  "--check",
+]
+tiers = ["pre-push", "pr-fast"]
+gate_when = "dep_changed"
+hard = true
+tool = "cargo"
+expected_runtime_secs = 2
+bucket = "bg"
+order = 29
+notes = """
+Phase 1 follow-up from
+`docs/dev/architecture/code_clean/phase_1_manifest_implementation_plan.md`
+(local-only) — issue #211.  Encodes the 15 Phase-1 manifest invariants
+(§3 of the plan) as machine-checkable assertions and runs them against
+every member `Cargo.toml`.  Catches the drift class the manual Phase-1
+audit can only detect on the annual cadence: a new crate landing
+without `[lints] workspace = true`, an accidental `edition = "..."`
+override, a `[profile.*]` block sneaking into a member manifest, a
+new path-dep pointing outside `[workspace.members]`, etc.
+
+Gated on `dep_changed` (Cargo.{toml,lock} | supply-chain/) because the
+audit only needs to fire when a manifest actually changes.  Documented
+exceptions (uffs-cli/uffs-format publish-pin, uffs-polars/polars
+facade-canonical, uffs-daemon/libmimalloc-sys feature-delta,
+uffs-diag underscore-bin names, 5-crate explicit-publish-true set)
+are hardcoded in the audit with in-code citations — adding a new
+deviation requires updating the exception list AND citing why,
+keeping the gate green on intentional deviations while still firing
+on accidental ones.
+"""
+
+[[gate]]
 id = "commit-subjects"
 label = "Conventional Commits subject validator"
 command = [

--- a/scripts/ci/manifest-audit/Cargo.toml
+++ b/scripts/ci/manifest-audit/Cargo.toml
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# UFFS — Workspace manifest-inheritance drift detector.
+#
+# Phase 1 follow-up from
+# `docs/dev/architecture/code_clean/phase_1_manifest_implementation_plan.md`
+# (local-only).  The Phase 1 audit closed cleanly with zero CHORE
+# findings against 15 manifest invariants; this crate encodes those
+# invariants as machine-checkable assertions so any future regression
+# (e.g. a contributor adding a new crate without `[lints] workspace =
+# true`) surfaces at PR time instead of waiting on the annual re-audit
+# cadence.  See issue #211 for the full motivation + acceptance
+# criteria.
+#
+# Design follows the `gen-workflow` Phase-3 structural-validator
+# pattern: read-only, `--check`-mode by default, exits non-zero on the
+# first drift detected with a per-finding diagnostic message.  No
+# `--write` mode — the tool can never break a manifest, only fail-loud
+# when one drifts.
+
+[package]
+name = "uffs-manifest-audit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Workspace manifest-inheritance drift detector (phase-1 follow-up, issue #211)"
+# Posture: **permanently non-publishable** — internal workspace CI tooling.
+# Distinct from the 8 Polars-blocked deferred-publishable crates: this
+# crate would remain non-publishable even if Polars upstream released,
+# because it is internal CI orchestration tied to this workspace's
+# manifest layout, not a reusable library.
+publish.workspace = true
+
+# Phase R6 of `release-automation-plan.md` step 3: docs.rs build configuration.
+# This crate is `publish = false` (internal CI orchestration), so docs.rs will
+# never build it; this block is preserved for workspace-uniform manifest shape
+# (per Phase 1 follow-up F1.15 / issue #214).  Pure Rust CLI tooling — the
+# docs.rs default (Linux x86_64) build is sufficient if it ever runs.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[[bin]]
+name = "manifest-audit"
+path = "src/main.rs"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dependencies
+# ─────────────────────────────────────────────────────────────────────────────
+# Every dependency is aliased to `[workspace.dependencies]` in the root
+# Cargo.toml so a single Cargo.lock entry serves this tool and every
+# other crate.  See `scripts/ci/gen-hooks/Cargo.toml` for the rationale.
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+toml = { workspace = true }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Lints (issue #212)
+# ─────────────────────────────────────────────────────────────────────────────
+# Inherit the full workspace lint stack (matches all 14 product crates +
+# uffs-diag).  CLI-inappropriate lints (`print_stderr` for the failure
+# report) are suppressed at file scope via `#![expect(...)]` blocks in
+# `src/main.rs` with `reason = "..."` strings, matching the precedent
+# established for `gen-hooks` / `gen-workflow` in PR #228.  See
+# `CLIPPY_POSTURE.md` § CLI-tooling for the policy.
+[lints]
+workspace = true

--- a/scripts/ci/manifest-audit/src/audit.rs
+++ b/scripts/ci/manifest-audit/src/audit.rs
@@ -1,0 +1,731 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! The 15 manifest invariants from
+//! `docs/dev/architecture/code_clean/phase_1_manifest_implementation_plan.md`
+//! §3, encoded as machine-checkable assertions.
+//!
+//! Each public function in this module corresponds to one or more
+//! invariants and returns a `Vec<Finding>` (empty on success).  The
+//! top-level [`audit_all`] entry point calls every check and
+//! concatenates the results — exit code is derived from
+//! `result.is_empty()`.
+//!
+//! # Design rationale
+//!
+//! * Findings are **plain text** (no JSON, no enum taxonomy) because the audit
+//!   only fires at PR time and a human is always the next reader.
+//! * The invariants are **deliberately conservative**: the audit prefers false
+//!   negatives (missing a real drift) over false positives (failing on
+//!   intentional exceptions).  The hardcoded exception list in
+//!   [`KnownExceptions`] documents every accepted deviation with an in-code
+//!   citation.
+
+use alloc::collections::BTreeSet;
+
+use crate::manifest::{MemberManifest, RootManifest, is_workspace_inherited};
+
+/// Single audit finding.  Self-contained diagnostic; the CI log
+/// alone tells the contributor what to fix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Finding {
+    /// Phase 1 invariant number (e.g. `"3.7"`).
+    pub(crate) invariant: &'static str,
+    /// Member crate id (e.g. `"uffs-core"`) for member-scoped findings,
+    /// or `"<root>"` for root-scoped ones.
+    pub(crate) member: String,
+    /// One-line diagnostic.
+    pub(crate) detail: String,
+}
+
+impl core::fmt::Display for Finding {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "[{}] {}: {}", self.invariant, self.member, self.detail)
+    }
+}
+
+/// Hardcoded set of intentional manifest deviations.  Update this
+/// whenever a new exception lands — the audit fires on every new
+/// deviation by default, forcing the contributor to either fix the
+/// manifest or extend this list with a citation.
+struct KnownExceptions {
+    /// Members allowed to set `publish = true` explicitly (not via
+    /// workspace inheritance).  Source: `release-automation-baseline.md`
+    /// §10 deviation row 5.
+    publish_explicit: BTreeSet<&'static str>,
+    /// Members allowed underscore-style `[[bin]] name = ...` (vs. the
+    /// hyphen convention).  Source: gen-workflow comment in
+    /// `scripts/ci/gen-workflow/src/main.rs`.
+    underscore_bin_ok: BTreeSet<&'static str>,
+    /// `(member, dep_name)` pairs allowed to bypass workspace
+    /// inheritance.  Documented in Phase 1 §3.6.
+    nonworkspace_dep_ok: BTreeSet<(&'static str, &'static str)>,
+}
+
+impl KnownExceptions {
+    /// Build the hardcoded exception set.  Update this list whenever a
+    /// new intentional deviation lands (with an in-code citation) — the
+    /// audit fires on every new deviation by default.
+    fn new() -> Self {
+        let publish_explicit: BTreeSet<&'static str> = [
+            "uffs-broker",
+            "uffs-broker-protocol",
+            "uffs-security",
+            "uffs-text",
+            "uffs-time",
+        ]
+        .into_iter()
+        .collect();
+
+        let underscore_bin_ok: BTreeSet<&'static str> = core::iter::once("uffs-diag").collect();
+
+        // uffs-cli is publishable (`release-automation-baseline.md` §10
+        // row 5).  Its `uffs-client` and `uffs-format` path deps pin
+        // a snapshotted older version (`0.5.90`) than the current
+        // workspace version so `cargo package` semver-validation
+        // continues to succeed against the published baseline.
+        // Workspace inheritance would force the live version pin,
+        // breaking publish.  Documented in `crates/uffs-cli/Cargo.toml`
+        // lines 54-71 (uffs-client) and 67-72 (uffs-format).
+        //
+        // uffs-cli's `uffs-client` also uses `default-features = false`
+        // to drop tokio + ws2_32.dll from the CLI binary — workspace
+        // inheritance cannot override `default-features` either.
+        //
+        // uffs-polars is the single canonical consumer of the `polars`
+        // crate (every other workspace member goes through it as a
+        // facade), and pins a specific git rev + feature set in its
+        // own manifest.  Adding `polars` to `[workspace.dependencies]`
+        // would either lock every facade-consumer to the same feature
+        // set or require per-consumer feature overrides — strictly
+        // worse than the current single-source-of-truth pin.
+        // Documented in `crates/uffs-polars/Cargo.toml:92+`.
+        //
+        // uffs-daemon pins `libmimalloc-sys` with the `extended`
+        // feature (workspace dep would force the feature on every
+        // consumer).  Documented in Phase 1 §3.6.
+        let nonworkspace_dep_ok: BTreeSet<(&'static str, &'static str)> = [
+            ("uffs-cli", "uffs-client"),
+            ("uffs-cli", "uffs-format"),
+            ("uffs-polars", "polars"),
+            ("uffs-daemon", "libmimalloc-sys"),
+        ]
+        .into_iter()
+        .collect();
+
+        Self {
+            publish_explicit,
+            underscore_bin_ok,
+            nonworkspace_dep_ok,
+        }
+    }
+}
+
+/// One discovered member: path + parsed manifest + raw source text.
+pub(crate) struct DiscoveredMember<'a> {
+    /// Workspace-relative path (e.g. `"crates/uffs-core/Cargo.toml"`).
+    pub(crate) manifest_path: &'a str,
+    /// Parsed shape.
+    pub(crate) manifest: &'a MemberManifest,
+}
+
+/// Run every audit invariant and concatenate findings.  An empty
+/// return value means the audit passed.
+pub(crate) fn audit_all(
+    root: &RootManifest,
+    root_text: &str,
+    members: &[DiscoveredMember<'_>],
+    discovered_paths: &BTreeSet<String>,
+) -> Vec<Finding> {
+    let exc = KnownExceptions::new();
+    let mut findings = Vec::new();
+
+    findings.extend(audit_member_list_accuracy(root, discovered_paths));
+    findings.extend(audit_root_is_virtual(root));
+    findings.extend(audit_resolver_pinned(root));
+    findings.extend(audit_default_members_intent(root_text));
+
+    for member in members {
+        let id = member_id_from_path(member.manifest_path);
+        findings.extend(audit_no_path_dep_outside_workspace(member, &id, root));
+        findings.extend(check_inherited(
+            member.manifest.package.edition.as_ref(),
+            "edition",
+            "3.3",
+            &id,
+        ));
+        findings.extend(check_inherited(
+            member.manifest.package.rust_version.as_ref(),
+            "rust-version",
+            "3.4",
+            &id,
+        ));
+        findings.extend(audit_metadata_fields(member, &id));
+        findings.extend(audit_deps_inherit_workspace(member, &id, &exc));
+        findings.extend(audit_lints_inherit_workspace(member, &id));
+        findings.extend(audit_no_workspace_policy_blocks(member, &id));
+        findings.extend(audit_lib_bin_name_convention(member, &id, &exc));
+        findings.extend(audit_publish_partition(member, &id, &exc));
+        findings.extend(audit_docs_rs_metadata_present(member, &id));
+    }
+
+    findings
+}
+
+/// `"crates/uffs-core/Cargo.toml"` → `"uffs-core"`.
+fn member_id_from_path(path: &str) -> String {
+    path.rsplit_once('/')
+        .and_then(|(parent, _)| parent.rsplit_once('/').map(|(_, last)| last))
+        .unwrap_or(path)
+        .to_owned()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Root-scoped invariants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// **Invariant 3.1**: declared `[workspace.members]` matches the
+/// set of discovered `Cargo.toml` files exactly.
+fn audit_member_list_accuracy(root: &RootManifest, discovered: &BTreeSet<String>) -> Vec<Finding> {
+    let Some(ws) = root.workspace.as_ref() else {
+        return vec![Finding {
+            invariant: "3.1",
+            member: "<root>".to_owned(),
+            detail: "root Cargo.toml has no [workspace] table".to_owned(),
+        }];
+    };
+    let declared: BTreeSet<&str> = ws.members.iter().map(String::as_str).collect();
+    let discovered_set: BTreeSet<&str> = discovered.iter().map(String::as_str).collect();
+    let mut findings = Vec::new();
+    for missing in discovered_set.difference(&declared) {
+        findings.push(Finding {
+            invariant: "3.1",
+            member: "<root>".to_owned(),
+            detail: format!("discovered `{missing}/Cargo.toml` but not in [workspace.members]"),
+        });
+    }
+    for extra in declared.difference(&discovered_set) {
+        findings.push(Finding {
+            invariant: "3.1",
+            member: "<root>".to_owned(),
+            detail: format!("[workspace.members] lists `{extra}` but no Cargo.toml exists there"),
+        });
+    }
+    findings
+}
+
+/// **Invariant 3.9**: root `Cargo.toml` is a virtual workspace.
+fn audit_root_is_virtual(root: &RootManifest) -> Vec<Finding> {
+    if root.package.is_some() {
+        vec![Finding {
+            invariant: "3.9",
+            member: "<root>".to_owned(),
+            detail: "root Cargo.toml has a [package] block; UFFS uses a virtual workspace"
+                .to_owned(),
+        }]
+    } else {
+        Vec::new()
+    }
+}
+
+/// **Invariant 3.10**: `resolver = "3"` (ed-2024 default).
+fn audit_resolver_pinned(root: &RootManifest) -> Vec<Finding> {
+    let Some(ws) = root.workspace.as_ref() else {
+        return Vec::new();
+    };
+    match ws.resolver.as_deref() {
+        Some("3") => Vec::new(),
+        Some(other) => vec![Finding {
+            invariant: "3.10",
+            member: "<root>".to_owned(),
+            detail: format!("[workspace].resolver = {other:?}; UFFS requires \"3\""),
+        }],
+        None => vec![Finding {
+            invariant: "3.10",
+            member: "<root>".to_owned(),
+            detail: "[workspace].resolver is unset; UFFS requires \"3\"".to_owned(),
+        }],
+    }
+}
+
+/// **Invariant 3.11**: `default-members` is set or the all-members
+/// fallback is documented in a nearby comment.
+fn audit_default_members_intent(root_text: &str) -> Vec<Finding> {
+    if root_text.contains("default-members") {
+        return Vec::new();
+    }
+    // Look for a comment mentioning default-members as a deliberate choice.
+    if root_text.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with('#') && trimmed.to_ascii_lowercase().contains("default-members")
+    }) {
+        return Vec::new();
+    }
+    vec![Finding {
+        invariant: "3.11",
+        member: "<root>".to_owned(),
+        detail: "root [workspace] neither sets `default-members` nor documents the all-members \
+                 fallback in a comment"
+            .to_owned(),
+    }]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-member invariants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// **Invariant 3.2**: no `path = "..."` dep points outside the
+/// declared `[workspace.members]`.
+fn audit_no_path_dep_outside_workspace(
+    member: &DiscoveredMember<'_>,
+    id: &str,
+    root: &RootManifest,
+) -> Vec<Finding> {
+    let Some(ws) = root.workspace.as_ref() else {
+        return Vec::new();
+    };
+    let allowed: BTreeSet<&str> = ws.members.iter().map(String::as_str).collect();
+    let mut findings = Vec::new();
+    for (dep_name, dep_value) in &member.manifest.dependencies {
+        let Some(table) = dep_value.as_table() else {
+            continue;
+        };
+        let Some(path_str) = table.get("path").and_then(toml::Value::as_str) else {
+            continue;
+        };
+        let resolved = normalise_path_dep(member.manifest_path, path_str);
+        if !allowed.contains(resolved.as_str()) {
+            findings.push(Finding {
+                invariant: "3.2",
+                member: id.to_owned(),
+                detail: format!(
+                    "dep `{dep_name}` uses `path = {path_str:?}` resolving to `{resolved}` — \
+                     not in [workspace.members]"
+                ),
+            });
+        }
+    }
+    findings
+}
+
+/// Resolve `../sibling`-style member-relative path against the
+/// member's directory.  Returns the path relative to the workspace
+/// root (e.g. `"crates/uffs-client"`).
+fn normalise_path_dep(member_manifest_path: &str, dep_path: &str) -> String {
+    let member_dir = member_manifest_path
+        .rsplit_once('/')
+        .map_or(member_manifest_path, |(parent, _)| parent);
+    let mut components: Vec<&str> = member_dir.split('/').collect();
+    for segment in dep_path.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                components.pop();
+            }
+            other => components.push(other),
+        }
+    }
+    components.join("/")
+}
+
+/// Shared 3.3 / 3.4 / 3.5 helper.
+fn check_inherited(
+    value: Option<&toml::Value>,
+    field_name: &str,
+    invariant: &'static str,
+    id: &str,
+) -> Vec<Finding> {
+    let Some(inner) = value else {
+        return Vec::new();
+    };
+    if is_workspace_inherited(inner) {
+        return Vec::new();
+    }
+    vec![Finding {
+        invariant,
+        member: id.to_owned(),
+        detail: format!(
+            "`{field_name}` is overridden per-crate; should be `{field_name}.workspace = true`"
+        ),
+    }]
+}
+
+/// **Invariant 3.5**: every fingerprint metadata field except
+/// `description` must inherit from workspace.
+fn audit_metadata_fields(member: &DiscoveredMember<'_>, id: &str) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    for (name, value) in [
+        ("version", member.manifest.package.version.as_ref()),
+        ("license", member.manifest.package.license.as_ref()),
+        ("authors", member.manifest.package.authors.as_ref()),
+        ("repository", member.manifest.package.repository.as_ref()),
+        ("readme", member.manifest.package.readme.as_ref()),
+        ("keywords", member.manifest.package.keywords.as_ref()),
+        ("categories", member.manifest.package.categories.as_ref()),
+        (
+            "documentation",
+            member.manifest.package.documentation.as_ref(),
+        ),
+    ] {
+        findings.extend(check_inherited(value, name, "3.5", id));
+    }
+    findings
+}
+
+/// **Invariant 3.6**: every dep should use workspace inheritance,
+/// modulo the documented exception list.
+fn audit_deps_inherit_workspace(
+    member: &DiscoveredMember<'_>,
+    id: &str,
+    exc: &KnownExceptions,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    for (dep_name, dep_value) in &member.manifest.dependencies {
+        if dep_inherits_workspace(dep_value) {
+            continue;
+        }
+        if exc.nonworkspace_dep_ok.contains(&(id, dep_name.as_str())) {
+            continue;
+        }
+        findings.push(Finding {
+            invariant: "3.6",
+            member: id.to_owned(),
+            detail: format!(
+                "dep `{dep_name}` is not workspace-inherited and not in the documented \
+                 exception list; declare it via `{dep_name}.workspace = true` and add the \
+                 corresponding entry under `[workspace.dependencies]` in root Cargo.toml"
+            ),
+        });
+    }
+    findings
+}
+
+/// `dep.workspace = true` or `dep = { workspace = true, ... }`?
+fn dep_inherits_workspace(value: &toml::Value) -> bool {
+    let Some(table) = value.as_table() else {
+        return false;
+    };
+    matches!(table.get("workspace"), Some(toml::Value::Boolean(true)))
+}
+
+/// **Invariant 3.7**: every member has `[lints] workspace = true`.
+fn audit_lints_inherit_workspace(member: &DiscoveredMember<'_>, id: &str) -> Vec<Finding> {
+    let Some(lints) = member.manifest.lints.as_ref() else {
+        return vec![Finding {
+            invariant: "3.7",
+            member: id.to_owned(),
+            detail: "no [lints] block; should be `[lints] workspace = true`".to_owned(),
+        }];
+    };
+    match lints.get("workspace") {
+        Some(toml::Value::Boolean(true)) => Vec::new(),
+        _ => vec![Finding {
+            invariant: "3.7",
+            member: id.to_owned(),
+            detail: "[lints] block does not set `workspace = true`".to_owned(),
+        }],
+    }
+}
+
+/// **Invariant 3.8**: members must not declare workspace-policy
+/// blocks (`[profile.*]`, `[patch.*]`, `[workspace.*]`).
+fn audit_no_workspace_policy_blocks(member: &DiscoveredMember<'_>, id: &str) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    if member.manifest.profile.is_some() {
+        findings.push(Finding {
+            invariant: "3.8",
+            member: id.to_owned(),
+            detail: "member declares `[profile.*]`; profile policy lives at the workspace root"
+                .to_owned(),
+        });
+    }
+    if member.manifest.patch.is_some() {
+        findings.push(Finding {
+            invariant: "3.8",
+            member: id.to_owned(),
+            detail: "member declares `[patch.*]`; patch policy lives at the workspace root"
+                .to_owned(),
+        });
+    }
+    if member.manifest.workspace.is_some() {
+        findings.push(Finding {
+            invariant: "3.8",
+            member: id.to_owned(),
+            detail: "member declares `[workspace]`; only root may declare `[workspace]`".to_owned(),
+        });
+    }
+    findings
+}
+
+/// **Invariant 3.13**: lib name uses `_`, bin name uses `-` (with
+/// the documented `uffs-diag` exception).
+fn audit_lib_bin_name_convention(
+    member: &DiscoveredMember<'_>,
+    id: &str,
+    exc: &KnownExceptions,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    if let Some(lib) = member.manifest.lib.as_ref()
+        && let Some(name) = lib.name.as_deref()
+        && name.contains('-')
+    {
+        findings.push(Finding {
+            invariant: "3.13",
+            member: id.to_owned(),
+            detail: format!("`[lib].name = {name:?}` contains `-`; use underscores"),
+        });
+    }
+    for bin in &member.manifest.bin {
+        let Some(name) = bin.name.as_deref() else {
+            continue;
+        };
+        if name.contains('_') && !exc.underscore_bin_ok.contains(id) {
+            findings.push(Finding {
+                invariant: "3.13",
+                member: id.to_owned(),
+                detail: format!(
+                    "`[[bin]].name = {name:?}` contains `_`; bin names use hyphens.  If this \
+                     is intentional, add `{id}` to `KnownExceptions::underscore_bin_ok` with a \
+                     citation."
+                ),
+            });
+        }
+    }
+    findings
+}
+
+/// **Invariant 3.14**: `publish` is `publish.workspace = true` for
+/// most members, or explicit `publish = true` for the documented
+/// publishable-set.
+fn audit_publish_partition(
+    member: &DiscoveredMember<'_>,
+    id: &str,
+    exc: &KnownExceptions,
+) -> Vec<Finding> {
+    let Some(publish) = member.manifest.package.publish.as_ref() else {
+        return vec![Finding {
+            invariant: "3.14",
+            member: id.to_owned(),
+            detail: "`publish` field is absent; must be `publish.workspace = true` or explicit \
+                     `publish = true` for the documented publishable-set"
+                .to_owned(),
+        }];
+    };
+    if is_workspace_inherited(publish) {
+        return Vec::new();
+    }
+    if matches!(publish, toml::Value::Boolean(true)) && exc.publish_explicit.contains(id) {
+        return Vec::new();
+    }
+    if matches!(publish, toml::Value::Boolean(false)) {
+        return vec![Finding {
+            invariant: "3.14",
+            member: id.to_owned(),
+            detail: "`publish = false` is redundant with workspace default; should be \
+                     `publish.workspace = true`"
+                .to_owned(),
+        }];
+    }
+    vec![Finding {
+        invariant: "3.14",
+        member: id.to_owned(),
+        detail: format!(
+            "`publish` is overridden per-crate ({publish:?}) but `{id}` is not in the \
+             documented publishable-set; see `release-automation-baseline.md` §10 row 5"
+        ),
+    }]
+}
+
+/// **Invariant 3.15**: every member has a `[package.metadata.docs.rs]`
+/// block.
+fn audit_docs_rs_metadata_present(member: &DiscoveredMember<'_>, id: &str) -> Vec<Finding> {
+    if let Some(metadata) = member.manifest.package.metadata.as_ref()
+        && metadata
+            .get("docs")
+            .and_then(|docs| docs.get("rs"))
+            .is_some()
+    {
+        return Vec::new();
+    }
+    vec![Finding {
+        invariant: "3.15",
+        member: id.to_owned(),
+        detail: "no `[package.metadata.docs.rs]` block; Phase R6 requires uniform docs.rs \
+                 metadata across every member"
+            .to_owned(),
+    }]
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::min_ident_chars,
+    clippy::indexing_slicing,
+    reason = "test code uses idiomatic short bindings + positional indexing against fixed-shape \
+              fixtures; failures panic with adequate context (issue #212)"
+)]
+mod tests {
+    use super::*;
+    use crate::manifest::parse_member;
+
+    const MEMBER_CLEAN: &str = r#"
+[package]
+name = "uffs-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+documentation.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+description = "per-crate description"
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+anyhow = { workspace = true }
+serde.workspace = true
+
+[lints]
+workspace = true
+"#;
+
+    fn disc<'a>(path: &'a str, m: &'a MemberManifest) -> DiscoveredMember<'a> {
+        DiscoveredMember {
+            manifest_path: path,
+            manifest: m,
+        }
+    }
+
+    #[test]
+    fn clean_member_passes_every_per_member_check() {
+        let m = parse_member(MEMBER_CLEAN).unwrap();
+        let d = disc("crates/uffs-core/Cargo.toml", &m);
+        let exc = KnownExceptions::new();
+        assert!(audit_metadata_fields(&d, "uffs-core").is_empty());
+        assert!(audit_deps_inherit_workspace(&d, "uffs-core", &exc).is_empty());
+        assert!(audit_lints_inherit_workspace(&d, "uffs-core").is_empty());
+        assert!(audit_no_workspace_policy_blocks(&d, "uffs-core").is_empty());
+        assert!(audit_publish_partition(&d, "uffs-core", &exc).is_empty());
+        assert!(audit_docs_rs_metadata_present(&d, "uffs-core").is_empty());
+    }
+
+    #[test]
+    fn missing_lints_block_fires_3_7() {
+        let text = MEMBER_CLEAN.replace("[lints]\nworkspace = true\n", "");
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-core/Cargo.toml", &m);
+        let findings = audit_lints_inherit_workspace(&d, "uffs-core");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].invariant, "3.7");
+    }
+
+    #[test]
+    fn edition_override_fires_3_3() {
+        let text = MEMBER_CLEAN.replace("edition.workspace = true", "edition = \"2024\"");
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-core/Cargo.toml", &m);
+        let findings = check_inherited(
+            d.manifest.package.edition.as_ref(),
+            "edition",
+            "3.3",
+            "uffs-core",
+        );
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].invariant, "3.3");
+    }
+
+    #[test]
+    fn profile_block_fires_3_8() {
+        let text = format!("{MEMBER_CLEAN}\n[profile.release]\nopt-level = 3\n");
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-core/Cargo.toml", &m);
+        let findings = audit_no_workspace_policy_blocks(&d, "uffs-core");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].invariant, "3.8");
+    }
+
+    #[test]
+    fn non_workspace_dep_fires_3_6() {
+        let text = MEMBER_CLEAN.replace("anyhow = { workspace = true }", r#"anyhow = "1.0.0""#);
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-core/Cargo.toml", &m);
+        let exc = KnownExceptions::new();
+        let findings = audit_deps_inherit_workspace(&d, "uffs-core", &exc);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].invariant, "3.6");
+    }
+
+    #[test]
+    fn known_exception_suppresses_3_6() {
+        let text = MEMBER_CLEAN.replace(
+            "anyhow = { workspace = true }",
+            r#"libmimalloc-sys = { version = "0.1.44", features = ["extended"] }"#,
+        );
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-daemon/Cargo.toml", &m);
+        let exc = KnownExceptions::new();
+        let findings = audit_deps_inherit_workspace(&d, "uffs-daemon", &exc);
+        assert!(
+            findings.is_empty(),
+            "exception should suppress; got: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn missing_docs_rs_metadata_fires_3_15() {
+        let text = MEMBER_CLEAN.replace("[package.metadata.docs.rs]\nall-features = true\n", "");
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-core/Cargo.toml", &m);
+        let findings = audit_docs_rs_metadata_present(&d, "uffs-core");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].invariant, "3.15");
+    }
+
+    #[test]
+    fn underscore_bin_name_fires_3_13_except_diag() {
+        let text = format!("{MEMBER_CLEAN}\n[[bin]]\nname = \"foo_bar\"\npath = \"src/main.rs\"\n");
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-core/Cargo.toml", &m);
+        let exc = KnownExceptions::new();
+        let findings = audit_lib_bin_name_convention(&d, "uffs-core", &exc);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].invariant, "3.13");
+
+        // Same shape under uffs-diag — should be suppressed.
+        let d_diag = disc("crates/uffs-diag/Cargo.toml", &m);
+        let suppressed = audit_lib_bin_name_convention(&d_diag, "uffs-diag", &exc);
+        assert!(suppressed.is_empty());
+    }
+
+    #[test]
+    fn normalise_path_dep_resolves_relative() {
+        assert_eq!(
+            normalise_path_dep("crates/uffs-cli/Cargo.toml", "../uffs-client"),
+            "crates/uffs-client"
+        );
+        assert_eq!(
+            normalise_path_dep(
+                "scripts/ci/gen-hooks/Cargo.toml",
+                "../../../crates/uffs-core"
+            ),
+            "crates/uffs-core"
+        );
+    }
+
+    #[test]
+    fn member_id_from_path_strips_prefix_and_filename() {
+        assert_eq!(
+            member_id_from_path("crates/uffs-core/Cargo.toml"),
+            "uffs-core"
+        );
+        assert_eq!(
+            member_id_from_path("scripts/ci/gen-hooks/Cargo.toml"),
+            "gen-hooks"
+        );
+    }
+}

--- a/scripts/ci/manifest-audit/src/main.rs
+++ b/scripts/ci/manifest-audit/src/main.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+#![expect(
+    clippy::print_stderr,
+    reason = "operational CLI tool — findings + summary go to stderr so consumers can pipe \
+              stdout (currently empty) without losing the diagnostic stream (issue #212)"
+)]
+
+//! `manifest-audit` — workspace manifest-inheritance drift detector.
+//!
+//! Phase 1 follow-up tool from
+//! `docs/dev/architecture/code_clean/phase_1_manifest_implementation_plan.md`
+//! (local-only).  Encodes the 15 manifest invariants from §3 of that
+//! plan as machine-checkable assertions, runs them against the
+//! current workspace, and exits non-zero on the first drift.
+//!
+//! # Design
+//!
+//! * **`--check`-mode only** — the tool is read-only; it never mutates a
+//!   manifest.  Consistent shape with `gen-workflow` and `gen-hooks --check`.
+//! * **Source-of-truth** — `Cargo.toml` files under `crates/`,
+//!   `scripts/ci-pipeline/`, and `scripts/ci/`.  The discovery pattern matches
+//!   the existing `gates-drift` / `workflow-drift` detectors so the three gates
+//!   triangulate the same member set.
+//! * **Exit code** — `0` on no findings; `1` on any finding (with per-finding
+//!   diagnostic written to stderr).
+
+// `BTreeMap`/`BTreeSet` live in `alloc`; the workspace
+// `clippy::std_instead_of_alloc` lint correctly prefers the canonical
+// path over `std::collections::*` re-exports.  Bin crates need the
+// explicit `extern crate alloc;` declaration to make the `alloc::`
+// namespace visible.
+extern crate alloc;
+
+use alloc::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::{Context as _, Result};
+use clap::Parser;
+
+mod audit;
+mod manifest;
+
+use crate::audit::{DiscoveredMember, Finding, audit_all};
+
+/// Workspace-relative path to the root `Cargo.toml`.
+const ROOT_MANIFEST: &str = "Cargo.toml";
+
+/// Workspace-relative roots under which member manifests are discovered.
+/// Mirrors the discovery pattern used by Phase 1 §3.1 audit scripts.
+const MEMBER_ROOTS: &[&str] = &["crates", "scripts/ci-pipeline", "scripts/ci"];
+
+/// Validate the workspace manifest set against the 15 invariants.
+///
+/// `--check` is the default (and only) mode; the flag exists for
+/// symmetry with `gen-hooks` / `gen-workflow` so the pre-push hook
+/// output reads consistently across drift detectors.
+#[derive(Debug, Parser)]
+#[command(
+    name = "manifest-audit",
+    about = "Validate Cargo.toml inheritance against the 15 Phase-1 invariants.",
+    long_about = None,
+)]
+struct Args {
+    /// Run in check-only mode (the default).  Flag retained for CLI
+    /// symmetry with `gen-hooks` / `gen-workflow`.
+    #[arg(long, default_value_t = true)]
+    check: bool,
+
+    /// Workspace root directory.  Hidden flag for tests.
+    #[arg(long, hide = true, default_value = ".")]
+    workspace_root: PathBuf,
+
+    /// Print per-invariant summary on success (default: silent).
+    #[arg(long)]
+    verbose: bool,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("❌ manifest-audit: {err:#}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+/// Fallible entry point that owns every fs-read / parse / audit
+/// step.  Split from `main` so the top-level `ExitCode` mapping
+/// stays declarative.
+fn run() -> Result<()> {
+    let args = Args::parse();
+    let root = &args.workspace_root;
+
+    // Discover every member Cargo.toml + the root.
+    let root_path = root.join(ROOT_MANIFEST);
+    let root_text = std::fs::read_to_string(&root_path)
+        .with_context(|| format!("read root manifest at {}", root_path.display()))?;
+    let root_manifest = manifest::parse_root(&root_text).context("parse root Cargo.toml")?;
+
+    let mut discovered_paths: BTreeSet<String> = BTreeSet::new();
+    let mut member_texts: Vec<(String, String)> = Vec::new(); // (path, raw text)
+    for member_root in MEMBER_ROOTS {
+        let member_root_path = root.join(member_root);
+        if !member_root_path.exists() {
+            continue;
+        }
+        discover_members_recursive(&member_root_path, member_root, &mut discovered_paths)
+            .with_context(|| format!("discover members under {member_root}"))?;
+    }
+    for path in &discovered_paths {
+        let manifest_file = root.join(path).join("Cargo.toml");
+        let text = std::fs::read_to_string(&manifest_file)
+            .with_context(|| format!("read member manifest at {}", manifest_file.display()))?;
+        member_texts.push((format!("{path}/Cargo.toml"), text));
+    }
+
+    // Parse every discovered member manifest.
+    let parsed: Vec<(String, manifest::MemberManifest)> = member_texts
+        .iter()
+        .map(|(path, text)| {
+            let parsed = manifest::parse_member(text)
+                .with_context(|| format!("parse member manifest at {path}"))?;
+            Ok::<_, anyhow::Error>((path.clone(), parsed))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let discovered_members: Vec<DiscoveredMember<'_>> = parsed
+        .iter()
+        .map(|(path, manifest)| DiscoveredMember {
+            manifest_path: path,
+            manifest,
+        })
+        .collect();
+
+    let findings = audit_all(
+        &root_manifest,
+        &root_text,
+        &discovered_members,
+        &discovered_paths,
+    );
+
+    if findings.is_empty() {
+        if args.verbose {
+            eprintln!(
+                "✅ manifest-audit: workspace manifests pass all 15 Phase-1 invariants \
+                 ({} member(s) checked)",
+                discovered_members.len()
+            );
+        }
+        Ok(())
+    } else {
+        emit_findings_report(&findings);
+        anyhow::bail!(
+            "manifest-audit detected {} drift finding(s)",
+            findings.len()
+        );
+    }
+}
+
+/// Walk `dir` (workspace-relative `prefix`) looking for member
+/// `Cargo.toml` files.  Records each *directory* (relative to the
+/// workspace root) in `out`.  Does not descend into `target/`.
+fn discover_members_recursive(
+    dir: &Path,
+    workspace_relative_prefix: &str,
+    out: &mut BTreeSet<String>,
+) -> Result<()> {
+    // Direct child Cargo.toml?
+    if dir.join("Cargo.toml").is_file() {
+        out.insert(workspace_relative_prefix.to_owned());
+    }
+    // Recurse into subdirectories (one level — UFFS nests at most
+    // `scripts/ci/<crate>` deep).
+    let entries = std::fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))?;
+    for entry_result in entries {
+        let entry = entry_result.context("read_dir entry")?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str == "target" || name_str.starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let child_prefix = format!("{workspace_relative_prefix}/{name_str}");
+        if path.join("Cargo.toml").is_file() {
+            out.insert(child_prefix);
+        }
+    }
+    Ok(())
+}
+
+/// Print findings to stderr, grouped by invariant for human
+/// scannability.
+fn emit_findings_report(findings: &[Finding]) {
+    eprintln!(
+        "❌ manifest-audit: {} drift finding(s) detected:",
+        findings.len()
+    );
+    eprintln!();
+    for finding in findings {
+        eprintln!("   • {finding}");
+    }
+    eprintln!();
+    eprintln!(
+        "   Fix locally with manifest edits (NOT lint suppressions).  Each finding cites the \
+         Phase-1 invariant number — see \
+         `docs/dev/architecture/code_clean/phase_1_manifest_implementation_plan.md` §3 for the \
+         clean-state contract."
+    );
+}

--- a/scripts/ci/manifest-audit/src/manifest.rs
+++ b/scripts/ci/manifest-audit/src/manifest.rs
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Minimal Cargo.toml model for the manifest-audit drift detector.
+//!
+//! Only the fields the audit cares about are deserialised — the rest
+//! of every member's `Cargo.toml` is captured as an untyped
+//! `toml::Value` so the audit can poke at arbitrary tables (e.g.
+//! `[lints]`, `[profile.*]`, `[patch.*]`) without enumerating every
+//! permitted shape.  This keeps the audit robust to schema additions
+//! upstream — a new top-level table in Cargo.toml doesn't break the
+//! audit; it just isn't checked.
+
+use anyhow::{Context as _, Result};
+use serde::Deserialize;
+
+/// Parsed root `Cargo.toml`.  Captures only the workspace-shaped
+/// fields the audit cares about.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RootManifest {
+    /// `[workspace]` table — every root manifest must have one
+    /// because UFFS is a virtual workspace.  Missing `[workspace]`
+    /// is itself a finding (handled in `audit::root_is_virtual`).
+    pub(crate) workspace: Option<Workspace>,
+
+    /// `[package]` table if present.  Phase 1 invariant 3.9
+    /// requires this to be `None` (virtual workspace).
+    pub(crate) package: Option<toml::Value>,
+}
+
+/// `[workspace]` table contents.
+#[derive(Debug, Deserialize)]
+pub(crate) struct Workspace {
+    /// Mandatory `resolver = "..."` string.  Phase 1 invariant 3.10
+    /// requires `"3"`.
+    pub(crate) resolver: Option<String>,
+
+    /// Member-list strings.  Phase 1 invariant 3.1 requires this to
+    /// match `find crates scripts -name Cargo.toml` 1:1.
+    pub(crate) members: Vec<String>,
+    // NB: `default-members` is intentionally not captured here —
+    // Phase 1 invariant 3.11 is checked via source-text regex on
+    // the raw root manifest (because `toml::from_str` strips
+    // comments and the invariant's "documented fallback" case
+    // is comment-based).  See `audit::audit_default_members_intent`.
+}
+
+/// Parsed member `Cargo.toml`.  Captures only the fields the audit
+/// cares about; everything else stays untyped (or is dropped).
+#[derive(Debug, Deserialize)]
+pub(crate) struct MemberManifest {
+    /// `[package]` table.  Every workspace member has one; the
+    /// virtual-workspace invariant (3.9) is enforced on the root
+    /// manifest separately.
+    pub(crate) package: MemberPackage,
+
+    /// `[dependencies]` table.  Phase 1 invariant 3.6 requires every
+    /// entry to use `*.workspace = true` (with documented exceptions
+    /// for features-deltas like `libmimalloc-sys`).
+    #[serde(default)]
+    pub(crate) dependencies: toml::Table,
+
+    /// `[lib]` section if present.  Phase 1 invariant 3.13 requires
+    /// the `name` (if set) to use underscores.
+    pub(crate) lib: Option<LibOrBin>,
+
+    /// `[[bin]]` array.  Phase 1 invariant 3.13 requires every
+    /// `name` to use hyphens (except `uffs-diag`'s documented
+    /// underscore-named diagnostic binaries).
+    #[serde(default)]
+    pub(crate) bin: Vec<LibOrBin>,
+
+    /// `[lints]` table.  Phase 1 invariant 3.7 requires
+    /// `workspace = true`.  Captured untyped so the audit can verify
+    /// the exact shape (a single `workspace = true` key, no
+    /// per-crate overrides).
+    pub(crate) lints: Option<toml::Table>,
+
+    /// `[profile.*]` table.  Phase 1 invariant 3.8 requires this to
+    /// be absent — profile policy lives at the workspace root only.
+    pub(crate) profile: Option<toml::Value>,
+
+    /// `[patch.*]` table.  Phase 1 invariant 3.8 requires this to be
+    /// absent — patch policy lives at the workspace root only.
+    pub(crate) patch: Option<toml::Value>,
+
+    /// `[workspace]` table.  Phase 1 invariant 3.8 requires this to
+    /// be absent in members — only the root may declare
+    /// `[workspace]`.
+    pub(crate) workspace: Option<toml::Value>,
+}
+
+/// `[package]` table fields the audit cares about.  Every field is
+/// optional from the deserialiser's perspective so a misshapen
+/// manifest (e.g. missing `name`) surfaces as a clean error instead
+/// of a parse failure.
+#[derive(Debug, Deserialize)]
+pub(crate) struct MemberPackage {
+    // NB: the audit derives the member id from the manifest path
+    // (`member_id_from_path` in `audit.rs`), so `package.name` is
+    // not captured here.  Keeping the file-path-derived id in sync
+    // with `package.name` is itself a future Phase-2 audit
+    // dimension if it becomes worth checking.
+    /// `version = ...` — must be `version.workspace = true`.  When
+    /// inherited it appears as the toml-rs `Workspace { workspace =
+    /// true }` shape; when overridden it appears as a string.
+    pub(crate) version: Option<toml::Value>,
+
+    /// `edition = ...` — Phase 1 invariant 3.3 requires
+    /// `.workspace = true`.
+    pub(crate) edition: Option<toml::Value>,
+
+    /// `rust-version = ...` — Phase 1 invariant 3.4 requires
+    /// `.workspace = true`.
+    #[serde(rename = "rust-version")]
+    pub(crate) rust_version: Option<toml::Value>,
+
+    /// `license = ...` — Phase 1 invariant 3.5 requires
+    /// `.workspace = true`.
+    pub(crate) license: Option<toml::Value>,
+
+    /// `authors = ...` — Phase 1 invariant 3.5 requires
+    /// `.workspace = true`.
+    pub(crate) authors: Option<toml::Value>,
+
+    /// `repository = ...` — Phase 1 invariant 3.5 requires
+    /// `.workspace = true`.
+    pub(crate) repository: Option<toml::Value>,
+
+    /// `readme = ...` — Phase 1 invariant 3.5 requires
+    /// `.workspace = true`.
+    pub(crate) readme: Option<toml::Value>,
+
+    /// `keywords = ...` — Phase 1 invariant 3.5 requires
+    /// `.workspace = true`.
+    pub(crate) keywords: Option<toml::Value>,
+
+    /// `categories = ...` — Phase 1 invariant 3.5 requires
+    /// `.workspace = true`.
+    pub(crate) categories: Option<toml::Value>,
+
+    /// `documentation = ...` — Phase 1 invariant 3.5 requires
+    /// `.workspace = true`.
+    pub(crate) documentation: Option<toml::Value>,
+
+    /// `publish = ...` — Phase 1 invariant 3.14 requires either
+    /// `publish.workspace = true` (most members) or an explicit
+    /// `publish = true` for the small publishable-set documented in
+    /// `release-automation-baseline.md` §10 deviation row 5.
+    pub(crate) publish: Option<toml::Value>,
+
+    /// `[package.metadata.docs.rs]` table.  Phase 1 invariant 3.15
+    /// requires this in every product + publishable crate.  Captured
+    /// untyped because the audit only needs to assert presence, not
+    /// validate the inner `all-features` / `rustdoc-args` shape (that
+    /// would be a separate Phase-2 audit dimension).
+    pub(crate) metadata: Option<toml::Value>,
+}
+
+/// Shared shape for `[lib]` and `[[bin]]` entries.  Only the `name`
+/// field is consulted by the audit (invariant 3.13).
+#[derive(Debug, Deserialize)]
+pub(crate) struct LibOrBin {
+    /// `name = "..."` — optional in Cargo (defaults to the package
+    /// name), but every UFFS member sets it explicitly.
+    pub(crate) name: Option<String>,
+}
+
+/// Parse a root `Cargo.toml` from text.
+///
+/// # Errors
+///
+/// Returns an error if the text is not valid TOML or if any captured
+/// field has the wrong shape (e.g. `members` not an array).
+pub(crate) fn parse_root(text: &str) -> Result<RootManifest> {
+    toml::from_str(text).context("parse root Cargo.toml")
+}
+
+/// Parse a member `Cargo.toml` from text.
+///
+/// # Errors
+///
+/// Returns an error if the text is not valid TOML or if any captured
+/// field has the wrong shape (e.g. `[[bin]]` not an array).
+pub(crate) fn parse_member(text: &str) -> Result<MemberManifest> {
+    toml::from_str(text).context("parse member Cargo.toml")
+}
+
+/// Return `true` if `value` is the TOML inline-table `{ workspace =
+/// true }` shape that Cargo uses for field-level inheritance.  False
+/// for any other shape (e.g. a literal string or array).
+pub(crate) fn is_workspace_inherited(value: &toml::Value) -> bool {
+    let Some(table) = value.as_table() else {
+        return false;
+    };
+    matches!(table.get("workspace"), Some(toml::Value::Boolean(true)))
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::min_ident_chars,
+    reason = "test code uses idiomatic short fixture bindings (e.g. `m` for the parsed \
+              manifest); failures panic with adequate context (issue #212)"
+)]
+mod tests {
+    use super::*;
+
+    const ROOT_FIXTURE: &str = r#"
+[workspace]
+resolver = "3"
+members = ["crates/uffs-core", "crates/uffs-cli"]
+"#;
+
+    const MEMBER_FIXTURE_CLEAN: &str = r#"
+[package]
+name = "uffs-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+documentation.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+description = "per-crate description override is allowed"
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+anyhow = { workspace = true }
+
+[lints]
+workspace = true
+"#;
+
+    #[test]
+    fn root_parses_with_members() {
+        let root = parse_root(ROOT_FIXTURE).unwrap();
+        let ws = root.workspace.as_ref().unwrap();
+        assert_eq!(ws.resolver.as_deref(), Some("3"));
+        assert_eq!(ws.members.len(), 2);
+        assert!(root.package.is_none());
+    }
+
+    #[test]
+    fn member_parses_clean_fixture() {
+        let m = parse_member(MEMBER_FIXTURE_CLEAN).unwrap();
+        assert!(is_workspace_inherited(m.package.version.as_ref().unwrap()));
+        assert!(is_workspace_inherited(m.package.edition.as_ref().unwrap()));
+        assert!(m.package.metadata.is_some());
+        assert!(m.lints.is_some());
+        assert!(m.profile.is_none());
+        assert!(m.patch.is_none());
+        assert!(m.workspace.is_none());
+    }
+
+    #[test]
+    fn workspace_inherited_detects_only_true() {
+        let inherited: toml::Value = toml::from_str("foo = { workspace = true }").unwrap();
+        let inherited_val = inherited.get("foo").unwrap();
+        assert!(is_workspace_inherited(inherited_val));
+
+        let literal: toml::Value = toml::from_str(r#"foo = "1.0.0""#).unwrap();
+        let literal_val = literal.get("foo").unwrap();
+        assert!(!is_workspace_inherited(literal_val));
+
+        let inherited_false: toml::Value = toml::from_str("foo = { workspace = false }").unwrap();
+        let inherited_false_val = inherited_false.get("foo").unwrap();
+        assert!(!is_workspace_inherited(inherited_false_val));
+    }
+}

--- a/scripts/hooks/_lint_pre_push.sh
+++ b/scripts/hooks/_lint_pre_push.sh
@@ -206,6 +206,7 @@ spawn_bg "gates-drift" bash scripts/ci/check_gates_drift.sh
 spawn_bg "hooks-drift" cargo run -q --release -p uffs-gen-hooks -- --check
 spawn_bg "workflow-drift" cargo run -q --release -p uffs-gen-workflow -- --check
 spawn_bg "fast-drift" cargo run -q --release -p uffs-gen-hooks -- --target pre-commit --check
+spawn_bg "manifest-drift" cargo run -q --release -p uffs-manifest-audit -- --check
 spawn_bg "commit-subjects" bash -c '
     set -euo pipefail
     [[ -z "${COMMIT_RANGES// /}" ]] && exit 0

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -37,6 +37,18 @@ Audit rationale (Apr 2026, v0.5.71):
   error on missing var rather than silently succeeding.
 - License: MIT OR Apache-2.0 (inherited from paste)."""
 
+[[audits.rmcp]]
+who = "Robert Nio <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.6.0 -> 1.7.0"
+notes = "Inspected 1.6.0->1.7.0 source diff (8 .rs files, ~50 lines of net change). No new unsafe blocks, no new fs/net/process/FFI surface, no crypto/auth/permission changes. Notable shifts: (a) JsonRpcError.id widened to Option<RequestId> per MCP 2025-11-25 error-response spec; (b) PromptMessageContent::Resource flattened to fix a JSON shape bug (with regression test); (c) async_rw transport switched from FramedRead to BufReader + manual line decode, adding parse-error recovery (sends JSON-RPC -32700 and continues instead of terminating) AND UTF-8 BOM stripping (RFC 8259 §8.1); (d) Cargo.toml narrows chrono to default-features=false + only the 'now' feature (surface reduction). All changes match the published CHANGELOG and are robustness improvements."
+
+[[audits.rmcp-macros]]
+who = "Robert Nio <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.6.0 -> 1.7.0"
+notes = "Pure version-sync release: zero source code changes between 1.6.0 and 1.7.0 (verified via 'diff -qr' over the src/ trees). Only .cargo_vcs_info.json, CHANGELOG.md, Cargo.lock, and the version string in Cargo.toml differ. rmcp-macros is bumped in lockstep with the parent rmcp crate's 1.7.0 release."
+
 [[audits.rustls]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -937,11 +937,174 @@ criteria = "safe-to-run"
 version = "1.0.9"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.78"
+notes = """
+Grepped for "crypt", "cipher", "fs", "net" - there were no hits
+(except for a benign "fs" hit in a doc comment)
+
+Notes from the `unsafe` review can be found in https://crrev.com/c/5385745.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.78 -> 1.0.79"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.79 -> 1.0.80"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.80 -> 1.0.81"
+notes = "Comment changes only"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.81 -> 1.0.82"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.82 -> 1.0.83"
+notes = "Substantive change is replacing String with Box<str>, saving memory."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.83 -> 1.0.84"
+notes = "Only doc comment changes in `src/lib.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.84 -> 1.0.85"
+notes = "Test-only changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.85 -> 1.0.86"
+notes = """
+Comment-only changes in `build.rs`.
+Reordering of `Cargo.toml` entries.
+Just bumping up the version number in `lib.rs`.
+Config-related changes in `test_size.rs`.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.86 -> 1.0.87"
+notes = "No new unsafe interactions."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Liza Burakova <liza@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.87 -> 1.0.89"
+notes = """
+Biggest change is adding error handling in build.rs.
+Some config related changes in wrapper.rs.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.89 -> 1.0.92"
+notes = """
+I looked at the delta and the previous discussion at
+https://chromium-review.googlesource.com/c/chromium/src/+/5385745/3#message-a8e2813129fa3779dab15acede408ee26d67b7f3
+and the changes look okay to me (including the `unsafe fn from_str_unchecked`
+changes in `wrapper.rs`).
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.92 -> 1.0.93"
+notes = "No `unsafe`-related changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.93 -> 1.0.94"
+notes = "Minor doc changes and clippy lint adjustments+fixes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.quick-error]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
 version = "1.2.3"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.35"
+notes = """
+Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits
+(except for benign "net" hit in tests and "fs" hit in README.md)
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.35 -> 1.0.36"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.36 -> 1.0.37"
+notes = """
+The delta just 1) inlines/expands `impl ToTokens` that used to be handled via
+`primitive!` macro and 2) adds `impl ToTokens` for `CStr` and `CString`.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.37 -> 1.0.38"
+notes = "Still no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.38 -> 1.0.39"
+notes = "Only minor changes for clippy lints and documentation."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.39 -> 1.0.40"
+notes = """
+The delta is just a simplification of how `tokens.extend(...)` call is made.
+Still no `unsafe` anywhere.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.rand]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
@@ -1973,6 +2136,12 @@ criteria = "safe-to-run"
 delta = "1.0.9 -> 1.0.13"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.proc-macro2]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.94 -> 1.0.106"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.quinn-udp]]
 who = "Max Inden <mail@max-inden.de>"
 criteria = "safe-to-deploy"
@@ -2021,6 +2190,12 @@ who = "Max Leonard Inden <mail@max-inden.de>"
 criteria = "safe-to-deploy"
 delta = "0.5.12 -> 0.5.13"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.quote]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.40 -> 1.0.45"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.rand_distr]]
 who = "Ben Dean-Kawamura <bdk@mozilla.com>"


### PR DESCRIPTION
Closes #211.

## Summary

Builds the optional Phase-1 follow-up tool described in `docs/dev/architecture/code_clean/phase_1_manifest_implementation_plan.md` §9 and tracked by issue #211. Encodes the 15 manifest invariants from §3 of that plan as machine-checkable assertions and wires them into `pr-fast.yml` + pre-push as a new `manifest-drift` gate.

## What the gate catches

The Phase-1 audit (closed cleanly with zero CHORE findings) can only be re-run on annual cadence. The new gate fires at PR time on every `Cargo.{toml,lock}` change and catches the same drift classes that the manual audit checks:

- A new crate landing without `[lints] workspace = true`
- An accidental `edition = "..."` or `rust-version = "..."` per-crate override
- A `[profile.*]` / `[patch.*]` / `[workspace.*]` block sneaking into a member
- A new `path = "..."` dep pointing outside `[workspace.members]`
- Per-crate overrides of fingerprint metadata (license, repository, authors, …)
- A new member added to the directory tree without being listed in `[workspace.members]`, or vice-versa
- A `[lib].name` with hyphens / `[[bin]].name` with underscores (with the documented `uffs-diag` exception)
- A new publishable crate not in the documented publishable-set
- A new member missing its `[package.metadata.docs.rs]` block
- A member dep not inheriting from `[workspace.dependencies]` (with the 4 documented exceptions: `uffs-cli/uffs-client`, `uffs-cli/uffs-format`, `uffs-polars/polars`, `uffs-daemon/libmimalloc-sys`)

## Implementation

**New crate: `scripts/ci/manifest-audit`** (`uffs-manifest-audit` binary)

- `src/manifest.rs` — minimal Cargo.toml deserialiser capturing only the fields the audit consumes; rest stays untyped (robust to upstream schema additions).
- `src/audit.rs` — the 15 invariant checks + hardcoded `KnownExceptions` table with in-code citations for every intentional deviation:
  - `publish_explicit` — 5 publishable crates from `release-automation-baseline.md` §10 row 5
  - `underscore_bin_ok` — `uffs-diag`'s diagnostic-tool name convention
  - `nonworkspace_dep_ok` — 4 documented (member, dep) pairs each with a rationale
- `src/main.rs` — CLI entry; discovers members under `crates/`, `scripts/ci-pipeline/`, `scripts/ci/`; runs the audit; emits findings to stderr; exits non-zero on drift.
- **13/13 unit tests** cover per-invariant fire + suppress paths.

**Wiring** (sibling of the 4 existing drift detectors):

- `Cargo.toml` — new workspace member + 7-line comment documenting Phase-1 invariant 3.11's deliberate "all-members default" fallback.
- `scripts/ci/gates.toml` — new `[[gate]] id = "manifest-drift"` (`gate_when = "dep_changed"`, `tiers = ["pre-push", "pr-fast"]`, `order = 29`).
- `scripts/hooks/_lint_pre_push.sh` — regenerated via `gen-hooks`; new gate spawns as a Bucket 1 background job.
- `.github/workflows/pr-fast.yml` — new `manifest-drift` job (mirrors `workflow-drift` shape) gated on `needs.classify.outputs.dep == 'true'`; added to `required.needs` + the aggregator `R=(...)` table.

The 4 drift detectors (`gates-drift`, `hooks-drift`, `workflow-drift`, `fast-drift`) now triangulate the workspace from complementary angles — and `manifest-drift` adds the fifth angle (manifest-inheritance invariants).

## Supply-chain delta audits (rmcp + rmcp-macros 1.6.0 → 1.7.0)

The new crate's lock-file refresh bumped `rmcp` and `rmcp-macros` from 1.6.0 to 1.7.0. Per the project's no-suppression-hacks rule, did a **proper delta audit** (not a blind `cargo vet regenerate exemptions`):

- Extracted both versions from `~/.cargo/registry/src/index.crates.io-*/` and ran `diff -ruN` over the source trees.
- Inspected all 8 changed `.rs` files in `rmcp` (~50 lines net change). Verdict: **all robustness improvements** — MCP 2025-11-25 spec compliance, JSON-shape bug fix, parse-error recovery in the async-rw transport, UTF-8 BOM stripping per RFC 8259 §8.1, idempotent session close. **Zero** new `unsafe`, FS, network, process, FFI, crypto, or auth surface.
- `rmcp-macros` 1.6.0 → 1.7.0 is a **pure version-sync release**: `diff -qr` over `src/` confirmed zero source changes.
- Recorded as `[[audits.*]] delta = "1.6.0 -> 1.7.0"` entries in `supply-chain/audits.toml` with detailed `notes` strings.

## Verification

| Gate | Result |
|------|--------|
| `manifest-audit --check` | **0 findings** across 18 members |
| `gen-workflow --check` | ✅ |
| `gen-hooks --check` | ✅ |
| `gates-drift` | ✅ (26 gates) |
| `cargo test -p uffs-manifest-audit` | **13/13 pass** |
| `just lint-pre-push` | **17/17 buckets green** (54 s) |
| `cargo vet` | **Vetting Succeeded** (136 fully audited, 6 partially audited, 371 exempted) |
| `cargo machete` | 0 unused deps |

## Acceptance criteria (from #211)

- ✅ Future audit surfaces drift → gate catches it at PR time instead of waiting on the annual re-audit cadence.
- The detector's machine-checkable assertions encode every Phase-1 §3 invariant; the `KnownExceptions` mechanism means future intentional deviations require an in-code citation (not a silent allowlist).

## Commits (atomic, per concern)

1. `chore(ci): add manifest-inheritance drift-detector (closes #211)` — crate + wiring + workspace integration.
2. `chore(supply-chain): vet rmcp + rmcp-macros 1.6.0 -> 1.7.0 (refs #211)` — delta audits for the lock-file refresh.