### PR TITLE
refactor: Phase 4.5a + 4.5b — Filetime + DriveLetter newtypes (refs #191)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,6 +4377,7 @@ dependencies = [
  "serde_json",
  "uffs-client",
  "uffs-format",
+ "uffs-mft",
  "uffs-time",
  "which",
  "winresource",
@@ -4396,6 +4397,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uffs-format",
+ "uffs-mft",
  "uffs-security",
  "windows 0.62.2",
 ]
@@ -4537,6 +4539,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uffs-client",
+ "uffs-mft",
 ]
 
 [[package]]
@@ -4559,6 +4562,7 @@ dependencies = [
  "rand_chacha 0.10.0",
  "rayon",
  "rustc-hash",
+ "serde",
  "sha2 0.11.0",
  "smallvec",
  "tempfile",

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -71,6 +71,12 @@ uffs-client = { path = "../uffs-client", version = "0.5.90", default-features = 
 # rationale (R6 of `release-automation-plan.md`).
 uffs-format = { path = "../uffs-format", version = "0.5.90" }
 
+# Typed drive-letter newtype.  Direct dep so the CLI command signatures
+# (`daemon_load`, `daemon_tiering`, etc.) name `DriveLetter` natively
+# rather than re-exporting through `uffs-client`.  Wire format is
+# unchanged — the (de)serialise impl emits a single ASCII char.
+uffs-mft.workspace = true
+
 # Error handling
 anyhow.workspace = true
 

--- a/crates/uffs-cli/src/args.rs
+++ b/crates/uffs-cli/src/args.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 /// # Errors
 ///
 /// Returns an error if the input is not a valid drive letter.
-pub(crate) fn parse_drive_letter(input: &str) -> Result<char, String> {
+pub(crate) fn parse_drive_letter(input: &str) -> Result<uffs_mft::platform::DriveLetter, String> {
     let trimmed = input.trim();
     let letter_str = trimmed.strip_suffix(':').unwrap_or(trimmed);
 
@@ -31,11 +31,8 @@ pub(crate) fn parse_drive_letter(input: &str) -> Result<char, String> {
         .next()
         .ok_or_else(|| format!("Invalid drive letter '{input}'"))?;
 
-    if !ch.is_ascii_alphabetic() {
-        return Err(format!("Invalid drive letter '{input}': must be A-Z"));
-    }
-
-    Ok(ch.to_ascii_uppercase())
+    uffs_mft::platform::DriveLetter::parse(ch)
+        .map_err(|err| format!("Invalid drive letter '{input}': {err}"))
 }
 
 // ── Subcommand types ───────────────────────────────────────────────────
@@ -63,7 +60,7 @@ pub(crate) enum DaemonAction {
         /// Data directory.
         data_dir: Option<PathBuf>,
         /// Drive letter(s) to load (filters `--data-dir` discovery).
-        drives: Vec<char>,
+        drives: Vec<uffs_mft::platform::DriveLetter>,
         /// Skip file cache.
         no_cache: bool,
         /// Log level.
@@ -98,7 +95,7 @@ pub(crate) enum DaemonAction {
         /// Data directory — discover and load a specific drive from it.
         data_dir: Option<PathBuf>,
         /// Drive letter(s) to load (Windows live only).
-        drives: Vec<char>,
+        drives: Vec<uffs_mft::platform::DriveLetter>,
         /// Skip cache when loading.
         no_cache: bool,
     },
@@ -108,7 +105,7 @@ pub(crate) enum DaemonAction {
     /// hibernate --help`.
     Hibernate {
         /// Drive letter(s) to hibernate; empty = all loaded drives.
-        drives: Vec<char>,
+        drives: Vec<uffs_mft::platform::DriveLetter>,
     },
     /// Promote drive(s) to `Hot` and pin the tier (Phase 8-C).
     ///
@@ -116,7 +113,7 @@ pub(crate) enum DaemonAction {
     /// (matches the daemon's `DEFAULT_PRELOAD_PIN_MINUTES`).
     Preload {
         /// Drive letter(s) to preload (must be non-empty).
-        drives: Vec<char>,
+        drives: Vec<uffs_mft::platform::DriveLetter>,
         /// Override the default 30-min pin window.
         pin_minutes: Option<u32>,
     },
@@ -128,7 +125,7 @@ pub(crate) enum DaemonAction {
     /// (clearing pins) before unlinking the cache files.
     Forget {
         /// Drive letter(s) to forget (must be non-empty).
-        drives: Vec<char>,
+        drives: Vec<uffs_mft::platform::DriveLetter>,
         /// Force-forget non-`Cold` drives by auto-hibernating first.
         force: bool,
     },
@@ -197,8 +194,8 @@ fn parse_daemon_start(rest: &[String]) -> DaemonAction {
             "--drive" => {
                 if let Some(val) = iter.next() {
                     for ch in val.chars() {
-                        if ch.is_ascii_alphabetic() {
-                            drives.push(ch.to_ascii_uppercase());
+                        if let Ok(letter) = uffs_mft::platform::DriveLetter::parse(ch) {
+                            drives.push(letter);
                         }
                     }
                 }
@@ -387,7 +384,7 @@ fn parse_daemon_forget(rest: &[String]) -> Result<DaemonAction, anyhow::Error> {
 /// values, and whitespace.  Silently skips entries that don't parse
 /// as ASCII letters - mirrors the lenient parsing already used by
 /// `parse_daemon_load`.
-fn extend_drives_from_csv(drives: &mut Vec<char>, value: &str) {
+fn extend_drives_from_csv(drives: &mut Vec<uffs_mft::platform::DriveLetter>, value: &str) {
     for part in value.split(',') {
         if let Ok(letter) = parse_drive_letter(part) {
             drives.push(letter);

--- a/crates/uffs-cli/src/commands/daemon_load.rs
+++ b/crates/uffs-cli/src/commands/daemon_load.rs
@@ -35,7 +35,7 @@ use uffs_client::connect_sync::UffsClientSync;
 pub(crate) fn daemon_load(
     mft_files: &[std::path::PathBuf],
     data_dir: Option<&std::path::Path>,
-    drives: &[char],
+    drives: &[uffs_mft::platform::DriveLetter],
     no_cache: bool,
 ) -> Result<()> {
     let Ok(mut client) = UffsClientSync::connect_raw() else {
@@ -62,11 +62,12 @@ pub(crate) fn daemon_load(
     // Drive letters without --data-dir → hot-load by letter.
     // On Windows this reads live NTFS; on non-Windows the daemon uses its
     // own data_dir.
-    let direct_drives: Vec<char> = if data_dir.is_none() && paths.is_empty() {
-        drives.to_vec()
-    } else {
-        Vec::new()
-    };
+    let direct_drives: Vec<uffs_mft::platform::DriveLetter> =
+        if data_dir.is_none() && paths.is_empty() {
+            drives.to_vec()
+        } else {
+            Vec::new()
+        };
 
     if paths.is_empty() && direct_drives.is_empty() {
         anyhow::bail!(
@@ -143,7 +144,10 @@ pub(crate) fn daemon_load(
 ///
 /// Returns the best MFT file path from each matching subdirectory.
 #[expect(clippy::print_stderr, reason = "CLI diagnostic warning")]
-fn resolve_drive_subdirs(data_dir: &std::path::Path, drives: &[char]) -> Vec<std::path::PathBuf> {
+fn resolve_drive_subdirs(
+    data_dir: &std::path::Path,
+    drives: &[uffs_mft::platform::DriveLetter],
+) -> Vec<std::path::PathBuf> {
     let mut results = Vec::new();
 
     let entries = match std::fs::read_dir(data_dir) {
@@ -169,12 +173,15 @@ fn resolve_drive_subdirs(data_dir: &std::path::Path, drives: &[char]) -> Vec<std
         let Some(letter_str) = name.strip_prefix("drive_") else {
             continue;
         };
-        let Some(letter) = letter_str.chars().next().filter(char::is_ascii_alphabetic) else {
+        let Some(letter_char) = letter_str.chars().next() else {
+            continue;
+        };
+        let Ok(letter) = uffs_mft::platform::DriveLetter::parse(letter_char) else {
             continue;
         };
 
         // If specific drives requested, skip others.
-        if !drives.is_empty() && !drives.iter().any(|dr| dr.eq_ignore_ascii_case(&letter)) {
+        if !drives.is_empty() && !drives.contains(&letter) {
             continue;
         }
 

--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -69,7 +69,7 @@ pub(crate) fn daemon(action: &DaemonAction) -> Result<()> {
 fn daemon_start(
     mft_files: &[std::path::PathBuf],
     data_dir: Option<&std::path::Path>,
-    drives: &[char],
+    drives: &[uffs_mft::platform::DriveLetter],
     no_cache: bool,
     log_level: &str,
     log_file: Option<&std::path::Path>,

--- a/crates/uffs-cli/src/commands/daemon_tiering.rs
+++ b/crates/uffs-cli/src/commands/daemon_tiering.rs
@@ -42,7 +42,7 @@ use uffs_client::protocol::response::{
 ///   Already Cold:     (none)
 /// ```
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
-pub(crate) fn daemon_hibernate(drives: &[char]) -> Result<()> {
+pub(crate) fn daemon_hibernate(drives: &[uffs_mft::platform::DriveLetter]) -> Result<()> {
     let mut client = UffsClientSync::connect_raw()
         .map_err(|err| anyhow::anyhow!("Daemon is not running: {err}"))?;
 
@@ -104,7 +104,10 @@ pub(crate) fn daemon_hibernate(drives: &[char]) -> Result<()> {
 ///   Pin expires at:    1700001800000 (Unix-millis)
 /// ```
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
-pub(crate) fn daemon_preload(drives: &[char], pin_minutes: Option<u32>) -> Result<()> {
+pub(crate) fn daemon_preload(
+    drives: &[uffs_mft::platform::DriveLetter],
+    pin_minutes: Option<u32>,
+) -> Result<()> {
     let mut client = UffsClientSync::connect_raw()
         .map_err(|err| anyhow::anyhow!("Daemon is not running: {err}"))?;
 
@@ -169,7 +172,7 @@ pub(crate) fn daemon_preload(drives: &[char], pin_minutes: Option<u32>) -> Resul
 ///   Already absent:   (none)
 /// ```
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
-pub(crate) fn daemon_forget(drives: &[char], force: bool) -> Result<()> {
+pub(crate) fn daemon_forget(drives: &[uffs_mft::platform::DriveLetter], force: bool) -> Result<()> {
     let mut client = UffsClientSync::connect_raw()
         .map_err(|err| anyhow::anyhow!("Daemon is not running: {err}"))?;
 
@@ -357,13 +360,16 @@ fn format_bytes(bytes: u64) -> String {
 /// `"(none)"` when the slice is empty.  Keeps the per-line output
 /// in [`daemon_hibernate`] / [`daemon_preload`] / [`daemon_forget`]
 /// visually aligned even on no-op calls.
-fn format_drive_list(drives: &[char]) -> String {
+fn format_drive_list(drives: &[uffs_mft::platform::DriveLetter]) -> String {
     if drives.is_empty() {
         "(none)".to_owned()
     } else {
+        // `DriveLetter` implements `Display` (renders as the
+        // uppercase ASCII char), so `ToString::to_string` produces
+        // the same output as the previous `char::to_string`.
         drives
             .iter()
-            .map(char::to_string)
+            .map(ToString::to_string)
             .collect::<Vec<_>>()
             .join(", ")
     }

--- a/crates/uffs-cli/src/commands/output/mod.rs
+++ b/crates/uffs-cli/src/commands/output/mod.rs
@@ -715,9 +715,14 @@ static LOCAL_TZ_OFFSET_SECS: std::sync::LazyLock<i32> =
 fn format_filetime_with_tz(filetime: i64, tz_offset_secs: i32) -> String {
     let local_ft = uffs_time::filetime_with_tz_bias(filetime, tz_offset_secs);
     match uffs_time::filetime_to_calendar(local_ft) {
-        Some((year, month, day, hour, minute, second)) => {
-            format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}")
-        }
+        Some(uffs_time::CalendarParts {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+        }) => format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}"),
         None => "0000-00-00 00:00:00".to_owned(),
     }
 }

--- a/crates/uffs-cli/src/commands/output/mod.rs
+++ b/crates/uffs-cli/src/commands/output/mod.rs
@@ -51,8 +51,9 @@ fn vb(row: &Value, key: &str) -> bool {
 
 /// Context for legacy baseline-compatible footer formatting.
 pub(crate) struct CppFooterContext<'a> {
-    /// Drive letters to include in the footer (e.g., `['C', 'D']`).
-    pub output_targets: &'a [char],
+    /// Drive letters to include in the footer (e.g.
+    /// `[DriveLetter::C, DriveLetter::D]`).
+    pub output_targets: &'a [uffs_mft::platform::DriveLetter],
     /// Original search pattern string.
     pub pattern: &'a str,
     /// Total result row count for fast-scan heuristic.
@@ -80,7 +81,7 @@ pub fn write_native_results(
     pos: &str,
     neg: &str,
     tz_offset: Option<i32>,
-    output_targets: &[char],
+    output_targets: &[uffs_mft::platform::DriveLetter],
     _elapsed: Duration,
     pattern: &str,
 ) -> Result<()> {

--- a/crates/uffs-cli/src/commands/output/output_tests.rs
+++ b/crates/uffs-cli/src/commands/output/output_tests.rs
@@ -96,7 +96,10 @@ fn write_native_csv_uses_columns_without_legacy_footer() -> TestResult {
         "1",
         "0",
         None,
-        &['C', 'D'],
+        &[
+            uffs_mft::platform::DriveLetter::C,
+            uffs_mft::platform::DriveLetter::D,
+        ],
         Duration::from_secs(2),
         "*.txt",
     )?;
@@ -124,7 +127,10 @@ fn write_native_custom_file_appends_legacy_drive_footer() -> TestResult {
         "1",
         "0",
         None,
-        &['C', 'D'],
+        &[
+            uffs_mft::platform::DriveLetter::C,
+            uffs_mft::platform::DriveLetter::D,
+        ],
         Duration::from_secs(2),
         "*.txt",
     )?;
@@ -162,7 +168,10 @@ fn write_native_json_file_has_no_footer() -> TestResult {
         "1",
         "0",
         None,
-        &['C', 'D'],
+        &[
+            uffs_mft::platform::DriveLetter::C,
+            uffs_mft::platform::DriveLetter::D,
+        ],
         Duration::from_secs(2),
         "*.txt",
     )?;
@@ -195,7 +204,7 @@ fn legacy_footer_includes_fast_scan_message_for_full_scan_pattern() -> TestResul
         "1",
         "0",
         None,
-        &['G'],
+        &[uffs_mft::platform::DriveLetter::G],
         Duration::from_millis(999),
         "*",
     )?;
@@ -224,7 +233,7 @@ fn legacy_footer_includes_fast_scan_for_transformed_pattern() -> TestResult {
         "1",
         "0",
         None,
-        &['G'],
+        &[uffs_mft::platform::DriveLetter::G],
         Duration::from_millis(999),
         ">G:.*",
     )?;
@@ -253,7 +262,7 @@ fn legacy_footer_omits_fast_scan_for_real_regex_pattern() -> TestResult {
         "1",
         "0",
         None,
-        &['G'],
+        &[uffs_mft::platform::DriveLetter::G],
         Duration::from_millis(999),
         r">G:.*\.(jpg|png)",
     )?;
@@ -282,7 +291,7 @@ fn legacy_footer_omits_fast_scan_message_when_many_results() -> TestResult {
         "1",
         "0",
         None,
-        &['G'],
+        &[uffs_mft::platform::DriveLetter::G],
         Duration::from_secs(2),
         ">G:.*",
     )?;
@@ -424,7 +433,7 @@ fn parity_row(
     modified_filetime: i64,
 ) -> uffs_client::protocol::response::SearchRow {
     uffs_client::protocol::response::SearchRow {
-        drive: 'C',
+        drive: uffs_mft::platform::DriveLetter::C,
         path: path.to_owned(),
         name: name.to_owned(),
         size: 4321,
@@ -534,7 +543,7 @@ fn parity_byte_parity_directory_rewrite() {
         0x0010,                      // DIRECTORY
         133_485_408_000_000_000_i64, // 2024-01-01 UTC
     );
-    row.drive = 'D';
+    row.drive = uffs_mft::platform::DriveLetter::D;
     row.size = 0;
     row.allocated = 0;
     row.treesize = 65_536;

--- a/crates/uffs-cli/src/commands/output/parity.rs
+++ b/crates/uffs-cli/src/commands/output/parity.rs
@@ -235,8 +235,12 @@ pub(super) fn write_legacy_drive_footer<W: Write + ?Sized>(
     writer: &mut W,
     ctx: &CppFooterContext<'_>,
 ) -> Result<()> {
+    // `uffs-format` deliberately does not depend on `uffs-mft` (issue
+    // #216); convert at the crate boundary so the format crate keeps
+    // its narrow char-only API.
+    let chars: Vec<char> = ctx.output_targets.iter().map(|dl| dl.as_char()).collect();
     let fmt_ctx = uffs_format::DriveFooterContext {
-        output_targets: ctx.output_targets,
+        output_targets: &chars,
         pattern: ctx.pattern,
         row_count: ctx.row_count,
     };

--- a/crates/uffs-cli/src/commands/output/parity.rs
+++ b/crates/uffs-cli/src/commands/output/parity.rs
@@ -199,8 +199,14 @@ fn push_u64(buf: &mut String, value: u64) {
 fn append_datetime_tz(buf: &mut String, filetime: i64, tz_offset_secs: i32) {
     use core::fmt::Write as _;
     let local_ft = uffs_time::filetime_with_tz_bias(filetime, tz_offset_secs);
-    if let Some((year, month, day, hour, minute, second)) =
-        uffs_time::filetime_to_calendar(local_ft)
+    if let Some(uffs_time::CalendarParts {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+    }) = uffs_time::filetime_to_calendar(local_ft)
     {
         let _ok = write!(
             buf,

--- a/crates/uffs-cli/src/commands/search/dispatch.rs
+++ b/crates/uffs-cli/src/commands/search/dispatch.rs
@@ -64,17 +64,25 @@ pub fn write_rows(rows: &[serde_json::Value], args: &[String]) -> Result<()> {
     let drive = arg_val(args, "--drive").or_else(|| arg_val(args, "-d"));
     let drives_str = arg_val(args, "--drives");
     let mft_str = arg_val(args, "--mft-file");
-    let mut targets: Vec<char> = Vec::new();
+    let mut targets: Vec<uffs_mft::platform::DriveLetter> = Vec::new();
     if let Some(drive_val) = drive {
-        if let Some(letter) = drive_val.chars().next().filter(char::is_ascii_alphabetic) {
-            targets.push(letter.to_ascii_uppercase());
+        if let Some(letter) = drive_val
+            .chars()
+            .next()
+            .and_then(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
+        {
+            targets.push(letter);
         }
     } else if let Some(drives_val) = drives_str {
         for part in drives_val.split(',') {
             let trimmed = part.trim();
             let stripped = trimmed.strip_suffix(':').unwrap_or(trimmed);
-            if let Some(letter) = stripped.chars().next().filter(char::is_ascii_alphabetic) {
-                targets.push(letter.to_ascii_uppercase());
+            if let Some(letter) = stripped
+                .chars()
+                .next()
+                .and_then(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
+            {
+                targets.push(letter);
             }
         }
     } else if let Some(mft_val) = mft_str {

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -647,9 +647,18 @@ mod tests {
 
     #[test]
     fn parse_drive_letter_accepts_letter_colon_and_whitespace_variants() {
-        assert_eq!(parse_drive_letter("c"), Ok('C'));
-        assert_eq!(parse_drive_letter("C:"), Ok('C'));
-        assert_eq!(parse_drive_letter(" d: "), Ok('D'));
+        assert_eq!(
+            parse_drive_letter("c"),
+            Ok(uffs_mft::platform::DriveLetter::C)
+        );
+        assert_eq!(
+            parse_drive_letter("C:"),
+            Ok(uffs_mft::platform::DriveLetter::C)
+        );
+        assert_eq!(
+            parse_drive_letter(" d: "),
+            Ok(uffs_mft::platform::DriveLetter::D)
+        );
     }
 
     #[test]
@@ -683,7 +692,7 @@ mod tests {
         // in uffs-client for the full rewrite semantics.
         assert_eq!(params.pattern, "*");
         assert_eq!(params.ext.as_deref(), Some("rs"));
-        assert_eq!(params.drives, vec!['C']);
+        assert_eq!(params.drives, vec![uffs_mft::platform::DriveLetter::C]);
         assert_eq!(params.output_tz_offset_hours, Some(-8));
     }
 

--- a/crates/uffs-client/Cargo.toml
+++ b/crates/uffs-client/Cargo.toml
@@ -56,6 +56,11 @@ uffs-security.workspace = true
 # output with the daemon's `--out=file` path.  Zero polars, zero
 # tokio — preserves the thin-client binary-size invariant.
 uffs-format.workspace = true
+# Typed drive-letter newtype.  Used in the protocol response shapes
+# (`LoadDriveResponse`, `TieringResponse`, ...) so the client surface
+# is typed end-to-end.  Wire format is unchanged — `DriveLetter`'s
+# serde impl emits/accepts a single ASCII char.
+uffs-mft.workspace = true
 
 # Async — optional; only pulled when the `async` feature is enabled.
 # The sync `UffsClientSync` used by the CLI does not depend on tokio.

--- a/crates/uffs-client/src/connect.rs
+++ b/crates/uffs-client/src/connect.rs
@@ -635,7 +635,10 @@ impl UffsClient {
     /// # Errors
     ///
     /// Returns a `ClientError` on connection, protocol, or timeout failure.
-    pub async fn refresh(&mut self, drives: &[char]) -> Result<(), crate::error::ClientError> {
+    pub async fn refresh(
+        &mut self,
+        drives: &[uffs_mft::platform::DriveLetter],
+    ) -> Result<(), crate::error::ClientError> {
         let params = serde_json::json!({"drives": drives});
         let _result = self.send_request("refresh", Some(params)).await?;
         Ok(())

--- a/crates/uffs-client/src/connect_sync.rs
+++ b/crates/uffs-client/src/connect_sync.rs
@@ -599,7 +599,7 @@ impl UffsClientSync {
     /// Returns `ClientError` on I/O, protocol, or timeout failure.
     pub fn load_drive_letters(
         &mut self,
-        drives: &[char],
+        drives: &[uffs_mft::platform::DriveLetter],
         no_cache: bool,
     ) -> Result<crate::protocol::response::LoadDriveResponse, ClientError> {
         let params = serde_json::json!({
@@ -615,7 +615,10 @@ impl UffsClientSync {
     /// # Errors
     ///
     /// Returns `ClientError` on I/O, protocol, or timeout failure.
-    pub fn refresh(&mut self, drives: &[char]) -> Result<(), ClientError> {
+    pub fn refresh(
+        &mut self,
+        drives: &[uffs_mft::platform::DriveLetter],
+    ) -> Result<(), ClientError> {
         let params = serde_json::json!({"drives": drives});
         let _result = self.send_request("refresh", Some(params))?;
         Ok(())

--- a/crates/uffs-client/src/format.rs
+++ b/crates/uffs-client/src/format.rs
@@ -339,19 +339,23 @@ pub(crate) fn is_aggregate_preset(spec: &str) -> bool {
 /// Extract a drive letter from a search pattern, if present.
 ///
 /// Patterns like `c:/*.txt` or `D:\folder` start with a drive prefix.
-/// Returns `Some('C')` (uppercased) if found, `None` otherwise.
+/// Returns the typed `DriveLetter` if found, `None` otherwise.
 ///
 /// ```
 /// # use uffs_client::format::extract_drive_letter;
-/// assert_eq!(extract_drive_letter("c:/*.txt"), Some('C'));
-/// assert_eq!(extract_drive_letter("D:\\folder"), Some('D'));
+/// # use uffs_mft::platform::DriveLetter;
+/// assert_eq!(extract_drive_letter("c:/*.txt"), Some(DriveLetter::C));
+/// assert_eq!(extract_drive_letter("D:\\folder"), Some(DriveLetter::D));
 /// assert_eq!(extract_drive_letter("*.txt"), None);
 /// assert_eq!(extract_drive_letter(">regex"), None);
 /// ```
 #[must_use]
-pub fn extract_drive_letter(pattern: &str) -> Option<char> {
+pub fn extract_drive_letter(pattern: &str) -> Option<uffs_mft::platform::DriveLetter> {
     let bytes = pattern.as_bytes();
     let first = *bytes.first()?;
     let second = *bytes.get(1)?;
-    (second == b':' && first.is_ascii_alphabetic()).then(|| (first as char).to_ascii_uppercase())
+    if second != b':' || !first.is_ascii_alphabetic() {
+        return None;
+    }
+    uffs_mft::platform::DriveLetter::parse(first as char).ok()
 }

--- a/crates/uffs-client/src/protocol/cli_args.rs
+++ b/crates/uffs-client/src/protocol/cli_args.rs
@@ -281,8 +281,8 @@ impl SearchParams {
 )]
 struct RawCliArgs {
     pattern: Option<String>,
-    drive: Option<char>,
-    drives: Option<Vec<char>>,
+    drive: Option<uffs_mft::platform::DriveLetter>,
+    drives: Option<Vec<uffs_mft::platform::DriveLetter>>,
     files_only: bool,
     dirs_only: bool,
     hide_system: bool,
@@ -552,7 +552,7 @@ impl RawCliArgs {
         let agg_only = !agg_specs.is_empty() && !force_rows;
 
         // ── Drives ─────────────────────────────────────────────────
-        let drives: Vec<char> = self
+        let drives: Vec<uffs_mft::platform::DriveLetter> = self
             .drives
             .or_else(|| self.drive.map(|ch| vec![ch]))
             .unwrap_or_default();

--- a/crates/uffs-client/src/protocol/cli_args_helpers.rs
+++ b/crates/uffs-client/src/protocol/cli_args_helpers.rs
@@ -41,7 +41,7 @@ pub(super) fn flag_val(
 }
 
 /// Parse comma-separated drive letters.
-pub(super) fn drives_csv(input: &str) -> Result<Vec<char>, String> {
+pub(super) fn drives_csv(input: &str) -> Result<Vec<uffs_mft::platform::DriveLetter>, String> {
     input
         .split(',')
         .map(|part| {
@@ -54,7 +54,12 @@ pub(super) fn drives_csv(input: &str) -> Result<Vec<char>, String> {
             if trimmed.len() != 1 || !ch.is_ascii_alphabetic() {
                 return Err(format!("Bad drive: '{part}'"));
             }
-            Ok(ch.to_ascii_uppercase())
+            // `is_ascii_alphabetic` proves the parse succeeds; we
+            // forward the `DriveLetterError` text for the (impossible)
+            // failure case so the error path is still readable if the
+            // invariant ever changes.
+            uffs_mft::platform::DriveLetter::parse(ch)
+                .map_err(|err| format!("Bad drive: '{part}' ({err})"))
         })
         .collect()
 }
@@ -201,7 +206,9 @@ pub(super) fn extract_extensions_from_regex(pattern: &str) -> Option<Vec<String>
 /// Mirrored by `uffs_core::search::backend::parse_bare_drive_prefix`
 /// (the daemon's belt-and-suspenders safety net at dispatch time).
 /// Keep the two definitions in sync.
-pub(super) fn parse_bare_drive_prefix(pattern: &str) -> Option<(char, &str)> {
+pub(super) fn parse_bare_drive_prefix(
+    pattern: &str,
+) -> Option<(uffs_mft::platform::DriveLetter, &str)> {
     let bytes = pattern.as_bytes();
     let letter = *bytes.first()?;
     if !letter.is_ascii_alphabetic() {
@@ -215,5 +222,9 @@ pub(super) fn parse_bare_drive_prefix(pattern: &str) -> Option<(char, &str)> {
     if rest.is_empty() || rest.starts_with(['\\', '/']) {
         return None;
     }
-    Some((letter.to_ascii_uppercase() as char, rest))
+    // The `is_ascii_alphabetic` guard above proves the `try_from`
+    // cannot fail; using `?` keeps the API a `Option` and avoids an
+    // unwrap.
+    let drive_letter = uffs_mft::platform::DriveLetter::try_from(letter).ok()?;
+    Some((drive_letter, rest))
 }

--- a/crates/uffs-client/src/protocol/mod.rs
+++ b/crates/uffs-client/src/protocol/mod.rs
@@ -291,7 +291,7 @@ pub struct SearchParams {
     pub predicates: Vec<SearchPredicate>,
     /// Specific drives to search (empty = all loaded).
     #[serde(default)]
-    pub drives: Vec<char>,
+    pub drives: Vec<uffs_mft::platform::DriveLetter>,
     /// Requested projection fields in canonical order.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub projection: Vec<String>,
@@ -523,7 +523,7 @@ pub struct SearchParams {
     /// C.mft` targets drive C for the footer but leaves `drives`
     /// empty because the MFT path is a separate wire selector.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub output_drive_targets: Vec<char>,
+    pub output_drive_targets: Vec<uffs_mft::platform::DriveLetter>,
 }
 
 /// Default-true helper for serde.

--- a/crates/uffs-client/src/protocol/response.rs
+++ b/crates/uffs-client/src/protocol/response.rs
@@ -29,7 +29,7 @@ use super::{
 pub struct RefreshParams {
     /// Specific drives to refresh (empty = all loaded).
     #[serde(default)]
-    pub drives: Vec<char>,
+    pub drives: Vec<uffs_mft::platform::DriveLetter>,
 }
 
 /// Parameters for the `load_drive` method.
@@ -46,7 +46,7 @@ pub struct LoadDriveParams {
     /// On Windows, reads the live NTFS MFT.
     /// On non-Windows, discovers from the daemon's `data_dir`.
     #[serde(default)]
-    pub drives: Vec<char>,
+    pub drives: Vec<uffs_mft::platform::DriveLetter>,
     /// Skip cache when loading.
     #[serde(default)]
     pub no_cache: bool,
@@ -56,9 +56,9 @@ pub struct LoadDriveParams {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LoadDriveResponse {
     /// Drives that were successfully loaded.
-    pub loaded: Vec<char>,
+    pub loaded: Vec<uffs_mft::platform::DriveLetter>,
     /// Drives that were already present (skipped).
-    pub already_loaded: Vec<char>,
+    pub already_loaded: Vec<uffs_mft::platform::DriveLetter>,
     /// Errors encountered (drive letter → message).
     pub errors: Vec<String>,
 }
@@ -449,7 +449,7 @@ const fn is_zero_u64(value: &u64) -> bool {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DriveProfile {
     /// Drive letter.
-    pub drive: char,
+    pub drive: uffs_mft::platform::DriveLetter,
     /// Records in this drive's index.
     pub records: usize,
     /// Matching rows found in this search.
@@ -473,7 +473,7 @@ pub struct DriveProfile {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SearchRow {
     /// Drive letter.
-    pub drive: char,
+    pub drive: uffs_mft::platform::DriveLetter,
     /// Full resolved path.
     pub path: String,
     /// Filename.
@@ -517,7 +517,11 @@ pub struct SearchRow {
 impl uffs_format::FormatRow for SearchRow {
     #[inline]
     fn drive(&self) -> char {
-        self.drive
+        // `uffs-format` is a foundation crate that intentionally
+        // doesn't depend on `uffs-mft`, so the trait surface stays
+        // `char`-typed.  We translate at this boundary; the cost is
+        // one byte read.
+        self.drive.as_char()
     }
     #[inline]
     fn path(&self) -> &str {

--- a/crates/uffs-client/src/protocol/response_status.rs
+++ b/crates/uffs-client/src/protocol/response_status.rs
@@ -61,7 +61,7 @@ pub enum ShardTier {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DriveInfo {
     /// Drive letter.
-    pub letter: char,
+    pub letter: uffs_mft::platform::DriveLetter,
     /// Number of records in the compact index.  `0` for `Parked` /
     /// `Cold` shards whose body has been released.
     pub records: usize,
@@ -121,7 +121,7 @@ pub struct StatusResponse {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DriveMemoryInfo {
     /// Drive letter.
-    pub drive: char,
+    pub drive: uffs_mft::platform::DriveLetter,
     /// Number of records in this drive's index.
     pub records: usize,
     /// Calculated heap footprint in bytes.
@@ -196,6 +196,6 @@ pub enum DaemonStatus {
     #[serde(rename = "refreshing")]
     Refreshing {
         /// Drives being refreshed.
-        drives: Vec<char>,
+        drives: Vec<uffs_mft::platform::DriveLetter>,
     },
 }

--- a/crates/uffs-client/src/protocol/response_tiering.rs
+++ b/crates/uffs-client/src/protocol/response_tiering.rs
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 pub struct HibernateParams {
     /// Specific drives to hibernate.  Empty vector = every loaded drive.
     #[serde(default)]
-    pub drives: Vec<char>,
+    pub drives: Vec<uffs_mft::platform::DriveLetter>,
 }
 
 /// Response for the `hibernate` method.
@@ -54,16 +54,16 @@ pub struct HibernateParams {
 pub struct HibernateResponse {
     /// Drives whose pre-call tier was `Hot`.
     #[serde(default)]
-    pub hot_demoted: Vec<char>,
+    pub hot_demoted: Vec<uffs_mft::platform::DriveLetter>,
     /// Drives whose pre-call tier was `Warm`.
     #[serde(default)]
-    pub warm_demoted: Vec<char>,
+    pub warm_demoted: Vec<uffs_mft::platform::DriveLetter>,
     /// Drives whose pre-call tier was `Parked`.
     #[serde(default)]
-    pub parked_demoted: Vec<char>,
+    pub parked_demoted: Vec<uffs_mft::platform::DriveLetter>,
     /// Drives that were already `Cold` (or unknown to the registry).
     #[serde(default)]
-    pub already_cold: Vec<char>,
+    pub already_cold: Vec<uffs_mft::platform::DriveLetter>,
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -91,7 +91,7 @@ pub struct PreloadParams {
     /// Drives to promote to `Hot`.  Empty = invalid (the daemon returns
     /// [`super::ERR_INVALID_PARAMS`]).
     #[serde(default)]
-    pub drives: Vec<char>,
+    pub drives: Vec<uffs_mft::platform::DriveLetter>,
     /// Pin duration in minutes.  `None` ⇒ [`DEFAULT_PRELOAD_PIN_MINUTES`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pin_minutes: Option<u32>,
@@ -107,11 +107,11 @@ pub struct PreloadParams {
 pub struct PreloadResponse {
     /// Drives that transitioned to `Hot` as part of this call.
     #[serde(default)]
-    pub promoted: Vec<char>,
+    pub promoted: Vec<uffs_mft::platform::DriveLetter>,
     /// Drives that were already `Hot`.  Pin window is still extended
     /// to the new [`Self::pin_until_unix_ms`].
     #[serde(default)]
-    pub already_hot: Vec<char>,
+    pub already_hot: Vec<uffs_mft::platform::DriveLetter>,
     /// Per-drive errors, prefixed with the drive letter
     /// (`"Z: cache file missing"`).
     #[serde(default)]
@@ -142,7 +142,7 @@ pub struct ForgetParams {
     /// Drives to forget.  Empty = invalid (the daemon returns
     /// [`super::ERR_INVALID_PARAMS`]).
     #[serde(default)]
-    pub drives: Vec<char>,
+    pub drives: Vec<uffs_mft::platform::DriveLetter>,
     /// Force-forget non-`Cold` drives by auto-hibernating first.
     /// Default `false` ⇒ refuse with [`super::ERR_DRIVE_BUSY`] so the
     /// side effect (memory drop) is explicit.
@@ -160,10 +160,10 @@ pub struct ForgetParams {
 pub struct ForgetResponse {
     /// Drives whose cache files were deleted in this call.
     #[serde(default)]
-    pub forgotten: Vec<char>,
+    pub forgotten: Vec<uffs_mft::platform::DriveLetter>,
     /// Drives that had no cache files on disk (idempotent no-op).
     #[serde(default)]
-    pub already_absent: Vec<char>,
+    pub already_absent: Vec<uffs_mft::platform::DriveLetter>,
     /// Cumulative bytes freed across every successfully-forgotten drive.
     #[serde(default)]
     pub freed_bytes: u64,
@@ -208,10 +208,14 @@ pub struct StatusDrivesResponse {
 /// `ShardEntry` state plus the per-shard usage counters maintained by
 /// the journal-loop telemetry.  See `crates/uffs-daemon/src/cache/`
 /// for the daemon-side source of truth.
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+///
+/// `Default` is intentionally not derived: `letter` is a typed
+/// `DriveLetter` which has no canonical zero value, and no caller
+/// currently constructs `DriveTierStatus` via `::default()`.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct DriveTierStatus {
     /// Drive letter.
-    pub letter: char,
+    pub letter: uffs_mft::platform::DriveLetter,
     /// Current tier name (lowercase, matching
     /// [`super::response_status::ShardTier`]).
     pub tier: String,

--- a/crates/uffs-client/src/protocol/tests.rs
+++ b/crates/uffs-client/src/protocol/tests.rs
@@ -186,7 +186,7 @@ fn daemon_status_round_trip() {
 fn search_response_inline_rows_round_trip() {
     let resp = SearchResponse {
         payload: SearchPayload::InlineRows(vec![SearchRow {
-            drive: 'C',
+            drive: uffs_mft::platform::DriveLetter::C,
             path: "C:\\test.rs".to_owned(),
             name: "test.rs".to_owned(),
             size: 1024,
@@ -1500,7 +1500,7 @@ fn from_cli_args_drive_prefix_with_ext_glob_promotes_both() {
     let params = SearchParams::from_cli_args(&args).expect("parse");
     assert_eq!(
         params.drives,
-        vec!['C'],
+        vec![uffs_mft::platform::DriveLetter::C],
         "drive prefix must populate drives filter"
     );
     assert_eq!(
@@ -1523,7 +1523,7 @@ fn from_cli_args_drive_prefix_with_ext_glob_promotes_both() {
 fn from_cli_args_drive_prefix_with_literal_preserves_pattern() {
     let args: Vec<String> = vec!["D:notepad.exe".into()];
     let params = SearchParams::from_cli_args(&args).expect("parse");
-    assert_eq!(params.drives, vec!['D']);
+    assert_eq!(params.drives, vec![uffs_mft::platform::DriveLetter::D]);
     assert_eq!(
         params.pattern, "notepad.exe",
         "literal pattern must be left alone after prefix strip"
@@ -1560,7 +1560,7 @@ fn from_cli_args_drive_prefix_lowercase_letter_is_uppercased() {
     let params = SearchParams::from_cli_args(&args).expect("parse");
     assert_eq!(
         params.drives,
-        vec!['C'],
+        vec![uffs_mft::platform::DriveLetter::C],
         "drive letter must be uppercased regardless of input case"
     );
     assert_eq!(params.pattern, "*");
@@ -1576,7 +1576,7 @@ fn from_cli_args_drive_prefix_respects_explicit_drive_flag() {
     let params = SearchParams::from_cli_args(&args).expect("parse");
     assert_eq!(
         params.drives,
-        vec!['D'],
+        vec![uffs_mft::platform::DriveLetter::D],
         "explicit --drive D must win over inferred C prefix"
     );
     // Prefix is still stripped; ext-glob promotion still fires on the rest.
@@ -1832,7 +1832,11 @@ fn default_preload_pin_minutes_is_thirty() {
 #[test]
 fn hibernate_params_round_trip() {
     let params = HibernateParams {
-        drives: vec!['C', 'D', 'E'],
+        drives: vec![
+            uffs_mft::platform::DriveLetter::C,
+            uffs_mft::platform::DriveLetter::D,
+            uffs_mft::platform::DriveLetter::E,
+        ],
     };
     let json = serde_json::to_string(&params).expect("serialize");
     let parsed: HibernateParams = serde_json::from_str(&json).expect("deserialize");
@@ -1854,10 +1858,16 @@ fn hibernate_params_empty_drives_means_all() {
 #[test]
 fn hibernate_response_round_trip() {
     let resp = HibernateResponse {
-        hot_demoted: vec!['C'],
-        warm_demoted: vec!['D', 'E'],
-        parked_demoted: vec!['F'],
-        already_cold: vec!['G', 'H'],
+        hot_demoted: vec![uffs_mft::platform::DriveLetter::C],
+        warm_demoted: vec![
+            uffs_mft::platform::DriveLetter::D,
+            uffs_mft::platform::DriveLetter::E,
+        ],
+        parked_demoted: vec![uffs_mft::platform::DriveLetter::F],
+        already_cold: vec![
+            uffs_mft::platform::DriveLetter::G,
+            uffs_mft::platform::DriveLetter::H,
+        ],
     };
     let json = serde_json::to_string(&resp).expect("serialize");
     let parsed: HibernateResponse = serde_json::from_str(&json).expect("deserialize");
@@ -1867,7 +1877,7 @@ fn hibernate_response_round_trip() {
 #[test]
 fn preload_params_round_trip() {
     let params = PreloadParams {
-        drives: vec!['C'],
+        drives: vec![uffs_mft::platform::DriveLetter::C],
         pin_minutes: Some(60_u32),
     };
     let json = serde_json::to_string(&params).expect("serialize");
@@ -1891,8 +1901,8 @@ fn preload_params_pin_minutes_optional() {
 #[test]
 fn preload_response_round_trip() {
     let resp = PreloadResponse {
-        promoted: vec!['C'],
-        already_hot: vec!['D'],
+        promoted: vec![uffs_mft::platform::DriveLetter::C],
+        already_hot: vec![uffs_mft::platform::DriveLetter::D],
         errors: vec!["Z: cache file missing".to_owned()],
         pin_until_unix_ms: 1_800_000_000_000_i64,
     };
@@ -1904,7 +1914,7 @@ fn preload_response_round_trip() {
 #[test]
 fn forget_params_round_trip() {
     let params = ForgetParams {
-        drives: vec!['Z'],
+        drives: vec![uffs_mft::platform::DriveLetter::Z],
         force: true,
     };
     let json = serde_json::to_string(&params).expect("serialize");
@@ -1928,8 +1938,8 @@ fn forget_params_force_defaults_false() {
 #[test]
 fn forget_response_round_trip() {
     let resp = ForgetResponse {
-        forgotten: vec!['Z'],
-        already_absent: vec!['Y'],
+        forgotten: vec![uffs_mft::platform::DriveLetter::Z],
+        already_absent: vec![uffs_mft::platform::DriveLetter::Y],
         freed_bytes: 1_234_567_890_u64,
         errors: vec!["X: permission denied".to_owned()],
     };
@@ -1955,7 +1965,7 @@ fn status_drives_response_round_trip() {
     let resp = StatusDrivesResponse {
         drives: vec![
             DriveTierStatus {
-                letter: 'C',
+                letter: uffs_mft::platform::DriveLetter::C,
                 tier: "hot".to_owned(),
                 resident_bytes: 1_073_741_824_u64, // 1 GiB
                 query_rate_per_min: 12.5_f64,
@@ -1964,7 +1974,7 @@ fn status_drives_response_round_trip() {
                 pin_until_unix_ms: 1_700_001_800_000_i64,
             },
             DriveTierStatus {
-                letter: 'D',
+                letter: uffs_mft::platform::DriveLetter::D,
                 tier: "cold".to_owned(),
                 resident_bytes: 0_u64,
                 query_rate_per_min: 0.0_f64,
@@ -2005,5 +2015,8 @@ fn hibernate_request_envelope_round_trip() {
     assert_eq!(parsed.id, Some(7));
     let inner: HibernateParams = serde_json::from_value(parsed.params.expect("params present"))
         .expect("nested params decode");
-    assert_eq!(inner.drives, vec!['C', 'D']);
+    assert_eq!(inner.drives, vec![
+        uffs_mft::platform::DriveLetter::C,
+        uffs_mft::platform::DriveLetter::D
+    ]);
 }

--- a/crates/uffs-client/src/shmem.rs
+++ b/crates/uffs-client/src/shmem.rs
@@ -206,7 +206,7 @@ pub fn write_search_results(
         let name_len = u32::try_from(name_bytes.len()).unwrap_or(u32::MAX);
 
         records.push(ShmemRecord {
-            drive: row.drive as u8,
+            drive: row.drive.as_byte(),
             is_directory: u8::from(row.is_directory),
             _pad: [0; 2],
             flags: row.flags,
@@ -372,7 +372,13 @@ pub fn read_search_results(path: &Path) -> io::Result<SearchResponse> {
             .map_err(|utf8_err| io::Error::new(io::ErrorKind::InvalidData, utf8_err))?;
 
         rows.push(SearchRow {
-            drive: char::from(rec.drive),
+            // Shmem records are written with `row.drive.as_byte()`
+            // (which is always in `b'A'..=b'Z'`), so the `TryFrom`
+            // succeeds in normal operation.  A fallback to
+            // `DriveLetter::X` keeps the reader resilient against
+            // truncated / corrupted blobs without panicking.
+            drive: uffs_mft::platform::DriveLetter::try_from(rec.drive)
+                .unwrap_or(uffs_mft::platform::DriveLetter::X),
             path: path_str.to_owned(),
             name: name_str.to_owned(),
             size: rec.size,

--- a/crates/uffs-client/src/shmem_tests.rs
+++ b/crates/uffs-client/src/shmem_tests.rs
@@ -65,7 +65,7 @@ fn lock_shmem_dir() -> MutexGuard<'static, ()> {
 /// Helper: build a minimal `SearchRow` for testing.
 fn sample_row(name: &str) -> SearchRow {
     SearchRow {
-        drive: 'C',
+        drive: uffs_mft::platform::DriveLetter::C,
         path: format!("C:\\test\\{name}"),
         name: name.to_owned(),
         size: 1024,

--- a/crates/uffs-core/benches/search_benchmarks.rs
+++ b/crates/uffs-core/benches/search_benchmarks.rs
@@ -333,14 +333,17 @@ fn bench_path_resolution(c: &mut Criterion) {
 
         // Benchmark building the resolver
         group.bench_with_input(BenchmarkId::new("build", size), &df, |b, df| {
-            b.iter(|| PathResolver::build(std::hint::black_box(df), 'C'))
+            b.iter(|| {
+                PathResolver::build(std::hint::black_box(df), uffs_mft::platform::DriveLetter::C)
+            })
         });
 
         // Benchmark resolving paths (with caching)
         group.bench_with_input(BenchmarkId::new("resolve_cached", size), &df, |b, df| {
             b.iter_batched(
                 || {
-                    let resolver = PathResolver::build(df, 'C').expect("valid resolver");
+                    let resolver = PathResolver::build(df, uffs_mft::platform::DriveLetter::C)
+                        .expect("valid resolver");
                     // Get some FRS values to resolve
                     let frs_col = df.column("frs").unwrap().u64().unwrap();
                     let frs_values: Vec<u64> = (0..std::cmp::min(100, df.height()))
@@ -375,14 +378,20 @@ fn bench_fast_path_resolution(c: &mut Criterion) {
 
         // Benchmark building the fast resolver
         group.bench_with_input(BenchmarkId::new("build", size), &df, |b, df| {
-            b.iter(|| FastPathResolver::build(std::hint::black_box(df), 'C'))
+            b.iter(|| {
+                FastPathResolver::build(
+                    std::hint::black_box(df),
+                    uffs_mft::platform::DriveLetter::C,
+                )
+            })
         });
 
         // Benchmark resolving paths (with caching)
         group.bench_with_input(BenchmarkId::new("resolve_cached", size), &df, |b, df| {
             b.iter_batched(
                 || {
-                    let resolver = FastPathResolver::build(df, 'C').expect("valid resolver");
+                    let resolver = FastPathResolver::build(df, uffs_mft::platform::DriveLetter::C)
+                        .expect("valid resolver");
                     // Get some FRS values to resolve
                     let frs_col = df.column("frs").unwrap().u64().unwrap();
                     let frs_values: Vec<u64> = (0..std::cmp::min(100, df.height()))
@@ -407,7 +416,8 @@ fn bench_fast_path_resolution(c: &mut Criterion) {
 
             b.iter_batched(
                 || {
-                    let resolver = FastPathResolver::build(df, 'C').expect("valid resolver");
+                    let resolver = FastPathResolver::build(df, uffs_mft::platform::DriveLetter::C)
+                        .expect("valid resolver");
                     (resolver, filtered_df.clone())
                 },
                 |(mut resolver, filtered): (FastPathResolver, DataFrame)| {
@@ -437,11 +447,21 @@ fn bench_resolver_comparison(c: &mut Criterion) {
 
     // Compare build times
     group.bench_function("hashmap_build", |b| {
-        b.iter(|| PathResolver::build(std::hint::black_box(&df), 'C'))
+        b.iter(|| {
+            PathResolver::build(
+                std::hint::black_box(&df),
+                uffs_mft::platform::DriveLetter::C,
+            )
+        })
     });
 
     group.bench_function("vec_build", |b| {
-        b.iter(|| FastPathResolver::build(std::hint::black_box(&df), 'C'))
+        b.iter(|| {
+            FastPathResolver::build(
+                std::hint::black_box(&df),
+                uffs_mft::platform::DriveLetter::C,
+            )
+        })
     });
 
     // Compare resolve times (100 paths each)
@@ -450,7 +470,10 @@ fn bench_resolver_comparison(c: &mut Criterion) {
 
     group.bench_function("hashmap_resolve_100", |b| {
         b.iter_batched(
-            || PathResolver::build(&df, 'C').expect("valid resolver"),
+            || {
+                PathResolver::build(&df, uffs_mft::platform::DriveLetter::C)
+                    .expect("valid resolver")
+            },
             |mut resolver| {
                 for &frs in &frs_values {
                     let _ = resolver.resolve(frs);
@@ -462,7 +485,10 @@ fn bench_resolver_comparison(c: &mut Criterion) {
 
     group.bench_function("vec_resolve_100", |b| {
         b.iter_batched(
-            || FastPathResolver::build(&df, 'C').expect("valid resolver"),
+            || {
+                FastPathResolver::build(&df, uffs_mft::platform::DriveLetter::C)
+                    .expect("valid resolver")
+            },
             |resolver| {
                 for &frs in &frs_values {
                     let _ = resolver.resolve(frs);
@@ -490,7 +516,8 @@ fn bench_parallel_path_resolution(c: &mut Criterion) {
     group.bench_function("sequential_50k", |b| {
         b.iter_batched(
             || {
-                let resolver = FastPathResolver::build(&df, 'C').expect("valid resolver");
+                let resolver = FastPathResolver::build(&df, uffs_mft::platform::DriveLetter::C)
+                    .expect("valid resolver");
                 (resolver, df.clone())
             },
             |(mut resolver, df)| resolver.add_path_column(&df),
@@ -502,7 +529,8 @@ fn bench_parallel_path_resolution(c: &mut Criterion) {
     group.bench_function("parallel_50k", |b| {
         b.iter_batched(
             || {
-                let resolver = FastPathResolver::build(&df, 'C').expect("valid resolver");
+                let resolver = FastPathResolver::build(&df, uffs_mft::platform::DriveLetter::C)
+                    .expect("valid resolver");
                 (resolver, df.clone())
             },
             |(resolver, df)| resolver.add_path_column_parallel(&df),

--- a/crates/uffs-core/src/aggregate/accumulators.rs
+++ b/crates/uffs-core/src/aggregate/accumulators.rs
@@ -619,7 +619,7 @@ fn extract_group_key(
             || u64::from(record.extension_id),
             |map| map.canonical_id(drive_ordinal, record.extension_id),
         ),
-        Some(FieldId::Drive) => u64::from(u32::from(drive.letter)),
+        Some(FieldId::Drive) => u64::from(u32::from(drive.letter.as_byte())),
         Some(FieldId::Type) => {
             use crate::search::derived::{
                 SEMANTIC_TYPE_ID_DIRECTORY, SEMANTIC_TYPE_ID_FILE, semantic_type_id_from_extension,

--- a/crates/uffs-core/src/aggregate/duplicates.rs
+++ b/crates/uffs-core/src/aggregate/duplicates.rs
@@ -343,7 +343,7 @@ mod tests {
     ///   - "config.ini" (FRS 104, 200 bytes)  — duplicate (2 copies)
     ///   - "config.ini" (FRS 105, 200 bytes)
     fn build_dup_drive() -> DriveCompactIndex {
-        let mut idx = MftIndex::new('T');
+        let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::T);
 
         // Root directory.
         let root_off = idx.add_name(".");
@@ -373,7 +373,7 @@ mod tests {
         add_file(&mut idx, 104, "config.ini", 200);
         add_file(&mut idx, 105, "config.ini", 200);
 
-        let (drive, _, _) = build_compact_index('T', &idx);
+        let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::T, &idx);
         drive
     }
 
@@ -587,7 +587,7 @@ mod tests {
 
     #[test]
     fn singleton_elimination_no_false_duplicates() {
-        let mut idx = MftIndex::new('T');
+        let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::T);
 
         // Root.
         let root_off = idx.add_name(".");
@@ -612,7 +612,7 @@ mod tests {
             rec.stdinfo.flags = 0x20;
         }
 
-        let (drive, _, _) = build_compact_index('T', &idx);
+        let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::T, &idx);
         let mut acc = DuplicateAccumulator::new(
             vec![FieldId::Size, FieldId::Name],
             DuplicateVerify::None,
@@ -635,7 +635,7 @@ mod tests {
 
     #[test]
     fn zero_byte_files_excluded_from_duplicates() {
-        let mut idx = MftIndex::new('T');
+        let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::T);
 
         let root_off = idx.add_name(".");
         let root = idx.get_or_create(ROOT_FRS);
@@ -659,7 +659,7 @@ mod tests {
             rec.stdinfo.flags = 0x20;
         }
 
-        let (drive, _, _) = build_compact_index('T', &idx);
+        let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::T, &idx);
         let mut acc = DuplicateAccumulator::new(
             vec![FieldId::Size, FieldId::Name],
             DuplicateVerify::None,
@@ -677,7 +677,7 @@ mod tests {
 
     #[test]
     fn directories_excluded_from_duplicates() {
-        let mut idx = MftIndex::new('T');
+        let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::T);
 
         let root_off = idx.add_name(".");
         let root = idx.get_or_create(ROOT_FRS);
@@ -702,7 +702,7 @@ mod tests {
             };
         }
 
-        let (drive, _, _) = build_compact_index('T', &idx);
+        let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::T, &idx);
         let mut acc = DuplicateAccumulator::new(
             vec![FieldId::Size, FieldId::Name],
             DuplicateVerify::None,
@@ -734,7 +734,7 @@ mod tests {
 
         // Load C: drive index.  `load_drive` returns `(index, timing)`;
         // the test only uses the index itself.
-        let source = MftSource::Live('C');
+        let source = MftSource::Live(uffs_mft::platform::DriveLetter::C);
         let (drive, _load_timing) = load_drive(&source, false).expect("failed to load C: drive");
 
         let mut acc = DuplicateAccumulator::new(

--- a/crates/uffs-core/src/aggregate/finalize.rs
+++ b/crates/uffs-core/src/aggregate/finalize.rs
@@ -780,7 +780,9 @@ fn format_range_key(index: usize, boundaries: &[u64]) -> String {
 /// Format a FILETIME timestamp key as an ISO date (`YYYY-MM-DD`).
 fn format_timestamp_key(filetime: i64) -> String {
     match uffs_time::filetime_to_calendar(filetime) {
-        Some((year, month, day, ..)) => format!("{year:04}-{month:02}-{day:02}"),
+        Some(uffs_time::CalendarParts {
+            year, month, day, ..
+        }) => format!("{year:04}-{month:02}-{day:02}"),
         None => "0000-00-00".to_owned(),
     }
 }

--- a/crates/uffs-core/src/aggregate/integration_tests.rs
+++ b/crates/uffs-core/src/aggregate/integration_tests.rs
@@ -37,7 +37,7 @@ const TS_JUN_2024: i64 = 133_633_536_000_000_000;
 ///
 /// Totals (files only): 7 files, 17400 bytes logical, 30628 bytes alloc.
 fn build_agg_test_drive() -> DriveCompactIndex {
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     // Root directory.
     let root_off = idx.add_name(".");
@@ -82,7 +82,7 @@ fn build_agg_test_drive() -> DriveCompactIndex {
         rec.stdinfo.modified = modified;
     }
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     drive
 }
 
@@ -779,7 +779,9 @@ fn s3f3_terms_extension_prefix_filter() {
     assert!(keys.contains(&"rs"), "should have rs: {keys:?}");
     assert!(keys.contains(&"md"), "should have md: {keys:?}");
 
-    // Prefix filter: only extensions starting with "r".
+    // Prefix filter: only extensions starting with "r".  Extension
+    // keys are lowercase strings — unrelated to `DriveLetter`, which
+    // is canonical uppercase.
     let filtered: Vec<_> = rows.iter().filter(|r| r.key.starts_with('r')).collect();
     assert_eq!(filtered.len(), 1, "only 'rs' starts with 'r'");
     assert_eq!(filtered[0].key, "rs");

--- a/crates/uffs-core/src/aggregate/rollup.rs
+++ b/crates/uffs-core/src/aggregate/rollup.rs
@@ -44,7 +44,9 @@ impl RollupAccumulator {
     #[inline]
     pub fn feed(&mut self, record: &CompactRecord, drive: &DriveCompactIndex, idx: usize) {
         let key = match self.mode {
-            RollupMode::Drive => u32::from(u8::try_from(u32::from(drive.letter)).unwrap_or(b'?')),
+            RollupMode::Drive => {
+                u32::from(u8::try_from(u32::from(drive.letter.as_byte())).unwrap_or(b'?'))
+            }
             RollupMode::Path { depth } => ancestor_at_depth(record, drive, idx, depth),
             RollupMode::Ancestor { record_idx } => child_of_ancestor(drive, idx, record_idx),
         };
@@ -319,7 +321,7 @@ mod tests {
         let children = ChildrenIndex::build(&records);
 
         DriveCompactIndex {
-            letter: 'C',
+            letter: uffs_mft::platform::DriveLetter::C,
             records: crate::compact_storage::ColumnStorage::from_vec(records),
             names: crate::compact_storage::ColumnStorage::from_vec(names_blob),
             trigram: TrigramIndex::empty(),

--- a/crates/uffs-core/src/compact.rs
+++ b/crates/uffs-core/src/compact.rs
@@ -333,7 +333,7 @@ impl ExtensionIndex {
 #[derive(Clone)]
 pub struct DriveCompactIndex {
     /// Drive letter (e.g., 'C').
-    pub letter: char,
+    pub letter: uffs_mft::platform::DriveLetter,
     /// Compact records — one per MFT file/directory.
     ///
     /// Backed by [`ColumnStorage`] so Phase 2b can transparently
@@ -674,19 +674,14 @@ fn expand_links_and_ads(
 pub(crate) fn compute_path_lengths(
     records: &mut [CompactRecord],
     names: &[u8],
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
 ) {
     // Drive prefix in characters: the letter (1 char) + colon (1 char) = 2.
-    // A `char` is always exactly one Unicode scalar value, so the letter
-    // always contributes 1 to the char count regardless of its UTF-8
-    // byte length.  Suppress the unused-variable lint by reading the
-    // parameter — if this ever becomes `&str` the arithmetic changes.
-    // `drive_letter` is read to guarantee callers pass a valid letter;
-    // the arithmetic only cares about "1 char + 1 colon".
-    debug_assert!(
-        drive_letter.is_ascii_alphabetic(),
-        "drive_letter must be ASCII A-Z, got {drive_letter:?}"
-    );
+    // `DriveLetter` is ASCII A–Z by construction (validated in
+    // `DriveLetter::parse`), so the previous runtime `debug_assert!`
+    // is now a tautology and was removed.  The arithmetic only cares
+    // about "1 letter char + 1 colon".
+    let _: uffs_mft::platform::DriveLetter = drive_letter;
     let drive_prefix_chars: u32 = 1 /* letter */ + 1 /* ':' */;
 
     // Build forward adjacency list (parent → children) for top-down BFS.
@@ -766,7 +761,7 @@ fn name_char_count(rec: &CompactRecord, names: &[u8]) -> u32 {
 /// Returns `(DriveCompactIndex, compact_build_ms, trigram_build_ms)`.
 #[must_use]
 pub fn build_compact_index(
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
     index: &MftIndex,
 ) -> (DriveCompactIndex, u128, u128) {
     use uffs_mft::index::PathResolver;
@@ -920,7 +915,7 @@ pub fn build_compact_index(
 /// Reclaims capacity slack from the doubling growth strategy used during
 /// construction.  Saves ~500 MB across 7 drives.
 fn shrink_compact_vecs(
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
     records: &mut Vec<CompactRecord>,
     names: &mut Vec<u8>,
     ext_names: &mut Vec<Box<str>>,
@@ -951,7 +946,9 @@ pub(crate) const INDEX_TTL_SECONDS: u64 = 14400;
 /// `drive_letter`. On success, log the result at `INFO` and any diffs
 /// from the compiled-in default at `WARN`. On failure, log at `WARN`
 /// and fall back to [`CaseFold::default_table()`].
-pub(crate) fn resolve_case_fold(drive_letter: char) -> uffs_text::case_fold::CaseFold {
+pub(crate) fn resolve_case_fold(
+    drive_letter: uffs_mft::platform::DriveLetter,
+) -> uffs_text::case_fold::CaseFold {
     let live_table = match uffs_mft::platform::upcase::read_upcase_table(drive_letter) {
         Ok(table) => table,
         Err(err) => {
@@ -971,7 +968,10 @@ pub(crate) fn resolve_case_fold(drive_letter: char) -> uffs_text::case_fold::Cas
 }
 
 /// Log the comparison between live and compiled-in `$UpCase` tables.
-fn log_upcase_comparison(drive_letter: char, live_fold: &uffs_text::case_fold::CaseFold) {
+fn log_upcase_comparison(
+    drive_letter: uffs_mft::platform::DriveLetter,
+    live_fold: &uffs_text::case_fold::CaseFold,
+) {
     let default = uffs_text::case_fold::CaseFold::default_table();
     let diffs = default.diff(live_fold);
 

--- a/crates/uffs-core/src/compact_cache.rs
+++ b/crates/uffs-core/src/compact_cache.rs
@@ -153,7 +153,7 @@ const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
 
 /// Returns the cache file path for a compact index.
 #[must_use]
-pub fn compact_cache_path(drive_letter: char) -> PathBuf {
+pub fn compact_cache_path(drive_letter: uffs_mft::platform::DriveLetter) -> PathBuf {
     uffs_mft::cache::cache_dir().join(format!("{drive_letter}_compact.uffs"))
 }
 
@@ -172,7 +172,7 @@ pub fn compact_cache_path(drive_letter: char) -> PathBuf {
 ///
 /// [`CursorStore`]: # "Trait defined in `uffs-daemon::cache::journal_loop`"
 #[must_use]
-pub fn usn_cursor_path(drive_letter: char) -> PathBuf {
+pub fn usn_cursor_path(drive_letter: uffs_mft::platform::DriveLetter) -> PathBuf {
     uffs_mft::cache::cache_dir().join(format!("{drive_letter}_usn.cursor"))
 }
 
@@ -216,7 +216,10 @@ pub fn usn_cursor_path(drive_letter: char) -> PathBuf {
 /// on every subsequent call.
 ///
 /// [`atomic_write`]: uffs_mft::cache::atomic_write
-fn purge_legacy_compact_cache_dir(path: &Path, drive: char) -> io::Result<()> {
+fn purge_legacy_compact_cache_dir(
+    path: &Path,
+    drive: uffs_mft::platform::DriveLetter,
+) -> io::Result<()> {
     let Ok(meta) = std::fs::symlink_metadata(path) else {
         // Path doesn't exist — nothing to purge.  `symlink_metadata`
         // (not `metadata`) so we don't follow a symlink and accidentally
@@ -296,7 +299,9 @@ pub fn compact_runtime_root() -> PathBuf {
 /// Returns an [`io::Error`] if the parent directory cannot be created
 /// or if the owner-only permissions cannot be applied (Unix `0o700`,
 /// Windows owner-only DACL).
-fn compact_runtime_tempfile_path(drive_letter: char) -> io::Result<PathBuf> {
+fn compact_runtime_tempfile_path(
+    drive_letter: uffs_mft::platform::DriveLetter,
+) -> io::Result<PathBuf> {
     let pid = std::process::id();
     let seq = RUNTIME_TEMPFILE_SEQ.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let parent = compact_runtime_root().join(pid.to_string());
@@ -503,7 +508,7 @@ fn write_u32<W: io::Write>(writer: &mut W, val: usize) -> io::Result<()> {
 /// Returns an error string if the data is truncated, wrong magic, or v1.
 pub fn deserialize_compact(
     data: &[u8],
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
 ) -> Result<(DriveCompactIndex, u128), &'static str> {
     let parsed = parse_compact_body(data, drive_letter)?;
     assemble_compact_index(parsed, |records_bytes, names_bytes| {
@@ -544,7 +549,7 @@ pub fn deserialize_compact(
 ///   checks (would indicate a `write_runtime_layout` bug).
 pub fn deserialize_compact_into_runtime(
     data: &[u8],
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
     runtime_dir: &dyn RuntimeDir,
     runtime_path: &Path,
 ) -> io::Result<(DriveCompactIndex, u128)> {
@@ -570,7 +575,7 @@ pub fn deserialize_compact_into_runtime(
 /// enough to stay heap-resident.
 struct ParsedCompactBody<'data> {
     /// Drive letter the cache was built for.
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
     /// Source epoch (u64) parsed from the header.
     source_epoch: u64,
     /// Records column as raw bytes — exact multiple of
@@ -616,7 +621,7 @@ struct ParsedCompactBody<'data> {
 /// instead of being eagerly copied into [`Vec`]s.
 fn parse_compact_body(
     data: &[u8],
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
 ) -> Result<ParsedCompactBody<'_>, &'static str> {
     let (source_epoch, body_offset, version) = parse_compact_header(data)?;
 
@@ -993,7 +998,7 @@ pub fn save_compact_cache_background(index: &DriveCompactIndex) -> io::Result<()
 /// Extracted from the `save_compact_cache_background` closure to keep
 /// cognitive complexity low.
 fn encrypt_and_write(
-    drive: char,
+    drive: uffs_mft::platform::DriveLetter,
     compressed: Vec<u8>,
     path: &Path,
     profile: bool,
@@ -1037,7 +1042,7 @@ fn encrypt_and_write(
 /// "stale vs MFT" without re-reading the metadata.
 fn check_compact_cache_freshness(
     path: &Path,
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
     ttl_seconds: u64,
     trust_ttl_only: bool,
 ) -> LoadCacheResult<()> {
@@ -1095,7 +1100,7 @@ fn check_compact_cache_freshness(
 /// (cold-boot rebuild) from "decryption failed" (key rotated;
 /// rebuild + alert) from "stale by epoch" (incremental refresh).
 pub fn load_compact_cache(
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
     ttl_seconds: u64,
     mft_build_epoch: u64,
     trust_ttl_only: bool,
@@ -1233,7 +1238,10 @@ fn log_compact_load_profile(index: &DriveCompactIndex, profile: &CompactLoadProf
 /// Extracted from [`ensure_compact_cached`] to keep that function's
 /// cognitive complexity below clippy's strict-gate ceiling (Phase 5
 /// added an extra match arm for #96 structured errors).
-fn try_load_for_ensure(drive_letter: char, build_epoch: u64) -> Option<DriveCompactIndex> {
+fn try_load_for_ensure(
+    drive_letter: uffs_mft::platform::DriveLetter,
+    build_epoch: u64,
+) -> Option<DriveCompactIndex> {
     match load_compact_cache(
         drive_letter,
         super::compact::INDEX_TTL_SECONDS,
@@ -1268,7 +1276,7 @@ fn try_load_for_ensure(drive_letter: char, build_epoch: u64) -> Option<DriveComp
 /// Emits `cache_profile` tracing events at `debug` level.
 /// The caller may discard the returned index if only the `MftIndex` is needed.
 pub fn ensure_compact_cached(
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
     mft_index: &uffs_mft::MftIndex,
 ) -> DriveCompactIndex {
     // Try loading existing compact cache (epoch check catches stale caches).
@@ -1302,7 +1310,7 @@ pub fn ensure_compact_cached(
 }
 
 /// Log on-disk sizes of both MFT and compact caches for a drive.
-fn log_disk_summary(drive_letter: char) {
+fn log_disk_summary(drive_letter: uffs_mft::platform::DriveLetter) {
     let compact_path = compact_cache_path(drive_letter);
     let mft_path = uffs_mft::cache::cache_file_path(drive_letter);
     let compact_disk = std::fs::metadata(&compact_path).map_or(0, |meta| meta.len());

--- a/crates/uffs-core/src/compact_cache/parked.rs
+++ b/crates/uffs-core/src/compact_cache/parked.rs
@@ -69,7 +69,7 @@ use crate::path_trie::PathTrie;
 #[derive(Clone)]
 pub struct ParkedBody {
     /// Drive letter the cache was built for.
-    pub letter: char,
+    pub letter: uffs_mft::platform::DriveLetter,
     /// `MftIndex.build_epoch` the source compact cache was built
     /// from — used as a staleness check on promote.
     pub source_epoch: u64,
@@ -128,7 +128,7 @@ impl core::fmt::Debug for ParkedBody {
 ///   / `filters_io::read_trie_section`).
 pub fn deserialize_parked_body(
     data: &[u8],
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
 ) -> Result<ParkedBody, &'static str> {
     let (filters_offset, source_epoch) = find_v9_filters_offset(data)?;
     let (bloom, after_bloom) = filters_io::read_bloom_section(data, filters_offset)?;
@@ -347,7 +347,7 @@ fn read_decompressed_plaintext(path: &std::path::Path) -> Option<(Vec<u8>, Parke
 fn is_compact_cache_stale_for_epoch(
     plaintext: &[u8],
     mft_build_epoch: u64,
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
 ) -> bool {
     if mft_build_epoch == 0 {
         return false;
@@ -419,7 +419,7 @@ fn emit_parked_load_profile(
 /// contract.
 #[must_use]
 pub fn load_parked_body(
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
     ttl_seconds: u64,
     mft_build_epoch: u64,
     trust_ttl_only: bool,
@@ -505,7 +505,7 @@ mod tests {
         let children = ChildrenIndex::build(&records);
         let ext_index = ExtensionIndex::build(&records);
         let mut index = DriveCompactIndex {
-            letter: 'C',
+            letter: uffs_mft::platform::DriveLetter::C,
             records: ColumnStorage::from_vec(records),
             names: ColumnStorage::from_vec(names),
             trigram,
@@ -533,7 +533,8 @@ mod tests {
         let index = make_test_index();
         let serialized = super::super::serialize_compact(&index);
 
-        let body = deserialize_parked_body(&serialized, 'C').expect("parked deser");
+        let body = deserialize_parked_body(&serialized, uffs_mft::platform::DriveLetter::C)
+            .expect("parked deser");
 
         // Bloom: every record's folded basename hits.
         let mut fold_buf: Vec<u8> = Vec::new();
@@ -558,7 +559,7 @@ mod tests {
         assert_eq!(body.path_trie.child_indices(), expected.child_indices());
 
         // Metadata: epoch + letter + fold round-trip.
-        assert_eq!(body.letter, 'C');
+        assert_eq!(body.letter, uffs_mft::platform::DriveLetter::C);
         assert_eq!(body.source_epoch, 1234);
     }
 
@@ -577,7 +578,8 @@ mod tests {
             .expect("buffer too short for version")
             .copy_from_slice(&8_u16.to_le_bytes());
 
-        let err = deserialize_parked_body(&serialized, 'C').expect_err("v8 must reject");
+        let err = deserialize_parked_body(&serialized, uffs_mft::platform::DriveLetter::C)
+            .expect_err("v8 must reject");
         assert!(
             err.contains("stale compact version"),
             "error should mention 'stale compact version': {err:?}",
@@ -595,7 +597,8 @@ mod tests {
         let byte = serialized.get_mut(0).expect("non-empty buffer");
         *byte = byte.wrapping_add(1);
 
-        let _err = deserialize_parked_body(&serialized, 'C').expect_err("bad magic must reject");
+        let _err = deserialize_parked_body(&serialized, uffs_mft::platform::DriveLetter::C)
+            .expect_err("bad magic must reject");
     }
 
     /// Truncating the buffer at successively shorter prefixes must
@@ -639,7 +642,7 @@ mod tests {
         ];
         for &prefix in &prefixes {
             let truncated = serialized.get(..prefix).expect("prefix in range");
-            let result = deserialize_parked_body(truncated, 'C');
+            let result = deserialize_parked_body(truncated, uffs_mft::platform::DriveLetter::C);
             assert!(
                 result.is_err(),
                 "prefix {prefix}/{parked_end} (full {full}) must be rejected (got {result:?})",
@@ -682,7 +685,8 @@ mod tests {
     fn parked_body_size_bytes_is_nonzero_and_bounded() {
         let index = make_test_index();
         let serialized = super::super::serialize_compact(&index);
-        let body = deserialize_parked_body(&serialized, 'C').expect("parked deser");
+        let body = deserialize_parked_body(&serialized, uffs_mft::platform::DriveLetter::C)
+            .expect("parked deser");
 
         let bloom_bytes = body.bloom.size_bytes();
         let trie_bytes = body.path_trie.size_bytes();

--- a/crates/uffs-core/src/compact_cache/tests.rs
+++ b/crates/uffs-core/src/compact_cache/tests.rs
@@ -70,7 +70,7 @@ fn make_test_index() -> DriveCompactIndex {
         })
         .collect();
     DriveCompactIndex {
-        letter: 'T',
+        letter: uffs_mft::platform::DriveLetter::T,
         records: ColumnStorage::from_vec(records),
         names: ColumnStorage::from_vec(names),
         trigram,
@@ -94,7 +94,8 @@ fn v6_round_trip_preserves_trigram() {
     assert!(original_key_count > 0, "test index should have trigrams");
 
     let serialized = serialize_compact(&index);
-    let (loaded, tri_ms) = deserialize_compact(&serialized, 'T').unwrap();
+    let (loaded, tri_ms) =
+        deserialize_compact(&serialized, uffs_mft::platform::DriveLetter::T).unwrap();
 
     // Trigram loaded from disk — should be fast (< 10ms on any hardware).
     assert!(
@@ -109,7 +110,7 @@ fn v6_round_trip_preserves_trigram() {
     assert_eq!(loaded_values, tri_values, "trigram values mismatch");
 
     // Verify other fields survived.
-    assert_eq!(loaded.letter, 'T');
+    assert_eq!(loaded.letter, uffs_mft::platform::DriveLetter::T);
     assert_eq!(loaded.records.len(), 3);
     assert_eq!(loaded.names.as_slice(), b"foobarbaz");
     assert_eq!(loaded.source_epoch, 42);
@@ -129,7 +130,7 @@ fn v9_rejected_forces_rebuild() {
         .get_mut(8..10)
         .expect("buffer too short for version")
         .copy_from_slice(&9_u16.to_le_bytes());
-    let err = deserialize_compact(&serialized, 'T')
+    let err = deserialize_compact(&serialized, uffs_mft::platform::DriveLetter::T)
         .err()
         .expect("v9 cache must be rejected");
     assert!(
@@ -158,7 +159,8 @@ fn v10_round_trip_preserves_frs_to_compact() {
     let serialized = serialize_compact(&index);
 
     // Heap deserialise path.
-    let (heap_loaded, _) = deserialize_compact(&serialized, 'T').expect("heap deser");
+    let (heap_loaded, _) =
+        deserialize_compact(&serialized, uffs_mft::platform::DriveLetter::T).expect("heap deser");
     assert_eq!(
         heap_loaded.frs_to_compact, original_mapping,
         "heap-loaded frs_to_compact must match the source mapping"
@@ -167,9 +169,13 @@ fn v10_round_trip_preserves_frs_to_compact() {
     // Runtime-mmap deserialise path.
     let (_tmp, runtime_path) = runtime_fixture("f2c_round_trip.live");
     let runtime_dir = uffs_security::runtime_dir::DefaultRuntimeDir::default();
-    let (mmap_loaded, _) =
-        deserialize_compact_into_runtime(&serialized, 'T', &runtime_dir, &runtime_path)
-            .expect("runtime mmap deser");
+    let (mmap_loaded, _) = deserialize_compact_into_runtime(
+        &serialized,
+        uffs_mft::platform::DriveLetter::T,
+        &runtime_dir,
+        &runtime_path,
+    )
+    .expect("runtime mmap deser");
     assert_eq!(
         mmap_loaded.frs_to_compact, original_mapping,
         "runtime-mmap-loaded frs_to_compact must match the source mapping"
@@ -185,7 +191,8 @@ fn v10_round_trip_empty_frs_to_compact() {
     let mut index = make_test_index();
     index.frs_to_compact = Vec::new();
     let serialized = serialize_compact(&index);
-    let (loaded, _) = deserialize_compact(&serialized, 'T').expect("empty mapping deser");
+    let (loaded, _) = deserialize_compact(&serialized, uffs_mft::platform::DriveLetter::T)
+        .expect("empty mapping deser");
     assert!(
         loaded.frs_to_compact.is_empty(),
         "empty-mapping round-trip must yield Vec::new()"
@@ -213,7 +220,8 @@ fn current_header_version() {
 fn v9_round_trip_preserves_bloom() {
     let index = make_test_index();
     let serialized = serialize_compact(&index);
-    let (loaded, _tri_ms) = deserialize_compact(&serialized, 'T').expect("deser v9");
+    let (loaded, _tri_ms) =
+        deserialize_compact(&serialized, uffs_mft::platform::DriveLetter::T).expect("deser v9");
 
     let bloom = loaded.bloom.as_ref().expect("v9 cache must carry bloom");
     let mut fold_buf: Vec<u8> = Vec::new();
@@ -245,7 +253,8 @@ fn v9_round_trip_preserves_path_trie() {
     let expected = index.build_path_trie();
 
     let serialized = serialize_compact(&index);
-    let (loaded, _tri_ms) = deserialize_compact(&serialized, 'T').expect("deser v9");
+    let (loaded, _tri_ms) =
+        deserialize_compact(&serialized, uffs_mft::platform::DriveLetter::T).expect("deser v9");
     let actual = loaded.path_trie.as_ref().expect("v9 cache must carry trie");
 
     assert_eq!(
@@ -282,7 +291,7 @@ fn v1_rejected() {
     data.get_mut(8..10)
         .expect("buffer too short for version")
         .copy_from_slice(&1_u16.to_le_bytes());
-    let err = deserialize_compact(&data, 'X')
+    let err = deserialize_compact(&data, uffs_mft::platform::DriveLetter::X)
         .err()
         .expect("v1 cache must be rejected");
     assert!(
@@ -293,14 +302,15 @@ fn v1_rejected() {
 
 #[test]
 fn truncated_data_rejected() {
-    assert!(deserialize_compact(b"short", 'X').is_err());
+    assert!(deserialize_compact(b"short", uffs_mft::platform::DriveLetter::X).is_err());
 }
 
 #[test]
 fn ext_names_round_trips() {
     let index = make_test_index();
     let serialized = serialize_compact(&index);
-    let (deser, _) = deserialize_compact(&serialized, 'T').expect("deser");
+    let (deser, _) =
+        deserialize_compact(&serialized, uffs_mft::platform::DriveLetter::T).expect("deser");
     assert_eq!(deser.ext_names, index.ext_names);
 }
 
@@ -326,9 +336,13 @@ fn v6_round_trip_via_runtime_mmap_preserves_trigram() {
     let serialized = serialize_compact(&index);
     let (_tmp, runtime_path) = runtime_fixture("v6_runtime_mmap.live");
     let runtime_dir = uffs_security::runtime_dir::DefaultRuntimeDir::default();
-    let (loaded, tri_ms) =
-        deserialize_compact_into_runtime(&serialized, 'T', &runtime_dir, &runtime_path)
-            .expect("runtime mmap deser");
+    let (loaded, tri_ms) = deserialize_compact_into_runtime(
+        &serialized,
+        uffs_mft::platform::DriveLetter::T,
+        &runtime_dir,
+        &runtime_path,
+    )
+    .expect("runtime mmap deser");
 
     // v6+ CSR is loaded from disk — never rebuilt.
     assert!(
@@ -344,7 +358,7 @@ fn v6_round_trip_via_runtime_mmap_preserves_trigram() {
 
     // Records + names columns are now mmap-backed but observably
     // identical to the heap-backed source.
-    assert_eq!(loaded.letter, 'T');
+    assert_eq!(loaded.letter, uffs_mft::platform::DriveLetter::T);
     assert_eq!(loaded.records.len(), 3);
     assert_eq!(loaded.names.as_slice(), b"foobarbaz");
     assert_eq!(loaded.source_epoch, 42);
@@ -356,13 +370,18 @@ fn mmap_path_byte_equal_to_heap_path() {
     let index = make_test_index();
     let serialized = serialize_compact(&index);
 
-    let (heap_loaded, _) = deserialize_compact(&serialized, 'T').expect("heap deser");
+    let (heap_loaded, _) =
+        deserialize_compact(&serialized, uffs_mft::platform::DriveLetter::T).expect("heap deser");
 
     let (_tmp, runtime_path) = runtime_fixture("byte_equal.live");
     let runtime_dir = uffs_security::runtime_dir::DefaultRuntimeDir::default();
-    let (mmap_loaded, _) =
-        deserialize_compact_into_runtime(&serialized, 'T', &runtime_dir, &runtime_path)
-            .expect("mmap deser");
+    let (mmap_loaded, _) = deserialize_compact_into_runtime(
+        &serialized,
+        uffs_mft::platform::DriveLetter::T,
+        &runtime_dir,
+        &runtime_path,
+    )
+    .expect("mmap deser");
 
     // The two storage variants must yield identical observable
     // contents — bytemuck-cast records and names slice should be
@@ -387,9 +406,14 @@ fn runtime_mmap_rejects_truncated_data() {
     let runtime_dir = uffs_security::runtime_dir::DefaultRuntimeDir::default();
     // `Result::err()` avoids the `T: Debug` bound that `expect_err`
     // would impose on `(DriveCompactIndex, u128)`.
-    let err = deserialize_compact_into_runtime(b"short", 'X', &runtime_dir, &runtime_path)
-        .err()
-        .expect("truncated data must error via runtime path");
+    let err = deserialize_compact_into_runtime(
+        b"short",
+        uffs_mft::platform::DriveLetter::X,
+        &runtime_dir,
+        &runtime_path,
+    )
+    .err()
+    .expect("truncated data must error via runtime path");
     assert_eq!(err.kind(), io::ErrorKind::Other);
 }
 
@@ -411,9 +435,13 @@ fn runtime_path_yields_mmap_backed_columns() {
 
     let (_tmp, runtime_path) = runtime_fixture("variant_mmap.live");
     let runtime_dir = uffs_security::runtime_dir::DefaultRuntimeDir::default();
-    let (loaded, _tri_ms) =
-        deserialize_compact_into_runtime(&serialized, 'T', &runtime_dir, &runtime_path)
-            .expect("mmap deser");
+    let (loaded, _tri_ms) = deserialize_compact_into_runtime(
+        &serialized,
+        uffs_mft::platform::DriveLetter::T,
+        &runtime_dir,
+        &runtime_path,
+    )
+    .expect("mmap deser");
 
     assert!(
         loaded.records.is_mmap(),
@@ -438,7 +466,8 @@ fn heap_path_yields_vec_backed_columns() {
     let index = make_test_index();
     let serialized = serialize_compact(&index);
 
-    let (loaded, _tri_ms) = deserialize_compact(&serialized, 'T').expect("heap deser");
+    let (loaded, _tri_ms) =
+        deserialize_compact(&serialized, uffs_mft::platform::DriveLetter::T).expect("heap deser");
 
     assert!(
         loaded.records.is_vec(),
@@ -475,7 +504,8 @@ fn purge_legacy_dir_missing_path_is_noop() {
     let path = tmp.path().join("Z_compact.uffs");
     assert!(!path.exists(), "precondition: path absent");
 
-    purge_legacy_compact_cache_dir(&path, 'Z').expect("missing path must be Ok(())");
+    purge_legacy_compact_cache_dir(&path, uffs_mft::platform::DriveLetter::Z)
+        .expect("missing path must be Ok(())");
 
     assert!(
         !path.exists(),
@@ -491,7 +521,8 @@ fn purge_legacy_dir_regular_file_is_noop() {
     let path = tmp.path().join("Z_compact.uffs");
     std::fs::write(&path, b"existing cache bytes").expect("seed regular file");
 
-    purge_legacy_compact_cache_dir(&path, 'Z').expect("regular file must be Ok(())");
+    purge_legacy_compact_cache_dir(&path, uffs_mft::platform::DriveLetter::Z)
+        .expect("regular file must be Ok(())");
 
     let bytes = std::fs::read(&path).expect("regular file must still be readable");
     assert_eq!(
@@ -510,7 +541,8 @@ fn purge_legacy_dir_empty_directory_is_removed() {
     std::fs::create_dir(&path).expect("seed empty directory");
     assert!(path.is_dir(), "precondition: path is empty dir");
 
-    purge_legacy_compact_cache_dir(&path, 'Z').expect("empty dir must be Ok(())");
+    purge_legacy_compact_cache_dir(&path, uffs_mft::platform::DriveLetter::Z)
+        .expect("empty dir must be Ok(())");
 
     assert!(
         !path.exists(),
@@ -530,7 +562,7 @@ fn purge_legacy_dir_non_empty_directory_is_refused() {
     std::fs::create_dir(&path).expect("seed dir");
     std::fs::write(path.join("unexpected.bin"), b"surprise").expect("seed dir contents");
 
-    let err = purge_legacy_compact_cache_dir(&path, 'Z')
+    let err = purge_legacy_compact_cache_dir(&path, uffs_mft::platform::DriveLetter::Z)
         .expect_err("non-empty dir must propagate the underlying io::Error");
     assert!(
         matches!(

--- a/crates/uffs-core/src/compact_filters.rs
+++ b/crates/uffs-core/src/compact_filters.rs
@@ -200,7 +200,7 @@ mod tests {
         let children = ChildrenIndex::build(&records);
         let ext_index = ExtensionIndex::build(&records);
         DriveCompactIndex {
-            letter: 'C',
+            letter: uffs_mft::platform::DriveLetter::C,
             records: ColumnStorage::from_vec(records),
             names: ColumnStorage::from_vec(names),
             trigram,
@@ -319,7 +319,7 @@ mod tests {
         let children = ChildrenIndex::build(&records);
         let ext_index = ExtensionIndex::build(&records);
         let drive = DriveCompactIndex {
-            letter: 'X',
+            letter: uffs_mft::platform::DriveLetter::X,
             records: ColumnStorage::from_vec(records),
             names: ColumnStorage::from_vec(names),
             trigram,

--- a/crates/uffs-core/src/compact_loader.rs
+++ b/crates/uffs-core/src/compact_loader.rs
@@ -41,10 +41,10 @@ pub struct LoadTiming {
 pub enum MftSource {
     /// Offline MFT file (`.uffs`, `.raw`, `.iocp` capture).
     /// Second field is an optional drive-letter override.
-    File(PathBuf, Option<char>),
+    File(PathBuf, Option<uffs_mft::platform::DriveLetter>),
     /// Live Windows NTFS volume (e.g., `'C'`).
     #[cfg(windows)]
-    Live(char),
+    Live(uffs_mft::platform::DriveLetter),
 }
 
 impl MftSource {
@@ -87,8 +87,8 @@ pub fn load_drive(
                 .unwrap_or("X");
             stem.chars()
                 .next()
-                .filter(char::is_ascii_alphabetic)
-                .map_or('X', |ch| ch.to_ascii_uppercase())
+                .and_then(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
+                .unwrap_or(uffs_mft::platform::DriveLetter::X)
         }),
         #[cfg(windows)]
         MftSource::Live(ch) => *ch,
@@ -200,7 +200,7 @@ pub struct RefreshTiming {
 /// and never propagates an error to the caller.
 #[cfg(windows)]
 pub fn load_drive_with_usn_refresh(
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
 ) -> anyhow::Result<(DriveCompactIndex, RefreshTiming)> {
     let total_start = Instant::now();
     let mft_start = Instant::now();
@@ -260,7 +260,7 @@ pub fn load_drive_with_usn_refresh(
 /// falling back to the bare compact-cache load.
 #[cfg(not(windows))]
 pub fn load_drive_with_usn_refresh(
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
 ) -> anyhow::Result<(DriveCompactIndex, RefreshTiming)> {
     anyhow::bail!(
         "USN refresh not supported on this platform (drive {drive_letter}); caller should fall back to load_compact_cache"
@@ -279,7 +279,7 @@ pub fn load_drive_with_usn_refresh(
 /// divergence that we avoid by picking the right parser up front.
 fn parse_mft_file_to_index(
     mft_path: &std::path::Path,
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
 ) -> anyhow::Result<MftIndex> {
     // `?` performs the `MftError → anyhow::Error` conversion via
     // `From<MftError> for anyhow::Error`, matching the original
@@ -304,7 +304,7 @@ fn parse_mft_file_to_index(
 
 /// Kick off the post-parse background cache save and emit a matching
 /// tracing line for success or failure.
-fn spawn_mft_cache_save(index: &MftIndex, drive_letter: char) {
+fn spawn_mft_cache_save(index: &MftIndex, drive_letter: uffs_mft::platform::DriveLetter) {
     match uffs_mft::cache::save_to_cache_background(index, drive_letter, 0, 0, 0) {
         Ok(()) => {
             tracing::info!(drive = %drive_letter, "💾 MFT cache save started (background)");
@@ -322,7 +322,7 @@ fn spawn_mft_cache_save(index: &MftIndex, drive_letter: char) {
 /// Load `MftIndex` from an offline file (cache → cold parse).
 fn load_mft_index_from_file(
     mft_path: &std::path::Path,
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
     no_cache: bool,
 ) -> anyhow::Result<MftIndex> {
     let cached = if no_cache {
@@ -355,7 +355,10 @@ fn load_mft_index_from_file(
 /// `clippy::single_call_fn` so this remains a one-call helper rather
 /// than being inlined.
 #[cfg(windows)]
-fn load_mft_index_live(drive_letter: char, no_cache: bool) -> anyhow::Result<MftIndex> {
+fn load_mft_index_live(
+    drive_letter: uffs_mft::platform::DriveLetter,
+    no_cache: bool,
+) -> anyhow::Result<MftIndex> {
     use anyhow::Context as _;
 
     let read_index = async {
@@ -439,7 +442,7 @@ pub fn refresh_drive(drive: &DriveCompactIndex) -> anyhow::Result<(DriveCompactI
 #[deprecated(note = "Use load_drive(MftSource::File(...)) instead")]
 pub fn load_mft_file(
     mft_path: &std::path::Path,
-    drive: Option<char>,
+    drive: Option<uffs_mft::platform::DriveLetter>,
     no_cache: bool,
 ) -> anyhow::Result<(DriveCompactIndex, LoadTiming)> {
     load_drive(&MftSource::File(mft_path.to_path_buf(), drive), no_cache)

--- a/crates/uffs-core/src/compact_loader_tests.rs
+++ b/crates/uffs-core/src/compact_loader_tests.rs
@@ -99,7 +99,7 @@ fn make_synthetic_drive() -> DriveCompactIndex {
         .collect();
 
     DriveCompactIndex {
-        letter: 'T',
+        letter: uffs_mft::platform::DriveLetter::T,
         records: ColumnStorage::from_vec(records),
         names: ColumnStorage::from_vec(names),
         trigram,

--- a/crates/uffs-core/src/compact_tests.rs
+++ b/crates/uffs-core/src/compact_tests.rs
@@ -23,7 +23,7 @@ fn push_name(index: &mut MftIndex, name: &str) -> IndexNameRef {
 
 /// Build a small fixture: root, one dir ("Docs"), a few files.
 fn fixture_index() -> MftIndex {
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     // Root (FRS 5)
     let root_name = push_name(&mut idx, ".");
@@ -121,7 +121,7 @@ fn fixture_index() -> MftIndex {
 #[test]
 fn compact_preserves_all_critical_fields() {
     let idx = fixture_index();
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
 
     // Find file.txt by scanning names
     let file_rec = drive
@@ -144,7 +144,7 @@ fn compact_preserves_all_critical_fields() {
 #[test]
 fn compact_preserves_directory_tree_metrics() {
     let idx = fixture_index();
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
 
     let docs_rec = drive
         .records
@@ -164,7 +164,7 @@ fn compact_preserves_directory_tree_metrics() {
 #[test]
 fn compact_expands_hardlink_names() {
     let idx = fixture_index();
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
 
     // Both primary and alternate hardlink names must appear as separate
     // CompactRecords so the unified pipeline matches the legacy pipeline.
@@ -195,7 +195,7 @@ fn compact_expands_hardlink_names() {
 #[test]
 fn compact_stores_only_primary_stream_size() {
     let idx = fixture_index();
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
 
     let ads_rec = drive
         .records
@@ -221,7 +221,7 @@ fn compact_stores_only_primary_stream_size() {
 #[test]
 fn compact_filters_system_metafiles() {
     let idx = fixture_index();
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
 
     // $MFT (FRS 0) must be filtered at build time — its CompactRecord should
     // have name_len=0 (default/zeroed), matching the legacy pipeline which
@@ -243,7 +243,7 @@ fn compact_filters_system_metafiles() {
 #[test]
 fn compact_parent_idx_and_children_correct() {
     let idx = fixture_index();
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
 
     // Find Docs' compact index
     let docs_pos = drive
@@ -281,7 +281,7 @@ fn compact_parent_idx_and_children_correct() {
 #[test]
 fn compact_names_lower_is_correct() {
     let idx = fixture_index();
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
 
     let docs_rec = drive
         .records
@@ -301,7 +301,7 @@ fn compact_names_lower_is_correct() {
 #[test]
 fn compact_record_count_includes_hardlinks() {
     let idx = fixture_index();
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     // Compact index has base records (same count as MftIndex) plus extra
     // records for expanded hardlink alternate names.
     assert!(
@@ -327,7 +327,7 @@ fn compact_record_count_includes_hardlinks() {
 #[test]
 fn compact_parity_root_present_sysfiles_absent_hardlinks_expanded() {
     let idx = fixture_index();
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
 
     // (A) System metafiles must NOT appear.
     let system_names: Vec<&str> = drive
@@ -369,7 +369,7 @@ fn compact_parity_root_present_sysfiles_absent_hardlinks_expanded() {
 
 /// Build a fixture with a file that has an ADS (Zone.Identifier).
 fn fixture_index_with_ads() -> MftIndex {
-    let mut idx = MftIndex::new('M');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::M);
 
     // Root (FRS 5)
     let root_name = push_name(&mut idx, ".");
@@ -421,7 +421,7 @@ fn fixture_index_with_ads() -> MftIndex {
 #[test]
 fn ads_expanded_into_compact_records() {
     let idx = fixture_index_with_ads();
-    let (compact, _, _) = build_compact_index('M', &idx);
+    let (compact, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::M, &idx);
 
     // Collect all non-empty names.
     let all_names: Vec<&str> = compact
@@ -444,7 +444,7 @@ fn ads_expanded_into_compact_records() {
 #[test]
 fn ads_compact_record_has_stream_size() {
     let idx = fixture_index_with_ads();
-    let (compact, _, _) = build_compact_index('M', &idx);
+    let (compact, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::M, &idx);
 
     let ads_rec = compact
         .records
@@ -464,7 +464,7 @@ fn ads_compact_record_has_stream_size() {
 #[test]
 fn ads_compact_record_inherits_timestamps() {
     let idx = fixture_index_with_ads();
-    let (compact, _, _) = build_compact_index('M', &idx);
+    let (compact, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::M, &idx);
 
     let base_rec = compact
         .records
@@ -497,7 +497,7 @@ fn ads_compact_record_inherits_timestamps() {
 
 #[test]
 fn ads_on_directory_strips_directory_flag() {
-    let mut idx = MftIndex::new('M');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::M);
 
     // Create root (FRS 5)
     let root_name = push_name(&mut idx, ".");
@@ -535,7 +535,7 @@ fn ads_on_directory_strips_directory_flag() {
     dir_mut.stream_count = 2;
     dir_mut.total_stream_count = 2;
 
-    let (compact, _, _) = build_compact_index('M', &idx);
+    let (compact, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::M, &idx);
 
     // The directory itself should have DIRECTORY flag.
     let dir_compact = compact

--- a/crates/uffs-core/src/index_search/tests.rs
+++ b/crates/uffs-core/src/index_search/tests.rs
@@ -41,7 +41,7 @@ fn push_file_name_ref(index: &mut MftIndex, name: &str) -> Result<IndexNameRef, 
 }
 
 fn build_index_query_fixture() -> Result<MftIndex, TestError> {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     let root_name = push_name_ref(&mut index, ".")?;
     let root = index.get_or_create(ROOT_FRS);
@@ -177,7 +177,7 @@ fn extensions() {
 
 #[test]
 fn extension_index_integration() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(uffs_mft::platform::DriveLetter::C);
     let root_name_offset = index.add_name(".");
     let root = index.get_or_create(ROOT_FRS);
     root.stdinfo.set_directory(true);

--- a/crates/uffs-core/src/output/config.rs
+++ b/crates/uffs-core/src/output/config.rs
@@ -478,8 +478,14 @@ impl OutputConfig {
         let Some(filetime) = filetime_opt else { return };
         let tz_offset_secs: i32 = fixed_tz.map_or(0_i32, chrono::FixedOffset::local_minus_utc);
         let local_ft = uffs_time::filetime_with_tz_bias(filetime, tz_offset_secs);
-        if let Some((year, month, day, hour, minute, second)) =
-            uffs_time::filetime_to_calendar(local_ft)
+        if let Some(uffs_time::CalendarParts {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+        }) = uffs_time::filetime_to_calendar(local_ft)
         {
             Self::append_display(
                 row_buffer,

--- a/crates/uffs-core/src/output/display_rows.rs
+++ b/crates/uffs-core/src/output/display_rows.rs
@@ -382,8 +382,14 @@ pub(crate) fn push_flag(buf: &mut String, cfg: &OutputConfig, flags: u32, mask: 
 /// submodule at `display_rows_tests.rs`.
 pub(crate) fn append_datetime_native(buf: &mut String, filetime: i64, tz_offset_secs: i32) {
     let local_ft = uffs_time::filetime_with_tz_bias(filetime, tz_offset_secs);
-    if let Some((year, month, day, hour, minute, second)) =
-        uffs_time::filetime_to_calendar(local_ft)
+    if let Some(uffs_time::CalendarParts {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+    }) = uffs_time::filetime_to_calendar(local_ft)
     {
         #[expect(
             clippy::let_underscore_must_use,

--- a/crates/uffs-core/src/output/display_rows.rs
+++ b/crates/uffs-core/src/output/display_rows.rs
@@ -327,7 +327,7 @@ pub(crate) fn write_display_row_columns(
                 buf.push_str(itoa_buf.format(pct));
             }
             OutputColumn::Drive => {
-                buf.push(row.drive);
+                buf.push(row.drive.as_char());
             }
             OutputColumn::Extension => {
                 buf.push_str(&cfg.quote);

--- a/crates/uffs-core/src/output/tests.rs
+++ b/crates/uffs-core/src/output/tests.rs
@@ -266,7 +266,7 @@ fn parity_compat_directory_formatting() {
 
     let file_row = DisplayRow::new(
         0,
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\Temp\\hello.txt".to_owned(),
         1024,
         false,
@@ -282,7 +282,7 @@ fn parity_compat_directory_formatting() {
 
     let dir_row = DisplayRow::new(
         0,
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\Temp".to_owned(),
         0,
         true,
@@ -375,7 +375,7 @@ fn parity_root_no_double_trailing_backslash() {
 
     let root_row = DisplayRow::new(
         0,
-        'G',
+        uffs_mft::platform::DriveLetter::G,
         "G:\\".to_owned(),
         0,
         true,
@@ -464,7 +464,7 @@ fn write_display_rows_emits_treesize_and_tree_allocated() {
 
     let dir_row = DisplayRow::new(
         0,
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\Big".to_owned(),
         0,
         true,
@@ -514,7 +514,7 @@ fn write_display_rows_emits_name_length_and_path_length() {
 
     let row = DisplayRow::new(
         0,
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\Very\\Long\\Path\\readme.txt".to_owned(),
         100,
         false,
@@ -619,7 +619,7 @@ fn write_display_rows_parallel_matches_sequential() {
         .map(|idx| {
             DisplayRow::new(
                 idx,
-                'C',
+                uffs_mft::platform::DriveLetter::C,
                 format!("C:\\tmp\\file_{idx:05}.dll"),
                 u64::from(idx) * 1024,
                 false,
@@ -717,7 +717,21 @@ fn extension_column_dot_gated_for_dotfiles_dotless_and_trailing_dot() {
     // Build one DisplayRow per case: dotfile, dotless, trailing-dot,
     // multi-dot directory name, and a normal file (positive control).
     fn row(path: &str) -> DisplayRow {
-        DisplayRow::new(0, 'C', path.to_owned(), 0, false, 0, 0, 0, 0, 0, 0, 0, 0)
+        DisplayRow::new(
+            0,
+            uffs_mft::platform::DriveLetter::C,
+            path.to_owned(),
+            0,
+            false,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
     }
 
     let rows = [

--- a/crates/uffs-core/src/output/tests_format_parity.rs
+++ b/crates/uffs-core/src/output/tests_format_parity.rs
@@ -74,7 +74,7 @@ fn format_parity_basic_file_row() {
 
     let rows = vec![DisplayRow::new(
         0_u32,
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\Temp\\sample.txt".to_owned(),
         256,
         false,
@@ -106,7 +106,7 @@ fn format_parity_parity_compat_directory_row() {
 
     let rows = vec![DisplayRow::new(
         0_u32,
-        'D',
+        uffs_mft::platform::DriveLetter::D,
         "D:\\Users\\alice\\Documents".to_owned(),
         0,
         true,
@@ -138,7 +138,7 @@ fn format_parity_all_columns_baseline() {
 
     let rows = vec![DisplayRow::new(
         0_u32,
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\Projects\\uffs\\README.md".to_owned(),
         4321,
         false,
@@ -171,7 +171,7 @@ fn format_parity_parallel_branch_matches() {
         .map(|idx| {
             DisplayRow::new(
                 idx,
-                'C',
+                uffs_mft::platform::DriveLetter::C,
                 format!("C:\\batch\\row_{idx:05}.bin"),
                 u64::from(idx),
                 false,

--- a/crates/uffs-core/src/path_resolver/fast.rs
+++ b/crates/uffs-core/src/path_resolver/fast.rs
@@ -54,7 +54,7 @@ pub struct FastPathResolver {
     /// Arena holding all file names.
     names: NameArena,
     /// Volume letter (e.g., 'C').
-    volume: char,
+    volume: uffs_mft::platform::DriveLetter,
     /// Pre-computed paths for caching.
     ///
     /// Uses `FxHashMap<u64, String>` instead of `Vec<Option<String>>` to
@@ -79,7 +79,7 @@ impl FastPathResolver {
     /// # Errors
     ///
     /// Returns an error if required columns are missing.
-    pub fn build(df: &DataFrame, volume: char) -> Result<Self> {
+    pub fn build(df: &DataFrame, volume: uffs_mft::platform::DriveLetter) -> Result<Self> {
         let frs_col = df.column("frs")?.u64()?;
         let parent_col = df.column("parent_frs")?.u64()?;
         let name_col = df.column("name")?.str()?;
@@ -193,7 +193,7 @@ impl FastPathResolver {
         }
 
         // Build final path (uppercase drive letter for legacy-output parity)
-        path_buf.push(self.volume.to_ascii_uppercase());
+        path_buf.push(self.volume.as_char());
         path_buf.push_str(":\\");
 
         // Append components in reverse order

--- a/crates/uffs-core/src/path_resolver/legacy.rs
+++ b/crates/uffs-core/src/path_resolver/legacy.rs
@@ -32,7 +32,7 @@ pub struct PathResolver {
     /// Cache of resolved paths
     cache: HashMap<u64, String>,
     /// Volume letter (e.g., 'C')
-    volume: char,
+    volume: uffs_mft::platform::DriveLetter,
 }
 
 impl PathResolver {
@@ -46,7 +46,7 @@ impl PathResolver {
     /// # Errors
     ///
     /// Returns an error if required columns are missing.
-    pub fn build(df: &DataFrame, volume: char) -> Result<Self> {
+    pub fn build(df: &DataFrame, volume: uffs_mft::platform::DriveLetter) -> Result<Self> {
         let frs_col = df.column("frs")?.u64()?;
         let parent_col = df.column("parent_frs")?.u64()?;
         let name_col = df.column("name")?.str()?;
@@ -101,11 +101,7 @@ impl PathResolver {
 
         // Build path from components (reverse order, uppercase drive letter)
         components.reverse();
-        let path = format!(
-            "{}:\\{}",
-            self.volume.to_ascii_uppercase(),
-            components.join("\\")
-        );
+        let path = format!("{}:\\{}", self.volume.as_char(), components.join("\\"));
 
         // Cache the result
         self.cache.insert(frs, path.clone());
@@ -173,7 +169,7 @@ pub fn add_path_column_multi_drive(df: &DataFrame) -> Result<DataFrame> {
     let name_col = df.column("name")?.str()?;
 
     // Build per-drive resolvers
-    let mut resolvers: HashMap<char, PathResolver> = HashMap::new();
+    let mut resolvers: HashMap<uffs_mft::platform::DriveLetter, PathResolver> = HashMap::new();
 
     // First pass: build entries for each drive
     for i in 0..df.height() {
@@ -183,8 +179,15 @@ pub fn add_path_column_multi_drive(df: &DataFrame) -> Result<DataFrame> {
             parent_col.get(i),
             name_col.get(i),
         ) {
-            // Extract drive letter from "C:" format
-            let drive_letter = drive_str.chars().next().unwrap_or('?');
+            // Extract drive letter from "C:" format; fall back to
+            // `DriveLetter::X` (matches the previous `'?'` sentinel
+            // semantics — any record whose drive prefix isn't ASCII
+            // A–Z gets bucketed under the "unknown" letter).
+            let drive_letter = drive_str
+                .chars()
+                .next()
+                .and_then(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
+                .unwrap_or(uffs_mft::platform::DriveLetter::X);
 
             let resolver = resolvers
                 .entry(drive_letter)
@@ -206,7 +209,11 @@ pub fn add_path_column_multi_drive(df: &DataFrame) -> Result<DataFrame> {
 
             match (drive_str, frs) {
                 (Some(drive), Some(frs_val)) => {
-                    let drive_letter = drive.chars().next().unwrap_or('?');
+                    let drive_letter = drive
+                        .chars()
+                        .next()
+                        .and_then(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
+                        .unwrap_or(uffs_mft::platform::DriveLetter::X);
                     resolvers.get_mut(&drive_letter).map_or_else(
                         || "<unknown>".to_owned(),
                         |resolver| {

--- a/crates/uffs-core/src/path_resolver/multi_drive.rs
+++ b/crates/uffs-core/src/path_resolver/multi_drive.rs
@@ -20,8 +20,8 @@ use crate::error::Result;
 /// ```rust,ignore
 /// // Build resolver from FULL MFT data (before filtering)
 /// let mut resolver = FastPathResolverMultiDrive::new();
-/// resolver.add_drive('C', &full_c_drive_df)?;
-/// resolver.add_drive('D', &full_d_drive_df)?;
+/// resolver.add_drive(uffs_mft::platform::DriveLetter::C, &full_c_drive_df)?;
+/// resolver.add_drive(uffs_mft::platform::DriveLetter::D, &full_d_drive_df)?;
 ///
 /// // Apply filters to get search results
 /// let filtered = apply_filters(&full_df)?;
@@ -32,7 +32,7 @@ use crate::error::Result;
 #[derive(Debug, Clone, Default)]
 pub struct FastPathResolverMultiDrive {
     /// Per-drive resolvers.
-    resolvers: HashMap<char, FastPathResolver>,
+    resolvers: HashMap<uffs_mft::platform::DriveLetter, FastPathResolver>,
 }
 
 impl FastPathResolverMultiDrive {
@@ -49,7 +49,11 @@ impl FastPathResolverMultiDrive {
     /// # Errors
     ///
     /// Returns an error if required columns are missing.
-    pub fn add_drive(&mut self, drive: char, full_mft_df: &DataFrame) -> Result<()> {
+    pub fn add_drive(
+        &mut self,
+        drive: uffs_mft::platform::DriveLetter,
+        full_mft_df: &DataFrame,
+    ) -> Result<()> {
         let resolver = FastPathResolver::build(full_mft_df, drive)?;
         self.resolvers.insert(drive, resolver);
         Ok(())
@@ -57,12 +61,15 @@ impl FastPathResolverMultiDrive {
 
     /// Get a resolver for a specific drive.
     #[must_use]
-    pub fn get(&self, drive: char) -> Option<&FastPathResolver> {
+    pub fn get(&self, drive: uffs_mft::platform::DriveLetter) -> Option<&FastPathResolver> {
         self.resolvers.get(&drive)
     }
 
     /// Get a mutable resolver for a specific drive.
-    pub fn get_mut(&mut self, drive: char) -> Option<&mut FastPathResolver> {
+    pub fn get_mut(
+        &mut self,
+        drive: uffs_mft::platform::DriveLetter,
+    ) -> Option<&mut FastPathResolver> {
         self.resolvers.get_mut(&drive)
     }
 
@@ -85,7 +92,13 @@ impl FastPathResolverMultiDrive {
 
                 match (drive_str, frs) {
                     (Some(drive), Some(frs_val)) => {
-                        let drive_letter = drive.chars().next().unwrap_or('?');
+                        // Fall back to `DriveLetter::X` for malformed
+                        // drive prefixes — see legacy.rs for rationale.
+                        let drive_letter = drive
+                            .chars()
+                            .next()
+                            .and_then(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
+                            .unwrap_or(uffs_mft::platform::DriveLetter::X);
                         self.resolvers.get_mut(&drive_letter).map_or_else(
                             || format!("<no resolver for {drive_letter}>"),
                             |resolver| resolver.resolve_cached(frs_val),
@@ -105,7 +118,7 @@ impl FastPathResolverMultiDrive {
 
     /// Get statistics for all drives.
     #[must_use]
-    pub fn stats(&self) -> Vec<(char, FastPathResolverStats)> {
+    pub fn stats(&self) -> Vec<(uffs_mft::platform::DriveLetter, FastPathResolverStats)> {
         self.resolvers
             .iter()
             .map(|(&drive, resolver)| (drive, resolver.stats()))
@@ -137,7 +150,7 @@ impl FastPathResolverMultiDrive {
 pub fn add_paths_from_full_data(
     full_mft_df: &DataFrame,
     filtered_df: &DataFrame,
-    volume: char,
+    volume: uffs_mft::platform::DriveLetter,
 ) -> Result<DataFrame> {
     let mut resolver = FastPathResolver::build(full_mft_df, volume)?;
     resolver.add_path_column(filtered_df)

--- a/crates/uffs-core/src/path_resolver/tests.rs
+++ b/crates/uffs-core/src/path_resolver/tests.rs
@@ -27,7 +27,7 @@ fn create_test_df() -> Result<DataFrame, uffs_polars::PolarsError> {
 #[test]
 fn resolve_path() -> TestResult {
     let df = create_test_df()?;
-    let mut resolver = PathResolver::build(&df, 'C')?;
+    let mut resolver = PathResolver::build(&df, uffs_mft::platform::DriveLetter::C)?;
 
     let path = resolver.resolve(102)?;
     assert_eq!(path, "C:\\Users\\john\\Documents");
@@ -37,7 +37,7 @@ fn resolve_path() -> TestResult {
 #[test]
 fn path_caching() -> TestResult {
     let df = create_test_df()?;
-    let mut resolver = PathResolver::build(&df, 'C')?;
+    let mut resolver = PathResolver::build(&df, uffs_mft::platform::DriveLetter::C)?;
 
     // First resolution
     let path1 = resolver.resolve(102)?;
@@ -55,7 +55,7 @@ fn path_caching() -> TestResult {
 #[test]
 fn fast_resolve_path() -> TestResult {
     let df = create_test_df()?;
-    let resolver = FastPathResolver::build(&df, 'C')?;
+    let resolver = FastPathResolver::build(&df, uffs_mft::platform::DriveLetter::C)?;
 
     let path = resolver.resolve(102);
     assert_eq!(path, "C:\\Users\\john\\Documents");
@@ -65,7 +65,7 @@ fn fast_resolve_path() -> TestResult {
 #[test]
 fn fast_resolve_root() -> TestResult {
     let df = create_test_df()?;
-    let resolver = FastPathResolver::build(&df, 'C')?;
+    let resolver = FastPathResolver::build(&df, uffs_mft::platform::DriveLetter::C)?;
 
     // Root directory (FRS 5) should resolve to just "C:\"
     let path = resolver.resolve(5);
@@ -76,7 +76,7 @@ fn fast_resolve_root() -> TestResult {
 #[test]
 fn fast_resolve_cached() -> TestResult {
     let df = create_test_df()?;
-    let mut resolver = FastPathResolver::build(&df, 'C')?;
+    let mut resolver = FastPathResolver::build(&df, uffs_mft::platform::DriveLetter::C)?;
 
     // First resolution (builds and caches)
     let path1 = resolver.resolve_cached(102);
@@ -95,7 +95,7 @@ fn fast_resolve_cached() -> TestResult {
 #[test]
 fn fast_resolve_missing_frs() -> TestResult {
     let df = create_test_df()?;
-    let resolver = FastPathResolver::build(&df, 'C')?;
+    let resolver = FastPathResolver::build(&df, uffs_mft::platform::DriveLetter::C)?;
 
     // FRS 999 doesn't exist
     let path = resolver.resolve(999);
@@ -106,7 +106,7 @@ fn fast_resolve_missing_frs() -> TestResult {
 #[test]
 fn fast_add_path_column() -> TestResult {
     let df = create_test_df()?;
-    let mut resolver = FastPathResolver::build(&df, 'C')?;
+    let mut resolver = FastPathResolver::build(&df, uffs_mft::platform::DriveLetter::C)?;
 
     let result = resolver.add_path_column(&df)?;
 
@@ -122,7 +122,7 @@ fn fast_add_path_column() -> TestResult {
 #[test]
 fn fast_resolver_stats() -> TestResult {
     let df = create_test_df()?;
-    let resolver = FastPathResolver::build(&df, 'C')?;
+    let resolver = FastPathResolver::build(&df, uffs_mft::platform::DriveLetter::C)?;
 
     let stats = resolver.stats();
     assert_eq!(stats.entry_count, 4);
@@ -161,7 +161,7 @@ fn name_arena_empty() {
 #[test]
 fn fast_add_path_column_parallel() -> TestResult {
     let df = create_test_df()?;
-    let resolver = FastPathResolver::build(&df, 'C')?;
+    let resolver = FastPathResolver::build(&df, uffs_mft::platform::DriveLetter::C)?;
 
     let result = resolver.add_path_column_parallel(&df)?;
 
@@ -180,7 +180,7 @@ fn fast_add_path_column_parallel() -> TestResult {
 #[test]
 fn fast_add_path_column_auto() -> TestResult {
     let df = create_test_df()?;
-    let mut resolver = FastPathResolver::build(&df, 'C')?;
+    let mut resolver = FastPathResolver::build(&df, uffs_mft::platform::DriveLetter::C)?;
 
     // Small DataFrame should use sequential
     let result = resolver.add_path_column_auto(&df)?;

--- a/crates/uffs-core/src/search/backend.rs
+++ b/crates/uffs-core/src/search/backend.rs
@@ -32,7 +32,16 @@ const UNLIMITED: usize = usize::MAX;
 /// The filename is **not** stored separately — it is derived from the `path`
 /// field using `name_start` (byte offset where the filename begins within
 /// `path`).  This avoids one heap allocation per result row.
-#[derive(Debug, Clone, Default)]
+///
+/// `Default` is implemented manually below: [`uffs_mft::platform::DriveLetter`]
+/// has no `Default` impl (it's a validated `A..=Z` newtype with no canonical
+/// zero), but the `sort_rows_with_fold` hot path uses
+/// [`core::mem::take`] to move rows out of a `&mut [DisplayRow]` slice
+/// as part of a Schwartzian decorate/sort/undecorate transform.  The
+/// take leaves a transient placeholder in the slice that's
+/// immediately overwritten by the put-back step, so any consistent
+/// drive letter works for the placeholder.
+#[derive(Debug, Clone)]
 #[expect(
     clippy::partial_pub_fields,
     reason = "name_start is private by design — accessed via name() method"
@@ -41,7 +50,7 @@ pub struct DisplayRow {
     /// Record index within the compact/cache file.
     pub record_index: u32,
     /// Drive letter this result belongs to.
-    pub drive: char,
+    pub drive: uffs_mft::platform::DriveLetter,
     /// Full resolved path (e.g., `C:\Users\file.txt`).
     pub path: String,
     /// Byte offset within `path` where the filename begins.
@@ -80,7 +89,7 @@ impl DisplayRow {
     )]
     pub fn new(
         record_index: u32,
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
         path: String,
         size: u64,
         is_directory: bool,
@@ -152,6 +161,33 @@ impl DisplayRow {
 /// hands back a struct field (or the pre-computed filename slice),
 /// matching the trait's inlineability requirement.
 ///
+/// Manual `Default` impl — see the struct doc-comment for why we
+/// don't derive it.  All fields default to their natural zero
+/// (`0`, `String::new()`, `false`) except `drive`, which we set to
+/// [`uffs_mft::platform::DriveLetter::A`] purely as a placeholder for
+/// [`core::mem::take`] in the sort hot path.  Callers never observe
+/// this value: the take is immediately followed by a put-back.
+impl Default for DisplayRow {
+    fn default() -> Self {
+        Self {
+            record_index: 0,
+            drive: uffs_mft::platform::DriveLetter::A,
+            path: String::new(),
+            name_start: 0,
+            size: 0,
+            is_directory: false,
+            modified: 0,
+            created: 0,
+            accessed: 0,
+            flags: 0,
+            allocated: 0,
+            descendants: 0,
+            treesize: 0,
+            tree_allocated: 0,
+        }
+    }
+}
+
 /// The trait method `name()` collides with `DisplayRow::name()` (the
 /// inherent accessor that pre-dates the trait); the trait impl
 /// delegates to the inherent impl so the behaviour is identical.
@@ -160,7 +196,11 @@ impl DisplayRow {
 impl uffs_format::FormatRow for DisplayRow {
     #[inline]
     fn drive(&self) -> char {
-        self.drive
+        // `uffs-format` is a foundation crate that intentionally
+        // doesn't depend on `uffs-mft`, so the trait surface
+        // stays `char`.  `DriveLetter::as_char` is the canonical
+        // zero-cost conversion to the ASCII letter.
+        self.drive.as_char()
     }
     #[inline]
     fn path(&self) -> &str {
@@ -323,7 +363,7 @@ pub struct SearchRequest<'a> {
     pub search_filters: &'a mut super::filters::SearchFilters,
     /// Drive-letter filter: only search drives whose letter is in this
     /// slice.  An empty slice means "search all loaded drives".
-    pub drives_filter: &'a [char],
+    pub drives_filter: &'a [uffs_mft::platform::DriveLetter],
 }
 
 impl<'a> SearchRequest<'a> {
@@ -378,7 +418,7 @@ impl DriveIndex {
 
     /// List loaded drives with record counts.
     #[must_use]
-    pub fn drive_summary(&self) -> Vec<(char, usize)> {
+    pub fn drive_summary(&self) -> Vec<(uffs_mft::platform::DriveLetter, usize)> {
         self.drives
             .iter()
             .map(|dr| (dr.letter, dr.records.len()))
@@ -433,7 +473,7 @@ impl MultiDriveBackend {
 
     /// List loaded drives with record counts.
     #[must_use]
-    pub fn drive_summary(&self) -> Vec<(char, usize)> {
+    pub fn drive_summary(&self) -> Vec<(uffs_mft::platform::DriveLetter, usize)> {
         self.drives
             .iter()
             .map(|dr| (dr.letter, dr.records.len()))
@@ -486,7 +526,7 @@ impl MultiDriveBackend {
         // docs for the composition rules.  `drive_from_prefix` owns the
         // single-element vec so the borrow in `effective_drives_filter`
         // stays valid through the stash-and-partition block below.
-        let mut drive_from_prefix: Vec<char> = Vec::new();
+        let mut drive_from_prefix: Vec<uffs_mft::platform::DriveLetter> = Vec::new();
         apply_dispatch_safety_nets(
             &mut pattern,
             match_path,
@@ -495,11 +535,12 @@ impl MultiDriveBackend {
             search_filters,
             &mut drive_from_prefix,
         );
-        let effective_drives_filter: &[char] = if drive_from_prefix.is_empty() {
-            drives_filter
-        } else {
-            &drive_from_prefix
-        };
+        let effective_drives_filter: &[uffs_mft::platform::DriveLetter] =
+            if drive_from_prefix.is_empty() {
+                drives_filter
+            } else {
+                &drive_from_prefix
+            };
 
         // When a drive filter is active, temporarily swap out non-matching
         // drives so the rest of the search logic (which uses `self.drives`)
@@ -508,11 +549,9 @@ impl MultiDriveBackend {
             None
         } else {
             let all = core::mem::take(&mut self.drives);
-            let (keep, rest): (Vec<_>, Vec<_>) = all.into_iter().partition(|dr| {
-                effective_drives_filter
-                    .iter()
-                    .any(|fl| fl.eq_ignore_ascii_case(&dr.letter))
-            });
+            let (keep, rest): (Vec<_>, Vec<_>) = all
+                .into_iter()
+                .partition(|dr| effective_drives_filter.contains(&dr.letter));
             self.drives = keep;
             Some(rest)
         };
@@ -752,7 +791,7 @@ pub fn search_index(
     // docs for the composition rules.  `drive_from_prefix` owns the
     // single-element vec so the borrow in `effective_drives_filter`
     // stays valid for the rest of the function.
-    let mut drive_from_prefix: Vec<char> = Vec::new();
+    let mut drive_from_prefix: Vec<uffs_mft::platform::DriveLetter> = Vec::new();
     apply_dispatch_safety_nets(
         &mut pattern,
         match_path,
@@ -761,21 +800,19 @@ pub fn search_index(
         search_filters,
         &mut drive_from_prefix,
     );
-    let effective_drives_filter: &[char] = if drive_from_prefix.is_empty() {
-        drives_filter
-    } else {
-        &drive_from_prefix
-    };
+    let effective_drives_filter: &[uffs_mft::platform::DriveLetter] =
+        if drive_from_prefix.is_empty() {
+            drives_filter
+        } else {
+            &drive_from_prefix
+        };
 
     // Filter drives without mutation — just skip non-matching ones.
     let mut active_drives: Vec<&DriveCompactIndex> = index
         .drives
         .iter()
         .filter(|dr| {
-            effective_drives_filter.is_empty()
-                || effective_drives_filter
-                    .iter()
-                    .any(|fl| fl.eq_ignore_ascii_case(&dr.letter))
+            effective_drives_filter.is_empty() || effective_drives_filter.contains(&dr.letter)
         })
         .map(Arc::as_ref)
         .collect();

--- a/crates/uffs-core/src/search/backend_tests.rs
+++ b/crates/uffs-core/src/search/backend_tests.rs
@@ -11,7 +11,13 @@ use super::*;
 // ── Helpers ──────────────────────────────────────────────────────────
 
 /// Build a minimal `DisplayRow` for sort / aggregation tests.
-fn row(name: &str, drive: char, size: u64, modified: i64, created: i64) -> DisplayRow {
+fn row(
+    name: &str,
+    drive: uffs_mft::platform::DriveLetter,
+    size: u64,
+    modified: i64,
+    created: i64,
+) -> DisplayRow {
     DisplayRow::new(
         0,
         drive,
@@ -29,7 +35,12 @@ fn row(name: &str, drive: char, size: u64, modified: i64, created: i64) -> Displ
     )
 }
 
-fn dir_row(name: &str, drive: char, descendants: u32, treesize: u64) -> DisplayRow {
+fn dir_row(
+    name: &str,
+    drive: uffs_mft::platform::DriveLetter,
+    descendants: u32,
+    treesize: u64,
+) -> DisplayRow {
     DisplayRow::new(
         0,
         drive,
@@ -195,8 +206,8 @@ fn format_sort_spec_with_extra_tiers() {
 #[test]
 fn sort_by_name_ascending() {
     let mut rows = vec![
-        row("zebra.txt", 'C', 100, 0, 0),
-        row("alpha.txt", 'C', 200, 0, 0),
+        row("zebra.txt", uffs_mft::platform::DriveLetter::C, 100, 0, 0),
+        row("alpha.txt", uffs_mft::platform::DriveLetter::C, 200, 0, 0),
     ];
     sort_rows(&mut rows, SortColumn::Name, false, &[]);
     assert_eq!(rows.first().expect("first").name(), "alpha.txt");
@@ -205,8 +216,8 @@ fn sort_by_name_ascending() {
 #[test]
 fn sort_by_modified_descending() {
     let mut rows = vec![
-        row("old.txt", 'C', 100, 1000, 0),
-        row("new.txt", 'C', 100, 9000, 0),
+        row("old.txt", uffs_mft::platform::DriveLetter::C, 100, 1000, 0),
+        row("new.txt", uffs_mft::platform::DriveLetter::C, 100, 9000, 0),
     ];
     sort_rows(&mut rows, SortColumn::Modified, true, &[]);
     assert_eq!(rows.first().expect("first").name(), "new.txt");
@@ -215,8 +226,8 @@ fn sort_by_modified_descending() {
 #[test]
 fn sort_by_created_descending() {
     let mut rows = vec![
-        row("old.txt", 'C', 100, 0, 1000),
-        row("new.txt", 'C', 100, 0, 9000),
+        row("old.txt", uffs_mft::platform::DriveLetter::C, 100, 0, 1000),
+        row("new.txt", uffs_mft::platform::DriveLetter::C, 100, 0, 9000),
     ];
     sort_rows(&mut rows, SortColumn::Created, true, &[]);
     assert_eq!(rows.first().expect("first").name(), "new.txt");
@@ -224,7 +235,10 @@ fn sort_by_created_descending() {
 
 #[test]
 fn sort_by_path_ascending() {
-    let mut rows = vec![row("z.txt", 'D', 100, 0, 0), row("a.txt", 'C', 100, 0, 0)];
+    let mut rows = vec![
+        row("z.txt", uffs_mft::platform::DriveLetter::D, 100, 0, 0),
+        row("a.txt", uffs_mft::platform::DriveLetter::C, 100, 0, 0),
+    ];
     sort_rows(&mut rows, SortColumn::Path, false, &[]);
     assert_eq!(rows.first().expect("first").name(), "a.txt");
 }
@@ -232,8 +246,8 @@ fn sort_by_path_ascending() {
 #[test]
 fn sort_by_extension_ascending() {
     let mut rows = vec![
-        row("file.zip", 'C', 100, 0, 0),
-        row("file.abc", 'C', 100, 0, 0),
+        row("file.zip", uffs_mft::platform::DriveLetter::C, 100, 0, 0),
+        row("file.abc", uffs_mft::platform::DriveLetter::C, 100, 0, 0),
     ];
     sort_rows(&mut rows, SortColumn::Extension, false, &[]);
     assert_eq!(rows.first().expect("first").name(), "file.abc");
@@ -242,8 +256,8 @@ fn sort_by_extension_ascending() {
 #[test]
 fn sort_by_descendants_descending() {
     let mut rows = vec![
-        dir_row("small", 'C', 5, 1000),
-        dir_row("big", 'C', 500, 50_000),
+        dir_row("small", uffs_mft::platform::DriveLetter::C, 5, 1000),
+        dir_row("big", uffs_mft::platform::DriveLetter::C, 500, 50_000),
     ];
     sort_rows(&mut rows, SortColumn::Descendants, true, &[]);
     assert_eq!(rows.first().expect("first").name(), "big");
@@ -252,18 +266,21 @@ fn sort_by_descendants_descending() {
 #[test]
 fn sort_by_drive_ascending() {
     let mut rows = vec![
-        row("file.txt", 'D', 100, 0, 0),
-        row("file.txt", 'C', 100, 0, 0),
+        row("file.txt", uffs_mft::platform::DriveLetter::D, 100, 0, 0),
+        row("file.txt", uffs_mft::platform::DriveLetter::C, 100, 0, 0),
     ];
     sort_rows(&mut rows, SortColumn::Drive, false, &[]);
-    assert_eq!(rows.first().expect("first").drive, 'C');
+    assert_eq!(
+        rows.first().expect("first").drive,
+        uffs_mft::platform::DriveLetter::C
+    );
 }
 
 #[test]
 fn sort_by_size_on_disk_descending() {
     let mut rows = vec![
-        row("small.txt", 'C', 100, 0, 0),
-        row("big.txt", 'C', 5000, 0, 0),
+        row("small.txt", uffs_mft::platform::DriveLetter::C, 100, 0, 0),
+        row("big.txt", uffs_mft::platform::DriveLetter::C, 5000, 0, 0),
     ];
     sort_rows(&mut rows, SortColumn::SizeOnDisk, true, &[]);
     assert_eq!(rows.first().expect("first").name(), "big.txt");
@@ -272,9 +289,9 @@ fn sort_by_size_on_disk_descending() {
 #[test]
 fn sort_multi_tier_size_then_name() {
     let mut rows = vec![
-        row("beta.txt", 'C', 100, 0, 0),
-        row("alpha.txt", 'C', 100, 0, 0),
-        row("gamma.txt", 'C', 200, 0, 0),
+        row("beta.txt", uffs_mft::platform::DriveLetter::C, 100, 0, 0),
+        row("alpha.txt", uffs_mft::platform::DriveLetter::C, 100, 0, 0),
+        row("gamma.txt", uffs_mft::platform::DriveLetter::C, 200, 0, 0),
     ];
     let tiers = vec![SortSpec {
         column: SortColumn::Name,
@@ -292,9 +309,9 @@ fn sort_by_type_groups_by_semantic_category() {
     // .rs → code, .zip → archive, .jpg → picture
     // ascending: archive < code < picture
     let mut rows = vec![
-        row("photo.jpg", 'C', 100, 0, 0),
-        row("main.rs", 'C', 200, 0, 0),
-        row("backup.zip", 'C', 50, 0, 0),
+        row("photo.jpg", uffs_mft::platform::DriveLetter::C, 100, 0, 0),
+        row("main.rs", uffs_mft::platform::DriveLetter::C, 200, 0, 0),
+        row("backup.zip", uffs_mft::platform::DriveLetter::C, 50, 0, 0),
     ];
     sort_rows(&mut rows, SortColumn::Type, false, &[]);
     assert_eq!(rows.first().expect("first").name(), "backup.zip"); // archive
@@ -305,9 +322,9 @@ fn sort_by_type_groups_by_semantic_category() {
 #[test]
 fn sort_by_type_descending() {
     let mut rows = vec![
-        row("photo.jpg", 'C', 100, 0, 0),
-        row("main.rs", 'C', 200, 0, 0),
-        row("backup.zip", 'C', 50, 0, 0),
+        row("photo.jpg", uffs_mft::platform::DriveLetter::C, 100, 0, 0),
+        row("main.rs", uffs_mft::platform::DriveLetter::C, 200, 0, 0),
+        row("backup.zip", uffs_mft::platform::DriveLetter::C, 50, 0, 0),
     ];
     sort_rows(&mut rows, SortColumn::Type, true, &[]);
     assert_eq!(rows.first().expect("first").name(), "photo.jpg"); // picture
@@ -319,9 +336,9 @@ fn sort_by_type_descending() {
 fn sort_by_type_then_size() {
     // Two code files with different sizes
     let mut rows = vec![
-        row("big.rs", 'C', 5000, 0, 0),
-        row("small.rs", 'C', 100, 0, 0),
-        row("photo.jpg", 'C', 300, 0, 0),
+        row("big.rs", uffs_mft::platform::DriveLetter::C, 5000, 0, 0),
+        row("small.rs", uffs_mft::platform::DriveLetter::C, 100, 0, 0),
+        row("photo.jpg", uffs_mft::platform::DriveLetter::C, 300, 0, 0),
     ];
     let tiers = vec![SortSpec {
         column: SortColumn::Size,
@@ -337,9 +354,9 @@ fn sort_by_type_then_size() {
 #[test]
 fn sort_by_descendants_in_dir() {
     let mut rows = vec![
-        dir_row("few", 'C', 5, 100),
-        dir_row("many", 'C', 50, 500),
-        dir_row("empty", 'C', 0, 0),
+        dir_row("few", uffs_mft::platform::DriveLetter::C, 5, 100),
+        dir_row("many", uffs_mft::platform::DriveLetter::C, 50, 500),
+        dir_row("empty", uffs_mft::platform::DriveLetter::C, 0, 0),
     ];
     sort_rows(&mut rows, SortColumn::Descendants, true, &[]);
     assert_eq!(rows.first().expect("first").name(), "many");
@@ -359,7 +376,10 @@ fn build_two_drive_backend() -> MultiDriveBackend {
 
     let mut backend = MultiDriveBackend::new();
 
-    for (letter, file_name, file_size) in [('C', "report.txt", 400_u64), ('D', "data.csv", 800)] {
+    for (letter, file_name, file_size) in [
+        (uffs_mft::platform::DriveLetter::C, "report.txt", 400_u64),
+        (uffs_mft::platform::DriveLetter::D, "data.csv", 800),
+    ] {
         let mut idx = MftIndex::new(letter);
         let root_off = idx.add_name(".");
         let root = idx.get_or_create(ROOT_FRS);
@@ -394,9 +414,16 @@ fn multi_drive_merges_results_from_both_drives() {
     let mut backend = build_two_drive_backend();
     let mut filters = super::super::filters::SearchFilters::default();
     let result = backend.search(SearchRequest::new("*", &mut filters));
-    let drives: std::collections::HashSet<char> = result.rows.iter().map(|row| row.drive).collect();
-    assert!(drives.contains(&'C'), "must include drive C results");
-    assert!(drives.contains(&'D'), "must include drive D results");
+    let drives: std::collections::HashSet<uffs_mft::platform::DriveLetter> =
+        result.rows.iter().map(|row| row.drive).collect();
+    assert!(
+        drives.contains(&uffs_mft::platform::DriveLetter::C),
+        "must include drive C results"
+    );
+    assert!(
+        drives.contains(&uffs_mft::platform::DriveLetter::D),
+        "must include drive D results"
+    );
 }
 
 #[test]
@@ -416,7 +443,7 @@ fn multi_drive_sort_across_drives() {
         "data.csv",
         "largest file across drives must be first"
     );
-    assert_eq!(first.drive, 'D');
+    assert_eq!(first.drive, uffs_mft::platform::DriveLetter::D);
 }
 
 #[test]
@@ -441,8 +468,20 @@ fn multi_drive_limit_caps_total() {
 #[test]
 fn display_rows_to_dataframe_column_count_and_height() {
     let rows = vec![
-        row("file.txt", 'C', 1024, 5_000_000, 1_000_000),
-        row("data.csv", 'D', 2048, 3_000_000, 2_000_000),
+        row(
+            "file.txt",
+            uffs_mft::platform::DriveLetter::C,
+            1024,
+            5_000_000,
+            1_000_000,
+        ),
+        row(
+            "data.csv",
+            uffs_mft::platform::DriveLetter::D,
+            2048,
+            3_000_000,
+            2_000_000,
+        ),
     ];
     let df = display_rows_to_dataframe(&rows).expect("DataFrame creation must not fail");
     assert_eq!(df.height(), 2, "row count");
@@ -451,7 +490,13 @@ fn display_rows_to_dataframe_column_count_and_height() {
 
 #[test]
 fn display_rows_to_dataframe_values_correct() {
-    let rows = vec![row("test.rs", 'C', 4096, 9_000_000, 1_000_000)];
+    let rows = vec![row(
+        "test.rs",
+        uffs_mft::platform::DriveLetter::C,
+        4096,
+        9_000_000,
+        1_000_000,
+    )];
     let df = display_rows_to_dataframe(&rows).expect("DataFrame creation must not fail");
 
     // Check name column
@@ -486,7 +531,7 @@ fn display_rows_to_dataframe_values_correct() {
 fn display_rows_to_dataframe_path_only_extracts_directory() {
     let rows = vec![DisplayRow::new(
         0,
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\Users\\john\\file.txt".to_owned(),
         100,
         false,
@@ -535,9 +580,9 @@ fn search_empty_pattern_returns_empty() {
 #[test]
 fn sort_by_treesize_uses_treesize_not_modified() {
     let mut rows = vec![
-        dir_row("small", 'C', 5, 1_000),
-        dir_row("large", 'C', 10, 1_000_000),
-        dir_row("medium", 'C', 7, 100_000),
+        dir_row("small", uffs_mft::platform::DriveLetter::C, 5, 1_000),
+        dir_row("large", uffs_mft::platform::DriveLetter::C, 10, 1_000_000),
+        dir_row("medium", uffs_mft::platform::DriveLetter::C, 7, 100_000),
     ];
     sort_rows(&mut rows, FieldId::TreeSize, true, &[]);
     let sizes: Vec<u64> = rows.iter().map(|row| row.treesize).collect();
@@ -551,9 +596,9 @@ fn sort_by_treesize_uses_treesize_not_modified() {
 #[test]
 fn sort_by_treesize_ascending() {
     let mut rows = vec![
-        dir_row("large", 'C', 10, 1_000_000),
-        dir_row("small", 'C', 5, 1_000),
-        dir_row("medium", 'C', 7, 100_000),
+        dir_row("large", uffs_mft::platform::DriveLetter::C, 10, 1_000_000),
+        dir_row("small", uffs_mft::platform::DriveLetter::C, 5, 1_000),
+        dir_row("medium", uffs_mft::platform::DriveLetter::C, 7, 100_000),
     ];
     sort_rows(&mut rows, FieldId::TreeSize, false, &[]);
     let sizes: Vec<u64> = rows.iter().map(|row| row.treesize).collect();
@@ -584,7 +629,7 @@ fn build_siblings_fixture() -> DriveIndex {
 
     use crate::compact::build_compact_index;
 
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
     root.stdinfo.set_directory(true);
@@ -614,7 +659,7 @@ fn build_siblings_fixture() -> DriveIndex {
         rec.stdinfo.flags = 0x20;
     }
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     DriveIndex {
         drives: vec![Arc::new(drive)],
     }
@@ -629,7 +674,10 @@ fn build_two_drive_index() -> DriveIndex {
     use crate::compact::build_compact_index;
 
     let mut drives = Vec::new();
-    for (letter, file_name, file_size) in [('C', "report.txt", 400_u64), ('D', "data.csv", 800)] {
+    for (letter, file_name, file_size) in [
+        (uffs_mft::platform::DriveLetter::C, "report.txt", 400_u64),
+        (uffs_mft::platform::DriveLetter::D, "data.csv", 800),
+    ] {
         let mut idx = MftIndex::new(letter);
         let root_off = idx.add_name(".");
         let root = idx.get_or_create(ROOT_FRS);
@@ -670,9 +718,16 @@ fn search_index_returns_results_from_both_drives() {
         true,
         &[],
     );
-    let drives: std::collections::HashSet<char> = result.rows.iter().map(|row| row.drive).collect();
-    assert!(drives.contains(&'C'), "must include C: results");
-    assert!(drives.contains(&'D'), "must include D: results");
+    let drives: std::collections::HashSet<uffs_mft::platform::DriveLetter> =
+        result.rows.iter().map(|row| row.drive).collect();
+    assert!(
+        drives.contains(&uffs_mft::platform::DriveLetter::C),
+        "must include C: results"
+    );
+    assert!(
+        drives.contains(&uffs_mft::platform::DriveLetter::D),
+        "must include D: results"
+    );
 }
 
 #[test]
@@ -682,7 +737,7 @@ fn search_index_drives_filter_excludes_non_matching() {
     let result = search_index(
         &index,
         SearchRequest {
-            drives_filter: &['C'],
+            drives_filter: &[uffs_mft::platform::DriveLetter::C],
             ..SearchRequest::new("*", &mut filters)
         },
         FieldId::Modified,
@@ -690,7 +745,10 @@ fn search_index_drives_filter_excludes_non_matching() {
         &[],
     );
     assert!(
-        result.rows.iter().all(|row| row.drive == 'C'),
+        result
+            .rows
+            .iter()
+            .all(|row| row.drive == uffs_mft::platform::DriveLetter::C),
         "drive filter must exclude D: results"
     );
     assert!(!result.rows.is_empty(), "must have at least one C: result");
@@ -876,7 +934,7 @@ fn build_dbt_triple_fixture() -> DriveIndex {
 
     use crate::compact::build_compact_index;
 
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
@@ -914,7 +972,7 @@ fn build_dbt_triple_fixture() -> DriveIndex {
         rec.stdinfo.flags = 0x20;
     }
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     DriveIndex {
         drives: vec![Arc::new(drive)],
     }
@@ -1094,7 +1152,7 @@ fn build_no_dbt_fixture() -> DriveIndex {
 
     use crate::compact::build_compact_index;
 
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
@@ -1136,7 +1194,7 @@ fn build_no_dbt_fixture() -> DriveIndex {
     txt_rec.first_name.parent_frs = ROOT_FRS;
     txt_rec.stdinfo.flags = 0x20;
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     DriveIndex {
         drives: vec![Arc::new(drive)],
     }
@@ -1247,7 +1305,11 @@ fn search_index_promotes_drive_prefix_with_ext_glob() {
         "drive-prefix + ext promotion must find exactly report.txt on C"
     );
     let first = result.rows.first().expect("asserted non-empty above");
-    assert_eq!(first.drive, 'C', "result must be from drive C only");
+    assert_eq!(
+        first.drive,
+        uffs_mft::platform::DriveLetter::C,
+        "result must be from drive C only"
+    );
     assert!(
         first.path.ends_with("report.txt"),
         "expected report.txt, got: {}",
@@ -1307,7 +1369,7 @@ fn search_index_drive_prefix_case_insensitive_letter() {
     );
     assert_eq!(
         result.rows.first().expect("one row").drive,
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "result must be from drive C"
     );
 }
@@ -1324,7 +1386,7 @@ fn search_index_drive_prefix_explicit_filter_not_clobbered() {
     let result = search_index(
         &index,
         SearchRequest {
-            drives_filter: &['D'],
+            drives_filter: &[uffs_mft::platform::DriveLetter::D],
             ..SearchRequest::new("C:*.txt", &mut filters)
         },
         FieldId::Modified,
@@ -1635,7 +1697,7 @@ fn build_nested_fixture() -> DriveIndex {
         rec.stdinfo.set_directory(true);
     }
 
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
     root.stdinfo.set_directory(true);
@@ -1655,7 +1717,7 @@ fn build_nested_fixture() -> DriveIndex {
     // `beta/c` contents.
     make_file(&mut idx, 220, "x.txt", 212);
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     DriveIndex {
         drives: vec![Arc::new(drive)],
     }
@@ -1860,7 +1922,7 @@ fn search_index_concurrent_calls_do_not_interfere() {
 fn flagged_row(name: &str, flags: u32) -> DisplayRow {
     DisplayRow::new(
         0,
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         format!("C:\\{name}"),
         100,
         flags & 0x0010 != 0,
@@ -2146,9 +2208,9 @@ fn sort_rows_numeric_fast_path_tiebreaker_is_raw_slice_cmp() {
     // tiebreaker fires.  Raw codepoint order puts 'B' (0x42) before 'a'
     // (0x61) before 'z' (0x7A): Beta.dll < alpha.dll < zeta.dll.
     let mut rows = vec![
-        row("zeta.dll", 'C', 100, 42, 0),
-        row("Beta.dll", 'C', 100, 42, 0),
-        row("alpha.dll", 'C', 100, 42, 0),
+        row("zeta.dll", uffs_mft::platform::DriveLetter::C, 100, 42, 0),
+        row("Beta.dll", uffs_mft::platform::DriveLetter::C, 100, 42, 0),
+        row("alpha.dll", uffs_mft::platform::DriveLetter::C, 100, 42, 0),
     ];
 
     sort_rows(&mut rows, SortColumn::Modified, true, &[]);
@@ -2168,9 +2230,9 @@ fn sort_rows_numeric_fast_path_tiebreaker_is_raw_slice_cmp() {
 #[test]
 fn sort_rows_mixed_tier_falls_back_to_schwartzian() {
     let mut rows = vec![
-        row("FILE.TXT", 'C', 100, 42, 0), // size=100, ext=TXT
-        row("file.log", 'C', 100, 42, 0), // size=100, ext=log
-        row("file.bin", 'C', 100, 42, 0), // size=100, ext=bin
+        row("FILE.TXT", uffs_mft::platform::DriveLetter::C, 100, 42, 0), // size=100, ext=TXT
+        row("file.log", uffs_mft::platform::DriveLetter::C, 100, 42, 0), // size=100, ext=log
+        row("file.bin", uffs_mft::platform::DriveLetter::C, 100, 42, 0), // size=100, ext=bin
     ];
 
     // Primary: Size (numeric, all tied at 100).
@@ -2197,9 +2259,9 @@ fn sort_rows_mixed_tier_falls_back_to_schwartzian() {
 #[test]
 fn sort_rows_extension_column_still_folds_ext_key() {
     let mut rows = vec![
-        row("file.TXT", 'C', 1, 0, 0),
-        row("file.log", 'C', 1, 0, 0),
-        row("file.Bin", 'C', 1, 0, 0),
+        row("file.TXT", uffs_mft::platform::DriveLetter::C, 1, 0, 0),
+        row("file.log", uffs_mft::platform::DriveLetter::C, 1, 0, 0),
+        row("file.Bin", uffs_mft::platform::DriveLetter::C, 1, 0, 0),
     ];
 
     // Sort by extension ascending: folded order is "bin" < "log" < "txt".
@@ -2233,7 +2295,7 @@ fn sort_rows_numeric_fast_parallel_branch_preserves_order() {
             let modified = if idx % 2 == 0 { 2000 } else { 1000 };
             row(
                 &format!("file_{idx:05}.dll"),
-                'C',
+                uffs_mft::platform::DriveLetter::C,
                 u64::from(idx),
                 modified,
                 0,
@@ -2318,7 +2380,10 @@ fn build_bloom_skip_fixture() -> DriveIndex {
     const TEST_FPR: f64 = 0.001;
 
     let mut drives = Vec::new();
-    for (letter, ext) in [('C', "txt"), ('D', "csv")] {
+    for (letter, ext) in [
+        (uffs_mft::platform::DriveLetter::C, "txt"),
+        (uffs_mft::platform::DriveLetter::D, "csv"),
+    ] {
         let mut idx = MftIndex::new(letter);
         let root_off = idx.add_name(".");
         let root = idx.get_or_create(ROOT_FRS);

--- a/crates/uffs-core/src/search/dataframe_convert.rs
+++ b/crates/uffs-core/src/search/dataframe_convert.rs
@@ -85,7 +85,8 @@ pub fn dataframe_to_display_rows(data_frame: &uffs_polars::DataFrame) -> Vec<Dis
         let path = col_str(data_frame, "path", row_idx).unwrap_or_default();
         let drive = col_str(data_frame, "drive", row_idx)
             .and_then(|val| val.chars().next())
-            .unwrap_or('?');
+            .and_then(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
+            .unwrap_or(uffs_mft::platform::DriveLetter::X);
         let size = col_u64(data_frame, "size", row_idx);
         let allocated = col_u64(data_frame, "allocated_size", row_idx);
         let flags = u32::try_from(col_u64(data_frame, "flags", row_idx)).unwrap_or(u32::MAX);

--- a/crates/uffs-core/src/search/derived.rs
+++ b/crates/uffs-core/src/search/derived.rs
@@ -377,7 +377,7 @@ mod tests {
     fn file_row(path: &str, size: u64) -> DisplayRow {
         DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             path.to_owned(),
             size,
             false,
@@ -395,7 +395,7 @@ mod tests {
     fn dir_row(path: &str, treesize: u64, tree_alloc: u64) -> DisplayRow {
         DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             path.to_owned(),
             0,
             true,
@@ -595,7 +595,7 @@ mod tests {
     fn bulkiness_uses_file_metrics_for_files() {
         let row = DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "C:\\f.txt".to_owned(),
             1000,
             false,
@@ -651,7 +651,7 @@ mod tests {
         let rec = compact_record(false, 1_000, 4_096, 0, 0);
         let row = DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             String::new(),
             rec.size,
             rec.is_directory(),

--- a/crates/uffs-core/src/search/dispatch.rs
+++ b/crates/uffs-core/src/search/dispatch.rs
@@ -153,7 +153,7 @@ fn extract_extensions_from_regex(pattern: &str) -> Option<Vec<String>> {
 /// Mirror of `uffs_client::protocol::cli_args::parse_bare_drive_prefix` —
 /// keep the two in sync.  See that function's doc for the full
 /// acceptance matrix.
-fn parse_bare_drive_prefix(pattern: &str) -> Option<(char, &str)> {
+fn parse_bare_drive_prefix(pattern: &str) -> Option<(uffs_mft::platform::DriveLetter, &str)> {
     let bytes = pattern.as_bytes();
     let letter = *bytes.first()?;
     if !letter.is_ascii_alphabetic() {
@@ -166,7 +166,8 @@ fn parse_bare_drive_prefix(pattern: &str) -> Option<(char, &str)> {
     if rest.is_empty() || rest.starts_with(['\\', '/']) {
         return None;
     }
-    Some((letter.to_ascii_uppercase() as char, rest))
+    let dl = uffs_mft::platform::DriveLetter::parse(letter as char).ok()?;
+    Some((dl, rest))
 }
 
 /// Apply dispatch-time pattern-rewrite safety nets, in canonical order.
@@ -184,8 +185,8 @@ fn parse_bare_drive_prefix(pattern: &str) -> Option<(char, &str)> {
 ///    Only fires when the caller's `drives_filter_empty` and not `match_path`.
 ///    Path-anchored forms (`C:\*.dll`) are excluded by
 ///    `parse_bare_drive_prefix`.  The promoted letter is pushed into
-///    `drive_buf` (which the caller uses as backing storage for a `&[char]`
-///    slice that lives for the rest of the dispatch).
+///    `drive_buf` (which the caller uses as backing storage for a
+///    `&[DriveLetter]` slice that lives for the rest of the dispatch).
 ///
 /// 2. `*.<ext>` → `pattern = "*"`, `extensions += [<ext_lower>]`. Only fires
 ///    when not `match_path`, not `case_sensitive`, and
@@ -217,7 +218,7 @@ pub(super) fn apply_dispatch_safety_nets(
     case_sensitive: bool,
     drives_filter_empty: bool,
     search_filters: &mut SearchFilters,
-    drive_buf: &mut Vec<char>,
+    drive_buf: &mut Vec<uffs_mft::platform::DriveLetter>,
 ) {
     if drives_filter_empty
         && !match_path
@@ -535,9 +536,12 @@ mod tests {
 
     // ── apply_dispatch_safety_nets (regex branch) ──────────────────
 
-    fn run_safety_nets<'a>(pattern: &'a str, filters: &mut SearchFilters) -> (&'a str, Vec<char>) {
+    fn run_safety_nets<'a>(
+        pattern: &'a str,
+        filters: &mut SearchFilters,
+    ) -> (&'a str, Vec<uffs_mft::platform::DriveLetter>) {
         let mut pat: &str = pattern;
-        let mut drive_buf: Vec<char> = Vec::new();
+        let mut drive_buf: Vec<uffs_mft::platform::DriveLetter> = Vec::new();
         apply_dispatch_safety_nets(
             &mut pat,
             false, // match_path

--- a/crates/uffs-core/src/search/filters/tests.rs
+++ b/crates/uffs-core/src/search/filters/tests.rs
@@ -38,7 +38,7 @@ fn test_record(name: &str, names: &mut Vec<u8>) -> CompactRecord {
 
 /// Helper: build a compact drive with a single `readme.rs` file.
 fn test_drive_with_rs_file() -> DriveCompactIndex {
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
@@ -59,7 +59,7 @@ fn test_drive_with_rs_file() -> DriveCompactIndex {
     rec.first_name.parent_frs = ROOT_FRS;
     rec.stdinfo.flags = 0x20;
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     drive
 }
 
@@ -493,7 +493,7 @@ fn apply_search_filters_matches_compact_behavior() {
     let mut rows = vec![
         DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "C:\\file.txt".to_owned(),
             1000,
             false,
@@ -508,7 +508,7 @@ fn apply_search_filters_matches_compact_behavior() {
         ),
         DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "C:\\$MFT".to_owned(),
             500_000,
             false,

--- a/crates/uffs-core/src/search/filters/tests_ext.rs
+++ b/crates/uffs-core/src/search/filters/tests_ext.rs
@@ -513,7 +513,7 @@ fn apply_type_filter_rejects_wrong_extension() {
         // .rs is "code"; .jpg is NOT code
         DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "C:\\src\\main.rs".to_owned(),
             100,
             false,
@@ -528,7 +528,7 @@ fn apply_type_filter_rejects_wrong_extension() {
         ),
         DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "C:\\pics\\photo.jpg".to_owned(),
             5000,
             false,
@@ -557,7 +557,7 @@ fn apply_path_contains_filters_by_substring() {
     let mut rows = vec![
         DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "C:\\Windows\\System32\\cmd.exe".to_owned(),
             100,
             false,
@@ -572,7 +572,7 @@ fn apply_path_contains_filters_by_substring() {
         ),
         DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "C:\\Users\\hello.exe".to_owned(),
             200,
             false,
@@ -614,7 +614,7 @@ fn apply_min_bulkiness_rejects_low_ratio() {
         // allocated=4096, size=4096 → bulkiness=1_000_000 (100%)
         DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "C:\\tight.bin".to_owned(),
             4096,
             false,
@@ -630,7 +630,7 @@ fn apply_min_bulkiness_rejects_low_ratio() {
         // allocated=20480, size=4096 → bulkiness=5_000_000 (500%)
         DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "C:\\bloated.bin".to_owned(),
             4096,
             false,
@@ -663,7 +663,7 @@ fn apply_min_path_len_rejects_short_paths() {
     let mut rows = vec![
         DisplayRow::new(
             0,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             short.to_owned(),
             100,
             false,
@@ -676,7 +676,21 @@ fn apply_min_path_len_rejects_short_paths() {
             0,
             0,
         ),
-        DisplayRow::new(0, 'C', long, 200, false, 0, 0, 0, 0x20, 4096, 0, 0, 0),
+        DisplayRow::new(
+            0,
+            uffs_mft::platform::DriveLetter::C,
+            long,
+            200,
+            false,
+            0,
+            0,
+            0,
+            0x20,
+            4096,
+            0,
+            0,
+            0,
+        ),
     ];
     let filters = SearchFilters {
         min_path_len: Some(200),

--- a/crates/uffs-core/src/search/filters/time_parsing.rs
+++ b/crates/uffs-core/src/search/filters/time_parsing.rs
@@ -7,7 +7,7 @@
 #[must_use]
 pub const fn month_from_filetime(filetime: i64) -> u32 {
     match uffs_time::filetime_to_calendar(filetime) {
-        Some((_, month, ..)) => month,
+        Some(uffs_time::CalendarParts { month, .. }) => month,
         None => 1, // default to January for unset timestamps
     }
 }

--- a/crates/uffs-core/src/search/query/mod.rs
+++ b/crates/uffs-core/src/search/query/mod.rs
@@ -240,7 +240,7 @@ fn extract_trigram_needle(needle: &str, is_glob: bool, is_or: bool) -> String {
     reason = "extracted from search_compact_drive to satisfy too_many_lines lint"
 )]
 fn log_search_profile(
-    letter: char,
+    letter: uffs_mft::platform::DriveLetter,
     tri_ms: u128,
     match_ms: u128,
     resolve_ms: u128,
@@ -519,7 +519,7 @@ pub(crate) fn search_compact_drive_tree(
 /// display hint is adjusted.
 pub(super) fn make_display_row(
     record_index: u32,
-    drive_letter: char,
+    drive_letter: uffs_mft::platform::DriveLetter,
     rec: &CompactRecord,
     name: &str,
     path: String,
@@ -549,8 +549,11 @@ pub(super) fn make_display_row(
 /// Returns a 3-byte `&str` without heap allocation.  Uses safe
 /// `from_utf8` with a fallback — the bytes are always valid ASCII.
 #[inline]
-pub(super) fn stack_volume_prefix(buf: &mut [u8; 4], letter: char) -> &str {
-    buf[0] = letter.to_ascii_uppercase() as u8;
+pub(super) fn stack_volume_prefix(
+    buf: &mut [u8; 4],
+    letter: uffs_mft::platform::DriveLetter,
+) -> &str {
+    buf[0] = letter.as_char() as u8;
     buf[1] = b':';
     buf[2] = b'\\';
     core::str::from_utf8(buf.get(..3).unwrap_or(b"?:\\")).unwrap_or("?:\\")

--- a/crates/uffs-core/src/search/query/numeric_top_n.rs
+++ b/crates/uffs-core/src/search/query/numeric_top_n.rs
@@ -70,7 +70,7 @@ fn extract_sort_key(rec: &CompactRecord, sort_column: FieldId, drive: &DriveComp
         FieldId::Drive => {
             let name = rec.name(&drive.names);
             let mut key = [0_u8; 8];
-            key[0] = u8::try_from(u32::from(drive.letter)).unwrap_or(b'?');
+            key[0] = u8::try_from(u32::from(drive.letter.as_byte())).unwrap_or(b'?');
             for (dst, ch) in key[1..].iter_mut().zip(name.chars()) {
                 let folded = drive_fold.fold_char(ch);
                 *dst = folded.to_be_bytes()[1];

--- a/crates/uffs-core/src/search/query_tests.rs
+++ b/crates/uffs-core/src/search/query_tests.rs
@@ -14,7 +14,7 @@ use crate::search::filters::SearchFilters;
 
 /// Build a test fixture with root + files + dir + system metafile.
 fn build_test_drive() -> DriveCompactIndex {
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
@@ -92,13 +92,13 @@ fn build_test_drive() -> DriveCompactIndex {
     };
     sys.stdinfo.flags = 0x06;
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     drive
 }
 
 /// Build a fixture with `count` files under root (for limit tests).
 fn build_large_drive(count: usize) -> DriveCompactIndex {
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
     root.stdinfo.set_directory(true);
@@ -123,7 +123,7 @@ fn build_large_drive(count: usize) -> DriveCompactIndex {
         };
         rec.stdinfo.flags = 0x20;
     }
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     drive
 }
 
@@ -149,7 +149,7 @@ fn display_row_fields_match_source_data() {
         .iter()
         .find(|row| row.name() == "readme.txt")
         .expect("not found");
-    assert_eq!(row.drive, 'C');
+    assert_eq!(row.drive, uffs_mft::platform::DriveLetter::C);
     assert_eq!(row.size, 400);
     assert_eq!(row.allocated, 512);
     assert_eq!(row.flags, 0x20);
@@ -363,7 +363,7 @@ fn build_ads_on_dir_drive() -> DriveCompactIndex {
         IndexNameRef, IndexStreamInfo, MftIndex, NO_ENTRY, ROOT_FRS, SizeInfo, StandardInfo,
     };
 
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
@@ -413,7 +413,7 @@ fn build_ads_on_dir_drive() -> DriveCompactIndex {
     dir_mut.stream_count = 2;
     dir_mut.total_stream_count = 2;
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     drive
 }
 
@@ -501,7 +501,7 @@ fn build_flag_test_drive(
     flagged_name: &str,
     unflagged_name: &str,
 ) -> DriveCompactIndex {
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     // Root directory.
     let root_off = idx.add_name(".");
@@ -548,7 +548,7 @@ fn build_flag_test_drive(
     f2.stdinfo.modified = 5_000_000; // same as f1 — deliberate
     f2.stdinfo.created = 5_000_000;
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     drive
 }
 
@@ -596,7 +596,7 @@ fn assert_boolean_sort(field: FieldId, flag_bit: u32) {
 #[test]
 fn top_n_sort_by_directory_flag() {
     // DirectoryFlag uses is_directory() (bit 0x0010).
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
@@ -627,7 +627,7 @@ fn top_n_sort_by_directory_flag() {
     };
     file_rec.stdinfo.modified = 5_000_000;
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     let drives = vec![drive];
     let mut filters = SearchFilters::default();
 
@@ -727,7 +727,7 @@ fn top_n_sort_by_unpinned_flag() {
 /// ALL records share the same `modified` timestamp so any sort that
 /// falls back to `rec.modified` will produce arbitrary (wrong) order.
 fn build_mixed_drive(n_files: usize, n_dirs: usize) -> DriveCompactIndex {
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     // Root directory (FRS 5).
     let root_off = idx.add_name(".");
@@ -771,7 +771,7 @@ fn build_mixed_drive(n_files: usize, n_dirs: usize) -> DriveCompactIndex {
         rec.stdinfo.created = 5_000_000;
     }
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     drive
 }
 
@@ -832,7 +832,7 @@ fn heap_eviction_directory_asc_files_come_last() {
 /// Heap eviction with hidden flag: 20 normal + 10 hidden, limit 5, desc.
 #[test]
 fn heap_eviction_hidden_desc() {
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
     root.stdinfo.set_directory(true);
@@ -873,7 +873,7 @@ fn heap_eviction_hidden_desc() {
         rec.stdinfo.flags = 0x22; // archive + hidden
         rec.stdinfo.modified = 5_000_000;
     }
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     let drives = vec![drive];
     let mut filters = SearchFilters::default();
 
@@ -992,7 +992,7 @@ fn search_index_star_sort_hidden_desc() {
     use crate::search::backend::{DriveIndex, SearchRequest, search_index};
 
     // Reuse the hidden drive from heap_eviction_hidden_desc.
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
     root.stdinfo.set_directory(true);
@@ -1030,7 +1030,7 @@ fn search_index_star_sort_hidden_desc() {
         rec.stdinfo.flags = 0x22; // archive + hidden
         rec.stdinfo.modified = 5_000_000;
     }
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     let index = DriveIndex {
         drives: vec![Arc::new(drive)],
     };
@@ -1079,7 +1079,7 @@ fn search_index_star_sort_hidden_desc() {
 /// are distinct and easy to rank: 1.0×, 2.0×, and 4.0× the logical
 /// size.  Returns (drive, expected descending order by name).
 fn build_bulkiness_test_drive() -> (DriveCompactIndex, [&'static str; 3]) {
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
@@ -1119,7 +1119,7 @@ fn build_bulkiness_test_drive() -> (DriveCompactIndex, [&'static str; 3]) {
         rec.stdinfo.created = 7_000_000;
     }
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     // Expected order when sorted by bulkiness DESC.
     (drive, ["sparse.dat", "medium.dat", "dense.dat"])
 }
@@ -1214,7 +1214,11 @@ fn top_n_sort_by_bulkiness_asc_orders_by_ratio() {
 /// *unique* `modified` timestamp equal to its FRS so the top-N by
 /// Modified-DESC is fully determined by the fixture (the N largest
 /// FRS values).
-fn build_modified_gradient_drive(letter: char, base_frs: u64, count: usize) -> DriveCompactIndex {
+fn build_modified_gradient_drive(
+    letter: uffs_mft::platform::DriveLetter,
+    base_frs: u64,
+    count: usize,
+) -> DriveCompactIndex {
     let mut idx = MftIndex::new(letter);
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
@@ -1264,9 +1268,9 @@ fn build_modified_gradient_drive(letter: char, base_frs: u64, count: usize) -> D
 fn parallel_drive_scan_merges_global_top_n_across_drives() {
     // Three drives, non-overlapping FRS ranges → deterministic
     // global top-10 = drive-C's highest 10 FRS values.
-    let drive_a = build_modified_gradient_drive('A', 100, 200);
-    let drive_b = build_modified_gradient_drive('B', 10_000, 200);
-    let drive_c = build_modified_gradient_drive('C', 1_000_000, 200);
+    let drive_a = build_modified_gradient_drive(uffs_mft::platform::DriveLetter::A, 100, 200);
+    let drive_b = build_modified_gradient_drive(uffs_mft::platform::DriveLetter::B, 10_000, 200);
+    let drive_c = build_modified_gradient_drive(uffs_mft::platform::DriveLetter::C, 1_000_000, 200);
     let drives = vec![drive_a, drive_b, drive_c];
     let mut filters = SearchFilters::default();
 
@@ -1283,7 +1287,7 @@ fn parallel_drive_scan_merges_global_top_n_across_drives() {
     for row in &rows {
         assert_eq!(
             row.drive,
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "Modified-DESC top-10 must all come from drive C \
              (highest FRS range); got {}:{}",
             row.drive,
@@ -1315,8 +1319,8 @@ fn parallel_drive_scan_merges_global_top_n_across_drives() {
 /// intermediate memory.
 #[test]
 fn parallel_drive_scan_respects_limit_smaller_than_per_drive_count() {
-    let drive_a = build_modified_gradient_drive('A', 100, 500);
-    let drive_b = build_modified_gradient_drive('B', 10_000, 500);
+    let drive_a = build_modified_gradient_drive(uffs_mft::platform::DriveLetter::A, 100, 500);
+    let drive_b = build_modified_gradient_drive(uffs_mft::platform::DriveLetter::B, 10_000, 500);
     let drives = vec![drive_a, drive_b];
     let mut filters = SearchFilters::default();
 
@@ -1333,7 +1337,11 @@ fn parallel_drive_scan_respects_limit_smaller_than_per_drive_count() {
     // Top-5 Modified-DESC across both drives must all come from B
     // (B's FRS range is higher, so B has the 5 newest records).
     for row in &rows {
-        assert_eq!(row.drive, 'B', "top-5 must all be from drive B");
+        assert_eq!(
+            row.drive,
+            uffs_mft::platform::DriveLetter::B,
+            "top-5 must all be from drive B"
+        );
     }
 }
 
@@ -1342,7 +1350,10 @@ fn parallel_drive_scan_respects_limit_smaller_than_per_drive_count() {
 /// the `FieldId::Path` ext fast-path regression test to verify that
 /// the ext-only fast path returns exactly the `.dll` rows — no
 /// `.txt` leakage — and in lexicographic full-path order.
-fn build_two_extension_drive(letter: char, count: usize) -> DriveCompactIndex {
+fn build_two_extension_drive(
+    letter: uffs_mft::platform::DriveLetter,
+    count: usize,
+) -> DriveCompactIndex {
     let mut idx = MftIndex::new(letter);
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
@@ -1384,7 +1395,7 @@ fn build_two_extension_drive(letter: char, count: usize) -> DriveCompactIndex {
 /// bypassed, this test fails.
 #[test]
 fn path_sort_ext_only_returns_matching_ext_in_path_order() {
-    let drive = build_two_extension_drive('C', 20);
+    let drive = build_two_extension_drive(uffs_mft::platform::DriveLetter::C, 20);
     let drives = vec![drive];
     let mut filters = SearchFilters {
         extensions: vec!["dll".into()],
@@ -1434,7 +1445,7 @@ fn path_sort_ext_only_returns_matching_ext_in_path_order() {
 /// FieldId::Path, sort_desc, ..)` inside the fast path.
 #[test]
 fn path_sort_ext_only_desc_returns_reverse_lex_order() {
-    let drive = build_two_extension_drive('C', 20);
+    let drive = build_two_extension_drive(uffs_mft::platform::DriveLetter::C, 20);
     let drives = vec![drive];
     let mut filters = SearchFilters {
         extensions: vec!["dll".into()],
@@ -1470,7 +1481,7 @@ fn path_sort_ext_only_desc_returns_reverse_lex_order() {
 /// disqualifies the fast path, so the tree walk runs instead.
 #[test]
 fn path_sort_non_ext_filter_uses_tree_walk() {
-    let drive = build_two_extension_drive('C', 20);
+    let drive = build_two_extension_drive(uffs_mft::platform::DriveLetter::C, 20);
     let drives = vec![drive];
     let mut filters = SearchFilters {
         // min_size disqualifies is_ext_only, forcing the tree walk.

--- a/crates/uffs-core/src/slot_pool.rs
+++ b/crates/uffs-core/src/slot_pool.rs
@@ -130,7 +130,7 @@ impl core::fmt::Debug for SlotPool {
 #[derive(Debug, Clone)]
 pub struct DriveLoadEstimate {
     /// Drive letter.
-    pub letter: char,
+    pub letter: uffs_mft::platform::DriveLetter,
     /// Estimated peak memory in bytes for loading this drive.
     pub peak_bytes: u64,
     /// Whether a compact cache hit is expected (much cheaper).
@@ -161,7 +161,7 @@ const CACHE_MISS_PEAK_MULTIPLIER: f64 = 1.4;
 ///    (transient `MftIndex` + compact build)
 /// 3. Neither → conservative default
 #[must_use]
-pub fn estimate_drive_cost(drive_letter: char) -> DriveLoadEstimate {
+pub fn estimate_drive_cost(drive_letter: uffs_mft::platform::DriveLetter) -> DriveLoadEstimate {
     let compact_path = crate::compact_cache::compact_cache_path(drive_letter);
     let mft_path = uffs_mft::cache::cache_file_path(drive_letter);
 
@@ -227,7 +227,7 @@ pub fn estimate_drive_cost(drive_letter: char) -> DriveLoadEstimate {
     clippy::float_arithmetic,
     reason = "Budget estimation uses approximate floating-point arithmetic by design"
 )]
-pub fn compute_load_budget(drives: &[char]) -> SlotPool {
+pub fn compute_load_budget(drives: &[uffs_mft::platform::DriveLetter]) -> SlotPool {
     if drives.is_empty() {
         return SlotPool::new(1);
     }
@@ -326,7 +326,11 @@ mod tests {
 
     #[test]
     fn compute_budget_returns_at_least_one() {
-        let pool = compute_load_budget(&['Z', 'Y', 'X']);
+        let pool = compute_load_budget(&[
+            uffs_mft::platform::DriveLetter::Z,
+            uffs_mft::platform::DriveLetter::Y,
+            uffs_mft::platform::DriveLetter::X,
+        ]);
         assert!(pool.total() >= 1, "budget must be at least 1 slot");
         assert!(pool.total() <= 3, "budget can't exceed num drives");
     }
@@ -339,7 +343,7 @@ mod tests {
 
     #[test]
     fn estimate_unknown_drive_uses_default() {
-        let est = estimate_drive_cost('Z');
+        let est = estimate_drive_cost(uffs_mft::platform::DriveLetter::Z);
         assert!(!est.compact_cache_hit);
         assert_eq!(est.peak_bytes, DEFAULT_PEAK_PER_DRIVE);
     }

--- a/crates/uffs-core/tests/filetime_output_parity.rs
+++ b/crates/uffs-core/tests/filetime_output_parity.rs
@@ -112,7 +112,7 @@ mod ft {
 fn row(path: &str, modified: i64, created: i64, accessed: i64) -> DisplayRow {
     DisplayRow::new(
         0_u32,
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         path.to_owned(),
         1024_u64,
         false,

--- a/crates/uffs-daemon/src/broker_client.rs
+++ b/crates/uffs-daemon/src/broker_client.rs
@@ -55,7 +55,9 @@ pub(crate) fn broker_available() -> bool {
 /// Returns the raw handle value (as a `u64`) that can be used for MFT reading.
 /// The handle is already duplicated into our process by the broker.
 #[cfg(windows)]
-pub(crate) fn request_volume_handle(drive_letter: char) -> anyhow::Result<u64> {
+pub(crate) fn request_volume_handle(
+    drive_letter: uffs_mft::platform::DriveLetter,
+) -> anyhow::Result<u64> {
     use std::io::{Read as _, Write as _};
 
     use uffs_broker_protocol::{
@@ -71,8 +73,10 @@ pub(crate) fn request_volume_handle(drive_letter: char) -> anyhow::Result<u64> {
         .map_err(|err| anyhow::anyhow!("Failed to connect to broker: {err}"))?;
 
     // Encode the 1-byte request via the shared protocol module.
+    // `uffs-broker-protocol` is a leaf crate with no `uffs-mft` dep,
+    // so we convert at the boundary.
     let request_bytes = HandleRequest {
-        drive: drive_letter,
+        drive: drive_letter.as_char(),
     }
     .encode();
     pipe.write_all(&request_bytes)?;
@@ -112,6 +116,8 @@ pub(crate) const fn broker_available() -> bool {
     clippy::single_call_fn,
     reason = "platform stub — mirrors Windows variant"
 )]
-pub(crate) fn request_volume_handle(_drive_letter: char) -> anyhow::Result<u64> {
+pub(crate) fn request_volume_handle(
+    _drive_letter: uffs_mft::platform::DriveLetter,
+) -> anyhow::Result<u64> {
     anyhow::bail!("Access Broker is a Windows-only feature")
 }

--- a/crates/uffs-daemon/src/cache/body_loader.rs
+++ b/crates/uffs-daemon/src/cache/body_loader.rs
@@ -51,7 +51,7 @@ use uffs_core::compact::DriveCompactIndex;
 pub(crate) trait BodyLoader: Send + Sync + 'static {
     /// Materialise the body for `letter`, or return `None` if the
     /// underlying source is missing / stale / corrupted.
-    fn load(&self, letter: char) -> Option<Arc<DriveCompactIndex>>;
+    fn load(&self, letter: uffs_mft::platform::DriveLetter) -> Option<Arc<DriveCompactIndex>>;
 }
 
 /// Production loader: reads
@@ -80,7 +80,7 @@ pub(crate) trait BodyLoader: Send + Sync + 'static {
 pub(crate) struct DiskBodyLoader;
 
 impl BodyLoader for DiskBodyLoader {
-    fn load(&self, letter: char) -> Option<Arc<DriveCompactIndex>> {
+    fn load(&self, letter: uffs_mft::platform::DriveLetter) -> Option<Arc<DriveCompactIndex>> {
         // Phase 5 (#94): primary path — USN-refreshed re-promote.
         // On Windows this applies USN deltas to the cached MftIndex
         // and rebuilds the compact index, so the body served to the

--- a/crates/uffs-daemon/src/cache/cache_cleaner.rs
+++ b/crates/uffs-daemon/src/cache/cache_cleaner.rs
@@ -47,7 +47,7 @@ pub(crate) trait CacheCleaner: Send + Sync + 'static {
     /// `metadata.len()` over every file actually removed; `errors`
     /// is empty on full success and one entry per non-`NotFound`
     /// `io::Error` otherwise.
-    fn forget(&self, letter: char) -> (u64, Vec<String>);
+    fn forget(&self, letter: uffs_mft::platform::DriveLetter) -> (u64, Vec<String>);
 }
 
 /// Production implementation that resolves the four canonical
@@ -69,7 +69,7 @@ pub(crate) trait CacheCleaner: Send + Sync + 'static {
 pub(crate) struct PlatformCacheCleaner;
 
 impl CacheCleaner for PlatformCacheCleaner {
-    fn forget(&self, letter: char) -> (u64, Vec<String>) {
+    fn forget(&self, letter: uffs_mft::platform::DriveLetter) -> (u64, Vec<String>) {
         let paths = drive_cache_paths(letter);
         delete_drive_cache_files(&paths)
     }
@@ -81,7 +81,7 @@ impl CacheCleaner for PlatformCacheCleaner {
 /// submodule can drive [`delete_drive_cache_files`] against a
 /// [`tempfile::TempDir`] without dragging the platform paths into
 /// the test fixture.
-fn drive_cache_paths(letter: char) -> [PathBuf; 4] {
+fn drive_cache_paths(letter: uffs_mft::platform::DriveLetter) -> [PathBuf; 4] {
     [
         uffs_core::compact_cache::compact_cache_path(letter),
         uffs_core::compact_cache::usn_cursor_path(letter),
@@ -148,7 +148,7 @@ fn format_path_error(path: &Path, err: &io::Error) -> String {
 /// separately by an `ErroringCacheCleaner` in the same test module.
 #[cfg(test)]
 pub(crate) struct CountingCacheCleaner {
-    calls: std::sync::Mutex<Vec<char>>,
+    calls: std::sync::Mutex<Vec<uffs_mft::platform::DriveLetter>>,
     freed_per_call: u64,
 }
 
@@ -167,7 +167,7 @@ impl CountingCacheCleaner {
     /// Snapshot the per-letter call sequence.  Cloned out of the
     /// internal `Mutex` so the assertion site doesn't have to hold
     /// the lock.
-    pub(crate) fn calls(&self) -> Vec<char> {
+    pub(crate) fn calls(&self) -> Vec<uffs_mft::platform::DriveLetter> {
         self.calls
             .lock()
             .expect("CountingCacheCleaner::calls — mutex poisoned in test fixture")
@@ -177,7 +177,7 @@ impl CountingCacheCleaner {
 
 #[cfg(test)]
 impl CacheCleaner for CountingCacheCleaner {
-    fn forget(&self, letter: char) -> (u64, Vec<String>) {
+    fn forget(&self, letter: uffs_mft::platform::DriveLetter) -> (u64, Vec<String>) {
         self.calls
             .lock()
             .expect("CountingCacheCleaner::forget — mutex poisoned in test fixture")

--- a/crates/uffs-daemon/src/cache/cursor_store.rs
+++ b/crates/uffs-daemon/src/cache/cursor_store.rs
@@ -56,7 +56,7 @@ impl DiskCursorStore {
     }
 
     /// Path to the cursor file for `letter`.
-    fn cursor_path(&self, letter: char) -> PathBuf {
+    fn cursor_path(&self, letter: uffs_mft::platform::DriveLetter) -> PathBuf {
         self.cache_root.join(format!("{letter}_usn.cursor"))
     }
 }
@@ -76,7 +76,7 @@ impl super::journal_loop::CursorStore for DiskCursorStore {
                   used in `crate::config::Config::load_from_path`.  \
                   Remove this expect once `error_in_core` stabilises."
     )]
-    fn load(&self, letter: char) -> u64 {
+    fn load(&self, letter: uffs_mft::platform::DriveLetter) -> u64 {
         let path = self.cursor_path(letter);
         match std::fs::read(&path) {
             Ok(bytes) => <[u8; 8]>::try_from(bytes.as_slice()).map_or_else(
@@ -112,7 +112,7 @@ impl super::journal_loop::CursorStore for DiskCursorStore {
     /// must remain resilient to a transient disk-full / permission
     /// glitch (the next save tick will retry, and an unsaved
     /// cursor is recoverable via journal-head re-replay).
-    fn store(&self, letter: char, cursor: u64) {
+    fn store(&self, letter: uffs_mft::platform::DriveLetter, cursor: u64) {
         let path = self.cursor_path(letter);
         // Ensure the cache directory exists with owner-only DACL —
         // matches the existing compact-cache writer's pattern.
@@ -153,8 +153,8 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let store = DiskCursorStore::new(tmp.path().to_path_buf());
 
-        store.store('C', 0x1234_5678_9ABC_DEF0);
-        let loaded = store.load('C');
+        store.store(uffs_mft::platform::DriveLetter::C, 0x1234_5678_9ABC_DEF0);
+        let loaded = store.load(uffs_mft::platform::DriveLetter::C);
 
         assert_eq!(loaded, 0x1234_5678_9ABC_DEF0);
     }
@@ -167,7 +167,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let store = DiskCursorStore::new(tmp.path().to_path_buf());
 
-        assert_eq!(store.load('C'), 0);
+        assert_eq!(store.load(uffs_mft::platform::DriveLetter::C), 0);
     }
 
     /// Corrupt cursor file (wrong byte count) → `load` returns `0`
@@ -182,7 +182,7 @@ mod tests {
         std::fs::write(&path, [0x01, 0x02, 0x03, 0x04]).expect("write corrupt cursor");
 
         let store = DiskCursorStore::new(tmp.path().to_path_buf());
-        assert_eq!(store.load('C'), 0);
+        assert_eq!(store.load(uffs_mft::platform::DriveLetter::C), 0);
     }
 
     /// `store` must create the cache directory if it doesn't yet
@@ -197,10 +197,10 @@ mod tests {
         assert!(!nested.exists(), "precondition: nested dir doesn't exist");
         let store = DiskCursorStore::new(nested.clone());
 
-        store.store('C', 42);
+        store.store(uffs_mft::platform::DriveLetter::C, 42);
 
         assert!(nested.exists(), "cache dir must be created on first store");
-        let loaded = store.load('C');
+        let loaded = store.load(uffs_mft::platform::DriveLetter::C);
         assert_eq!(loaded, 42);
     }
 
@@ -212,13 +212,13 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let store = DiskCursorStore::new(tmp.path().to_path_buf());
 
-        store.store('C', 100);
-        store.store('D', 200);
-        store.store('E', 300);
+        store.store(uffs_mft::platform::DriveLetter::C, 100);
+        store.store(uffs_mft::platform::DriveLetter::D, 200);
+        store.store(uffs_mft::platform::DriveLetter::E, 300);
 
-        assert_eq!(store.load('C'), 100);
-        assert_eq!(store.load('D'), 200);
-        assert_eq!(store.load('E'), 300);
+        assert_eq!(store.load(uffs_mft::platform::DriveLetter::C), 100);
+        assert_eq!(store.load(uffs_mft::platform::DriveLetter::D), 200);
+        assert_eq!(store.load(uffs_mft::platform::DriveLetter::E), 300);
     }
 
     /// Overwriting an existing cursor must succeed atomically and
@@ -231,11 +231,11 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let store = DiskCursorStore::new(tmp.path().to_path_buf());
 
-        store.store('C', 100);
-        assert_eq!(store.load('C'), 100);
-        store.store('C', 200);
-        assert_eq!(store.load('C'), 200);
-        store.store('C', u64::MAX);
-        assert_eq!(store.load('C'), u64::MAX);
+        store.store(uffs_mft::platform::DriveLetter::C, 100);
+        assert_eq!(store.load(uffs_mft::platform::DriveLetter::C), 100);
+        store.store(uffs_mft::platform::DriveLetter::C, 200);
+        assert_eq!(store.load(uffs_mft::platform::DriveLetter::C), 200);
+        store.store(uffs_mft::platform::DriveLetter::C, u64::MAX);
+        assert_eq!(store.load(uffs_mft::platform::DriveLetter::C), u64::MAX);
     }
 }

--- a/crates/uffs-daemon/src/cache/journal_loop.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop.rs
@@ -144,9 +144,9 @@ pub(crate) trait JournalSource: Send + Sync + 'static {
 /// 3. Swaps the new body via
 ///    [`crate::cache::ShardRegistry::replace_warm_body`].
 ///
-/// Tests wire it to a `Mutex<Vec<(char, Vec<FileChange>)>>` recorder
-/// so the test can assert which letters saw which changes without
-/// touching a real registry.
+/// Tests wire it to a `Mutex<Vec<(uffs_mft::platform::DriveLetter,
+/// Vec<FileChange>)>>` recorder so the test can assert which letters saw which
+/// changes without touching a real registry.
 ///
 /// The sink is **synchronous** (no `async fn`) for consistency with
 /// the rest of the cache traits and so the loop body stays
@@ -160,7 +160,7 @@ pub(crate) trait PatchSink: Send + Sync + 'static {
     /// caller should treat the tick as a no-op (Parked / Cold
     /// shard, registry race, etc.).  The boolean is purely
     /// informational — the loop continues in either case.
-    fn accept(&self, letter: char, changes: &[FileChange]) -> bool;
+    fn accept(&self, letter: uffs_mft::platform::DriveLetter, changes: &[FileChange]) -> bool;
 
     /// Trigger a background compact-cache save for `letter`.
     ///
@@ -175,7 +175,7 @@ pub(crate) trait PatchSink: Send + Sync + 'static {
     /// background thread; the loop does not wait for it.  If
     /// the save fails, the implementor logs but does not
     /// propagate — the next threshold crossing will retry.
-    fn trigger_save(&self, letter: char, reason: SaveReason);
+    fn trigger_save(&self, letter: uffs_mft::platform::DriveLetter, reason: SaveReason);
 
     /// Notify the sink that the USN journal for `letter` was
     /// detected to have wrapped (Phase 7 task 7.7).
@@ -194,7 +194,7 @@ pub(crate) trait PatchSink: Send + Sync + 'static {
     /// next poll starts from the new journal's head.  No patches
     /// are applied for the wrap-tick — the sink's `accept` is
     /// **not** called.
-    fn journal_wrapped(&self, letter: char);
+    fn journal_wrapped(&self, letter: uffs_mft::platform::DriveLetter);
 }
 
 /// Pluggable cursor-persistence surface (Phase 7 task 7.6).
@@ -215,14 +215,14 @@ pub(crate) trait CursorStore: Send + Sync + 'static {
     /// Load the persisted cursor for `letter`.  Returns 0 (the
     /// "start from journal head" sentinel) when no cursor has
     /// been persisted yet or when the load failed.
-    fn load(&self, letter: char) -> u64;
+    fn load(&self, letter: uffs_mft::platform::DriveLetter) -> u64;
 
     /// Persist `cursor` for `letter`.  Best-effort — the
     /// implementor logs failures but does not propagate.  The
     /// loop calls this every time it fires a save trigger so
     /// the on-disk cursor advances in lockstep with the on-disk
     /// snapshot.
-    fn store(&self, letter: char, cursor: u64);
+    fn store(&self, letter: uffs_mft::platform::DriveLetter, cursor: u64);
 }
 
 /// Why a [`PatchSink::trigger_save`] call fired.
@@ -365,7 +365,7 @@ impl Default for JournalLoopConfig {
 /// only state-machine entry point is [`Self::run`].
 pub(crate) struct JournalLoop {
     /// Drive letter this loop polls.
-    letter: char,
+    letter: uffs_mft::platform::DriveLetter,
     /// Plug-in journal-data source.
     source: Arc<dyn JournalSource>,
     /// Plug-in patch consumer.
@@ -399,7 +399,7 @@ impl JournalLoop {
     /// watching `cancel_rx`, configured by `config`.
     #[must_use]
     pub(crate) fn new(
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         source: Arc<dyn JournalSource>,
         sink: Arc<dyn PatchSink>,
         cursor_store: Arc<dyn CursorStore>,
@@ -497,7 +497,7 @@ impl JournalLoop {
 async fn wait_for_next_tick(
     cancel_rx: &mut watch::Receiver<bool>,
     poll_interval: Duration,
-    letter: char,
+    letter: uffs_mft::platform::DriveLetter,
 ) -> bool {
     if *cancel_rx.borrow() {
         tracing::debug!(drive = %letter, "Journal loop cancellation requested before tick");
@@ -527,7 +527,7 @@ async fn wait_for_next_tick(
 async fn poll_blocking(
     source: Arc<dyn JournalSource>,
     cursor: u64,
-    letter: char,
+    letter: uffs_mft::platform::DriveLetter,
 ) -> Option<JournalPollResult> {
     let poll_result = tokio::task::spawn_blocking(move || source.poll(cursor)).await;
     match poll_result {
@@ -562,7 +562,7 @@ async fn poll_blocking(
 /// caller persists the cursor in lockstep), `false` otherwise.
 fn process_tick(
     sink: &dyn PatchSink,
-    letter: char,
+    letter: uffs_mft::platform::DriveLetter,
     cursor: u64,
     changes: &[FileChange],
     save_trigger: &mut SaveTrigger,
@@ -629,7 +629,7 @@ impl JournalLoopHandle {
 /// before the runtime tears down.
 #[must_use]
 pub(crate) fn spawn_journal_loop(
-    letter: char,
+    letter: uffs_mft::platform::DriveLetter,
     source: Arc<dyn JournalSource>,
     sink: Arc<dyn PatchSink>,
     cursor_store: Arc<dyn CursorStore>,

--- a/crates/uffs-daemon/src/cache/journal_loop/sources.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/sources.rs
@@ -88,14 +88,14 @@ impl JournalSource for MacStubJournalSource {
 #[derive(Debug)]
 pub(crate) struct WindowsJournalSource {
     /// Drive letter for which this source reads the USN journal.
-    drive: char,
+    drive: uffs_mft::platform::DriveLetter,
 }
 
 #[cfg(windows)]
 impl WindowsJournalSource {
     /// Create a source bound to `drive`.
     #[must_use]
-    pub(crate) const fn new(drive: char) -> Self {
+    pub(crate) const fn new(drive: uffs_mft::platform::DriveLetter) -> Self {
         Self { drive }
     }
 }
@@ -166,8 +166,8 @@ impl JournalSource for WindowsJournalSource {
 pub(crate) struct NullCursorStore;
 
 impl CursorStore for NullCursorStore {
-    fn load(&self, _letter: char) -> u64 {
+    fn load(&self, _letter: uffs_mft::platform::DriveLetter) -> u64 {
         0
     }
-    fn store(&self, _letter: char, _cursor: u64) {}
+    fn store(&self, _letter: uffs_mft::platform::DriveLetter, _cursor: u64) {}
 }

--- a/crates/uffs-daemon/src/cache/journal_loop/tests.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests.rs
@@ -163,16 +163,16 @@ struct RecordingSink {
     /// Storing only the count (not the full `Vec<FileChange>`)
     /// keeps the Mutex contention minimal and the assertions
     /// focused on the loop semantics rather than payload shape.
-    calls: Mutex<Vec<(char, usize)>>,
+    calls: Mutex<Vec<(uffs_mft::platform::DriveLetter, usize)>>,
     /// One entry per `trigger_save()` call: `(letter, reason)`.
     /// Phase 7-C surface — lets tests assert the threshold state
     /// machine fires the right reason at the right time.
-    save_calls: Mutex<Vec<(char, SaveReason)>>,
+    save_calls: Mutex<Vec<(uffs_mft::platform::DriveLetter, SaveReason)>>,
     /// One entry per `journal_wrapped()` call: `letter`.
     /// Phase 7-D surface — lets tests assert the wrap-detection
     /// state machine fires when `journal_id` changes between
     /// successive non-zero polls.
-    wrap_calls: Mutex<Vec<char>>,
+    wrap_calls: Mutex<Vec<uffs_mft::platform::DriveLetter>>,
     /// Boolean to return from `accept()`.  Tests flip this to
     /// `false` to exercise the registry-race / Parked-shard path
     /// (loop must continue cleanly when accept returns false).
@@ -189,45 +189,45 @@ impl RecordingSink {
         }
     }
 
-    fn calls(&self) -> Vec<(char, usize)> {
+    fn calls(&self) -> Vec<(uffs_mft::platform::DriveLetter, usize)> {
         lock_or_recover(&self.calls).clone()
     }
 
-    fn save_calls(&self) -> Vec<(char, SaveReason)> {
+    fn save_calls(&self) -> Vec<(uffs_mft::platform::DriveLetter, SaveReason)> {
         lock_or_recover(&self.save_calls).clone()
     }
 
-    fn wrap_calls(&self) -> Vec<char> {
+    fn wrap_calls(&self) -> Vec<uffs_mft::platform::DriveLetter> {
         lock_or_recover(&self.wrap_calls).clone()
     }
 }
 
 impl PatchSink for RecordingSink {
-    fn accept(&self, letter: char, changes: &[FileChange]) -> bool {
+    fn accept(&self, letter: uffs_mft::platform::DriveLetter, changes: &[FileChange]) -> bool {
         lock_or_recover(&self.calls).push((letter, changes.len()));
         *lock_or_recover(&self.accept_outcome)
     }
 
-    fn trigger_save(&self, letter: char, reason: SaveReason) {
+    fn trigger_save(&self, letter: uffs_mft::platform::DriveLetter, reason: SaveReason) {
         lock_or_recover(&self.save_calls).push((letter, reason));
     }
 
-    fn journal_wrapped(&self, letter: char) {
+    fn journal_wrapped(&self, letter: uffs_mft::platform::DriveLetter) {
         lock_or_recover(&self.wrap_calls).push(letter);
     }
 }
 
-/// In-memory cursor store backed by a `HashMap<char, u64>`.
-/// Pre-loaded by tests via [`Self::set_cursor`] to seed the
+/// In-memory cursor store backed by a `HashMap<uffs_mft::platform::DriveLetter,
+/// u64>`. Pre-loaded by tests via [`Self::set_cursor`] to seed the
 /// loop's initial cursor; observed via [`Self::store_log`] to
 /// assert the loop's persistence behaviour.
 struct FakeCursorStore {
-    cursors: Mutex<std::collections::HashMap<char, u64>>,
+    cursors: Mutex<std::collections::HashMap<uffs_mft::platform::DriveLetter, u64>>,
     /// Append-only log of every `(letter, cursor)` passed to
     /// `store()`, in call order.  Lets tests assert which
     /// cursors were persisted at which points (not just the
     /// final state).
-    store_log: Mutex<Vec<(char, u64)>>,
+    store_log: Mutex<Vec<(uffs_mft::platform::DriveLetter, u64)>>,
 }
 
 impl FakeCursorStore {
@@ -238,24 +238,24 @@ impl FakeCursorStore {
         }
     }
 
-    fn set_cursor(&self, letter: char, cursor: u64) {
+    fn set_cursor(&self, letter: uffs_mft::platform::DriveLetter, cursor: u64) {
         lock_or_recover(&self.cursors).insert(letter, cursor);
     }
 
-    fn store_log(&self) -> Vec<(char, u64)> {
+    fn store_log(&self) -> Vec<(uffs_mft::platform::DriveLetter, u64)> {
         lock_or_recover(&self.store_log).clone()
     }
 }
 
 impl CursorStore for FakeCursorStore {
-    fn load(&self, letter: char) -> u64 {
+    fn load(&self, letter: uffs_mft::platform::DriveLetter) -> u64 {
         lock_or_recover(&self.cursors)
             .get(&letter)
             .copied()
             .unwrap_or(0)
     }
 
-    fn store(&self, letter: char, cursor: u64) {
+    fn store(&self, letter: uffs_mft::platform::DriveLetter, cursor: u64) {
         lock_or_recover(&self.cursors).insert(letter, cursor);
         lock_or_recover(&self.store_log).push((letter, cursor));
     }

--- a/crates/uffs-daemon/src/cache/journal_loop/tests/basics.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests/basics.rs
@@ -35,7 +35,7 @@ async fn empty_tick_does_not_call_accept() {
 
     // Empty queue → poll() returns default (empty changes).
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         null_cursor_store(),
@@ -77,7 +77,7 @@ async fn non_empty_tick_invokes_accept_once() {
     source.enqueue_changes(vec![one_change(10), one_change(11)], 100);
 
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         null_cursor_store(),
@@ -99,7 +99,7 @@ async fn non_empty_tick_invokes_accept_once() {
     assert_eq!(calls.len(), 1, "exactly one accept() call expected");
     assert_eq!(
         calls.first().copied(),
-        Some(('C', 2_usize)),
+        Some((uffs_mft::platform::DriveLetter::C, 2_usize)),
         "letter + change-count must round-trip"
     );
 }
@@ -115,7 +115,7 @@ async fn cursor_advances_monotonically_across_ticks() {
     source.enqueue_changes(vec![one_change(12)], 300);
 
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         null_cursor_store(),
@@ -164,7 +164,7 @@ async fn source_error_does_not_abort_loop() {
     source.enqueue_changes(vec![one_change(10)], 100);
 
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         null_cursor_store(),
@@ -190,7 +190,7 @@ async fn cancel_exits_within_convergence_deadline() {
     let sink = Arc::new(RecordingSink::new());
 
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         null_cursor_store(),

--- a/crates/uffs-daemon/src/cache/journal_loop/tests/integration.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests/integration.rs
@@ -97,7 +97,7 @@ async fn ten_thousand_events_end_to_end() {
         save_threshold_age: Duration::from_hours(24),
     };
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         Arc::clone(&cursor_store) as Arc<dyn CursorStore>,
@@ -132,7 +132,9 @@ async fn ten_thousand_events_end_to_end() {
     );
     // Every accept call was for letter 'C'.
     assert!(
-        calls.iter().all(|(letter, _)| *letter == 'C'),
+        calls
+            .iter()
+            .all(|(letter, _)| *letter == uffs_mft::platform::DriveLetter::C),
         "every accept() must be for drive 'C'; got {calls:?}"
     );
 
@@ -147,7 +149,9 @@ async fn ten_thousand_events_end_to_end() {
         saves.len()
     );
     assert!(
-        saves.iter().all(|(letter, _)| *letter == 'C'),
+        saves
+            .iter()
+            .all(|(letter, _)| *letter == uffs_mft::platform::DriveLetter::C),
         "every save must be for drive 'C'; got {saves:?}"
     );
 

--- a/crates/uffs-daemon/src/cache/journal_loop/tests/save_log_message.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests/save_log_message.rs
@@ -80,7 +80,7 @@ fn compact_cache_save_log_message_pins_string_target_and_level() {
     let changes = [one_change(10), one_change(11), one_change(12)];
     let saved = process_tick(
         &sink as &dyn PatchSink,
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         100, // cursor
         &changes,
         &mut trigger,
@@ -98,7 +98,10 @@ fn compact_cache_save_log_message_pins_string_target_and_level() {
     let save_calls = sink.save_calls();
     assert_eq!(
         save_calls.as_slice(),
-        &[('C', SaveReason::EventsExceeded)],
+        &[(
+            uffs_mft::platform::DriveLetter::C,
+            SaveReason::EventsExceeded
+        )],
         "trigger_save must fire exactly once with EventsExceeded reason; got {save_calls:?}",
     );
 

--- a/crates/uffs-daemon/src/cache/journal_loop/tests/thresholds.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests/thresholds.rs
@@ -44,7 +44,7 @@ async fn events_threshold_triggers_save() {
         save_threshold_age: Duration::from_hours(24),
     };
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         null_cursor_store(),
@@ -69,7 +69,10 @@ async fn events_threshold_triggers_save() {
     );
     assert_eq!(
         saves.first().copied(),
-        Some(('C', SaveReason::EventsExceeded)),
+        Some((
+            uffs_mft::platform::DriveLetter::C,
+            SaveReason::EventsExceeded
+        )),
         "save reason must be EventsExceeded"
     );
 }
@@ -90,7 +93,7 @@ async fn age_threshold_triggers_save_with_pending_events() {
         save_threshold_age: Duration::from_millis(30),
     };
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         null_cursor_store(),
@@ -128,7 +131,7 @@ async fn age_threshold_triggers_save_with_pending_events() {
     let saves = sink.save_calls();
     assert_eq!(
         saves.first().copied(),
-        Some(('C', SaveReason::AgeElapsed)),
+        Some((uffs_mft::platform::DriveLetter::C, SaveReason::AgeElapsed)),
         "save reason must be AgeElapsed; got {saves:?}"
     );
 }
@@ -149,7 +152,7 @@ async fn zero_events_drive_does_not_trigger_save() {
         save_threshold_age: Duration::from_millis(20),
     };
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         null_cursor_store(),
@@ -201,7 +204,7 @@ async fn counter_resets_after_save() {
         save_threshold_age: Duration::from_hours(24),
     };
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         null_cursor_store(),

--- a/crates/uffs-daemon/src/cache/journal_loop/tests/wrap_and_persistence.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests/wrap_and_persistence.rs
@@ -32,12 +32,12 @@ async fn cursor_loaded_from_store_at_spawn() {
     let source = Arc::new(FakeJournalSource::new());
     let sink = Arc::new(RecordingSink::new());
     let cursor_store = Arc::new(FakeCursorStore::new());
-    cursor_store.set_cursor('C', 42);
+    cursor_store.set_cursor(uffs_mft::platform::DriveLetter::C, 42);
 
     // No batches enqueued; the loop will tick on empty results.
     // We're asserting the FIRST poll's cursor argument.
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         Arc::clone(&cursor_store) as Arc<dyn CursorStore>,
@@ -88,7 +88,7 @@ async fn cursor_persisted_on_save_trigger() {
         save_threshold_age: Duration::from_hours(24),
     };
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         Arc::clone(&cursor_store) as Arc<dyn CursorStore>,
@@ -108,7 +108,7 @@ async fn cursor_persisted_on_save_trigger() {
     let log = cursor_store.store_log();
     assert!(
         log.iter()
-            .any(|&(letter, cursor)| letter == 'C' && cursor == 100),
+            .any(|&(letter, cursor)| letter == uffs_mft::platform::DriveLetter::C && cursor == 100),
         "cursor 100 must be persisted alongside the save trigger; log = {log:?}"
     );
 }
@@ -126,7 +126,7 @@ async fn journal_wrap_fires_journal_wrapped_and_skips_patch() {
     source.enqueue_changes_with_journal_id(vec![one_change(11)], 200, 2);
 
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         Arc::clone(&cursor_store) as Arc<dyn CursorStore>,
@@ -149,7 +149,10 @@ async fn journal_wrap_fires_journal_wrapped_and_skips_patch() {
         1,
         "exactly one journal_wrapped call expected; got {wraps:?}"
     );
-    assert_eq!(wraps.first().copied(), Some('C'));
+    assert_eq!(
+        wraps.first().copied(),
+        Some(uffs_mft::platform::DriveLetter::C)
+    );
 
     // The first batch (journal_id=1) MUST have been accepted; the
     // second (journal_id=2 wrap-tick) must NOT have produced an
@@ -160,7 +163,10 @@ async fn journal_wrap_fires_journal_wrapped_and_skips_patch() {
         1,
         "only the pre-wrap batch must be accepted; got {calls:?}"
     );
-    assert_eq!(calls.first().copied(), Some(('C', 1_usize)));
+    assert_eq!(
+        calls.first().copied(),
+        Some((uffs_mft::platform::DriveLetter::C, 1_usize))
+    );
 }
 
 #[tokio::test]
@@ -179,7 +185,7 @@ async fn journal_wrap_resets_cursor_to_zero() {
     source.enqueue_changes_with_journal_id(vec![one_change(12)], 300, 2);
 
     let handle = spawn_journal_loop(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         Arc::clone(&source) as Arc<dyn JournalSource>,
         Arc::clone(&sink) as Arc<dyn PatchSink>,
         Arc::clone(&cursor_store) as Arc<dyn CursorStore>,

--- a/crates/uffs-daemon/src/cache/journal_sink.rs
+++ b/crates/uffs-daemon/src/cache/journal_sink.rs
@@ -21,10 +21,10 @@
 //! receiver and processes messages serially.
 //!
 //! Phase 8 B3 extension: per-letter
-//! [`std::sync::Mutex<HashMap<char, Vec<FileChange>>>`] **pending
-//! buffer** owned by the sink.  `accept` appends to the buffer
-//! synchronously (no mpsc traffic).  `trigger_save` drains the buffer
-//! for that letter and ships the drained `Vec<FileChange>` into
+//! [`std::sync::Mutex<HashMap<uffs_mft::platform::DriveLetter,
+//! Vec<FileChange>>>`] **pending buffer** owned by the sink.  `accept` appends
+//! to the buffer synchronously (no mpsc traffic).  `trigger_save` drains the
+//! buffer for that letter and ships the drained `Vec<FileChange>` into
 //! [`ApplyMsg::Save`] so the applier can run a *surgical*
 //! [`crate::cache::ShardEntry::apply_usn_patch_to_body`] instead of a
 //! full [`uffs_core::compact_loader::load_drive_with_usn_refresh`].
@@ -83,7 +83,7 @@ enum ApplyMsg {
     /// failure log.
     Save {
         /// Drive letter to refresh.
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         /// Why the save threshold fired.
         reason: SaveReason,
         /// Drained per-letter event buffer.  Empty on age-elapsed
@@ -98,7 +98,7 @@ enum ApplyMsg {
     /// against the new journal head.
     Wrap {
         /// Drive letter whose USN journal was recreated.
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
     },
 }
 
@@ -138,7 +138,7 @@ pub(crate) struct RegistryPatchSink {
     /// tick cadence.  Poisoning is recovered via
     /// [`std::sync::PoisonError::into_inner`] (matching the
     /// `lock_journal_handles` helper in `index/journal.rs`).
-    pending: Mutex<HashMap<char, Vec<FileChange>>>,
+    pending: Mutex<HashMap<uffs_mft::platform::DriveLetter, Vec<FileChange>>>,
 }
 
 impl RegistryPatchSink {
@@ -175,7 +175,9 @@ impl RegistryPatchSink {
     /// would otherwise propagate a panic from the applier task into
     /// every subsequent journal-loop tick, killing the whole
     /// journal-refresh subsystem.
-    fn lock_pending(&self) -> std::sync::MutexGuard<'_, HashMap<char, Vec<FileChange>>> {
+    fn lock_pending(
+        &self,
+    ) -> std::sync::MutexGuard<'_, HashMap<uffs_mft::platform::DriveLetter, Vec<FileChange>>> {
         self.pending
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -201,7 +203,7 @@ impl RegistryPatchSink {
 }
 
 impl PatchSink for RegistryPatchSink {
-    fn accept(&self, letter: char, changes: &[FileChange]) -> bool {
+    fn accept(&self, letter: uffs_mft::platform::DriveLetter, changes: &[FileChange]) -> bool {
         // Phase 8: append to the per-letter pending buffer instead
         // of putting traffic on the mpsc channel.  `trigger_save`
         // drains this buffer and forwards the changes into the
@@ -218,7 +220,7 @@ impl PatchSink for RegistryPatchSink {
         true
     }
 
-    fn trigger_save(&self, letter: char, reason: SaveReason) {
+    fn trigger_save(&self, letter: uffs_mft::platform::DriveLetter, reason: SaveReason) {
         // Drain the per-letter buffer in one swoop so the applier
         // sees a snapshot of all events accumulated since the
         // previous save.  An empty drained Vec is forwarded as-is
@@ -234,7 +236,7 @@ impl PatchSink for RegistryPatchSink {
         });
     }
 
-    fn journal_wrapped(&self, letter: char) {
+    fn journal_wrapped(&self, letter: uffs_mft::platform::DriveLetter) {
         // Wrap means the journal head reset; any buffered events
         // are stale relative to the new cursor.  Discard the
         // pending buffer and rely on the applier's full reload to
@@ -353,7 +355,10 @@ mod tests {
     /// dropping the `lock_pending()` guard before returning so the
     /// caller's assertions don't hold the mutex (satisfies
     /// `clippy::significant_drop_tightening` in tests).
-    fn pending_frs_for_letter(sink: &RegistryPatchSink, letter: char) -> Option<Vec<u64>> {
+    fn pending_frs_for_letter(
+        sink: &RegistryPatchSink,
+        letter: uffs_mft::platform::DriveLetter,
+    ) -> Option<Vec<u64>> {
         let guard = sink.lock_pending();
         guard
             .get(&letter)
@@ -366,11 +371,14 @@ mod tests {
     async fn accept_buffers_changes_without_enqueueing() {
         let (sink, mut rx) = RegistryPatchSink::new_for_test();
 
-        let accepted = sink.accept('C', &[make_change(100), make_change(101)]);
+        let accepted = sink.accept(uffs_mft::platform::DriveLetter::C, &[
+            make_change(100),
+            make_change(101),
+        ]);
         assert!(accepted, "accept must return true optimistically");
 
         // The pending buffer holds the two events for letter 'C'.
-        let buf = pending_frs_for_letter(&sink, 'C')
+        let buf = pending_frs_for_letter(&sink, uffs_mft::platform::DriveLetter::C)
             .expect("accept must populate pending buffer for 'C'");
         assert_eq!(
             buf,
@@ -392,11 +400,15 @@ mod tests {
     async fn multiple_accepts_accumulate_in_pending() {
         let (sink, _rx) = RegistryPatchSink::new_for_test();
 
-        sink.accept('C', &[make_change(1)]);
-        sink.accept('C', &[make_change(2), make_change(3)]);
-        sink.accept('C', &[make_change(4)]);
+        sink.accept(uffs_mft::platform::DriveLetter::C, &[make_change(1)]);
+        sink.accept(uffs_mft::platform::DriveLetter::C, &[
+            make_change(2),
+            make_change(3),
+        ]);
+        sink.accept(uffs_mft::platform::DriveLetter::C, &[make_change(4)]);
 
-        let buf = pending_frs_for_letter(&sink, 'C').expect("buffer for 'C' must exist");
+        let buf = pending_frs_for_letter(&sink, uffs_mft::platform::DriveLetter::C)
+            .expect("buffer for 'C' must exist");
         assert_eq!(
             buf,
             [1, 2, 3, 4],
@@ -411,8 +423,14 @@ mod tests {
     async fn trigger_save_drains_pending_into_save_message() {
         let (sink, mut rx) = RegistryPatchSink::new_for_test();
 
-        sink.accept('C', &[make_change(10), make_change(11)]);
-        sink.trigger_save('C', SaveReason::EventsExceeded);
+        sink.accept(uffs_mft::platform::DriveLetter::C, &[
+            make_change(10),
+            make_change(11),
+        ]);
+        sink.trigger_save(
+            uffs_mft::platform::DriveLetter::C,
+            SaveReason::EventsExceeded,
+        );
 
         let ApplyMsg::Save {
             letter,
@@ -422,7 +440,7 @@ mod tests {
         else {
             panic!("expected ApplyMsg::Save, got Wrap");
         };
-        assert_eq!(letter, 'C');
+        assert_eq!(letter, uffs_mft::platform::DriveLetter::C);
         assert!(matches!(reason, SaveReason::EventsExceeded));
         assert_eq!(
             changes.iter().map(|change| change.frs).collect::<Vec<_>>(),
@@ -432,7 +450,7 @@ mod tests {
 
         // Pending buffer for 'C' is gone after the drain.
         assert!(
-            pending_frs_for_letter(&sink, 'C').is_none(),
+            pending_frs_for_letter(&sink, uffs_mft::platform::DriveLetter::C).is_none(),
             "trigger_save must remove the per-letter pending entry",
         );
     }
@@ -444,7 +462,7 @@ mod tests {
     async fn trigger_save_with_no_pending_sends_empty_changes() {
         let (sink, mut rx) = RegistryPatchSink::new_for_test();
 
-        sink.trigger_save('Z', SaveReason::AgeElapsed);
+        sink.trigger_save(uffs_mft::platform::DriveLetter::Z, SaveReason::AgeElapsed);
 
         let ApplyMsg::Save {
             letter,
@@ -454,7 +472,7 @@ mod tests {
         else {
             panic!("expected ApplyMsg::Save, got Wrap");
         };
-        assert_eq!(letter, 'Z');
+        assert_eq!(letter, uffs_mft::platform::DriveLetter::Z);
         assert!(matches!(reason, SaveReason::AgeElapsed));
         assert!(
             changes.is_empty(),
@@ -470,22 +488,25 @@ mod tests {
     async fn journal_wrapped_discards_pending_buffer_and_sends_wrap() {
         let (sink, mut rx) = RegistryPatchSink::new_for_test();
 
-        sink.accept('C', &[make_change(5), make_change(6)]);
-        sink.journal_wrapped('C');
+        sink.accept(uffs_mft::platform::DriveLetter::C, &[
+            make_change(5),
+            make_change(6),
+        ]);
+        sink.journal_wrapped(uffs_mft::platform::DriveLetter::C);
 
         let ApplyMsg::Wrap { letter } = rx.try_recv().expect("journal_wrapped must enqueue Wrap")
         else {
             panic!("expected ApplyMsg::Wrap, got Save");
         };
-        assert_eq!(letter, 'C');
+        assert_eq!(letter, uffs_mft::platform::DriveLetter::C);
 
         assert!(
-            pending_frs_for_letter(&sink, 'C').is_none(),
+            pending_frs_for_letter(&sink, uffs_mft::platform::DriveLetter::C).is_none(),
             "journal_wrapped must discard the per-letter pending entry",
         );
 
         // A subsequent trigger_save must see an empty buffer.
-        sink.trigger_save('C', SaveReason::AgeElapsed);
+        sink.trigger_save(uffs_mft::platform::DriveLetter::C, SaveReason::AgeElapsed);
         let ApplyMsg::Save {
             changes: post_wrap_changes,
             ..
@@ -505,11 +526,17 @@ mod tests {
     async fn pending_buffers_are_per_letter() {
         let (sink, mut rx) = RegistryPatchSink::new_for_test();
 
-        sink.accept('C', &[make_change(1)]);
-        sink.accept('D', &[make_change(2), make_change(3)]);
+        sink.accept(uffs_mft::platform::DriveLetter::C, &[make_change(1)]);
+        sink.accept(uffs_mft::platform::DriveLetter::D, &[
+            make_change(2),
+            make_change(3),
+        ]);
 
         // Drain 'C' first — should NOT include any of 'D's events.
-        sink.trigger_save('C', SaveReason::EventsExceeded);
+        sink.trigger_save(
+            uffs_mft::platform::DriveLetter::C,
+            SaveReason::EventsExceeded,
+        );
         let ApplyMsg::Save {
             letter: c_letter,
             changes: c_changes,
@@ -518,7 +545,7 @@ mod tests {
         else {
             panic!("expected ApplyMsg::Save for 'C'");
         };
-        assert_eq!(c_letter, 'C');
+        assert_eq!(c_letter, uffs_mft::platform::DriveLetter::C);
         assert_eq!(
             c_changes
                 .iter()
@@ -528,7 +555,10 @@ mod tests {
         );
 
         // 'D's buffer must still hold its events.
-        sink.trigger_save('D', SaveReason::EventsExceeded);
+        sink.trigger_save(
+            uffs_mft::platform::DriveLetter::D,
+            SaveReason::EventsExceeded,
+        );
         let ApplyMsg::Save {
             letter: d_letter,
             changes: d_changes,
@@ -537,7 +567,7 @@ mod tests {
         else {
             panic!("expected ApplyMsg::Save for 'D'");
         };
-        assert_eq!(d_letter, 'D');
+        assert_eq!(d_letter, uffs_mft::platform::DriveLetter::D);
         assert_eq!(
             d_changes
                 .iter()
@@ -589,7 +619,10 @@ mod tests {
         // Send one message so the applier wakes up, observes the
         // dropped Weak, and exits.  Without this the applier blocks
         // on `recv().await` forever (no Weak-watch primitive in tokio).
-        sink.trigger_save('C', SaveReason::EventsExceeded);
+        sink.trigger_save(
+            uffs_mft::platform::DriveLetter::C,
+            SaveReason::EventsExceeded,
+        );
 
         let join_result = tokio::time::timeout(core::time::Duration::from_secs(2), applier).await;
         assert!(
@@ -633,7 +666,13 @@ mod tests {
         // fast path in `handle_journal_save` short-circuits to a
         // debug-log no-op.  The test verifies the applier processes
         // all 5 in order before the sink's drop closes the channel.
-        for letter in ['C', 'D', 'E', 'F', 'G'] {
+        for letter in [
+            uffs_mft::platform::DriveLetter::C,
+            uffs_mft::platform::DriveLetter::D,
+            uffs_mft::platform::DriveLetter::E,
+            uffs_mft::platform::DriveLetter::F,
+            uffs_mft::platform::DriveLetter::G,
+        ] {
             sink.trigger_save(letter, SaveReason::EventsExceeded);
         }
 

--- a/crates/uffs-daemon/src/cache/registry.rs
+++ b/crates/uffs-daemon/src/cache/registry.rs
@@ -204,12 +204,16 @@ impl ShardRegistry {
     /// `eq_ignore_ascii_case` to handle drive letters that flow
     /// through the daemon in either case.
     #[must_use]
-    pub(crate) fn replace(&self, match_letter: char, body: Arc<DriveCompactIndex>) -> Self {
+    pub(crate) fn replace(
+        &self,
+        match_letter: uffs_mft::platform::DriveLetter,
+        body: Arc<DriveCompactIndex>,
+    ) -> Self {
         let new_letter = body.letter;
         let mut shards: Vec<Arc<ShardEntry>> = self
             .shards
             .iter()
-            .filter(|shard| !shard.drive.eq_ignore_ascii_case(&match_letter))
+            .filter(|shard| shard.drive != match_letter)
             .cloned()
             .collect();
         shards.push(Arc::new(ShardEntry::new_warm(new_letter, body)));
@@ -226,11 +230,11 @@ impl ShardRegistry {
     /// [`crate::index::IndexManager::forget_drives`] calls `remove`
     /// after the eviction guard checks pass.
     #[must_use]
-    pub(crate) fn remove(&self, drive: char) -> Self {
+    pub(crate) fn remove(&self, drive: uffs_mft::platform::DriveLetter) -> Self {
         let shards: Vec<Arc<ShardEntry>> = self
             .shards
             .iter()
-            .filter(|shard| !shard.drive.eq_ignore_ascii_case(&drive))
+            .filter(|shard| shard.drive != drive)
             .cloned()
             .collect();
         Self::from_shards(shards)
@@ -278,7 +282,11 @@ impl ShardRegistry {
     /// carry `reason="pressure-cascade"` instead of the default
     /// `reason="demote"`.
     #[must_use]
-    pub(crate) fn demote_letter(&self, letter: char, target: ShardState) -> Option<Self> {
+    pub(crate) fn demote_letter(
+        &self,
+        letter: uffs_mft::platform::DriveLetter,
+        target: ShardState,
+    ) -> Option<Self> {
         self.demote_letter_with_reason(letter, target, DemoteReason::IdleTtl)
     }
 
@@ -320,7 +328,7 @@ impl ShardRegistry {
     #[must_use]
     pub(crate) fn demote_letter_with_reason(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         target: ShardState,
         reason: DemoteReason,
     ) -> Option<Self> {
@@ -331,7 +339,7 @@ impl ShardRegistry {
             .shards
             .iter()
             .enumerate()
-            .find(|(_, shard)| shard.drive.eq_ignore_ascii_case(&letter))?;
+            .find(|(_, shard)| shard.drive == letter)?;
         let from_state = old_arc.state();
         if !is_legal_demote_target(from_state, target) {
             return None;
@@ -361,7 +369,7 @@ impl ShardRegistry {
                 let Some(body) = old_arc.body() else {
                     tracing::error!(
                         target: "shard.transition",
-                        letter = %letter.to_ascii_uppercase(),
+                        letter = %letter,
                         from = %from_state,
                         to = %target,
                         reason = reason.as_str(),
@@ -400,7 +408,7 @@ impl ShardRegistry {
             .collect();
         tracing::info!(
             target: "shard.transition",
-            letter = %letter.to_ascii_uppercase(),
+            letter = %letter,
             from = %from_state,
             to = %target,
             freed_mb,
@@ -429,14 +437,14 @@ impl ShardRegistry {
     #[must_use]
     pub(crate) fn promote_letter(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         body: Arc<DriveCompactIndex>,
     ) -> Option<Self> {
         let (pos, old_arc) = self
             .shards
             .iter()
             .enumerate()
-            .find(|(_, shard)| shard.drive.eq_ignore_ascii_case(&letter))?;
+            .find(|(_, shard)| shard.drive == letter)?;
         let from_state = old_arc.state();
         if !matches!(from_state, ShardState::Parked | ShardState::Cold) {
             return None;
@@ -459,7 +467,7 @@ impl ShardRegistry {
             .collect();
         tracing::info!(
             target: "shard.transition",
-            letter = %letter.to_ascii_uppercase(),
+            letter = %letter,
             from = %from_state,
             to = %ShardState::Warm,
             restored_mb,
@@ -496,14 +504,14 @@ impl ShardRegistry {
     #[must_use]
     pub(crate) fn promote_letter_to_hot(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         body: Arc<DriveCompactIndex>,
     ) -> Option<Self> {
         let (pos, old_arc) = self
             .shards
             .iter()
             .enumerate()
-            .find(|(_, shard)| shard.drive.eq_ignore_ascii_case(&letter))?;
+            .find(|(_, shard)| shard.drive == letter)?;
         let from_state = old_arc.state();
         if !matches!(
             from_state,
@@ -542,7 +550,7 @@ impl ShardRegistry {
             .collect();
         tracing::info!(
             target: "shard.transition",
-            letter = %letter.to_ascii_uppercase(),
+            letter = %letter,
             from = %from_state,
             to = %ShardState::Hot,
             restored_mb,
@@ -575,14 +583,14 @@ impl ShardRegistry {
     #[must_use]
     pub(crate) fn replace_warm_body(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         body: Arc<DriveCompactIndex>,
     ) -> Option<Self> {
         let (pos, old_arc) = self
             .shards
             .iter()
             .enumerate()
-            .find(|(_, shard)| shard.drive.eq_ignore_ascii_case(&letter))?;
+            .find(|(_, shard)| shard.drive == letter)?;
         let from_state = old_arc.state();
         if !matches!(from_state, ShardState::Warm | ShardState::Hot) {
             return None;
@@ -605,7 +613,7 @@ impl ShardRegistry {
             .collect();
         tracing::info!(
             target: "shard.transition",
-            letter = %letter.to_ascii_uppercase(),
+            letter = %letter,
             from = %from_state,
             to = %ShardState::Warm,
             refreshed_mb,
@@ -622,13 +630,13 @@ impl ShardRegistry {
 
     /// `true` iff any shard exists for `drive` (regardless of tier).
     #[must_use]
-    pub(crate) fn contains(&self, drive: char) -> bool {
+    pub(crate) fn contains(&self, drive: uffs_mft::platform::DriveLetter) -> bool {
         self.shards.iter().any(|shard| shard.drive == drive)
     }
 
     /// Drive letters of every loaded shard in load order.
     #[must_use]
-    pub(crate) fn loaded_letters(&self) -> Vec<char> {
+    pub(crate) fn loaded_letters(&self) -> Vec<uffs_mft::platform::DriveLetter> {
         self.shards.iter().map(|shard| shard.drive).collect()
     }
 }
@@ -656,8 +664,11 @@ mod tests {
         assert!(reg.is_empty());
         assert_eq!(reg.len(), 0);
         assert_eq!(reg.active_index().drives.len(), 0);
-        assert_eq!(reg.loaded_letters(), Vec::<char>::new());
-        assert!(!reg.contains('C'));
+        assert_eq!(
+            reg.loaded_letters(),
+            Vec::<uffs_mft::platform::DriveLetter>::new()
+        );
+        assert!(!reg.contains(uffs_mft::platform::DriveLetter::C));
     }
 
     /// `Default` matches `new()`.
@@ -682,7 +693,7 @@ mod tests {
     /// `IndexManager::replace_drive` relies on for fresh inserts.
     #[test]
     fn remove_missing_is_noop() {
-        let reg = ShardRegistry::new().remove('Z');
+        let reg = ShardRegistry::new().remove(uffs_mft::platform::DriveLetter::Z);
         assert!(reg.is_empty());
         assert_eq!(reg.len(), 0);
         assert_eq!(reg.active_index().drives.len(), 0);

--- a/crates/uffs-daemon/src/cache/shard.rs
+++ b/crates/uffs-daemon/src/cache/shard.rs
@@ -200,7 +200,7 @@ impl StdError for IllegalTransition {}
 pub(crate) struct ShardEntry {
     /// Drive letter (`'C'`, `'D'`, …). Capital ASCII per existing
     /// daemon convention.
-    pub(crate) drive: char,
+    pub(crate) drive: uffs_mft::platform::DriveLetter,
     /// Tier state. Read on every search via [`Self::state`]; mutated
     /// only by [`Self::try_transition`] (test-only) or by the
     /// registry's tier-transition rebuilds (production path).
@@ -252,7 +252,10 @@ impl ShardEntry {
     /// constructor.  Phase 3 adds [`Self::new_parked`] /
     /// [`Self::new_cold`] for tier-transition rebuilds.
     #[must_use]
-    pub(crate) fn new_warm(drive: char, body: Arc<DriveCompactIndex>) -> Self {
+    pub(crate) fn new_warm(
+        drive: uffs_mft::platform::DriveLetter,
+        body: Arc<DriveCompactIndex>,
+    ) -> Self {
         Self {
             drive,
             state: AtomicU8::new(ShardState::Warm as u8),
@@ -270,7 +273,7 @@ impl ShardEntry {
     /// query counters survive the round-trip through demote-and-back.
     #[must_use]
     pub(crate) const fn new_warm_with_stats(
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
         body: Arc<DriveCompactIndex>,
         stats: Arc<DriveStats>,
     ) -> Self {
@@ -299,7 +302,7 @@ impl ShardEntry {
     /// through Cold/Parked → Warm → Hot.
     #[must_use]
     pub(crate) const fn new_hot_with_stats(
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
         body: Arc<DriveCompactIndex>,
         stats: Arc<DriveStats>,
     ) -> Self {
@@ -327,7 +330,7 @@ impl ShardEntry {
     /// Commit D, extended in Phase 4 Commit F).
     #[must_use]
     pub(crate) const fn new_parked(
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
         stats: Arc<DriveStats>,
         parked_body: Arc<ParkedBody>,
     ) -> Self {
@@ -352,7 +355,10 @@ impl ShardEntry {
     /// Commit D, when a `Parked` shard's idle time exceeds
     /// `PARKED_TO_COLD_IDLE_SECS`).
     #[must_use]
-    pub(crate) const fn new_cold(drive: char, stats: Arc<DriveStats>) -> Self {
+    pub(crate) const fn new_cold(
+        drive: uffs_mft::platform::DriveLetter,
+        stats: Arc<DriveStats>,
+    ) -> Self {
         Self {
             drive,
             state: AtomicU8::new(ShardState::Cold as u8),

--- a/crates/uffs-daemon/src/cache/shard/tests.rs
+++ b/crates/uffs-daemon/src/cache/shard/tests.rs
@@ -47,16 +47,16 @@ use super::{
 /// `index/tests/mod.rs::build_test_drive` fixture (which builds a
 /// 7-record drive from a real `MftIndex` and is overkill for the
 /// patch-method shape tests below).
-fn make_test_body(letter: char) -> DriveCompactIndex {
+fn make_test_body(letter: uffs_mft::platform::DriveLetter) -> DriveCompactIndex {
     // Names blob: letter + "/" + "f.txt".
-    let names = vec![letter as u8, b'f', b'.', b't', b'x', b't'];
+    let names = vec![letter.as_byte(), b'f', b'.', b't', b'x', b't'];
     let records = vec![
         CompactRecord {
             name_offset: 0,
             flags: 0x10, // directory
             parent_idx: u32::MAX,
             name_len: 1,
-            name_first_byte: letter as u8,
+            name_first_byte: letter.as_byte(),
             ..CompactRecord::default()
         },
         CompactRecord {
@@ -107,7 +107,7 @@ fn make_test_body(letter: char) -> DriveCompactIndex {
 /// Sufficient to exercise `ShardEntry::new_parked` and the
 /// `parked_body()` accessor without pulling in fixture-builder
 /// machinery from `crate::index::tests`.
-fn make_test_parked_body(letter: char, source_epoch: u64) -> ParkedBody {
+fn make_test_parked_body(letter: uffs_mft::platform::DriveLetter, source_epoch: u64) -> ParkedBody {
     let bloom = Bloom::with_size_and_k(64, 7);
     let path_trie = PathTrie::build(&[], &[]);
     ParkedBody {
@@ -464,9 +464,16 @@ fn new_parked_has_no_body_and_shares_stats_and_parked_body() {
     stats.record_query();
     stats.record_query();
 
-    let parked_body = Arc::new(make_test_parked_body('C', 99));
-    let shard = ShardEntry::new_parked('C', Arc::clone(&stats), Arc::clone(&parked_body));
-    assert_eq!(shard.drive, 'C');
+    let parked_body = Arc::new(make_test_parked_body(
+        uffs_mft::platform::DriveLetter::C,
+        99,
+    ));
+    let shard = ShardEntry::new_parked(
+        uffs_mft::platform::DriveLetter::C,
+        Arc::clone(&stats),
+        Arc::clone(&parked_body),
+    );
+    assert_eq!(shard.drive, uffs_mft::platform::DriveLetter::C);
     assert_eq!(shard.state(), ShardState::Parked);
     assert!(shard.body().is_none());
 
@@ -481,7 +488,7 @@ fn new_parked_has_no_body_and_shares_stats_and_parked_body() {
     // same Arc, so the bloom / trie / epoch round-trip without copy.
     let from_shard = shard.parked_body().expect("parked shard has body");
     assert!(Arc::ptr_eq(&from_shard, &parked_body));
-    assert_eq!(from_shard.letter, 'C');
+    assert_eq!(from_shard.letter, uffs_mft::platform::DriveLetter::C);
     assert_eq!(from_shard.source_epoch, 99);
 }
 
@@ -490,8 +497,8 @@ fn new_parked_has_no_body_and_shares_stats_and_parked_body() {
 #[test]
 fn new_cold_has_no_body_and_shares_stats() {
     let stats = Arc::new(DriveStats::new());
-    let shard = ShardEntry::new_cold('D', Arc::clone(&stats));
-    assert_eq!(shard.drive, 'D');
+    let shard = ShardEntry::new_cold(uffs_mft::platform::DriveLetter::D, Arc::clone(&stats));
+    assert_eq!(shard.drive, uffs_mft::platform::DriveLetter::D);
     assert_eq!(shard.state(), ShardState::Cold);
     assert!(shard.body().is_none());
 
@@ -510,8 +517,8 @@ fn new_cold_has_no_body_and_shares_stats() {
 /// previous body.
 #[test]
 fn apply_usn_patch_to_body_returns_new_arc_on_warm() {
-    let body = Arc::new(make_test_body('C'));
-    let shard = ShardEntry::new_warm('C', Arc::clone(&body));
+    let body = Arc::new(make_test_body(uffs_mft::platform::DriveLetter::C));
+    let shard = ShardEntry::new_warm(uffs_mft::platform::DriveLetter::C, Arc::clone(&body));
 
     // Empty change batch — the method must still produce a fresh
     // Arc so the caller's swap path is exercised even on no-op ticks.
@@ -537,8 +544,8 @@ fn apply_usn_patch_to_body_returns_new_arc_on_warm() {
 #[test]
 fn apply_usn_patch_to_body_returns_none_on_parked() {
     let stats = Arc::new(DriveStats::new());
-    let parked_body = Arc::new(make_test_parked_body('C', 1));
-    let shard = ShardEntry::new_parked('C', stats, parked_body);
+    let parked_body = Arc::new(make_test_parked_body(uffs_mft::platform::DriveLetter::C, 1));
+    let shard = ShardEntry::new_parked(uffs_mft::platform::DriveLetter::C, stats, parked_body);
 
     let changes = vec![FileChange {
         frs: 10,
@@ -560,7 +567,7 @@ fn apply_usn_patch_to_body_returns_none_on_parked() {
 #[test]
 fn apply_usn_patch_to_body_returns_none_on_cold() {
     let stats = Arc::new(DriveStats::new());
-    let shard = ShardEntry::new_cold('C', stats);
+    let shard = ShardEntry::new_cold(uffs_mft::platform::DriveLetter::C, stats);
 
     let result = shard.apply_usn_patch_to_body(&[]);
     assert!(
@@ -577,8 +584,8 @@ fn apply_usn_patch_to_body_returns_none_on_cold() {
 /// `uffs_core::compact_loader::apply_usn_patch`.
 #[test]
 fn apply_usn_patch_to_body_lands_delete_on_new_arc() {
-    let body = Arc::new(make_test_body('C'));
-    let shard = ShardEntry::new_warm('C', Arc::clone(&body));
+    let body = Arc::new(make_test_body(uffs_mft::platform::DriveLetter::C));
+    let shard = ShardEntry::new_warm(uffs_mft::platform::DriveLetter::C, Arc::clone(&body));
 
     // FRS 10 → compact_idx 1 in the fixture's `frs_to_compact`
     // (populated by `make_test_body`); the test exercises the

--- a/crates/uffs-daemon/src/events.rs
+++ b/crates/uffs-daemon/src/events.rs
@@ -33,7 +33,7 @@ pub(crate) enum DaemonEvent {
     /// A single drive finished loading.
     DriveLoaded {
         /// Drive letter (e.g. 'C').
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
         /// Number of records in the drive index.
         records: usize,
         /// MFT parse time in milliseconds.
@@ -59,12 +59,12 @@ pub(crate) enum DaemonEvent {
     /// A drive refresh has started.
     RefreshStarted {
         /// Drives being refreshed.
-        drives: Vec<char>,
+        drives: Vec<uffs_mft::platform::DriveLetter>,
     },
     /// A single drive finished refreshing.
     DriveRefreshed {
         /// Drive letter.
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
         /// Updated record count.
         records: usize,
         /// MFT parse time in milliseconds.
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn event_to_json_line_produces_valid_jsonrpc_notification() {
         let event = DaemonEvent::DriveLoaded {
-            drive: 'C',
+            drive: uffs_mft::platform::DriveLetter::C,
             records: 3_400_000,
             mft_ms: 2100,
             compact_ms: 850,
@@ -291,7 +291,7 @@ mod tests {
                 version: "test".to_owned(),
             },
             DaemonEvent::DriveLoaded {
-                drive: 'D',
+                drive: uffs_mft::platform::DriveLetter::D,
                 records: 100,
                 mft_ms: 10,
                 compact_ms: 5,
@@ -305,10 +305,13 @@ mod tests {
                 startup_ms: 50,
             },
             DaemonEvent::RefreshStarted {
-                drives: vec!['C', 'D'],
+                drives: vec![
+                    uffs_mft::platform::DriveLetter::C,
+                    uffs_mft::platform::DriveLetter::D,
+                ],
             },
             DaemonEvent::DriveRefreshed {
-                drive: 'C',
+                drive: uffs_mft::platform::DriveLetter::C,
                 records: 200,
                 mft_ms: 20,
                 compact_ms: 10,
@@ -368,7 +371,7 @@ mod tests {
 
         // Emit two events
         tx.emit(DaemonEvent::DriveLoaded {
-            drive: 'C',
+            drive: uffs_mft::platform::DriveLetter::C,
             records: 100,
             mft_ms: 10,
             compact_ms: 5,

--- a/crates/uffs-daemon/src/handler.rs
+++ b/crates/uffs-daemon/src/handler.rs
@@ -417,8 +417,8 @@ impl RequestHandler {
             .and_then(|val| serde_json::from_value(val.clone()).ok())
             .unwrap_or_default();
 
-        let mut loaded: Vec<char> = Vec::new();
-        let mut already_loaded: Vec<char> = Vec::new();
+        let mut loaded: Vec<uffs_mft::platform::DriveLetter> = Vec::new();
+        let mut already_loaded: Vec<uffs_mft::platform::DriveLetter> = Vec::new();
         let mut errors: Vec<String> = Vec::new();
 
         // Hot-load by MFT file path.
@@ -431,12 +431,17 @@ impl RequestHandler {
             {
                 Ok(Some(letter)) => loaded.push(letter),
                 Ok(None) => {
-                    // Infer the letter for reporting.
+                    // Infer the drive letter from the file stem for
+                    // reporting.  Falls back to `DriveLetter::X` for
+                    // malformed filenames — matches the historical
+                    // `'?'` sentinel behaviour (rows get bucketed
+                    // under the "unknown" letter).
                     let letter = path
                         .file_name()
                         .and_then(|name| name.to_str())
                         .and_then(|stem| stem.chars().next())
-                        .map_or('?', |ch| ch.to_ascii_uppercase());
+                        .and_then(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
+                        .unwrap_or(uffs_mft::platform::DriveLetter::X);
                     already_loaded.push(letter);
                 }
                 Err(load_err) => {
@@ -451,7 +456,9 @@ impl RequestHandler {
             match self.index.hot_load_drive(letter, params.no_cache).await {
                 Ok(records) => {
                     tracing::info!(drive = %letter, records, "Drive hot-loaded via RPC");
-                    loaded.push(letter.to_ascii_uppercase());
+                    // `DriveLetter` is uppercase by construction; no
+                    // remap needed before push.
+                    loaded.push(letter);
                 }
                 Err(load_err) => {
                     errors.push(format!("{letter}: {load_err}"));
@@ -573,8 +580,8 @@ impl RequestHandler {
         }
         let pin_minutes = params.pin_minutes.unwrap_or(DEFAULT_PRELOAD_PIN_MINUTES);
 
-        let mut promoted: Vec<char> = Vec::new();
-        let mut already_hot: Vec<char> = Vec::new();
+        let mut promoted: Vec<uffs_mft::platform::DriveLetter> = Vec::new();
+        let mut already_hot: Vec<uffs_mft::platform::DriveLetter> = Vec::new();
         let mut errors: Vec<String> = Vec::new();
         let mut latest_pin_until_ms: i64 = 0;
 
@@ -582,11 +589,11 @@ impl RequestHandler {
             use crate::index::tiering_ops::PreloadOutcome;
             match self.index.preload_drive(letter, pin_minutes).await {
                 PreloadOutcome::Promoted { pin_until_ms, .. } => {
-                    promoted.push(letter.to_ascii_uppercase());
+                    promoted.push(letter);
                     latest_pin_until_ms = i64::try_from(pin_until_ms).unwrap_or(i64::MAX);
                 }
                 PreloadOutcome::AlreadyHot { pin_until_ms } => {
-                    already_hot.push(letter.to_ascii_uppercase());
+                    already_hot.push(letter);
                     latest_pin_until_ms = i64::try_from(pin_until_ms).unwrap_or(i64::MAX);
                 }
                 PreloadOutcome::UnknownDrive => {
@@ -655,16 +662,8 @@ impl RequestHandler {
             }
             ForgetOutcomeOrBusy::Ok(outcome) => {
                 let response = ForgetResponse {
-                    forgotten: outcome
-                        .forgotten
-                        .into_iter()
-                        .map(|letter| letter.to_ascii_uppercase())
-                        .collect(),
-                    already_absent: outcome
-                        .already_absent
-                        .into_iter()
-                        .map(|letter| letter.to_ascii_uppercase())
-                        .collect(),
+                    forgotten: outcome.forgotten,
+                    already_absent: outcome.already_absent,
                     freed_bytes: outcome.freed_bytes,
                     errors: outcome.errors,
                 };

--- a/crates/uffs-daemon/src/handler_blob.rs
+++ b/crates/uffs-daemon/src/handler_blob.rs
@@ -278,9 +278,17 @@ impl RequestHandler {
             return;
         };
 
+        // `uffs-format` is char-typed at its public API; convert
+        // the typed slice at the boundary so the format crate keeps
+        // its narrow no-`uffs-mft` dep (issue #216).
+        let drive_chars: Vec<char> = params
+            .output_drive_targets
+            .iter()
+            .map(|dl| dl.as_char())
+            .collect();
         let footer_ctx =
             Self::wants_custom_footer(params).then(|| uffs_format::DriveFooterContext {
-                output_targets: &params.output_drive_targets,
+                output_targets: &drive_chars,
                 pattern: &params.pattern,
                 row_count: rows.len(),
             });

--- a/crates/uffs-daemon/src/handler_csv_blob_tests.rs
+++ b/crates/uffs-daemon/src/handler_csv_blob_tests.rs
@@ -52,7 +52,12 @@ fn bare_response(rows: Vec<SearchRow>) -> SearchResponse {
 /// flags, timestamps).  The row's size is tuned per test via
 /// `size` so the produced blob can cross the 512 KB threshold on
 /// demand.
-fn sample_row(drive: char, path: String, name: String, size: u64) -> SearchRow {
+fn sample_row(
+    drive: uffs_mft::platform::DriveLetter,
+    path: String,
+    name: String,
+    size: u64,
+) -> SearchRow {
     SearchRow {
         drive,
         path,
@@ -80,7 +85,7 @@ fn sample_row(drive: char, path: String, name: String, size: u64) -> SearchRow {
 /// exact aggregated values that replace logical size / allocated
 /// on dir rows.
 fn sample_dir_row(
-    drive: char,
+    drive: uffs_mft::platform::DriveLetter,
     path: String,
     name: String,
     descendants: u32,
@@ -108,9 +113,24 @@ fn sample_dir_row(
 #[test]
 fn try_pack_csv_blob_happy_path_multi_column() {
     let rows = vec![
-        sample_row('C', "C:\\a\\f1.dll".to_owned(), "f1.dll".to_owned(), 1024),
-        sample_row('C', "C:\\a\\f2.dll".to_owned(), "f2.dll".to_owned(), 2048),
-        sample_row('D', "D:\\b\\f3.txt".to_owned(), "f3.txt".to_owned(), 4096),
+        sample_row(
+            uffs_mft::platform::DriveLetter::C,
+            "C:\\a\\f1.dll".to_owned(),
+            "f1.dll".to_owned(),
+            1024,
+        ),
+        sample_row(
+            uffs_mft::platform::DriveLetter::C,
+            "C:\\a\\f2.dll".to_owned(),
+            "f2.dll".to_owned(),
+            2048,
+        ),
+        sample_row(
+            uffs_mft::platform::DriveLetter::D,
+            "D:\\b\\f3.txt".to_owned(),
+            "f3.txt".to_owned(),
+            4096,
+        ),
     ];
     let mut response = bare_response(rows);
     let params = SearchParams {
@@ -165,7 +185,7 @@ fn try_pack_csv_blob_happy_path_multi_column() {
 #[test]
 fn try_pack_csv_blob_skips_json_response_mode() {
     let mut response = bare_response(vec![sample_row(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\a.dll".to_owned(),
         "a.dll".to_owned(),
         1024,
@@ -203,7 +223,7 @@ fn try_pack_csv_blob_skips_non_csv_format() {
         // stray-space value means the caller mangled the param
         // in-flight (e.g. a broken shell-quote round-trip).
         let mut response = bare_response(vec![sample_row(
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "C:\\a.dll".to_owned(),
             "a.dll".to_owned(),
             1024,
@@ -232,7 +252,7 @@ fn try_pack_csv_blob_skips_non_csv_format() {
 fn try_pack_csv_blob_accepts_explicit_csv_format() {
     for fmt in ["csv", "CSV", "Csv"] {
         let mut response = bare_response(vec![sample_row(
-            'C',
+            uffs_mft::platform::DriveLetter::C,
             "C:\\a.dll".to_owned(),
             "a.dll".to_owned(),
             1024,
@@ -261,7 +281,7 @@ fn try_pack_csv_blob_accepts_explicit_csv_format() {
 #[test]
 fn try_pack_csv_blob_skips_aggregations() {
     let mut response = bare_response(vec![sample_row(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\a.dll".to_owned(),
         "a.dll".to_owned(),
         1024,
@@ -297,7 +317,7 @@ fn try_pack_csv_blob_skips_aggregations() {
 #[test]
 fn try_pack_csv_blob_skips_when_output_file_set() {
     let mut response = bare_response(vec![sample_row(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\a.dll".to_owned(),
         "a.dll".to_owned(),
         1024,
@@ -335,7 +355,7 @@ fn try_pack_csv_blob_skips_when_output_file_set() {
 #[test]
 fn try_pack_csv_blob_accepts_columns_parity() {
     let mut response = bare_response(vec![sample_dir_row(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\Program Files\\app".to_owned(),
         "app".to_owned(),
         12,
@@ -392,7 +412,7 @@ fn try_pack_csv_blob_accepts_columns_parity() {
 #[test]
 fn try_pack_csv_blob_accepts_parity_compat_flag() {
     let mut response = bare_response(vec![sample_dir_row(
-        'D',
+        uffs_mft::platform::DriveLetter::D,
         "D:\\Users\\alice".to_owned(),
         "alice".to_owned(),
         3,
@@ -435,7 +455,7 @@ fn try_pack_csv_blob_accepts_parity_compat_flag() {
 #[test]
 fn try_pack_csv_blob_parity_forces_header_when_disabled() {
     let mut response = bare_response(vec![sample_row(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\a.txt".to_owned(),
         "a.txt".to_owned(),
         100,
@@ -472,7 +492,7 @@ fn try_pack_csv_blob_parity_forces_header_when_disabled() {
 #[test]
 fn try_pack_csv_blob_custom_appends_footer_when_drives_set() {
     let mut response = bare_response(vec![sample_row(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\one.txt".to_owned(),
         "one.txt".to_owned(),
         1,
@@ -482,7 +502,7 @@ fn try_pack_csv_blob_custom_appends_footer_when_drives_set() {
         projection: vec!["path".to_owned(), "name".to_owned()],
         output_columns: Some("path,name".to_owned()),
         output_format: Some("custom".to_owned()),
-        output_drive_targets: vec!['C'],
+        output_drive_targets: vec![uffs_mft::platform::DriveLetter::C],
         ..SearchParams::default()
     };
 
@@ -518,7 +538,7 @@ fn try_pack_csv_blob_custom_appends_footer_when_drives_set() {
 #[test]
 fn try_pack_csv_blob_custom_omits_footer_when_no_drives() {
     let mut response = bare_response(vec![sample_row(
-        'C',
+        uffs_mft::platform::DriveLetter::C,
         "C:\\one.txt".to_owned(),
         "one.txt".to_owned(),
         1,
@@ -589,7 +609,7 @@ fn try_pack_csv_blob_offloads_large_blob_to_shmem() {
                 "C:\\very_long_parent_folder_{idx:08}\\deeper_subfolder_with_padding\\file_{idx:010}.extension",
             );
             let name = format!("file_{idx:010}.extension");
-            sample_row('C', path, name, 1024)
+            sample_row(uffs_mft::platform::DriveLetter::C, path, name, 1024)
         })
         .collect();
 
@@ -683,8 +703,18 @@ fn try_pack_csv_blob_offloads_large_blob_to_shmem() {
 #[test]
 fn try_pack_csv_blob_skips_when_output_format_none() {
     let mut response = bare_response(vec![
-        sample_row('C', "C:\\a\\f1.dll".to_owned(), "f1.dll".to_owned(), 1024),
-        sample_row('C', "C:\\a\\f2.dll".to_owned(), "f2.dll".to_owned(), 2048),
+        sample_row(
+            uffs_mft::platform::DriveLetter::C,
+            "C:\\a\\f1.dll".to_owned(),
+            "f1.dll".to_owned(),
+            1024,
+        ),
+        sample_row(
+            uffs_mft::platform::DriveLetter::C,
+            "C:\\a\\f2.dll".to_owned(),
+            "f2.dll".to_owned(),
+            2048,
+        ),
     ]);
     let params = SearchParams {
         // Multi-column projection typical of MCP search

--- a/crates/uffs-daemon/src/handler_paths_blob_tests.rs
+++ b/crates/uffs-daemon/src/handler_paths_blob_tests.rs
@@ -23,7 +23,7 @@ use super::RequestHandler;
 /// because the packing loop only reads `row.path`.
 fn path_only_row(path: String) -> SearchRow {
     SearchRow {
-        drive: 'C',
+        drive: uffs_mft::platform::DriveLetter::C,
         path,
         name: String::new(),
         size: 0,

--- a/crates/uffs-daemon/src/index/aggregation.rs
+++ b/crates/uffs-daemon/src/index/aggregation.rs
@@ -230,7 +230,7 @@ pub(crate) struct AggregationRequest<'a> {
     /// disables name matching.
     pub pattern: Option<&'a str>,
     /// Subset of drive letters to include; empty = all drives.
-    pub drives_filter: &'a [char],
+    pub drives_filter: &'a [uffs_mft::platform::DriveLetter],
     /// O(1)-per-record predicates: extension IDs, directory flag,
     /// size bounds.  Defaults to "no filter" via
     /// [`AggregateFilter::default`].
@@ -287,12 +287,7 @@ impl IndexManager {
         let drive_refs: Vec<&uffs_core::compact::DriveCompactIndex> = snapshot
             .drives
             .iter()
-            .filter(|arc| {
-                drives_filter.is_empty()
-                    || drives_filter
-                        .iter()
-                        .any(|f| f.eq_ignore_ascii_case(&arc.letter))
-            })
+            .filter(|arc| drives_filter.is_empty() || drives_filter.contains(&arc.letter))
             .map(|arc| arc.as_ref())
             .collect();
         // ── Cache lookup ────────────────────────────────────────────
@@ -444,7 +439,7 @@ impl IndexManager {
     fn build_agg_cache_key(
         specs: &[uffs_core::aggregate::spec::AggregateSpec],
         pattern: Option<&str>,
-        drives_filter: &[char],
+        drives_filter: &[uffs_mft::platform::DriveLetter],
         record_filter: &uffs_core::aggregate::AggregateFilter,
         query_predicates: &[DrilldownPredicate],
     ) -> u64 {

--- a/crates/uffs-daemon/src/index/dispatch.rs
+++ b/crates/uffs-daemon/src/index/dispatch.rs
@@ -95,7 +95,7 @@ impl IndexManager {
     /// case, single read-lock acquisition only.
     pub(super) async fn ensure_warm_for_dispatch(
         &self,
-        params_drives: &[char],
+        params_drives: &[uffs_mft::platform::DriveLetter],
         ext_terms: &[String],
     ) {
         // ── Phase 1: read-lock detection (fast path) ───────────
@@ -110,16 +110,11 @@ impl IndexManager {
         // contract).  Cold shards drop their bloom on demote, so
         // they always promote.  Empty `ext_terms` short-circuits
         // to the Phase-3 always-promote behaviour.
-        let needs_promote: Vec<char> = {
+        let needs_promote: Vec<uffs_mft::platform::DriveLetter> = {
             let guard = self.index.read().await;
             guard
                 .iter()
-                .filter(|shard| {
-                    params_drives.is_empty()
-                        || params_drives
-                            .iter()
-                            .any(|filter| filter.eq_ignore_ascii_case(&shard.drive))
-                })
+                .filter(|shard| params_drives.is_empty() || params_drives.contains(&shard.drive))
                 .filter(|shard| {
                     matches!(
                         shard.state(),
@@ -225,10 +220,7 @@ impl IndexManager {
                 // (single-store, no queries_total bump) so the
                 // per-drive query count stays accurate.
                 let now_ms = unix_now_ms();
-                if let Some(shard) = new_registry
-                    .iter()
-                    .find(|shard| shard.drive.eq_ignore_ascii_case(&letter))
-                {
+                if let Some(shard) = new_registry.iter().find(|shard| shard.drive == letter) {
                     shard.stats.mark_loaded_at(now_ms);
                 }
                 *guard = Arc::new(new_registry);
@@ -280,7 +272,7 @@ impl IndexManager {
         in_flight: InFlightPromotes,
         loader: Arc<dyn crate::cache::body_loader::BodyLoader>,
         prefetch: Arc<dyn crate::cache::prefetch::Prefetch>,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
     ) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
         // The synchronous slot lookup + install lives in its own
         // helper so the `MutexGuard` it acquires is naturally scoped
@@ -309,7 +301,7 @@ impl IndexManager {
         in_flight: &InFlightPromotes,
         loader: &Arc<dyn crate::cache::body_loader::BodyLoader>,
         prefetch: &Arc<dyn crate::cache::prefetch::Prefetch>,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
     ) -> InFlightLoad {
         use std::collections::hash_map::Entry;
 
@@ -385,7 +377,7 @@ impl IndexManager {
     async fn build_load_future(
         loader: Arc<dyn crate::cache::body_loader::BodyLoader>,
         prefetch: Arc<dyn crate::cache::prefetch::Prefetch>,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
     ) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
         // `catch_unwind` lives in `std` (needs the unwinding
         // runtime); `AssertUnwindSafe` lives in `core` (the

--- a/crates/uffs-daemon/src/index/forget_drive.rs
+++ b/crates/uffs-daemon/src/index/forget_drive.rs
@@ -52,11 +52,11 @@ use crate::cache::{ShardState, unix_now_ms};
 pub(crate) struct ForgetOutcome {
     /// Drives whose cache files were deleted in this call (any
     /// `freed_bytes > 0`).
-    pub forgotten: Vec<char>,
+    pub forgotten: Vec<uffs_mft::platform::DriveLetter>,
     /// Drives that had no cache files on disk and weren't loaded in
     /// the registry (idempotent no-op, e.g. a re-run after a previous
     /// successful `forget`).
-    pub already_absent: Vec<char>,
+    pub already_absent: Vec<uffs_mft::platform::DriveLetter>,
     /// Cumulative bytes freed across every successfully-forgotten
     /// drive.
     pub freed_bytes: u64,
@@ -85,7 +85,7 @@ pub(crate) enum ForgetOutcomeOrBusy {
     /// All-or-nothing refusal: one or more drives are non-`Cold`
     /// and `force` was `false`.  Vec carries `(letter, current_tier)`
     /// for every refused drive in registry order.
-    Busy(Vec<(char, ShardState)>),
+    Busy(Vec<(uffs_mft::platform::DriveLetter, ShardState)>),
 }
 
 impl IndexManager {
@@ -103,20 +103,25 @@ impl IndexManager {
     /// Returns [`ForgetOutcomeOrBusy::Busy`] when the all-or-nothing
     /// refusal triggers; otherwise [`ForgetOutcomeOrBusy::Ok`] with
     /// the populated [`ForgetOutcome`].
-    pub(crate) async fn forget_drives(&self, drives: &[char], force: bool) -> ForgetOutcomeOrBusy {
+    pub(crate) async fn forget_drives(
+        &self,
+        drives: &[uffs_mft::platform::DriveLetter],
+        force: bool,
+    ) -> ForgetOutcomeOrBusy {
         // ── Phase 1: read-lock detect ──────────────────────────────
         //
         // Enumerate (letter, current_tier) tuples for every requested
         // drive.  Drives not in the registry record `None` so the
         // cleaner phase still gets a chance to remove stale on-disk
         // files (idempotent re-run semantics).
-        let mut snapshots: Vec<(char, Option<ShardState>)> = Vec::with_capacity(drives.len());
-        let mut busy: Vec<(char, ShardState)> = Vec::new();
+        let mut snapshots: Vec<(uffs_mft::platform::DriveLetter, Option<ShardState>)> =
+            Vec::with_capacity(drives.len());
+        let mut busy: Vec<(uffs_mft::platform::DriveLetter, ShardState)> = Vec::new();
         let guard = self.index.read().await;
         for &requested in drives {
             let found = guard
                 .iter()
-                .find(|shard| shard.drive.eq_ignore_ascii_case(&requested))
+                .find(|shard| shard.drive == requested)
                 .map(|shard| (shard.drive, shard.state()));
             match found {
                 Some((drive, state)) => {
@@ -168,7 +173,10 @@ impl IndexManager {
     /// `hibernate_shards`'s per-letter rebuild pattern).  Pins are
     /// cleared implicitly — the rebuilt `ShardEntry` starts at
     /// `pin_until_ms = 0`.
-    async fn auto_hibernate_for_forget(&self, snapshots: &[(char, Option<ShardState>)]) {
+    async fn auto_hibernate_for_forget(
+        &self,
+        snapshots: &[(uffs_mft::platform::DriveLetter, Option<ShardState>)],
+    ) {
         for &(drive, state_opt) in snapshots {
             let Some(state) = state_opt else {
                 continue;
@@ -201,7 +209,11 @@ impl IndexManager {
     /// Classifies the result into [`ForgetOutcome::forgotten`] /
     /// [`ForgetOutcome::already_absent`] / [`ForgetOutcome::errors`]
     /// per the rules documented on [`ForgetOutcome`] above.
-    async fn forget_one(&self, letter: char, outcome: &mut ForgetOutcome) {
+    async fn forget_one(
+        &self,
+        letter: uffs_mft::platform::DriveLetter,
+        outcome: &mut ForgetOutcome,
+    ) {
         // Step 1: evict from registry (idempotent — `remove` is a
         // no-op when the letter isn't present).
         let mut guard = self.index.write().await;

--- a/crates/uffs-daemon/src/index/hotload.rs
+++ b/crates/uffs-daemon/src/index/hotload.rs
@@ -36,7 +36,7 @@ impl IndexManager {
         &self,
         mft_path: &std::path::Path,
         no_cache: bool,
-    ) -> anyhow::Result<Option<char>> {
+    ) -> anyhow::Result<Option<uffs_mft::platform::DriveLetter>> {
         let letter = Self::infer_drive_letter(mft_path);
 
         // Skip if already loaded.
@@ -69,15 +69,17 @@ impl IndexManager {
     /// Derive the drive letter from a `.mft` / `.iocp` snapshot path.
     ///
     /// Convention: the first ASCII-alphabetic character of the file
-    /// stem (e.g. `G_mft.iocp` → `'G'`).  Falls back to `'X'` for
-    /// non-conforming names so the caller still gets a stable handle
-    /// to log against rather than an `Option`.
-    pub(super) fn infer_drive_letter(mft_path: &std::path::Path) -> char {
+    /// stem (e.g. `G_mft.iocp` → `DriveLetter::G`).  Falls back to
+    /// `DriveLetter::X` for non-conforming names so the caller still
+    /// gets a stable handle to log against rather than an `Option`.
+    pub(super) fn infer_drive_letter(
+        mft_path: &std::path::Path,
+    ) -> uffs_mft::platform::DriveLetter {
         let stem = mft_path.file_name().and_then(|n| n.to_str()).unwrap_or("X");
         stem.chars()
             .next()
-            .filter(char::is_ascii_alphabetic)
-            .map_or('X', |ch| ch.to_ascii_uppercase())
+            .and_then(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
+            .unwrap_or(uffs_mft::platform::DriveLetter::X)
     }
 
     /// Fold the `JoinError`/`anyhow::Error` ladder of a hot-load
@@ -89,7 +91,7 @@ impl IndexManager {
     /// caller can surface it to the RPC layer.
     async fn apply_hot_load_result(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         mft_path: &std::path::Path,
         result: Result<
             anyhow::Result<(
@@ -98,7 +100,7 @@ impl IndexManager {
             )>,
             tokio::task::JoinError,
         >,
-    ) -> anyhow::Result<Option<char>> {
+    ) -> anyhow::Result<Option<uffs_mft::platform::DriveLetter>> {
         match result {
             Ok(Ok((drive_index, timing))) => {
                 let records = drive_index.records.len();
@@ -153,10 +155,10 @@ impl IndexManager {
     /// Returns `Ok(records)` on success.
     pub(crate) async fn hot_load_drive(
         &self,
-        drive_letter: char,
+        drive_letter: uffs_mft::platform::DriveLetter,
         no_cache: bool,
     ) -> anyhow::Result<usize> {
-        let letter = drive_letter.to_ascii_uppercase();
+        let letter = drive_letter;
 
         if self.is_drive_loaded(letter).await {
             tracing::info!(drive = %letter, "Drive already loaded — will hot-swap after re-read");
@@ -179,7 +181,7 @@ impl IndexManager {
     }
 
     /// Check whether a drive letter is already in the index.
-    async fn is_drive_loaded(&self, letter: char) -> bool {
+    async fn is_drive_loaded(&self, letter: uffs_mft::platform::DriveLetter) -> bool {
         let guard = self.index.read().await;
         guard.contains(letter)
     }
@@ -208,7 +210,10 @@ impl IndexManager {
                       non-Windows path needs &self.data_dir and propagates Result"
         )
     )]
-    fn resolve_drive_source(&self, letter: char) -> anyhow::Result<uffs_core::compact::MftSource> {
+    fn resolve_drive_source(
+        &self,
+        letter: uffs_mft::platform::DriveLetter,
+    ) -> anyhow::Result<uffs_core::compact::MftSource> {
         #[cfg(windows)]
         {
             Ok(uffs_core::compact::MftSource::Live(letter))
@@ -220,7 +225,9 @@ impl IndexManager {
                     "No data_dir configured — cannot load drive {letter}: on non-Windows"
                 )
             })?;
-            let drive_subdir = data_dir.join(format!("drive_{}", letter.to_ascii_lowercase()));
+            // Path convention: lowercase `drive_<x>` subdir.
+            let drive_lower = letter.as_char().to_ascii_lowercase();
+            let drive_subdir = data_dir.join(format!("drive_{drive_lower}"));
             let mft_path =
                 uffs_mft::discovery::find_best_mft_file(&drive_subdir).ok_or_else(|| {
                     anyhow::anyhow!("No MFT file found in {}", drive_subdir.display())
@@ -254,7 +261,7 @@ impl IndexManager {
     /// Emit a `DriveLoaded` event for a single hot-loaded drive.
     fn emit_drive_loaded(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         records: usize,
         timing: &uffs_core::compact::LoadTiming,
     ) {
@@ -275,7 +282,11 @@ impl IndexManager {
     }
 
     /// Persist per-drive load timing for `--profile` reporting.
-    async fn store_drive_timing(&self, letter: char, timing: &uffs_core::compact::LoadTiming) {
+    async fn store_drive_timing(
+        &self,
+        letter: uffs_mft::platform::DriveLetter,
+        timing: &uffs_core::compact::LoadTiming,
+    ) {
         self.drive_timings
             .write()
             .await
@@ -293,14 +304,16 @@ impl IndexManager {
     /// `Ok(false)` if no MFT file was found for it, or an error.
     pub(crate) async fn discover_and_load_drive(
         &self,
-        drive_letter: char,
+        drive_letter: uffs_mft::platform::DriveLetter,
         no_cache: bool,
     ) -> anyhow::Result<bool> {
         let Some(data_dir) = &self.data_dir else {
             return Ok(false);
         };
 
-        let drive_lower = drive_letter.to_ascii_lowercase();
+        // Path convention: lowercase `drive_<x>` subdir.  `DriveLetter`
+        // is canonical uppercase, so convert at the path boundary.
+        let drive_lower = drive_letter.as_char().to_ascii_lowercase();
         let drive_subdir = data_dir.join(format!("drive_{drive_lower}"));
 
         if !drive_subdir.is_dir() {
@@ -332,16 +345,20 @@ impl IndexManager {
     ///
     /// Returns a list of drive letters that could NOT be loaded (no data
     /// source found).
-    pub(crate) async fn ensure_drives_loaded(&self, drives: &[char], no_cache: bool) -> Vec<char> {
+    pub(crate) async fn ensure_drives_loaded(
+        &self,
+        drives: &[uffs_mft::platform::DriveLetter],
+        no_cache: bool,
+    ) -> Vec<uffs_mft::platform::DriveLetter> {
         if drives.is_empty() {
             return Vec::new();
         }
 
         let loaded = self.loaded_drive_letters().await;
-        let mut missing: Vec<char> = Vec::new();
+        let mut missing: Vec<uffs_mft::platform::DriveLetter> = Vec::new();
 
         for &letter in drives {
-            let upper = letter.to_ascii_uppercase();
+            let upper = letter;
             if loaded.contains(&upper) {
                 continue;
             }
@@ -359,7 +376,11 @@ impl IndexManager {
     /// fresh discovery), `false` when no data source was found or the
     /// load failed.  Each branch is traced at its appropriate level so
     /// callers can stay flat.
-    async fn try_auto_discover_drive(&self, letter: char, no_cache: bool) -> bool {
+    async fn try_auto_discover_drive(
+        &self,
+        letter: uffs_mft::platform::DriveLetter,
+        no_cache: bool,
+    ) -> bool {
         match self.discover_and_load_drive(letter, no_cache).await {
             Ok(true) => {
                 tracing::info!(drive = %letter, "Auto-discovered and loaded missing drive");

--- a/crates/uffs-daemon/src/index/info.rs
+++ b/crates/uffs-daemon/src/index/info.rs
@@ -25,8 +25,8 @@
 //!    `Option<Value>` in [`InfoResponse`].
 //! 2. [`Self::info_tree_lookup`] — the synchronous walker.  Drives the parse +
 //!    segment-by-segment match.
-//! 3. [`Self::parse_drive_prefix`] — helper that splits `"C:\\foo"` into `('C',
-//!    "foo")`.
+//! 3. [`Self::parse_drive_prefix`] — helper that splits `"C:\\foo"` into
+//!    `(uffs_mft::platform::DriveLetter::C, "foo")`.
 //! 4. [`Self::build_info_json`] — turns a matching
 //!    [`uffs_core::compact::CompactRecord`] into the JSON payload the response
 //!    carries.
@@ -61,7 +61,8 @@ impl IndexManager {
     /// Fast tree-walk lookup: parse path → drive letter + segments, then
     /// walk `children` index matching each segment case-insensitively.
     fn info_tree_lookup(snap: &DriveIndex, file_path: &str) -> Option<serde_json::Value> {
-        // Parse "C:\Windows\System32\notepad.exe" → ('C', ["Windows", "System32",
+        // Parse "C:\Windows\System32\notepad.exe" →
+        // (uffs_mft::platform::DriveLetter::C, ["Windows", "System32",
         // "notepad.exe"])
         let normalized = file_path.replace('/', "\\");
         let (drive_letter, remainder) = Self::parse_drive_prefix(&normalized)?;
@@ -75,10 +76,7 @@ impl IndexManager {
         }
 
         // Find the matching drive.
-        let drive = snap
-            .drives
-            .iter()
-            .find(|dr| dr.letter.eq_ignore_ascii_case(&drive_letter))?;
+        let drive = snap.drives.iter().find(|dr| dr.letter == drive_letter)?;
 
         // Find root entries (parent_idx == u32::MAX) as starting candidates.
         let mut candidates: Vec<u32> = Vec::new();
@@ -150,12 +148,10 @@ impl IndexManager {
     }
 
     /// Parse `C:\...` or `c:/...` into `(drive_letter, remainder)`.
-    fn parse_drive_prefix(path: &str) -> Option<(char, &str)> {
+    fn parse_drive_prefix(path: &str) -> Option<(uffs_mft::platform::DriveLetter, &str)> {
         let mut chars = path.chars();
-        let letter = chars.next()?;
-        if !letter.is_ascii_alphabetic() {
-            return None;
-        }
+        let letter_ch = chars.next()?;
+        let letter = uffs_mft::platform::DriveLetter::parse(letter_ch).ok()?;
         if chars.next()? != ':' {
             return None;
         }

--- a/crates/uffs-daemon/src/index/journal.rs
+++ b/crates/uffs-daemon/src/index/journal.rs
@@ -57,8 +57,13 @@ use crate::cache::journal_loop::JournalLoopHandle;
 /// handling pattern in this crate (per the `in_flight_promotes`
 /// field doc rationale).
 fn lock_journal_handles(
-    map: &std::sync::Mutex<std::collections::HashMap<char, JournalLoopHandle>>,
-) -> std::sync::MutexGuard<'_, std::collections::HashMap<char, JournalLoopHandle>> {
+    map: &std::sync::Mutex<
+        std::collections::HashMap<uffs_mft::platform::DriveLetter, JournalLoopHandle>,
+    >,
+) -> std::sync::MutexGuard<
+    '_,
+    std::collections::HashMap<uffs_mft::platform::DriveLetter, JournalLoopHandle>,
+> {
     map.lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
@@ -94,7 +99,11 @@ impl IndexManager {
     /// `false` is **not** an error to propagate — the caller logs
     /// at warn/debug level depending on whether the failure was a
     /// real I/O error or just a benign demote race.
-    pub(crate) async fn handle_journal_refresh(&self, letter: char, reason: &str) -> bool {
+    pub(crate) async fn handle_journal_refresh(
+        &self,
+        letter: uffs_mft::platform::DriveLetter,
+        reason: &str,
+    ) -> bool {
         // Heavy work: live MFT read + USN replay + compact rebuild.
         // Runs on the blocking pool so the runtime's worker threads
         // stay free to service search RPCs concurrent with the refresh.
@@ -148,7 +157,7 @@ impl IndexManager {
     ///     returns `false`).
     pub(crate) async fn handle_journal_save(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         reason: &str,
         changes: Vec<FileChange>,
     ) -> bool {
@@ -194,7 +203,7 @@ impl IndexManager {
     /// snapshot observing the pre-tick state.
     async fn snapshot_shard_for_letter(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
     ) -> Option<Arc<crate::cache::shard::ShardEntry>> {
         let guard = self.index.read().await;
         guard.iter().find(|entry| entry.drive == letter).cloned()
@@ -215,7 +224,7 @@ impl IndexManager {
     async fn run_surgical_patch_task(
         &self,
         shard: &Arc<crate::cache::shard::ShardEntry>,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         reason: &str,
         changes: Vec<FileChange>,
     ) -> PatchTaskOutcome {
@@ -240,7 +249,11 @@ impl IndexManager {
     /// happens in the production flow because each drive is loaded
     /// exactly once before this method fires), the previous handle
     /// is **cancelled** so the orphaned loop tears down cleanly.
-    pub(crate) fn attach_journal_handle(&self, letter: char, handle: JournalLoopHandle) {
+    pub(crate) fn attach_journal_handle(
+        &self,
+        letter: uffs_mft::platform::DriveLetter,
+        handle: JournalLoopHandle,
+    ) {
         let mut guard = lock_journal_handles(&self.journal_handles);
         if let Some(previous) = guard.insert(letter, handle) {
             tracing::warn!(
@@ -264,7 +277,7 @@ impl IndexManager {
     /// — a benign race that we log at debug-level and absorb.
     async fn apply_journal_body(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         reason: &str,
         body: Arc<uffs_core::compact::DriveCompactIndex>,
     ) -> bool {
@@ -297,7 +310,7 @@ impl IndexManager {
 /// batches; the surgical patch short-circuits to a debug-log no-op
 /// so the journal loop's cursor still advances and the per-shard
 /// save trigger resets.
-fn log_save_empty_batch(letter: char, reason: &str) {
+fn log_save_empty_batch(letter: uffs_mft::platform::DriveLetter, reason: &str) {
     tracing::debug!(
         target: "shard.journal",
         drive = %letter,
@@ -313,7 +326,7 @@ fn log_save_empty_batch(letter: char, reason: &str) {
 /// has been registered via `add_drive` before its journal loop
 /// starts.  Reaching this arm indicates a startup-ordering bug or
 /// an out-of-order drive eject, both worth surfacing.
-fn log_save_no_shard(letter: char, reason: &str, change_count: usize) {
+fn log_save_no_shard(letter: uffs_mft::platform::DriveLetter, reason: &str, change_count: usize) {
     tracing::debug!(
         target: "shard.journal",
         drive = %letter,
@@ -330,7 +343,11 @@ fn log_save_no_shard(letter: char, reason: &str, change_count: usize) {
 /// surgical-patch blocking task.  The next promote re-reads the
 /// on-disk body which a previous patch tick already updated, so
 /// the per-shard drift is bounded by the per-shard save cadence.
-fn log_save_shard_demoted(letter: char, reason: &str, change_count: usize) {
+fn log_save_shard_demoted(
+    letter: uffs_mft::platform::DriveLetter,
+    reason: &str,
+    change_count: usize,
+) {
     tracing::debug!(
         target: "shard.journal",
         drive = %letter,
@@ -345,7 +362,7 @@ fn log_save_shard_demoted(letter: char, reason: &str, change_count: usize) {
 /// stats so operators can grep for the surgical-patch tick rate
 /// and the create / delete / rename / skip mix per drive.
 fn log_save_patch_applied(
-    letter: char,
+    letter: uffs_mft::platform::DriveLetter,
     reason: &str,
     change_count: usize,
     stats: &uffs_core::compact_loader::PatchStats,
@@ -380,7 +397,10 @@ fn log_save_patch_applied(
 /// failure for operator visibility.  The next save tick re-attempts
 /// from the latest in-memory body, so transient disk errors heal
 /// themselves.
-fn spawn_compact_cache_save_task(letter: char, body: Arc<uffs_core::compact::DriveCompactIndex>) {
+fn spawn_compact_cache_save_task(
+    letter: uffs_mft::platform::DriveLetter,
+    body: Arc<uffs_core::compact::DriveCompactIndex>,
+) {
     let _save_join = tokio::task::spawn_blocking(move || {
         if let Err(err) = uffs_core::compact_cache::save_compact_cache_background(&body) {
             tracing::warn!(
@@ -436,7 +456,7 @@ fn classify_patch_result(
         )>,
         tokio::task::JoinError,
     >,
-    letter: char,
+    letter: uffs_mft::platform::DriveLetter,
     reason: &str,
     change_count: usize,
 ) -> PatchTaskOutcome {
@@ -479,7 +499,7 @@ fn unwrap_refreshed_body(
         )>,
         tokio::task::JoinError,
     >,
-    letter: char,
+    letter: uffs_mft::platform::DriveLetter,
     reason: &str,
 ) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
     match body_result {

--- a/crates/uffs-daemon/src/index/loading.rs
+++ b/crates/uffs-daemon/src/index/loading.rs
@@ -229,7 +229,7 @@ impl IndexManager {
     )]
     pub(crate) async fn load_live_drives(
         &self,
-        drives: &[char],
+        drives: &[uffs_mft::platform::DriveLetter],
         no_cache: bool,
         lifecycle: &crate::lifecycle::LifecycleHandle,
     ) {
@@ -272,10 +272,10 @@ impl IndexManager {
         reason = "[diag] diagnostic tracing — remove after D: drive issue is resolved"
     )]
     fn spawn_drive_loaders(
-        drives: &[char],
+        drives: &[uffs_mft::platform::DriveLetter],
         no_cache: bool,
     ) -> tokio::task::JoinSet<(
-        char,
+        uffs_mft::platform::DriveLetter,
         anyhow::Result<(
             uffs_core::compact::DriveCompactIndex,
             uffs_core::compact::LoadTiming,
@@ -307,7 +307,7 @@ impl IndexManager {
     async fn collect_drive_load_results(
         &self,
         mut join_set: tokio::task::JoinSet<(
-            char,
+            uffs_mft::platform::DriveLetter,
             anyhow::Result<(
                 uffs_core::compact::DriveCompactIndex,
                 uffs_core::compact::LoadTiming,
@@ -376,7 +376,7 @@ impl IndexManager {
         &self,
         join_result: Result<
             (
-                char,
+                uffs_mft::platform::DriveLetter,
                 anyhow::Result<(
                     uffs_core::compact::DriveCompactIndex,
                     uffs_core::compact::LoadTiming,
@@ -412,7 +412,7 @@ impl IndexManager {
     #[cfg(windows)]
     async fn install_loaded_drive(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         drive_index: uffs_core::compact::DriveCompactIndex,
         timing: uffs_core::compact::LoadTiming,
         loaded: usize,
@@ -518,10 +518,7 @@ impl IndexManager {
         // mounted shard so the demote-controller's idle clock starts
         // ticking from now, not from epoch zero.  See
         // `DriveStats::mark_loaded_at` doc.
-        if let Some(shard) = new_registry
-            .iter()
-            .find(|shard| shard.drive.eq_ignore_ascii_case(&letter))
-        {
+        if let Some(shard) = new_registry.iter().find(|shard| shard.drive == letter) {
             shard.stats.mark_loaded_at(now_ms);
         }
         *guard = Arc::new(new_registry);
@@ -537,7 +534,7 @@ impl IndexManager {
     /// computed against the pre-refresh snapshot.
     pub(super) async fn replace_drive(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         new_drive: uffs_core::compact::DriveCompactIndex,
     ) {
         let body = Arc::new(new_drive);
@@ -551,10 +548,7 @@ impl IndexManager {
         // The replaced shard gets a fresh `Arc<DriveStats>` (replace
         // builds a new ShardEntry), so we don't need to preserve any
         // older counters here.
-        if let Some(shard) = new_registry
-            .iter()
-            .find(|shard| shard.drive.eq_ignore_ascii_case(&canonical))
-        {
+        if let Some(shard) = new_registry.iter().find(|shard| shard.drive == canonical) {
             shard.stats.mark_loaded_at(now_ms);
         }
         *guard = Arc::new(new_registry);

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -77,7 +77,8 @@ type InFlightLoad = Shared<BoxFuture<'static, Option<Arc<uffs_core::compact::Dri
 /// `HashMap` stores no invariants that need recovery, so we recover
 /// the inner state via [`std::sync::PoisonError::into_inner`] rather
 /// than panicking on poisoning.
-type InFlightPromotes = Arc<StdMutex<std::collections::HashMap<char, InFlightLoad>>>;
+type InFlightPromotes =
+    Arc<StdMutex<std::collections::HashMap<uffs_mft::platform::DriveLetter, InFlightLoad>>>;
 
 /// Per-drive load timing stored for profile reporting.
 ///
@@ -176,7 +177,8 @@ pub(crate) struct IndexManager {
     /// Duration from daemon start to `Ready` (microseconds, set once).
     startup_duration_us: AtomicU64,
     /// Per-drive load timing for `--profile` reporting.
-    drive_timings: RwLock<std::collections::HashMap<char, StoredDriveTiming>>,
+    drive_timings:
+        RwLock<std::collections::HashMap<uffs_mft::platform::DriveLetter, StoredDriveTiming>>,
     /// Source for `Parked` / `Cold` shard bodies during
     /// promote-on-search.  Production paths use
     /// [`crate::cache::body_loader::DiskBodyLoader`]; the
@@ -303,7 +305,12 @@ pub(crate) struct IndexManager {
     /// [`JournalLoopHandle`]: crate::cache::journal_loop::JournalLoopHandle
     /// [`watch::Sender`]: tokio::sync::watch::Sender
     journal_handles: Arc<
-        StdMutex<std::collections::HashMap<char, crate::cache::journal_loop::JournalLoopHandle>>,
+        StdMutex<
+            std::collections::HashMap<
+                uffs_mft::platform::DriveLetter,
+                crate::cache::journal_loop::JournalLoopHandle,
+            >,
+        >,
     >,
     /// Parsed `daemon.toml` (Phase 6).  Loaded once at
     /// [`crate::run_daemon`] startup via
@@ -527,7 +534,7 @@ impl IndexManager {
     /// Cold).  Pre-Phase-3 this matched the active-index drive list
     /// exactly; post-Phase-3 it can include shards whose body has been
     /// dropped.
-    pub(crate) async fn loaded_drive_letters(&self) -> Vec<char> {
+    pub(crate) async fn loaded_drive_letters(&self) -> Vec<uffs_mft::platform::DriveLetter> {
         let guard = self.index.read().await;
         guard.loaded_letters()
     }

--- a/crates/uffs-daemon/src/index/refresh.rs
+++ b/crates/uffs-daemon/src/index/refresh.rs
@@ -33,8 +33,8 @@ use crate::events::DaemonEvent;
 
 impl IndexManager {
     /// Refresh specific drives (or all if empty).
-    pub(crate) async fn refresh(&self, drives: &[char]) {
-        let drives_to_refresh: Vec<char> = if drives.is_empty() {
+    pub(crate) async fn refresh(&self, drives: &[uffs_mft::platform::DriveLetter]) {
+        let drives_to_refresh: Vec<uffs_mft::platform::DriveLetter> = if drives.is_empty() {
             let snap = self.snapshot().await;
             snap.drives.iter().map(|dr| dr.letter).collect()
         } else {
@@ -72,7 +72,7 @@ impl IndexManager {
     /// shared index on success, and traces the outcome of every arm
     /// of the resulting `Result<Result<_, _>, JoinError>`.  Caller
     /// holds no locks across the await points.
-    async fn refresh_one_drive(&self, letter: char) {
+    async fn refresh_one_drive(&self, letter: uffs_mft::platform::DriveLetter) {
         let Some(source) = self.lookup_drive_source(letter).await else {
             tracing::warn!(drive = %letter, "Drive not found for refresh");
             return;
@@ -101,7 +101,7 @@ impl IndexManager {
     /// matching error trace.
     async fn apply_refresh_result(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         result: Result<
             anyhow::Result<(
                 uffs_core::compact::DriveCompactIndex,
@@ -128,7 +128,10 @@ impl IndexManager {
     /// Returned by clone so the caller can hand the source to
     /// `spawn_blocking` without keeping the read guard alive across
     /// the await.
-    async fn lookup_drive_source(&self, letter: char) -> Option<uffs_core::compact::IndexSource> {
+    async fn lookup_drive_source(
+        &self,
+        letter: uffs_mft::platform::DriveLetter,
+    ) -> Option<uffs_core::compact::IndexSource> {
         let snap = self.snapshot().await;
         snap.drives
             .iter()
@@ -142,7 +145,7 @@ impl IndexManager {
     /// stay in lockstep with the index.
     async fn apply_refresh_success(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         new_drive: uffs_core::compact::DriveCompactIndex,
         timing: &uffs_core::compact::LoadTiming,
     ) {
@@ -177,7 +180,7 @@ impl IndexManager {
     /// [`MftSource`]: uffs_core::compact::MftSource
     fn resolve_refresh_mft_source(
         mft_path: &std::path::Path,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
     ) -> uffs_core::compact::MftSource {
         if Self::is_live_drive_marker(mft_path) {
             #[cfg(windows)]

--- a/crates/uffs-daemon/src/index/search.rs
+++ b/crates/uffs-daemon/src/index/search.rs
@@ -178,7 +178,7 @@ impl IndexManager {
         let lock_us = t_lock.map_or(0, |ts| ts.elapsed().as_micros());
 
         // Snapshot per-drive info (only when profiling).
-        let drive_info: Vec<(char, usize)> = if profiling {
+        let drive_info: Vec<(uffs_mft::platform::DriveLetter, usize)> = if profiling {
             snapshot.drive_summary()
         } else {
             Vec::new()
@@ -321,8 +321,8 @@ impl IndexManager {
         // measurements.  One pass over `filtered_rows` with a
         // pre-sized hash map keeps the complexity at O(rows) and
         // makes the profiling cost independent of drive count.
-        let drive_match_counts: Vec<(char, usize)> = if profiling {
-            let mut tally: std::collections::HashMap<char, usize> =
+        let drive_match_counts: Vec<(uffs_mft::platform::DriveLetter, usize)> = if profiling {
+            let mut tally: std::collections::HashMap<uffs_mft::platform::DriveLetter, usize> =
                 std::collections::HashMap::with_capacity(drive_info.len().max(1));
             for row in &filtered_rows {
                 *tally.entry(row.drive).or_insert(0) += 1;
@@ -564,8 +564,8 @@ impl IndexManager {
         row_build_us: u128,
         write_us: u128,
         phase_timings: Option<PhaseTimings>,
-        drive_info: &[(char, usize)],
-        drive_match_counts: &[(char, usize)],
+        drive_info: &[(uffs_mft::platform::DriveLetter, usize)],
+        drive_match_counts: &[(uffs_mft::platform::DriveLetter, usize)],
     ) -> SearchProfile {
         let timings = self.drive_timings.read().await;
         let startup_us = self.startup_duration_us.load(Ordering::Relaxed);

--- a/crates/uffs-daemon/src/index/status_drives.rs
+++ b/crates/uffs-daemon/src/index/status_drives.rs
@@ -56,11 +56,9 @@ impl IndexManager {
             drop(guard);
             rows
         };
-        drives.sort_by(|lhs, rhs| {
-            lhs.letter
-                .to_ascii_uppercase()
-                .cmp(&rhs.letter.to_ascii_uppercase())
-        });
+        // `DriveLetter` is canonical uppercase, so sort-by-letter is
+        // case-insensitive by construction.
+        drives.sort_by_key(|row| row.letter);
         StatusDrivesResponse { drives }
     }
 }

--- a/crates/uffs-daemon/src/index/test_helpers.rs
+++ b/crates/uffs-daemon/src/index/test_helpers.rs
@@ -39,7 +39,9 @@ impl IndexManager {
     /// Test-only escape hatch so integration tests in `crate::index::tests`
     /// can verify the [`Self::record_search_dispatch`] wiring without
     /// exposing the registry to production callers.
-    pub(crate) async fn shard_query_totals_for_test(&self) -> Vec<(char, u64)> {
+    pub(crate) async fn shard_query_totals_for_test(
+        &self,
+    ) -> Vec<(uffs_mft::platform::DriveLetter, u64)> {
         let guard = self.index.read().await;
         guard
             .iter()
@@ -59,7 +61,7 @@ impl IndexManager {
     /// legal), `false` otherwise (unknown letter or illegal target).
     pub(crate) async fn demote_letter_for_test(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         target: crate::cache::ShardState,
     ) -> bool {
         let mut guard = self.index.write().await;
@@ -88,13 +90,13 @@ impl IndexManager {
     /// epsilon` and asserting the demote happened.
     pub(crate) async fn backdate_last_query_at_ms_for_test(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         ts_ms: u64,
     ) -> bool {
         let guard = self.index.read().await;
         guard
             .iter()
-            .find(|shard| shard.drive.eq_ignore_ascii_case(&letter))
+            .find(|shard| shard.drive == letter)
             .is_some_and(|shard| {
                 shard.stats.mark_loaded_at(ts_ms);
                 true
@@ -107,7 +109,9 @@ impl IndexManager {
     /// only through [`Self::snapshot`] (which filters Warm/Hot).
     /// Commit C tests need to assert the *full* tier distribution
     /// (Parked/Cold) before and after `ensure_warm_for_dispatch`.
-    pub(crate) async fn shard_states_for_test(&self) -> Vec<(char, crate::cache::ShardState)> {
+    pub(crate) async fn shard_states_for_test(
+        &self,
+    ) -> Vec<(uffs_mft::platform::DriveLetter, crate::cache::ShardState)> {
         let guard = self.index.read().await;
         guard
             .iter()

--- a/crates/uffs-daemon/src/index/tests/body_loader_fakes.rs
+++ b/crates/uffs-daemon/src/index/tests/body_loader_fakes.rs
@@ -41,7 +41,10 @@ use super::IndexManager;
 pub(super) struct MissingBodyLoader;
 
 impl crate::cache::body_loader::BodyLoader for MissingBodyLoader {
-    fn load(&self, _letter: char) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
+    fn load(
+        &self,
+        _letter: uffs_mft::platform::DriveLetter,
+    ) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
         None
     }
 }
@@ -54,7 +57,10 @@ impl crate::cache::body_loader::BodyLoader for MissingBodyLoader {
 pub(super) struct PanickingBodyLoader;
 
 impl crate::cache::body_loader::BodyLoader for PanickingBodyLoader {
-    fn load(&self, _letter: char) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
+    fn load(
+        &self,
+        _letter: uffs_mft::platform::DriveLetter,
+    ) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
         panic!("PanickingBodyLoader::load — synthetic panic for the JoinError arm");
     }
 }
@@ -91,7 +97,10 @@ impl SlowBodyLoader {
 }
 
 impl crate::cache::body_loader::BodyLoader for SlowBodyLoader {
-    fn load(&self, _letter: char) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
+    fn load(
+        &self,
+        _letter: uffs_mft::platform::DriveLetter,
+    ) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
         use core::sync::atomic::Ordering;
 
         let now = self.in_flight.fetch_add(1, Ordering::AcqRel) + 1;
@@ -161,7 +170,10 @@ impl CountingBodyLoader {
 }
 
 impl crate::cache::body_loader::BodyLoader for CountingBodyLoader {
-    fn load(&self, _letter: char) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
+    fn load(
+        &self,
+        _letter: uffs_mft::platform::DriveLetter,
+    ) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
         self.calls
             .fetch_add(1, core::sync::atomic::Ordering::AcqRel);
         std::thread::sleep(self.delay);

--- a/crates/uffs-daemon/src/index/tests/ensure_warm.rs
+++ b/crates/uffs-daemon/src/index/tests/ensure_warm.rs
@@ -56,16 +56,19 @@ async fn ensure_warm_for_dispatch_no_op_when_all_warm() {
 
     let states_before = mgr.shard_states_for_test().await;
     assert_eq!(states_before, vec![
-        ('C', ShardState::Warm),
-        ('D', ShardState::Warm)
+        (uffs_mft::platform::DriveLetter::C, ShardState::Warm),
+        (uffs_mft::platform::DriveLetter::D, ShardState::Warm)
     ]);
 
     // Empty filter → all touched.  Non-empty filter → subset.
     // Either way, no shard is Parked/Cold so this is a no-op.
     mgr.ensure_warm_for_dispatch(&[], &[]).await;
-    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
-    mgr.ensure_warm_for_dispatch(&['c'], &[]).await; // case-insensitive
-    mgr.ensure_warm_for_dispatch(&['Z'], &[]).await; // unknown letter
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+        .await;
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+        .await; // case-insensitive
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::Z], &[])
+        .await; // unknown letter
 
     let states_after = mgr.shard_states_for_test().await;
     assert_eq!(
@@ -87,13 +90,17 @@ async fn ensure_warm_for_dispatch_skips_parked_shard_outside_filter() {
     mgr.add_drive(build_test_drive_d()).await;
 
     // Demote C to Parked (test escape hatch).
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
     let states_pre = mgr.shard_states_for_test().await;
-    assert!(states_pre.contains(&('C', ShardState::Parked)));
+    assert!(states_pre.contains(&(uffs_mft::platform::DriveLetter::C, ShardState::Parked)));
 
     // Search targets only D — C must stay Parked.  The on-disk
     // cache lookup for D would no-op because D is already Warm.
-    mgr.ensure_warm_for_dispatch(&['D'], &[]).await;
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::D], &[])
+        .await;
 
     let states_post = mgr.shard_states_for_test().await;
     assert_eq!(
@@ -108,7 +115,7 @@ async fn ensure_warm_for_dispatch_skips_parked_shard_outside_filter() {
 ///    registry).
 /// 2. Configure the manager with a `FixedBodyLoader` carrying a fresh body for
 ///    C.
-/// 3. Call `ensure_warm_for_dispatch(&['C'])`.
+/// 3. Call `ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C])`.
 /// 4. Assert C is now Warm AND the registry's view sees the body again (via
 ///    `total_index_heap_bytes` — the Parked shard has `body == None` so its
 ///    `heap_size_bytes()` is 0; the promoted shard reports the test-drive's
@@ -129,16 +136,23 @@ async fn ensure_warm_for_dispatch_promotes_with_fixed_body_loader() {
     assert!(warm_heap > 0, "Warm shard must report nonzero heap_bytes");
 
     // Demote — the body Arc inside the registry is now None.
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
 
     // Promote via ensure_warm_for_dispatch.
-    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+        .await;
 
     // Shard is Warm again AND the heap-bytes metric is back to its
     // pre-demote value (the FixedBodyLoader handed back a body
     // identical in shape to the original).
     let states = mgr.shard_states_for_test().await;
-    assert_eq!(states, vec![('C', ShardState::Warm)]);
+    assert_eq!(states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Warm
+    )]);
     let promoted_heap = mgr.total_index_heap_bytes().await;
     assert_eq!(
         promoted_heap, warm_heap,
@@ -160,12 +174,19 @@ async fn ensure_warm_for_dispatch_handles_missing_cache_gracefully() {
     let mgr = IndexManager::with_body_loader_for_test(None, tx, Arc::new(MissingBodyLoader));
     mgr.add_drive(build_test_drive()).await;
 
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
     let states_pre = mgr.shard_states_for_test().await;
-    assert_eq!(states_pre, vec![('C', ShardState::Parked)]);
+    assert_eq!(states_pre, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Parked
+    )]);
 
     // Loader returns None → graceful failure path.
-    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+        .await;
 
     let states_post = mgr.shard_states_for_test().await;
     assert_eq!(
@@ -186,25 +207,30 @@ async fn ensure_warm_for_dispatch_handles_panicking_body_loader_gracefully() {
     let mgr = IndexManager::with_body_loader_for_test(None, tx, Arc::new(PanickingBodyLoader));
     mgr.add_drive(build_test_drive()).await;
 
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
 
     // Loader panics → JoinError arm runs → shard stays Parked.
-    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+        .await;
 
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
         states,
-        vec![('C', ShardState::Parked)],
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Parked)],
         "panicking loader → JoinError → shard stays Parked, no daemon crash"
     );
 
     // Subsequent ensure_warm_for_dispatch on the same manager
     // still works (no global daemon state corruption).
-    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+        .await;
     let states_again = mgr.shard_states_for_test().await;
     assert_eq!(
         states_again,
-        vec![('C', ShardState::Parked)],
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Parked)],
         "second call after a panicking-loader call must also be graceful"
     );
 }
@@ -249,12 +275,29 @@ async fn ensure_warm_for_dispatch_promotes_in_parallel() {
     mgr.add_drive(build_test_drive_e()).await;
 
     // Demote all three to Parked so they all need the loader.
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
-    assert!(mgr.demote_letter_for_test('D', ShardState::Parked).await);
-    assert!(mgr.demote_letter_for_test('E', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::D, ShardState::Parked)
+            .await
+    );
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::E, ShardState::Parked)
+            .await
+    );
 
     let start = std::time::Instant::now();
-    mgr.ensure_warm_for_dispatch(&['C', 'D', 'E'], &[]).await;
+    mgr.ensure_warm_for_dispatch(
+        &[
+            uffs_mft::platform::DriveLetter::C,
+            uffs_mft::platform::DriveLetter::D,
+            uffs_mft::platform::DriveLetter::E,
+        ],
+        &[],
+    )
+    .await;
     let elapsed = start.elapsed();
 
     // All three shards promoted.
@@ -262,9 +305,9 @@ async fn ensure_warm_for_dispatch_promotes_in_parallel() {
     assert_eq!(
         states,
         vec![
-            ('C', ShardState::Warm),
-            ('D', ShardState::Warm),
-            ('E', ShardState::Warm),
+            (uffs_mft::platform::DriveLetter::C, ShardState::Warm),
+            (uffs_mft::platform::DriveLetter::D, ShardState::Warm),
+            (uffs_mft::platform::DriveLetter::E, ShardState::Warm),
         ],
         "all three Parked shards must be Warm after ensure_warm_for_dispatch"
     );
@@ -376,9 +419,15 @@ async fn ensure_warm_for_dispatch_keeps_parked_when_bloom_misses() {
     // Demote C → Parked.  The Parked transition extracts a
     // `ParkedBody` from the Warm body, preserving the bloom we just
     // tightened.
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
     let states_pre = mgr.shard_states_for_test().await;
-    assert_eq!(states_pre, vec![('C', ShardState::Parked)]);
+    assert_eq!(states_pre, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Parked
+    )]);
 
     // The drive's actual extensions are `md`, `rs`, `toml`, `bin`.
     // `csv` is novel; the 0.001-FPR bloom misses it with probability
@@ -398,7 +447,7 @@ async fn ensure_warm_for_dispatch_keeps_parked_when_bloom_misses() {
     // existing `ensure_warm_for_dispatch_keeps_parked_on_panicking_loader`
     // test which establishes the catch_unwind contract; here we rely
     // on it as a known-good infrastructure.
-    mgr.ensure_warm_for_dispatch(&['C'], &["csv".to_owned()])
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &["csv".to_owned()])
         .await;
 
     let states_post = mgr.shard_states_for_test().await;
@@ -430,20 +479,26 @@ async fn ensure_warm_for_dispatch_promotes_parked_when_bloom_hits() {
     let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
     mgr.add_drive(build_test_drive_with_tight_bloom()).await;
 
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
     let states_pre = mgr.shard_states_for_test().await;
-    assert_eq!(states_pre, vec![('C', ShardState::Parked)]);
+    assert_eq!(states_pre, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Parked
+    )]);
 
     // `rs` IS in the drive (`main.rs`, `lib.rs`).  Bloom hits →
     // bloom-pre-check returns true → loader is called → returns the
     // fresh body → shard transitions to Warm.
-    mgr.ensure_warm_for_dispatch(&['C'], &["rs".to_owned()])
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &["rs".to_owned()])
         .await;
 
     let states_post = mgr.shard_states_for_test().await;
     assert_eq!(
         states_post,
-        vec![('C', ShardState::Warm)],
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Warm)],
         "bloom hit must promote the shard back to Warm via the loader"
     );
 }
@@ -507,7 +562,10 @@ async fn ensure_warm_for_dispatch_dedupes_concurrent_promotes_for_same_letter() 
     mgr.add_drive(build_test_drive()).await;
 
     // Demote C → Parked; the body Arc is dropped from the registry.
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
 
     // Spawn 10 concurrent ensure_warm_for_dispatch calls — each
     // independently observes C as Parked.  Without the dedup, each
@@ -517,7 +575,9 @@ async fn ensure_warm_for_dispatch_dedupes_concurrent_promotes_for_same_letter() 
     for _ in 0_u32..10_u32 {
         let mgr_clone = Arc::clone(&mgr);
         handles.push(tokio::spawn(async move {
-            mgr_clone.ensure_warm_for_dispatch(&['C'], &[]).await;
+            mgr_clone
+                .ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+                .await;
         }));
     }
     for handle in handles {
@@ -530,7 +590,7 @@ async fn ensure_warm_for_dispatch_dedupes_concurrent_promotes_for_same_letter() 
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
         states,
-        vec![('C', ShardState::Warm)],
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Warm)],
         "all 10 concurrent ensure_warm_for_dispatch callers must observe C as Warm",
     );
 
@@ -576,23 +636,34 @@ async fn ensure_warm_for_dispatch_slot_clears_so_re_promote_after_demote_loads_f
     mgr.add_drive(build_test_drive()).await;
 
     // ── First Parked → Warm cycle ──────────────────────────────
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
-    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+        .await;
     assert_eq!(
         loader.call_count(),
         1,
         "first promote must trigger exactly one load",
     );
     let states_after_first = mgr.shard_states_for_test().await;
-    assert_eq!(states_after_first, vec![('C', ShardState::Warm)]);
+    assert_eq!(states_after_first, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Warm
+    )]);
 
     // Wait for the cleanup task to drain the slot.  Polling via
     // the accessor avoids real-time-sleep flakiness on slow CI.
     wait_for_in_flight_clear(&mgr).await;
 
     // ── Second Parked → Warm cycle ─────────────────────────────
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
-    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+        .await;
 
     // The fresh load contract: re-promote after the cleanup task
     // ran must call `BodyLoader::load` again — not reuse the
@@ -634,14 +705,19 @@ async fn ensure_warm_for_dispatch_dedupes_concurrent_failures_for_same_letter() 
         None, tx, loader_dyn,
     ));
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
 
     // 5 concurrent callers, all of which will see the loader return None.
     let mut handles = Vec::with_capacity(5);
     for _ in 0_u32..5_u32 {
         let mgr_clone = Arc::clone(&mgr);
         handles.push(tokio::spawn(async move {
-            mgr_clone.ensure_warm_for_dispatch(&['C'], &[]).await;
+            mgr_clone
+                .ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+                .await;
         }));
     }
     for handle in handles {
@@ -654,7 +730,7 @@ async fn ensure_warm_for_dispatch_dedupes_concurrent_failures_for_same_letter() 
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
         states,
-        vec![('C', ShardState::Parked)],
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Parked)],
         "5 concurrent failed promotes must all leave C Parked (no half-promoted state)",
     );
 

--- a/crates/uffs-daemon/src/index/tests/forget_status.rs
+++ b/crates/uffs-daemon/src/index/tests/forget_status.rs
@@ -70,21 +70,26 @@ async fn forget_cold_drive_evicts_and_unlinks() {
     let cleaner = Arc::new(CountingCacheCleaner::new(1_024));
     let mgr = make_manager(Arc::clone(&cleaner), None);
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
-    let outcome = mgr.forget_drives(&['C'], false).await;
+    let outcome = mgr
+        .forget_drives(&[uffs_mft::platform::DriveLetter::C], false)
+        .await;
 
     let ForgetOutcomeOrBusy::Ok(out) = outcome else {
         panic!("expected Ok outcome on Cold-drive forget; got {outcome:?}");
     };
-    assert_eq!(out.forgotten, vec!['C']);
+    assert_eq!(out.forgotten, vec![uffs_mft::platform::DriveLetter::C]);
     assert!(out.already_absent.is_empty());
     assert_eq!(out.freed_bytes, 1_024);
     assert!(out.errors.is_empty());
 
     assert_eq!(
         cleaner.calls(),
-        vec!['C'],
+        vec![uffs_mft::platform::DriveLetter::C],
         "cache cleaner must have been invoked exactly once for C"
     );
     let states = mgr.shard_states_for_test().await;
@@ -103,12 +108,17 @@ async fn forget_warm_without_force_refuses_with_busy_listing() {
     let mgr = make_manager(Arc::clone(&cleaner), None);
     mgr.add_drive(build_test_drive()).await; // C lands in Warm.
 
-    let outcome = mgr.forget_drives(&['C'], false).await;
+    let outcome = mgr
+        .forget_drives(&[uffs_mft::platform::DriveLetter::C], false)
+        .await;
 
     let ForgetOutcomeOrBusy::Busy(busy) = outcome else {
         panic!("expected Busy refusal for Warm drive without force; got {outcome:?}");
     };
-    assert_eq!(busy, vec![('C', ShardState::Warm)]);
+    assert_eq!(busy, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Warm
+    )]);
     assert!(
         cleaner.calls().is_empty(),
         "cache cleaner must NOT have been invoked on the refused path"
@@ -116,7 +126,7 @@ async fn forget_warm_without_force_refuses_with_busy_listing() {
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
         states,
-        vec![('C', ShardState::Warm)],
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Warm)],
         "registry must be untouched on refusal"
     );
 }
@@ -131,19 +141,33 @@ async fn forget_warm_with_force_auto_hibernates_then_evicts() {
     mgr.add_drive(build_test_drive()).await;
     mgr.add_drive(build_test_drive_d()).await;
 
-    let outcome = mgr.forget_drives(&['C', 'D'], true).await;
+    let outcome = mgr
+        .forget_drives(
+            &[
+                uffs_mft::platform::DriveLetter::C,
+                uffs_mft::platform::DriveLetter::D,
+            ],
+            true,
+        )
+        .await;
 
     let ForgetOutcomeOrBusy::Ok(out) = outcome else {
         panic!("expected Ok outcome with force; got {outcome:?}");
     };
-    assert_eq!(out.forgotten, vec!['C', 'D']);
+    assert_eq!(out.forgotten, vec![
+        uffs_mft::platform::DriveLetter::C,
+        uffs_mft::platform::DriveLetter::D
+    ]);
     assert_eq!(out.freed_bytes, 4_096, "2 drives × 2_048 bytes each");
     assert!(out.already_absent.is_empty());
     assert!(out.errors.is_empty());
 
     assert_eq!(
         cleaner.calls(),
-        vec!['C', 'D'],
+        vec![
+            uffs_mft::platform::DriveLetter::C,
+            uffs_mft::platform::DriveLetter::D
+        ],
         "cache cleaner invoked once per drive in input order"
     );
     let states = mgr.shard_states_for_test().await;
@@ -160,25 +184,27 @@ async fn forget_unknown_drive_is_idempotent_already_absent() {
     let mgr = make_manager(Arc::clone(&cleaner), None);
     mgr.add_drive(build_test_drive()).await; // C only.
 
-    let outcome = mgr.forget_drives(&['Z'], false).await;
+    let outcome = mgr
+        .forget_drives(&[uffs_mft::platform::DriveLetter::Z], false)
+        .await;
 
     let ForgetOutcomeOrBusy::Ok(out) = outcome else {
         panic!("expected Ok for unknown drive; got {outcome:?}");
     };
     assert!(out.forgotten.is_empty());
-    assert_eq!(out.already_absent, vec!['Z']);
+    assert_eq!(out.already_absent, vec![uffs_mft::platform::DriveLetter::Z]);
     assert_eq!(out.freed_bytes, 0);
     assert!(out.errors.is_empty());
 
     assert_eq!(
         cleaner.calls(),
-        vec!['Z'],
+        vec![uffs_mft::platform::DriveLetter::Z],
         "cleaner still runs for unknown drives so stale on-disk files are purged"
     );
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
         states,
-        vec![('C', ShardState::Warm)],
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Warm)],
         "C must remain Warm — the unknown-drive forget call must not touch other drives"
     );
 }
@@ -202,22 +228,32 @@ async fn forget_pinned_hot_drive_with_force_clears_pin() {
         Some(loader as Arc<dyn crate::cache::body_loader::BodyLoader>),
     );
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
     // Preload C → Hot + pin.
-    let preload = mgr.preload_drive('C', 30).await;
+    let preload = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 30)
+        .await;
     assert!(matches!(preload, PreloadOutcome::Promoted { .. }));
 
     // Pre-condition assertion: C is Hot and pinned.
     let pre_states = mgr.shard_states_for_test().await;
-    assert_eq!(pre_states, vec![('C', ShardState::Hot)]);
+    assert_eq!(pre_states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Hot
+    )]);
 
     // Force-forget must succeed despite the pin.
-    let outcome = mgr.forget_drives(&['C'], true).await;
+    let outcome = mgr
+        .forget_drives(&[uffs_mft::platform::DriveLetter::C], true)
+        .await;
     let ForgetOutcomeOrBusy::Ok(out) = outcome else {
         panic!("expected Ok with force; got {outcome:?}");
     };
-    assert_eq!(out.forgotten, vec!['C']);
+    assert_eq!(out.forgotten, vec![uffs_mft::platform::DriveLetter::C]);
     assert_eq!(out.freed_bytes, 512);
 
     let post_states = mgr.shard_states_for_test().await;
@@ -233,17 +269,28 @@ async fn forget_mixed_request_refuses_when_any_drive_busy_without_force() {
     let mgr = make_manager(Arc::clone(&cleaner), None);
     mgr.add_drive(build_test_drive()).await; // C: Warm
     mgr.add_drive(build_test_drive_d()).await; // D: Warm
-    assert!(mgr.demote_letter_for_test('D', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::D, ShardState::Cold)
+            .await
+    );
     // Now: C is Warm, D is Cold.
 
-    let outcome = mgr.forget_drives(&['C', 'D'], false).await;
+    let outcome = mgr
+        .forget_drives(
+            &[
+                uffs_mft::platform::DriveLetter::C,
+                uffs_mft::platform::DriveLetter::D,
+            ],
+            false,
+        )
+        .await;
 
     let ForgetOutcomeOrBusy::Busy(busy) = outcome else {
         panic!("expected all-or-nothing Busy refusal; got {outcome:?}");
     };
     assert_eq!(
         busy,
-        vec![('C', ShardState::Warm)],
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Warm)],
         "only C should be reported as busy; D is Cold and would be safe"
     );
     assert!(
@@ -254,8 +301,8 @@ async fn forget_mixed_request_refuses_when_any_drive_busy_without_force() {
     // Both shards must still be present.
     let states = mgr.shard_states_for_test().await;
     assert_eq!(states, vec![
-        ('C', ShardState::Warm),
-        ('D', ShardState::Cold)
+        (uffs_mft::platform::DriveLetter::C, ShardState::Warm),
+        (uffs_mft::platform::DriveLetter::D, ShardState::Cold)
     ]);
 }
 
@@ -290,7 +337,7 @@ async fn status_drives_single_warm_shard_full_snapshot() {
             response.drives.len()
         );
     };
-    assert_eq!(row.letter, 'C');
+    assert_eq!(row.letter, uffs_mft::platform::DriveLetter::C);
     assert_eq!(row.tier, "warm");
     assert!(
         row.resident_bytes > 0,
@@ -321,8 +368,14 @@ async fn status_drives_mixed_tier_distribution_one_row_per_shard() {
     mgr.add_drive(build_test_drive_e()).await;
 
     // C stays Warm; D demotes to Parked; E demotes to Cold.
-    assert!(mgr.demote_letter_for_test('D', ShardState::Parked).await);
-    assert!(mgr.demote_letter_for_test('E', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::D, ShardState::Parked)
+            .await
+    );
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::E, ShardState::Cold)
+            .await
+    );
 
     let response = mgr.status_drives().await;
 
@@ -334,14 +387,14 @@ async fn status_drives_mixed_tier_distribution_one_row_per_shard() {
     };
 
     // Sorted ascending by letter.
-    assert_eq!(c_row.letter, 'C');
+    assert_eq!(c_row.letter, uffs_mft::platform::DriveLetter::C);
     assert_eq!(c_row.tier, "warm");
     assert!(
         c_row.resident_bytes > 0,
         "Warm shard reports nonzero resident_bytes (body heap)"
     );
 
-    assert_eq!(d_row.letter, 'D');
+    assert_eq!(d_row.letter, uffs_mft::platform::DriveLetter::D);
     assert_eq!(d_row.tier, "parked");
     // Parked shards report parked_body.size_bytes() (bloom + trie).
     // The tiny synthetic test fixture builds a non-empty trie + bloom,
@@ -352,7 +405,7 @@ async fn status_drives_mixed_tier_distribution_one_row_per_shard() {
         d_row.resident_bytes
     );
 
-    assert_eq!(e_row.letter, 'E');
+    assert_eq!(e_row.letter, uffs_mft::platform::DriveLetter::E);
     assert_eq!(e_row.tier, "cold");
     assert_eq!(
         e_row.resident_bytes, 0,
@@ -377,9 +430,14 @@ async fn status_drives_preloaded_hot_drive_surfaces_pin_expiry() {
         Some(loader as Arc<dyn crate::cache::body_loader::BodyLoader>),
     );
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
-    let preload = mgr.preload_drive('C', 30).await;
+    let preload = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 30)
+        .await;
     assert!(matches!(preload, PreloadOutcome::Promoted { .. }));
 
     let response = mgr.status_drives().await;
@@ -413,10 +471,15 @@ async fn status_drives_sorts_rows_by_letter_ascending() {
 
     let response = mgr.status_drives().await;
 
-    let letters: Vec<char> = response.drives.iter().map(|drive| drive.letter).collect();
+    let letters: Vec<uffs_mft::platform::DriveLetter> =
+        response.drives.iter().map(|drive| drive.letter).collect();
     assert_eq!(
         letters,
-        vec!['C', 'D', 'E'],
+        vec![
+            uffs_mft::platform::DriveLetter::C,
+            uffs_mft::platform::DriveLetter::D,
+            uffs_mft::platform::DriveLetter::E
+        ],
         "rows must be sorted by drive letter ascending regardless of load order"
     );
 }
@@ -441,7 +504,10 @@ async fn status_drives_surfaces_promotions_total_after_cold_to_hot_preload() {
         Some(loader as Arc<dyn crate::cache::body_loader::BodyLoader>),
     );
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
     // Pre-condition: status_drives reports promotions_total = 0.
     let pre = mgr.status_drives().await;
@@ -457,7 +523,9 @@ async fn status_drives_surfaces_promotions_total_after_cold_to_hot_preload() {
     );
 
     // Drive: preload C from Cold (the canonical Phase 9 bump path).
-    let preload = mgr.preload_drive('C', 30).await;
+    let preload = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 30)
+        .await;
     assert!(matches!(preload, PreloadOutcome::Promoted { .. }));
 
     // Post-condition: status_drives reports promotions_total = 1.
@@ -494,15 +562,22 @@ async fn status_drives_promotions_total_does_not_double_count_already_hot_preloa
         Some(loader as Arc<dyn crate::cache::body_loader::BodyLoader>),
     );
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
     // First preload: Cold → Hot, bumps counter to 1.
-    let first = mgr.preload_drive('C', 5).await;
+    let first = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 5)
+        .await;
     assert!(matches!(first, PreloadOutcome::Promoted { .. }));
 
     // Second preload: AlreadyHot path — extends pin only, must
     // NOT bump the counter.
-    let second = mgr.preload_drive('C', 60).await;
+    let second = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 60)
+        .await;
     assert!(
         matches!(second, PreloadOutcome::AlreadyHot { .. }),
         "second preload must hit the AlreadyHot arm (no rebuild); got {second:?}",

--- a/crates/uffs-daemon/src/index/tests/idle_demote.rs
+++ b/crates/uffs-daemon/src/index/tests/idle_demote.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! Phase 3 Commit D & E + Commit E tracing-event contract tests.
+//! Phase 3 Commit D — `IndexManager::demote_idle_shards` state-ladder tests.
 //!
 //! Covers:
 //!
@@ -9,31 +9,22 @@
 //! * `demote_idle_shards` no-op / Warm→Parked / Parked→Cold / batch-multiple /
 //!   round-trip query stats.
 //! * Plan tasks 3.7 / 3.8 — virtual-time multi-drive demote tests.
-//! * Plan task 3.9 — `shard.transition` tracing events with the `letter` /
-//!   `from` / `to` / `reason` / `freed_mb` / `restored_mb` / `last_query_at_ms`
-//!   field contract.
-//! * Phase 5 G4 follow-up — single-canonical-event regression for the
-//!   pressure-cascade demote path.
 //!
-//! The shared `tracing::Subscriber` capture scaffold (`EventLog` /
-//! `CapturedEvent` / `FieldCapture`) lives in the sibling
-//! [`super::tracing_capture`] module.
+//! `shard.transition` tracing-event contract tests (Phase 3 Commit E +
+//! Phase 5 G4 + PR-f promote-thrash regression) live in the sibling
+//! [`super::idle_demote_tracing`] module; the shared `EventLog` /
+//! `CapturedEvent` capture scaffold is in [`super::tracing_capture`].
 
 #![expect(
-    clippy::indexing_slicing,
     clippy::min_ident_chars,
     clippy::std_instead_of_alloc,
-    reason = "test code — assertions index into known-shape vectors, use short \
-              drive-letter idents like `c`/`d`, and pull `Arc` from `std` to \
-              match the rest of the daemon's test fixtures"
+    reason = "test code — short drive-letter idents like `c`/`d`, and `Arc` \
+              pulled from `std` to match the rest of the daemon's test fixtures"
 )]
 
 use std::sync::Arc;
 
-use super::tracing_capture::{CapturedEvent, EventLog};
-use super::{
-    FixedBodyLoader, IndexManager, build_test_drive, build_test_drive_d, build_test_drive_e,
-};
+use super::{IndexManager, build_test_drive, build_test_drive_d, build_test_drive_e};
 
 // ── Phase 3 Commit D — IndexManager::demote_idle_shards ────────────
 
@@ -62,7 +53,10 @@ async fn mark_loaded_at_seeds_freshly_added_drive() {
     // (huge) and demote, but a seeded shard sees `idle_ms = 1` ms
     // (basically 0 s) and stays Warm.
     let states_before = mgr.shard_states_for_test().await;
-    assert_eq!(states_before, vec![('C', crate::cache::ShardState::Warm)]);
+    assert_eq!(states_before, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        crate::cache::ShardState::Warm
+    )]);
 
     // Synthetic now_ms a billion ms in the future would catch
     // unseeded `last_query_at_ms == 0`.  But a seeded shard has
@@ -94,16 +88,22 @@ async fn demote_idle_shards_no_op_when_all_fresh() {
 
     // Pretend every shard was queried at t=10_000_000_000 ms.
     let load_ts = 10_000_000_000_u64;
-    assert!(mgr.backdate_last_query_at_ms_for_test('C', load_ts).await);
-    assert!(mgr.backdate_last_query_at_ms_for_test('D', load_ts).await);
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::C, load_ts)
+            .await
+    );
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::D, load_ts)
+            .await
+    );
 
     // `now_ms` only 1 ms after load → idle_secs = 0 → no demote.
     mgr.demote_idle_shards(load_ts + 1).await;
 
     let states = mgr.shard_states_for_test().await;
     assert_eq!(states, vec![
-        ('C', ShardState::Warm),
-        ('D', ShardState::Warm)
+        (uffs_mft::platform::DriveLetter::C, ShardState::Warm),
+        (uffs_mft::platform::DriveLetter::D, ShardState::Warm)
     ]);
 }
 
@@ -120,7 +120,7 @@ async fn demote_idle_shards_warm_to_parked_at_ttl() {
     // Backdate C's last_query_at_ms to t=1_000_000_000 ms.
     let last_query_ms = 1_000_000_000_u64;
     assert!(
-        mgr.backdate_last_query_at_ms_for_test('C', last_query_ms)
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::C, last_query_ms)
             .await
     );
 
@@ -130,7 +130,10 @@ async fn demote_idle_shards_warm_to_parked_at_ttl() {
     mgr.demote_idle_shards(now_ms).await;
 
     let states = mgr.shard_states_for_test().await;
-    assert_eq!(states, vec![('C', crate::cache::ShardState::Parked)]);
+    assert_eq!(states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        crate::cache::ShardState::Parked
+    )]);
 }
 
 /// Warm shard idle just below `WARM_TO_PARKED_IDLE_SECS` stays
@@ -145,7 +148,7 @@ async fn demote_idle_shards_below_ttl_keeps_warm() {
 
     let last_query_ms = 1_000_000_000_u64;
     assert!(
-        mgr.backdate_last_query_at_ms_for_test('C', last_query_ms)
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::C, last_query_ms)
             .await
     );
 
@@ -156,7 +159,10 @@ async fn demote_idle_shards_below_ttl_keeps_warm() {
     mgr.demote_idle_shards(now_ms).await;
 
     let states = mgr.shard_states_for_test().await;
-    assert_eq!(states, vec![('C', crate::cache::ShardState::Warm)]);
+    assert_eq!(states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        crate::cache::ShardState::Warm
+    )]);
 }
 
 /// Parked shard idle past `PARKED_TO_COLD_IDLE_SECS` demotes to
@@ -178,12 +184,15 @@ async fn demote_idle_shards_parked_to_cold_at_ttl() {
     mgr.add_drive(build_test_drive()).await;
 
     // Seed C as Parked via the test escape hatch.
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
 
     // Backdate so the Parked shard has been idle past its TTL.
     let last_query_ms = 1_000_000_000_u64;
     assert!(
-        mgr.backdate_last_query_at_ms_for_test('C', last_query_ms)
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::C, last_query_ms)
             .await
     );
 
@@ -191,7 +200,10 @@ async fn demote_idle_shards_parked_to_cold_at_ttl() {
     mgr.demote_idle_shards(now_ms).await;
 
     let states = mgr.shard_states_for_test().await;
-    assert_eq!(states, vec![('C', ShardState::Cold)]);
+    assert_eq!(states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Cold
+    )]);
 }
 
 /// `demote_idle_shards` batches multiple demotes inside a single
@@ -208,7 +220,10 @@ async fn demote_idle_shards_batches_multiple_demotes() {
     mgr.add_drive(build_test_drive_d()).await;
 
     let last_query_ms = 1_000_000_000_u64;
-    for letter in ['C', 'D'] {
+    for letter in [
+        uffs_mft::platform::DriveLetter::C,
+        uffs_mft::platform::DriveLetter::D,
+    ] {
         assert!(
             mgr.backdate_last_query_at_ms_for_test(letter, last_query_ms)
                 .await
@@ -227,7 +242,10 @@ async fn demote_idle_shards_batches_multiple_demotes() {
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
         states,
-        vec![('C', ShardState::Parked), ('D', ShardState::Parked)],
+        vec![
+            (uffs_mft::platform::DriveLetter::C, ShardState::Parked),
+            (uffs_mft::platform::DriveLetter::D, ShardState::Parked)
+        ],
         "all backdated Warm shards must demote in a single batch call"
     );
     assert_eq!(
@@ -252,22 +270,27 @@ fn demote_then_promote_round_trips_query_stats() {
     // Arc is what the new shard's `.stats` points at.
     for round in 0_u64..3_u64 {
         reg.iter()
-            .find(|s| s.drive == 'C')
+            .find(|s| s.drive == uffs_mft::platform::DriveLetter::C)
             .unwrap()
             .stats
             .mark_query_at(1_000 + round);
-        reg = reg.demote_letter('C', ShardState::Parked).expect("demote");
+        reg = reg
+            .demote_letter(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .expect("demote");
         reg.iter()
-            .find(|s| s.drive == 'C')
+            .find(|s| s.drive == uffs_mft::platform::DriveLetter::C)
             .unwrap()
             .stats
             .mark_query_at(2_000 + round);
         reg = reg
-            .promote_letter('C', Arc::clone(&body_c))
+            .promote_letter(uffs_mft::platform::DriveLetter::C, Arc::clone(&body_c))
             .expect("promote");
     }
 
-    let final_c = reg.iter().find(|s| s.drive == 'C').unwrap();
+    let final_c = reg
+        .iter()
+        .find(|s| s.drive == uffs_mft::platform::DriveLetter::C)
+        .unwrap();
     // 6 mark_query_at calls total across 3 rounds (3 pre-demote +
     // 3 post-demote-pre-promote).
     assert_eq!(final_c.stats.queries_total(), 6);
@@ -304,7 +327,11 @@ async fn demote_idle_shards_warm_only_for_unqueried_drives() {
 
     let load_ts = 1_000_000_000_u64;
     // Seed all three to the load timestamp.
-    for letter in ['C', 'D', 'E'] {
+    for letter in [
+        uffs_mft::platform::DriveLetter::C,
+        uffs_mft::platform::DriveLetter::D,
+        uffs_mft::platform::DriveLetter::E,
+    ] {
         assert!(
             mgr.backdate_last_query_at_ms_for_test(letter, load_ts)
                 .await
@@ -315,7 +342,7 @@ async fn demote_idle_shards_warm_only_for_unqueried_drives() {
     // load_ts + 30min).  D and E remain at load_ts.
     let c_last_query_ms = load_ts + 30 * 60 * 1000;
     assert!(
-        mgr.backdate_last_query_at_ms_for_test('C', c_last_query_ms)
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::C, c_last_query_ms)
             .await
     );
 
@@ -335,9 +362,9 @@ async fn demote_idle_shards_warm_only_for_unqueried_drives() {
     assert_eq!(
         states,
         vec![
-            ('C', ShardState::Warm),
-            ('D', ShardState::Parked),
-            ('E', ShardState::Parked),
+            (uffs_mft::platform::DriveLetter::C, ShardState::Warm),
+            (uffs_mft::platform::DriveLetter::D, ShardState::Parked),
+            (uffs_mft::platform::DriveLetter::E, ShardState::Parked),
         ],
         "C must stay Warm (recently queried); D and E must demote to Parked"
     );
@@ -366,7 +393,11 @@ async fn demote_idle_shards_parked_drives_demote_to_cold_past_threshold() {
     // Parked via the test escape hatch.  Order: backdate first so
     // the demote controller doesn't trip on the seeding tick.
     let load_ts = 1_000_000_000_u64;
-    for letter in ['C', 'D', 'E'] {
+    for letter in [
+        uffs_mft::platform::DriveLetter::C,
+        uffs_mft::platform::DriveLetter::D,
+        uffs_mft::platform::DriveLetter::E,
+    ] {
         assert!(
             mgr.backdate_last_query_at_ms_for_test(letter, load_ts)
                 .await
@@ -376,9 +407,9 @@ async fn demote_idle_shards_parked_drives_demote_to_cold_past_threshold() {
 
     let pre_states = mgr.shard_states_for_test().await;
     assert_eq!(pre_states, vec![
-        ('C', ShardState::Parked),
-        ('D', ShardState::Parked),
-        ('E', ShardState::Parked),
+        (uffs_mft::platform::DriveLetter::C, ShardState::Parked),
+        (uffs_mft::platform::DriveLetter::D, ShardState::Parked),
+        (uffs_mft::platform::DriveLetter::E, ShardState::Parked),
     ],);
 
     // now_ms = load_ts + 25 hours (≥ PARKED_TO_COLD_IDLE_SECS = 24h).
@@ -392,392 +423,10 @@ async fn demote_idle_shards_parked_drives_demote_to_cold_past_threshold() {
     assert_eq!(
         states,
         vec![
-            ('C', ShardState::Cold),
-            ('D', ShardState::Cold),
-            ('E', ShardState::Cold),
+            (uffs_mft::platform::DriveLetter::C, ShardState::Cold),
+            (uffs_mft::platform::DriveLetter::D, ShardState::Cold),
+            (uffs_mft::platform::DriveLetter::E, ShardState::Cold),
         ],
         "all three Parked shards past the cold-tier TTL must demote to Cold"
-    );
-}
-
-// ── Phase 3 Commit E — tracing-event contract (plan task 3.9) ──────
-
-/// Plan task 3.9 — every demote / promote transition emits exactly
-/// one `tracing::event!(target: "shard.transition", ...)` event.
-///
-/// Pins the operator-facing observability contract: the tracing
-/// fields (`letter`, `from`, `to`, `reason`, `freed_mb` /
-/// `restored_mb`) are part of the public log surface, so a refactor
-/// that silently drops or renames them would break dashboards and
-/// alerting.  This test captures every event during a
-/// demote-then-promote round-trip and asserts on the field values.
-///
-/// `tokio::test` defaults to a `current_thread` runtime, so the
-/// thread-local `tracing::subscriber::set_default` we install at
-/// the top of the test captures every event emitted from inside
-/// the test future — including the events from `demote_letter` /
-/// `promote_letter` running on the same thread.
-#[tokio::test]
-async fn shard_transition_events_emitted_on_demote_and_promote() {
-    use crate::cache::ShardState;
-
-    let log = EventLog::default();
-    // Hold a second registered `Dispatch` for the duration of the test
-    // body so `tracing-core` keeps `Dispatchers::has_just_one` at
-    // `false`, which forces every callsite-interest rebuild to walk
-    // the global `LOCKED_DISPATCHERS` list (containing OUR subscriber)
-    // instead of taking the `JustOne` fast path.
-    //
-    // The `JustOne` fast path (`tracing-core::callsite::Dispatchers::
-    // rebuilder` at v0.1.36 line 544–549) calls
-    // `dispatcher::get_default(f)`, which is THREAD-LOCAL.  When a
-    // sibling test on a different thread fires a `shard.transition`
-    // callsite for the first time (registering it against
-    // `NoSubscriber` because that thread never called `set_default`),
-    // the per-callsite `Interest` cache gets pinned to `never` GLOBALLY,
-    // and OUR thread-local subscriber never gets a chance to vote
-    // — even if we later call `rebuild_interest_cache`, that rebuild
-    // also takes the `JustOne` path and asks the wrong (sibling)
-    // thread's default.
-    //
-    // Holding a dummy `NoSubscriber` Dispatch alive flips
-    // `has_just_one` to `false`, so the rebuilder switches to
-    // `Rebuilder::Read(LOCKED_DISPATCHERS)` which walks every
-    // registered dispatcher (ours + the dummy).  Our subscriber's
-    // `register_callsite` is then consulted on every callsite,
-    // and the `Interest` cache reflects our `Interest::always`
-    // independently of which thread first encountered the callsite.
-    let _interest_rebuild_dummy =
-        tracing::Dispatch::new(tracing::subscriber::NoSubscriber::default());
-    let _guard = tracing::subscriber::set_default(log.clone());
-    // Force every existing callsite to re-register against the dispatchers
-    // we just expanded with the dummy + our subscriber, in case sibling
-    // tests already pinned cache entries to `never` before this test ran.
-    tracing::callsite::rebuild_interest_cache();
-
-    let (tx, _rx) = crate::events::event_channel();
-    let body = Arc::new(build_test_drive());
-    let loader = Arc::new(FixedBodyLoader {
-        body: Arc::clone(&body),
-    });
-    let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
-    mgr.add_drive(build_test_drive()).await;
-
-    // Demote → expect one demote event.
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
-    // Promote via ensure_warm_for_dispatch → expect one promote event.
-    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
-
-    let events = log.events();
-    // Filter to the operator-facing observability contract: the
-    // INFO-level `shard.transition` events with a tier-transition
-    // `reason` (`demote`, `promote`, `usn-refresh`).  Other levels
-    // on this target are best-effort observability noise that may
-    // legitimately fire on a tier transition without violating the
-    // contract — e.g. the Phase 5 `Prefetch::hint failed` warn,
-    // which can fire on Linux for synthetic small heap regions
-    // even when the promote itself succeeds (and is documented at
-    // `crates/uffs-daemon/src/cache/prefetch.rs` to be best-effort
-    // with warn-level logging on failure).  Pinning by level +
-    // reason makes this test robust to the runtime-topology
-    // detail of *which thread* the prefetch hint runs on (the
-    // PR-e refactor moved the hint from a `spawn_blocking` closure
-    // into the surrounding async task — both paths are observably
-    // correct, but only the latter is captured by the
-    // `set_default` thread-local subscriber on a `current_thread`
-    // runtime).
-    let transitions: Vec<&CapturedEvent> = events
-        .iter()
-        .filter(|event| {
-            event.target == "shard.transition"
-                && event.level == tracing::Level::INFO
-                && matches!(
-                    event.field("reason"),
-                    Some("demote" | "promote" | "usn-refresh")
-                )
-        })
-        .collect();
-
-    assert_eq!(
-        transitions.len(),
-        2,
-        "expected exactly two INFO `shard.transition` events with reason in \
-         {{demote, promote, usn-refresh}} (one demote + one promote), got {}: {:#?}",
-        transitions.len(),
-        transitions
-    );
-
-    // `ShardState`'s `Display` impl emits lowercase variant names
-    // (`warm`, `parked`, `cold`, …) — that's the wire contract this
-    // test pins.  See `impl fmt::Display for ShardState` in
-    // `cache/shard.rs`.
-    let demote = transitions[0];
-    assert_eq!(demote.level, tracing::Level::INFO);
-    assert_eq!(demote.field("reason"), Some("demote"));
-    assert_eq!(demote.field("from"), Some("warm"));
-    assert_eq!(demote.field("to"), Some("parked"));
-    assert_eq!(demote.field("letter"), Some("C"));
-    assert!(
-        demote.has_field("freed_mb"),
-        "demote event must carry freed_mb field for resident-delta accounting"
-    );
-    // G4 follow-up: `last_query_at_ms` is now part of the canonical
-    // demote event (used to be cascade-only).  Pinning its presence
-    // here so a future refactor can't drop the field and silently
-    // break operator runbooks that grep for it.
-    assert!(
-        demote.has_field("last_query_at_ms"),
-        "demote event must carry last_query_at_ms field (G4 follow-up)",
-    );
-
-    let promote = transitions[1];
-    assert_eq!(promote.level, tracing::Level::INFO);
-    assert_eq!(promote.field("reason"), Some("promote"));
-    assert_eq!(promote.field("from"), Some("parked"));
-    assert_eq!(promote.field("to"), Some("warm"));
-    assert_eq!(promote.field("letter"), Some("C"));
-    assert!(
-        promote.has_field("restored_mb"),
-        "promote event must carry restored_mb field for resident-delta accounting"
-    );
-}
-
-/// Phase 5 G4 follow-up — the pressure-cascade demote path must
-/// emit exactly **one** `INFO`-level `shard.transition` event per
-/// shard, with `reason="pressure-cascade"` and `last_query_at_ms`
-/// in the field set.
-///
-/// Pre-refactor, every cascade demote produced **two** events: the
-/// registry primitive's generic `reason="demote"` event followed by
-/// a second `reason="pressure-cascade"` event from
-/// `cascade_demote_one_step` itself.  The two were separated by the
-/// `WorkingSetTrim::trim` syscall duration (6-22 ms typically; up
-/// to ~1 s on the first cascade demote when the daemon's working
-/// set was still large) which confused operator log analysis.
-///
-/// This test pins the single-event contract so a future refactor
-/// can't reintroduce the dual-event pattern.  It also pins the
-/// presence of `last_query_at_ms` (formerly cascade-only, now part
-/// of the canonical demote event for both TTL and pressure paths).
-///
-/// Test topology: 1 Warm drive (`C`) with a known
-/// `last_query_at_ms = 1_234` so the assertion can use a literal
-/// value instead of `has_field`.  `ControllablePressureSignal` is
-/// injected for completeness but never driven — the test calls
-/// `cascade_demote_one_step` directly, mirroring the contract of
-/// the existing
-/// `cascade_demote_one_step_picks_lru_warm_and_drains_in_order`
-/// test in `lifecycle_hooks.rs` (which pins the demote ordering
-/// and trim-call counts but doesn't capture tracing events).
-#[tokio::test]
-async fn cascade_demote_emits_single_event_with_pressure_cascade_reason() {
-    use crate::cache::ShardState;
-    use crate::cache::pressure::tests::ControllablePressureSignal;
-    use crate::cache::working_set::tests::CountingWorkingSetTrim;
-
-    // Same dummy-Dispatch + thread-local-default + interest-rebuild
-    // dance as `shard_transition_events_emitted_on_demote_and_promote`
-    // — see that test's docstring for the rationale.  Without this,
-    // a sibling test on a different thread can pin the
-    // `shard.transition` callsite's `Interest` cache to `never`
-    // before our subscriber gets a chance to vote, and the cascade
-    // event silently disappears.
-    let log = EventLog::default();
-    let _interest_rebuild_dummy =
-        tracing::Dispatch::new(tracing::subscriber::NoSubscriber::default());
-    let _guard = tracing::subscriber::set_default(log.clone());
-    tracing::callsite::rebuild_interest_cache();
-
-    let (tx, _rx) = crate::events::event_channel();
-    let counting_trim = Arc::new(CountingWorkingSetTrim::new());
-    let pressure_fake = Arc::new(ControllablePressureSignal::new());
-    let hooks = crate::index::constructors::LifecycleHooks {
-        working_set_trim: Arc::clone(&counting_trim)
-            as Arc<dyn crate::cache::working_set::WorkingSetTrim>,
-        pressure: Arc::clone(&pressure_fake) as Arc<dyn crate::cache::pressure::PressureSignal>,
-        ..crate::index::constructors::LifecycleHooks::production()
-    };
-    let mgr = IndexManager::with_lifecycle_hooks_for_test(
-        None,
-        tx,
-        hooks,
-        Arc::new(crate::config::Config::default()),
-    );
-    mgr.add_drive(build_test_drive()).await;
-
-    // Backdate to a known timestamp so the assertion can use a
-    // literal value below.  `add_drive` already stamped
-    // `mark_loaded_at(unix_now_ms())`, which would make the assertion
-    // wall-clock-dependent.
-    assert!(mgr.backdate_last_query_at_ms_for_test('C', 1_234).await);
-
-    // Drive the cascade once.  With one Warm shard, the LRU pick is
-    // unambiguous and the call returns `Some(('C', Parked))`.
-    let result = mgr.cascade_demote_one_step().await;
-    assert_eq!(
-        result,
-        Some(('C', ShardState::Parked)),
-        "single-shard cascade demotes C and returns Some",
-    );
-
-    // Filter to INFO-level `shard.transition` events whose `reason`
-    // is in the demote vocabulary.  We accept both `"demote"` (the
-    // legacy generic value) and `"pressure-cascade"` (the new
-    // discriminator) so this test would still catch a regression
-    // that flipped the cascade path back to emitting `"demote"`
-    // — the assertion below pins the EXACT value.
-    let events = log.events();
-    let demotes: Vec<&CapturedEvent> = events
-        .iter()
-        .filter(|event| {
-            event.target == "shard.transition"
-                && event.level == tracing::Level::INFO
-                && matches!(event.field("reason"), Some("demote" | "pressure-cascade"))
-        })
-        .collect();
-
-    assert_eq!(
-        demotes.len(),
-        1,
-        "G4 follow-up: cascade demote must emit exactly ONE info \
-         `shard.transition` event (the registry primitive's canonical \
-         event with reason=\"pressure-cascade\"); the legacy second \
-         event from `cascade_demote_one_step` is gone.  got {}: {:#?}",
-        demotes.len(),
-        demotes,
-    );
-
-    let cascade = demotes[0];
-    assert_eq!(cascade.field("reason"), Some("pressure-cascade"));
-    assert_eq!(cascade.field("from"), Some("warm"));
-    assert_eq!(cascade.field("to"), Some("parked"));
-    assert_eq!(cascade.field("letter"), Some("C"));
-    assert!(
-        cascade.has_field("freed_mb"),
-        "cascade demote event must carry freed_mb field",
-    );
-    assert_eq!(
-        cascade.field("last_query_at_ms"),
-        Some("1234"),
-        "cascade demote event must carry last_query_at_ms (formerly \
-         cascade-only; now part of the canonical demote event)",
-    );
-
-    // Sanity: trim fired exactly once for the single cascade step.
-    assert_eq!(
-        counting_trim.calls(),
-        1,
-        "single cascade step → single trim call",
-    );
-}
-
-// Phase 6 fix (2026-05-07 24-h soak finding) — `shard.ttl` event
-// shape regression test extracted to the sibling
-// [`super::shard_ttl_events`] module to keep this file under the
-// workspace's 800-LOC file-size policy.
-
-// ── PR-f — promote-side `mark_loaded_at` regression test ──────────
-
-/// Pin the PR-f fix at
-/// `@/Users/rnio/Private/Github/UltraFastFileSearch/crates/uffs-daemon/src/
-/// index/mod.rs:1208` — promoting a Parked shard whose `last_query_at_ms` is
-/// older than `WARM_TO_PARKED_IDLE_SECS` must NOT cause an
-/// immediate-re-demote on the very next idle tick.
-///
-/// **Background:** the v0.5.85 Windows soak captured a clear
-/// promote-then-immediate-demote thrash in the daemon log (lines
-/// 5540 → 5733 of `LOG/windows 0.5.85`):
-///
-/// ```text
-/// 21:46:59.819  letter=G from=parked to=warm restored_mb=1
-/// 21:47:04.754  letter=G from=warm   to=parked freed_mb=1
-///                              ↑ only 4.9 s of "warm" life
-/// 21:47:11      letter=G from=parked to=warm restored_mb=1   ← thrash
-/// ```
-///
-/// Three drives (G/F/M) were re-demoted within 0.5 – 5 s of their
-/// promotes, then re-promoted seconds later when the search
-/// finally completed `ensure_warm_for_dispatch` and ran
-/// `record_search_dispatch`.
-///
-/// **Root cause:** `IndexManager::ensure_warm_for_dispatch`'s
-/// per-letter promote loop did the registry write-swap but did
-/// not stamp `last_query_at_ms` on the freshly-promoted shard.
-/// The shard inherited its pre-park value from the previous
-/// `Arc<DriveStats>` (preserved by `new_warm_with_stats`).  When
-/// the shard had been Parked for > 5 min, that inherited value
-/// was already past `WARM_TO_PARKED_IDLE_SECS`, so the very next
-/// 30-s `demote_idle_shards` tick (firing while the search was
-/// still awaiting other concurrent loads) re-demoted the shard
-/// before the eventual `record_search_dispatch` could refresh it.
-///
-/// **Fix:** call `shard.stats.mark_loaded_at(now_ms)` right after
-/// the promote write-swap, mirroring the seed in
-/// `Self::add_drive` and `Self::replace_drive`.
-///
-/// **Test sequence:**
-///
-/// 1. Add C with a fresh load timestamp (Phase-3 default).
-/// 2. Park C, then backdate `last_query_at_ms` to a deep-past value (year 2001,
-///    ≪ `WARM_TO_PARKED_IDLE_SECS` ago by any real wall clock).  This
-///    faithfully reproduces the v0.5.85 state: a parked shard whose timestamp
-///    is from a long time ago.
-/// 3. Promote C via `ensure_warm_for_dispatch`.
-/// 4. Immediately fire one `demote_idle_shards(unix_now_ms())` tick — the same
-///    race-window the Windows soak hit.
-/// 5. Assert C is still Warm.  Without PR-f, `idle_secs` would be
-///    `(unix_now_ms() - 1_000_000_000) / 1000 ≫ 300`, so the shard would
-///    re-demote.  With PR-f, `last_query_at_ms ≈ unix_now_ms()` after the
-///    promote, so `idle_secs ≈ 0` and the shard stays Warm.
-#[tokio::test]
-async fn promote_resets_idle_clock_against_thrash() {
-    use crate::cache::ShardState;
-
-    let (tx, _rx) = crate::events::event_channel();
-    let body = Arc::new(build_test_drive());
-    let loader = Arc::new(FixedBodyLoader {
-        body: Arc::clone(&body),
-    });
-    let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
-    mgr.add_drive(build_test_drive()).await;
-
-    // ── Step 1–2: Park C and backdate `last_query_at_ms` to
-    // simulate a shard that has been Parked for a very long time
-    // (the production thrash precondition).
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
-    let ancient_ts_ms = 1_000_000_000_u64; // 2001-09-09T01:46:40Z
-    assert!(
-        mgr.backdate_last_query_at_ms_for_test('C', ancient_ts_ms)
-            .await,
-        "test fixture must be able to backdate last_query_at_ms",
-    );
-
-    // ── Step 3: Promote.  PR-f bumps `last_query_at_ms` to
-    // ~`unix_now_ms()` inside the registry write-swap.
-    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
-    assert_eq!(
-        mgr.shard_states_for_test().await,
-        vec![('C', ShardState::Warm)],
-        "ensure_warm_for_dispatch must promote Parked → Warm",
-    );
-
-    // ── Step 4: Idle tick at "real now".  Without PR-f the demote
-    // controller sees the still-stale ancient_ts_ms → idle_secs
-    // ~25 years → re-demote.  With PR-f the promote refreshed the
-    // timestamp → idle_secs ≈ 0 → no demote.
-    let now_ms = crate::cache::unix_now_ms();
-    mgr.demote_idle_shards(now_ms).await;
-
-    // ── Step 5: Assert no re-demote.  Pre-PR-f this assertion
-    // fails: states_post_tick == [('C', Parked)].  Post-PR-f the
-    // shard stays Warm.
-    assert_eq!(
-        mgr.shard_states_for_test().await,
-        vec![('C', ShardState::Warm)],
-        "promote must refresh `last_query_at_ms` so the next idle \
-         tick sees a fresh idle clock; without the PR-f \
-         `mark_loaded_at(now_ms)` bump, this re-demotes immediately \
-         (the v0.5.85 Windows soak thrash captured at \
-         `LOG/windows 0.5.85` lines 5540 → 5733)",
     );
 }

--- a/crates/uffs-daemon/src/index/tests/idle_demote_tracing.rs
+++ b/crates/uffs-daemon/src/index/tests/idle_demote_tracing.rs
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase 3 Commit E + Phase 5 G4 — `shard.transition` tracing-event
+//! contract tests.
+//!
+//! Split from [`super::idle_demote`] so the state-transition ladder
+//! tests stay focused on TTL / multi-drive behaviour while this
+//! sibling module owns the operator-facing observability contract:
+//!
+//! * Plan task 3.9 — every demote / promote emits exactly one
+//!   `tracing::event!(target: "shard.transition", ...)` with the `letter` /
+//!   `from` / `to` / `reason` / `freed_mb` / `restored_mb` / `last_query_at_ms`
+//!   field surface.
+//! * Phase 5 G4 follow-up — single-canonical-event regression for the
+//!   pressure-cascade demote path.
+//! * PR-f — promote refreshes `last_query_at_ms` so the next idle tick doesn't
+//!   immediately re-demote the just-promoted shard (anti-thrash invariant).
+//!
+//! Shared `EventLog` / `CapturedEvent` capture scaffold lives in
+//! [`super::tracing_capture`].
+
+#![expect(
+    clippy::indexing_slicing,
+    clippy::std_instead_of_alloc,
+    reason = "test code — assertions index into known-shape `EventLog` \
+              vectors, and `Arc` pulled from `std` to match the rest of \
+              the daemon's test fixtures"
+)]
+
+use std::sync::Arc;
+
+use super::tracing_capture::{CapturedEvent, EventLog};
+use super::{FixedBodyLoader, IndexManager, build_test_drive};
+
+// ── Phase 3 Commit E — tracing-event contract (plan task 3.9) ──────
+
+/// Plan task 3.9 — every demote / promote transition emits exactly
+/// one `tracing::event!(target: "shard.transition", ...)` event.
+///
+/// Pins the operator-facing observability contract: the tracing
+/// fields (`letter`, `from`, `to`, `reason`, `freed_mb` /
+/// `restored_mb`) are part of the public log surface, so a refactor
+/// that silently drops or renames them would break dashboards and
+/// alerting.  This test captures every event during a
+/// demote-then-promote round-trip and asserts on the field values.
+///
+/// `tokio::test` defaults to a `current_thread` runtime, so the
+/// thread-local `tracing::subscriber::set_default` we install at
+/// the top of the test captures every event emitted from inside
+/// the test future — including the events from `demote_letter` /
+/// `promote_letter` running on the same thread.
+#[tokio::test]
+async fn shard_transition_events_emitted_on_demote_and_promote() {
+    use crate::cache::ShardState;
+
+    let log = EventLog::default();
+    // Hold a second registered `Dispatch` for the duration of the test
+    // body so `tracing-core` keeps `Dispatchers::has_just_one` at
+    // `false`, which forces every callsite-interest rebuild to walk
+    // the global `LOCKED_DISPATCHERS` list (containing OUR subscriber)
+    // instead of taking the `JustOne` fast path.
+    //
+    // The `JustOne` fast path (`tracing-core::callsite::Dispatchers::
+    // rebuilder` at v0.1.36 line 544–549) calls
+    // `dispatcher::get_default(f)`, which is THREAD-LOCAL.  When a
+    // sibling test on a different thread fires a `shard.transition`
+    // callsite for the first time (registering it against
+    // `NoSubscriber` because that thread never called `set_default`),
+    // the per-callsite `Interest` cache gets pinned to `never` GLOBALLY,
+    // and OUR thread-local subscriber never gets a chance to vote
+    // — even if we later call `rebuild_interest_cache`, that rebuild
+    // also takes the `JustOne` path and asks the wrong (sibling)
+    // thread's default.
+    //
+    // Holding a dummy `NoSubscriber` Dispatch alive flips
+    // `has_just_one` to `false`, so the rebuilder switches to
+    // `Rebuilder::Read(LOCKED_DISPATCHERS)` which walks every
+    // registered dispatcher (ours + the dummy).  Our subscriber's
+    // `register_callsite` is then consulted on every callsite,
+    // and the `Interest` cache reflects our `Interest::always`
+    // independently of which thread first encountered the callsite.
+    let _interest_rebuild_dummy =
+        tracing::Dispatch::new(tracing::subscriber::NoSubscriber::default());
+    let _guard = tracing::subscriber::set_default(log.clone());
+    // Force every existing callsite to re-register against the dispatchers
+    // we just expanded with the dummy + our subscriber, in case sibling
+    // tests already pinned cache entries to `never` before this test ran.
+    tracing::callsite::rebuild_interest_cache();
+
+    let (tx, _rx) = crate::events::event_channel();
+    let body = Arc::new(build_test_drive());
+    let loader = Arc::new(FixedBodyLoader {
+        body: Arc::clone(&body),
+    });
+    let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
+    mgr.add_drive(build_test_drive()).await;
+
+    // Demote → expect one demote event.
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
+    // Promote via ensure_warm_for_dispatch → expect one promote event.
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+        .await;
+
+    let events = log.events();
+    // Filter to the operator-facing observability contract: the
+    // INFO-level `shard.transition` events with a tier-transition
+    // `reason` (`demote`, `promote`, `usn-refresh`).  Other levels
+    // on this target are best-effort observability noise that may
+    // legitimately fire on a tier transition without violating the
+    // contract — e.g. the Phase 5 `Prefetch::hint failed` warn,
+    // which can fire on Linux for synthetic small heap regions
+    // even when the promote itself succeeds (and is documented at
+    // `crates/uffs-daemon/src/cache/prefetch.rs` to be best-effort
+    // with warn-level logging on failure).  Pinning by level +
+    // reason makes this test robust to the runtime-topology
+    // detail of *which thread* the prefetch hint runs on (the
+    // PR-e refactor moved the hint from a `spawn_blocking` closure
+    // into the surrounding async task — both paths are observably
+    // correct, but only the latter is captured by the
+    // `set_default` thread-local subscriber on a `current_thread`
+    // runtime).
+    let transitions: Vec<&CapturedEvent> = events
+        .iter()
+        .filter(|event| {
+            event.target == "shard.transition"
+                && event.level == tracing::Level::INFO
+                && matches!(
+                    event.field("reason"),
+                    Some("demote" | "promote" | "usn-refresh")
+                )
+        })
+        .collect();
+
+    assert_eq!(
+        transitions.len(),
+        2,
+        "expected exactly two INFO `shard.transition` events with reason in \
+         {{demote, promote, usn-refresh}} (one demote + one promote), got {}: {:#?}",
+        transitions.len(),
+        transitions
+    );
+
+    // `ShardState`'s `Display` impl emits lowercase variant names
+    // (`warm`, `parked`, `cold`, …) — that's the wire contract this
+    // test pins.  See `impl fmt::Display for ShardState` in
+    // `cache/shard.rs`.
+    let demote = transitions[0];
+    assert_eq!(demote.level, tracing::Level::INFO);
+    assert_eq!(demote.field("reason"), Some("demote"));
+    assert_eq!(demote.field("from"), Some("warm"));
+    assert_eq!(demote.field("to"), Some("parked"));
+    assert_eq!(demote.field("letter"), Some("C"));
+    assert!(
+        demote.has_field("freed_mb"),
+        "demote event must carry freed_mb field for resident-delta accounting"
+    );
+    // G4 follow-up: `last_query_at_ms` is now part of the canonical
+    // demote event (used to be cascade-only).  Pinning its presence
+    // here so a future refactor can't drop the field and silently
+    // break operator runbooks that grep for it.
+    assert!(
+        demote.has_field("last_query_at_ms"),
+        "demote event must carry last_query_at_ms field (G4 follow-up)",
+    );
+
+    let promote = transitions[1];
+    assert_eq!(promote.level, tracing::Level::INFO);
+    assert_eq!(promote.field("reason"), Some("promote"));
+    assert_eq!(promote.field("from"), Some("parked"));
+    assert_eq!(promote.field("to"), Some("warm"));
+    assert_eq!(promote.field("letter"), Some("C"));
+    assert!(
+        promote.has_field("restored_mb"),
+        "promote event must carry restored_mb field for resident-delta accounting"
+    );
+}
+
+/// Phase 5 G4 follow-up — the pressure-cascade demote path must
+/// emit exactly **one** `INFO`-level `shard.transition` event per
+/// shard, with `reason="pressure-cascade"` and `last_query_at_ms`
+/// in the field set.
+///
+/// Pre-refactor, every cascade demote produced **two** events: the
+/// registry primitive's generic `reason="demote"` event followed by
+/// a second `reason="pressure-cascade"` event from
+/// `cascade_demote_one_step` itself.  The two were separated by the
+/// `WorkingSetTrim::trim` syscall duration (6-22 ms typically; up
+/// to ~1 s on the first cascade demote when the daemon's working
+/// set was still large) which confused operator log analysis.
+///
+/// This test pins the single-event contract so a future refactor
+/// can't reintroduce the dual-event pattern.  It also pins the
+/// presence of `last_query_at_ms` (formerly cascade-only, now part
+/// of the canonical demote event for both TTL and pressure paths).
+///
+/// Test topology: 1 Warm drive (`C`) with a known
+/// `last_query_at_ms = 1_234` so the assertion can use a literal
+/// value instead of `has_field`.  `ControllablePressureSignal` is
+/// injected for completeness but never driven — the test calls
+/// `cascade_demote_one_step` directly, mirroring the contract of
+/// the existing
+/// `cascade_demote_one_step_picks_lru_warm_and_drains_in_order`
+/// test in `lifecycle_hooks.rs` (which pins the demote ordering
+/// and trim-call counts but doesn't capture tracing events).
+#[tokio::test]
+async fn cascade_demote_emits_single_event_with_pressure_cascade_reason() {
+    use crate::cache::ShardState;
+    use crate::cache::pressure::tests::ControllablePressureSignal;
+    use crate::cache::working_set::tests::CountingWorkingSetTrim;
+
+    // Same dummy-Dispatch + thread-local-default + interest-rebuild
+    // dance as `shard_transition_events_emitted_on_demote_and_promote`
+    // — see that test's docstring for the rationale.  Without this,
+    // a sibling test on a different thread can pin the
+    // `shard.transition` callsite's `Interest` cache to `never`
+    // before our subscriber gets a chance to vote, and the cascade
+    // event silently disappears.
+    let log = EventLog::default();
+    let _interest_rebuild_dummy =
+        tracing::Dispatch::new(tracing::subscriber::NoSubscriber::default());
+    let _guard = tracing::subscriber::set_default(log.clone());
+    tracing::callsite::rebuild_interest_cache();
+
+    let (tx, _rx) = crate::events::event_channel();
+    let counting_trim = Arc::new(CountingWorkingSetTrim::new());
+    let pressure_fake = Arc::new(ControllablePressureSignal::new());
+    let hooks = crate::index::constructors::LifecycleHooks {
+        working_set_trim: Arc::clone(&counting_trim)
+            as Arc<dyn crate::cache::working_set::WorkingSetTrim>,
+        pressure: Arc::clone(&pressure_fake) as Arc<dyn crate::cache::pressure::PressureSignal>,
+        ..crate::index::constructors::LifecycleHooks::production()
+    };
+    let mgr = IndexManager::with_lifecycle_hooks_for_test(
+        None,
+        tx,
+        hooks,
+        Arc::new(crate::config::Config::default()),
+    );
+    mgr.add_drive(build_test_drive()).await;
+
+    // Backdate to a known timestamp so the assertion can use a
+    // literal value below.  `add_drive` already stamped
+    // `mark_loaded_at(unix_now_ms())`, which would make the assertion
+    // wall-clock-dependent.
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::C, 1_234)
+            .await
+    );
+
+    // Drive the cascade once.  With one Warm shard, the LRU pick is
+    // unambiguous and the call returns `Some((uffs_mft::platform::DriveLetter::C,
+    // Parked))`.
+    let result = mgr.cascade_demote_one_step().await;
+    assert_eq!(
+        result,
+        Some((uffs_mft::platform::DriveLetter::C, ShardState::Parked)),
+        "single-shard cascade demotes C and returns Some",
+    );
+
+    // Filter to INFO-level `shard.transition` events whose `reason`
+    // is in the demote vocabulary.  We accept both `"demote"` (the
+    // legacy generic value) and `"pressure-cascade"` (the new
+    // discriminator) so this test would still catch a regression
+    // that flipped the cascade path back to emitting `"demote"`
+    // — the assertion below pins the EXACT value.
+    let events = log.events();
+    let demotes: Vec<&CapturedEvent> = events
+        .iter()
+        .filter(|event| {
+            event.target == "shard.transition"
+                && event.level == tracing::Level::INFO
+                && matches!(event.field("reason"), Some("demote" | "pressure-cascade"))
+        })
+        .collect();
+
+    assert_eq!(
+        demotes.len(),
+        1,
+        "G4 follow-up: cascade demote must emit exactly ONE info \
+         `shard.transition` event (the registry primitive's canonical \
+         event with reason=\"pressure-cascade\"); the legacy second \
+         event from `cascade_demote_one_step` is gone.  got {}: {:#?}",
+        demotes.len(),
+        demotes,
+    );
+
+    let cascade = demotes[0];
+    assert_eq!(cascade.field("reason"), Some("pressure-cascade"));
+    assert_eq!(cascade.field("from"), Some("warm"));
+    assert_eq!(cascade.field("to"), Some("parked"));
+    assert_eq!(cascade.field("letter"), Some("C"));
+    assert!(
+        cascade.has_field("freed_mb"),
+        "cascade demote event must carry freed_mb field",
+    );
+    assert_eq!(
+        cascade.field("last_query_at_ms"),
+        Some("1234"),
+        "cascade demote event must carry last_query_at_ms (formerly \
+         cascade-only; now part of the canonical demote event)",
+    );
+
+    // Sanity: trim fired exactly once for the single cascade step.
+    assert_eq!(
+        counting_trim.calls(),
+        1,
+        "single cascade step → single trim call",
+    );
+}
+
+// Phase 6 fix (2026-05-07 24-h soak finding) — `shard.ttl` event
+// shape regression test extracted to the sibling
+// [`super::shard_ttl_events`] module to keep this file under the
+// workspace's 800-LOC file-size policy.
+
+// ── PR-f — promote-side `mark_loaded_at` regression test ──────────
+
+/// Pin the PR-f fix at
+/// `@/Users/rnio/Private/Github/UltraFastFileSearch/crates/uffs-daemon/src/
+/// index/mod.rs:1208` — promoting a Parked shard whose `last_query_at_ms` is
+/// older than `WARM_TO_PARKED_IDLE_SECS` must NOT cause an
+/// immediate-re-demote on the very next idle tick.
+///
+/// **Background:** the v0.5.85 Windows soak captured a clear
+/// promote-then-immediate-demote thrash in the daemon log (lines
+/// 5540 → 5733 of `LOG/windows 0.5.85`):
+///
+/// ```text
+/// 21:46:59.819  letter=G from=parked to=warm restored_mb=1
+/// 21:47:04.754  letter=G from=warm   to=parked freed_mb=1
+///                              ↑ only 4.9 s of "warm" life
+/// 21:47:11      letter=G from=parked to=warm restored_mb=1   ← thrash
+/// ```
+///
+/// Three drives (G/F/M) were re-demoted within 0.5 – 5 s of their
+/// promotes, then re-promoted seconds later when the search
+/// finally completed `ensure_warm_for_dispatch` and ran
+/// `record_search_dispatch`.
+///
+/// **Root cause:** `IndexManager::ensure_warm_for_dispatch`'s
+/// per-letter promote loop did the registry write-swap but did
+/// not stamp `last_query_at_ms` on the freshly-promoted shard.
+/// The shard inherited its pre-park value from the previous
+/// `Arc<DriveStats>` (preserved by `new_warm_with_stats`).  When
+/// the shard had been Parked for > 5 min, that inherited value
+/// was already past `WARM_TO_PARKED_IDLE_SECS`, so the very next
+/// 30-s `demote_idle_shards` tick (firing while the search was
+/// still awaiting other concurrent loads) re-demoted the shard
+/// before the eventual `record_search_dispatch` could refresh it.
+///
+/// **Fix:** call `shard.stats.mark_loaded_at(now_ms)` right after
+/// the promote write-swap, mirroring the seed in
+/// `Self::add_drive` and `Self::replace_drive`.
+///
+/// **Test sequence:**
+///
+/// 1. Add C with a fresh load timestamp (Phase-3 default).
+/// 2. Park C, then backdate `last_query_at_ms` to a deep-past value (year 2001,
+///    ≪ `WARM_TO_PARKED_IDLE_SECS` ago by any real wall clock).  This
+///    faithfully reproduces the v0.5.85 state: a parked shard whose timestamp
+///    is from a long time ago.
+/// 3. Promote C via `ensure_warm_for_dispatch`.
+/// 4. Immediately fire one `demote_idle_shards(unix_now_ms())` tick — the same
+///    race-window the Windows soak hit.
+/// 5. Assert C is still Warm.  Without PR-f, `idle_secs` would be
+///    `(unix_now_ms() - 1_000_000_000) / 1000 ≫ 300`, so the shard would
+///    re-demote.  With PR-f, `last_query_at_ms ≈ unix_now_ms()` after the
+///    promote, so `idle_secs ≈ 0` and the shard stays Warm.
+#[tokio::test]
+async fn promote_resets_idle_clock_against_thrash() {
+    use crate::cache::ShardState;
+
+    let (tx, _rx) = crate::events::event_channel();
+    let body = Arc::new(build_test_drive());
+    let loader = Arc::new(FixedBodyLoader {
+        body: Arc::clone(&body),
+    });
+    let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
+    mgr.add_drive(build_test_drive()).await;
+
+    // ── Step 1–2: Park C and backdate `last_query_at_ms` to
+    // simulate a shard that has been Parked for a very long time
+    // (the production thrash precondition).
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
+    let ancient_ts_ms = 1_000_000_000_u64; // 2001-09-09T01:46:40Z
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::C, ancient_ts_ms)
+            .await,
+        "test fixture must be able to backdate last_query_at_ms",
+    );
+
+    // ── Step 3: Promote.  PR-f bumps `last_query_at_ms` to
+    // ~`unix_now_ms()` inside the registry write-swap.
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+        .await;
+    assert_eq!(
+        mgr.shard_states_for_test().await,
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Warm)],
+        "ensure_warm_for_dispatch must promote Parked → Warm",
+    );
+
+    // ── Step 4: Idle tick at "real now".  Without PR-f the demote
+    // controller sees the still-stale ancient_ts_ms → idle_secs
+    // ~25 years → re-demote.  With PR-f the promote refreshed the
+    // timestamp → idle_secs ≈ 0 → no demote.
+    let now_ms = crate::cache::unix_now_ms();
+    mgr.demote_idle_shards(now_ms).await;
+
+    // ── Step 5: Assert no re-demote.  Pre-PR-f this assertion
+    // fails: states_post_tick == [(uffs_mft::platform::DriveLetter::C, Parked)].
+    // Post-PR-f the shard stays Warm.
+    assert_eq!(
+        mgr.shard_states_for_test().await,
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Warm)],
+        "promote must refresh `last_query_at_ms` so the next idle \
+         tick sees a fresh idle clock; without the PR-f \
+         `mark_loaded_at(now_ms)` bump, this re-demotes immediately \
+         (the v0.5.85 Windows soak thrash captured at \
+         `LOG/windows 0.5.85` lines 5540 → 5733)",
+    );
+}

--- a/crates/uffs-daemon/src/index/tests/lifecycle_hooks.rs
+++ b/crates/uffs-daemon/src/index/tests/lifecycle_hooks.rs
@@ -64,9 +64,15 @@ async fn drives_rpc_enumerates_warm_parked_and_cold_shards_with_tier_markers() {
     mgr.add_drive(build_test_drive_e()).await;
 
     // Demote D → Parked (body released; bloom + trie resident).
-    assert!(mgr.demote_letter_for_test('D', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::D, ShardState::Parked)
+            .await
+    );
     // Demote E → Cold (no body, no filters).
-    assert!(mgr.demote_letter_for_test('E', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::E, ShardState::Cold)
+            .await
+    );
 
     let response = mgr.drives().await;
     assert_eq!(
@@ -76,13 +82,22 @@ async fn drives_rpc_enumerates_warm_parked_and_cold_shards_with_tier_markers() {
     );
 
     // Load-order preserved (matches ShardRegistry::iter()).
-    let letters: Vec<char> = response.drives.iter().map(|dr| dr.letter).collect();
-    assert_eq!(letters, vec!['C', 'D', 'E'], "load order preserved");
+    let letters: Vec<uffs_mft::platform::DriveLetter> =
+        response.drives.iter().map(|dr| dr.letter).collect();
+    assert_eq!(
+        letters,
+        vec![
+            uffs_mft::platform::DriveLetter::C,
+            uffs_mft::platform::DriveLetter::D,
+            uffs_mft::platform::DriveLetter::E
+        ],
+        "load order preserved"
+    );
 
     // C — Warm: body present, records nonzero, tier=Warm,
     // source from the body's IndexSource (live MFT path "C:").
     let c = &response.drives[0];
-    assert_eq!(c.letter, 'C');
+    assert_eq!(c.letter, uffs_mft::platform::DriveLetter::C);
     assert_eq!(c.tier, Some(ShardTier::Warm), "C remains Warm");
     assert!(c.records > 0, "Warm shard reports its body's records.len()");
     assert_eq!(c.source, "live", "Warm shard's body source flows through");
@@ -90,7 +105,7 @@ async fn drives_rpc_enumerates_warm_parked_and_cold_shards_with_tier_markers() {
     // D — Parked: no body, records=0, tier=Parked,
     // source synthesized as "parked".
     let d = &response.drives[1];
-    assert_eq!(d.letter, 'D');
+    assert_eq!(d.letter, uffs_mft::platform::DriveLetter::D);
     assert_eq!(d.tier, Some(ShardTier::Parked), "D demoted to Parked");
     assert_eq!(d.records, 0, "Parked shard has no body in RAM");
     assert_eq!(
@@ -101,7 +116,7 @@ async fn drives_rpc_enumerates_warm_parked_and_cold_shards_with_tier_markers() {
     // E — Cold: no body, no filters, records=0, tier=Cold,
     // source synthesized as "cold".
     let e = &response.drives[2];
-    assert_eq!(e.letter, 'E');
+    assert_eq!(e.letter, uffs_mft::platform::DriveLetter::E);
     assert_eq!(e.tier, Some(ShardTier::Cold), "E demoted to Cold");
     assert_eq!(e.records, 0, "Cold shard has nothing in RAM");
     assert_eq!(
@@ -164,7 +179,11 @@ async fn demote_idle_shards_invokes_working_set_trim_once_per_batch() {
     // Backdate every shard's last_query_at_ms past the Warm→Parked
     // threshold so the controller picks up all three in one batch.
     let last_query_ms = 1_000_000_000_u64;
-    for letter in ['C', 'D', 'E'] {
+    for letter in [
+        uffs_mft::platform::DriveLetter::C,
+        uffs_mft::platform::DriveLetter::D,
+        uffs_mft::platform::DriveLetter::E,
+    ] {
         assert!(
             mgr.backdate_last_query_at_ms_for_test(letter, last_query_ms)
                 .await
@@ -180,9 +199,18 @@ async fn demote_idle_shards_invokes_working_set_trim_once_per_batch() {
     // Post-batch: every shard demoted, hook fired exactly once.
     let states = mgr.shard_states_for_test().await;
     assert_eq!(states, vec![
-        ('C', crate::cache::ShardState::Parked),
-        ('D', crate::cache::ShardState::Parked),
-        ('E', crate::cache::ShardState::Parked),
+        (
+            uffs_mft::platform::DriveLetter::C,
+            crate::cache::ShardState::Parked
+        ),
+        (
+            uffs_mft::platform::DriveLetter::D,
+            crate::cache::ShardState::Parked
+        ),
+        (
+            uffs_mft::platform::DriveLetter::E,
+            crate::cache::ShardState::Parked
+        ),
     ]);
     assert_eq!(
         counting_trim.calls(),
@@ -237,16 +265,23 @@ async fn ensure_warm_for_dispatch_invokes_prefetch_with_records_and_names_region
         Arc::new(crate::config::Config::default()),
     );
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
 
     // Pre-promote: no prefetch calls.
     assert!(recording_prefetch.calls().is_empty());
 
-    mgr.ensure_warm_for_dispatch(&['C'], &[]).await;
+    mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
+        .await;
 
     // Shard promoted (the Phase-3 contract this test depends on).
     let states = mgr.shard_states_for_test().await;
-    assert_eq!(states, vec![('C', ShardState::Warm)]);
+    assert_eq!(states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Warm
+    )]);
 
     // Prefetch invoked exactly once, with two regions in a fixed
     // order: records first (typed slice → byte length), names
@@ -335,9 +370,18 @@ async fn cascade_demote_one_step_picks_lru_warm_and_drains_in_order() {
     // already stamped `mark_loaded_at(unix_now_ms())` on each shard, so
     // we backdate to known values to remove wall-clock skew from the
     // assertion.
-    assert!(mgr.backdate_last_query_at_ms_for_test('D', 1_000).await);
-    assert!(mgr.backdate_last_query_at_ms_for_test('E', 2_000).await);
-    assert!(mgr.backdate_last_query_at_ms_for_test('C', 3_000).await);
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::D, 1_000)
+            .await
+    );
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::E, 2_000)
+            .await
+    );
+    assert!(
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::C, 3_000)
+            .await
+    );
 
     // Pre-cascade: trim hook never fired.
     assert_eq!(counting_trim.calls(), 0, "no cascade yet → no trim");
@@ -346,7 +390,7 @@ async fn cascade_demote_one_step_picks_lru_warm_and_drains_in_order() {
     let step1 = mgr.cascade_demote_one_step().await;
     assert_eq!(
         step1,
-        Some(('D', ShardState::Parked)),
+        Some((uffs_mft::platform::DriveLetter::D, ShardState::Parked)),
         "first cascade step demotes the LRU Warm shard (D, ts=1000)",
     );
     assert_eq!(
@@ -359,7 +403,7 @@ async fn cascade_demote_one_step_picks_lru_warm_and_drains_in_order() {
     let step2 = mgr.cascade_demote_one_step().await;
     assert_eq!(
         step2,
-        Some(('E', ShardState::Parked)),
+        Some((uffs_mft::platform::DriveLetter::E, ShardState::Parked)),
         "second cascade step demotes the next-LRU Warm shard (E, ts=2000)",
     );
     assert_eq!(counting_trim.calls(), 2);
@@ -368,7 +412,7 @@ async fn cascade_demote_one_step_picks_lru_warm_and_drains_in_order() {
     let step3 = mgr.cascade_demote_one_step().await;
     assert_eq!(
         step3,
-        Some(('C', ShardState::Parked)),
+        Some((uffs_mft::platform::DriveLetter::C, ShardState::Parked)),
         "third cascade step demotes the last Warm shard (C, ts=3000)",
     );
     assert_eq!(counting_trim.calls(), 3);
@@ -391,9 +435,9 @@ async fn cascade_demote_one_step_picks_lru_warm_and_drains_in_order() {
     // order from `shard_states_for_test`).
     let states = mgr.shard_states_for_test().await;
     assert_eq!(states, vec![
-        ('C', ShardState::Parked),
-        ('D', ShardState::Parked),
-        ('E', ShardState::Parked),
+        (uffs_mft::platform::DriveLetter::C, ShardState::Parked),
+        (uffs_mft::platform::DriveLetter::D, ShardState::Parked),
+        (uffs_mft::platform::DriveLetter::E, ShardState::Parked),
     ]);
 
     // The pressure fake was never driven — this test exercises the
@@ -579,9 +623,18 @@ mod pressure_subscriber_fixtures {
         mgr.add_drive(build_test_drive()).await;
         mgr.add_drive(build_test_drive_d()).await;
         mgr.add_drive(build_test_drive_e()).await;
-        assert!(mgr.backdate_last_query_at_ms_for_test('D', 1_000).await);
-        assert!(mgr.backdate_last_query_at_ms_for_test('E', 2_000).await);
-        assert!(mgr.backdate_last_query_at_ms_for_test('C', 3_000).await);
+        assert!(
+            mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::D, 1_000)
+                .await
+        );
+        assert!(
+            mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::E, 2_000)
+                .await
+        );
+        assert!(
+            mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::C, 3_000)
+                .await
+        );
         let initial_states = mgr.shard_states_for_test().await;
         assert!(
             initial_states.iter().all(|(_, s)| *s == ShardState::Warm),
@@ -610,7 +663,7 @@ mod pressure_subscriber_fixtures {
     /// failed assertion site, not as a hung test.
     pub(super) async fn poll_until<F>(mgr: &IndexManager, predicate: F, label: &str)
     where
-        F: Fn(&[(char, ShardState)]) -> bool,
+        F: Fn(&[(uffs_mft::platform::DriveLetter, ShardState)]) -> bool,
     {
         let deadline = std::time::Instant::now() + CASCADE_DEADLINE;
         loop {

--- a/crates/uffs-daemon/src/index/tests/manager.rs
+++ b/crates/uffs-daemon/src/index/tests/manager.rs
@@ -150,34 +150,40 @@ fn infer_drive_letter_pins_canonical_mapping() {
     // Standard captures: `<letter>_mft.iocp`.
     assert_eq!(
         IndexManager::infer_drive_letter(Path::new("G_mft.iocp")),
-        'G'
+        uffs_mft::platform::DriveLetter::G
     );
     assert_eq!(
         IndexManager::infer_drive_letter(Path::new("c_mft.iocp")),
-        'C'
+        uffs_mft::platform::DriveLetter::C
     );
 
     // Lone letter, no extension.
-    assert_eq!(IndexManager::infer_drive_letter(Path::new("d")), 'D');
+    assert_eq!(
+        IndexManager::infer_drive_letter(Path::new("d")),
+        uffs_mft::platform::DriveLetter::D
+    );
 
     // Path with directory components — only the file stem matters.
     assert_eq!(
         IndexManager::infer_drive_letter(Path::new("data_dir/drive_e/E_mft.iocp")),
-        'E'
+        uffs_mft::platform::DriveLetter::E
     );
 
     // Non-conforming names fall back to 'X' rather than panicking.
     assert_eq!(
         IndexManager::infer_drive_letter(Path::new("1bad_name")),
-        'X'
+        uffs_mft::platform::DriveLetter::X
     );
     assert_eq!(
         IndexManager::infer_drive_letter(Path::new("_underscore.iocp")),
-        'X'
+        uffs_mft::platform::DriveLetter::X
     );
 
     // Empty path components default to 'X' (file_name() returns None).
-    assert_eq!(IndexManager::infer_drive_letter(Path::new("")), 'X');
+    assert_eq!(
+        IndexManager::infer_drive_letter(Path::new("")),
+        uffs_mft::platform::DriveLetter::X
+    );
 }
 
 /// `is_live_drive_marker` distinguishes a cached source whose

--- a/crates/uffs-daemon/src/index/tests/mod.rs
+++ b/crates/uffs-daemon/src/index/tests/mod.rs
@@ -17,13 +17,16 @@
 //! * [`ensure_warm`] — `ensure_warm_for_dispatch` happy-path, missing-cache,
 //!   panicking-loader, parallel re-promote, and bloom-aware promote-side gating
 //!   (Phase 4 task 4.11).
-//! * [`idle_demote`] — `demote_idle_shards` TTL-driven cascade, round-trip
-//!   query stats, and `shard.transition` event emission.
+//! * [`idle_demote`] — `demote_idle_shards` TTL-driven cascade and round-trip
+//!   query stats (state-ladder behaviour only).
+//! * [`idle_demote_tracing`] — `shard.transition` tracing-event contract,
+//!   pressure-cascade single-event regression, and the PR-f promote anti-thrash
+//!   invariant.
 //! * [`lifecycle_hooks`] — Phase 5 task 5.8 / 5.9 / 5.10 `WorkingSetTrim` +
 //!   `Prefetch` + `PressureSignal` injection tests, plus the `drives` RPC
 //!   tier-marker enumeration.
 //! * [`tracing_capture`] — shared `tracing::Subscriber` scaffold (`EventLog` /
-//!   `CapturedEvent`) used by [`idle_demote`]'s `shard.transition`
+//!   `CapturedEvent`) used by [`idle_demote_tracing`] and other
 //!   observability-contract tests.
 
 #![expect(
@@ -48,6 +51,7 @@ mod body_loader_fakes;
 mod ensure_warm;
 mod forget_status;
 mod idle_demote;
+mod idle_demote_tracing;
 mod lifecycle_hooks;
 mod manager;
 mod registry;
@@ -64,7 +68,7 @@ pub(crate) mod tracing_capture;
 /// Build a synthetic drive with root + 1 dir + 5 files of varied
 /// sizes/extensions.
 fn build_test_drive() -> uffs_core::compact::DriveCompactIndex {
-    let mut idx = MftIndex::new('C');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::C);
 
     // Root directory
     let root_off = idx.add_name(".");
@@ -107,7 +111,7 @@ fn build_test_drive() -> uffs_core::compact::DriveCompactIndex {
         rec.stdinfo.modified = 1_000_000;
     }
 
-    let (drive, _, _) = build_compact_index('C', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::C, &idx);
     drive
 }
 
@@ -129,7 +133,7 @@ fn spec(kind: &str) -> AggregateSpecWire {
 /// Same shape as [`build_test_drive`] but a different letter so a
 /// 2-drive registry is unambiguous.
 fn build_test_drive_d() -> uffs_core::compact::DriveCompactIndex {
-    let mut idx = MftIndex::new('D');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::D);
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
     root.stdinfo.set_directory(true);
@@ -149,7 +153,7 @@ fn build_test_drive_d() -> uffs_core::compact::DriveCompactIndex {
     rec.stdinfo.flags = 0x20;
     rec.stdinfo.modified = 1_000_000;
 
-    let (drive, _, _) = build_compact_index('D', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::D, &idx);
     drive
 }
 
@@ -158,7 +162,7 @@ fn build_test_drive_d() -> uffs_core::compact::DriveCompactIndex {
 /// need to verify "queries on C only → D and E both demote, C
 /// stays Warm" and "advance past parked TTL → all three Cold".
 fn build_test_drive_e() -> uffs_core::compact::DriveCompactIndex {
-    let mut idx = MftIndex::new('E');
+    let mut idx = MftIndex::new(uffs_mft::platform::DriveLetter::E);
     let root_off = idx.add_name(".");
     let root = idx.get_or_create(ROOT_FRS);
     root.stdinfo.set_directory(true);
@@ -178,7 +182,7 @@ fn build_test_drive_e() -> uffs_core::compact::DriveCompactIndex {
     rec.stdinfo.flags = 0x20;
     rec.stdinfo.modified = 1_000_000;
 
-    let (drive, _, _) = build_compact_index('E', &idx);
+    let (drive, _, _) = build_compact_index(uffs_mft::platform::DriveLetter::E, &idx);
     drive
 }
 
@@ -190,7 +194,10 @@ struct FixedBodyLoader {
 }
 
 impl crate::cache::body_loader::BodyLoader for FixedBodyLoader {
-    fn load(&self, _letter: char) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
+    fn load(
+        &self,
+        _letter: uffs_mft::platform::DriveLetter,
+    ) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
         Some(Arc::clone(&self.body))
     }
 }

--- a/crates/uffs-daemon/src/index/tests/registry.rs
+++ b/crates/uffs-daemon/src/index/tests/registry.rs
@@ -48,20 +48,22 @@ fn shard_registry_add_replace_remove_round_trip() {
     reg = reg.add(Arc::clone(&body_c));
     reg = reg.add(Arc::clone(&body_d));
     assert_eq!(reg.active_index().drives.len(), 2);
-    assert!(reg.contains('C'));
-    assert!(reg.contains('D'));
+    assert!(reg.contains(uffs_mft::platform::DriveLetter::C));
+    assert!(reg.contains(uffs_mft::platform::DriveLetter::D));
 
-    reg = reg.replace('c', Arc::clone(&body_c_v2));
+    reg = reg.replace(uffs_mft::platform::DriveLetter::C, Arc::clone(&body_c_v2));
     assert_eq!(
         reg.active_index().drives.len(),
         2,
         "replace must not duplicate",
     );
 
-    reg = reg.remove('d');
-    assert!(!reg.contains('D'));
+    reg = reg.remove(uffs_mft::platform::DriveLetter::D);
+    assert!(!reg.contains(uffs_mft::platform::DriveLetter::D));
     assert_eq!(reg.active_index().drives.len(), 1);
-    assert_eq!(reg.loaded_letters(), vec!['C']);
+    assert_eq!(reg.loaded_letters(), vec![
+        uffs_mft::platform::DriveLetter::C
+    ]);
 }
 
 /// `ShardEntry::try_transition` enforces the legal-transition graph
@@ -76,7 +78,7 @@ fn shard_entry_try_transition_legal_and_illegal() {
     use crate::cache::shard::ShardEntry;
 
     let body = Arc::new(build_test_drive());
-    let shard = ShardEntry::new_warm('C', Arc::clone(&body));
+    let shard = ShardEntry::new_warm(uffs_mft::platform::DriveLetter::C, Arc::clone(&body));
     assert_eq!(shard.state(), ShardState::Warm);
 
     // Legal: Warm → Hot.
@@ -139,9 +141,16 @@ async fn shard_registry_search_two_drives_returns_rows_from_each() {
     // Both drives must contribute records to the snapshot.
     let snap = mgr.snapshot().await;
     assert_eq!(snap.drives.len(), 2);
-    let letters: std::collections::HashSet<char> = snap.drives.iter().map(|d| d.letter).collect();
-    assert!(letters.contains(&'C'), "C drive must be in the snapshot");
-    assert!(letters.contains(&'D'), "D drive must be in the snapshot");
+    let letters: std::collections::HashSet<uffs_mft::platform::DriveLetter> =
+        snap.drives.iter().map(|d| d.letter).collect();
+    assert!(
+        letters.contains(&uffs_mft::platform::DriveLetter::C),
+        "C drive must be in the snapshot"
+    );
+    assert!(
+        letters.contains(&uffs_mft::platform::DriveLetter::D),
+        "D drive must be in the snapshot"
+    );
 }
 
 /// `IndexManager::search` records one query per dispatch on every
@@ -209,7 +218,7 @@ fn demote_letter_warm_to_parked_drops_body_and_preserves_stats() {
     // rebuild.
     let c_shard_pre = reg
         .iter()
-        .find(|s| s.drive == 'C')
+        .find(|s| s.drive == uffs_mft::platform::DriveLetter::C)
         .expect("C present pre-demote");
     for _ in 0_u32..5_u32 {
         c_shard_pre.stats.record_query();
@@ -217,17 +226,20 @@ fn demote_letter_warm_to_parked_drops_body_and_preserves_stats() {
     assert_eq!(c_shard_pre.stats.queries_total(), 5);
 
     reg = reg
-        .demote_letter('C', ShardState::Parked)
+        .demote_letter(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
         .expect("warm → parked is legal");
 
     // Active index now only contains D.
     assert_eq!(reg.active_index().drives.len(), 1);
-    assert_eq!(reg.active_index().drives[0].letter, 'D');
+    assert_eq!(
+        reg.active_index().drives[0].letter,
+        uffs_mft::platform::DriveLetter::D
+    );
 
     // Both shards are still loaded; C is Parked, body lifted.
     let c_shard = reg
         .iter()
-        .find(|s| s.drive == 'C')
+        .find(|s| s.drive == uffs_mft::platform::DriveLetter::C)
         .expect("C still loaded post-demote");
     assert_eq!(c_shard.state(), ShardState::Parked);
     assert!(c_shard.body().is_none());
@@ -248,11 +260,14 @@ fn demote_letter_warm_to_cold_drops_body() {
     let body_c = Arc::new(build_test_drive());
     let mut reg = ShardRegistry::new().add(body_c);
     reg = reg
-        .demote_letter('C', ShardState::Cold)
+        .demote_letter(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
         .expect("warm → cold is legal");
 
     assert_eq!(reg.active_index().drives.len(), 0);
-    let c_shard = reg.iter().find(|s| s.drive == 'C').expect("C still loaded");
+    let c_shard = reg
+        .iter()
+        .find(|s| s.drive == uffs_mft::platform::DriveLetter::C)
+        .expect("C still loaded");
     assert_eq!(c_shard.state(), ShardState::Cold);
     assert!(c_shard.body().is_none());
 }
@@ -265,7 +280,8 @@ fn demote_letter_unknown_letter_returns_none() {
     let body_c = Arc::new(build_test_drive());
     let reg = ShardRegistry::new().add(body_c);
     assert!(
-        reg.demote_letter('Z', ShardState::Parked).is_none(),
+        reg.demote_letter(uffs_mft::platform::DriveLetter::Z, ShardState::Parked)
+            .is_none(),
         "demote on unknown letter must return None"
     );
 }
@@ -285,7 +301,8 @@ fn demote_letter_illegal_target_returns_none() {
         ShardState::Evicting,
     ] {
         assert!(
-            reg.demote_letter('C', bad_target).is_none(),
+            reg.demote_letter(uffs_mft::platform::DriveLetter::C, bad_target)
+                .is_none(),
             "demote target {bad_target} must be rejected"
         );
     }
@@ -301,18 +318,20 @@ fn demote_letter_self_demote_returns_none() {
     let body_c = Arc::new(build_test_drive());
     let mut reg = ShardRegistry::new().add(body_c);
     reg = reg
-        .demote_letter('C', ShardState::Parked)
+        .demote_letter(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
         .expect("first demote");
     assert!(
-        reg.demote_letter('C', ShardState::Parked).is_none(),
+        reg.demote_letter(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .is_none(),
         "Parked → Parked must be rejected"
     );
 
     reg = reg
-        .demote_letter('C', ShardState::Cold)
+        .demote_letter(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
         .expect("parked → cold");
     assert!(
-        reg.demote_letter('C', ShardState::Cold).is_none(),
+        reg.demote_letter(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .is_none(),
         "Cold → Cold must be rejected"
     );
 }
@@ -327,20 +346,28 @@ fn promote_letter_parked_to_warm_restores_body_and_preserves_stats() {
     let mut reg = ShardRegistry::new().add(Arc::clone(&body_c));
     // Bump a few queries before demote so we have something to
     // verify across the round trip.
-    let pre = reg.iter().find(|s| s.drive == 'C').unwrap();
+    let pre = reg
+        .iter()
+        .find(|s| s.drive == uffs_mft::platform::DriveLetter::C)
+        .unwrap();
     for _ in 0_u32..3_u32 {
         pre.stats.record_query();
     }
-    reg = reg.demote_letter('C', ShardState::Parked).expect("demote");
+    reg = reg
+        .demote_letter(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+        .expect("demote");
 
     // Promote with a fresh body (Phase 4+ will fault the original
     // back from disk; for this test we just hand it the same Arc).
     reg = reg
-        .promote_letter('C', Arc::clone(&body_c))
+        .promote_letter(uffs_mft::platform::DriveLetter::C, Arc::clone(&body_c))
         .expect("promote");
 
     assert_eq!(reg.active_index().drives.len(), 1);
-    let c = reg.iter().find(|s| s.drive == 'C').unwrap();
+    let c = reg
+        .iter()
+        .find(|s| s.drive == uffs_mft::platform::DriveLetter::C)
+        .unwrap();
     assert_eq!(c.state(), ShardState::Warm);
     assert!(c.body().is_some());
     assert_eq!(
@@ -359,7 +386,8 @@ fn promote_letter_unknown_letter_returns_none() {
     let body_d = Arc::new(build_test_drive_d());
     let reg = ShardRegistry::new().add(body_c);
     assert!(
-        reg.promote_letter('Z', body_d).is_none(),
+        reg.promote_letter(uffs_mft::platform::DriveLetter::Z, body_d)
+            .is_none(),
         "promote on unknown letter must return None"
     );
 }
@@ -372,7 +400,8 @@ fn promote_letter_already_warm_returns_none() {
     let body_c = Arc::new(build_test_drive());
     let reg = ShardRegistry::new().add(Arc::clone(&body_c));
     assert!(
-        reg.promote_letter('C', body_c).is_none(),
+        reg.promote_letter(uffs_mft::platform::DriveLetter::C, body_c)
+            .is_none(),
         "promote on already-Warm shard must return None"
     );
 }
@@ -390,10 +419,12 @@ fn promote_letter_to_hot_bumps_promotions_total_when_source_is_cold() {
     let body_c = Arc::new(build_test_drive());
     let mut reg = ShardRegistry::new().add(Arc::clone(&body_c));
     // Demote C to Cold (the typical state pre-`preload`).
-    reg = reg.demote_letter('C', ShardState::Cold).expect("demote");
+    reg = reg
+        .demote_letter(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+        .expect("demote");
     assert_eq!(
         reg.iter()
-            .find(|shard| shard.drive == 'C')
+            .find(|shard| shard.drive == uffs_mft::platform::DriveLetter::C)
             .expect("C present after Cold demote")
             .stats
             .promotions_total(),
@@ -403,12 +434,12 @@ fn promote_letter_to_hot_bumps_promotions_total_when_source_is_cold() {
 
     // Promote Cold → Hot (the actual preload-from-Cold path).
     reg = reg
-        .promote_letter_to_hot('C', Arc::clone(&body_c))
+        .promote_letter_to_hot(uffs_mft::platform::DriveLetter::C, Arc::clone(&body_c))
         .expect("promote_letter_to_hot from Cold");
 
     let c = reg
         .iter()
-        .find(|shard| shard.drive == 'C')
+        .find(|shard| shard.drive == uffs_mft::platform::DriveLetter::C)
         .expect("C present post-promote");
     assert_eq!(c.state(), ShardState::Hot, "post-promote tier must be Hot");
     assert_eq!(
@@ -431,7 +462,7 @@ fn promote_letter_to_hot_does_not_bump_promotions_total_when_source_is_warm() {
     // C lands in Warm (the default after add).
     let pre_state = reg
         .iter()
-        .find(|shard| shard.drive == 'C')
+        .find(|shard| shard.drive == uffs_mft::platform::DriveLetter::C)
         .expect("C present after add")
         .state();
     assert_eq!(pre_state, ShardState::Warm);
@@ -439,12 +470,12 @@ fn promote_letter_to_hot_does_not_bump_promotions_total_when_source_is_warm() {
     // Promote Warm → Hot (the operator preloads an already-Warm
     // drive — a no-cost tier-marker flip).
     reg = reg
-        .promote_letter_to_hot('C', Arc::clone(&body_c))
+        .promote_letter_to_hot(uffs_mft::platform::DriveLetter::C, Arc::clone(&body_c))
         .expect("promote_letter_to_hot from Warm");
 
     let c = reg
         .iter()
-        .find(|shard| shard.drive == 'C')
+        .find(|shard| shard.drive == uffs_mft::platform::DriveLetter::C)
         .expect("C present post-promote");
     assert_eq!(c.state(), ShardState::Hot);
     assert_eq!(
@@ -468,17 +499,17 @@ fn promote_letter_to_hot_does_not_bump_promotions_total_when_source_is_parked() 
     let body_c = Arc::new(build_test_drive());
     let mut reg = ShardRegistry::new().add(Arc::clone(&body_c));
     reg = reg
-        .demote_letter('C', ShardState::Parked)
+        .demote_letter(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
         .expect("demote to Parked");
 
     // Promote Parked → Hot.
     reg = reg
-        .promote_letter_to_hot('C', Arc::clone(&body_c))
+        .promote_letter_to_hot(uffs_mft::platform::DriveLetter::C, Arc::clone(&body_c))
         .expect("promote_letter_to_hot from Parked");
 
     let c = reg
         .iter()
-        .find(|shard| shard.drive == 'C')
+        .find(|shard| shard.drive == uffs_mft::platform::DriveLetter::C)
         .expect("C present post-promote");
     assert_eq!(c.state(), ShardState::Hot);
     assert_eq!(
@@ -504,16 +535,18 @@ fn promote_letter_to_hot_accumulates_across_repeated_cold_to_hot_cycles() {
 
     for _ in 0_u32..2_u32 {
         // Demote to Cold.
-        reg = reg.demote_letter('C', ShardState::Cold).expect("demote");
+        reg = reg
+            .demote_letter(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .expect("demote");
         // Promote Cold → Hot.
         reg = reg
-            .promote_letter_to_hot('C', Arc::clone(&body_c))
+            .promote_letter_to_hot(uffs_mft::platform::DriveLetter::C, Arc::clone(&body_c))
             .expect("promote_letter_to_hot");
     }
 
     let c = reg
         .iter()
-        .find(|shard| shard.drive == 'C')
+        .find(|shard| shard.drive == uffs_mft::platform::DriveLetter::C)
         .expect("C present post-cycle");
     assert_eq!(c.state(), ShardState::Hot);
     assert_eq!(

--- a/crates/uffs-daemon/src/index/tests/shard_ttl_events.rs
+++ b/crates/uffs-daemon/src/index/tests/shard_ttl_events.rs
@@ -72,7 +72,7 @@ async fn shard_ttl_event_emits_all_three_thresholds() {
     // path (emits the canonical `idle-demote` shard.ttl event).
     let last_query_ms = 1_000_000_000_u64;
     assert!(
-        mgr.backdate_last_query_at_ms_for_test('C', last_query_ms)
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::C, last_query_ms)
             .await
     );
     let now_ms = last_query_ms + WARM_TO_PARKED_IDLE_SECS * 1000;
@@ -80,7 +80,10 @@ async fn shard_ttl_event_emits_all_three_thresholds() {
 
     // Verify the Warm→Parked transition actually happened.
     let states = mgr.shard_states_for_test().await;
-    assert_eq!(states, vec![('C', ShardState::Parked)]);
+    assert_eq!(states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Parked
+    )]);
 
     // Find the `idle-demote`-reason `shard.ttl` event for drive C.
     let events = log.events();
@@ -205,7 +208,10 @@ async fn below_ttl_event_pins_target_level_message_and_reason() {
     // The drive must NOT have demoted — that's the precondition
     // for the below-ttl branch to be the one that fired.
     let states = mgr.shard_states_for_test().await;
-    assert_eq!(states, vec![('C', ShardState::Warm)]);
+    assert_eq!(states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Warm
+    )]);
 
     let events = log.events();
     let ttl_events: Vec<&CapturedEvent> = events

--- a/crates/uffs-daemon/src/index/tests/tiering_ops.rs
+++ b/crates/uffs-daemon/src/index/tests/tiering_ops.rs
@@ -57,7 +57,10 @@ async fn hibernate_demotes_all_loaded_drives_to_cold() {
 
     assert_eq!(
         outcome.warm_demoted,
-        vec!['C', 'D'],
+        vec![
+            uffs_mft::platform::DriveLetter::C,
+            uffs_mft::platform::DriveLetter::D
+        ],
         "both freshly-loaded Warm drives must be reported as warm-demoted"
     );
     assert!(outcome.hot_demoted.is_empty());
@@ -67,13 +70,16 @@ async fn hibernate_demotes_all_loaded_drives_to_cold() {
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
         states,
-        vec![('C', ShardState::Cold), ('D', ShardState::Cold)],
+        vec![
+            (uffs_mft::platform::DriveLetter::C, ShardState::Cold),
+            (uffs_mft::platform::DriveLetter::D, ShardState::Cold)
+        ],
         "every shard must be Cold post-hibernate"
     );
 }
 
-/// Phase 8-B — `hibernate_shards(&['C'])` only demotes the named
-/// drive; other loaded drives stay in their pre-call tier.
+/// Phase 8-B — `hibernate_shards(&[uffs_mft::platform::DriveLetter::C])` only
+/// demotes the named drive; other loaded drives stay in their pre-call tier.
 #[tokio::test]
 async fn hibernate_subset_only_demotes_specified_drives() {
     let (tx, _rx) = crate::events::event_channel();
@@ -82,9 +88,13 @@ async fn hibernate_subset_only_demotes_specified_drives() {
     mgr.add_drive(build_test_drive_d()).await;
     mgr.add_drive(build_test_drive_e()).await;
 
-    let outcome = mgr.hibernate_shards(&['C']).await;
+    let outcome = mgr
+        .hibernate_shards(&[uffs_mft::platform::DriveLetter::C])
+        .await;
 
-    assert_eq!(outcome.warm_demoted, vec!['C']);
+    assert_eq!(outcome.warm_demoted, vec![
+        uffs_mft::platform::DriveLetter::C
+    ]);
     assert!(
         outcome.already_cold.is_empty(),
         "non-targeted drives are filtered out before the tier check, not reported in already_cold"
@@ -94,9 +104,9 @@ async fn hibernate_subset_only_demotes_specified_drives() {
     assert_eq!(
         states,
         vec![
-            ('C', ShardState::Cold),
-            ('D', ShardState::Warm),
-            ('E', ShardState::Warm),
+            (uffs_mft::platform::DriveLetter::C, ShardState::Cold),
+            (uffs_mft::platform::DriveLetter::D, ShardState::Warm),
+            (uffs_mft::platform::DriveLetter::E, ShardState::Warm),
         ],
         "only C must be Cold; D and E must stay Warm"
     );
@@ -113,12 +123,19 @@ async fn hibernate_reports_already_cold_drives_separately() {
     mgr.add_drive(build_test_drive_d()).await;
 
     // Seed C as Cold via the pre-existing test escape hatch.
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
     let outcome = mgr.hibernate_shards(&[]).await;
 
-    assert_eq!(outcome.already_cold, vec!['C']);
-    assert_eq!(outcome.warm_demoted, vec!['D']);
+    assert_eq!(outcome.already_cold, vec![
+        uffs_mft::platform::DriveLetter::C
+    ]);
+    assert_eq!(outcome.warm_demoted, vec![
+        uffs_mft::platform::DriveLetter::D
+    ]);
     assert!(outcome.hot_demoted.is_empty());
     assert!(outcome.parked_demoted.is_empty());
 }
@@ -138,10 +155,15 @@ async fn preload_promotes_cold_to_hot_with_pin() {
     mgr.add_drive(build_test_drive()).await;
 
     // Seed C as Cold so preload exercises the body-load path.
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
     let before_ms = unix_now_ms();
-    let outcome = mgr.preload_drive('C', 30).await;
+    let outcome = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 30)
+        .await;
 
     let PreloadOutcome::Promoted {
         from_state,
@@ -159,7 +181,10 @@ async fn preload_promotes_cold_to_hot_with_pin() {
     );
 
     let states = mgr.shard_states_for_test().await;
-    assert_eq!(states, vec![('C', ShardState::Hot)]);
+    assert_eq!(states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Hot
+    )]);
 }
 
 /// Phase 8-C — `preload C:` against an already-`Hot` shard skips
@@ -174,12 +199,17 @@ async fn preload_already_hot_extends_pin_without_rebuild() {
     });
     let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
     // First preload — Cold → Hot.  Use let-else so neither a
     // wildcard arm (clippy::wildcard_enum_match_arm) nor an
     // `unreachable!` (clippy::unreachable) is needed.
-    let first = mgr.preload_drive('C', 5).await;
+    let first = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 5)
+        .await;
     let PreloadOutcome::Promoted {
         pin_until_ms: pin1, ..
     } = first
@@ -188,7 +218,9 @@ async fn preload_already_hot_extends_pin_without_rebuild() {
     };
 
     // Second preload — Hot → Hot (pin extension only).
-    let second = mgr.preload_drive('C', 60).await;
+    let second = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 60)
+        .await;
     let PreloadOutcome::AlreadyHot { pin_until_ms: pin2 } = second else {
         panic!("expected AlreadyHot on the second preload call, got {second:?}");
     };
@@ -199,7 +231,10 @@ async fn preload_already_hot_extends_pin_without_rebuild() {
     );
 
     let states = mgr.shard_states_for_test().await;
-    assert_eq!(states, vec![('C', ShardState::Hot)]);
+    assert_eq!(states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Hot
+    )]);
 }
 
 /// Phase 8-C pin-contract — pinned shards skip the idle-demote
@@ -219,15 +254,20 @@ async fn preload_pin_blocks_idle_demote() {
     });
     let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
-    let outcome = mgr.preload_drive('C', 30).await;
+    let outcome = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 30)
+        .await;
     assert!(matches!(outcome, PreloadOutcome::Promoted { .. }));
 
     // Backdate the idle clock so the policy would otherwise demote.
     let last_query_ms = 1_000_000_000_u64;
     assert!(
-        mgr.backdate_last_query_at_ms_for_test('C', last_query_ms)
+        mgr.backdate_last_query_at_ms_for_test(uffs_mft::platform::DriveLetter::C, last_query_ms)
             .await
     );
 
@@ -238,7 +278,7 @@ async fn preload_pin_blocks_idle_demote() {
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
         states,
-        vec![('C', ShardState::Hot)],
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Hot)],
         "pinned shard must stay Hot even when the idle clock is past the TTL"
     );
 }
@@ -256,9 +296,14 @@ async fn preload_pin_blocks_cascade_demote() {
     });
     let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
-    let outcome = mgr.preload_drive('C', 30).await;
+    let outcome = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 30)
+        .await;
     assert!(matches!(outcome, PreloadOutcome::Promoted { .. }));
 
     // The cascade picks Warm shards only, but the test fixture also
@@ -283,15 +328,15 @@ async fn preload_pin_blocks_cascade_demote() {
     // (unpinned).
     let pre_states = mgr.shard_states_for_test().await;
     assert_eq!(pre_states, vec![
-        ('C', ShardState::Hot),
-        ('D', ShardState::Warm)
+        (uffs_mft::platform::DriveLetter::C, ShardState::Hot),
+        (uffs_mft::platform::DriveLetter::D, ShardState::Warm)
     ]);
 
     // Cascade: must pick D (Warm, unpinned), not C (Hot, pinned).
     let picked = mgr.cascade_demote_one_step().await;
     assert_eq!(
         picked,
-        Some(('D', ShardState::Parked)),
+        Some((uffs_mft::platform::DriveLetter::D, ShardState::Parked)),
         "cascade must pick the unpinned Warm shard D, not the pinned Hot shard C"
     );
 
@@ -299,7 +344,10 @@ async fn preload_pin_blocks_cascade_demote() {
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
         states,
-        vec![('C', ShardState::Hot), ('D', ShardState::Parked)],
+        vec![
+            (uffs_mft::platform::DriveLetter::C, ShardState::Hot),
+            (uffs_mft::platform::DriveLetter::D, ShardState::Parked)
+        ],
         "pinned shard C must still be Hot; unpinned D must be Parked"
     );
 }
@@ -317,11 +365,15 @@ async fn hibernate_overrides_preload_pin() {
     });
     let mgr = IndexManager::with_body_loader_for_test(None, tx, loader);
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
     // Pin C in Hot for 30 min.
     assert!(matches!(
-        mgr.preload_drive('C', 30).await,
+        mgr.preload_drive(uffs_mft::platform::DriveLetter::C, 30)
+            .await,
         PreloadOutcome::Promoted { .. }
     ));
 
@@ -329,14 +381,14 @@ async fn hibernate_overrides_preload_pin() {
     let outcome = mgr.hibernate_shards(&[]).await;
     assert_eq!(
         outcome.hot_demoted,
-        vec!['C'],
+        vec![uffs_mft::platform::DriveLetter::C],
         "hibernate must report C as hot-demoted (pre-call tier)"
     );
 
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
         states,
-        vec![('C', ShardState::Cold)],
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Cold)],
         "hibernate must override the pin and demote to Cold"
     );
 }
@@ -349,7 +401,9 @@ async fn preload_unknown_drive_returns_unknown() {
     let mgr = IndexManager::new(None, tx, Arc::new(crate::config::Config::default()));
     mgr.add_drive(build_test_drive()).await;
 
-    let outcome = mgr.preload_drive('Z', 30).await;
+    let outcome = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::Z, 30)
+        .await;
     assert!(
         matches!(outcome, PreloadOutcome::UnknownDrive),
         "unknown drive Z must produce UnknownDrive; got {outcome:?}"
@@ -357,7 +411,10 @@ async fn preload_unknown_drive_returns_unknown() {
 
     // Loaded shard untouched.
     let states = mgr.shard_states_for_test().await;
-    assert_eq!(states, vec![('C', ShardState::Warm)]);
+    assert_eq!(states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Warm
+    )]);
 }
 
 /// Phase 8-C — when the body loader returns `None` for the
@@ -369,9 +426,14 @@ async fn preload_load_failure_keeps_pre_call_state() {
     let (tx, _rx) = crate::events::event_channel();
     let mgr = IndexManager::with_body_loader_for_test(None, tx, Arc::new(MissingBodyLoader));
     mgr.add_drive(build_test_drive()).await;
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
 
-    let outcome = mgr.preload_drive('C', 30).await;
+    let outcome = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 30)
+        .await;
     assert!(
         matches!(outcome, PreloadOutcome::LoadFailed),
         "MissingBodyLoader must surface as LoadFailed; got {outcome:?}"
@@ -380,7 +442,7 @@ async fn preload_load_failure_keeps_pre_call_state() {
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
         states,
-        vec![('C', ShardState::Cold)],
+        vec![(uffs_mft::platform::DriveLetter::C, ShardState::Cold)],
         "shard must stay in pre-call Cold after load failure"
     );
 }
@@ -400,7 +462,10 @@ async fn preload_warm_drive_skips_body_load() {
     struct PanicOnLoad;
 
     impl BodyLoaderTrait for PanicOnLoad {
-        fn load(&self, letter: char) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
+        fn load(
+            &self,
+            letter: uffs_mft::platform::DriveLetter,
+        ) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
             panic!(
                 "PanicOnLoad::load — unexpected call for {letter}; Warm-source preload must reuse the live body"
             )
@@ -411,14 +476,19 @@ async fn preload_warm_drive_skips_body_load() {
     let mgr = IndexManager::with_body_loader_for_test(None, tx, Arc::new(PanicOnLoad));
     mgr.add_drive(build_test_drive()).await; // C lands in Warm.
 
-    let outcome = mgr.preload_drive('C', 30).await;
+    let outcome = mgr
+        .preload_drive(uffs_mft::platform::DriveLetter::C, 30)
+        .await;
     let PreloadOutcome::Promoted { from_state, .. } = outcome else {
         panic!("expected Promoted; got {outcome:?}");
     };
     assert_eq!(from_state, ShardState::Warm);
 
     let states = mgr.shard_states_for_test().await;
-    assert_eq!(states, vec![('C', ShardState::Hot)]);
+    assert_eq!(states, vec![(
+        uffs_mft::platform::DriveLetter::C,
+        ShardState::Hot
+    )]);
 }
 
 // ── Phase 9 — `promotions_total` Cold→Hot counter contract ──────────
@@ -466,9 +536,13 @@ async fn preload_cold_to_hot_bumps_promotions_total_per_cycle() {
     );
 
     // ── Cycle 1: Cold → Hot ─────────────────────────────────────
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
     assert!(matches!(
-        mgr.preload_drive('C', 5).await,
+        mgr.preload_drive(uffs_mft::platform::DriveLetter::C, 5)
+            .await,
         PreloadOutcome::Promoted { .. }
     ));
     assert_eq!(
@@ -479,7 +553,8 @@ async fn preload_cold_to_hot_bumps_promotions_total_per_cycle() {
 
     // ── AlreadyHot — must NOT bump ──────────────────────────────
     assert!(matches!(
-        mgr.preload_drive('C', 60).await,
+        mgr.preload_drive(uffs_mft::platform::DriveLetter::C, 60)
+            .await,
         PreloadOutcome::AlreadyHot { .. }
     ));
     assert_eq!(
@@ -491,9 +566,13 @@ async fn preload_cold_to_hot_bumps_promotions_total_per_cycle() {
     // ── Cycle 2: Hot → Cold (via test escape) → Hot ─────────────
     // `demote_letter_for_test` overrides the pin; same effect as
     // an operator `hibernate` for counter-bump purposes.
-    assert!(mgr.demote_letter_for_test('C', ShardState::Cold).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Cold)
+            .await
+    );
     assert!(matches!(
-        mgr.preload_drive('C', 5).await,
+        mgr.preload_drive(uffs_mft::platform::DriveLetter::C, 5)
+            .await,
         PreloadOutcome::Promoted { .. }
     ));
     assert_eq!(
@@ -518,7 +597,10 @@ async fn preload_warm_to_hot_does_not_bump_promotions_total() {
 
     struct PanicOnLoad;
     impl BodyLoaderTrait for PanicOnLoad {
-        fn load(&self, letter: char) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
+        fn load(
+            &self,
+            letter: uffs_mft::platform::DriveLetter,
+        ) -> Option<Arc<uffs_core::compact::DriveCompactIndex>> {
             panic!(
                 "PanicOnLoad::load — Warm→Hot source arm must not call the loader (letter={letter})"
             )
@@ -530,7 +612,8 @@ async fn preload_warm_to_hot_does_not_bump_promotions_total() {
     mgr.add_drive(build_test_drive()).await; // C lands in Warm.
 
     assert!(matches!(
-        mgr.preload_drive('C', 5).await,
+        mgr.preload_drive(uffs_mft::platform::DriveLetter::C, 5)
+            .await,
         PreloadOutcome::Promoted {
             from_state: ShardState::Warm,
             ..
@@ -568,10 +651,14 @@ async fn preload_parked_to_hot_does_not_bump_promotions_total() {
     mgr.add_drive(build_test_drive()).await;
 
     // Seed C as Parked (legal demote target from Warm).
-    assert!(mgr.demote_letter_for_test('C', ShardState::Parked).await);
+    assert!(
+        mgr.demote_letter_for_test(uffs_mft::platform::DriveLetter::C, ShardState::Parked)
+            .await
+    );
 
     assert!(matches!(
-        mgr.preload_drive('C', 5).await,
+        mgr.preload_drive(uffs_mft::platform::DriveLetter::C, 5)
+            .await,
         PreloadOutcome::Promoted {
             from_state: ShardState::Parked,
             ..

--- a/crates/uffs-daemon/src/index/tiering_ops.rs
+++ b/crates/uffs-daemon/src/index/tiering_ops.rs
@@ -39,24 +39,24 @@ use crate::cache::{ShardState, unix_now_ms};
 
 /// Outcome of a [`IndexManager::hibernate_shards`] call.
 ///
-/// Each `Vec<char>` lists the drives whose pre-call tier matched the
-/// field name and that are now `Cold` (or, for `already_cold`, were
-/// already there).  The handler maps this 1:1 onto
+/// Each `Vec<uffs_mft::platform::DriveLetter>` lists the drives whose pre-call
+/// tier matched the field name and that are now `Cold` (or, for `already_cold`,
+/// were already there).  The handler maps this 1:1 onto
 /// [`uffs_client::protocol::response::HibernateResponse`]; the
 /// internal type exists so the RPC layer can do the serialisation
 /// without re-walking the registry.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct HibernateOutcome {
     /// Drives whose pre-call tier was `Hot`.
-    pub hot_demoted: Vec<char>,
+    pub hot_demoted: Vec<uffs_mft::platform::DriveLetter>,
     /// Drives whose pre-call tier was `Warm`.
-    pub warm_demoted: Vec<char>,
+    pub warm_demoted: Vec<uffs_mft::platform::DriveLetter>,
     /// Drives whose pre-call tier was `Parked`.
-    pub parked_demoted: Vec<char>,
+    pub parked_demoted: Vec<uffs_mft::platform::DriveLetter>,
     /// Drives that were already `Cold` (or whose state was
     /// `Unknown` / `Evicting`, which the operator path cannot
     /// pre-empt).  No registry rebuild for these.
-    pub already_cold: Vec<char>,
+    pub already_cold: Vec<uffs_mft::platform::DriveLetter>,
 }
 
 /// Outcome of a [`IndexManager::preload_drive`] call for one drive.
@@ -127,19 +127,18 @@ impl IndexManager {
     /// canonical `shard.transition` event so operators can grep
     /// `reason="operator-hibernate"` to distinguish manual
     /// hibernation from idle-tick or pressure-cascade demotes.
-    pub(crate) async fn hibernate_shards(&self, drives: &[char]) -> HibernateOutcome {
+    pub(crate) async fn hibernate_shards(
+        &self,
+        drives: &[uffs_mft::platform::DriveLetter],
+    ) -> HibernateOutcome {
         // ── Phase 1: read-lock detect ──────────────────────────────
         let mut outcome = HibernateOutcome::default();
-        let demotes: Vec<(char, ShardState)> = {
+        let demotes: Vec<(uffs_mft::platform::DriveLetter, ShardState)> = {
             let guard = self.index.read().await;
-            let mut to_demote: Vec<(char, ShardState)> = Vec::new();
+            let mut to_demote: Vec<(uffs_mft::platform::DriveLetter, ShardState)> = Vec::new();
             for shard in guard.iter() {
                 let drive = shard.drive;
-                if !drives.is_empty()
-                    && !drives
-                        .iter()
-                        .any(|filter| filter.eq_ignore_ascii_case(&drive))
-                {
+                if !drives.is_empty() && !drives.contains(&drive) {
                     continue;
                 }
                 let from_state = shard.state();
@@ -173,8 +172,8 @@ impl IndexManager {
                 }
             }
             // Explicit early drop so the read lock is released
-            // before the `Vec<(char, ShardState)>` is returned and
-            // the surrounding block exits.  Tightens the read-lock
+            // before the `Vec<(uffs_mft::platform::DriveLetter, ShardState)>` is returned
+            // and the surrounding block exits.  Tightens the read-lock
             // hold time for any concurrent dispatcher while keeping
             // clippy::significant_drop_tightening satisfied.
             drop(guard);
@@ -248,13 +247,17 @@ impl IndexManager {
     /// the moment the pin is armed (Unix-millis).  Pre-existing
     /// pins are overwritten — every `preload` call resets the pin
     /// window, even for already-pinned drives.
-    pub(crate) async fn preload_drive(&self, letter: char, pin_minutes: u32) -> PreloadOutcome {
+    pub(crate) async fn preload_drive(
+        &self,
+        letter: uffs_mft::platform::DriveLetter,
+        pin_minutes: u32,
+    ) -> PreloadOutcome {
         // ── Phase 1: read-lock detect (state + body) ───────────────
         let snapshot = {
             let guard = self.index.read().await;
             guard
                 .iter()
-                .find(|shard| shard.drive.eq_ignore_ascii_case(&letter))
+                .find(|shard| shard.drive == letter)
                 .map(|shard| (shard.drive, shard.state(), shard.body(), Arc::clone(shard)))
         };
         let Some((drive, from_state, current_body, current_arc)) = snapshot else {
@@ -276,7 +279,7 @@ impl IndexManager {
                 current_arc.pin_until(pin_until_ms);
                 tracing::info!(
                     target: "shard.transition",
-                    letter = %drive.to_ascii_uppercase(),
+                    letter = %drive,
                     pin_until_ms,
                     pin_minutes,
                     reason = "preload-pin-extend",
@@ -325,7 +328,7 @@ impl IndexManager {
     /// readable above and the swap mechanics auditable here.
     async fn swap_in_hot_with_pin(
         &self,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         body: Arc<uffs_core::compact::DriveCompactIndex>,
         pin_until_ms: u64,
     ) -> PreloadOutcome {
@@ -339,7 +342,7 @@ impl IndexManager {
         // forces the rebuild to fail.
         let prev_state = guard
             .iter()
-            .find(|shard| shard.drive.eq_ignore_ascii_case(&letter))
+            .find(|shard| shard.drive == letter)
             .map_or(ShardState::Unknown, |shard| shard.state());
 
         let Some(new_registry) = guard.promote_letter_to_hot(letter, body) else {
@@ -359,10 +362,7 @@ impl IndexManager {
         // `find` short-circuit is defensive — the drive must
         // exist in the rebuilt registry by construction.
         let now_ms = unix_now_ms();
-        if let Some(new_shard) = new_registry
-            .iter()
-            .find(|shard| shard.drive.eq_ignore_ascii_case(&letter))
-        {
+        if let Some(new_shard) = new_registry.iter().find(|shard| shard.drive == letter) {
             new_shard.stats.mark_loaded_at(now_ms);
             new_shard.pin_until(pin_until_ms);
         }
@@ -386,7 +386,7 @@ impl IndexManager {
     /// `target: "shard.transition"` and the preload continues.
     fn prefault_body(
         prefetch: &Arc<dyn crate::cache::prefetch::Prefetch>,
-        letter: char,
+        letter: uffs_mft::platform::DriveLetter,
         body: &Arc<uffs_core::compact::DriveCompactIndex>,
     ) {
         // Build the records + names regions inline, mirroring the

--- a/crates/uffs-daemon/src/index/transitions.rs
+++ b/crates/uffs-daemon/src/index/transitions.rs
@@ -102,7 +102,7 @@ impl IndexManager {
         // adaptive-TTL telemetry is meant to surface tuning
         // signals, not pin-window noise.
         let config = Arc::clone(&self.config);
-        let demotes: Vec<(char, ShardState)> = {
+        let demotes: Vec<(uffs_mft::platform::DriveLetter, ShardState)> = {
             let guard = self.index.read().await;
             guard
                 .iter()
@@ -191,7 +191,9 @@ impl IndexManager {
     /// the cascade promptly), so there's no batch to coalesce.
     ///
     /// [`WorkingSetTrim::trim`]: crate::cache::working_set::WorkingSetTrim::trim
-    pub(crate) async fn cascade_demote_one_step(&self) -> Option<(char, ShardState)> {
+    pub(crate) async fn cascade_demote_one_step(
+        &self,
+    ) -> Option<(uffs_mft::platform::DriveLetter, ShardState)> {
         // ── Phase 1: read-lock detect (LRU pick) ────────────────────
         // Enumerate Warm shards and keep the one with the oldest
         // `last_query_at_ms`.  `min_by_key` returns `None` when no
@@ -205,7 +207,7 @@ impl IndexManager {
         // and waking on the next pressure transition.  Operators
         // who explicitly pinned a shard accepted that trade-off.
         let now_ms = crate::cache::unix_now_ms();
-        let pick: Option<(char, u64)> = {
+        let pick: Option<(uffs_mft::platform::DriveLetter, u64)> = {
             let guard = self.index.read().await;
             guard
                 .iter()
@@ -296,8 +298,10 @@ fn build_thresholds(rate_qpm: f64, tiers: &TiersConfig) -> TierThresholds {
 /// (the plan §11 example uses `"C:"`; the env-var-style convention
 /// just uses `"C"`), and forcing one form would silently swallow
 /// the user's intent.
-fn min_tier_for_drive(letter: char, config: &Config) -> Option<ShardState> {
-    let letter_upper = letter.to_ascii_uppercase();
+fn min_tier_for_drive(
+    letter: uffs_mft::platform::DriveLetter,
+    config: &Config,
+) -> Option<ShardState> {
     config
         .shards
         .per_drive
@@ -308,7 +312,7 @@ fn min_tier_for_drive(letter: char, config: &Config) -> Option<ShardState> {
                 && trimmed
                     .chars()
                     .next()
-                    .is_some_and(|ch| ch.eq_ignore_ascii_case(&letter_upper))
+                    .is_some_and(|ch| letter.eq_ignore_ascii_case(ch))
         })
         .and_then(|(_, per_drive)| per_drive.min_tier)
         .map(crate::config::TierLevel::to_state)
@@ -481,7 +485,8 @@ mod commit_c_tests {
 
         // C: has min_tier = Warm.  The Warm → Parked proposal is
         // below the floor and must be suppressed.
-        let floor = min_tier_for_drive('C', &config).expect("min_tier resolved for C");
+        let floor = min_tier_for_drive(uffs_mft::platform::DriveLetter::C, &config)
+            .expect("min_tier resolved for C");
         assert_eq!(floor, ShardState::Warm);
         assert!(tier_rank(ShardState::Parked) < tier_rank(floor));
         // The Hot → Warm proposal is at the floor and is allowed.
@@ -511,12 +516,27 @@ mod commit_c_tests {
             ..Config::default()
         };
 
-        assert_eq!(min_tier_for_drive('C', &config), Some(ShardState::Warm));
-        assert_eq!(min_tier_for_drive('c', &config), Some(ShardState::Warm));
-        assert_eq!(min_tier_for_drive('D', &config), Some(ShardState::Hot));
-        assert_eq!(min_tier_for_drive('d', &config), Some(ShardState::Hot));
+        assert_eq!(
+            min_tier_for_drive(uffs_mft::platform::DriveLetter::C, &config),
+            Some(ShardState::Warm)
+        );
+        assert_eq!(
+            min_tier_for_drive(uffs_mft::platform::DriveLetter::C, &config),
+            Some(ShardState::Warm)
+        );
+        assert_eq!(
+            min_tier_for_drive(uffs_mft::platform::DriveLetter::D, &config),
+            Some(ShardState::Hot)
+        );
+        assert_eq!(
+            min_tier_for_drive(uffs_mft::platform::DriveLetter::D, &config),
+            Some(ShardState::Hot)
+        );
         // Untouched letter falls through to the static-Cold ladder.
-        assert_eq!(min_tier_for_drive('E', &config), None);
+        assert_eq!(
+            min_tier_for_drive(uffs_mft::platform::DriveLetter::E, &config),
+            None
+        );
     }
 
     /// Plan task 6.4 — at `rate_qpm = 0` the adaptive thresholds

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -171,7 +171,7 @@ pub struct DaemonConfig {
     /// Data directory containing `drive_*` subdirectories.
     pub data_dir: Option<PathBuf>,
     /// Explicit drive letters (Windows only).
-    pub drives: Vec<char>,
+    pub drives: Vec<uffs_mft::platform::DriveLetter>,
     /// Idle timeout in seconds (0 = use default 7200s / 2 hours).
     pub idle_timeout: u64,
     /// Disable auto-retire.
@@ -190,7 +190,7 @@ pub struct DaemonConfig {
 /// Bail if the daemon has nothing to serve.
 fn validate_data_sources(
     mft_files: &[PathBuf],
-    drives: &[char],
+    drives: &[uffs_mft::platform::DriveLetter],
     lifecycle_mgr: &lifecycle::LifecycleManager,
 ) -> anyhow::Result<()> {
     let has_data = !mft_files.is_empty() || {
@@ -203,7 +203,7 @@ fn validate_data_sources(
             // `drives` is Windows-only; no auto-discovery on macOS/Linux.
             // The explicit type pins the annotation clippy expects on
             // discarded bindings.
-            let _: &[char] = drives;
+            let _: &[uffs_mft::platform::DriveLetter] = drives;
             false
         }
     };
@@ -474,18 +474,18 @@ fn gather_mft_files(config: &DaemonConfig) -> Vec<PathBuf> {
 
 /// Returns `true` when `path`'s parent directory carries a
 /// `drive_<letter>` prefix that matches one of `wanted` (case-
-/// insensitive).
-fn drive_letter_matches(path: &std::path::Path, wanted: &[char]) -> bool {
+/// insensitive — `DriveLetter::parse` canonicalises to uppercase).
+fn drive_letter_matches(
+    path: &std::path::Path,
+    wanted: &[uffs_mft::platform::DriveLetter],
+) -> bool {
     path.parent()
         .and_then(|parent| parent.file_name())
         .and_then(|name| name.to_str())
         .and_then(|name| name.strip_prefix("drive_"))
         .and_then(|suffix| suffix.chars().next())
-        .is_some_and(|letter| {
-            wanted
-                .iter()
-                .any(|drive| drive.eq_ignore_ascii_case(&letter))
-        })
+        .and_then(|letter_ch| uffs_mft::platform::DriveLetter::parse(letter_ch).ok())
+        .is_some_and(|letter| wanted.contains(&letter))
 }
 
 /// Resolve the drive list to scan.
@@ -494,7 +494,7 @@ fn drive_letter_matches(path: &std::path::Path, wanted: &[char]) -> bool {
 /// respects the explicit list.  Always empty on non-Windows since
 /// live MFT scanning is Windows-only.
 #[cfg(windows)]
-fn resolve_drive_list(config: &DaemonConfig) -> Vec<char> {
+fn resolve_drive_list(config: &DaemonConfig) -> Vec<uffs_mft::platform::DriveLetter> {
     let explicit = config.drives.clone();
     if explicit.is_empty() {
         let auto_drives = uffs_mft::detect_ntfs_drives();
@@ -516,7 +516,7 @@ fn resolve_drive_list(config: &DaemonConfig) -> Vec<char> {
 /// Non-Windows variant: live MFT scanning is unsupported, so the
 /// drive list is always empty regardless of `config`.
 #[cfg(not(windows))]
-const fn resolve_drive_list(_config: &DaemonConfig) -> Vec<char> {
+const fn resolve_drive_list(_config: &DaemonConfig) -> Vec<uffs_mft::platform::DriveLetter> {
     Vec::new()
 }
 
@@ -527,7 +527,7 @@ const fn resolve_drive_list(_config: &DaemonConfig) -> Vec<char> {
 fn spawn_load_task(
     load_index: Arc<index::IndexManager>,
     mft_files: Vec<PathBuf>,
-    drives: Vec<char>,
+    drives: Vec<uffs_mft::platform::DriveLetter>,
     no_cache: bool,
     load_lifecycle: lifecycle::LifecycleHandle,
 ) -> tokio::task::JoinHandle<()> {
@@ -551,7 +551,8 @@ fn spawn_load_task(
         )
         .await;
         if broker_is_available {
-            let _handle_result = broker_client::request_volume_handle('C');
+            let _handle_result =
+                broker_client::request_volume_handle(uffs_mft::platform::DriveLetter::C);
         }
         tracing::info!("Load task completed");
 
@@ -583,7 +584,7 @@ fn spawn_load_task(
 #[cfg(windows)]
 async fn load_live_drives_if_windows(
     load_index: &Arc<index::IndexManager>,
-    drives: &[char],
+    drives: &[uffs_mft::platform::DriveLetter],
     no_cache: bool,
     load_lifecycle: &lifecycle::LifecycleHandle,
     broker_is_available: bool,
@@ -606,7 +607,7 @@ async fn load_live_drives_if_windows(
 /// per-drive elevation prompt.  Failures are debug-traced and
 /// ignored — the direct-open path takes over transparently.
 #[cfg(windows)]
-fn warm_up_broker_handles(drives: &[char]) {
+fn warm_up_broker_handles(drives: &[uffs_mft::platform::DriveLetter]) {
     for &drive_letter in drives {
         match broker_client::request_volume_handle(drive_letter) {
             Ok(handle) => {
@@ -836,7 +837,9 @@ async fn spawn_journal_loops_for_warm_shards(
 /// Mac/Linux uses the canonical `_letter` rename rather than a
 /// `let _ = letter;` body workaround that clippy flags.
 #[cfg(windows)]
-fn make_journal_source(letter: char) -> Arc<dyn cache::journal_loop::JournalSource> {
+fn make_journal_source(
+    letter: uffs_mft::platform::DriveLetter,
+) -> Arc<dyn cache::journal_loop::JournalSource> {
     Arc::new(cache::journal_loop::sources::WindowsJournalSource::new(
         letter,
     ))
@@ -846,7 +849,9 @@ fn make_journal_source(letter: char) -> Arc<dyn cache::journal_loop::JournalSour
 /// the [`crate::cache::journal_loop::sources::MacStubJournalSource`]
 /// stub (no NTFS USN journal on these platforms).
 #[cfg(not(windows))]
-fn make_journal_source(_letter: char) -> Arc<dyn cache::journal_loop::JournalSource> {
+fn make_journal_source(
+    _letter: uffs_mft::platform::DriveLetter,
+) -> Arc<dyn cache::journal_loop::JournalSource> {
     Arc::new(cache::journal_loop::sources::MacStubJournalSource)
 }
 

--- a/crates/uffs-daemon/src/main.rs
+++ b/crates/uffs-daemon/src/main.rs
@@ -90,7 +90,7 @@ struct Cli {
 
     /// Live drives to load (Windows only, e.g. C D E).
     #[arg(long = "drive", value_name = "LETTER")]
-    drives: Vec<char>,
+    drives: Vec<uffs_mft::platform::DriveLetter>,
 
     /// Idle timeout in seconds before auto-retire (default: 7200 = 2 hours).
     #[arg(long, default_value = "7200")]
@@ -210,7 +210,7 @@ fn log_load_response(resp: &LoadDriveResponse) {
     reason = "[diag] diagnostic tracing — remove after D: drive issue is resolved"
 )]
 fn forward_to_running_daemon(
-    drives: &[char],
+    drives: &[uffs_mft::platform::DriveLetter],
     mft_files: &[String],
     no_cache: bool,
 ) -> anyhow::Result<()> {

--- a/crates/uffs-daemon/src/tests.rs
+++ b/crates/uffs-daemon/src/tests.rs
@@ -22,17 +22,21 @@ fn drive_letter_matches_accepts_canonical_prefix() {
     // Standard discovery layout: `<data_dir>/drive_<letter>/<letter>_mft.iocp`.
     assert!(drive_letter_matches(
         Path::new("/data/drive_c/C_mft.iocp"),
-        &['C']
+        &[uffs_mft::platform::DriveLetter::C]
     ));
     // Case-insensitive match: filter is uppercase, dir is lowercase.
     assert!(drive_letter_matches(
         Path::new("/data/drive_d/D_mft.iocp"),
-        &['d']
+        &[uffs_mft::platform::DriveLetter::D]
     ));
     // Multi-letter filter: any match in `wanted` succeeds.
     assert!(drive_letter_matches(
         Path::new("/data/drive_e/E_mft.iocp"),
-        &['C', 'D', 'E']
+        &[
+            uffs_mft::platform::DriveLetter::C,
+            uffs_mft::platform::DriveLetter::D,
+            uffs_mft::platform::DriveLetter::E
+        ]
     ));
 }
 
@@ -41,7 +45,7 @@ fn drive_letter_matches_rejects_non_matching_prefix() {
     // Different drive letter.
     assert!(!drive_letter_matches(
         Path::new("/data/drive_c/C_mft.iocp"),
-        &['D']
+        &[uffs_mft::platform::DriveLetter::D]
     ));
     // Empty `wanted` slice rejects everything (caller must
     // gate on `is_empty()` for the "all drives" case).
@@ -56,13 +60,15 @@ fn drive_letter_matches_rejects_unknown_layout() {
     // Parent dir doesn't carry the `drive_` prefix.
     assert!(!drive_letter_matches(
         Path::new("/data/snapshot/C_mft.iocp"),
-        &['C']
+        &[uffs_mft::platform::DriveLetter::C]
     ));
     // No parent at all — root file.
-    assert!(!drive_letter_matches(Path::new("C_mft.iocp"), &['C']));
+    assert!(!drive_letter_matches(Path::new("C_mft.iocp"), &[
+        uffs_mft::platform::DriveLetter::C
+    ]));
     // `drive_` prefix with no letter after (suffix.chars().next() = None).
     assert!(!drive_letter_matches(
         Path::new("/data/drive_/C_mft.iocp"),
-        &['C']
+        &[uffs_mft::platform::DriveLetter::C]
     ));
 }

--- a/crates/uffs-diag/src/bin/dump_mft_extents.rs
+++ b/crates/uffs-diag/src/bin/dump_mft_extents.rs
@@ -84,11 +84,11 @@ fn real_main() -> Result<()> {
         .next()
         .context("Drive letter argument must not be empty")?;
 
-    if !drive_input.is_ascii_alphabetic() {
-        anyhow::bail!("Drive letter must be A-Z, got: {drive_input}");
-    }
-
-    let drive = drive_input.to_ascii_uppercase();
+    // `DriveLetter::parse` enforces ASCII-letter validation and
+    // canonicalises to uppercase, replacing the previous hand-rolled
+    // `is_ascii_alphabetic` + `to_ascii_uppercase` pair.
+    let drive = uffs_mft::platform::DriveLetter::parse(drive_input)
+        .with_context(|| format!("Drive letter must be A-Z, got: {drive_input}"))?;
 
     println!("===============================================");
     println!("Dumping $MFT extents for volume {drive}:");

--- a/crates/uffs-diag/src/bin/dump_mft_records.rs
+++ b/crates/uffs-diag/src/bin/dump_mft_records.rs
@@ -349,7 +349,10 @@ fn test_merge(raw_path: &str, base_frs: u64, ext_frs: u64) -> Result<()> {
 
     // Now build the MftIndex and check the record
     println!("\n=== Building MftIndex from merged records ===");
-    let index = uffs_mft::index::MftIndex::from_parsed_records('D', merged_records);
+    let index = uffs_mft::index::MftIndex::from_parsed_records(
+        uffs_mft::platform::DriveLetter::D,
+        merged_records,
+    );
     println!("  records.len(): {}", index.records.len());
     println!("  children.len(): {}", index.children_count());
 

--- a/crates/uffs-format/src/datetime.rs
+++ b/crates/uffs-format/src/datetime.rs
@@ -21,8 +21,14 @@ use core::fmt::Write as _;
 /// timestamps.
 pub(crate) fn append_datetime_native(buf: &mut String, filetime: i64, tz_offset_secs: i32) {
     let local_ft = uffs_time::filetime_with_tz_bias(filetime, tz_offset_secs);
-    if let Some((year, month, day, hour, minute, second)) =
-        uffs_time::filetime_to_calendar(local_ft)
+    if let Some(uffs_time::CalendarParts {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+    }) = uffs_time::filetime_to_calendar(local_ft)
     {
         #[expect(
             clippy::let_underscore_must_use,

--- a/crates/uffs-mcp/Cargo.toml
+++ b/crates/uffs-mcp/Cargo.toml
@@ -62,6 +62,10 @@ streamable-http = [
 [dependencies]
 # Internal
 uffs-client.workspace = true
+# Typed drive-letter newtype.  Direct dep so the MCP roots / schema
+# code can name `DriveLetter` natively (parse into the typed value
+# rather than chasing the re-export through `uffs-client`).
+uffs-mft.workspace = true
 
 # Async — `net` re-enabled because the HTTP gateway binds a TCP
 # listener and the health-check probes use `tokio::net::TcpStream`.

--- a/crates/uffs-mcp/src/bin/http_gateway.rs
+++ b/crates/uffs-mcp/src/bin/http_gateway.rs
@@ -28,6 +28,7 @@ use thiserror as _;
 use tower_service as _;
 use tracing_appender as _;
 use uffs_client as _;
+use uffs_mft as _;
 
 /// CLI arguments for the HTTP gateway.
 #[derive(Clone, Debug)]

--- a/crates/uffs-mcp/src/lib_tests.rs
+++ b/crates/uffs-mcp/src/lib_tests.rs
@@ -64,7 +64,7 @@ mod text_tests {
 
     fn test_row(name: &str, size: u64, modified: i64, path: &str) -> SearchRow {
         SearchRow {
-            drive: 'C',
+            drive: uffs_mft::platform::DriveLetter::C,
             name: name.to_owned(),
             size,
             is_directory: false,

--- a/crates/uffs-mcp/src/main.rs
+++ b/crates/uffs-mcp/src/main.rs
@@ -27,6 +27,7 @@ use thiserror as _;
 #[cfg(feature = "streamable-http")]
 use tower_service as _;
 use tracing_appender as _;
+use uffs_mft as _;
 
 mod process;
 

--- a/crates/uffs-mcp/src/roots.rs
+++ b/crates/uffs-mcp/src/roots.rs
@@ -170,8 +170,16 @@ pub(crate) fn apply_roots_scope(state: &RootsState, params: &mut SearchParams) {
     };
 
     // Only apply drive scoping when the caller didn't set explicit drives.
+    // Drives advertised by the client come from the `roots/list` MCP
+    // exchange; we validate via `DriveLetter::parse` and drop entries
+    // that aren't ASCII A..=Z (silently — malformed roots are a client
+    // bug, not a server-side error).
     if params.drives.is_empty() && !drives.is_empty() {
-        params.drives = drives.iter().filter_map(|drv| drv.chars().next()).collect();
+        params.drives = drives
+            .iter()
+            .filter_map(|drv| drv.chars().next())
+            .filter_map(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
+            .collect();
     }
 
     // Only inject path-prefix predicates when the caller didn't already
@@ -375,7 +383,7 @@ mod tests {
         let mut params = SearchParams::default();
         apply_roots_scope(&state, &mut params);
 
-        assert_eq!(params.drives, vec!['C']);
+        assert_eq!(params.drives, vec![uffs_mft::platform::DriveLetter::C]);
         assert_eq!(params.predicates.len(), 1);
         assert_eq!(params.predicates[0].field, "path");
         assert_eq!(params.predicates[0].op, SearchPredicateOp::StartsWith);
@@ -394,7 +402,7 @@ mod tests {
         let mut params = SearchParams::default();
         apply_roots_scope(&state, &mut params);
 
-        assert_eq!(params.drives, vec!['D']);
+        assert_eq!(params.drives, vec![uffs_mft::platform::DriveLetter::D]);
         // "D:" is only 2 chars — should NOT inject a path predicate.
         assert!(params.predicates.is_empty());
     }
@@ -406,13 +414,13 @@ mod tests {
         update_roots_state(&mut state, &roots);
 
         let mut params = SearchParams {
-            drives: vec!['D'], // User explicitly set drives.
+            drives: vec![uffs_mft::platform::DriveLetter::D], // User explicitly set drives.
             ..Default::default()
         };
         apply_roots_scope(&state, &mut params);
 
         // Should NOT override explicit drives.
-        assert_eq!(params.drives, vec!['D']);
+        assert_eq!(params.drives, vec![uffs_mft::platform::DriveLetter::D]);
         // But should still add path predicate since no path pred exists.
         assert_eq!(params.predicates.len(), 1);
     }
@@ -450,7 +458,7 @@ mod tests {
         let mut params = SearchParams::default();
         apply_roots_scope(&state, &mut params);
 
-        assert_eq!(params.drives, vec!['C']);
+        assert_eq!(params.drives, vec![uffs_mft::platform::DriveLetter::C]);
         // Common prefix is "C:\Users\me\" (truncated at last separator).
         assert_eq!(params.predicates.len(), 1);
         assert_eq!(

--- a/crates/uffs-mcp/src/schemas.rs
+++ b/crates/uffs-mcp/src/schemas.rs
@@ -43,8 +43,12 @@ pub(crate) struct SearchOutput {
 /// `structuredContent` exposes 100% of the data the CLI/API returns.
 #[derive(Debug, Serialize, JsonSchema)]
 pub(crate) struct SearchRowOutput {
-    /// Drive letter.
-    pub drive: char,
+    /// Drive letter (single ASCII A..=Z over the wire — see
+    /// `DriveLetter` serde impl).  JSON schema is `char` to preserve
+    /// the prior MCP contract since `DriveLetter` lives in `uffs-mft`
+    /// (no `schemars` dep).
+    #[schemars(with = "char")]
+    pub drive: uffs_mft::platform::DriveLetter,
     /// Filename.
     pub name: String,
     /// File extension (lowercase, without leading dot). Empty for directories
@@ -103,8 +107,11 @@ pub(crate) struct DrivesOutput {
 /// A single drive entry (structured).
 #[derive(Debug, Serialize, JsonSchema)]
 pub(crate) struct DriveOutput {
-    /// Drive letter (e.g. 'C').
-    pub letter: char,
+    /// Drive letter (e.g. `DriveLetter::C`).  Serialized as a single
+    /// ASCII char (e.g. `"C"`) to keep wire compatibility with prior
+    /// `char`-typed schema.  JSON schema is `char` (see [`SearchRowOutput`]).
+    #[schemars(with = "char")]
+    pub letter: uffs_mft::platform::DriveLetter,
     /// Number of records in the compact index.
     pub records: usize,
     /// Data source (`"cache"`, `"live"`, `"mft_file"`).

--- a/crates/uffs-mcp/src/tools/aggregate.rs
+++ b/crates/uffs-mcp/src/tools/aggregate.rs
@@ -100,10 +100,11 @@ pub(crate) async fn run(
         });
     }
 
-    let drives: Vec<char> = args
+    let drives: Vec<uffs_mft::platform::DriveLetter> = args
         .drives
         .iter()
-        .filter_map(|ch| ch.chars().next())
+        .filter_map(|drv| drv.chars().next())
+        .filter_map(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
         .collect();
 
     let mut params = SearchParams {

--- a/crates/uffs-mcp/src/tools/search.rs
+++ b/crates/uffs-mcp/src/tools/search.rs
@@ -284,11 +284,16 @@ pub(crate) async fn run(
     // Resolve cursor offset.
     let offset = args.cursor.as_deref().map_or(0, decode_cursor);
 
-    // Convert explicit drive strings to chars.
-    let explicit_drives: Vec<char> = args
+    // Convert explicit drive strings to typed `DriveLetter` values.
+    // Malformed entries (non-ASCII, multi-char) are silently dropped
+    // — the prior `char` path took only the first character and
+    // forwarded it as-is, so this is a stricter version of the same
+    // observable behaviour.
+    let explicit_drives: Vec<uffs_mft::platform::DriveLetter> = args
         .drives
         .iter()
         .filter_map(|drv| drv.chars().next())
+        .filter_map(|ch| uffs_mft::platform::DriveLetter::parse(ch).ok())
         .collect();
 
     // Ask the daemon for offset + limit rows so we can skip the first `offset`.

--- a/crates/uffs-mcp/tests/mcp_protocol.rs
+++ b/crates/uffs-mcp/tests/mcp_protocol.rs
@@ -39,6 +39,7 @@ use tracing_appender as _;
 use tracing_subscriber as _;
 use uffs_client as _;
 use uffs_mcp::handler::UffsMcpServer;
+use uffs_mft as _;
 
 /// Spin up an in-process MCP server + client pair over a duplex channel.
 ///

--- a/crates/uffs-mft/Cargo.toml
+++ b/crates/uffs-mft/Cargo.toml
@@ -87,6 +87,12 @@ hostname.workspace = true
 rustc-hash.workspace = true
 zerocopy.workspace = true
 
+# Wire-format (de)serialisation for `DriveLetter` — used by the
+# daemon event stream and the compact index header.  The dep is
+# narrow: only the `Serialize`/`Deserialize` derives + manual impls
+# on `DriveLetter` itself.
+serde.workspace = true
+
 # Chaos test harness dependencies (ChaosMftReader is public for CLI)
 rand.workspace = true
 rand_chacha.workspace = true

--- a/crates/uffs-mft/benches/mft_read.rs
+++ b/crates/uffs-mft/benches/mft_read.rs
@@ -32,6 +32,9 @@ use rand as _;
 use rand_chacha as _;
 use rayon as _;
 use rustc_hash as _;
+// `serde` is a library-only dep (DriveLetter Serialize/Deserialize);
+// acknowledge it to keep `unused-crate-dependencies` quiet here too.
+use serde as _;
 use sha2 as _;
 use smallvec as _;
 use tempfile as _;

--- a/crates/uffs-mft/src/cache.rs
+++ b/crates/uffs-mft/src/cache.rs
@@ -235,8 +235,8 @@ pub fn cache_dir() -> PathBuf {
 ///
 /// Returns `{SECURE_CACHE_DIR}/{DRIVE}_index.uffs`.
 #[must_use]
-pub fn cache_file_path(drive: char) -> PathBuf {
-    cache_dir().join(format!("{}_index.uffs", drive.to_ascii_uppercase()))
+pub fn cache_file_path(drive: crate::platform::DriveLetter) -> PathBuf {
+    cache_dir().join(format!("{}_index.uffs", drive.as_char()))
 }
 
 /// Checks if a cached index file exists and is fresh (within TTL).
@@ -250,7 +250,7 @@ pub fn cache_file_path(drive: char) -> PathBuf {
 ///
 /// `true` if the cache file exists and was modified within the TTL window.
 #[must_use]
-pub fn is_cache_fresh(drive: char, ttl_seconds: u64) -> bool {
+pub fn is_cache_fresh(drive: crate::platform::DriveLetter, ttl_seconds: u64) -> bool {
     let path = cache_file_path(drive);
     std::fs::metadata(&path).is_ok_and(|meta| {
         meta.modified().is_ok_and(|modified| {
@@ -266,7 +266,7 @@ pub fn is_cache_fresh(drive: char, ttl_seconds: u64) -> bool {
 ///
 /// Returns `None` if the file doesn't exist or age cannot be determined.
 #[must_use]
-pub fn cache_age_seconds(drive: char) -> Option<u64> {
+pub fn cache_age_seconds(drive: crate::platform::DriveLetter) -> Option<u64> {
     let path = cache_file_path(drive);
     let meta = std::fs::metadata(&path).ok()?;
     let modified = meta.modified().ok()?;
@@ -287,7 +287,10 @@ pub fn cache_age_seconds(drive: char) -> Option<u64> {
 ///
 /// `Some((index, header))` if cache is fresh, `None` otherwise.
 #[must_use]
-pub fn load_cached_index(drive: char, ttl_seconds: u64) -> Option<(MftIndex, IndexHeader)> {
+pub fn load_cached_index(
+    drive: crate::platform::DriveLetter,
+    ttl_seconds: u64,
+) -> Option<(MftIndex, IndexHeader)> {
     if !is_cache_fresh(drive, ttl_seconds) {
         return None;
     }
@@ -304,7 +307,7 @@ pub fn load_cached_index(drive: char, ttl_seconds: u64) -> Option<(MftIndex, Ind
     match result {
         Ok(Some((index, header))) => {
             // Verify the volume matches
-            (header.volume == drive.to_ascii_uppercase()).then_some((index, header))
+            (header.volume == drive).then_some((index, header))
         }
         _ => None,
     }
@@ -321,7 +324,7 @@ pub fn load_cached_index(drive: char, ttl_seconds: u64) -> Option<(MftIndex, Ind
 /// Returns an error if directory creation, locking, or file writing fails.
 pub fn save_to_cache(
     index: &MftIndex,
-    drive: char,
+    drive: crate::platform::DriveLetter,
     volume_serial: u64,
     usn_journal_id: u64,
     next_usn: i64,
@@ -361,7 +364,7 @@ pub fn save_to_cache(
 /// propagated (best-effort save).
 pub fn save_to_cache_background(
     index: &MftIndex,
-    drive: char,
+    drive: crate::platform::DriveLetter,
     volume_serial: u64,
     usn_journal_id: u64,
     next_usn: i64,
@@ -417,8 +420,8 @@ pub fn save_to_cache_background(
 ///
 /// Called automatically by [`save_to_cache`] to ensure the compact index
 /// is rebuilt from the updated `MftIndex`.
-fn invalidate_compact_cache(drive: char) {
-    let compact_path = cache_dir().join(format!("{drive}_compact.uffs"));
+fn invalidate_compact_cache(drive: crate::platform::DriveLetter) {
+    let compact_path = cache_dir().join(format!("{}_compact.uffs", drive.as_char()));
     if compact_path.exists() {
         if let Err(err) = std::fs::remove_file(&compact_path) {
             tracing::warn!(
@@ -439,7 +442,7 @@ fn invalidate_compact_cache(drive: char) {
 ///
 /// Overwrites the file with zeros before deleting. Does nothing if the
 /// file doesn't exist.
-pub fn remove_cached_index(drive: char) {
+pub fn remove_cached_index(drive: crate::platform::DriveLetter) {
     let path = cache_file_path(drive);
     let _rm_cache = secure_remove(&path);
     // Also clean up the lock file
@@ -471,20 +474,22 @@ pub fn remove_all_cached_indices() {
 ///
 /// Returns a vector of drive letters that have cached indices.
 #[must_use]
-pub fn list_cached_drives() -> Vec<char> {
+pub fn list_cached_drives() -> Vec<crate::platform::DriveLetter> {
     let dir = cache_dir();
     let mut drives = Vec::new();
 
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
             if let Some(name) = entry.file_name().to_str() {
-                // Parse "C_index.uffs" -> 'C'
+                // Parse "C_index.uffs" -> DriveLetter::C.  Non-letter
+                // prefixes (e.g. stray `.tmp` / `.lock` files) fall
+                // out via `DriveLetter::parse`.
                 if name.ends_with("_index.uffs")
                     && name.len() >= 12
                     && let Some(drive_char) = name.chars().next()
-                    && drive_char.is_ascii_alphabetic()
+                    && let Ok(letter) = crate::platform::DriveLetter::parse(drive_char)
                 {
-                    drives.push(drive_char.to_ascii_uppercase());
+                    drives.push(letter);
                 }
             }
         }
@@ -508,7 +513,7 @@ pub fn list_cached_drives() -> Vec<char> {
 ///
 /// `true` if any drive's cache is missing or expired.
 #[must_use]
-pub fn any_cache_expired(drives: &[char], ttl_seconds: u64) -> bool {
+pub fn any_cache_expired(drives: &[crate::platform::DriveLetter], ttl_seconds: u64) -> bool {
     for &drive in drives {
         if !is_cache_fresh(drive, ttl_seconds) {
             return true;
@@ -568,8 +573,8 @@ const CACHE_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
 ///
 /// E.g. `{SECURE_CACHE_DIR}/C_index.lock`
 #[must_use]
-pub fn cache_lock_path(drive: char) -> PathBuf {
-    cache_dir().join(format!("{}_index.lock", drive.to_ascii_uppercase()))
+pub fn cache_lock_path(drive: crate::platform::DriveLetter) -> PathBuf {
+    cache_dir().join(format!("{}_index.lock", drive.as_char()))
 }
 
 /// Result of a cache check operation.
@@ -604,7 +609,7 @@ pub enum CacheStatus {
 /// This is a high-level function that returns the cache status and optionally
 /// loads the index if fresh.
 #[must_use]
-pub fn check_cache_status(drive: char, ttl_seconds: u64) -> CacheStatus {
+pub fn check_cache_status(drive: crate::platform::DriveLetter, ttl_seconds: u64) -> CacheStatus {
     let path = cache_file_path(drive);
 
     // Check if file exists
@@ -626,7 +631,7 @@ pub fn check_cache_status(drive: char, ttl_seconds: u64) -> CacheStatus {
         // Try to load the index
         match MftIndex::load_from_file(&path) {
             Ok((index, header)) => {
-                if header.volume == drive.to_ascii_uppercase() {
+                if header.volume == drive {
                     CacheStatus::Fresh {
                         index,
                         header,
@@ -647,13 +652,13 @@ pub fn check_cache_status(drive: char, ttl_seconds: u64) -> CacheStatus {
 #[derive(Debug)]
 pub enum MultiDriveCacheStatus {
     /// All drives have fresh caches.
-    AllFresh(Vec<(char, MftIndex, IndexHeader)>),
+    AllFresh(Vec<(crate::platform::DriveLetter, MftIndex, IndexHeader)>),
     /// Some or all drives need refresh - rebuild all.
     NeedsRebuild {
         /// Drives that need rebuilding.
-        stale_drives: Vec<char>,
+        stale_drives: Vec<crate::platform::DriveLetter>,
         /// Drives that are fresh (but will be rebuilt anyway for consistency).
-        fresh_drives: Vec<char>,
+        fresh_drives: Vec<crate::platform::DriveLetter>,
     },
 }
 
@@ -662,7 +667,10 @@ pub enum MultiDriveCacheStatus {
 /// For multi-drive operations, if ANY drive is stale, we recommend rebuilding
 /// ALL drives to ensure consistency.
 #[must_use]
-pub fn check_multi_drive_cache(drives: &[char], ttl_seconds: u64) -> MultiDriveCacheStatus {
+pub fn check_multi_drive_cache(
+    drives: &[crate::platform::DriveLetter],
+    ttl_seconds: u64,
+) -> MultiDriveCacheStatus {
     let mut fresh = Vec::new();
     let mut stale = Vec::new();
     let mut indices = Vec::new();

--- a/crates/uffs-mft/src/cache_dataframe.rs
+++ b/crates/uffs-mft/src/cache_dataframe.rs
@@ -39,7 +39,7 @@ use super::{load_cached_index, save_to_cache_background};
 /// on a dedicated blocking thread, we avoid this issue.
 #[cfg(windows)]
 pub async fn load_or_build_dataframe_cached(
-    drive: char,
+    drive: crate::platform::DriveLetter,
     ttl_seconds: u64,
 ) -> crate::Result<uffs_polars::DataFrame> {
     tracing::debug!(drive = %drive, ttl_seconds, "Entering cached DataFrame load/build");
@@ -68,7 +68,7 @@ pub async fn load_or_build_dataframe_cached(
 /// It performs all MFT reading and polars operations synchronously.
 #[cfg(windows)]
 fn load_or_build_dataframe_cached_sync(
-    drive: char,
+    drive: crate::platform::DriveLetter,
     ttl_seconds: u64,
 ) -> crate::Result<uffs_polars::DataFrame> {
     tracing::debug!(
@@ -89,7 +89,7 @@ fn load_or_build_dataframe_cached_sync(
 /// any conversion failure); returns `None` only on cache miss.
 #[cfg(windows)]
 fn load_cached_dataframe(
-    drive: char,
+    drive: crate::platform::DriveLetter,
     ttl_seconds: u64,
 ) -> Option<crate::Result<uffs_polars::DataFrame>> {
     let (index, _header) = load_cached_index(drive, ttl_seconds)?;
@@ -106,7 +106,9 @@ fn load_cached_dataframe(
 /// Read the MFT fresh, kick off a background cache save, and convert the
 /// resulting index into a [`DataFrame`].  Used after a cache miss.
 #[cfg(windows)]
-fn build_fresh_dataframe(drive: char) -> crate::Result<uffs_polars::DataFrame> {
+fn build_fresh_dataframe(
+    drive: crate::platform::DriveLetter,
+) -> crate::Result<uffs_polars::DataFrame> {
     let index = read_fresh_index(drive)?;
     spawn_cache_save(drive, &index)?;
 
@@ -123,7 +125,7 @@ fn build_fresh_dataframe(drive: char) -> crate::Result<uffs_polars::DataFrame> {
 /// Open the MFT reader for `drive` and synchronously read every record
 /// into an [`MftIndex`].  Wraps the tracing pair around the slow read.
 #[cfg(windows)]
-fn read_fresh_index(drive: char) -> crate::Result<crate::index::MftIndex> {
+fn read_fresh_index(drive: crate::platform::DriveLetter) -> crate::Result<crate::index::MftIndex> {
     use crate::reader::MftReader;
 
     tracing::info!(drive = %drive, "📖 Cache miss - reading MFT fresh");
@@ -144,7 +146,10 @@ fn read_fresh_index(drive: char) -> crate::Result<crate::index::MftIndex> {
 /// logged at warn so the surrounding [`build_fresh_dataframe`] flow can
 /// still hand the freshly-built [`DataFrame`] back to the user.
 #[cfg(windows)]
-fn spawn_cache_save(drive: char, index: &crate::index::MftIndex) -> crate::Result<()> {
+fn spawn_cache_save(
+    drive: crate::platform::DriveLetter,
+    index: &crate::index::MftIndex,
+) -> crate::Result<()> {
     use crate::VolumeHandle;
     use crate::usn::query_usn_journal;
 
@@ -165,7 +170,7 @@ fn spawn_cache_save(drive: char, index: &crate::index::MftIndex) -> crate::Resul
 /// the index came from the cache or a fresh MFT read.
 #[cfg(windows)]
 fn log_conversion_result(
-    drive: char,
+    drive: crate::platform::DriveLetter,
     df: &crate::Result<uffs_polars::DataFrame>,
     source: &'static str,
 ) {

--- a/crates/uffs-mft/src/cli.rs
+++ b/crates/uffs-mft/src/cli.rs
@@ -28,7 +28,7 @@ pub(crate) enum Commands {
     Read {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
 
         /// Output file path (Parquet format)
         #[arg(short, long)]
@@ -66,7 +66,7 @@ pub(crate) enum Commands {
     Info {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
 
         /// Perform deep scan (reads all MFT records for detailed statistics)
         #[arg(long)]
@@ -93,7 +93,7 @@ pub(crate) enum Commands {
     Bench {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
 
         /// Output results as JSON (for scripting)
         #[arg(long)]
@@ -144,7 +144,7 @@ pub(crate) enum Commands {
     BitmapDiag {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
 
         /// Show sample of individual record states
         #[arg(long)]
@@ -166,7 +166,7 @@ pub(crate) enum Commands {
         /// Drive letter to read MFT from (e.g., C, D, E).
         /// Required for MFT save; defaults to boot drive for --upcase.
         #[arg(short, long, value_name = "LETTER")]
-        drive: Option<char>,
+        drive: Option<uffs_mft::platform::DriveLetter>,
 
         /// Output file path.
         /// Required for MFT save; defaults to `upcase.bin` for --upcase.
@@ -250,7 +250,7 @@ pub(crate) enum Commands {
         /// Required for raw NTFS files that don't have this info in header.
         /// For UFFS-MFT format files, this overrides the stored volume letter.
         #[arg(short, long, value_name = "LETTER")]
-        drive: Option<char>,
+        drive: Option<uffs_mft::platform::DriveLetter>,
 
         /// Include forensic records (deleted, corrupt, extension records).
         /// Adds `is_deleted`, `is_corrupt`, `is_extension`, `base_frs` columns.
@@ -275,7 +275,7 @@ pub(crate) enum Commands {
     BenchmarkMft {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
     },
 
     /// Full index build benchmark (aligned with the reference
@@ -293,7 +293,7 @@ pub(crate) enum Commands {
     BenchmarkIndex {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
     },
 
     /// Lean index build benchmark (no `DataFrame` overhead)
@@ -312,7 +312,7 @@ pub(crate) enum Commands {
     BenchmarkIndexLean {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
 
         /// Read mode: auto, parallel, streaming, prefetch, pipelined,
         /// pipelined-parallel
@@ -384,7 +384,7 @@ pub(crate) enum Commands {
     BenchmarkTree {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
 
         /// Number of iterations to run (for averaging).
         /// Default: 3
@@ -412,7 +412,7 @@ pub(crate) enum Commands {
     BenchmarkMultiVolume {
         /// Comma-separated list of drive letters (e.g., C,D,S)
         #[arg(short, long, value_delimiter = ',')]
-        drives: Vec<char>,
+        drives: Vec<uffs_mft::platform::DriveLetter>,
     },
 
     /// Query USN Journal information for a drive (M5 optimization).
@@ -428,7 +428,7 @@ pub(crate) enum Commands {
     UsnInfo {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
     },
 
     /// Read recent USN Journal changes for a drive (M5 optimization).
@@ -446,7 +446,7 @@ pub(crate) enum Commands {
     UsnRead {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
 
         /// Starting USN (default: read from journal start)
         #[arg(long)]
@@ -470,7 +470,7 @@ pub(crate) enum Commands {
     IndexSave {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
 
         /// Output file path
         #[arg(short, long)]
@@ -528,7 +528,7 @@ pub(crate) enum Commands {
     CacheGet {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
 
         /// Force rebuild even if cache is fresh
         #[arg(long)]
@@ -553,7 +553,7 @@ pub(crate) enum Commands {
     CacheClear {
         /// Drive letter to clear (e.g., C, D, E)
         #[arg(short, long)]
-        drive: Option<char>,
+        drive: Option<uffs_mft::platform::DriveLetter>,
 
         /// Clear ALL cached indices
         #[arg(long)]
@@ -574,7 +574,7 @@ pub(crate) enum Commands {
     IndexUpdate {
         /// Drive letter (e.g., C, D, E)
         #[arg(short, long)]
-        drive: char,
+        drive: uffs_mft::platform::DriveLetter,
 
         /// Force full MFT scan instead of incremental update
         #[arg(long)]
@@ -605,7 +605,7 @@ pub(crate) enum Commands {
     IndexAll {
         /// Comma-separated list of drive letters (default: all NTFS drives)
         #[arg(short, long, value_delimiter = ',')]
-        drives: Option<Vec<char>>,
+        drives: Option<Vec<uffs_mft::platform::DriveLetter>>,
 
         /// Skip cache (always read fresh from disk, still saves to cache)
         #[arg(long)]

--- a/crates/uffs-mft/src/commands/load.rs
+++ b/crates/uffs-mft/src/commands/load.rs
@@ -47,7 +47,7 @@ pub(crate) fn cmd_load(
     info_only: bool,
     build_index: bool,
     debug_tree: bool,
-    drive_override: Option<char>,
+    drive_override: Option<uffs_mft::platform::DriveLetter>,
     forensic: bool,
 ) -> Result<()> {
     use std::time::Instant;
@@ -75,7 +75,7 @@ pub(crate) fn cmd_load(
     // Load header first (with volume letter override if provided)
     let load_options = LoadRawOptions {
         header_only: true,
-        volume_letter: drive_override.map(|c| c.to_ascii_uppercase()),
+        volume_letter: drive_override,
         forensic,
     };
     let raw_data = load_raw_mft(input, &load_options)
@@ -152,7 +152,7 @@ pub(crate) fn cmd_load(
     // Create load options for data loading (not header-only)
     let data_load_options = LoadRawOptions {
         header_only: false,
-        volume_letter: drive_override.map(|c| c.to_ascii_uppercase()),
+        volume_letter: drive_override,
         forensic,
     };
 

--- a/crates/uffs-mft/src/commands/windows/bench.rs
+++ b/crates/uffs-mft/src/commands/windows/bench.rs
@@ -37,7 +37,7 @@ use crate::display::format_number_commas;
 /// Truncates a string to a maximum length, adding "..." if truncated.
 #[cfg(windows)]
 pub(crate) async fn cmd_bench(
-    drive: char,
+    drive: uffs_mft::platform::DriveLetter,
     json: bool,
     no_df: bool,
     requested_runs: u32,
@@ -46,14 +46,13 @@ pub(crate) async fn cmd_bench(
 ) -> Result<()> {
     use uffs_mft::{BenchmarkResult, MftReadMode, MftReader};
 
-    let drive_upper = drive.to_ascii_uppercase();
     let runs = requested_runs.max(1);
 
     // Parse read mode
     let mode: MftReadMode = mode_str.parse().map_err(|e: String| anyhow::anyhow!(e))?;
 
     if !json {
-        println!("🔬 Benchmarking MFT read on drive {drive_upper}:");
+        println!("🔬 Benchmarking MFT read on drive {drive}:");
         println!("   Runs: {runs}");
         println!("   Skip DataFrame: {no_df}");
         println!("   Mode: {mode}");
@@ -62,7 +61,7 @@ pub(crate) async fn cmd_bench(
     }
 
     info!(
-        drive = %drive_upper,
+        drive = %drive,
         runs,
         skip_df = no_df,
         mode = %mode,
@@ -476,7 +475,7 @@ pub(crate) async fn cmd_bench_all(
 /// skipping the `DataFrame` build when `no_df` is set.
 #[cfg(windows)]
 async fn benchmark_single_drive(
-    drive: char,
+    drive: uffs_mft::platform::DriveLetter,
     no_df: bool,
     runs: u32,
     full: bool,

--- a/crates/uffs-mft/src/commands/windows/benchmark_index.rs
+++ b/crates/uffs-mft/src/commands/windows/benchmark_index.rs
@@ -41,24 +41,22 @@ use uffs_mft::{MftReader, bytes_to_mb_f64, f64_to_u64, millis_to_u64, u64_to_f64
 
 /// Converts a byte to a printable ASCII character or '.' for non-printable.
 #[cfg(windows)]
-pub(crate) async fn cmd_benchmark_index(drive: char) -> Result<()> {
+pub(crate) async fn cmd_benchmark_index(drive: uffs_mft::platform::DriveLetter) -> Result<()> {
     use std::time::Instant;
 
     use uffs_mft::platform::VolumeHandle;
     use uffs_mft::{MftReadMode, MftReader};
 
-    let drive_upper = drive.to_ascii_uppercase();
-
     println!("=== Index Build Benchmark Tool ===");
-    println!("Drive: {drive_upper}:");
+    println!("Drive: {drive}:");
     println!(
         "This measures the full UFFS indexing pipeline (async I/O + parsing + DataFrame building)"
     );
     println!();
 
     // Get volume info via VolumeHandle
-    let handle = VolumeHandle::open(drive_upper)
-        .with_context(|| format!("Failed to open volume {drive_upper}:"))?;
+    let handle =
+        VolumeHandle::open(drive).with_context(|| format!("Failed to open volume {drive}:"))?;
     let vol_data = handle.volume_data();
     let mft_size = vol_data.mft_valid_data_length;
     let record_size = vol_data.bytes_per_file_record_segment;
@@ -75,7 +73,7 @@ pub(crate) async fn cmd_benchmark_index(drive: char) -> Result<()> {
     println!("MFT Total Size: {mft_size} bytes ({mft_size_mb} MB)");
     println!();
 
-    println!("Creating index for {drive_upper}:\\ ...");
+    println!("Creating index for {drive}:\\ ...");
     println!("Indexing in progress...");
     println!();
 
@@ -85,13 +83,13 @@ pub(crate) async fn cmd_benchmark_index(drive: char) -> Result<()> {
     let start_time = Instant::now();
 
     // Open reader and read MFT
-    let reader = MftReader::open(drive_upper)
-        .with_context(|| format!("Failed to open drive {drive_upper}:"))?
+    let reader = MftReader::open(drive)
+        .with_context(|| format!("Failed to open drive {drive}:"))?
         .with_mode(MftReadMode::Auto);
 
     let df = reader
         .read_all()
-        .with_context(|| format!("Failed to read MFT from {drive_upper}:"))?;
+        .with_context(|| format!("Failed to read MFT from {drive}:"))?;
 
     let elapsed = start_time.elapsed();
     let elapsed_ms = millis_to_u64(elapsed.as_millis());
@@ -189,7 +187,7 @@ pub(crate) struct BenchmarkIndexLeanOptions {
 /// overhead. Should be ~2x faster than `benchmark-index` on large drives.
 #[cfg(windows)]
 pub(crate) async fn cmd_benchmark_index_lean(
-    drive: char,
+    drive: uffs_mft::platform::DriveLetter,
     mode_str: &str,
     opts: BenchmarkIndexLeanOptions,
 ) -> Result<()> {
@@ -207,17 +205,15 @@ pub(crate) async fn cmd_benchmark_index_lean(
         parse_workers,
     } = opts;
 
-    let drive_upper = drive.to_ascii_uppercase();
-
     // Parse read mode
     let mode: MftReadMode = mode_str.parse().map_err(|e: String| anyhow::anyhow!(e))?;
 
     // Get drive type for adaptive defaults display
-    let drive_type = uffs_mft::platform::detect_drive_type(drive_upper);
+    let drive_type = uffs_mft::platform::detect_drive_type(drive);
     let effective_io_size_kb = io_size_kb.unwrap_or_else(|| drive_type.optimal_io_size() / 1024);
 
     println!("=== Lean Index Build Benchmark Tool ===");
-    println!("Drive: {drive_upper}:");
+    println!("Drive: {drive}:");
     println!("Drive Type: {drive_type:?}");
     println!("Mode: {mode}");
     println!("Bitmap: {}", if no_bitmap { "disabled" } else { "enabled" });
@@ -267,8 +263,8 @@ pub(crate) async fn cmd_benchmark_index_lean(
     println!();
 
     // Get volume info via VolumeHandle
-    let handle = VolumeHandle::open(drive_upper)
-        .with_context(|| format!("Failed to open volume {drive_upper}:"))?;
+    let handle =
+        VolumeHandle::open(drive).with_context(|| format!("Failed to open volume {drive}:"))?;
     let vol_data = handle.volume_data();
     let mft_size = vol_data.mft_valid_data_length;
     let record_size = vol_data.bytes_per_file_record_segment;
@@ -285,7 +281,7 @@ pub(crate) async fn cmd_benchmark_index_lean(
     println!("MFT Total Size: {mft_size} bytes ({mft_size_mb} MB)");
     println!();
 
-    println!("Creating lean index for {drive_upper}:\\ ...");
+    println!("Creating lean index for {drive}:\\ ...");
     println!("Indexing in progress...");
     println!();
 
@@ -301,8 +297,8 @@ pub(crate) async fn cmd_benchmark_index_lean(
     // - io_size_kb: I/O chunk size in KB (None = auto based on drive type)
     // - parallel_parse: enable M3 parallel parsing optimization
     // - parse_workers: number of parsing worker threads
-    let mut reader = MftReader::open(drive_upper)
-        .with_context(|| format!("Failed to open drive {drive_upper}:"))?
+    let mut reader = MftReader::open(drive)
+        .with_context(|| format!("Failed to open drive {drive}:"))?
         .with_mode(mode)
         .with_use_bitmap(!no_bitmap)
         .with_add_placeholders(!no_placeholders);
@@ -327,7 +323,7 @@ pub(crate) async fn cmd_benchmark_index_lean(
     let (index, benchmark) = reader
         .read_all_index_with_timing()
         .await
-        .with_context(|| format!("Failed to read MFT from {drive_upper}:"))?;
+        .with_context(|| format!("Failed to read MFT from {drive}:"))?;
 
     let elapsed = start_time.elapsed();
     let elapsed_ms = millis_to_u64(elapsed.as_millis());
@@ -428,8 +424,8 @@ pub(crate) async fn cmd_benchmark_index_lean(
     // =========================================================================
     println!("=== Reference Benchmark Guide ===");
     println!("To compare with the reference uffs.com binary:");
-    println!("  uffs.com --benchmark-mft={drive_upper}:   Raw I/O only");
-    println!("  uffs.com --benchmark-index={drive_upper}: I/O + Parse + Preprocess");
+    println!("  uffs.com --benchmark-mft={drive}:   Raw I/O only");
+    println!("  uffs.com --benchmark-index={drive}: I/O + Parse + Preprocess");
     println!();
     println!("Rust equivalent phases:");
     println!(
@@ -461,7 +457,7 @@ pub(crate) async fn cmd_benchmark_index_lean(
 /// performance.
 #[cfg(windows)]
 pub(crate) async fn cmd_benchmark_tree(
-    drive: char,
+    drive: uffs_mft::platform::DriveLetter,
     iterations: usize,
     no_cache: bool,
 ) -> Result<()> {
@@ -469,10 +465,8 @@ pub(crate) async fn cmd_benchmark_tree(
 
     use uffs_mft::cache::{INDEX_TTL_SECONDS, load_cached_index};
 
-    let drive_upper = drive.to_ascii_uppercase();
-
     println!("=== Tree Metrics Benchmark ===");
-    println!("Drive: {drive_upper}:");
+    println!("Drive: {drive}:");
     println!("Iterations: {iterations}");
     println!("Cache: {}", if no_cache { "disabled" } else { "enabled" });
     println!();
@@ -483,24 +477,24 @@ pub(crate) async fn cmd_benchmark_tree(
     let load_start = Instant::now();
     let mut index = if no_cache {
         println!("Building fresh index from disk...");
-        let reader = MftReader::open(drive_upper)
-            .with_context(|| format!("Failed to open drive {drive_upper}:"))?;
+        let reader =
+            MftReader::open(drive).with_context(|| format!("Failed to open drive {drive}:"))?;
         reader
             .read_all_index()
             .await
-            .with_context(|| format!("Failed to read MFT from {drive_upper}:"))?
+            .with_context(|| format!("Failed to read MFT from {drive}:"))?
     } else {
         println!("Loading index from cache...");
-        if let Some((cached, _header)) = load_cached_index(drive_upper, INDEX_TTL_SECONDS) {
+        if let Some((cached, _header)) = load_cached_index(drive, INDEX_TTL_SECONDS) {
             cached
         } else {
             println!("Cache miss - building fresh index...");
-            let reader = MftReader::open(drive_upper)
-                .with_context(|| format!("Failed to open drive {drive_upper}:"))?;
+            let reader =
+                MftReader::open(drive).with_context(|| format!("Failed to open drive {drive}:"))?;
             reader
                 .read_all_index()
                 .await
-                .with_context(|| format!("Failed to read MFT from {drive_upper}:"))?
+                .with_context(|| format!("Failed to read MFT from {drive}:"))?
         }
     };
     let load_ms = millis_to_u64(load_start.elapsed().as_millis());
@@ -583,7 +577,7 @@ pub(crate) async fn cmd_benchmark_tree(
     // Reference benchmark guide
     println!("=== Reference Benchmark Guide ===");
     println!("To compare with the reference uffs.com binary:");
-    println!("  1. Run: uffs.com --benchmark-index={drive_upper}:");
+    println!("  1. Run: uffs.com --benchmark-index={drive}:");
     println!("  2. Look for the 'Preprocess' phase timing");
     println!("  3. Compare with Rust 'Tree Metrics' timing above");
     println!();
@@ -597,7 +591,9 @@ pub(crate) async fn cmd_benchmark_tree(
 
 /// Benchmark multi-volume indexing using single IOCP (M4 optimization).
 #[cfg(windows)]
-pub(crate) async fn cmd_benchmark_multi_volume(drives: Vec<char>) -> Result<()> {
+pub(crate) async fn cmd_benchmark_multi_volume(
+    drives: Vec<uffs_mft::platform::DriveLetter>,
+) -> Result<()> {
     use std::time::Instant;
 
     use uffs_mft::io::{MultiVolumeIocpReader, prepare_volume_state};
@@ -607,17 +603,17 @@ pub(crate) async fn cmd_benchmark_multi_volume(drives: Vec<char>) -> Result<()> 
         anyhow::bail!("No drives specified. Use --drives C,D,S");
     }
 
-    let upper_drives: Vec<char> = drives.iter().map(char::to_ascii_uppercase).collect();
+    // `DriveLetter` is uppercase by construction; no per-element remap.
 
     println!("=== Multi-Volume IOCP Benchmark (M4 Optimization) ===");
-    println!("Drives: {upper_drives:?}");
+    println!("Drives: {drives:?}");
     println!();
 
     // Prepare volume states
     let mut volume_states = Vec::new();
     let start_time = Instant::now();
 
-    for &drive in &upper_drives {
+    for &drive in &drives {
         println!("📂 Preparing volume {drive}:...");
 
         // Open volume handle

--- a/crates/uffs-mft/src/commands/windows/benchmark_mft.rs
+++ b/crates/uffs-mft/src/commands/windows/benchmark_mft.rs
@@ -50,7 +50,7 @@ use crate::display::char_or_dot;
     unsafe_code,
     reason = "FFI: SetFilePointerEx, ReadFile for raw volume I/O"
 )]
-pub(crate) async fn cmd_benchmark_mft(drive: char) -> Result<()> {
+pub(crate) async fn cmd_benchmark_mft(drive: uffs_mft::platform::DriveLetter) -> Result<()> {
     use std::time::Instant;
 
     use uffs_mft::io::AlignedBuffer;
@@ -58,20 +58,18 @@ pub(crate) async fn cmd_benchmark_mft(drive: char) -> Result<()> {
     use windows::Win32::Foundation::HANDLE;
     use windows::Win32::Storage::FileSystem::{FILE_BEGIN, ReadFile, SetFilePointerEx};
 
-    let drive_upper = drive.to_ascii_uppercase();
-
     // =========================================================================
     // Open volume and get metadata
     // =========================================================================
-    let handle = VolumeHandle::open(drive_upper)
-        .with_context(|| format!("Failed to open volume {drive_upper}:"))?;
+    let handle =
+        VolumeHandle::open(drive).with_context(|| format!("Failed to open volume {drive}:"))?;
 
     let vol_data = handle.volume_data();
 
     // Get MFT extents
     let extents = handle
         .get_mft_extents()
-        .with_context(|| format!("Failed to get MFT extents for {drive_upper}:"))?;
+        .with_context(|| format!("Failed to get MFT extents for {drive}:"))?;
 
     // Calculate MFT metrics
     let mft_size = vol_data.mft_valid_data_length;
@@ -83,7 +81,7 @@ pub(crate) async fn cmd_benchmark_mft(drive: char) -> Result<()> {
     // Print Volume Information (matches the reference benchmark layout)
     // =========================================================================
     println!("=== MFT Read Benchmark Tool ===");
-    println!("Drive: {drive_upper}:");
+    println!("Drive: {drive}:");
     println!();
     println!("Volume Information:");
     println!("  BytesPerSector: {}", vol_data.bytes_per_sector);

--- a/crates/uffs-mft/src/commands/windows/bitmap_diag.rs
+++ b/crates/uffs-mft/src/commands/windows/bitmap_diag.rs
@@ -38,19 +38,20 @@ use uffs_mft::{bytes_to_mb_f64, u64_to_f64, usize_to_f64, usize_to_u64};
 
 /// Diagnose MFT bitmap to investigate why records aren't being skipped.
 #[cfg(windows)]
-pub(crate) async fn cmd_bitmap_diag(drive: char, show_samples: bool) -> Result<()> {
+pub(crate) async fn cmd_bitmap_diag(
+    drive: uffs_mft::platform::DriveLetter,
+    show_samples: bool,
+) -> Result<()> {
     use uffs_mft::VolumeHandle;
 
-    let drive_upper = drive.to_ascii_uppercase();
-
     println!("═══════════════════════════════════════════════════════════════");
-    println!("              MFT BITMAP DIAGNOSTIC - Drive {drive_upper}:");
+    println!("              MFT BITMAP DIAGNOSTIC - Drive {drive}:");
     println!("═══════════════════════════════════════════════════════════════");
     println!();
 
     // Open volume
-    let handle = VolumeHandle::open(drive_upper)
-        .with_context(|| format!("Failed to open volume {drive_upper}:"))?;
+    let handle =
+        VolumeHandle::open(drive).with_context(|| format!("Failed to open volume {drive}:"))?;
 
     let volume_data = handle.volume_data();
     let record_size = volume_data.bytes_per_file_record_segment;

--- a/crates/uffs-mft/src/commands/windows/incremental.rs
+++ b/crates/uffs-mft/src/commands/windows/incremental.rs
@@ -43,7 +43,10 @@ use crate::display::format_number;
 
 /// Save index to disk for incremental updates.
 #[cfg(windows)]
-pub(crate) async fn cmd_index_save(drive: char, output: &Path) -> Result<()> {
+pub(crate) async fn cmd_index_save(
+    drive: uffs_mft::platform::DriveLetter,
+    output: &Path,
+) -> Result<()> {
     use std::time::Instant;
 
     use uffs_mft::usn::query_usn_journal;
@@ -208,7 +211,11 @@ pub(crate) async fn cmd_cache_status(clean: bool, purge: bool) -> Result<()> {
 
 /// Get or refresh a cached index for a drive.
 #[cfg(windows)]
-pub(crate) async fn cmd_cache_get(drive: char, force: bool, ttl: Option<u64>) -> Result<()> {
+pub(crate) async fn cmd_cache_get(
+    drive: uffs_mft::platform::DriveLetter,
+    force: bool,
+    ttl: Option<u64>,
+) -> Result<()> {
     use std::time::Instant;
 
     use uffs_mft::cache::{CacheStatus, INDEX_TTL_SECONDS, check_cache_status, save_to_cache};
@@ -302,7 +309,10 @@ pub(crate) async fn cmd_cache_get(drive: char, force: bool, ttl: Option<u64>) ->
 
 /// Clear cached indices.
 #[cfg(windows)]
-pub(crate) async fn cmd_cache_clear(drive: Option<char>, all: bool) -> Result<()> {
+pub(crate) async fn cmd_cache_clear(
+    drive: Option<uffs_mft::platform::DriveLetter>,
+    all: bool,
+) -> Result<()> {
     use uffs_mft::cache::{
         cache_dir, cache_file_path, list_cached_drives, remove_all_cached_indices,
         remove_cached_index,
@@ -341,7 +351,7 @@ pub(crate) async fn cmd_cache_clear(drive: Option<char>, all: bool) -> Result<()
 /// Incremental index update using USN Journal.
 #[cfg(windows)]
 pub(crate) async fn cmd_index_update(
-    drive: char,
+    drive: uffs_mft::platform::DriveLetter,
     force_full: bool,
     ttl: Option<u64>,
 ) -> Result<()> {
@@ -544,7 +554,7 @@ pub(crate) async fn cmd_index_update(
 
 /// Helper function to do a full index build and cache it.
 #[cfg(windows)]
-async fn do_full_index_build(drive: char) -> Result<()> {
+async fn do_full_index_build(drive: uffs_mft::platform::DriveLetter) -> Result<()> {
     use std::time::Instant;
 
     use uffs_mft::cache::save_to_cache;
@@ -603,7 +613,7 @@ async fn do_full_index_build(drive: char) -> Result<()> {
 /// Index ALL NTFS drives in parallel using the optimized lean index path.
 #[cfg(windows)]
 pub(crate) async fn cmd_index_all(
-    drives: Option<Vec<char>>,
+    drives: Option<Vec<uffs_mft::platform::DriveLetter>>,
     no_cache: bool,
     ttl: u64,
 ) -> Result<()> {
@@ -614,8 +624,8 @@ pub(crate) async fn cmd_index_all(
     let start = Instant::now();
 
     // Detect drives if not specified
-    let drive_list: Vec<char> = match drives {
-        Some(d) if !d.is_empty() => d.into_iter().map(|c| c.to_ascii_uppercase()).collect(),
+    let drive_list: Vec<uffs_mft::platform::DriveLetter> = match drives {
+        Some(d) if !d.is_empty() => d,
         _ => {
             println!("🔍 Detecting NTFS drives...");
             detect_ntfs_drives()

--- a/crates/uffs-mft/src/commands/windows/info.rs
+++ b/crates/uffs-mft/src/commands/windows/info.rs
@@ -40,16 +40,20 @@ use crate::display::{format_bytes, format_duration, format_number_commas, trunca
 /// disables the `$Bitmap`-driven skip optimisation, and `unique` reports
 /// unique-FRS counts in addition to total parse counts.
 #[cfg(windows)]
-pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: bool) -> Result<()> {
+pub(crate) async fn cmd_info(
+    drive: uffs_mft::platform::DriveLetter,
+    deep: bool,
+    no_bitmap: bool,
+    unique: bool,
+) -> Result<()> {
     use std::time::Instant;
 
     use tracing::debug;
     use uffs_mft::platform::{VolumeHandle, detect_drive_type};
 
     let start_time = Instant::now();
-    let drive_upper = drive.to_ascii_uppercase();
     info!(
-        drive = %drive_upper,
+        drive = %drive,
         deep,
         no_bitmap,
         unique,
@@ -59,13 +63,13 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
         if unique { " (unique FRS mode)" } else { "" }
     );
 
-    debug!(drive = %drive_upper, "🔓 Opening volume handle");
+    debug!(drive = %drive, "🔓 Opening volume handle");
     let handle = VolumeHandle::open(drive).with_context(|| format!("Failed to open {drive}:"))?;
 
     // Detect drive type for display
-    let drive_type = detect_drive_type(drive_upper);
+    let drive_type = detect_drive_type(drive);
     let drive_type_str = drive_type_label(drive_type, "Unknown");
-    debug!(drive = %drive_upper, drive_type = drive_type_str, "🚀 Drive type detected");
+    debug!(drive = %drive, drive_type = drive_type_str, "🚀 Drive type detected");
 
     let vol_data = handle.volume_data();
 
@@ -87,7 +91,7 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
 
     // Log detailed metrics
     info!(
-        drive = %drive_upper,
+        drive = %drive,
         bytes_per_sector = vol_data.bytes_per_sector,
         bytes_per_cluster = vol_data.bytes_per_cluster,
         bytes_per_record = vol_data.bytes_per_file_record_segment,
@@ -95,14 +99,14 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
     );
 
     info!(
-        drive = %drive_upper,
+        drive = %drive,
         total_clusters = vol_data.total_clusters,
         volume_size_gb = format!("{:.2}", volume_size_gb),
         "💾 Volume capacity"
     );
 
     info!(
-        drive = %drive_upper,
+        drive = %drive,
         mft_start_lcn = vol_data.mft_start_lcn,
         mft_valid_length = vol_data.mft_valid_data_length,
         mft_size_mb = format!("{:.2}", mft_size_mb),
@@ -120,7 +124,7 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
 
         if is_fragmented {
             info!(
-                drive = %drive_upper,
+                drive = %drive,
                 extent_count,
                 "⚠️  MFT is fragmented across multiple extents"
             );
@@ -140,7 +144,7 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
             }
         } else {
             info!(
-                drive = %drive_upper,
+                drive = %drive,
                 "✅ MFT is contiguous (single extent)"
             );
         }
@@ -156,7 +160,7 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
         utilization = (u64_to_f64(in_use_records) / u64_to_f64(record_count)) * 100.0;
 
         info!(
-            drive = %drive_upper,
+            drive = %drive,
             in_use_records,
             free_records,
             utilization = format!("{:.1}%", utilization),
@@ -184,7 +188,7 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
     } else {
         println!("                    MFT INFO (Lightweight)");
     }
-    println!("                    Drive: {drive_upper}: ({drive_type_str})");
+    println!("                    Drive: {drive}: ({drive_type_str})");
     println!("═══════════════════════════════════════════════════════════════");
     println!();
     println!("📐 VOLUME GEOMETRY");
@@ -537,7 +541,7 @@ pub(crate) async fn cmd_info(drive: char, deep: bool, no_bitmap: bool, unique: b
 #[cfg(windows)]
 struct DriveInfo {
     /// Drive letter (e.g. `C`, `D`).
-    letter: char,
+    letter: uffs_mft::platform::DriveLetter,
     /// `true` when this drive hosts the running OS.
     is_boot: bool,
     /// Volume label as reported by `GetVolumeInformationW`.
@@ -712,7 +716,7 @@ pub(crate) async fn cmd_drives() -> Result<()> {
     unsafe_code,
     reason = "required for windows ffi call to GetVolumeInformationW"
 )]
-fn get_volume_label(drive: char) -> Option<String> {
+fn get_volume_label(drive: uffs_mft::platform::DriveLetter) -> Option<String> {
     use std::ffi::OsString;
     use std::os::windows::ffi::OsStringExt as _;
 

--- a/crates/uffs-mft/src/commands/windows/read.rs
+++ b/crates/uffs-mft/src/commands/windows/read.rs
@@ -26,7 +26,7 @@ use crate::progress::spinner;
 /// `full`, `unique`, `info_only`, `build_index`, `debug_tree`, and
 /// `forensic` toggle output sections per the CLI flags.
 pub(crate) async fn cmd_read(
-    drive: char,
+    drive: uffs_mft::platform::DriveLetter,
     output: PathBuf,
     mode_str: &str,
     full: bool,
@@ -38,17 +38,16 @@ pub(crate) async fn cmd_read(
     use uffs_mft::MftReadMode;
 
     let start_time = Instant::now();
-    let drive_upper = drive.to_ascii_uppercase();
 
     warn_unsupported_forensic(forensic);
 
     let mode: MftReadMode = mode_str
         .parse()
         .map_err(|err: String| anyhow::anyhow!(err))?;
-    log_read_startup(drive_upper, &output, mode, full, unique);
+    log_read_startup(drive, &output, mode, full, unique);
 
     let pb = spinner("Opening volume...");
-    let reader = open_reader_with_logging(drive, drive_upper, mode, full, unique)?;
+    let reader = open_reader_with_logging(drive, mode, full, unique)?;
 
     pb.set_message("Reading MFT records...");
     let (mut df, record_count) = read_records_with_logging(&reader)?;
@@ -59,7 +58,7 @@ pub(crate) async fn cmd_read(
     let total_elapsed = start_time.elapsed();
     let file_size_mb = bytes_to_mb_f64(file_size);
     info!(
-        drive = %drive_upper,
+        drive = %drive,
         records = record_count,
         total_elapsed_ms = total_elapsed.as_millis(),
         output_size_mb = format!("{:.2}", file_size_mb),
@@ -92,7 +91,7 @@ fn warn_unsupported_forensic(forensic: bool) {
 /// Single startup `info!` for the live-read pipeline; encapsulates the
 /// branch on `unique` so the caller stays linear.
 fn log_read_startup(
-    drive_upper: char,
+    drive: uffs_mft::platform::DriveLetter,
     output: &std::path::Path,
     mode: uffs_mft::MftReadMode,
     full: bool,
@@ -104,7 +103,7 @@ fn log_read_startup(
         " (expanding hard links)"
     };
     info!(
-        drive = %drive_upper,
+        drive = %drive,
         output = %output.display(),
         mode = %mode,
         full,
@@ -117,8 +116,7 @@ fn log_read_startup(
 /// Open the volume handle, configure the reader, and trace the open
 /// duration.  Returns the prepared [`MftReader`] for the read phase.
 fn open_reader_with_logging(
-    drive: char,
-    drive_upper: char,
+    drive: uffs_mft::platform::DriveLetter,
     mode: uffs_mft::MftReadMode,
     full: bool,
     unique: bool,
@@ -127,7 +125,7 @@ fn open_reader_with_logging(
 
     use tracing::debug;
 
-    debug!(drive = %drive_upper, "🔓 Opening volume handle");
+    debug!(drive = %drive, "🔓 Opening volume handle");
     let open_start = Instant::now();
     let reader = MftReader::open(drive)
         .with_context(|| format!("Failed to open drive {drive}:"))?
@@ -136,7 +134,7 @@ fn open_reader_with_logging(
         .with_expand_links(!unique);
 
     info!(
-        drive = %drive_upper,
+        drive = %drive,
         elapsed_ms = open_start.elapsed().as_millis(),
         "✅ Volume opened successfully"
     );

--- a/crates/uffs-mft/src/commands/windows/save.rs
+++ b/crates/uffs-mft/src/commands/windows/save.rs
@@ -61,7 +61,7 @@ use crate::display::{clean_path_for_display, format_bytes, format_duration, form
 #[cfg(windows)]
 #[expect(clippy::too_many_arguments, reason = "CLI command with many options")]
 pub(crate) async fn cmd_save(
-    drive: char,
+    drive: uffs_mft::platform::DriveLetter,
     output: &Path,
     compress: bool,
     compression_level: i32,
@@ -88,15 +88,14 @@ pub(crate) async fn cmd_save(
     use uffs_mft::{MftReader, SaveRawOptions};
 
     let start_time = Instant::now();
-    let drive_upper = drive.to_ascii_uppercase();
 
-    info!(drive = %drive_upper, "Reading raw MFT from drive");
+    info!(drive = %drive, "Reading raw MFT from drive");
 
     // Get volume info for display
     let handle = VolumeHandle::open(drive).with_context(|| format!("Failed to open {drive}:"))?;
     let vol_data = handle.volume_data();
 
-    let drive_type = detect_drive_type(drive_upper);
+    let drive_type = detect_drive_type(drive);
     let drive_type_str = drive_type_label(drive_type, "Unknown");
 
     // Calculate metrics
@@ -129,7 +128,7 @@ pub(crate) async fn cmd_save(
     let options = SaveRawOptions {
         compress: if raw_compat { false } else { compress },
         compression_level,
-        volume_letter: drive_upper,
+        volume_letter: drive,
         raw_compat,
     };
 
@@ -146,7 +145,7 @@ pub(crate) async fn cmd_save(
     // Print formatted output
     println!("═══════════════════════════════════════════════════════════════");
     println!("                         MFT SAVED");
-    println!("                    Drive: {drive_upper}: ({drive_type_str})");
+    println!("                    Drive: {drive}: ({drive_type_str})");
     println!("═══════════════════════════════════════════════════════════════");
     println!();
     println!("📁 MFT STRUCTURE");
@@ -211,7 +210,7 @@ pub(crate) async fn cmd_save(
 /// capturing the non-deterministic I/O ordering for realistic testing.
 #[cfg(windows)]
 async fn cmd_save_iocp(
-    drive: char,
+    drive: uffs_mft::platform::DriveLetter,
     output: &Path,
     compress: bool,
     compression_level: i32,
@@ -223,15 +222,14 @@ async fn cmd_save_iocp(
     use uffs_mft::{IocpCaptureOptions, MftReader};
 
     let start_time = Instant::now();
-    let drive_upper = drive.to_ascii_uppercase();
 
-    info!(drive = %drive_upper, concurrency, "Reading MFT with IOCP capture mode");
+    info!(drive = %drive, concurrency, "Reading MFT with IOCP capture mode");
 
     // Get volume info for display
     let handle = VolumeHandle::open(drive).with_context(|| format!("Failed to open {drive}:"))?;
     let vol_data = handle.volume_data();
 
-    let drive_type = detect_drive_type(drive_upper);
+    let drive_type = detect_drive_type(drive);
     let drive_type_str = drive_type_label(drive_type, "Unknown");
 
     // Calculate metrics
@@ -240,7 +238,7 @@ async fn cmd_save_iocp(
 
     println!("═══════════════════════════════════════════════════════════════");
     println!("                    MFT IOCP CAPTURE");
-    println!("                    Drive: {drive_upper}: ({drive_type_str})");
+    println!("                    Drive: {drive}: ({drive_type_str})");
     println!("═══════════════════════════════════════════════════════════════");
     println!();
     println!("📊 MFT INFO");
@@ -257,7 +255,7 @@ async fn cmd_save_iocp(
     let options = IocpCaptureOptions {
         compress,
         compression_level,
-        volume_letter: drive_upper,
+        volume_letter: drive,
         // IOCP concurrency is bounded by the CLI parser (max 255); the
         // saturating `try_from` fallback is unreachable for valid CLI
         // input and replaces the previous truncating `as u8` cast.
@@ -317,27 +315,26 @@ async fn cmd_save_iocp(
 /// `$UpCase` is public NTFS specification data).
 #[cfg(windows)]
 #[expect(clippy::print_stdout, reason = "intentional user-facing CLI output")]
-async fn cmd_save_upcase(drive: char, output: &Path) -> Result<()> {
+async fn cmd_save_upcase(drive: uffs_mft::platform::DriveLetter, output: &Path) -> Result<()> {
     use std::time::Instant;
 
     use uffs_mft::platform::VolumeHandle;
     use uffs_mft::platform::upcase::{self, UpcaseHeader};
 
     let start = Instant::now();
-    let drive_upper = drive.to_ascii_uppercase();
 
     println!("═══════════════════════════════════════════════════════════════");
-    println!("  Reading $UpCase table from {drive_upper}: via raw volume I/O");
+    println!("  Reading $UpCase table from {drive}: via raw volume I/O");
     println!("═══════════════════════════════════════════════════════════════");
     println!();
 
     // Read the table from the live volume.
     let table = upcase::read_upcase_table(drive)
-        .with_context(|| format!("Failed to read $UpCase from {drive_upper}:"))?;
+        .with_context(|| format!("Failed to read $UpCase from {drive}:"))?;
 
     // Get volume metadata for the header.
     let handle = VolumeHandle::open(drive)
-        .with_context(|| format!("Failed to open {drive_upper}: for metadata"))?;
+        .with_context(|| format!("Failed to open {drive}: for metadata"))?;
     let vol = handle.volume_data();
 
     // Compute CRC-32 of the raw table bytes.
@@ -354,7 +351,7 @@ async fn cmd_save_upcase(drive: char, output: &Path) -> Result<()> {
         volume_serial: vol.volume_serial_number,
         table_crc32,
         timestamp,
-        drive: drive_upper,
+        drive,
     };
 
     // Atomic write (header + raw table, no encryption).

--- a/crates/uffs-mft/src/commands/windows/usn.rs
+++ b/crates/uffs-mft/src/commands/windows/usn.rs
@@ -29,7 +29,7 @@ use crate::display::format_usn_reason;
 
 /// Query USN Journal information for a drive.
 #[cfg(windows)]
-pub(crate) async fn cmd_usn_info(drive: char) -> Result<()> {
+pub(crate) async fn cmd_usn_info(drive: uffs_mft::platform::DriveLetter) -> Result<()> {
     use uffs_mft::usn::query_usn_journal;
 
     println!("🔍 Querying USN Journal for {drive}:...");
@@ -72,7 +72,11 @@ pub(crate) async fn cmd_usn_info(drive: char) -> Result<()> {
 
 /// Read recent USN Journal changes for a drive.
 #[cfg(windows)]
-pub(crate) async fn cmd_usn_read(drive: char, start_usn: Option<i64>, limit: usize) -> Result<()> {
+pub(crate) async fn cmd_usn_read(
+    drive: uffs_mft::platform::DriveLetter,
+    start_usn: Option<i64>,
+    limit: usize,
+) -> Result<()> {
     use uffs_mft::usn::{query_usn_journal, read_usn_journal};
 
     println!("🔍 Reading USN Journal for {drive}:...");

--- a/crates/uffs-mft/src/error.rs
+++ b/crates/uffs-mft/src/error.rs
@@ -15,7 +15,7 @@ pub enum MftError {
     #[error("Failed to open volume '{volume}': {source}")]
     VolumeOpen {
         /// The volume letter that failed to open.
-        volume: char,
+        volume: crate::platform::DriveLetter,
         /// The underlying I/O error.
         #[source]
         source: std::io::Error,
@@ -23,7 +23,7 @@ pub enum MftError {
 
     /// Volume is not NTFS formatted.
     #[error("Volume '{0}' is not NTFS formatted")]
-    NotNtfs(char),
+    NotNtfs(crate::platform::DriveLetter),
 
     /// Insufficient privileges to read MFT.
     #[error("Insufficient privileges to read MFT. Run as Administrator.")]

--- a/crates/uffs-mft/src/index/base.rs
+++ b/crates/uffs-mft/src/index/base.rs
@@ -7,6 +7,7 @@ use super::{
     ChildInfo, ExtensionIndex, ExtensionTable, FileRecord, IndexNameRef, IndexStreamInfo, LinkInfo,
     MftIndex, MftStats, NO_ENTRY, frs_to_usize, len_to_u32,
 };
+use crate::platform::DriveLetter;
 
 /// Returns the current Unix-microsecond timestamp for `build_epoch`.
 #[must_use]
@@ -19,7 +20,7 @@ fn current_epoch_micros() -> u64 {
 impl MftIndex {
     /// Create a new empty index for the given volume
     #[must_use]
-    pub fn new(volume: char) -> Self {
+    pub fn new(volume: DriveLetter) -> Self {
         Self {
             volume,
             extensions: ExtensionTable::new(),
@@ -30,7 +31,7 @@ impl MftIndex {
 
     /// Create with pre-allocated capacity
     #[must_use]
-    pub fn with_capacity(volume: char, record_capacity: usize) -> Self {
+    pub fn with_capacity(volume: DriveLetter, record_capacity: usize) -> Self {
         Self {
             volume,
             records: Vec::with_capacity(record_capacity),
@@ -58,7 +59,7 @@ impl MftIndex {
     ///
     /// # Arguments
     ///
-    /// * `volume` - Volume letter (e.g., 'C')
+    /// * `volume` - Volume letter (e.g., [`DriveLetter::C`])
     /// * `estimated_records` - Number of valid records from bitmap popcount
     /// * `max_frs` - Highest FRS number from bitmap (used for `frs_to_idx`
     ///   sizing)
@@ -76,7 +77,11 @@ impl MftIndex {
     /// - `children`: `estimated_records * 3 / 2` (directories have multiple
     ///   children)
     #[must_use]
-    pub fn with_capacity_optimized(volume: char, estimated_records: usize, max_frs: u64) -> Self {
+    pub fn with_capacity_optimized(
+        volume: DriveLetter,
+        estimated_records: usize,
+        max_frs: u64,
+    ) -> Self {
         // Safety margin for placeholder records added during path resolution
         let records_capacity = estimated_records + (estimated_records / 20);
 
@@ -360,7 +365,7 @@ impl MftIndex {
     /// # Example
     ///
     /// ```rust,ignore
-    /// let mut index = MftIndex::new('C');
+    /// let mut index = MftIndex::new(DriveLetter::C);
     /// // ... parse MFT records ...
     /// index.build_extension_index();
     ///

--- a/crates/uffs-mft/src/index/builder.rs
+++ b/crates/uffs-mft/src/index/builder.rs
@@ -50,7 +50,10 @@ impl MftIndex {
         skip_all,
         fields(volume = %volume, input_records = records.len())
     )]
-    pub fn from_parsed_records(volume: char, records: Vec<crate::parse::ParsedRecord>) -> Self {
+    pub fn from_parsed_records(
+        volume: crate::platform::DriveLetter,
+        records: Vec<crate::parse::ParsedRecord>,
+    ) -> Self {
         /// System metafiles are FRS 0-15 (except root at FRS 5)
         const SYSTEM_METAFILE_MAX_FRS: u64 = 15;
         const ROOT_FRS_LOCAL: u64 = 5;
@@ -457,7 +460,7 @@ impl MftIndex {
         fields(volume = %volume, input_records = records.len())
     )]
     pub fn from_parsed_records_with_timing(
-        volume: char,
+        volume: crate::platform::DriveLetter,
         records: Vec<crate::parse::ParsedRecord>,
     ) -> (Self, IndexBuildTiming) {
         use std::time::Instant;

--- a/crates/uffs-mft/src/index/child_order.rs
+++ b/crates/uffs-mft/src/index/child_order.rs
@@ -160,7 +160,7 @@ impl MftIndex {
     /// # Example
     ///
     /// ```ignore
-    /// let mut index = MftIndex::new('C');
+    /// let mut index = MftIndex::new(crate::platform::DriveLetter::C);
     /// // ... parse MFT records ...
     /// index.sort_directory_children(); // Sort all directory children
     /// ```

--- a/crates/uffs-mft/src/index/model.rs
+++ b/crates/uffs-mft/src/index/model.rs
@@ -7,6 +7,7 @@ use super::{
     ExtensionIndex, ExtensionTable, FileRecord, IndexStreamInfo, InternalStreamInfo, LinkInfo,
     MftStats,
 };
+use crate::platform::DriveLetter;
 
 /// Directory child entry.
 ///
@@ -37,10 +38,18 @@ pub struct ChildInfo {
 }
 
 /// Lean in-memory MFT index used by the parser and query layers.
-#[derive(Debug, Default)]
+///
+/// `Default` is implemented manually rather than derived because
+/// [`DriveLetter`] has no canonical default — `Default::default()`
+/// supplies [`DriveLetter::C`] as a placeholder and the four
+/// production constructors ([`MftIndex::new`], `with_capacity`,
+/// `with_capacity_optimized`, plus the test fixtures in
+/// `index/tests_ads.rs`) all overwrite it with the caller's actual
+/// volume immediately after the struct-update.
+#[derive(Debug)]
 pub struct MftIndex {
-    /// Volume letter (e.g., 'C').
-    pub volume: char,
+    /// Volume letter (e.g., `C`).
+    pub volume: DriveLetter,
     /// All file and directory records.
     pub records: Vec<FileRecord>,
     /// FRS → record index lookup (O(1) access).
@@ -76,6 +85,32 @@ pub struct MftIndex {
     /// build or mutation (e.g. USN update).  Downstream caches (compact
     /// index) compare their `source_epoch` against this to detect staleness.
     pub build_epoch: u64,
+}
+
+impl Default for MftIndex {
+    /// Placeholder index used as the `..Default::default()` spread source
+    /// inside [`MftIndex::new`].  The `volume` field is supplied as
+    /// [`DriveLetter::C`] only to satisfy the type system — every public
+    /// constructor overwrites it with the caller-provided letter
+    /// immediately after the struct-update.
+    fn default() -> Self {
+        Self {
+            volume: DriveLetter::C,
+            records: Vec::new(),
+            frs_to_idx: Vec::new(),
+            names: String::new(),
+            links: Vec::new(),
+            streams: Vec::new(),
+            internal_streams: Vec::new(),
+            children: Vec::new(),
+            stats: MftStats::default(),
+            extensions: ExtensionTable::default(),
+            extension_index: None,
+            forensic_mode: false,
+            reserved_allocated_bytes: 0,
+            build_epoch: 0,
+        }
+    }
 }
 
 /// Proportional hard-link size division formula used by tree metrics.

--- a/crates/uffs-mft/src/index/path_resolver.rs
+++ b/crates/uffs-mft/src/index/path_resolver.rs
@@ -41,7 +41,7 @@ pub struct PathResolver {
     /// State for each record index (UNSEEN, VISITING, VALID, INVALID).
     state: Vec<u8>,
     /// Volume letter for path prefix.
-    volume: char,
+    volume: crate::platform::DriveLetter,
     /// Count of valid records.
     valid_count: u32,
     /// Count of invalid records.
@@ -171,7 +171,7 @@ impl PathResolver {
         }
 
         // No cache hit — build from scratch.
-        out.push(self.volume.to_ascii_uppercase());
+        out.push(self.volume.as_char());
         out.push(':');
         for &chain_idx in chain.iter().rev() {
             if let Some(record) = index.records.get(chain_idx) {
@@ -266,7 +266,7 @@ impl PathResolver {
             }
         }
         let mut path = String::with_capacity(total_len);
-        path.push(self.volume.to_ascii_uppercase());
+        path.push(self.volume.as_char());
         path.push(':');
         for &chain_idx in chain.iter().rev() {
             if let Some(record) = index.records.get(chain_idx) {
@@ -328,7 +328,7 @@ impl PathResolver {
 
         // Build path with single allocation
         let mut path = String::with_capacity(total_len);
-        path.push(self.volume.to_ascii_uppercase());
+        path.push(self.volume.as_char());
         path.push(':');
 
         for &chain_idx in chain.iter().rev() {
@@ -371,7 +371,7 @@ impl PathResolver {
             // Normalize root to "X:\\" (not "X:") so hardlink paths keep
             // standard absolute-drive semantics.
             let mut root_path = String::with_capacity(3);
-            root_path.push(self.volume.to_ascii_uppercase());
+            root_path.push(self.volume.as_char());
             root_path.push(':');
             root_path.push('\\');
             root_path

--- a/crates/uffs-mft/src/index/paths.rs
+++ b/crates/uffs-mft/src/index/paths.rs
@@ -237,11 +237,7 @@ impl MftIndex {
 
         // Reverse and join with a standard drive-qualified backslash path.
         components.reverse();
-        format!(
-            "{}:\\{}",
-            self.volume.to_ascii_uppercase(),
-            components.join("\\")
-        )
+        format!("{}:\\{}", self.volume.as_char(), components.join("\\"))
     }
 
     /// Build the full path including stream name for ADS.
@@ -299,10 +295,6 @@ impl MftIndex {
 
         // Reverse and join with a standard drive-qualified backslash path.
         components.reverse();
-        format!(
-            "{}:\\{}",
-            self.volume.to_ascii_uppercase(),
-            components.join("\\")
-        )
+        format!("{}:\\{}", self.volume.as_char(), components.join("\\"))
     }
 }

--- a/crates/uffs-mft/src/index/storage/deserialize.rs
+++ b/crates/uffs-mft/src/index/storage/deserialize.rs
@@ -9,6 +9,7 @@ use crate::index::{
     ChildInfo, ExtensionTable, FileRecord, IndexNameRef, IndexStreamInfo, LinkInfo, MftIndex,
     MftStats, NO_ENTRY, SizeInfo, StandardInfo,
 };
+use crate::platform::DriveLetter;
 impl MftIndex {
     /// Deserializes an index from a byte slice.
     ///
@@ -140,7 +141,14 @@ impl MftIndex {
         pos += 8;
 
         let version = read_u32!();
-        let volume = char::from_u32(read_u32!()).ok_or("Invalid volume char")?;
+        // Wire format: u32-LE drive byte, originally written as `char as
+        // u32` (5a) or `DriveLetter::as_byte() as u32` (5b+).  Both
+        // produce the same 4 bytes for ASCII A..=Z, so v0..=v13 files
+        // round-trip cleanly.
+        let volume_raw = read_u32!();
+        let volume = char::from_u32(volume_raw)
+            .and_then(|ch| DriveLetter::parse(ch).ok())
+            .ok_or("Invalid volume drive letter")?;
         let volume_serial = read_u64!();
         let usn_journal_id = read_u64!();
         let next_usn = read_i64!();

--- a/crates/uffs-mft/src/index/storage/header.rs
+++ b/crates/uffs-mft/src/index/storage/header.rs
@@ -4,6 +4,7 @@
 //! Storage header and format version metadata.
 
 use crate::index::MftIndex;
+use crate::platform::DriveLetter;
 
 /// Magic bytes for index file format.
 const INDEX_MAGIC: &[u8; 8] = b"UFFSIDX\0";
@@ -32,8 +33,8 @@ pub struct IndexHeader {
     pub magic: [u8; 8],
     /// Format version for compatibility
     pub version: u32,
-    /// Volume letter (e.g., 'C')
-    pub volume: char,
+    /// Volume letter (e.g., [`DriveLetter::C`]).
+    pub volume: DriveLetter,
     /// Volume serial number for validation
     pub volume_serial: u64,
     /// USN Journal ID at time of index creation

--- a/crates/uffs-mft/src/index/storage/serialize.rs
+++ b/crates/uffs-mft/src/index/storage/serialize.rs
@@ -47,7 +47,10 @@ impl MftIndex {
         // Write header
         buffer.extend_from_slice(&header.magic);
         buffer.extend_from_slice(&header.version.to_le_bytes());
-        buffer.extend_from_slice(&(header.volume as u32).to_le_bytes());
+        // Wire format unchanged: header.volume is a DriveLetter (u8
+        // ASCII byte), widened to u32-LE so older readers that did
+        // `char::from_u32(...)` keep parsing the same 4 bytes.
+        buffer.extend_from_slice(&u32::from(header.volume.as_byte()).to_le_bytes());
         buffer.extend_from_slice(&header.volume_serial.to_le_bytes());
         buffer.extend_from_slice(&header.usn_journal_id.to_le_bytes());
         buffer.extend_from_slice(&header.next_usn.to_le_bytes());

--- a/crates/uffs-mft/src/index/tests_ads.rs
+++ b/crates/uffs-mft/src/index/tests_ads.rs
@@ -11,7 +11,7 @@ use super::*;
 
 /// Create a minimal index with a file that has ADS streams.
 fn create_index_with_ads() -> MftIndex {
-    let mut index = MftIndex::new('M');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::M);
 
     // Create a file record (FRS 100)
     let name_ref = push_index_name(&mut index, "test.pdf");

--- a/crates/uffs-mft/src/index/tests_children.rs
+++ b/crates/uffs-mft/src/index/tests_children.rs
@@ -7,7 +7,7 @@ use super::*;
 
 #[test]
 fn sort_directory_children_basic() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Create a directory (FRS 100)
     let dir_frs = 100_u64;
@@ -77,7 +77,7 @@ fn sort_directory_children_basic() {
 
 #[test]
 fn sort_directory_children_empty() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Create a directory with no children
     let dir_frs = 100_u64;
@@ -94,7 +94,7 @@ fn sort_directory_children_empty() {
 
 #[test]
 fn sort_directory_children_single_child() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Create a directory with one child
     let dir_frs = 100_u64;
@@ -137,7 +137,7 @@ fn sort_directory_children_single_child() {
 fn sort_directory_children_performance() {
     use std::time::Instant;
 
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Create a directory with 1000 children
     let dir_frs = 100_u64;

--- a/crates/uffs-mft/src/index/tests_core.rs
+++ b/crates/uffs-mft/src/index/tests_core.rs
@@ -37,7 +37,7 @@ fn file_record_size() {
 
 #[test]
 fn index_basic_operations() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Add a record
     let record = index.get_or_create(100);
@@ -77,7 +77,7 @@ fn index_name_ref_bit_packing() {
 
 #[test]
 fn names_buffer() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     let offset1 = index.add_name("test.txt");
     let offset2 = index.add_name("hello.rs");

--- a/crates/uffs-mft/src/index/tests_extensions.rs
+++ b/crates/uffs-mft/src/index/tests_extensions.rs
@@ -62,7 +62,7 @@ fn extension_table_record_file() {
 
 #[test]
 fn intern_extension() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Test basic extension extraction
     assert_eq!(index.intern_extension("test.txt"), 1);
@@ -80,7 +80,7 @@ fn intern_extension() {
 )]
 fn extension_table_serialization() {
     // Create an index with some extensions
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Add names and extensions first (before getting mutable references to records)
     let name1_offset = index.add_name("test.txt");
@@ -116,7 +116,7 @@ fn extension_table_serialization() {
         MftIndex::deserialize(&serialized).expect("Deserialization failed");
 
     // Verify header
-    assert_eq!(header.volume, 'C');
+    assert_eq!(header.volume, crate::platform::DriveLetter::C);
     assert_eq!(header.volume_serial, 12345);
     assert_eq!(header.usn_journal_id, 67890);
     assert_eq!(header.next_usn, 100);
@@ -154,7 +154,7 @@ fn extension_table_serialization() {
 
 #[test]
 fn extension_index_build() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Add files with different extensions
     let name1 = "file1.txt";
@@ -234,7 +234,7 @@ fn extension_index_build() {
     reason = "test code with known valid indices"
 )]
 fn extension_index_with_hard_links() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Create a file with multiple hard links with different extensions
     let name1 = "file.txt";
@@ -287,7 +287,7 @@ fn extension_index_with_hard_links() {
 
 #[test]
 fn extension_index_empty() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Build on empty index
     index.build_extension_index();
@@ -344,7 +344,7 @@ fn size_bucket_assignment() {
     reason = "test code with known valid indices"
 )]
 fn extension_table_top_by_bytes() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Add files with different extensions and sizes
     let files = [
@@ -399,7 +399,7 @@ fn extension_table_top_by_bytes() {
     reason = "test code with known valid indices"
 )]
 fn extension_table_top_by_count() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Add files with different extensions
     let files = [
@@ -447,7 +447,7 @@ fn extension_table_top_by_count() {
 
 #[test]
 fn byte_tracking_accuracy() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Add files with different sizes and attributes
     let files = [
@@ -537,7 +537,7 @@ fn byte_tracking_accuracy() {
 fn extension_index_performance() {
     use std::time::Instant;
 
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Create a large index with 10,000 files
     // 100 txt files, 9,900 other files

--- a/crates/uffs-mft/src/index/tests_merge.rs
+++ b/crates/uffs-mft/src/index/tests_merge.rs
@@ -116,7 +116,7 @@ fn cross_fragment_merge_extension_placeholder() {
     assert_ne!(fragment_b.get_or_create(100).stdinfo.created, 0);
     assert!(fragment_b.get_or_create(100).has_base_data());
 
-    let mut index = MftIndex::new('D');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::D);
     index.merge_fragments(vec![fragment_a, fragment_b]);
 
     let record = &index.records[index.frs_to_idx[100] as usize];
@@ -158,7 +158,7 @@ fn cross_fragment_merge_multiple_extension_names() {
     record_b.stdinfo.created = 132_456_789_012_345_678;
     record_b.stdinfo.modified = 132_456_789_012_345_678;
 
-    let mut index = MftIndex::new('D');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::D);
     index.merge_fragments(vec![fragment_a, fragment_b]);
 
     let record = &index.records[index.frs_to_idx[100] as usize];
@@ -206,7 +206,7 @@ fn cross_fragment_merge_base_first() {
     record_b.first_name.next_entry = link_c_idx;
     record_b.name_count = 2;
 
-    let mut index = MftIndex::new('D');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::D);
     index.merge_fragments(vec![fragment_a, fragment_b]);
 
     let record = &index.records[index.frs_to_idx[100] as usize];
@@ -226,7 +226,7 @@ fn cross_fragment_merge_base_first() {
 /// references.
 #[test]
 fn rebuild_children_from_names_basic() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     let root_frs = 5_u64;
     let root_rec = index.get_or_create(root_frs);
@@ -281,7 +281,7 @@ fn rebuild_children_from_names_basic() {
 /// Test that `rebuild_children_from_names()` handles hard links correctly.
 #[test]
 fn rebuild_children_from_names_hardlinks() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     let dir1_frs = 100_u64;
     let dir2_frs = 101_u64;
@@ -340,7 +340,7 @@ fn rebuild_children_from_names_hardlinks() {
 /// Test that `rebuild_children_from_names()` skips self-referencing root.
 #[test]
 fn rebuild_children_from_names_skips_root_self_reference() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     let root_frs = 5_u64;
     let rec = index.get_or_create(root_frs);
@@ -360,7 +360,7 @@ fn rebuild_children_from_names_skips_root_self_reference() {
 /// Test that tree metrics correctly handles empty directories.
 #[test]
 fn tree_metrics_empty_directory_descendants() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     let root_frs = 5_u64;
     let root_rec = index.get_or_create(root_frs);
@@ -387,7 +387,7 @@ fn tree_metrics_empty_directory_descendants() {
 /// Test that tree metrics correctly handles directories with internal streams.
 #[test]
 fn tree_metrics_internal_streams_two_channel() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     let root_frs = 5_u64;
     let root_rec = index.get_or_create(root_frs);

--- a/crates/uffs-mft/src/index/tests_perf.rs
+++ b/crates/uffs-mft/src/index/tests_perf.rs
@@ -8,7 +8,7 @@ use super::*;
 #[test]
 fn display_stats() {
     // Create a simple index with some files
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Add a few files with different extensions
     let txt_ext_id = index.extensions.intern("txt");
@@ -53,7 +53,7 @@ fn extension_index_query_performance() {
     use std::time::Instant;
 
     // Create index with 10K files across 10 extensions
-    let mut index = MftIndex::with_capacity('C', 10_000);
+    let mut index = MftIndex::with_capacity(crate::platform::DriveLetter::C, 10_000);
 
     // Create 10 different extensions
     let mut ext_ids = Vec::new();
@@ -114,7 +114,7 @@ fn full_postprocessing_performance() {
     use std::time::Instant;
 
     // Create a realistic index with 100K files
-    let mut index = MftIndex::with_capacity('C', 100_000);
+    let mut index = MftIndex::with_capacity(crate::platform::DriveLetter::C, 100_000);
 
     // Add root directory
     let root_frs = 5;

--- a/crates/uffs-mft/src/index/tests_storage.rs
+++ b/crates/uffs-mft/src/index/tests_storage.rs
@@ -10,7 +10,7 @@ const NAMES_SIZE_OFFSET: usize = 56;
 const LINKS_COUNT_OFFSET: usize = 64;
 
 fn empty_serialized_index() -> Vec<u8> {
-    MftIndex::new('C').serialize(123, 456, 789)
+    MftIndex::new(crate::platform::DriveLetter::C).serialize(123, 456, 789)
 }
 
 fn write_u64(bytes: &mut [u8], offset: usize, value: u64) {

--- a/crates/uffs-mft/src/index/tests_tree.rs
+++ b/crates/uffs-mft/src/index/tests_tree.rs
@@ -7,7 +7,7 @@ use super::*;
 
 #[test]
 fn compute_tree_metrics_simple() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Create a simple tree:
     // root (FRS 5)
@@ -111,7 +111,7 @@ fn compute_tree_metrics_simple() {
 
 #[test]
 fn compute_tree_metrics_deep_tree() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Create a deep tree:
     // root (FRS 5)
@@ -203,7 +203,7 @@ fn compute_tree_metrics_deep_tree() {
 
 #[test]
 fn compute_tree_metrics_empty() {
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Empty index should not crash
     index.compute_tree_metrics();
@@ -215,7 +215,7 @@ fn compute_tree_metrics_empty() {
 fn compute_tree_metrics_performance() {
     use std::time::Instant;
 
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
 
     // Create a large tree with 10,000 files
     // Structure: root -> 100 directories -> 100 files each

--- a/crates/uffs-mft/src/index/tree.rs
+++ b/crates/uffs-mft/src/index/tree.rs
@@ -35,7 +35,7 @@ impl MftIndex {
     /// # Example
     ///
     /// ```ignore
-    /// let mut index = MftIndex::new('C');
+    /// let mut index = MftIndex::new(crate::platform::DriveLetter::C);
     /// // ... parse MFT records ...
     /// index.compute_tree_metrics(); // Compute tree metrics for all directories
     /// ```

--- a/crates/uffs-mft/src/io/parser/mod.rs
+++ b/crates/uffs-mft/src/io/parser/mod.rs
@@ -34,7 +34,7 @@ mod tests {
 
     #[test]
     fn parse_record_to_index_rejects_short_buffers() {
-        let mut index = MftIndex::new('C');
+        let mut index = MftIndex::new(crate::platform::DriveLetter::C);
         assert!(!parse_record_to_index(&[0_u8; 3], 42, &mut index));
     }
 

--- a/crates/uffs-mft/src/io/readers/iocp/multi_volume.rs
+++ b/crates/uffs-mft/src/io/readers/iocp/multi_volume.rs
@@ -10,7 +10,7 @@ use super::prelude::*;
 #[derive(Debug)]
 pub struct VolumeState {
     /// Drive letter (e.g., 'C')
-    pub drive_letter: char,
+    pub drive_letter: crate::platform::DriveLetter,
     /// Volume handle (opened with OVERLAPPED flag)
     pub handle: HANDLE,
     /// Extent map for this volume's MFT
@@ -414,7 +414,7 @@ impl MultiVolumeIocpReader {
 #[cfg(windows)]
 #[must_use]
 pub fn prepare_volume_state(
-    drive_letter: char,
+    drive_letter: crate::platform::DriveLetter,
     handle: HANDLE,
     extent_map: MftExtentMap,
     bitmap: Option<crate::platform::MftBitmap>,

--- a/crates/uffs-mft/src/io/readers/parallel/tests_chaos.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/tests_chaos.rs
@@ -113,7 +113,11 @@ impl ChaosMftReader {
         reason = "chaos reader: load, chunk, shuffle, spawn parser threads, merge — \
                   single orchestration pipeline that must remain cohesive"
     )]
-    pub fn read_with_chaos(&self, mft_path: &Path, volume: char) -> anyhow::Result<MftIndex> {
+    pub fn read_with_chaos(
+        &self,
+        mft_path: &Path,
+        volume: crate::platform::DriveLetter,
+    ) -> anyhow::Result<MftIndex> {
         use alloc::sync::Arc;
         use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -628,7 +632,7 @@ mod chaos_integration_tests {
 
         let chaos_reader = ChaosMftReader::new(ChaosStrategy::Reverse, 2 * 1024 * 1024);
 
-        let result = chaos_reader.read_with_chaos(&mft_path, 'D');
+        let result = chaos_reader.read_with_chaos(&mft_path, crate::platform::DriveLetter::D);
 
         match result {
             Ok(index) => {
@@ -662,7 +666,7 @@ mod chaos_integration_tests {
 
         let chaos_reader = ChaosMftReader::new(ChaosStrategy::Interleaved, 2 * 1024 * 1024);
 
-        let result = chaos_reader.read_with_chaos(&mft_path, 'D');
+        let result = chaos_reader.read_with_chaos(&mft_path, crate::platform::DriveLetter::D);
 
         match result {
             Ok(index) => {

--- a/crates/uffs-mft/src/io/readers/parallel/to_index.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/to_index.rs
@@ -83,7 +83,7 @@ impl ParallelMftReader {
     pub(crate) fn read_all_sliding_window_iocp_to_index<F>(
         &self,
         overlapped_handle: HANDLE,
-        volume: char,
+        volume: crate::platform::DriveLetter,
         concurrency: Option<usize>,
         io_chunk_size: Option<usize>,
         _progress_callback: Option<F>,

--- a/crates/uffs-mft/src/io/readers/parallel/to_index_parallel.rs
+++ b/crates/uffs-mft/src/io/readers/parallel/to_index_parallel.rs
@@ -91,7 +91,7 @@ impl ParallelMftReader {
     pub fn read_all_sliding_window_iocp_to_index_parallel<F>(
         &self,
         overlapped_handle: HANDLE,
-        volume: char,
+        volume: crate::platform::DriveLetter,
         concurrency: Option<usize>,
         io_chunk_size: Option<usize>,
         num_workers: Option<usize>,

--- a/crates/uffs-mft/src/lib.rs
+++ b/crates/uffs-mft/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! fn main() -> Result<(), Box<dyn core::error::Error>> {
 //!     // Read MFT from C: drive (requires admin privileges)
-//!     let df = MftReader::open('C')?.read_all()?;
+//!     let df = MftReader::open(crate::platform::DriveLetter::C)?.read_all()?;
 //!
 //!     println!("Found {} files", df.height());
 //!

--- a/crates/uffs-mft/src/main.rs
+++ b/crates/uffs-mft/src/main.rs
@@ -60,6 +60,10 @@ use rand as _;
 use rand_chacha as _;
 use rayon as _;
 use rustc_hash as _;
+// `serde` is used only by the library (DriveLetter Serialize/Deserialize);
+// the binary doesn't reference it directly.  Acknowledge to keep
+// `unused-crate-dependencies` quiet.
+use serde as _;
 #[cfg(test)]
 use sha2 as _;
 // SmallVec for path chain building (used in index.rs PathResolver)

--- a/crates/uffs-mft/src/parse/direct_index_extension_tests.rs
+++ b/crates/uffs-mft/src/parse/direct_index_extension_tests.rs
@@ -58,7 +58,7 @@ fn dir_index_extension_before_base_snapshot_restore() {
     // Extension has dir_index_size=4096, base has dir_index_size=8192
     // Result should be cumulative: 4096 + 8192 = 12288
 
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
     index.frs_to_idx.resize(101, NO_ENTRY);
     index.frs_to_idx[100] = 0;
 
@@ -99,7 +99,7 @@ fn dir_index_base_before_extension_snapshot_restore() {
     // Base has dir_index_size=8192, extension has dir_index_size=4096
     // Result should be cumulative: 8192 + 4096 = 12288
 
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
     index.frs_to_idx.resize(101, NO_ENTRY);
     index.frs_to_idx[100] = 0;
 
@@ -125,7 +125,7 @@ fn dir_index_multiple_extensions_snapshot_restore() {
     // Scenario: Multiple extension records all arrive before base
     // All should accumulate properly using saturating_add
 
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
     index.frs_to_idx.resize(101, NO_ENTRY);
     index.frs_to_idx[100] = 0;
 
@@ -158,7 +158,7 @@ fn dir_index_zero_extension_values() {
     // Scenario: Extension has zero dir_index (branch not taken in actual code,
     // but verify the logic handles it correctly)
 
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
     index.frs_to_idx.resize(101, NO_ENTRY);
     index.frs_to_idx[100] = 0;
 
@@ -181,7 +181,7 @@ fn dir_index_zero_extension_values() {
 fn dir_index_saturating_add_no_overflow() {
     // Verify saturating_add prevents overflow
 
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
     index.frs_to_idx.resize(101, NO_ENTRY);
     index.frs_to_idx[100] = 0;
 
@@ -209,7 +209,7 @@ fn dir_index_regression_old_unconditional_add_bug() {
     // OLD CODE (buggy): Always used += , losing data when extension arrives first
     // NEW CODE (correct): Uses snapshot/restore pattern
 
-    let mut index = MftIndex::new('C');
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
     index.frs_to_idx.resize(101, NO_ENTRY);
     index.frs_to_idx[100] = 0;
 

--- a/crates/uffs-mft/src/platform.rs
+++ b/crates/uffs-mft/src/platform.rs
@@ -16,6 +16,12 @@
 //! This module uses Windows FFI and requires careful handling of raw handles.
 
 mod bitmap;
+/// Drive-letter newtype — validated Windows drive identifier (`A..=Z`).
+///
+/// Phase 4 sub-phase 5b: replaces 117 raw `char` parameters across the
+/// workspace with a `#[repr(transparent)]` newtype that canonicalises
+/// case and rejects non-ASCII-letter input at the parse boundary.
+pub mod drive_letter;
 mod extents;
 mod system;
 /// `$UpCase` table reading from live NTFS volume.
@@ -24,6 +30,7 @@ pub mod upcase;
 mod volume;
 
 pub use bitmap::MftBitmap;
+pub use drive_letter::{DriveLetter, DriveLetterError};
 pub use extents::MftExtent;
 // Export DriveType unconditionally (needed for tests), but Windows-specific functions only on
 // Windows
@@ -68,8 +75,10 @@ mod tests {
 
     #[test]
     fn volume_root_path_works() {
-        assert_eq!(volume_root_path('c'), PathBuf::from("C:\\"));
-        assert_eq!(volume_root_path('D'), PathBuf::from("D:\\"));
+        // [`DriveLetter`] canonicalises to uppercase at construction
+        // time, so a single mapping covers both former cases.
+        assert_eq!(volume_root_path(DriveLetter::C), PathBuf::from("C:\\"));
+        assert_eq!(volume_root_path(DriveLetter::D), PathBuf::from("D:\\"));
     }
 
     #[test]

--- a/crates/uffs-mft/src/platform/drive_letter.rs
+++ b/crates/uffs-mft/src/platform/drive_letter.rs
@@ -1,0 +1,506 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Drive-letter newtype — Phase 4 sub-phase 5b.
+//!
+//! A [`DriveLetter`] is a validated Windows drive letter: an uppercase
+//! ASCII byte in `A..=Z`.  The [`DriveLetter::parse`] constructor
+//! canonicalises lowercase ASCII to uppercase so both `'c'` and `'C'`
+//! produce [`DriveLetter::C`].
+//!
+//! # Why a newtype?
+//!
+//! Pre-5b, every drive-letter parameter in the workspace was a raw
+//! `char` — 117 function signatures across 50+ files all took `char`
+//! and immediately called `to_ascii_uppercase()` or formatted into a
+//! path.  An invalid `'9'` or `'é'` getting through was the failure
+//! mode that the type system did nothing about.
+//!
+//! With `DriveLetter`:
+//!
+//! - Every drive-letter parameter is statically validated at the construction
+//!   site (CLI argument parsing, OS API result wrapping, test fixture).
+//! - No `.to_ascii_uppercase()` ceremony at every consumer — `parse` already
+//!   canonicalised.
+//! - Constants ([`DriveLetter::A`] … [`DriveLetter::Z`]) provide a
+//!   compile-time-validated form for code-internal use (tests, sentinel
+//!   values).
+//!
+//! # Layer
+//!
+//! `DriveLetter` lives in `uffs-mft::platform` because `uffs-mft` is
+//! the producer crate (the Windows API wrappers that returned `char`
+//! before this newtype existed all live here).  Every downstream crate
+//! (`uffs-core`, `uffs-daemon`, `uffs-cli`, `uffs-broker`) already
+//! depends on `uffs-mft` transitively, so no new dependency edge is
+//! introduced.
+
+use core::fmt;
+
+/// A validated Windows drive letter — uppercase ASCII `A..=Z`.
+///
+/// `DriveLetter` is `#[repr(transparent)]` over `u8` so its in-memory
+/// layout is identical to the underlying ASCII byte; no conversion
+/// cost is paid at FFI / NTFS-parse boundaries.
+///
+/// # Invariant
+///
+/// The wrapped byte is ALWAYS in `b'A'..=b'Z'`.  This is upheld by:
+///
+/// - [`DriveLetter::parse`] — accepts both ASCII case forms and canonicalises
+///   to uppercase.
+/// - The 26 [`DriveLetter::A`] … [`DriveLetter::Z`] constants — compile-time
+///   validated.
+///
+/// There is no `pub fn new(u8)` because every external entry point
+/// must either parse (for unvalidated input) or use a constant (for
+/// code-internal use).  The crate-internal `from_byte_unchecked`
+/// helper is `pub(crate)` and used only inside Windows API wrappers
+/// where the byte was just emitted by `b'A' + i` from a validated `i`
+/// in `0..26`.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct DriveLetter(u8);
+
+/// Error returned by [`DriveLetter::parse`] when the input is not an
+/// ASCII letter.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[non_exhaustive]
+pub struct DriveLetterError {
+    /// The original character that failed to parse.
+    pub raw: char,
+}
+
+impl fmt::Display for DriveLetterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "drive letter must be ASCII A..=Z (case insensitive); got '{}'",
+            self.raw.escape_default()
+        )
+    }
+}
+
+impl core::error::Error for DriveLetterError {}
+
+impl DriveLetter {
+    /// Parse a Windows drive letter, accepting both ASCII case forms.
+    ///
+    /// Lowercase input is canonicalised to uppercase, so
+    /// `DriveLetter::parse('c')` and `DriveLetter::parse('C')` produce
+    /// the same value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DriveLetterError`] if `letter` is not ASCII A..=Z
+    /// (a..=z).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uffs_mft::platform::DriveLetter;
+    /// assert_eq!(DriveLetter::parse('c').unwrap(), DriveLetter::C);
+    /// assert_eq!(DriveLetter::parse('C').unwrap(), DriveLetter::C);
+    /// assert!(DriveLetter::parse('1').is_err());
+    /// assert!(DriveLetter::parse('é').is_err());
+    /// ```
+    pub const fn parse(letter: char) -> Result<Self, DriveLetterError> {
+        let upper = letter.to_ascii_uppercase();
+        if upper.is_ascii_uppercase() {
+            // `upper` is provably in `'A'..='Z'`, so its 32-bit code
+            // point is in `0x41..=0x5A` and the `as u8` cast is exact.
+            // Clippy narrows `cast_possible_truncation` here using the
+            // `is_ascii_uppercase` guard, which is why we don't carry
+            // an `#[expect(clippy::cast_possible_truncation)]` attribute.
+            Ok(Self(upper as u8))
+        } else {
+            Err(DriveLetterError { raw: letter })
+        }
+    }
+
+    /// Wrap a byte that the caller has already verified to be in
+    /// `b'A'..=b'Z'`.  Crate-internal only — public surfaces must use
+    /// [`DriveLetter::parse`] so the invariant check is in the type
+    /// system, not in caller discipline.
+    ///
+    /// Production callers all live behind `#[cfg(windows)]`
+    /// (`platform::system::detect_ntfs_drives`), so the helper is
+    /// itself `cfg(any(windows, test))` — the `test` arm keeps the
+    /// invariant-pinning unit test compiled on every target.
+    #[cfg(any(windows, test))]
+    #[inline]
+    #[must_use]
+    pub(crate) const fn from_byte_unchecked(byte: u8) -> Self {
+        debug_assert!(byte.is_ascii_uppercase(), "DriveLetter invariant: A..=Z");
+        Self(byte)
+    }
+
+    /// Returns the uppercase ASCII char (e.g. `'C'`).
+    ///
+    /// Used at FFI / Display / path-format boundaries where the API
+    /// demands `char`.  Pure-Rust code paths inside the workspace
+    /// should prefer methods on `DriveLetter` over `.as_char()` +
+    /// free-function dispatch.
+    #[inline]
+    #[must_use]
+    pub const fn as_char(self) -> char {
+        self.0 as char
+    }
+
+    /// Returns the uppercase ASCII byte (e.g. `b'C'`).
+    ///
+    /// Used when building a `[u8; N]` path prefix or volume root for
+    /// a Win32 API call.
+    #[inline]
+    #[must_use]
+    pub const fn as_byte(self) -> u8 {
+        self.0
+    }
+
+    /// Returns the zero-based alphabet index (A=0, B=1, …, Z=25).
+    ///
+    /// Used to index a 26-entry `Vec<T>` of per-drive state without a
+    /// `HashMap` allocation.
+    #[inline]
+    #[must_use]
+    pub const fn alphabet_index(self) -> usize {
+        (self.0 - b'A') as usize
+    }
+
+    /// Case-insensitive ASCII comparison against a raw `char`.
+    ///
+    /// `DriveLetter` is uppercase-canonical by construction, so this is
+    /// equivalent to `self.as_char() == other.to_ascii_uppercase()`
+    /// when `other` is an ASCII letter, and always `false` otherwise.
+    ///
+    /// Kept as an inherent method so legacy `char`-flavoured call
+    /// sites (CLI filters, JSON wire formats) can compare without an
+    /// intermediate `DriveLetter::parse` allocation/branch.
+    #[inline]
+    #[must_use]
+    pub fn eq_ignore_ascii_case(self, other: char) -> bool {
+        // Non-ASCII inputs are by definition not an ASCII letter and
+        // so can never match a `DriveLetter` (A..=Z by construction).
+        // `u8::try_from` returns `Err` for any code point above 0xFF,
+        // and the explicit `is_ascii()` guard rejects 0x80..=0xFF.
+        if !other.is_ascii() {
+            return false;
+        }
+        let Ok(byte) = u8::try_from(u32::from(other)) else {
+            return false;
+        };
+        // Clear the ASCII case bit (0x20) to fold `'a'..='z'` to
+        // their uppercase counterparts; uppercase letters and
+        // non-letter ASCII bytes are left alone.  The trailing
+        // `is_ascii_uppercase` guard rejects everything that didn't
+        // end up in `b'A'..=b'Z'` (digits, symbols, control bytes).
+        let folded = byte & !0x20;
+        self.0 == folded && folded.is_ascii_uppercase()
+    }
+}
+
+impl fmt::Debug for DriveLetter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Matches the existing `tracing` log convention (`letter='C'`
+        // / `drive='C'`) used across the daemon and cache modules.
+        write!(f, "DriveLetter({})", self.0 as char)
+    }
+}
+
+impl fmt::Display for DriveLetter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&(self.0 as char), f)
+    }
+}
+
+impl TryFrom<char> for DriveLetter {
+    type Error = DriveLetterError;
+
+    /// Delegates to [`DriveLetter::parse`].  Provided so generic code
+    /// (e.g. `iter.map(TryInto::try_into)`) works without referring
+    /// to the inherent method by name.
+    #[inline]
+    fn try_from(letter: char) -> Result<Self, Self::Error> {
+        Self::parse(letter)
+    }
+}
+
+impl TryFrom<u8> for DriveLetter {
+    type Error = DriveLetterError;
+
+    /// Wire-format conversion: accepts an ASCII byte and validates it
+    /// is in `b'A'..=b'Z'` (canonicalising `b'a'..=b'z'` to uppercase
+    /// for symmetry with [`DriveLetter::parse`]).  Used by the
+    /// shared-memory record format (`uffs_client::shmem::ShmemRecord::drive`)
+    /// which stores the letter as a single byte for compact layout.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DriveLetterError`] when the byte is not an ASCII
+    /// letter.  The `raw` field is set to the byte's char form for
+    /// consistent error messages with [`DriveLetter::parse`].
+    #[inline]
+    fn try_from(byte: u8) -> Result<Self, Self::Error> {
+        // ASCII bytes round-trip losslessly via `char::from(u8)`.
+        Self::parse(char::from(byte))
+    }
+}
+
+impl core::str::FromStr for DriveLetter {
+    type Err = DriveLetterError;
+
+    /// Parse a single-character string into a [`DriveLetter`].
+    ///
+    /// Provided so `clap`-derive structs can use `DriveLetter`
+    /// directly as a typed field (clap dispatches to `FromStr`).
+    /// Accepts both ASCII case forms; rejects empty strings,
+    /// multi-character strings, and any input that
+    /// [`DriveLetter::parse`] would reject.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DriveLetterError`] if the string is empty, longer
+    /// than one character, or contains a character that is not
+    /// ASCII A..=Z (a..=z).
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut chars = s.chars();
+        match (chars.next(), chars.next()) {
+            (Some(ch), None) => Self::parse(ch),
+            // Empty or multi-char: surface the offending payload as
+            // the *first* character (or U+FFFD for the empty case)
+            // so the error message points at the user's input rather
+            // than a synthetic sentinel.
+            (None, _) => Err(DriveLetterError { raw: '\u{FFFD}' }),
+            (Some(ch), Some(_)) => Err(DriveLetterError { raw: ch }),
+        }
+    }
+}
+
+/// JSON / IPC wire format: a single-character ASCII uppercase string
+/// (`"C"`).  Stays byte-compatible with the historical
+/// `drive: char` serialisation that the daemon's event stream and the
+/// MCP server already emit, so this migration is invisible on the
+/// wire.
+impl serde::Serialize for DriveLetter {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_char(self.as_char())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for DriveLetter {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct DriveLetterVisitor;
+
+        impl serde::de::Visitor<'_> for DriveLetterVisitor {
+            type Value = DriveLetter;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an ASCII letter A..=Z (case-insensitive) as a char or string")
+            }
+
+            fn visit_char<E: serde::de::Error>(self, v: char) -> Result<Self::Value, E> {
+                DriveLetter::parse(v).map_err(serde::de::Error::custom)
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                v.parse::<DriveLetter>().map_err(serde::de::Error::custom)
+            }
+        }
+
+        // `deserialize_char` accepts both `char` and `str` payloads
+        // from JSON via the visitor above, so a remote
+        // `"C"` (string) and `'C'` (char in MessagePack etc.) both
+        // decode identically.
+        deserializer.deserialize_char(DriveLetterVisitor)
+    }
+}
+
+/// Internal helper macro: declares the 26 [`DriveLetter`] associated
+/// constants (`A`…`Z`) from a list of `letter = byte` pairs.
+///
+/// Kept as a macro so the alphabet table stays in lock-step with the
+/// `as_byte` representation, and so we get one `Self::X = Self(b'X')`
+/// line per letter instead of 26 hand-written copies that could
+/// silently drift apart.
+macro_rules! drive_letter_consts {
+    ($( $letter:ident = $byte:literal ),* $(,)?) => {
+        impl DriveLetter {
+            $(
+                #[doc = concat!("Drive letter `", stringify!($letter), "`.")]
+                pub const $letter: Self = Self($byte);
+            )*
+        }
+    };
+}
+
+drive_letter_consts! {
+    A = b'A', B = b'B', C = b'C', D = b'D', E = b'E', F = b'F', G = b'G',
+    H = b'H', I = b'I', J = b'J', K = b'K', L = b'L', M = b'M', N = b'N',
+    O = b'O', P = b'P', Q = b'Q', R = b'R', S = b'S', T = b'T', U = b'U',
+    V = b'V', W = b'W', X = b'X', Y = b'Y', Z = b'Z',
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DriveLetter, DriveLetterError};
+
+    #[test]
+    fn parse_accepts_uppercase() {
+        assert_eq!(DriveLetter::parse('C').unwrap(), DriveLetter::C);
+        assert_eq!(DriveLetter::parse('A').unwrap(), DriveLetter::A);
+        assert_eq!(DriveLetter::parse('Z').unwrap(), DriveLetter::Z);
+    }
+
+    #[test]
+    fn parse_canonicalises_lowercase() {
+        assert_eq!(DriveLetter::parse('c').unwrap(), DriveLetter::C);
+        assert_eq!(DriveLetter::parse('a').unwrap(), DriveLetter::A);
+        assert_eq!(DriveLetter::parse('z').unwrap(), DriveLetter::Z);
+    }
+
+    #[test]
+    fn parse_rejects_digits() {
+        assert_eq!(DriveLetter::parse('1').unwrap_err(), DriveLetterError {
+            raw: '1'
+        });
+        DriveLetter::parse('0').unwrap_err();
+        DriveLetter::parse('9').unwrap_err();
+    }
+
+    #[test]
+    fn parse_rejects_non_ascii() {
+        DriveLetter::parse('é').unwrap_err();
+        DriveLetter::parse('☃').unwrap_err();
+        DriveLetter::parse('\u{0}').unwrap_err();
+    }
+
+    #[test]
+    fn parse_rejects_punctuation() {
+        DriveLetter::parse(':').unwrap_err();
+        DriveLetter::parse('/').unwrap_err();
+        DriveLetter::parse(' ').unwrap_err();
+    }
+
+    #[test]
+    fn as_char_returns_uppercase() {
+        assert_eq!(DriveLetter::C.as_char(), 'C');
+        assert_eq!(DriveLetter::parse('c').unwrap().as_char(), 'C');
+    }
+
+    #[test]
+    fn as_byte_returns_ascii_byte() {
+        assert_eq!(DriveLetter::C.as_byte(), b'C');
+        assert_eq!(DriveLetter::A.as_byte(), b'A');
+        assert_eq!(DriveLetter::Z.as_byte(), b'Z');
+    }
+
+    #[test]
+    fn alphabet_index_runs_a_to_z() {
+        assert_eq!(DriveLetter::A.alphabet_index(), 0);
+        assert_eq!(DriveLetter::B.alphabet_index(), 1);
+        assert_eq!(DriveLetter::M.alphabet_index(), 12);
+        assert_eq!(DriveLetter::Z.alphabet_index(), 25);
+    }
+
+    #[test]
+    fn from_byte_unchecked_round_trips_uppercase_range() {
+        // The Windows drive-bitmask path in `platform::system` is the
+        // sole production caller, but the invariant (`b'A'..=b'Z'` ↦
+        // canonical `DriveLetter`) is platform-agnostic.  Pinning it
+        // here means the helper stays linked on every target and a
+        // future refactor can't silently change the round-trip shape.
+        for offset in 0_u8..26 {
+            let byte = b'A' + offset;
+            let dl = DriveLetter::from_byte_unchecked(byte);
+            assert_eq!(dl.as_byte(), byte);
+            assert_eq!(dl.as_char(), char::from(byte));
+            assert_eq!(usize::from(offset), dl.alphabet_index());
+        }
+    }
+
+    #[test]
+    fn try_from_delegates_to_parse() {
+        let from_try: DriveLetter = 'c'.try_into().unwrap();
+        let from_parse: DriveLetter = DriveLetter::parse('c').unwrap();
+        assert_eq!(from_try, from_parse);
+    }
+
+    #[test]
+    fn display_is_uppercase_letter() {
+        let buf = format!("{}", DriveLetter::C);
+        assert_eq!(buf, "C");
+    }
+
+    #[test]
+    fn debug_includes_letter() {
+        let buf = format!("{:?}", DriveLetter::C);
+        assert_eq!(buf, "DriveLetter(C)");
+    }
+
+    #[test]
+    fn ordering_matches_alphabet() {
+        assert!(DriveLetter::A < DriveLetter::B);
+        assert!(DriveLetter::C < DriveLetter::Z);
+        let mut sorted = [DriveLetter::Z, DriveLetter::A, DriveLetter::M];
+        sorted.sort_unstable();
+        assert_eq!(sorted, [DriveLetter::A, DriveLetter::M, DriveLetter::Z]);
+    }
+
+    #[test]
+    fn repr_transparent_size_alignment() {
+        // `#[repr(transparent)]` over `u8` guarantees identical layout.
+        assert_eq!(size_of::<DriveLetter>(), size_of::<u8>());
+        assert_eq!(align_of::<DriveLetter>(), align_of::<u8>());
+    }
+
+    #[test]
+    fn error_display_includes_input_char() {
+        let err = DriveLetter::parse('1').unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("'1'"), "got: {msg}");
+        assert!(msg.contains("A..=Z"), "got: {msg}");
+    }
+
+    #[test]
+    fn error_implements_std_error() {
+        // Compile-time check: `core::error::Error` requires Debug + Display.
+        fn assert_error<E: core::error::Error>() {}
+        assert_error::<DriveLetterError>();
+    }
+
+    #[test]
+    fn parse_is_const_fn() {
+        // `DriveLetter::parse` is `const fn`, so this compiles at
+        // compile time — pin the const-evaluability invariant.
+        const PARSED: Result<DriveLetter, DriveLetterError> = DriveLetter::parse('c');
+        assert_eq!(PARSED.unwrap(), DriveLetter::C);
+    }
+
+    #[test]
+    fn from_str_accepts_single_letter() {
+        use core::str::FromStr as _;
+        assert_eq!(DriveLetter::from_str("c").unwrap(), DriveLetter::C);
+        assert_eq!(DriveLetter::from_str("Z").unwrap(), DriveLetter::Z);
+        assert_eq!("A".parse::<DriveLetter>().unwrap(), DriveLetter::A);
+    }
+
+    #[test]
+    fn from_str_rejects_empty_and_multichar() {
+        use core::str::FromStr as _;
+        DriveLetter::from_str("").unwrap_err();
+        DriveLetter::from_str("CD").unwrap_err();
+        DriveLetter::from_str("C:").unwrap_err();
+        // Multi-char surfaces the FIRST character in the error so users
+        // see what they typed.
+        let err = DriveLetter::from_str("XY").unwrap_err();
+        assert_eq!(err.raw, 'X');
+    }
+
+    #[test]
+    fn from_str_rejects_non_letter_single_char() {
+        use core::str::FromStr as _;
+        DriveLetter::from_str("1").unwrap_err();
+        DriveLetter::from_str(":").unwrap_err();
+        DriveLetter::from_str("é").unwrap_err();
+    }
+}

--- a/crates/uffs-mft/src/platform/system.rs
+++ b/crates/uffs-mft/src/platform/system.rs
@@ -43,6 +43,8 @@ use windows::Win32::Storage::FileSystem::FILE_FLAGS_AND_ATTRIBUTES;
 use windows::core::PCWSTR;
 
 #[cfg(windows)]
+use super::drive_letter::DriveLetter;
+#[cfg(windows)]
 use super::volume::HandleGuard;
 
 /// Checks if the current process has Administrator privileges.
@@ -93,27 +95,34 @@ pub fn is_elevated() -> bool {
 /// Returns the path to the volume root (e.g., "C:\").
 #[cfg(windows)]
 #[must_use]
-pub fn volume_root_path(volume: char) -> PathBuf {
-    PathBuf::from(format!("{}:\\", volume.to_ascii_uppercase()))
+pub fn volume_root_path(volume: DriveLetter) -> PathBuf {
+    PathBuf::from(format!("{}:\\", volume.as_char()))
 }
 
 /// Infer drive letter from a file path.
+///
+/// Returns `None` for paths without a drive-letter prefix (UNC paths,
+/// relative paths when the CWD lookup also fails).  The drive byte
+/// from the OS prefix is always an ASCII letter, so the
+/// [`DriveLetter::parse`] conversion never fails in practice; `.ok()`
+/// discards the theoretical error rather than introducing a fallible
+/// API at this call site.
 #[cfg(windows)]
 #[must_use]
-pub fn infer_drive_from_path(path: &Path) -> Option<char> {
+pub fn infer_drive_from_path(path: &Path) -> Option<DriveLetter> {
     use std::path::{Component, Prefix};
 
     if let Some(Component::Prefix(prefix)) = path.components().next()
         && let Prefix::Disk(drive_byte) | Prefix::VerbatimDisk(drive_byte) = prefix.kind()
     {
-        return Some((drive_byte as char).to_ascii_uppercase());
+        return DriveLetter::parse(drive_byte as char).ok();
     }
 
     std::env::current_dir().ok().and_then(|cwd| {
         if let Some(Component::Prefix(prefix)) = cwd.components().next()
             && let Prefix::Disk(drive_byte) | Prefix::VerbatimDisk(drive_byte) = prefix.kind()
         {
-            Some((drive_byte as char).to_ascii_uppercase())
+            DriveLetter::parse(drive_byte as char).ok()
         } else {
             None
         }
@@ -122,30 +131,30 @@ pub fn infer_drive_from_path(path: &Path) -> Option<char> {
 
 /// Returns the boot/system drive letter (from `%SystemDrive%`, typically `C`).
 ///
-/// Falls back to `'C'` if the environment variable is missing or malformed.
+/// Falls back to [`DriveLetter::C`] if the environment variable is
+/// missing or malformed.
 #[cfg(windows)]
 #[must_use]
-pub fn detect_boot_drive() -> char {
+pub fn detect_boot_drive() -> DriveLetter {
     std::env::var("SystemDrive")
         .ok()
         .and_then(|drive| drive.chars().next())
-        .map(|ch| ch.to_ascii_uppercase())
-        .filter(char::is_ascii_uppercase)
-        .unwrap_or('C')
+        .and_then(|ch| DriveLetter::parse(ch).ok())
+        .unwrap_or(DriveLetter::C)
 }
 
 /// Returns `true` if the given drive letter is the boot/system drive.
 #[cfg(windows)]
 #[must_use]
-pub fn is_boot_drive(drive_letter: char) -> bool {
-    drive_letter.to_ascii_uppercase() == detect_boot_drive()
+pub fn is_boot_drive(drive_letter: DriveLetter) -> bool {
+    drive_letter == detect_boot_drive()
 }
 
 /// Detects all available NTFS drives on the system.
 #[cfg(windows)]
 #[must_use]
 #[expect(unsafe_code, reason = "FFI: windows API (GetLogicalDrives)")]
-pub fn detect_ntfs_drives() -> Vec<char> {
+pub fn detect_ntfs_drives() -> Vec<DriveLetter> {
     use windows::Win32::Storage::FileSystem::GetLogicalDrives;
 
     let mut ntfs_drives = Vec::new();
@@ -160,7 +169,9 @@ pub fn detect_ntfs_drives() -> Vec<char> {
 
     for i in 0_u8..26 {
         if (drive_mask & (1_u32 << i)) != 0 {
-            let drive_letter = char::from(b'A' + i);
+            // `b'A' + i` for `i in 0..26` is always in `b'A'..=b'Z'`, so
+            // the invariant of `DriveLetter::from_byte_unchecked` holds.
+            let drive_letter = DriveLetter::from_byte_unchecked(b'A' + i);
 
             if is_ntfs_volume(drive_letter) {
                 ntfs_drives.push(drive_letter);
@@ -177,10 +188,10 @@ pub fn detect_ntfs_drives() -> Vec<char> {
     unsafe_code,
     reason = "FFI: windows API (GetDriveTypeW, GetVolumeInformationW)"
 )]
-fn is_ntfs_volume(drive_letter: char) -> bool {
+fn is_ntfs_volume(drive_letter: DriveLetter) -> bool {
     use windows::Win32::Storage::FileSystem::{GetDriveTypeW, GetVolumeInformationW};
 
-    let root_path: Vec<u16> = format!("{}:\\", drive_letter.to_ascii_uppercase())
+    let root_path: Vec<u16> = format!("{}:\\", drive_letter.as_char())
         .encode_utf16()
         .chain(core::iter::once(0))
         .collect();
@@ -222,12 +233,12 @@ fn is_ntfs_volume(drive_letter: char) -> bool {
 #[cfg(windows)]
 #[must_use]
 #[expect(unsafe_code, reason = "FFI: windows API (GetVolumeInformationW)")]
-pub fn is_volume_read_only(drive_letter: char) -> bool {
+pub fn is_volume_read_only(drive_letter: DriveLetter) -> bool {
     use windows::Win32::Storage::FileSystem::GetVolumeInformationW;
 
     const FILE_READ_ONLY_VOLUME: u32 = 0x0008_0000;
 
-    let root_path: Vec<u16> = format!("{}:\\", drive_letter.to_ascii_uppercase())
+    let root_path: Vec<u16> = format!("{}:\\", drive_letter.as_char())
         .encode_utf16()
         .chain(core::iter::once(0))
         .collect();
@@ -341,7 +352,7 @@ impl DriveType {
     clippy::too_many_lines,
     reason = "drive-type detection ladder: opens a single physical-drive handle then runs a fall-through sequence of IOCTL probes (storage descriptor for NVMe → seek-penalty for SSD/HDD → TRIM-support fallback). Splitting would either replicate the FFI handle/struct setup per-probe or hide the ordered fall-through behind helper indirection"
 )]
-pub fn detect_drive_type(drive_letter: char) -> DriveType {
+pub fn detect_drive_type(drive_letter: DriveLetter) -> DriveType {
     use windows::Win32::Storage::FileSystem::{
         CreateFileW, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
     };
@@ -370,7 +381,7 @@ pub fn detect_drive_type(drive_letter: char) -> DriveType {
         incurs_seek_penalty: u8,
     }
 
-    let drive_path: Vec<u16> = format!("\\\\.\\{}:", drive_letter.to_ascii_uppercase())
+    let drive_path: Vec<u16> = format!("\\\\.\\{}:", drive_letter.as_char())
         .encode_utf16()
         .chain(core::iter::once(0))
         .collect();
@@ -505,7 +516,7 @@ pub fn detect_drive_type(drive_letter: char) -> DriveType {
     unsafe_code,
     reason = "FFI: windows API (CreateFileW, DeviceIoControl) for trim detection"
 )]
-fn detect_drive_type_via_trim(drive_letter: char) -> DriveType {
+fn detect_drive_type_via_trim(drive_letter: DriveLetter) -> DriveType {
     use windows::Win32::Storage::FileSystem::{
         CreateFileW, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
     };
@@ -529,7 +540,7 @@ fn detect_drive_type_via_trim(drive_letter: char) -> DriveType {
         trim_enabled: u8,
     }
 
-    let drive_path: Vec<u16> = format!("\\\\.\\{}:", drive_letter.to_ascii_uppercase())
+    let drive_path: Vec<u16> = format!("\\\\.\\{}:", drive_letter.as_char())
         .encode_utf16()
         .chain(core::iter::once(0))
         .collect();

--- a/crates/uffs-mft/src/platform/upcase.rs
+++ b/crates/uffs-mft/src/platform/upcase.rs
@@ -80,7 +80,7 @@ pub struct UpcaseHeader {
     /// Timestamp (Unix epoch seconds) when the table was captured.
     pub timestamp: u64,
     /// Drive letter (ASCII uppercase).
-    pub drive: char,
+    pub drive: crate::platform::DriveLetter,
 }
 
 impl UpcaseHeader {
@@ -103,7 +103,7 @@ impl UpcaseHeader {
         buf[16..24].copy_from_slice(&self.volume_serial.to_le_bytes());
         buf[24..28].copy_from_slice(&self.table_crc32.to_le_bytes());
         buf[28..36].copy_from_slice(&self.timestamp.to_le_bytes());
-        buf[36] = self.drive as u8;
+        buf[36] = self.drive.as_byte();
         // 37..64 reserved (already zeroed)
 
         let raw: &[u8] = bytemuck::cast_slice(table.as_ref());
@@ -154,7 +154,8 @@ impl UpcaseHeader {
             timestamp: u64::from_le_bytes([
                 data[28], data[29], data[30], data[31], data[32], data[33], data[34], data[35],
             ]),
-            drive: data[36] as char,
+            drive: crate::platform::DriveLetter::parse(char::from(data[36]))
+                .unwrap_or(crate::platform::DriveLetter::X),
         })
     }
 }
@@ -319,7 +320,7 @@ fn parse_data_runs(record_bytes: &[u8]) -> Result<UpcaseDataRuns> {
 ///
 /// Returns [`MftError::PlatformNotSupported`] on non-Windows.
 #[cfg(not(windows))]
-pub const fn read_upcase_table(_drive: char) -> Result<Box<[u16; 65_536]>> {
+pub const fn read_upcase_table(_drive: crate::platform::DriveLetter) -> Result<Box<[u16; 65_536]>> {
     Err(MftError::PlatformNotSupported)
 }
 
@@ -332,7 +333,7 @@ pub const fn read_upcase_table(_drive: char) -> Result<Box<[u16; 65_536]>> {
 /// [`MftError::InvalidData`] if the assembled table is shorter than the
 /// expected 128 KiB (65 536 code-point entries).
 #[cfg(windows)]
-pub fn read_upcase_table(drive: char) -> Result<Box<[u16; 65_536]>> {
+pub fn read_upcase_table(drive: crate::platform::DriveLetter) -> Result<Box<[u16; 65_536]>> {
     use crate::parse::apply_fixup;
     use crate::platform::VolumeHandle;
 
@@ -520,7 +521,7 @@ mod tests {
             volume_serial: 0xDEAD_BEEF_CAFE_1234,
             table_crc32: table_crc,
             timestamp: 1_700_000_000,
-            drive: 'C',
+            drive: crate::platform::DriveLetter::C,
         };
 
         let dir = std::env::temp_dir().join("uffs_upcase_test");
@@ -539,7 +540,7 @@ mod tests {
         assert_eq!(loaded_hdr.ntfs_minor, 1);
         assert_eq!(loaded_hdr.volume_serial, 0xDEAD_BEEF_CAFE_1234);
         assert_eq!(loaded_hdr.table_crc32, table_crc);
-        assert_eq!(loaded_hdr.drive, 'C');
+        assert_eq!(loaded_hdr.drive, crate::platform::DriveLetter::C);
 
         // Table contents must match.
         assert_eq!(loaded_tbl.as_ref(), table.as_ref());
@@ -572,7 +573,7 @@ mod tests {
         let (hdr, tbl) = load_upcase_from_file(&ref_path)?;
 
         // Header sanity.
-        assert_eq!(hdr.drive, 'C');
+        assert_eq!(hdr.drive, crate::platform::DriveLetter::C);
         assert_eq!(hdr.table_crc32, 0xCEE8_CFFA);
 
         // Table must match the embedded default exactly.

--- a/crates/uffs-mft/src/platform/volume.rs
+++ b/crates/uffs-mft/src/platform/volume.rs
@@ -91,7 +91,7 @@ pub struct VolumeHandle {
     /// The raw Windows handle.
     handle: HANDLE,
     /// The volume letter.
-    volume: char,
+    volume: super::DriveLetter,
     /// NTFS volume data from `FSCTL_GET_NTFS_VOLUME_DATA`.
     volume_data: NtfsVolumeData,
 }
@@ -179,20 +179,11 @@ impl VolumeHandle {
     /// elevated), or if `FSCTL_GET_NTFS_VOLUME_DATA` cannot read the volume
     /// descriptor for the opened handle.
     #[expect(unsafe_code, reason = "FFI: windows API (CreateFileW)")]
-    pub fn open(volume: char) -> Result<Self> {
-        let normalized_volume = volume.to_ascii_uppercase();
-
-        if !normalized_volume.is_ascii_alphabetic() {
-            return Err(MftError::VolumeOpen {
-                volume: normalized_volume,
-                source: std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "Invalid volume letter",
-                ),
-            });
-        }
-
-        let volume_path: Vec<u16> = format!("\\\\.\\{normalized_volume}:")
+    pub fn open(volume: super::DriveLetter) -> Result<Self> {
+        // `DriveLetter` is already validated (`A..=Z`), so no fallible
+        // pre-check is needed here.  The wire path uses the
+        // canonical uppercase ASCII byte directly.
+        let volume_path: Vec<u16> = format!("\\\\.\\{}:", volume.as_char())
             .encode_utf16()
             .chain(core::iter::once(0))
             .collect();
@@ -224,24 +215,24 @@ impl VolumeHandle {
                     return Err(MftError::InsufficientPrivileges);
                 }
                 return Err(MftError::VolumeOpen {
-                    volume: normalized_volume,
+                    volume,
                     source: std::io::Error::from_raw_os_error(err.code().0),
                 });
             }
         };
 
-        let volume_data = Self::get_ntfs_volume_data(handle, normalized_volume)?;
+        let volume_data = Self::get_ntfs_volume_data(handle, volume)?;
 
         Ok(Self {
             handle,
-            volume: normalized_volume,
+            volume,
             volume_data,
         })
     }
 
     /// Retrieves NTFS volume data using `FSCTL_GET_NTFS_VOLUME_DATA`.
     #[expect(unsafe_code, reason = "FFI: windows API (DeviceIoControl)")]
-    fn get_ntfs_volume_data(handle: HANDLE, volume: char) -> Result<NtfsVolumeData> {
+    fn get_ntfs_volume_data(handle: HANDLE, volume: super::DriveLetter) -> Result<NtfsVolumeData> {
         use windows::Win32::System::IO::DeviceIoControl;
 
         let mut buffer = NTFS_VOLUME_DATA_BUFFER::default();
@@ -306,7 +297,7 @@ impl VolumeHandle {
 
     /// Returns the volume letter.
     #[must_use]
-    pub const fn volume(&self) -> char {
+    pub const fn volume(&self) -> super::DriveLetter {
         self.volume
     }
 

--- a/crates/uffs-mft/src/raw/mod.rs
+++ b/crates/uffs-mft/src/raw/mod.rs
@@ -80,9 +80,13 @@ pub struct RawMftHeader {
     pub original_size: u64,
     /// Compressed size (0 if not compressed).
     pub compressed_size: u64,
-    /// Volume letter (e.g., 'C', 'D'). Added in v2.
-    /// For v1 files, this defaults to 'X'.
-    pub volume_letter: char,
+    /// Volume letter (e.g., `C`, `D`).  Added in v2.
+    ///
+    /// For v1 files (and for raw-NTFS dumps with no volume context),
+    /// this defaults to [`crate::platform::DriveLetter::X`] — the
+    /// historical sentinel meaning "unknown source volume; let the
+    /// loader override via `LoadRawOptions::volume_letter`".
+    pub volume_letter: crate::platform::DriveLetter,
 }
 
 impl RawMftHeader {
@@ -103,8 +107,8 @@ impl RawMftHeader {
         buf[20..28].copy_from_slice(&self.record_count.to_le_bytes());
         buf[28..36].copy_from_slice(&self.original_size.to_le_bytes());
         buf[36..44].copy_from_slice(&self.compressed_size.to_le_bytes());
-        // Volume letter at byte 44 (v2+)
-        buf[44] = self.volume_letter as u8;
+        // Volume letter at byte 44 (v2+) — single ASCII byte.
+        buf[44] = self.volume_letter.as_byte();
         // Reserved bytes 45-63 are already zero
         buf
     }
@@ -140,11 +144,14 @@ impl RawMftHeader {
             buf[36], buf[37], buf[38], buf[39], buf[40], buf[41], buf[42], buf[43],
         ]);
 
-        // Volume letter at byte 44 (v2+), default to 'X' for v1 files
-        let volume_letter = if version >= 2 && buf[44].is_ascii_alphabetic() {
-            char::from(buf[44]).to_ascii_uppercase()
+        // Volume letter at byte 44 (v2+); falls back to the historical
+        // [`DriveLetter::X`] sentinel for v1 files and for v2 files where
+        // the byte isn't a valid ASCII letter (e.g. truncated or zeroed).
+        let volume_letter = if version >= 2 {
+            crate::platform::DriveLetter::parse(char::from(buf[44]))
+                .unwrap_or(crate::platform::DriveLetter::X)
         } else {
-            'X'
+            crate::platform::DriveLetter::X
         };
 
         Ok(Self {
@@ -166,8 +173,10 @@ pub struct SaveRawOptions {
     pub compress: bool,
     /// Compression level (1-22, default 3).
     pub compression_level: i32,
-    /// Volume letter (e.g., 'C', 'D').
-    pub volume_letter: char,
+    /// Volume letter (e.g., `C`, `D`).  Defaults to
+    /// [`crate::platform::DriveLetter::X`] — see
+    /// [`RawMftHeader::volume_letter`] for the sentinel convention.
+    pub volume_letter: crate::platform::DriveLetter,
     /// If true, save in raw compatibility mode (no header, just raw MFT bytes).
     /// This format is compatible with other MFT tools like analyzeMFT, MFT2CSV.
     pub raw_compat: bool,
@@ -178,7 +187,7 @@ impl Default for SaveRawOptions {
         Self {
             compress: true,
             compression_level: 3,
-            volume_letter: 'X',
+            volume_letter: crate::platform::DriveLetter::X,
             raw_compat: false,
         }
     }
@@ -190,8 +199,9 @@ pub struct LoadRawOptions {
     /// If true, only load the header without reading data.
     pub header_only: bool,
     /// Override volume letter (useful for raw NTFS files that don't have this
-    /// info). If None, uses 'X' as default for raw files.
-    pub volume_letter: Option<char>,
+    /// info).  `None` falls back to [`crate::platform::DriveLetter::X`] for raw
+    /// files.
+    pub volume_letter: Option<crate::platform::DriveLetter>,
     /// Enable forensic mode: include deleted, corrupt, and extension records.
     /// Adds `is_deleted`, `is_corrupt`, `is_extension`, `base_frs` columns to
     /// output. WARNING: May significantly increase output size (10-50% more
@@ -450,7 +460,9 @@ pub fn load_raw_mft<P: AsRef<Path>>(path: P, options: &LoadRawOptions) -> Result
             record_count,
             original_size: file_size,
             compressed_size: 0,
-            volume_letter: options.volume_letter.unwrap_or('X'),
+            volume_letter: options
+                .volume_letter
+                .unwrap_or(crate::platform::DriveLetter::X),
         };
 
         // If header-only mode, return empty data

--- a/crates/uffs-mft/src/raw/streaming_writer.rs
+++ b/crates/uffs-mft/src/raw/streaming_writer.rs
@@ -41,7 +41,7 @@ pub struct StreamingRawMftWriter {
     /// Whether compression is enabled.
     compress: bool,
     /// Volume letter (e.g., 'C', 'D').
-    volume_letter: char,
+    volume_letter: crate::platform::DriveLetter,
     /// Whether raw compatibility mode is enabled (no header).
     raw_compat: bool,
     /// Zstd encoder (if compressing).

--- a/crates/uffs-mft/src/raw/tests.rs
+++ b/crates/uffs-mft/src/raw/tests.rs
@@ -16,7 +16,7 @@ fn header_roundtrip() -> TestResult {
         record_count: 1000,
         original_size: 1024 * 1000,
         compressed_size: 500_000,
-        volume_letter: 'G',
+        volume_letter: crate::platform::DriveLetter::G,
     };
 
     let bytes = header.to_bytes();
@@ -61,14 +61,14 @@ fn save_load_uncompressed() -> TestResult {
     let options = SaveRawOptions {
         compress: false,
         compression_level: 3,
-        volume_letter: 'C',
+        volume_letter: crate::platform::DriveLetter::C,
         raw_compat: false,
     };
     let header = save_raw_mft(&path, &data, record_size, &options)?;
 
     assert_eq!(header.record_count, 4);
     assert_eq!(header.record_size, record_size);
-    assert_eq!(header.volume_letter, 'C');
+    assert_eq!(header.volume_letter, crate::platform::DriveLetter::C);
     assert!(!header.is_compressed());
 
     let loaded = load_raw_mft(&path, &LoadRawOptions::default())?;
@@ -127,7 +127,7 @@ fn load_header_only() -> TestResult {
     let options = SaveRawOptions {
         compress: false,
         compression_level: 3,
-        volume_letter: 'D',
+        volume_letter: crate::platform::DriveLetter::D,
         raw_compat: false,
     };
     save_raw_mft(&path, &data, record_size, &options)?;
@@ -154,7 +154,7 @@ fn iter_records() {
         record_count: 3,
         original_size: 12,
         compressed_size: 0,
-        volume_letter: 'X',
+        volume_letter: crate::platform::DriveLetter::X,
     };
 
     let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
@@ -178,14 +178,14 @@ fn volume_letter_preserved() -> TestResult {
     let options = SaveRawOptions {
         compress: false,
         compression_level: 3,
-        volume_letter: 'G',
+        volume_letter: crate::platform::DriveLetter::G,
         raw_compat: false,
     };
     let header = save_raw_mft(&path, &data, record_size, &options)?;
-    assert_eq!(header.volume_letter, 'G');
+    assert_eq!(header.volume_letter, crate::platform::DriveLetter::G);
 
     let loaded = load_raw_mft(&path, &LoadRawOptions::default())?;
-    assert_eq!(loaded.header.volume_letter, 'G');
+    assert_eq!(loaded.header.volume_letter, crate::platform::DriveLetter::G);
 
     std::fs::remove_file(&path)?;
 
@@ -210,7 +210,7 @@ fn raw_compat_mode() -> TestResult {
     let options = SaveRawOptions {
         compress: false,
         compression_level: 3,
-        volume_letter: 'G',
+        volume_letter: crate::platform::DriveLetter::G,
         raw_compat: true,
     };
 
@@ -264,16 +264,19 @@ fn load_raw_ntfs_format() -> TestResult {
     assert_eq!(loaded.header.version, 0);
     assert_eq!(loaded.header.record_size, record_size);
     assert_eq!(loaded.header.record_count, record_count);
-    assert_eq!(loaded.header.volume_letter, 'X');
+    assert_eq!(loaded.header.volume_letter, crate::platform::DriveLetter::X);
     assert_eq!(loaded.data, data);
 
     let options = LoadRawOptions {
         header_only: false,
-        volume_letter: Some('D'),
+        volume_letter: Some(crate::platform::DriveLetter::D),
         forensic: false,
     };
     let loaded_with_override = load_raw_mft(&path, &options)?;
-    assert_eq!(loaded_with_override.header.volume_letter, 'D');
+    assert_eq!(
+        loaded_with_override.header.volume_letter,
+        crate::platform::DriveLetter::D
+    );
 
     std::fs::remove_file(&path)?;
 

--- a/crates/uffs-mft/src/raw_iocp.rs
+++ b/crates/uffs-mft/src/raw_iocp.rs
@@ -83,8 +83,8 @@ pub struct IocpCaptureHeader {
     pub total_records: u64,
     /// Total uncompressed data size.
     pub total_data_size: u64,
-    /// Volume letter (e.g., 'C').
-    pub volume_letter: char,
+    /// Volume letter (e.g., [`crate::platform::DriveLetter::C`]).
+    pub volume_letter: crate::platform::DriveLetter,
     /// IOCP concurrency level used during capture.
     pub concurrency: u8,
     /// Bytes of NTFS reserved clusters added to root's `tree_allocated`.
@@ -113,7 +113,7 @@ impl IocpCaptureHeader {
         buf[24..28].copy_from_slice(&self.chunk_count.to_le_bytes());
         buf[28..36].copy_from_slice(&self.total_records.to_le_bytes());
         buf[36..44].copy_from_slice(&self.total_data_size.to_le_bytes());
-        buf[44] = self.volume_letter as u8;
+        buf[44] = self.volume_letter.as_byte();
         buf[45] = self.concurrency;
         // Reserved_allocated_bytes at bytes 46-53 (zero for legacy captures).
         buf[46..54].copy_from_slice(&self.reserved_allocated_bytes.to_le_bytes());
@@ -149,11 +149,12 @@ impl IocpCaptureHeader {
         let total_data_size = u64::from_le_bytes([
             buf[36], buf[37], buf[38], buf[39], buf[40], buf[41], buf[42], buf[43],
         ]);
-        let volume_letter = if buf[44].is_ascii_alphabetic() {
-            char::from(buf[44]).to_ascii_uppercase()
-        } else {
-            'X'
-        };
+        // Drive letter at byte 44.  Falls back to the historical
+        // `'X'` sentinel ([`DriveLetter::X`]) for captures with no
+        // volume context (e.g. legacy v0 dumps that didn't set the
+        // field).
+        let volume_letter = crate::platform::DriveLetter::parse(char::from(buf[44]))
+            .unwrap_or(crate::platform::DriveLetter::X);
         let concurrency = buf[45];
         // Bytes 46-53: reserved_allocated_bytes (zero for v1 captures).
         let reserved_allocated_bytes = u64::from_le_bytes([
@@ -227,8 +228,11 @@ pub struct IocpCaptureOptions {
     pub compress: bool,
     /// Compression level (1-22, default 3).
     pub compression_level: i32,
-    /// Volume letter (e.g., 'C', 'D').
-    pub volume_letter: char,
+    /// Volume letter (e.g., `C`, `D`).  Defaults to
+    /// [`crate::platform::DriveLetter::X`]
+    /// — see [`IocpCaptureHeader::volume_letter`] for the sentinel
+    /// convention.
+    pub volume_letter: crate::platform::DriveLetter,
     /// IOCP concurrency level.
     pub concurrency: u8,
     /// Bytes of NTFS reserved clusters for root `tree_allocated`.
@@ -244,7 +248,7 @@ impl Default for IocpCaptureOptions {
         Self {
             compress: true,
             compression_level: 3,
-            volume_letter: 'X',
+            volume_letter: crate::platform::DriveLetter::X,
             concurrency: 8,
             reserved_allocated_bytes: 0,
         }
@@ -261,7 +265,7 @@ pub struct IocpCaptureWriter {
     /// MFT record size.
     record_size: u32,
     /// Volume letter.
-    volume_letter: char,
+    volume_letter: crate::platform::DriveLetter,
     /// IOCP concurrency.
     concurrency: u8,
     /// Compression enabled.
@@ -412,7 +416,7 @@ impl IocpCaptureData {
 
     /// Returns the volume letter.
     #[must_use]
-    pub const fn volume_letter(&self) -> char {
+    pub const fn volume_letter(&self) -> crate::platform::DriveLetter {
         self.header.volume_letter
     }
 }

--- a/crates/uffs-mft/src/reader.rs
+++ b/crates/uffs-mft/src/reader.rs
@@ -39,11 +39,18 @@ pub use self::stats::{MftProgress, MftStats};
 /// from a previously captured `.mft` file (cross-platform). This enum lets
 /// `MftReader` dispatch to the correct pipeline without `#[cfg]` gates on
 /// every public method.
+///
+/// The `LiveVolume` variant boxes its [`VolumeHandle`] so the enum stays
+/// compact (one pointer per variant) instead of allocating the
+/// `VolumeHandle`-sized inline payload (~120 bytes including the NTFS
+/// volume-data block) on every `MftReader` instance — also silences the
+/// rustc `variant_size_differences` lint comparing against the
+/// pointer-sized `File(PathBuf)` arm.
 #[derive(Debug)]
 pub(crate) enum MftSource {
     /// Live NTFS volume accessed via Windows IOCP.
     #[cfg(windows)]
-    LiveVolume(VolumeHandle),
+    LiveVolume(Box<VolumeHandle>),
     /// Pre-captured `.mft` file (cross-platform).
     File(PathBuf),
 }
@@ -69,7 +76,7 @@ pub(crate) enum MftSource {
 /// use uffs_mft::MftReader;
 ///
 /// fn main() -> Result<(), Box<dyn core::error::Error>> {
-///     let reader = MftReader::open('C')?;
+///     let reader = MftReader::open(crate::platform::DriveLetter::C)?;
 ///     let df = reader.read_all()?;
 ///     println!("Found {} files", df.height());
 ///     Ok(())
@@ -81,8 +88,8 @@ pub(crate) enum MftSource {
     reason = "builder pattern with boolean options"
 )]
 pub struct MftReader {
-    /// The volume letter (e.g., 'C').
-    volume: char,
+    /// The volume letter (e.g., [`crate::platform::DriveLetter::C`]).
+    volume: crate::platform::DriveLetter,
     /// Data source: live NTFS volume or pre-captured `.mft` file.
     source: MftSource,
     /// Read mode selection.
@@ -161,7 +168,8 @@ impl MftReader {
     ///
     /// # Arguments
     ///
-    /// * `volume` - The drive letter (e.g., 'C', 'D')
+    /// * `volume` - The drive letter (e.g.,
+    ///   [`crate::platform::DriveLetter::C`])
     ///
     /// # Errors
     ///
@@ -174,12 +182,12 @@ impl MftReader {
     ///
     /// This function is only available on Windows.
     #[cfg(windows)]
-    pub fn open(volume: char) -> Result<Self> {
+    pub fn open(volume: crate::platform::DriveLetter) -> Result<Self> {
         let handle = VolumeHandle::open(volume)?;
 
         Ok(Self {
-            volume: volume.to_ascii_uppercase(),
-            source: MftSource::LiveVolume(handle),
+            volume,
+            source: MftSource::LiveVolume(Box::new(handle)),
             mode: MftReadMode::Auto,
             merge_extensions: true,
             use_bitmap: true,
@@ -200,7 +208,7 @@ impl MftReader {
     /// Always returns `MftError::PlatformNotSupported` on non-Windows
     /// platforms.
     #[cfg(not(windows))]
-    pub const fn open(_volume: char) -> Result<Self> {
+    pub const fn open(_volume: crate::platform::DriveLetter) -> Result<Self> {
         Err(MftError::PlatformNotSupported)
     }
 
@@ -212,11 +220,12 @@ impl MftReader {
     /// # Arguments
     ///
     /// * `path` - Path to the `.mft` capture file
-    /// * `volume` - The volume letter to associate (e.g., 'C')
+    /// * `volume` - The volume letter to associate (e.g.,
+    ///   [`crate::platform::DriveLetter::C`])
     #[must_use]
-    pub fn from_file<P: Into<PathBuf>>(path: P, volume: char) -> Self {
+    pub fn from_file<P: Into<PathBuf>>(path: P, volume: crate::platform::DriveLetter) -> Self {
         Self {
-            volume: volume.to_ascii_uppercase(),
+            volume,
             source: MftSource::File(path.into()),
             mode: MftReadMode::Auto,
             merge_extensions: true,
@@ -512,7 +521,7 @@ impl MftReader {
 
     /// Get the volume letter this reader is attached to.
     #[must_use]
-    pub const fn volume(&self) -> char {
+    pub const fn volume(&self) -> crate::platform::DriveLetter {
         self.volume
     }
 }
@@ -527,7 +536,7 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn open_valid_volume() {
-        let result = MftReader::open('C');
+        let result = MftReader::open(crate::platform::DriveLetter::C);
         // This will fail without admin privileges, but should not panic
         assert!(result.is_ok() || matches!(result, Err(MftError::InsufficientPrivileges)));
     }
@@ -535,7 +544,7 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn platform_not_supported() {
-        let result = MftReader::open('C');
+        let result = MftReader::open(crate::platform::DriveLetter::C);
         assert!(matches!(result, Err(MftError::PlatformNotSupported)));
     }
 
@@ -563,8 +572,16 @@ mod tests {
 
     #[test]
     fn multi_drive_reader_new() {
-        let reader = MultiDriveMftReader::new(vec!['c', 'd', 'e']);
-        assert_eq!(reader.drives(), &['C', 'D', 'E']);
+        // [`DriveLetter`] canonicalises to uppercase at construction,
+        // so the input list is already normalised.  The accessor
+        // returns the same letters in order.
+        use crate::platform::DriveLetter;
+        let reader = MultiDriveMftReader::new(vec![DriveLetter::C, DriveLetter::D, DriveLetter::E]);
+        assert_eq!(reader.drives(), &[
+            DriveLetter::C,
+            DriveLetter::D,
+            DriveLetter::E
+        ]);
     }
 
     #[test]
@@ -576,7 +593,10 @@ mod tests {
     #[tokio::test]
     #[cfg(not(windows))]
     async fn multi_drive_platform_not_supported() {
-        let reader = MultiDriveMftReader::new(vec!['C', 'D']);
+        let reader = MultiDriveMftReader::new(vec![
+            crate::platform::DriveLetter::C,
+            crate::platform::DriveLetter::D,
+        ]);
         let result = reader.read_all().await;
         assert!(matches!(result, Err(MftError::PlatformNotSupported)));
     }
@@ -584,7 +604,10 @@ mod tests {
     #[tokio::test]
     #[cfg(not(windows))]
     async fn multi_drive_index_platform_not_supported() {
-        let reader = MultiDriveMftReader::new(vec!['C', 'D']);
+        let reader = MultiDriveMftReader::new(vec![
+            crate::platform::DriveLetter::C,
+            crate::platform::DriveLetter::D,
+        ]);
         let result = reader.read_all_index().await;
         assert!(matches!(result, Err(MftError::PlatformNotSupported)));
     }
@@ -592,7 +615,10 @@ mod tests {
     #[tokio::test]
     #[cfg(not(windows))]
     async fn multi_drive_index_cached_platform_not_supported() {
-        let reader = MultiDriveMftReader::new(vec!['C', 'D']);
+        let reader = MultiDriveMftReader::new(vec![
+            crate::platform::DriveLetter::C,
+            crate::platform::DriveLetter::D,
+        ]);
         let result = reader.read_all_index_cached(3600).await;
         assert!(matches!(result, Err(MftError::PlatformNotSupported)));
     }
@@ -607,7 +633,7 @@ mod tests {
     #[cfg(windows)]
     fn mft_reader_uses_none_defaults() {
         // This test requires admin privileges, so we check if we can open
-        let reader = match MftReader::open('C') {
+        let reader = match MftReader::open(crate::platform::DriveLetter::C) {
             Ok(opened) => opened,
             Err(MftError::InsufficientPrivileges) => {
                 // Skip test if not running as admin
@@ -639,7 +665,7 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn mft_reader_builder_overrides() {
-        let reader = match MftReader::open('C') {
+        let reader = match MftReader::open(crate::platform::DriveLetter::C) {
             Ok(opened) => opened,
             Err(MftError::InsufficientPrivileges) => return,
             Err(err) => panic!("Unexpected error: {err:?}"),
@@ -663,7 +689,7 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn mft_reader_default_mode_is_auto() {
-        let reader = match MftReader::open('C') {
+        let reader = match MftReader::open(crate::platform::DriveLetter::C) {
             Ok(opened) => opened,
             Err(MftError::InsufficientPrivileges) => return,
             Err(err) => panic!("Unexpected error: {err:?}"),
@@ -680,7 +706,7 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn mft_reader_boolean_defaults() {
-        let reader = match MftReader::open('C') {
+        let reader = match MftReader::open(crate::platform::DriveLetter::C) {
             Ok(opened) => opened,
             Err(MftError::InsufficientPrivileges) => return,
             Err(err) => panic!("Unexpected error: {err:?}"),

--- a/crates/uffs-mft/src/reader/benchmark.rs
+++ b/crates/uffs-mft/src/reader/benchmark.rs
@@ -60,7 +60,7 @@ impl PhaseTimings {
 #[derive(Debug, Clone)]
 pub struct DriveCharacteristics {
     /// Drive letter (e.g., 'C').
-    pub drive_letter: char,
+    pub drive_letter: crate::platform::DriveLetter,
     /// Detected drive type (SSD, HDD, Unknown).
     pub drive_type: String,
     /// Total MFT size in bytes.
@@ -176,7 +176,7 @@ pub(super) struct MftMetrics {
 #[must_use]
 #[cfg(windows)]
 pub(super) fn build_drive_characteristics(
-    drive_letter: char,
+    drive_letter: crate::platform::DriveLetter,
     drive_type: DriveType,
     mft: MftMetrics,
     chunk_size_bytes: usize,

--- a/crates/uffs-mft/src/reader/index_cache.rs
+++ b/crates/uffs-mft/src/reader/index_cache.rs
@@ -164,7 +164,7 @@ impl MftReader {
     /// from `apply_usn_updates_to_fresh_index`.
     #[cfg(windows)]
     fn apply_or_skip_usn_changes(
-        drive: char,
+        drive: crate::platform::DriveLetter,
         index: crate::index::MftIndex,
         handle: &crate::platform::VolumeHandle,
         journal_id: u64,
@@ -203,7 +203,7 @@ impl MftReader {
     ///    save the updated index back to cache.
     #[cfg(windows)]
     fn apply_usn_changes_and_save(
-        drive: char,
+        drive: crate::platform::DriveLetter,
         mut index: crate::index::MftIndex,
         handle: &crate::platform::VolumeHandle,
         records: &[crate::usn::UsnRecord],

--- a/crates/uffs-mft/src/reader/index_read.rs
+++ b/crates/uffs-mft/src/reader/index_read.rs
@@ -107,7 +107,7 @@ impl MftReader {
             let handle = VolumeHandle::open(volume)?;
             let reader = Self {
                 volume,
-                source: super::MftSource::LiveVolume(handle),
+                source: super::MftSource::LiveVolume(Box::new(handle)),
                 mode,
                 merge_extensions,
                 use_bitmap,
@@ -137,7 +137,7 @@ impl MftReader {
     /// Returns [`MftError`] if the file cannot be read or parsed.
     fn read_index_from_file(
         path: &std::path::Path,
-        volume: char,
+        volume: crate::platform::DriveLetter,
     ) -> Result<crate::index::MftIndex> {
         // Detect IOCP capture vs raw MFT format
         let is_iocp = crate::is_iocp_capture(path).unwrap_or(false);
@@ -249,7 +249,7 @@ impl MftReader {
             let handle = VolumeHandle::open(volume)?;
             let reader = Self {
                 volume,
-                source: super::MftSource::LiveVolume(handle),
+                source: super::MftSource::LiveVolume(Box::new(handle)),
                 mode,
                 merge_extensions,
                 use_bitmap,

--- a/crates/uffs-mft/src/reader/index_timing.rs
+++ b/crates/uffs-mft/src/reader/index_timing.rs
@@ -56,7 +56,7 @@ impl MftReader {
             let handle = VolumeHandle::open(volume)?;
             let reader = Self {
                 volume,
-                source: super::MftSource::LiveVolume(handle),
+                source: super::MftSource::LiveVolume(Box::new(handle)),
                 mode,
                 merge_extensions,
                 use_bitmap,

--- a/crates/uffs-mft/src/reader/multi_drive/dataframe.rs
+++ b/crates/uffs-mft/src/reader/multi_drive/dataframe.rs
@@ -23,7 +23,8 @@ impl MultiDriveMftReader {
     ///
     /// Returns an error if all drives fail to read.
     pub async fn read_all(&self) -> Result<DataFrame> {
-        self.read_all_internal(None::<fn(char, MftProgress)>).await
+        self.read_all_internal(None::<fn(crate::platform::DriveLetter, MftProgress)>)
+            .await
     }
 
     /// Read MFTs from all drives with per-drive progress callbacks.
@@ -39,7 +40,7 @@ impl MultiDriveMftReader {
     /// Returns an error if all drives fail to read.
     pub async fn read_with_progress<F>(&self, callback: F) -> Result<DataFrame>
     where
-        F: Fn(char, MftProgress) + Send + Sync + Clone + 'static,
+        F: Fn(crate::platform::DriveLetter, MftProgress) + Send + Sync + Clone + 'static,
     {
         self.read_all_internal(Some(callback)).await
     }
@@ -47,7 +48,7 @@ impl MultiDriveMftReader {
     /// Internal implementation for concurrent drive reading.
     async fn read_all_internal<F>(&self, callback: Option<F>) -> Result<DataFrame>
     where
-        F: Fn(char, MftProgress) + Send + Sync + Clone + 'static,
+        F: Fn(crate::platform::DriveLetter, MftProgress) + Send + Sync + Clone + 'static,
     {
         if self.drives.is_empty() {
             return Err(MftError::InvalidInput("No drives specified".into()));
@@ -74,7 +75,7 @@ impl MultiDriveMftReader {
         }
 
         let mut dataframes: Vec<DataFrame> = Vec::new();
-        let mut errors: Vec<(char, MftError)> = Vec::new();
+        let mut errors: Vec<(crate::platform::DriveLetter, MftError)> = Vec::new();
 
         while let Some(result) = join_set.join_next().await {
             match result {
@@ -93,7 +94,7 @@ impl MultiDriveMftReader {
                 }
                 Err(join_err) => {
                     errors.push((
-                        '?',
+                        crate::platform::DriveLetter::X,
                         MftError::InvalidInput(format!("Task failed: {join_err}")),
                     ));
                 }
@@ -147,9 +148,12 @@ impl MultiDriveMftReader {
     ///
     /// Uses `spawn_blocking` because `MftReader` contains Windows HANDLEs
     /// which are not `Send`, and the MFT reading is blocking I/O.
-    async fn read_single_drive<F>(drive: char, callback: Option<Arc<F>>) -> Result<DataFrame>
+    async fn read_single_drive<F>(
+        drive: crate::platform::DriveLetter,
+        callback: Option<Arc<F>>,
+    ) -> Result<DataFrame>
     where
-        F: Fn(char, MftProgress) + Send + Sync + 'static,
+        F: Fn(crate::platform::DriveLetter, MftProgress) + Send + Sync + 'static,
     {
         tokio::task::spawn_blocking(move || {
             let reader = MftReader::open(drive)?;
@@ -189,8 +193,10 @@ impl MultiDriveMftReader {
         for _ in 0..budget {
             if let Some(drive) = pending_drives.next() {
                 join_set.spawn(async move {
-                    let read_result =
-                        Self::read_single_drive::<fn(char, MftProgress)>(drive, None).await;
+                    let read_result = Self::read_single_drive::<
+                        fn(crate::platform::DriveLetter, MftProgress),
+                    >(drive, None)
+                    .await;
                     DriveReadResult {
                         drive,
                         dataframe: read_result.as_ref().ok().cloned(),
@@ -206,7 +212,7 @@ impl MultiDriveMftReader {
                 Ok(drive_result) => results.push(drive_result),
                 Err(join_err) => {
                     results.push(DriveReadResult {
-                        drive: '?',
+                        drive: crate::platform::DriveLetter::X,
                         dataframe: None,
                         error: Some(MftError::InvalidInput(format!("Task failed: {join_err}"))),
                     });
@@ -215,8 +221,10 @@ impl MultiDriveMftReader {
 
             if let Some(drive) = pending_drives.next() {
                 join_set.spawn(async move {
-                    let read_result =
-                        Self::read_single_drive::<fn(char, MftProgress)>(drive, None).await;
+                    let read_result = Self::read_single_drive::<
+                        fn(crate::platform::DriveLetter, MftProgress),
+                    >(drive, None)
+                    .await;
                     DriveReadResult {
                         drive,
                         dataframe: read_result.as_ref().ok().cloned(),

--- a/crates/uffs-mft/src/reader/multi_drive/index.rs
+++ b/crates/uffs-mft/src/reader/multi_drive/index.rs
@@ -34,7 +34,7 @@ impl MultiDriveMftReader {
     ///
     /// Returns an error if all drives fail to read.
     pub async fn read_all_index(&self) -> Result<Vec<MftIndex>> {
-        self.read_all_index_internal(None::<fn(char, MftProgress)>)
+        self.read_all_index_internal(None::<fn(crate::platform::DriveLetter, MftProgress)>)
             .await
     }
 
@@ -47,7 +47,7 @@ impl MultiDriveMftReader {
     /// Returns an error if all drives fail to read.
     pub async fn read_all_index_with_progress<F>(&self, callback: F) -> Result<Vec<MftIndex>>
     where
-        F: Fn(char, MftProgress) + Send + Sync + Clone + 'static,
+        F: Fn(crate::platform::DriveLetter, MftProgress) + Send + Sync + Clone + 'static,
     {
         self.read_all_index_internal(Some(callback)).await
     }
@@ -115,15 +115,15 @@ impl MultiDriveMftReader {
         }
 
         let mut indices: Vec<MftIndex> = Vec::new();
-        let mut errors: Vec<(char, MftError)> = Vec::new();
+        let mut errors: Vec<(crate::platform::DriveLetter, MftError)> = Vec::new();
 
         while let Some(result) = join_set.join_next().await {
             match result {
                 Ok(Ok(index)) => indices.push(index),
-                Ok(Err(error)) => errors.push(('?', error)),
+                Ok(Err(error)) => errors.push((crate::platform::DriveLetter::X, error)),
                 Err(join_err) => {
                     errors.push((
-                        '?',
+                        crate::platform::DriveLetter::X,
                         MftError::InvalidInput(format!("Task failed: {join_err}")),
                     ));
                 }
@@ -177,7 +177,7 @@ impl MultiDriveMftReader {
     /// Internal implementation for concurrent lean index reading.
     async fn read_all_index_internal<F>(&self, callback: Option<F>) -> Result<Vec<MftIndex>>
     where
-        F: Fn(char, MftProgress) + Send + Sync + Clone + 'static,
+        F: Fn(crate::platform::DriveLetter, MftProgress) + Send + Sync + Clone + 'static,
     {
         if self.drives.is_empty() {
             return Err(MftError::InvalidInput("No drives specified".into()));
@@ -196,15 +196,15 @@ impl MultiDriveMftReader {
         }
 
         let mut indices: Vec<MftIndex> = Vec::new();
-        let mut errors: Vec<(char, MftError)> = Vec::new();
+        let mut errors: Vec<(crate::platform::DriveLetter, MftError)> = Vec::new();
 
         while let Some(result) = join_set.join_next().await {
             match result {
                 Ok(Ok(index)) => indices.push(index),
-                Ok(Err(error)) => errors.push(('?', error)),
+                Ok(Err(error)) => errors.push((crate::platform::DriveLetter::X, error)),
                 Err(join_err) => {
                     errors.push((
-                        '?',
+                        crate::platform::DriveLetter::X,
                         MftError::InvalidInput(format!("Task failed: {join_err}")),
                     ));
                 }
@@ -227,9 +227,12 @@ impl MultiDriveMftReader {
     }
 
     /// Read a single drive into lean index with optional progress callback.
-    async fn read_single_drive_index<F>(drive: char, callback: Option<Arc<F>>) -> Result<MftIndex>
+    async fn read_single_drive_index<F>(
+        drive: crate::platform::DriveLetter,
+        callback: Option<Arc<F>>,
+    ) -> Result<MftIndex>
     where
-        F: Fn(char, MftProgress) + Send + Sync + 'static,
+        F: Fn(crate::platform::DriveLetter, MftProgress) + Send + Sync + 'static,
     {
         tokio::task::spawn_blocking(move || {
             let reader = MftReader::open(drive)?;
@@ -248,14 +251,14 @@ impl MultiDriveMftReader {
     }
 
     /// Read a single drive and save to cache.
-    async fn read_and_cache_single_drive(drive: char) -> Result<MftIndex> {
+    async fn read_and_cache_single_drive(drive: crate::platform::DriveLetter) -> Result<MftIndex> {
         tokio::task::spawn_blocking(move || Self::read_and_cache_single_drive_sync(drive))
             .await
             .map_err(|error| MftError::InvalidInput(format!("Task join error: {error}")))?
     }
 
     /// Synchronous implementation of `read_and_cache_single_drive`.
-    fn read_and_cache_single_drive_sync(drive: char) -> Result<MftIndex> {
+    fn read_and_cache_single_drive_sync(drive: crate::platform::DriveLetter) -> Result<MftIndex> {
         let reader = MftReader::open(drive)?;
         let index = reader.read_all_index_sync()?;
 
@@ -283,7 +286,7 @@ impl MultiDriveMftReader {
     /// If USN Journal is unavailable or the journal has wrapped, falls back
     /// to a full rebuild.
     async fn apply_usn_updates_to_cached_index(
-        drive: char,
+        drive: crate::platform::DriveLetter,
         index: MftIndex,
         header: IndexHeader,
     ) -> Result<MftIndex> {
@@ -296,7 +299,7 @@ impl MultiDriveMftReader {
 
     /// Synchronous implementation of `apply_usn_updates_to_cached_index`.
     fn apply_usn_updates_to_cached_index_sync(
-        drive: char,
+        drive: crate::platform::DriveLetter,
         index: MftIndex,
         header: &IndexHeader,
     ) -> Result<MftIndex> {
@@ -319,7 +322,10 @@ impl MultiDriveMftReader {
     /// that handles the `query_usn_journal` failure path here: when the
     /// journal is unavailable we fall back to [`UsnDecision::UseCached`]
     /// so the cached index is still served instead of erroring out.
-    fn classify_usn_state(drive: char, header: &IndexHeader) -> UsnDecision {
+    fn classify_usn_state(
+        drive: crate::platform::DriveLetter,
+        header: &IndexHeader,
+    ) -> UsnDecision {
         match query_usn_journal(drive) {
             Ok(info) => classify_with_journal_info(drive, header, &info),
             Err(error) => {
@@ -341,7 +347,7 @@ impl MultiDriveMftReader {
     /// to returning the original cached `index`; there is no fallible
     /// outcome to surface, so this returns `MftIndex` directly.
     fn apply_or_skip_usn_changes(
-        drive: char,
+        drive: crate::platform::DriveLetter,
         index: MftIndex,
         journal_id: u64,
         start_usn: i64,
@@ -374,7 +380,7 @@ impl MultiDriveMftReader {
     /// 3. Rebuild extension index + tree metrics if anything changed, then save
     ///    the updated index back to cache.
     fn apply_usn_changes_and_save(
-        drive: char,
+        drive: crate::platform::DriveLetter,
         mut index: MftIndex,
         records: &[crate::usn::UsnRecord],
         journal_id: u64,

--- a/crates/uffs-mft/src/reader/multi_drive/mod.rs
+++ b/crates/uffs-mft/src/reader/multi_drive/mod.rs
@@ -41,7 +41,7 @@ pub(super) fn drive_reader_budget(total_drives: usize) -> usize {
 #[derive(Debug)]
 pub struct DriveReadResult {
     /// The drive letter.
-    pub drive: char,
+    pub drive: crate::platform::DriveLetter,
     /// The `DataFrame` (if successful).
     pub dataframe: Option<DataFrame>,
     /// The error (if failed).
@@ -58,10 +58,15 @@ pub struct DriveReadResult {
 ///
 /// ```rust,ignore
 /// use uffs_mft::MultiDriveMftReader;
+/// use uffs_mft::platform::DriveLetter;
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn core::error::Error>> {
-///     let reader = MultiDriveMftReader::new(vec!['C', 'D', 'E']);
+///     let reader = MultiDriveMftReader::new(vec![
+///         DriveLetter::C,
+///         DriveLetter::D,
+///         DriveLetter::E,
+///     ]);
 ///     let df = reader.read_all().await?;
 ///     println!("Found {} files across all drives", df.height());
 ///     Ok(())
@@ -70,7 +75,7 @@ pub struct DriveReadResult {
 #[derive(Debug, Clone)]
 pub struct MultiDriveMftReader {
     /// The drive letters to read from.
-    drives: Vec<char>,
+    drives: Vec<crate::platform::DriveLetter>,
 }
 
 impl MultiDriveMftReader {
@@ -78,20 +83,17 @@ impl MultiDriveMftReader {
     ///
     /// # Arguments
     ///
-    /// * `drives` - List of drive letters to read (e.g., `vec!['C', 'D', 'E']`)
+    /// * `drives` - List of drive letters to read (e.g., `vec![DriveLetter::C,
+    ///   DriveLetter::D, DriveLetter::E]`). Already validated and canonicalised
+    ///   to uppercase by the [`crate::platform::DriveLetter`] newtype.
     #[must_use]
-    pub fn new(drives: Vec<char>) -> Self {
-        Self {
-            drives: drives
-                .into_iter()
-                .map(|ch| ch.to_ascii_uppercase())
-                .collect(),
-        }
+    pub const fn new(drives: Vec<crate::platform::DriveLetter>) -> Self {
+        Self { drives }
     }
 
     /// Returns the list of drives this reader will process.
     #[must_use]
-    pub fn drives(&self) -> &[char] {
+    pub fn drives(&self) -> &[crate::platform::DriveLetter] {
         &self.drives
     }
 
@@ -117,7 +119,7 @@ impl MultiDriveMftReader {
     #[expect(clippy::unused_async, reason = "async for API parity with windows")]
     pub async fn read_with_progress<F>(&self, _callback: F) -> Result<DataFrame>
     where
-        F: Fn(char, MftProgress) + Send + Sync + Clone + 'static,
+        F: Fn(crate::platform::DriveLetter, MftProgress) + Send + Sync + Clone + 'static,
     {
         Err(MftError::PlatformNotSupported)
     }
@@ -159,7 +161,7 @@ impl MultiDriveMftReader {
         _callback: F,
     ) -> Result<Vec<crate::index::MftIndex>>
     where
-        F: Fn(char, MftProgress) + Send + Sync + Clone + 'static,
+        F: Fn(crate::platform::DriveLetter, MftProgress) + Send + Sync + Clone + 'static,
     {
         Err(MftError::PlatformNotSupported)
     }

--- a/crates/uffs-mft/src/reader/persistence_capture.rs
+++ b/crates/uffs-mft/src/reader/persistence_capture.rs
@@ -311,7 +311,7 @@ unsafe fn prime_in_flight_reads(
 #[cfg(windows)]
 fn plan_iocp_capture_chunks(
     vol_handle: &crate::platform::VolumeHandle,
-    volume: char,
+    volume: crate::platform::DriveLetter,
     record_size: u32,
 ) -> (Vec<crate::io::ReadChunk>, usize) {
     use crate::io::{MftExtentMap, generate_read_chunks};

--- a/crates/uffs-mft/src/reader/usn_apply.rs
+++ b/crates/uffs-mft/src/reader/usn_apply.rs
@@ -67,7 +67,7 @@ pub(super) enum UsnDecision {
 /// in production traces; callers only need to act on the boolean.
 #[cfg(windows)]
 pub(super) fn usn_journal_invalidates_cache(
-    drive: char,
+    drive: crate::platform::DriveLetter,
     header: &IndexHeader,
     current_info: &UsnJournalInfo,
 ) -> bool {
@@ -102,7 +102,7 @@ pub(super) fn usn_journal_invalidates_cache(
 /// [`UsnDecision::UseCached`] so the cached index is still served.
 #[cfg(windows)]
 pub(super) fn classify_usn_state(
-    drive: char,
+    drive: crate::platform::DriveLetter,
     header: &IndexHeader,
     current_info: &UsnJournalInfo,
 ) -> UsnDecision {
@@ -128,7 +128,7 @@ pub(super) fn classify_usn_state(
 /// the missed entries.
 #[cfg(windows)]
 pub(super) fn apply_targeted_usn_reads(
-    drive: char,
+    drive: crate::platform::DriveLetter,
     handle: &VolumeHandle,
     index: &mut MftIndex,
     frs_to_read: &[u64],
@@ -168,7 +168,11 @@ pub(super) fn apply_targeted_usn_reads(
 /// actually mutated `index`.  When nothing changed we skip both passes;
 /// the cached structures are still valid.
 #[cfg(windows)]
-pub(super) fn rebuild_derived_after_usn(drive: char, index: &mut MftIndex, stats: &UsnApplyStats) {
+pub(super) fn rebuild_derived_after_usn(
+    drive: crate::platform::DriveLetter,
+    index: &mut MftIndex,
+    stats: &UsnApplyStats,
+) {
     let had_changes = stats.deleted > 0 || stats.targeted_reads > 0;
     if had_changes {
         debug!(drive = %drive, "🔨 Rebuilding extension index after USN updates");
@@ -191,7 +195,7 @@ pub(super) fn rebuild_derived_after_usn(drive: char, index: &mut MftIndex, stats
 /// in-memory index that callers continue to use.
 #[cfg(windows)]
 pub(super) fn persist_usn_checkpoint(
-    drive: char,
+    drive: crate::platform::DriveLetter,
     handle: &VolumeHandle,
     index: &MftIndex,
     journal_id: u64,

--- a/crates/uffs-mft/src/usn.rs
+++ b/crates/uffs-mft/src/usn.rs
@@ -322,7 +322,7 @@ mod windows_impl {
     const READ_USN_JOURNAL_DATA_V0_SIZE: u32 = u32_size_of::<ReadUsnJournalDataV0>();
 
     /// Open a `\\.\X:` volume handle with read access for USN-journal ioctls.
-    fn open_volume_handle(volume: char) -> Result<HANDLE, std::io::Error> {
+    fn open_volume_handle(volume: crate::platform::DriveLetter) -> Result<HANDLE, std::io::Error> {
         let path = format!("\\\\.\\{volume}:");
         let wide: Vec<u16> = OsStr::new(&path)
             .encode_wide()
@@ -373,7 +373,9 @@ mod windows_impl {
     /// `FSCTL_QUERY_USN_JOURNAL` fails — typically `ERROR_JOURNAL_NOT_ACTIVE`
     /// when the NTFS USN journal has not been enabled for the volume, or
     /// `ERROR_ACCESS_DENIED` when the caller is not elevated.
-    pub fn query_usn_journal(volume: char) -> Result<UsnJournalInfo, std::io::Error> {
+    pub fn query_usn_journal(
+        volume: crate::platform::DriveLetter,
+    ) -> Result<UsnJournalInfo, std::io::Error> {
         let handle = open_volume_handle(volume)?;
         let mut journal_data = UsnJournalDataV0::default();
         let mut bytes_returned: u32 = 0;
@@ -420,7 +422,7 @@ mod windows_impl {
     /// read-loop. `ERROR_JOURNAL_ENTRY_DELETED` is surfaced unchanged so
     /// callers can decide whether to rebuild their checkpoint.
     pub fn read_usn_journal(
-        volume: char,
+        volume: crate::platform::DriveLetter,
         journal_id: u64,
         start_usn: i64,
     ) -> Result<(Vec<UsnRecord>, i64), std::io::Error> {
@@ -733,7 +735,9 @@ mod windows_impl {
     reason = "core::io::Error is not yet stable — see rust-lang/rust#103765. \
               Remove this expect once `error_in_core` stabilises."
 )]
-pub fn query_usn_journal(_volume: char) -> Result<UsnJournalInfo, std::io::Error> {
+pub fn query_usn_journal(
+    _volume: crate::platform::DriveLetter,
+) -> Result<UsnJournalInfo, std::io::Error> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
         "USN Journal is only available on Windows",
@@ -752,7 +756,7 @@ pub fn query_usn_journal(_volume: char) -> Result<UsnJournalInfo, std::io::Error
               Remove this expect once `error_in_core` stabilises."
 )]
 pub fn read_usn_journal(
-    _volume: char,
+    _volume: crate::platform::DriveLetter,
     _journal_id: u64,
     _start_usn: i64,
 ) -> Result<(Vec<UsnRecord>, i64), std::io::Error> {

--- a/crates/uffs-time/src/lib.rs
+++ b/crates/uffs-time/src/lib.rs
@@ -14,6 +14,30 @@
 //! Extracted from `uffs_mft::ntfs` so the thin CLI can format timestamps
 //! without pulling in the full MFT reader (which in turn depends on
 //! `polars`, `tokio`, `reqwest`, and `object_store`).
+//!
+//! # Domain types ([`Filetime`], [`CalendarParts`])
+//!
+//! The two newtypes added in Phase 4 sub-phase 5a (per
+//! `docs/dev/architecture/code_clean/phase_4_type_design_implementation_plan.
+//! md` §4.1.C / §4.4) coexist with the existing `i64`-based free functions:
+//!
+//! - [`Filetime`] is a zero-cost (`#[repr(transparent)]`) wrapper around the
+//!   raw 100-ns tick count.  Inherent methods mirror the free functions
+//!   one-for-one so callers can opt into the newtype without having to convert
+//!   at every boundary.
+//! - [`CalendarParts`] is the named-struct replacement for the previous `(year,
+//!   month, day, hour, minute, second)` 6-tuple return of
+//!   [`filetime_to_calendar`].  The tuple shape was a textbook "primitive
+//!   obsession" / "tuple where a named struct would be clearer" smell — every
+//!   call site of the old API destructured the tuple in declaration order, with
+//!   no compile-time guard against a swap.
+//!
+//! The free functions retain `i64`-based signatures because the
+//! NTFS parser (`uffs-mft::raw_iocp`, `uffs-mft::parse`) reads FILETIME
+//! ticks directly from on-disk structures as `i64` and would otherwise
+//! pay an unnecessary `Filetime::from_ticks` ceremony at every read
+//! site.  Future sub-phases may push [`Filetime`] deeper into the index
+//! / query layers.
 
 #![no_std]
 
@@ -26,6 +50,129 @@ pub const FILETIME_TICKS_PER_MICROSECOND: i64 = 10;
 /// Difference between the FILETIME epoch (1601-01-01) and the Unix epoch
 /// (1970-01-01), in 100-nanosecond intervals.
 pub const FILETIME_UNIX_DIFF: i64 = 116_444_736_000_000_000;
+
+/// NTFS FILETIME: a 64-bit signed tick count of 100-nanosecond intervals
+/// since 1601-01-01 UTC.
+///
+/// `Filetime` is `#[repr(transparent)]` over `i64`, so its in-memory
+/// layout is identical to the underlying tick count and no conversion
+/// cost is paid at the FFI / NTFS-parse boundary.
+///
+/// # Sentinel
+///
+/// FILETIME `0` is the documented "unset / null timestamp" sentinel in
+/// the NTFS on-disk format.  [`Filetime::UNSET`] is the canonical
+/// constant for it; [`Filetime::to_calendar`] returns `None` for
+/// `UNSET` (consistent with the free [`filetime_to_calendar`]).
+///
+/// # Construction
+///
+/// The wrapper is intentionally unvalidated — any `i64` is a valid
+/// `Filetime` at the type level.  Semantic correctness ("this value
+/// came from a trusted NTFS source") is the caller's responsibility,
+/// because validating every FILETIME at every read site would dominate
+/// the index-build cost without adding real safety.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[repr(transparent)]
+pub struct Filetime(i64);
+
+impl Filetime {
+    /// The "unset / null timestamp" sentinel — FILETIME `0`.
+    ///
+    /// `Filetime::to_calendar(Filetime::UNSET)` returns `None`,
+    /// matching the long-standing free-function convention.
+    pub const UNSET: Self = Self(0);
+
+    /// Wrap a raw FILETIME tick count.
+    ///
+    /// No validation — the caller has established that `ticks` came
+    /// from a trusted NTFS source (or constructed it from a known
+    /// reference epoch via [`FILETIME_UNIX_DIFF`] +
+    /// [`FILETIME_TICKS_PER_SECOND`]).
+    #[inline]
+    #[must_use]
+    pub const fn from_ticks(ticks: i64) -> Self {
+        Self(ticks)
+    }
+
+    /// Unwrap to the raw 100-ns tick count.
+    ///
+    /// Used at FFI / serde / Display boundaries where the API demands
+    /// `i64`.  Pure-Rust code paths inside the workspace should prefer
+    /// the inherent methods over `ticks()` + free function.
+    #[inline]
+    #[must_use]
+    pub const fn ticks(self) -> i64 {
+        self.0
+    }
+
+    /// Convert to Unix timestamp microseconds.
+    ///
+    /// Mirrors the free [`filetime_to_unix_micros`].  Returns `0` for
+    /// `Filetime::UNSET` (matching the existing convention).
+    #[inline]
+    #[must_use]
+    pub const fn to_unix_micros(self) -> i64 {
+        filetime_to_unix_micros(self.0)
+    }
+
+    /// Apply a timezone bias in seconds, returning a new `Filetime`.
+    ///
+    /// Mirrors the free [`filetime_with_tz_bias`].
+    #[inline]
+    #[must_use]
+    pub const fn with_tz_bias(self, tz_bias_secs: i32) -> Self {
+        Self(filetime_with_tz_bias(self.0, tz_bias_secs))
+    }
+
+    /// Decompose into proleptic-Gregorian-UTC [`CalendarParts`].
+    ///
+    /// Mirrors the free [`filetime_to_calendar`].  Returns `None` for
+    /// `Filetime::UNSET`.
+    #[inline]
+    #[must_use]
+    pub const fn to_calendar(self) -> Option<CalendarParts> {
+        filetime_to_calendar(self.0)
+    }
+}
+
+/// Calendar breakdown of a [`Filetime`] in the proleptic Gregorian
+/// calendar, UTC.
+///
+/// Returned by [`Filetime::to_calendar`] and [`filetime_to_calendar`].
+/// Replaces the previous `(i32, u32, u32, u32, u32, u32)` 6-tuple
+/// return whose declaration-order destructuring offered no compile-
+/// time guard against a `(day, month, …)` swap at the call site.
+///
+/// # Field ranges
+///
+/// All values are produced by Howard Hinnant's civil-calendar algorithm
+/// applied to a 64-bit signed tick count, so the ranges are:
+///
+/// - `year`: any `i32` (the algorithm's domain is unbounded by year); in
+///   practice an NTFS FILETIME of `i64::MAX` decodes to ~year 30828 and
+///   `i64::MIN` decodes to a year far enough negative to overflow `i32` —
+///   callers reading those values are likely operating on corrupt data anyway.
+/// - `month`: `1..=12`
+/// - `day`: `1..=31`
+/// - `hour`: `0..=23`
+/// - `minute`: `0..=59`
+/// - `second`: `0..=59` (no leap-second handling in NTFS time)
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct CalendarParts {
+    /// Year — Gregorian, proleptic, signed (negative for BCE).
+    pub year: i32,
+    /// Month, 1-based: `1` = January … `12` = December.
+    pub month: u32,
+    /// Day of month, 1-based.
+    pub day: u32,
+    /// Hour, 0-based: `0..=23`.
+    pub hour: u32,
+    /// Minute, 0-based: `0..=59`.
+    pub minute: u32,
+    /// Second, 0-based: `0..=59` (no leap seconds).
+    pub second: u32,
+}
 
 /// Converts a Windows FILETIME (100-nanosecond intervals since 1601-01-01)
 /// to Unix timestamp in microseconds.
@@ -41,21 +188,25 @@ pub const fn filetime_to_unix_micros(filetime: i64) -> i64 {
     (filetime - FILETIME_UNIX_DIFF) / FILETIME_TICKS_PER_MICROSECOND
 }
 
-/// Decompose a raw FILETIME into calendar fields `(year, month, day, hour,
-/// minute, second)`.
+/// Decompose a raw FILETIME into [`CalendarParts`] in proleptic
+/// Gregorian UTC.
 ///
 /// This mirrors the Windows `RtlTimeToTimeFields` approach — works directly
 /// with FILETIME ticks (100-ns intervals since 1601-01-01), no intermediate
 /// Unix conversion.  Handles all valid FILETIME values including pre-1970.
 ///
 /// Returns `None` for `filetime == 0` (unset / null timestamp in NTFS).
+///
+/// Prefer [`Filetime::to_calendar`] in new code so the FILETIME argument
+/// carries its semantic at the type level instead of being just another
+/// `i64`.
 #[must_use]
 #[expect(
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,
     reason = "Hinnant algorithm: intermediate values are bounded and non-negative for valid dates"
 )]
-pub const fn filetime_to_calendar(filetime: i64) -> Option<(i32, u32, u32, u32, u32, u32)> {
+pub const fn filetime_to_calendar(filetime: i64) -> Option<CalendarParts> {
     if filetime == 0 {
         return None;
     }
@@ -83,7 +234,14 @@ pub const fn filetime_to_calendar(filetime: i64) -> Option<(i32, u32, u32, u32, 
     let month = if mp < 10 { mp + 3 } else { mp - 9 };
     let year = if month <= 2 { y + 1 } else { y };
 
-    Some((year as i32, month, day, hour, minute, second))
+    Some(CalendarParts {
+        year: year as i32,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+    })
 }
 
 /// Apply a timezone bias (in seconds) to a raw FILETIME value.
@@ -97,14 +255,14 @@ pub const fn filetime_with_tz_bias(filetime: i64, tz_bias_secs: i32) -> i64 {
 
 #[cfg(test)]
 #[expect(
-    clippy::min_ident_chars,
     clippy::default_numeric_fallback,
-    reason = "test code — relaxed linting for test clarity"
+    reason = "test code — integer literals are unambiguous in the surrounding assertions"
 )]
 mod tests {
     use super::{
-        FILETIME_TICKS_PER_MICROSECOND, FILETIME_TICKS_PER_SECOND, FILETIME_UNIX_DIFF,
-        filetime_to_calendar, filetime_to_unix_micros, filetime_with_tz_bias,
+        CalendarParts, FILETIME_TICKS_PER_MICROSECOND, FILETIME_TICKS_PER_SECOND,
+        FILETIME_UNIX_DIFF, Filetime, filetime_to_calendar, filetime_to_unix_micros,
+        filetime_with_tz_bias,
     };
 
     #[test]
@@ -119,7 +277,17 @@ mod tests {
         // 2024-01-01 00:00:00 UTC
         let filetime: i64 = 133_485_408_000_000_000;
         let cal = filetime_to_calendar(filetime);
-        assert_eq!(cal, Some((2024, 1, 1, 0, 0, 0)));
+        assert_eq!(
+            cal,
+            Some(CalendarParts {
+                year: 2024,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     #[test]
@@ -133,7 +301,17 @@ mod tests {
         let unix_secs: i64 = -318_197_650;
         let filetime = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
         let cal = filetime_to_calendar(filetime);
-        assert_eq!(cal, Some((1959, 12, 2, 3, 45, 50)));
+        assert_eq!(
+            cal,
+            Some(CalendarParts {
+                year: 1959,
+                month: 12,
+                day: 2,
+                hour: 3,
+                minute: 45,
+                second: 50,
+            })
+        );
     }
 
     #[test]
@@ -196,7 +374,17 @@ mod tests {
         // Unix micros → days → should match calendar day
         let days_since_epoch = us / (86_400 * 1_000_000);
         assert_eq!(days_since_epoch, 19723); // 2024-01-01 is day 19723
-        assert_eq!(cal, Some((2024, 1, 1, 0, 0, 0)));
+        assert_eq!(
+            cal,
+            Some(CalendarParts {
+                year: 2024,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -208,7 +396,17 @@ mod tests {
         // 2000-02-29 12:00:00 — Feb 29 in a century leap year.
         let unix_secs: i64 = 951_825_600; // 2000-02-29 12:00:00 UTC
         let ft = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
-        assert_eq!(filetime_to_calendar(ft), Some((2000, 2, 29, 12, 0, 0)));
+        assert_eq!(
+            filetime_to_calendar(ft),
+            Some(CalendarParts {
+                year: 2000,
+                month: 2,
+                day: 29,
+                hour: 12,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     #[test]
@@ -216,7 +414,17 @@ mod tests {
         // 2024-02-29 23:59:59 — last second of a leap day.
         let unix_secs: i64 = 1_709_251_199; // 2024-02-29 23:59:59 UTC
         let ft = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
-        assert_eq!(filetime_to_calendar(ft), Some((2024, 2, 29, 23, 59, 59)));
+        assert_eq!(
+            filetime_to_calendar(ft),
+            Some(CalendarParts {
+                year: 2024,
+                month: 2,
+                day: 29,
+                hour: 23,
+                minute: 59,
+                second: 59,
+            })
+        );
     }
 
     #[test]
@@ -224,7 +432,17 @@ mod tests {
         // 1900-02-28 — 1900 is NOT a leap year (divisible by 100 but not 400).
         let unix_secs: i64 = -2_203_977_600; // 1900-02-28 00:00:00 UTC
         let ft = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
-        assert_eq!(filetime_to_calendar(ft), Some((1900, 2, 28, 0, 0, 0)));
+        assert_eq!(
+            filetime_to_calendar(ft),
+            Some(CalendarParts {
+                year: 1900,
+                month: 2,
+                day: 28,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     #[test]
@@ -234,25 +452,61 @@ mod tests {
         let ft_jan01 = (946_684_800_i64) * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
         assert_eq!(
             filetime_to_calendar(ft_dec31),
-            Some((1999, 12, 31, 23, 59, 59))
+            Some(CalendarParts {
+                year: 1999,
+                month: 12,
+                day: 31,
+                hour: 23,
+                minute: 59,
+                second: 59,
+            })
         );
-        assert_eq!(filetime_to_calendar(ft_jan01), Some((2000, 1, 1, 0, 0, 0)));
+        assert_eq!(
+            filetime_to_calendar(ft_jan01),
+            Some(CalendarParts {
+                year: 2000,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     #[test]
     fn filetime_to_calendar_filetime_epoch_itself() {
         // FILETIME = 1 tick → 1601-01-01 00:00:00 (essentially).
         let cal = filetime_to_calendar(1);
-        assert_eq!(cal, Some((1601, 1, 1, 0, 0, 0)));
+        assert_eq!(
+            cal,
+            Some(CalendarParts {
+                year: 1601,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
     }
 
     #[test]
     fn filetime_to_calendar_midnight_exact() {
         // Exactly midnight — time components must all be zero.
         let ft = 86400_i64 * FILETIME_TICKS_PER_SECOND; // day 1 since 1601
-        let cal = filetime_to_calendar(ft);
-        if let Some((_, _, _, h, m, s)) = cal {
-            assert_eq!((h, m, s), (0, 0, 0), "midnight should have 00:00:00");
+        if let Some(CalendarParts {
+            hour,
+            minute,
+            second,
+            ..
+        }) = filetime_to_calendar(ft)
+        {
+            assert_eq!(
+                (hour, minute, second),
+                (0, 0, 0),
+                "midnight should have 00:00:00"
+            );
         }
     }
 
@@ -272,7 +526,18 @@ mod tests {
         let ft: i64 = 133_485_408_000_000_000; // 2024-01-01 00:00:00 UTC
         let biased = filetime_with_tz_bias(ft, 5 * 3600);
         let cal = filetime_to_calendar(biased);
-        assert_eq!(cal, Some((2024, 1, 1, 5, 0, 0)), "UTC+5 should show 05:00");
+        assert_eq!(
+            cal,
+            Some(CalendarParts {
+                year: 2024,
+                month: 1,
+                day: 1,
+                hour: 5,
+                minute: 0,
+                second: 0,
+            }),
+            "UTC+5 should show 05:00"
+        );
     }
 
     #[test]
@@ -284,7 +549,14 @@ mod tests {
         // 00:00 - 8h = previous day 16:00
         assert_eq!(
             cal,
-            Some((2023, 12, 31, 16, 0, 0)),
+            Some(CalendarParts {
+                year: 2023,
+                month: 12,
+                day: 31,
+                hour: 16,
+                minute: 0,
+                second: 0,
+            }),
             "UTC-8 should roll back to Dec 31"
         );
     }
@@ -297,8 +569,98 @@ mod tests {
         let cal = filetime_to_calendar(biased);
         assert_eq!(
             cal,
-            Some((2024, 1, 1, 5, 30, 0)),
+            Some(CalendarParts {
+                year: 2024,
+                month: 1,
+                day: 1,
+                hour: 5,
+                minute: 30,
+                second: 0,
+            }),
             "UTC+5:30 should show 05:30"
+        );
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Filetime newtype + CalendarParts — Phase 4 sub-phase 5a tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn filetime_unset_round_trip() {
+        assert_eq!(Filetime::UNSET.ticks(), 0);
+        assert_eq!(Filetime::from_ticks(0), Filetime::UNSET);
+        assert_eq!(Filetime::UNSET.to_calendar(), None);
+        assert_eq!(Filetime::UNSET.to_unix_micros(), 0);
+    }
+
+    #[test]
+    fn filetime_newtype_to_calendar_matches_free_fn() {
+        // Newtype path and free-fn path MUST produce byte-identical output.
+        let ft: i64 = 133_485_408_000_000_000;
+        let via_newtype = Filetime::from_ticks(ft).to_calendar();
+        let via_free = filetime_to_calendar(ft);
+        assert_eq!(via_newtype, via_free);
+        assert_eq!(
+            via_newtype,
+            Some(CalendarParts {
+                year: 2024,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn filetime_newtype_with_tz_bias_returns_filetime() {
+        let utc = Filetime::from_ticks(133_485_408_000_000_000);
+        let pst = utc.with_tz_bias(-8 * 3600);
+        assert_eq!(
+            pst.to_calendar(),
+            Some(CalendarParts {
+                year: 2023,
+                month: 12,
+                day: 31,
+                hour: 16,
+                minute: 0,
+                second: 0,
+            })
+        );
+        // Symmetric round-trip.
+        assert_eq!(pst.with_tz_bias(8 * 3600), utc);
+    }
+
+    #[test]
+    fn filetime_newtype_repr_transparent_size() {
+        // `#[repr(transparent)]` over `i64` guarantees identical layout.
+        // Verified at compile time via `size_of` and `align_of` (both in
+        // the 2024 edition prelude — no `core::mem::` qualifier needed).
+        assert_eq!(size_of::<Filetime>(), size_of::<i64>());
+        assert_eq!(align_of::<Filetime>(), align_of::<i64>());
+    }
+
+    #[test]
+    fn calendar_parts_field_layout_matches_doc_ranges() {
+        // The 2024-02-29 leap-day case exercises every field independently.
+        let unix_secs: i64 = 1_709_251_199; // 2024-02-29 23:59:59 UTC
+        let ft = unix_secs * FILETIME_TICKS_PER_SECOND + FILETIME_UNIX_DIFF;
+        let parts = Filetime::from_ticks(ft).to_calendar().expect("non-zero");
+        assert_eq!(parts.year, 2024);
+        assert_eq!(parts.month, 2);
+        assert_eq!(parts.day, 29);
+        assert_eq!(parts.hour, 23);
+        assert_eq!(parts.minute, 59);
+        assert_eq!(parts.second, 59);
+    }
+
+    #[test]
+    fn filetime_to_unix_micros_via_newtype() {
+        let ft: i64 = 133_485_408_000_000_000;
+        assert_eq!(
+            Filetime::from_ticks(ft).to_unix_micros(),
+            filetime_to_unix_micros(ft)
         );
     }
 

--- a/scripts/ci/file_size_exceptions.txt
+++ b/scripts/ci/file_size_exceptions.txt
@@ -2,8 +2,6 @@
 # Format: relative_path|reason
 # All files listed here MUST also have an `//! Exception:` comment in their first 60 lines.
 #
-# --- Wave 1–5 targets (temporary exceptions, will be split) ---
-#
 # --- Permanent exceptions (documented justification) ---
 crates/uffs-core/src/search/field/field_metadata.rs|PERMANENT: Single const fn match table — one FieldMeta per FieldId variant; cannot be split without breaking the match
 crates/uffs-core/src/search/filters/tests.rs|PERMANENT: Integration test suite for filter pipeline; splitting further would scatter related test fixtures

--- a/scripts/dev/mcp-readiness.rs
+++ b/scripts/dev/mcp-readiness.rs
@@ -1114,14 +1114,24 @@ fn discover_drive_mft_files(data_dir: &str) -> Vec<(char, String)> {
 
 /// Parse drive count and individual drive letters from `uffs daemon status`.
 ///
-/// The status output format is:
+/// The status output format (v0.5.95+, Phase 8-E memory-tiering) is:
+/// ```text
+///   Drives:
+///     [Warm]   C: —  3,428,455 records (file:.../C_mft.iocp) — 730 MB ...
+///     [Parked] D: — bloom + trie kept resident; body released
+/// ```
+///
+/// Legacy daemons (≤ v0.5.94) used the un-tiered shape:
 /// ```text
 ///   Drives:      7 loaded (25,846,853 records)
 ///     C:  3,428,455 records
 ///     D:  7,065,539 records
 /// ```
 ///
-/// Returns `(count_from_header, vec_of_drive_letters)`.
+/// Returns `(count, vec_of_drive_letters)`.  The parser accepts both
+/// shapes: it strips an optional `[Tier]` prefix on per-drive lines
+/// before looking for the letter, and falls back to the header count
+/// only when no per-drive lines parsed (legacy header-only format).
 fn parse_drives_from_status(status_output: &str) -> (usize, Vec<char>) {
     let mut header_count: usize = 0;
     let mut letters: Vec<char> = Vec::new();
@@ -1129,7 +1139,8 @@ fn parse_drives_from_status(status_output: &str) -> (usize, Vec<char>) {
     for line in status_output.lines() {
         let trimmed = line.trim();
 
-        // Parse "Drives:      N loaded ..." header.
+        // Parse legacy "Drives:      N loaded ..." header (skipped on
+        // v0.5.95+ where the header is just "Drives:").
         if let Some(rest) = trimmed.strip_prefix("Drives:") {
             let rest = rest.trim();
             if let Some(num_str) = rest.split_whitespace().next() {
@@ -1140,19 +1151,22 @@ fn parse_drives_from_status(status_output: &str) -> (usize, Vec<char>) {
             continue;
         }
 
-        // Parse individual drive lines like "  C: —  3,428,455 records".
-        // After trimming: starts with a single letter, then `:`.
-        if trimmed.len() >= 2 {
-            let mut chars = trimmed.chars();
-            if let Some(letter) = chars.next() {
-                if letter.is_ascii_alphabetic() && chars.next() == Some(':') {
-                    letters.push(letter.to_ascii_uppercase());
-                }
+        // Skip an optional `[Tier]` prefix (v0.5.95+ format), then
+        // look for `<letter>:` at the start of the remainder.
+        let after_tier = trimmed
+            .strip_prefix('[')
+            .and_then(|rest| rest.split_once(']'))
+            .map_or(trimmed, |(_, after)| after.trim_start());
+        let mut chars = after_tier.chars();
+        if let Some(letter) = chars.next() {
+            if letter.is_ascii_alphabetic() && chars.next() == Some(':') {
+                letters.push(letter.to_ascii_uppercase());
             }
         }
     }
 
-    // Prefer the counted letters; fall back to header count.
+    // Prefer the counted letters; fall back to header count when the
+    // per-drive lines didn't parse (legacy header-only shape).
     if letters.is_empty() && header_count > 0 {
         (header_count, letters)
     } else {

--- a/scripts/windows/api-validation.rs
+++ b/scripts/windows/api-validation.rs
@@ -1943,17 +1943,47 @@ fn run_rpc_custom_validator(name: &str, result: &Value) -> Result<String> {
         }
 
         // ── RPC.2: drives method ────────────────────────────────────
+        //
+        // Tier-aware contract (Phase 3+): Warm / Hot shards have their
+        // body in RAM and must report `records > 0`; Parked / Cold
+        // shards legitimately report `records: 0` because their body
+        // was released by the demote ladder (bloom + trie stay
+        // resident).  The `tier` field is populated by every daemon
+        // from v0.5.82 onward; for older daemons we fall back to the
+        // `source` string ("parked" / "cold") which carries the same
+        // information.
         "RPC.2" => {
             let drives = result.get("drives").and_then(|v| v.as_array())
                 .ok_or_else(|| anyhow::anyhow!("Missing 'drives' array"))?;
             if drives.is_empty() { bail!("No drives loaded"); }
+            let mut resident = 0_usize;
+            let mut demoted = 0_usize;
             for (i, d) in drives.iter().enumerate() {
                 let letter = d.get("letter").and_then(|v| v.as_str()).unwrap_or("");
                 if letter.is_empty() { bail!("Drive {i}: missing 'letter'"); }
                 let records = d.get("records").and_then(|v| v.as_u64()).unwrap_or(0);
-                if records == 0 { bail!("Drive {i} ({letter}): 0 records"); }
+                let tier = d.get("tier").and_then(|v| v.as_str()).unwrap_or("");
+                let source = d.get("source").and_then(|v| v.as_str()).unwrap_or("");
+                // Body-released shards: `tier` ∈ {parked, cold, evicting,
+                // unknown}, or (pre-v0.5.82 daemons) `source` ∈ {parked, cold}.
+                let body_released = matches!(tier, "parked" | "cold" | "evicting" | "unknown")
+                    || matches!(source, "parked" | "cold");
+                if body_released {
+                    demoted += 1;
+                    continue;
+                }
+                if records == 0 {
+                    bail!(
+                        "Drive {i} ({letter}, tier={tier:?}, source={source:?}): \
+                         0 records but shard is not Parked/Cold — body should be loaded"
+                    );
+                }
+                resident += 1;
             }
-            Ok(format!("{} drives loaded", drives.len()))
+            Ok(format!(
+                "{} drives loaded ({resident} resident, {demoted} demoted)",
+                drives.len(),
+            ))
         }
 
         // ── RPC.3: info method ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Completes the **Phase 4 type-design playbook** (issue #191) with two type-system upgrades:

- **Sub-phase 5a** (already on the branch from a prior commit): `Filetime` newtype + `CalendarParts` struct.
- **Sub-phase 5b** (new in this PR): `DriveLetter` newtype migration across the workspace.

The `DriveLetter` newtype encodes the canonical-uppercase `A..=Z` invariant in the type system, eliminating scattered `eq_ignore_ascii_case` / `to_ascii_uppercase` / `is_ascii_alphabetic` runtime checks at every drive-letter call site.

## Commits

1. `refactor(time): Phase 4 sub-phase 5a — Filetime newtype + CalendarParts struct` (refs #191)
2. `refactor: complete Phase 4 sub-phase 5b DriveLetter newtype migration`
3. `fix(api-validation): make RPC.2 drives method check tier-aware`

## What changed (Sub-phase 5b highlights)

### Type-flow changes
- `SearchRequest.drives_filter`, `AggregationRequest.drives_filter`, `SearchParams.drives`, `HibernateOutcome.*`, `ForgetOutcome.*` and related plumbing now carry `DriveLetter` end-to-end.
- `spawn_drive_loaders` / `collect_drive_load_results` / `handle_drive_load_result` JoinSets and `apply_dispatch_safety_nets` drive buffers all return / accept `DriveLetter`.
- `infer_drive_letter` returns `DriveLetter` with an explicit `DriveLetter::X` fallback that matches the prior `'X'` sentinel.
- `drive_letter_matches` (auto-discovery filter) parses via `DriveLetter::parse` and uses `slice::contains` for membership.

### Boundary conversions (wire-format compatibility preserved)
- `uffs-format::DriveFooterContext` stays `&[char]` (issue #216 keeps the format crate dep-free); CLI + daemon callers map `DriveLetter` → `char` at the boundary.
- `uffs-broker-protocol::HandleRequest.drive` stays `char`; daemon's `broker_client` converts via `as_char()` before encoding.
- `uffs-mcp` JSON schema preserves the prior `char` shape via `#[schemars(with = "char")]` annotations on `SearchRowOutput` and `DriveOutput` (DriveLetter lives in uffs-mft which deliberately has no schemars dep).

### Idiomatic cleanups
- Drop `eq_ignore_ascii_case` callers where both sides are now `DriveLetter` (canonical uppercase by construction); use `slice::contains` for filter membership.
- Replace `drives.sort_by(|l,r| l.letter.cmp(&r.letter))` with `sort_by_key(|row| row.letter)`.
- Improve `parse_drive_letter` error surface (`uffs-cli/args.rs`) by forwarding the typed `DriveLetterError` Display.

### uffs-mft internal
- Gate `DriveLetter::from_byte_unchecked` to `cfg(any(windows, test))` matching its sole production caller (`detect_ntfs_drives`); add a platform-agnostic round-trip unit test pinning the invariant.

### Test fixtures
- Migrate every char-literal `'C'`/`'D'`/`'E'` etc. used in test fixtures (`events`, `journal_sink`, `journal_loop`, `idle_demote`, `lifecycle_hooks`, `registry`, `handler_paths_blob_tests`, `handler_csv_blob_tests`, `lib_tests`, `output_tests`) to the typed `DriveLetter` constants.
- Revert a misguided `DriveLetter::R.as_char()` rewrite in `uffs-core` aggregate integration tests: those tests filter lowercase extension-name keys (`"rs"`, `"md"`), unrelated to `DriveLetter`, and the uppercase canonical char broke them.

### Test-file split
- `idle_demote.rs` was bumped to 835 LOC purely because rustfmt expands typed array literals over multiple lines. Split into:
  - `idle_demote.rs` — TTL state-ladder tests (~432 LOC).
  - `idle_demote_tracing.rs` — `shard.transition` event-contract + pressure-cascade + PR-f promote anti-thrash (~430 LOC).
- Follows the existing thematic-submodule pattern; no `file_size_exceptions.txt` entry needed.

## Validation tooling fix (third commit)

`RPC.2 drives method` validator in `scripts/windows/api-validation.rs` was pre-Phase-3 and assumed every loaded drive must have `records > 0`. Phase 3+ Parked / Cold shards legitimately report `records: 0` because the body is released. Made the validator tier-aware via the wire-format `tier` field with `source` fallback for pre-v0.5.82 daemons.

## Verification

- `just lint-all` (macOS) — green, including `fmt-check`.
- `just lint-ci-windows` — green.
- `cargo nextest run --workspace --all-features` — **1748 pass / 14 skipped / 0 fail**.
- `cargo test --doc --workspace --all-features` with `-Dwarnings -Dmissing_docs` — green.
- Full `lint-pre-push` (8 gates: fmt-check, file-size, typos, reuse, taplo, lint-ci, lint-prod, lint-tests, lint-ci-windows, rustdoc, doc-tests, tests, smoke, deny) — **green**.
- `rust-script scripts/windows/api-validation.rs --tests RPC.2` — **PASS** (`7 drives loaded (7 resident, 0 demoted)`).

Refs #191.
