### PR TITLE
chore(publish-prep): opt the 5 publishable lib crates into docs.rs cfg-badge rendering

### DIFF
--- a/crates/uffs-client/src/lib.rs
+++ b/crates/uffs-client/src/lib.rs
@@ -34,6 +34,13 @@
 //!   `uffs-cli`.
 //! - **§3.7** N/A — no `pub trait` declarations in this crate.
 
+// On docs.rs only: enable the `doc_cfg` rustdoc feature so cfg-gated items
+// (`#[cfg(feature = "async")]`, `#[cfg(windows)]`, etc.) render with their
+// cfg badge.  Gated behind `cfg(docsrs)` so local `cargo doc` never
+// exercises the nightly-only feature.  Post-Rust-1.92 the `doc_auto_cfg`
+// feature was merged into `doc_cfg` (rust-lang/rust#138907).
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 // Suppress unused crate warnings for deps used in sub-modules
 use serde as _;
 use uffs_security as _;

--- a/crates/uffs-mcp/src/lib.rs
+++ b/crates/uffs-mcp/src/lib.rs
@@ -26,6 +26,13 @@
 //! # }
 //! ```
 
+// On docs.rs only: enable the `doc_cfg` rustdoc feature so cfg-gated items
+// render with their cfg badge.  Gated behind `cfg(docsrs)` so local
+// `cargo doc` never exercises the nightly-only feature.  Post-Rust-1.92
+// the `doc_auto_cfg` feature was merged into `doc_cfg`
+// (rust-lang/rust#138907).
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 // `clap` is used by the `uffsmcp` binary, not this library crate.
 use clap as _;
 

--- a/crates/uffs-mft/src/lib.rs
+++ b/crates/uffs-mft/src/lib.rs
@@ -90,6 +90,12 @@
 //! No `pub trait` declarations live in this crate, so the
 //! sealed-trait decision (§3.7) is **N/A**.
 
+// On docs.rs only: enable the `doc_cfg` rustdoc feature so cfg-gated items
+// (`#[cfg(windows)]`, `#[cfg(feature = "...")]`, etc.) render with their
+// cfg badge.  Gated behind `cfg(docsrs)` so local `cargo doc` never
+// exercises the nightly-only feature.  Post-Rust-1.92 the `doc_auto_cfg`
+// feature was merged into `doc_cfg` (rust-lang/rust#138907).
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(clippy::all, clippy::pedantic)]
 #![expect(
     clippy::module_name_repetitions,

--- a/crates/uffs-text/src/lib.rs
+++ b/crates/uffs-text/src/lib.rs
@@ -32,4 +32,11 @@
 //! - Locale-aware collation
 //! - Search tokenisation
 
+// On docs.rs only: enable the `doc_cfg` rustdoc feature so cfg-gated items
+// render with their cfg badge.  Gated behind `cfg(docsrs)` so local
+// `cargo doc` never exercises the nightly-only feature.  Post-Rust-1.92
+// the `doc_auto_cfg` feature was merged into `doc_cfg`
+// (rust-lang/rust#138907) — `doc_cfg` is now the unified name.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub mod case_fold;

--- a/crates/uffs-time/src/lib.rs
+++ b/crates/uffs-time/src/lib.rs
@@ -39,6 +39,15 @@
 //! site.  Future sub-phases may push [`Filetime`] deeper into the index
 //! / query layers.
 
+// On docs.rs only: enable the `doc_cfg` rustdoc feature so cfg-gated items
+// (e.g. `#[cfg(feature = "...")]` or `#[cfg(target_os = "...")]`) render
+// with their cfg badge on the rendered docs.  Gated behind `cfg(docsrs)`
+// so local `cargo doc` (which doesn't pass `--cfg docsrs`) never exercises
+// the nightly-only feature.  See `[package.metadata.docs.rs]` in Cargo.toml
+// for the cfg wiring.  The previously-used `doc_auto_cfg` feature was
+// merged into `doc_cfg` in Rust 1.92 (rust-lang/rust#138907); the unified
+// `doc_cfg` feature preserves the automatic cfg-badge inference behaviour.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
 /// Number of 100-nanosecond intervals per second.


### PR DESCRIPTION
## What

Adds `#![cfg_attr(docsrs, feature(doc_cfg))]` to the `lib.rs` of every publishable library crate so that **docs.rs renders cfg-availability badges** on cfg-gated public items.

The 5 lib crates touched:

| Crate | Insertion site | Existing `#![…]` neighbours |
|---|---|---|
| `uffs-time` | `crates/uffs-time/src/lib.rs` | grouped with `#![no_std]` |
| `uffs-text` | `crates/uffs-text/src/lib.rs` | standalone (no other `#![…]`) |
| `uffs-mft` | `crates/uffs-mft/src/lib.rs` | grouped with the existing `#![warn(…)]` cluster |
| `uffs-client` | `crates/uffs-client/src/lib.rs` | standalone |
| `uffs-mcp` | `crates/uffs-mcp/src/lib.rs` | standalone |

`uffs-cli` is binary-only (no `lib.rs`) — no directive needed.

## Why

Each publishable crate already declares the docs.rs rendering hint in its manifest:

```toml
[package.metadata.docs.rs]
all-features = true
rustdoc-args = ["--cfg", "docsrs"]
```

`--cfg docsrs` only takes effect when the crate root opts in. With this attribute, items behind `#[cfg(feature = "async")]`, `#[cfg(windows)]`, `#[cfg(target_os = "…")]`, etc. render with their cfg-availability badge on docs.rs. Without it, those badges silently don't appear.

Local `cargo doc` does **not** pass `--cfg docsrs`, so the `cfg_attr` wrapper bypasses the directive entirely — the nightly-only `doc_cfg` feature is never exercised in normal workflows.

## Why `doc_cfg`, not `doc_auto_cfg`

The earlier-typed `doc_auto_cfg` got rejected by rustc:

```
error[E0557]: feature has been removed
  --> crates/uffs-text/src/lib.rs:38:29
   |
38 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in 1.92.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
   = note: merged into `doc_cfg`
```

Rust 1.92 (rust-lang/rust#138907) merged `doc_auto_cfg` into `doc_cfg`. The unified `doc_cfg` feature provides **both** the explicit `#[doc(cfg(…))]` attribute **and** the automatic cfg-badge inference behaviour that `doc_auto_cfg` used to offer alone. Our pinned nightly (`nightly-2026-05-14` per `rust-toolchain.toml`, rustc 1.97-nightly) is well past the merge.

## Verification

Locally on macOS Apple Silicon, all of these pass:

```bash
cargo check -p uffs-time -p uffs-text                        # OK
RUSTDOCFLAGS="--cfg docsrs" cargo doc -p uffs-time -p uffs-text -p uffs-mft -p uffs-client -p uffs-mcp --no-deps   # OK
cargo fmt --check                                            # OK
cargo clippy -p uffs-time -p uffs-text -- -D warnings        # OK
```

The pre-push `lint-pre-push` gate (smoke + lint-ci-windows) also passed before push.

## Adherence to the 5 user-mandated rules

1. **No suppression hacks** — the directive is gated behind `cfg(docsrs)` which is the canonical docs.rs feature-opt-in pattern (used by tokio, serde, tracing, …); it does **not** suppress any lint, warning, or test.
2. **Surgical fix** — 36 lines added across 5 files, each a single `#![cfg_attr(…)]` line plus a justifying comment block.
3. **Preserve behaviour** — no public API changes. Local builds (no `--cfg docsrs`) bypass the directive entirely; only docs.rs rendering is affected.
4. **Tests** — no existing tests touched; no new tests added because the directive has zero runtime / type-system surface (it's a rustdoc-only opt-in).
5. **Documented & atomic** — single commit, conventional-commit subject, detailed body explaining the why and the `doc_auto_cfg` → `doc_cfg` migration.

## Scope context

Part of the **crates.io publish-readiness umbrella** tracked in #241, specifically **gap #2** (the `doc_auto_cfg` directive item). One more PR-B remains in that umbrella (per-crate `keywords` + `categories` allow-list + apply) before the actionable-now backlog is closed.

## Test plan

- [x] `cargo check` on the 2 polars-free crates
- [x] `RUSTDOCFLAGS="--cfg docsrs" cargo doc --no-deps` on all 5 lib crates
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings` on the 2 polars-free crates
- [x] `lint-pre-push` (smoke + lint-ci-windows) passes pre-push

Refs: #241
