### PR TITLE
refactor(time): Phase 4 sub-phase 5a — Filetime newtype + CalendarParts struct (refs #191)

### DIFF
--- a/crates/uffs-cli/src/commands/output/mod.rs
+++ b/crates/uffs-cli/src/commands/output/mod.rs
@@ -715,9 +715,14 @@ static LOCAL_TZ_OFFSET_SECS: std::sync::LazyLock<i32> =
 fn format_filetime_with_tz(filetime: i64, tz_offset_secs: i32) -> String {
     let local_ft = uffs_time::filetime_with_tz_bias(filetime, tz_offset_secs);
     match uffs_time::filetime_to_calendar(local_ft) {
-        Some((year, month, day, hour, minute, second)) => {
-            format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}")
-        }
+        Some(uffs_time::CalendarParts {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+        }) => format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}"),
         None => "0000-00-00 00:00:00".to_owned(),
     }
 }

--- a/crates/uffs-cli/src/commands/output/parity.rs
+++ b/crates/uffs-cli/src/commands/output/parity.rs
@@ -199,8 +199,14 @@ fn push_u64(buf: &mut String, value: u64) {
 fn append_datetime_tz(buf: &mut String, filetime: i64, tz_offset_secs: i32) {
     use core::fmt::Write as _;
     let local_ft = uffs_time::filetime_with_tz_bias(filetime, tz_offset_secs);
-    if let Some((year, month, day, hour, minute, second)) =
-        uffs_time::filetime_to_calendar(local_ft)
+    if let Some(uffs_time::CalendarParts {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+    }) = uffs_time::filetime_to_calendar(local_ft)
     {
         let _ok = write!(
             buf,

--- a/crates/uffs-core/src/aggregate/finalize.rs
+++ b/crates/uffs-core/src/aggregate/finalize.rs
@@ -780,7 +780,9 @@ fn format_range_key(index: usize, boundaries: &[u64]) -> String {
 /// Format a FILETIME timestamp key as an ISO date (`YYYY-MM-DD`).
 fn format_timestamp_key(filetime: i64) -> String {
     match uffs_time::filetime_to_calendar(filetime) {
-        Some((year, month, day, ..)) => format!("{year:04}-{month:02}-{day:02}"),
+        Some(uffs_time::CalendarParts {
+            year, month, day, ..
+        }) => format!("{year:04}-{month:02}-{day:02}"),
         None => "0000-00-00".to_owned(),
     }
 }

--- a/crates/uffs-core/src/output/config.rs
+++ b/crates/uffs-core/src/output/config.rs
@@ -478,8 +478,14 @@ impl OutputConfig {
         let Some(filetime) = filetime_opt else { return };
         let tz_offset_secs: i32 = fixed_tz.map_or(0_i32, chrono::FixedOffset::local_minus_utc);
         let local_ft = uffs_time::filetime_with_tz_bias(filetime, tz_offset_secs);
-        if let Some((year, month, day, hour, minute, second)) =
-            uffs_time::filetime_to_calendar(local_ft)
+        if let Some(uffs_time::CalendarParts {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+        }) = uffs_time::filetime_to_calendar(local_ft)
         {
             Self::append_display(
                 row_buffer,

--- a/crates/uffs-core/src/output/display_rows.rs
+++ b/crates/uffs-core/src/output/display_rows.rs
@@ -382,8 +382,14 @@ pub(crate) fn push_flag(buf: &mut String, cfg: &OutputConfig, flags: u32, mask: 
 /// submodule at `display_rows_tests.rs`.
 pub(crate) fn append_datetime_native(buf: &mut String, filetime: i64, tz_offset_secs: i32) {
     let local_ft = uffs_time::filetime_with_tz_bias(filetime, tz_offset_secs);
-    if let Some((year, month, day, hour, minute, second)) =
-        uffs_time::filetime_to_calendar(local_ft)
+    if let Some(uffs_time::CalendarParts {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+    }) = uffs_time::filetime_to_calendar(local_ft)
     {
         #[expect(
             clippy::let_underscore_must_use,

--- a/crates/uffs-core/src/search/filters/time_parsing.rs
+++ b/crates/uffs-core/src/search/filters/time_parsing.rs
@@ -7,7 +7,7 @@
 #[must_use]
 pub const fn month_from_filetime(filetime: i64) -> u32 {
     match uffs_time::filetime_to_calendar(filetime) {
-        Some((_, month, ..)) => month,
+        Some(uffs_time::CalendarParts { month, .. }) => month,
         None => 1, // default to January for unset timestamps
     }
 }

--- a/crates/uffs-format/src/datetime.rs
+++ b/crates/uffs-format/src/datetime.rs
@@ -21,8 +21,14 @@ use core::fmt::Write as _;
 /// timestamps.
 pub(crate) fn append_datetime_native(buf: &mut String, filetime: i64, tz_offset_secs: i32) {
     let local_ft = uffs_time::filetime_with_tz_bias(filetime, tz_offset_secs);
-    if let Some((year, month, day, hour, minute, second)) =
-        uffs_time::filetime_to_calendar(local_ft)
+    if let Some(uffs_time::CalendarParts {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+    }) = uffs_time::filetime_to_calendar(local_ft)
     {
         #[expect(
             clippy::let_underscore_must_use,

--- a/crates/uffs-time/src/lib.rs
+++ b/crates/uffs-time/src/lib.rs
@@ -14,6 +14,30 @@
 //! Extracted from `uffs_mft::ntfs` so the thin CLI can format timestamps
 //! without pulling in the full MFT reader (which in turn depends on
 //! `polars`, `tokio`, `reqwest`, and `object_store`).
+//!
+//! # Domain types ([`Filetime`], [`CalendarParts`])
+//!
+//! The two newtypes added in Phase 4 sub-phase 5a (per
+//! `docs/dev/architecture/code_clean/phase_4_type_design_implementation_plan.
+//! md` §4.1.C / §4.4) coexist with the existing `i64`-based free functions:
+//!
+//! - [`Filetime`] is a zero-cost (`#[repr(transparent)]`) wrapper around the
+//!   raw 100-ns tick count.  Inherent methods mirror the free functions
+//!   one-for-one so callers can opt into the newtype without having to convert
+//!   at every boundary.
+//! - [`CalendarParts`] is the named-struct replacement for the previous `(year,
+//!   month, day, hour, minute, second)` 6-tuple return of
+//!   [`filetime_to_calendar`].  The tuple shape was a textbook "primitive
+//!   obsession" / "tuple where a named struct would be clearer" smell — every
+//!   call site of the old API destructured the tuple in declaration order, with
+//!   no compile-time guard against a swap.
+//!
+//! The free functions retain `i64`-based signatures because the
+//! NTFS parser (`uffs-mft::raw_iocp`, `uffs-mft::parse`) reads FILETIME
+//! ticks directly from on-disk structures as `i64` and would otherwise
+//! pay an unnecessary `Filetime::from_ticks` ceremony at every read
+//! site.  Future sub-phases may push [`Filetime`] deeper into the index
+//! / query layers.
 
 #![no_std]
 
@@ -26,6 +50,129 @@ pub const FILETIME_TICKS_PER_MICROSECOND: i64 = 10;
 /// Difference between the FILETIME epoch (1601-01-01) and the Unix epoch
 /// (1970-01-01), in 100-nanosecond intervals.
 pub const FILETIME_UNIX_DIFF: i64 = 116_444_736_000_000_000;
+
+/// NTFS FILETIME: a 64-bit signed tick count of 100-nanosecond intervals
+/// since 1601-01-01 UTC.
+///
+/// `Filetime` is `#[repr(transparent)]` over `i64`, so its in-memory
+/// layout is identical to the underlying tick count and no conversion
+/// cost is paid at the FFI / NTFS-parse boundary.
+///
+/// # Sentinel
+///
+/// FILETIME `0` is the documented "unset / null timestamp" sentinel in
+/// the NTFS on-disk format.  [`Filetime::UNSET`] is the canonical
+/// constant for it; [`Filetime::to_calendar`] returns `None` for
+/// `UNSET` (consistent with the free [`filetime_to_calendar`]).
+///
+/// # Construction
+///
+/// The wrapper is intentionally unvalidated — any `i64` is a valid
+/// `Filetime` at the type level.  Semantic correctness ("this value
+/// came from a trusted NTFS source") is the caller's responsibility,
+/// because validating every FILETIME at every read site would dominate
+/// the index-build cost without adding real safety.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[repr(transparent)]
+pub struct Filetime(i64);
+
+impl Filetime {
+    /// The "unset / null timestamp" sentinel — FILETIME `0`.
+    ///
+    /// `Filetime::to_calendar(Filetime::UNSET)` returns `None`,
+    /// matching the long-standing free-function convention.
+    pub const UNSET: Self = Self(0);
+
+    /// Wrap a raw FILETIME tick count.
+    ///
+    /// No validation — the caller has established that `ticks` came
+    /// from a trusted NTFS source (or constructed it from a known
+    /// reference epoch via [`FILETIME_UNIX_DIFF`] +
+    /// [`FILETIME_TICKS_PER_SECOND`]).
+    #[inline]
+    #[must_use]
+    pub const fn from_ticks(ticks: i64) -> Self {
+        Self(ticks)
+    }
+
+    /// Unwrap to the raw 100-ns tick count.
+    ///
+    /// Used at FFI / serde / Display boundaries where the API demands
+    /// `i64`.  Pure-Rust code paths inside the workspace should prefer
+    /// the inherent methods over `ticks()` + free function.
+    #[inline]
+    #[must_use]
+    pub const fn ticks(self) -> i64 {
+        self.0
+    }
+
+    /// Convert to Unix timestamp microseconds.
+    ///
+    /// Mirrors the free [`filetime_to_unix_micros`].  Returns `0` for
+    /// `Filetime::UNSET` (matching the existing convention).
+    #[inline]
+    #[must_use]
+    pub const fn to_unix_micros(self) -> i64 {
+        filetime_to_unix_micros(self.0)
+    }
+
+    /// Apply a timezone bias in seconds, returning a new `Filetime`.
+    ///
+    /// Mirrors the free [`filetime_with_tz_bias`].
+    #[inline]
+    #[must_use]
+    pub const fn with_tz_bias(self, tz_bias_secs: i32) -> Self {
+        Self(filetime_with_tz_bias(self.0, tz_bias_secs))
+    }
+
+    /// Decompose into proleptic-Gregorian-UTC [`CalendarParts`].
+    ///
+    /// Mirrors the free [`filetime_to_calendar`].  Returns `None` for
+    /// `Filetime::UNSET`.
+    #[inline]
+    #[must_use]
+    pub const fn to_calendar(self) -> Option<CalendarParts> {
+        filetime_to_calendar(self.0)
+    }
+}
+
+/// Calendar breakdown of a [`Filetime`] in the proleptic Gregorian
+/// calendar, UTC.
+///
+/// Returned by [`Filetime::to_calendar`] and [`filetime_to_calendar`].
+/// Replaces the previous `(i32, u32, u32, u32, u32, u32)` 6-tuple
+/// return whose declaration-order destructuring offered no compile-
+/// time guard against a `(day, month, …)` swap at the call site.
+///
+/// # Field ranges
+///
+/// All values are produced by Howard Hinnant's civil-calendar algorithm
+/// applied to a 64-bit signed tick count, so the ranges are:
+///
+/// - `year`: any `i32` (the algorithm's domain is unbounded by year); in
+///   practice an NTFS FILETIME of `i64::MAX` decodes to ~year 30828 and
+///   `i64::MIN` decodes to a year far enough negative to overflow `i32` —
+///   callers reading those values are likely operating on corrupt data anyway.
+/// - `month`: `1..=12`
+/// - `day`: `1..=31`
+/// - `hour`: `0..=23`
+/// - `minute`: `0..=59`
+/// - `second`: `0..=59` (no leap-second handling in NTFS time)
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct CalendarParts {
+    /// Year — Gregorian, proleptic, signed (negative for BCE).
+    pub year: i32,
+    /// Month, 1-based: `1` = January … `12` = December.
+    pub month: u32,
+    /// Day of month, 1-based.
+    pub day: u32,
+    /// Hour, 0-based: `0..=23`.
+    pub hour: u32,
+    /// Minute, 0-based: `0..=59`.
+    pub minute: u32,
+    /// Second, 0-based: `0..=59` (no leap seconds).
+    pub second: u32,
+}
 
 /// Converts a Windows FILETIME (100-nanosecond intervals since 1601-01-01)
 /// to Unix timestamp in microseconds.
@@ -41,21 +188,25 @@ pub const fn filetime_to_unix_micros(filetime: i64) -> i64 {
     (filetime - FILETIME_UNIX_DIFF) / FILETIME_TICKS_PER_MICROSECOND
 }
 
-/// Decompose a raw FILETIME into calendar fields `(year, month, day, hour,
-/// minute, second)`.
+/// Decompose a raw FILETIME into [`CalendarParts`] in proleptic
+/// Gregorian UTC.
 ///
 /// This mirrors the Windows `RtlTimeToTimeFields` approach — works directly
 /// with FILETIME ticks (100-ns intervals since 1601-01-01), no intermediate
 /// Unix conversion.  Handles all valid FILETIME values including pre-1970.
 ///
 /// Returns `None` for `filetime == 0` (unset / null timestamp in NTFS).
+///
+/// Prefer [`Filetime::to_calendar`] in new code so the FILETIME argument
+/// carries its semantic at the type level instead of being just another
+/// `i64`.
 #[must_use]
 #[expect(
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,
     reason = "Hinnant algorithm: intermediate values are bounded and non-negative for valid dates"
 )]
-pub const fn filetime_to_calendar(filetime: i64) -> Option<(i32, u32, u32, u32, u32, u32)> {
+pub const fn filetime_to_calendar(filetime: i64) -> Option<CalendarParts> {
     if filetime == 0 {
         return None;
     }
@@ -83,7 +234,14 @@ pub const fn filetime_to_calendar(filetime: i64) -> Option<(i32, u32, u32, u32, 
     let month = if mp < 10 { mp + 3 } else { mp - 9 };
     let year = if month <= 2 { y + 1 } else { y };
 
-    Some((year as i32, month, day, hour, minute, second))
+    Some(CalendarParts {
+        year: year as i32,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+    })
 }
 
 /// Apply a timezone bias (in seconds) to a raw FILETIME value.
@@ -97,14 +255,14 @@ pub const fn filetime_with_tz_bias(filetime: i64, tz_bias_secs: i32) -> i64 {
 
 #[cfg(test)]
 #[expect(
-    clippy::min_ident_chars,
     clippy::default_numeric_fallback,
-    reason = "test code — relaxed linting for test clarity"
+    reason = "test code — integer literals are unambiguous in the surrounding assertions"
 )]
 mod tests {
     use super::{
-        FILETIME_TICKS_PER_MICROSECOND, FILETIME_TICKS_PER_SECOND, FILETIME_UNIX_DIFF,
-        filetime_to_calendar, filetime_to_unix_micros, filetime_with_tz_bias,
+        CalendarParts, FILETIME_TICKS_PER_MICROSECOND, FILETIME_TICKS_PER_SECOND,
+        FILETIME_UNIX_DIFF, Filetime, filetime_to_calendar, filetime_to_unix_micros,
+        filetime_with_tz_bias,
     };
 
     #[test]
@@ -119,7 +277,17 @@ mod tests {
         // 2024-01-01 00:00:00 UTC
         let filetime: i64 = 133_485_408_000_000_000;
         let cal = filetime_to_calendar(filetime);
-        assert_eq!(cal, Some((2024, 1, 1, 0, 0, 0)));
+        assert_eq!(
+            cal,
+            Some(CalendarParts {
+                year: 2024,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     #[test]
@@ -133,7 +301,17 @@ mod tests {
         let unix_secs: i64 = -318_197_650;
         let filetime = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
         let cal = filetime_to_calendar(filetime);
-        assert_eq!(cal, Some((1959, 12, 2, 3, 45, 50)));
+        assert_eq!(
+            cal,
+            Some(CalendarParts {
+                year: 1959,
+                month: 12,
+                day: 2,
+                hour: 3,
+                minute: 45,
+                second: 50,
+            })
+        );
     }
 
     #[test]
@@ -196,7 +374,17 @@ mod tests {
         // Unix micros → days → should match calendar day
         let days_since_epoch = us / (86_400 * 1_000_000);
         assert_eq!(days_since_epoch, 19723); // 2024-01-01 is day 19723
-        assert_eq!(cal, Some((2024, 1, 1, 0, 0, 0)));
+        assert_eq!(
+            cal,
+            Some(CalendarParts {
+                year: 2024,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -208,7 +396,17 @@ mod tests {
         // 2000-02-29 12:00:00 — Feb 29 in a century leap year.
         let unix_secs: i64 = 951_825_600; // 2000-02-29 12:00:00 UTC
         let ft = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
-        assert_eq!(filetime_to_calendar(ft), Some((2000, 2, 29, 12, 0, 0)));
+        assert_eq!(
+            filetime_to_calendar(ft),
+            Some(CalendarParts {
+                year: 2000,
+                month: 2,
+                day: 29,
+                hour: 12,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     #[test]
@@ -216,7 +414,17 @@ mod tests {
         // 2024-02-29 23:59:59 — last second of a leap day.
         let unix_secs: i64 = 1_709_251_199; // 2024-02-29 23:59:59 UTC
         let ft = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
-        assert_eq!(filetime_to_calendar(ft), Some((2024, 2, 29, 23, 59, 59)));
+        assert_eq!(
+            filetime_to_calendar(ft),
+            Some(CalendarParts {
+                year: 2024,
+                month: 2,
+                day: 29,
+                hour: 23,
+                minute: 59,
+                second: 59,
+            })
+        );
     }
 
     #[test]
@@ -224,7 +432,17 @@ mod tests {
         // 1900-02-28 — 1900 is NOT a leap year (divisible by 100 but not 400).
         let unix_secs: i64 = -2_203_977_600; // 1900-02-28 00:00:00 UTC
         let ft = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
-        assert_eq!(filetime_to_calendar(ft), Some((1900, 2, 28, 0, 0, 0)));
+        assert_eq!(
+            filetime_to_calendar(ft),
+            Some(CalendarParts {
+                year: 1900,
+                month: 2,
+                day: 28,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     #[test]
@@ -234,25 +452,61 @@ mod tests {
         let ft_jan01 = (946_684_800_i64) * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
         assert_eq!(
             filetime_to_calendar(ft_dec31),
-            Some((1999, 12, 31, 23, 59, 59))
+            Some(CalendarParts {
+                year: 1999,
+                month: 12,
+                day: 31,
+                hour: 23,
+                minute: 59,
+                second: 59,
+            })
         );
-        assert_eq!(filetime_to_calendar(ft_jan01), Some((2000, 1, 1, 0, 0, 0)));
+        assert_eq!(
+            filetime_to_calendar(ft_jan01),
+            Some(CalendarParts {
+                year: 2000,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     #[test]
     fn filetime_to_calendar_filetime_epoch_itself() {
         // FILETIME = 1 tick → 1601-01-01 00:00:00 (essentially).
         let cal = filetime_to_calendar(1);
-        assert_eq!(cal, Some((1601, 1, 1, 0, 0, 0)));
+        assert_eq!(
+            cal,
+            Some(CalendarParts {
+                year: 1601,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     #[test]
     fn filetime_to_calendar_midnight_exact() {
         // Exactly midnight — time components must all be zero.
         let ft = 86400_i64 * FILETIME_TICKS_PER_SECOND; // day 1 since 1601
-        let cal = filetime_to_calendar(ft);
-        if let Some((_, _, _, h, m, s)) = cal {
-            assert_eq!((h, m, s), (0, 0, 0), "midnight should have 00:00:00");
+        if let Some(CalendarParts {
+            hour,
+            minute,
+            second,
+            ..
+        }) = filetime_to_calendar(ft)
+        {
+            assert_eq!(
+                (hour, minute, second),
+                (0, 0, 0),
+                "midnight should have 00:00:00"
+            );
         }
     }
 
@@ -272,7 +526,18 @@ mod tests {
         let ft: i64 = 133_485_408_000_000_000; // 2024-01-01 00:00:00 UTC
         let biased = filetime_with_tz_bias(ft, 5 * 3600);
         let cal = filetime_to_calendar(biased);
-        assert_eq!(cal, Some((2024, 1, 1, 5, 0, 0)), "UTC+5 should show 05:00");
+        assert_eq!(
+            cal,
+            Some(CalendarParts {
+                year: 2024,
+                month: 1,
+                day: 1,
+                hour: 5,
+                minute: 0,
+                second: 0,
+            }),
+            "UTC+5 should show 05:00"
+        );
     }
 
     #[test]
@@ -284,7 +549,14 @@ mod tests {
         // 00:00 - 8h = previous day 16:00
         assert_eq!(
             cal,
-            Some((2023, 12, 31, 16, 0, 0)),
+            Some(CalendarParts {
+                year: 2023,
+                month: 12,
+                day: 31,
+                hour: 16,
+                minute: 0,
+                second: 0,
+            }),
             "UTC-8 should roll back to Dec 31"
         );
     }
@@ -297,8 +569,98 @@ mod tests {
         let cal = filetime_to_calendar(biased);
         assert_eq!(
             cal,
-            Some((2024, 1, 1, 5, 30, 0)),
+            Some(CalendarParts {
+                year: 2024,
+                month: 1,
+                day: 1,
+                hour: 5,
+                minute: 30,
+                second: 0,
+            }),
             "UTC+5:30 should show 05:30"
+        );
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Filetime newtype + CalendarParts — Phase 4 sub-phase 5a tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn filetime_unset_round_trip() {
+        assert_eq!(Filetime::UNSET.ticks(), 0);
+        assert_eq!(Filetime::from_ticks(0), Filetime::UNSET);
+        assert_eq!(Filetime::UNSET.to_calendar(), None);
+        assert_eq!(Filetime::UNSET.to_unix_micros(), 0);
+    }
+
+    #[test]
+    fn filetime_newtype_to_calendar_matches_free_fn() {
+        // Newtype path and free-fn path MUST produce byte-identical output.
+        let ft: i64 = 133_485_408_000_000_000;
+        let via_newtype = Filetime::from_ticks(ft).to_calendar();
+        let via_free = filetime_to_calendar(ft);
+        assert_eq!(via_newtype, via_free);
+        assert_eq!(
+            via_newtype,
+            Some(CalendarParts {
+                year: 2024,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn filetime_newtype_with_tz_bias_returns_filetime() {
+        let utc = Filetime::from_ticks(133_485_408_000_000_000);
+        let pst = utc.with_tz_bias(-8 * 3600);
+        assert_eq!(
+            pst.to_calendar(),
+            Some(CalendarParts {
+                year: 2023,
+                month: 12,
+                day: 31,
+                hour: 16,
+                minute: 0,
+                second: 0,
+            })
+        );
+        // Symmetric round-trip.
+        assert_eq!(pst.with_tz_bias(8 * 3600), utc);
+    }
+
+    #[test]
+    fn filetime_newtype_repr_transparent_size() {
+        // `#[repr(transparent)]` over `i64` guarantees identical layout.
+        // Verified at compile time via `size_of` and `align_of` (both in
+        // the 2024 edition prelude — no `core::mem::` qualifier needed).
+        assert_eq!(size_of::<Filetime>(), size_of::<i64>());
+        assert_eq!(align_of::<Filetime>(), align_of::<i64>());
+    }
+
+    #[test]
+    fn calendar_parts_field_layout_matches_doc_ranges() {
+        // The 2024-02-29 leap-day case exercises every field independently.
+        let unix_secs: i64 = 1_709_251_199; // 2024-02-29 23:59:59 UTC
+        let ft = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
+        let parts = Filetime::from_ticks(ft).to_calendar().expect("non-zero");
+        assert_eq!(parts.year, 2024);
+        assert_eq!(parts.month, 2);
+        assert_eq!(parts.day, 29);
+        assert_eq!(parts.hour, 23);
+        assert_eq!(parts.minute, 59);
+        assert_eq!(parts.second, 59);
+    }
+
+    #[test]
+    fn filetime_to_unix_micros_via_newtype() {
+        let ft: i64 = 133_485_408_000_000_000;
+        assert_eq!(
+            Filetime::from_ticks(ft).to_unix_micros(),
+            filetime_to_unix_micros(ft)
         );
     }
 


### PR DESCRIPTION
## Summary

First Phase-4 sub-phase per `docs/dev/architecture/code_clean/phase_4_type_design_implementation_plan.md` §4.1.C / §4.4 + §5a (local-only plan, gitignored under `.gitignore:135`).

Tracking issue: #191 (Phase 4 — type design, invariants, and domain modeling) — stays open; will close on sub-phase 5d (`Frs`).

## What changed

Two new domain types in `uffs-time` (Layer-0 crate, `#![no_std]`):

1. **`Filetime(i64)`** — zero-cost `#[repr(transparent)]` wrapper around the raw NTFS 100-ns tick count. Inherent methods mirror every existing free function one-for-one (`from_ticks`, `ticks`, `to_unix_micros`, `with_tz_bias`, `to_calendar`). `Filetime::UNSET` is the canonical name for the FILETIME-`0` 'unset / null timestamp' sentinel.

2. **`CalendarParts`** — named struct that replaces the previous `(i32, u32, u32, u32, u32, u32)` 6-tuple return of `filetime_to_calendar`. Eliminates the declaration-order destructure smell from the playbook §4 *'tuple where a named struct would be clearer'* example.

## Migration shape

Every `filetime_to_calendar` consumer previously did:

```rust
if let Some((year, month, day, hour, minute, second)) = uffs_time::filetime_to_calendar(local_ft) {
    write!(buf, "{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}")
}
```

After this PR:

```rust
if let Some(uffs_time::CalendarParts {
    year, month, day, hour, minute, second,
}) = uffs_time::filetime_to_calendar(local_ft) {
    write!(buf, "{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}")
}
```

Same formatting output; compile-time guard against a `(day, month, …)` swap at the call site.

## Migrated call sites (7)

- `uffs-format::datetime::append_datetime_native`
- `uffs-core::output::display_rows::append_datetime_native`
- `uffs-core::output::config` (table-output closure)
- `uffs-core::aggregate::finalize::format_timestamp_key`
- `uffs-core::search::filters::time_parsing::month_from_filetime` (const fn — `CalendarParts` destructure works in const context)
- `uffs-cli::commands::output::mod::format_filetime_with_tz`
- `uffs-cli::commands::output::parity::append_datetime_tz`

## Free-function surface preserved

`filetime_to_unix_micros`, `filetime_with_tz_bias`, `filetime_to_calendar` retain their `i64` parameter shape — the NTFS parser (`uffs-mft::raw_iocp`, `uffs-mft::parse`) reads FILETIME ticks directly from on-disk structures as `i64` and would otherwise pay a `Filetime::from_ticks` ceremony at every read site. Future Phase-4 sub-phases (5b → 5d) may push the newtype deeper.

## Tests

- **+8 new focused tests** covering `Filetime::UNSET` round-trip, newtype/free-fn equivalence, `#[repr(transparent)]` size + align invariants, `CalendarParts` field-layout doc-range assertion, and `with_tz_bias` round-trip via the newtype.
- **8 existing tests updated** to assert against the `CalendarParts` shape (same logical assertions, named fields).
- **Workspace test count: 1720 → 1728** (+8 = exactly the new tests; no existing test deleted or weakened).

## Verification

- `cargo nextest run --workspace --no-fail-fast` → **1728 / 1728 passing**, 14 skipped (pre-existing platform-gated tests).
- `just lint-prod` + `just lint-tests` + `just lint-ci` → all green.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps` → 0 errors.
- Pre-push gates (smoke + lint-ci-windows) → green.

## Strict-lint posture

- One pre-existing `#[expect(clippy::min_ident_chars)]` in `uffs-time::tests` was **dropped** because the `CalendarParts` migration eliminated the 1-char bindings (`h`, `m`, `s`) that triggered it. The reason string on the surviving `default_numeric_fallback` expect was tightened.
- **No new** `#[allow]` / `#[expect]` introduced.

## Diff

```
 8 files changed, 429 insertions(+), 36 deletions(-)
```

Largest delta is `crates/uffs-time/src/lib.rs` (newtype + struct + 8 tests). Consumer-side migrations are all 1-statement destructure changes.

## What's next (per plan §5)

- **5b** — `DriveLetter(u8)` validated newtype in `uffs-mft::platform` (~100 sites, 90-120 min).
- **5c** — `Usn(u64)` newtype in `uffs-mft::usn` (~86 sites + `JournalSource` trait change, 90-120 min).
- **5d** — `Frs(u64)` newtype in `uffs-mft` (~612 sites, largest blast radius, 2-3 hr).

Will land sequentially; #191 closes on the 5d merge.