### PR TITLE
chore: release v0.5.96 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -639,7 +639,7 @@ hunting for the wrong things.
   ticks Phase 7 retroactively; Phase 6 stays open pending one
   more 24-h run with the trace-level harness fix.
 
-## [0.5.95] - 2026-05-08
+## [0.5.96] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -648,7 +648,7 @@ hunting for the wrong things.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.95`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.96`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,14 +4346,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "clap",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "chrono",
  "itoa",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "clap",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "clap",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "clap",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "axum",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4581,14 +4581,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4603,14 +4603,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.95"
+version = "0.5.96"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.95"
+version = "0.5.96"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires
@@ -116,21 +116,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.95" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.95" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.95" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.95" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.95" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.95" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.95" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.95" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.96" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.96" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.96" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.96" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.96" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.96" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.96" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.96" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.95" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.96" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/crates/uffs-client/src/connect_sync_tests.rs
+++ b/crates/uffs-client/src/connect_sync_tests.rs
@@ -26,7 +26,7 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
-use std::io::{BufReader, Cursor, Read, Write};
+use std::io::{BufReader, Read, Write};
 use std::sync::Mutex;
 
 use crate::connect_sync::UffsClientSync;
@@ -81,8 +81,12 @@ impl Write for CapturingWriter {
 /// JSON-RPC response.  The returned [`CapturingWriter`] snapshots
 /// whatever the client writes — tests use it to assert the request
 /// shape when that matters.
-fn client_with_canned_response(response_body: &[u8]) -> (UffsClientSync, CapturingWriter) {
-    let reader: Box<dyn Read + Send> = Box::new(Cursor::new(response_body.to_vec()));
+fn client_with_canned_response(response_body: &'static [u8]) -> (UffsClientSync, CapturingWriter) {
+    // `&[u8]` already implements `Read` (stdlib blanket impl) — no need for
+    // an intermediate owning wrapper.  All callers pass byte-string literals
+    // (`b""`, `br#"..."#`), which are `&'static [u8]`, so the `'static` bound
+    // on `Box<dyn Read + Send>` is satisfied without an owning Vec.
+    let reader: Box<dyn Read + Send> = Box::new(response_body);
     let writer = CapturingWriter::new();
     let writer_box: Box<dyn Write + Send> = Box::new(writer.clone());
     let client = UffsClientSync::from_parts_for_test(BufReader::new(reader), writer_box);

--- a/crates/uffs-mft/src/raw_iocp.rs
+++ b/crates/uffs-mft/src/raw_iocp.rs
@@ -454,8 +454,12 @@ pub fn load_iocp_capture<P: AsRef<Path>>(file_path: P) -> Result<IocpCaptureData
 
     let data = if header.is_compressed() {
         let mut data = Vec::with_capacity(crate::index::frs_to_usize(header.total_data_size));
-        let cursor = std::io::Cursor::new(&compressed);
-        let mut decoder = zstd::stream::Decoder::new(cursor)?;
+        // `&[u8]` implements `Read` directly — no need for an intermediate
+        // `Cursor` wrapper.  This also sidesteps the (over-eager on recent
+        // nightlies) `clippy::std_instead_of_core` lint that suggests
+        // `core::io::Cursor`, which is still gated behind unstable
+        // `feature(core_io)`.
+        let mut decoder = zstd::stream::Decoder::new(compressed.as_slice())?;
         decoder.read_to_end(&mut data)?;
         data
     } else {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -30,7 +30,7 @@
 # CI pipeline will auto-refresh on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed — use that flag (or plain `just ship`) while the upstream regression
 # persists.
-channel = "nightly-2026-05-12"
+channel = "nightly-2026-05-14"
 
 # Specify components that should always be available
 components = [


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.96**.  Binaries + GitHub Release v0.5.96 are already live (step 09).  This PR routes the corresponding commit through branch-protection rules.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

Local `main` had this commit with a different SHA before squash rewrote it onto main; recover with `git fetch origin && git reset --hard origin/main`.