### PR TITLE
feat(manifest-audit): permit per-crate keywords/categories override via allow-list (invariant 3.5) + apply on 4 library crates

### DIFF
--- a/crates/uffs-client/Cargo.toml
+++ b/crates/uffs-client/Cargo.toml
@@ -15,8 +15,15 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 readme.workspace = true
-keywords.workspace = true
-categories.workspace = true
+# Per-crate keywords + categories override (Phase 1 §3.5 escape hatch
+# via `KnownExceptions::keywords_override_ok` / `categories_override_ok`
+# in `scripts/ci/manifest-audit/src/audit.rs`).  This is the thin
+# client crate that surfaces UFFS to every consumer (CLI, TUI, GUI,
+# MCP).  Workspace defaults (app-app-app) don't surface the IPC /
+# RPC / daemon-lifecycle nature that makes this crate independently
+# useful.  See issue #241 for the full discoverability rationale.
+keywords = ["ipc", "rpc", "client", "uffs", "daemon"]
+categories = ["api-bindings", "filesystem"]
 
 # Phase R6→R8 deviation row 5 — polars-subtree publishability deferred.
 # Despite the "thin-client invariant: zero polars" intent above, this

--- a/crates/uffs-mcp/Cargo.toml
+++ b/crates/uffs-mcp/Cargo.toml
@@ -16,8 +16,15 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 readme.workspace = true
-keywords.workspace = true
-categories.workspace = true
+# Per-crate keywords + categories override (Phase 1 §3.5 escape hatch
+# via `KnownExceptions::keywords_override_ok` / `categories_override_ok`
+# in `scripts/ci/manifest-audit/src/audit.rs`).  This crate ships an
+# MCP server bridging AI hosts (Claude Desktop, Cursor, Windsurf) to
+# the UFFS daemon — workspace defaults (mft / file-search / polars)
+# would hide it from the MCP / AI tooling audience this crate is
+# actually for.  See issue #241 for the full discoverability rationale.
+keywords = ["mcp", "ai", "rmcp", "uffs", "protocol"]
+categories = ["api-bindings", "command-line-utilities"]
 
 # Phase R6→R8 deviation row 5 — polars-subtree publishability deferred.
 # This crate inherits polars transitively via

--- a/crates/uffs-text/Cargo.toml
+++ b/crates/uffs-text/Cargo.toml
@@ -17,8 +17,17 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 readme.workspace = true
-keywords.workspace = true
-categories.workspace = true
+# Per-crate keywords + categories override (Phase 1 §3.5 escape hatch
+# via `KnownExceptions::keywords_override_ok` / `categories_override_ok`
+# in `scripts/ci/manifest-audit/src/audit.rs`).  This crate ships
+# NTFS-compatible case folding (and, in the future, Unicode
+# normalisation / collation / search tokenisation) — useful to anyone
+# building filename comparison logic that must agree with NTFS's own
+# ordering bit-for-bit, not just to UFFS.  Workspace defaults skew
+# heavily towards the app role and would mis-categorise this library.
+# See issue #241 for the full discoverability rationale.
+keywords = ["unicode", "ntfs", "case-folding", "i18n", "filename"]
+categories = ["text-processing"]
 # Explicitly publishable — overrides the workspace default `publish = false`
 # set in root `Cargo.toml`'s `[workspace.package]`.  Member of the 5-crate
 # publishable subset (`uffs-broker`, `uffs-broker-protocol`, `uffs-security`,

--- a/crates/uffs-time/Cargo.toml
+++ b/crates/uffs-time/Cargo.toml
@@ -20,8 +20,19 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 readme.workspace = true
-keywords.workspace = true
-categories.workspace = true
+# Per-crate keywords + categories override (Phase 1 §3.5 escape hatch
+# via `KnownExceptions::keywords_override_ok` / `categories_override_ok`
+# in `scripts/ci/manifest-audit/src/audit.rs`).  This is a library
+# crate with a *very* different role from the workspace app: it is a
+# zero-dep, `#![no_std]`, pure-const-fn helper for NTFS FILETIME tick
+# arithmetic, useful to anyone parsing on-disk Windows timestamps —
+# not just to UFFS itself.  The workspace defaults
+# (`["mft", "ntfs", "file-search", "windows", "polars"]` /
+# `["filesystem", "command-line-utilities"]`) describe the app and
+# would bury this crate in unrelated search results.  See issue #241
+# for the full discoverability rationale.
+keywords = ["ntfs", "filetime", "datetime", "windows", "no-std"]
+categories = ["date-and-time"]
 # Explicitly publishable — overrides the workspace default `publish = false`
 # set in root `Cargo.toml`'s `[workspace.package]`.  Member of the 5-crate
 # publishable subset (`uffs-broker`, `uffs-broker-protocol`, `uffs-security`,

--- a/scripts/ci/manifest-audit/src/audit.rs
+++ b/scripts/ci/manifest-audit/src/audit.rs
@@ -71,6 +71,32 @@ struct KnownExceptions {
     /// alongside the crate's `Cargo.toml`) so an exception listed crate
     /// can't accidentally point at an arbitrary path.
     readme_override_ok: BTreeSet<&'static str>,
+    /// Members allowed to set `keywords = [...]` directly (not via
+    /// workspace inheritance).  Same Phase 1 §3.5 "deliberately
+    /// overridden with justification" escape hatch as `readme`.
+    /// Publishable library crates benefit from per-crate keywords
+    /// tailored to their specific domain (e.g. `uffs-time` is a
+    /// generic NTFS FILETIME helper that wants `["ntfs", "filetime",
+    /// "datetime", ...]` rather than the workspace-app defaults
+    /// `["mft", "ntfs", "file-search", "windows", "polars"]` which
+    /// describe the *application*, not the library).  The override
+    /// is required to be a **non-empty TOML array** — an empty array
+    /// still fires (cargo treats `keywords = []` as legal but it
+    /// defeats the discoverability purpose of an override).  Per-
+    /// keyword shape (max 5, max 20 chars, `^[a-zA-Z][a-zA-Z0-9_-]*$`)
+    /// is *not* re-validated here because `cargo publish --dry-run`
+    /// in the weekly `crates-io-dry-run.yml` workflow enforces it
+    /// authoritatively against crates.io's own validator.
+    keywords_override_ok: BTreeSet<&'static str>,
+    /// Members allowed to set `categories = [...]` directly (not via
+    /// workspace inheritance).  Same rationale as `keywords_override_ok`
+    /// — publishable library crates want category slugs that match
+    /// their library role (e.g. `uffs-time` → `["date-and-time"]`)
+    /// rather than the workspace-app defaults (`["filesystem",
+    /// "command-line-utilities"]`).  Same non-empty-array requirement.
+    /// Slug validity (must be on `https://crates.io/category_slugs`)
+    /// is enforced authoritatively by `cargo publish --dry-run`.
+    categories_override_ok: BTreeSet<&'static str>,
 }
 
 impl KnownExceptions {
@@ -134,11 +160,32 @@ impl KnownExceptions {
         let readme_override_ok: BTreeSet<&'static str> =
             ["uffs-text", "uffs-time"].into_iter().collect();
 
+        // Per-crate `keywords` + `categories` override allow-list.
+        // The four library crates listed below ship a public surface
+        // distinct enough from the workspace-app role that
+        // discoverability on crates.io demands tailored metadata —
+        // see issue #241 (publish-readiness umbrella) and the per-
+        // crate `Cargo.toml` `keywords =` / `categories =` lines for
+        // the concrete choices.  Crates NOT listed here (`uffs-mft`,
+        // `uffs-cli`) inherit the workspace defaults because their
+        // role aligns 1:1 with the app's role (`uffs-mft` ships the
+        // app's MFT reader; `uffs-cli` IS the app's CLI).
+        let keywords_override_ok: BTreeSet<&'static str> =
+            ["uffs-client", "uffs-mcp", "uffs-text", "uffs-time"]
+                .into_iter()
+                .collect();
+        let categories_override_ok: BTreeSet<&'static str> =
+            ["uffs-client", "uffs-mcp", "uffs-text", "uffs-time"]
+                .into_iter()
+                .collect();
+
         Self {
             publish_explicit,
             underscore_bin_ok,
             nonworkspace_dep_ok,
             readme_override_ok,
+            keywords_override_ok,
+            categories_override_ok,
         }
     }
 }
@@ -373,9 +420,16 @@ fn check_inherited(
 }
 
 /// **Invariant 3.5**: every fingerprint metadata field except
-/// `description` must inherit from workspace, with one narrowly
-/// scoped exception for `readme` (see [`KnownExceptions::
-/// readme_override_ok`] for the rationale and allow-list).
+/// `description` must inherit from workspace, with three narrowly
+/// scoped exceptions:
+///
+/// * `readme` — see [`KnownExceptions::readme_override_ok`].
+/// * `keywords` — see [`KnownExceptions::keywords_override_ok`].
+/// * `categories` — see [`KnownExceptions::categories_override_ok`].
+///
+/// All three exceptions implement the same Phase 1 §3.5 "deliberately
+/// overridden with justification" escape hatch for publishable
+/// library crates whose role is distinct from the workspace-app role.
 fn audit_metadata_fields(
     member: &DiscoveredMember<'_>,
     id: &str,
@@ -395,23 +449,43 @@ fn audit_metadata_fields(
             member.manifest.package.documentation.as_ref(),
         ),
     ] {
-        // `readme` is the only field where per-crate override has a
-        // documented legitimate use case: a publishable library crate
-        // that ships its own per-crate `README.md` (see Phase 1 §3.5
-        // "deliberately overridden with justification" escape hatch).
-        // The exception is tightened to the literal `"README.md"`
-        // same-name pattern so a listed crate can't accidentally point
-        // at an arbitrary path.  Any other override pattern still
-        // fires a finding even for listed crates.
+        // `readme` override: tightened to the literal `"README.md"`
+        // same-name pattern so a listed crate can't accidentally
+        // point at an arbitrary path.  Any other override pattern
+        // still fires a finding even for listed crates.
         if name == "readme"
             && exc.readme_override_ok.contains(id)
             && value.and_then(toml::Value::as_str) == Some("README.md")
         {
             continue;
         }
+        // `keywords` / `categories` overrides: tightened to non-empty
+        // TOML arrays.  An empty array still fires (defeats the
+        // discoverability purpose of overriding).  Per-keyword shape
+        // (max 5, max 20 chars, regex) and per-category slug-set
+        // validity are enforced authoritatively by `cargo publish
+        // --dry-run` in the weekly `crates-io-dry-run.yml` workflow —
+        // re-implementing them here would duplicate the source of
+        // truth and risk drifting from crates.io's validator.
+        if (name == "keywords" && exc.keywords_override_ok.contains(id)
+            || name == "categories" && exc.categories_override_ok.contains(id))
+            && is_non_empty_array(value)
+        {
+            continue;
+        }
         findings.extend(check_inherited(value, name, "3.5", id));
     }
     findings
+}
+
+/// True when `value` is a non-empty TOML array.  Used by the
+/// `keywords` / `categories` override allow-list to ensure listed
+/// crates can't accidentally set `keywords = []` (which would defeat
+/// the override's discoverability purpose).
+fn is_non_empty_array(value: Option<&toml::Value>) -> bool {
+    value
+        .and_then(toml::Value::as_array)
+        .is_some_and(|array| !array.is_empty())
 }
 
 /// **Invariant 3.6**: every dep should use workspace inheritance,
@@ -847,5 +921,152 @@ workspace = true
             member_id_from_path("scripts/ci/gen-hooks/Cargo.toml"),
             "gen-hooks"
         );
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Invariant 3.5 — keywords / categories override allow-list
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn keywords_override_on_allowlisted_crate_is_suppressed() {
+        // `uffs-time` is on the keywords allow-list and uses a
+        // well-formed non-empty array — must not fire.
+        let text = MEMBER_CLEAN.replace(
+            "keywords.workspace = true",
+            r#"keywords = ["ntfs", "filetime", "datetime"]"#,
+        );
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-time/Cargo.toml", &m);
+        let exc = KnownExceptions::new();
+        let findings = audit_metadata_fields(&d, "uffs-time", &exc);
+        assert!(
+            !findings.iter().any(|f| f.detail.contains("`keywords`")),
+            "allow-listed keywords override should be suppressed; got: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn categories_override_on_allowlisted_crate_is_suppressed() {
+        let text = MEMBER_CLEAN.replace(
+            "categories.workspace = true",
+            r#"categories = ["date-and-time"]"#,
+        );
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-time/Cargo.toml", &m);
+        let exc = KnownExceptions::new();
+        let findings = audit_metadata_fields(&d, "uffs-time", &exc);
+        assert!(
+            !findings.iter().any(|f| f.detail.contains("`categories`")),
+            "allow-listed categories override should be suppressed; got: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn keywords_override_on_unlisted_crate_still_fires_3_5() {
+        // `uffs-core` is NOT on the keywords allow-list — override
+        // must fire even with a well-formed array.
+        let text = MEMBER_CLEAN.replace("keywords.workspace = true", r#"keywords = ["something"]"#);
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-core/Cargo.toml", &m);
+        let exc = KnownExceptions::new();
+        let findings = audit_metadata_fields(&d, "uffs-core", &exc);
+        let kw_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.detail.contains("`keywords`"))
+            .collect();
+        assert_eq!(
+            kw_findings.len(),
+            1,
+            "unlisted crate keywords override must fire 3.5; got: {findings:?}"
+        );
+        assert_eq!(kw_findings[0].invariant, "3.5");
+    }
+
+    #[test]
+    fn empty_keywords_array_on_allowlisted_crate_still_fires_3_5() {
+        // `uffs-time` is on the allow-list but the override is
+        // tightened to **non-empty** arrays.  `keywords = []` is
+        // legal TOML but defeats the discoverability purpose of an
+        // override; it must still fire.
+        let text = MEMBER_CLEAN.replace("keywords.workspace = true", "keywords = []");
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-time/Cargo.toml", &m);
+        let exc = KnownExceptions::new();
+        let findings = audit_metadata_fields(&d, "uffs-time", &exc);
+        let kw_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.detail.contains("`keywords`"))
+            .collect();
+        assert_eq!(
+            kw_findings.len(),
+            1,
+            "empty keywords array on listed crate must still fire 3.5; got: {findings:?}"
+        );
+        assert_eq!(kw_findings[0].invariant, "3.5");
+    }
+
+    #[test]
+    fn empty_categories_array_on_allowlisted_crate_still_fires_3_5() {
+        let text = MEMBER_CLEAN.replace("categories.workspace = true", "categories = []");
+        let m = parse_member(&text).unwrap();
+        let d = disc("crates/uffs-time/Cargo.toml", &m);
+        let exc = KnownExceptions::new();
+        let findings = audit_metadata_fields(&d, "uffs-time", &exc);
+        let cat_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.detail.contains("`categories`"))
+            .collect();
+        assert_eq!(
+            cat_findings.len(),
+            1,
+            "empty categories array on listed crate must still fire 3.5; got: {findings:?}"
+        );
+        assert_eq!(cat_findings[0].invariant, "3.5");
+    }
+
+    #[test]
+    fn keywords_and_categories_workspace_inherit_passes_for_every_member() {
+        // The default state (workspace inheritance) must pass for
+        // both allow-listed and non-allow-listed crates.
+        let m = parse_member(MEMBER_CLEAN).unwrap();
+        let exc = KnownExceptions::new();
+        for id in [
+            "uffs-core",
+            "uffs-time",
+            "uffs-text",
+            "uffs-client",
+            "uffs-mcp",
+            "uffs-mft",
+            "uffs-cli",
+            "uffs-broker",
+        ] {
+            let path = format!("crates/{id}/Cargo.toml");
+            let d = disc(&path, &m);
+            let findings = audit_metadata_fields(&d, id, &exc);
+            assert!(
+                !findings
+                    .iter()
+                    .any(|f| f.detail.contains("`keywords`") || f.detail.contains("`categories`")),
+                "`keywords.workspace = true` / `categories.workspace = true` must not fire for \
+                 `{id}`; got: {findings:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_non_empty_array_distinguishes_shapes() {
+        // Empty array → false.
+        let empty = toml::Value::Array(Vec::new());
+        assert!(!is_non_empty_array(Some(&empty)));
+        // Non-empty array → true.
+        let one = toml::Value::Array(vec![toml::Value::String("a".to_owned())]);
+        assert!(is_non_empty_array(Some(&one)));
+        // None → false.
+        assert!(!is_non_empty_array(None));
+        // Workspace-inheritance shape (table with `workspace = true`) → false.
+        let mut table = toml::value::Table::new();
+        table.insert("workspace".to_owned(), toml::Value::Boolean(true));
+        let inherit_value = toml::Value::Table(table);
+        assert!(!is_non_empty_array(Some(&inherit_value)));
     }
 }

--- a/scripts/ci/manifest-audit/src/manifest.rs
+++ b/scripts/ci/manifest-audit/src/manifest.rs
@@ -137,11 +137,22 @@ pub(crate) struct MemberPackage {
     pub(crate) readme: Option<toml::Value>,
 
     /// `keywords = ...` — Phase 1 invariant 3.5 requires
-    /// `.workspace = true`.
+    /// `.workspace = true`, with one narrowly scoped exception:
+    /// crates listed in `KnownExceptions::keywords_override_ok` may
+    /// instead set a **non-empty TOML array** of crates.io-shaped
+    /// keywords to tailor discoverability for their library role.
+    /// An empty array still fires (defeats the override's purpose).
+    /// Per-keyword shape rules (max 5, max 20 chars, regex) are
+    /// enforced authoritatively by `cargo publish --dry-run`.
     pub(crate) keywords: Option<toml::Value>,
 
     /// `categories = ...` — Phase 1 invariant 3.5 requires
-    /// `.workspace = true`.
+    /// `.workspace = true`, with the same narrow exception as
+    /// `keywords`: crates listed in
+    /// `KnownExceptions::categories_override_ok` may instead set a
+    /// **non-empty TOML array** of crates.io category slugs.  Slug
+    /// validity (`https://crates.io/category_slugs`) is enforced
+    /// authoritatively by `cargo publish --dry-run`.
     pub(crate) categories: Option<toml::Value>,
 
     /// `documentation = ...` — Phase 1 invariant 3.5 requires


### PR DESCRIPTION
## What

Mirrors the `readme_override_ok` pattern from #238 to two more
fingerprint metadata fields (`keywords`, `categories`) and applies the
override on the 4 library crates that materially benefit from
crates.io discoverability tailored to their library role (not the
workspace-app role).

## Why

Workspace defaults (root `Cargo.toml:71-72`):

```toml
keywords   = ["mft", "ntfs", "file-search", "windows", "polars"]
categories = ["filesystem", "command-line-utilities"]
```

These describe **the application**, not its libraries. Inheriting them
on `uffs-time` (a `#![no_std]` FILETIME helper) or `uffs-mcp` (an MCP
server for AI hosts) buries those crates in unrelated search results
on crates.io.

## Allow-list mechanism (`scripts/ci/manifest-audit/`)

| Change | Location |
|---|---|
| `KnownExceptions::keywords_override_ok: BTreeSet<&'static str>` | `audit.rs:90` |
| `KnownExceptions::categories_override_ok: BTreeSet<&'static str>` | `audit.rs:99` |
| Both initialised with `["uffs-client", "uffs-mcp", "uffs-text", "uffs-time"]` | `audit.rs:163-180` |
| `audit_metadata_fields` extended with the new exception branch | `audit.rs:462-475` |
| `is_non_empty_array(value)` helper | `audit.rs:485-489` |
| Docstrings on `keywords` / `categories` fields | `manifest.rs:139-156` |
| Phase 1 plan doc §3.5 entry | `docs/dev/architecture/code_clean/phase_1_manifest_implementation_plan.md` (local-only) |

### Tightening: non-empty TOML array only

The allow-list suppresses the invariant-3.5 finding **only when** the
override is a non-empty TOML array. `keywords = []` is legal TOML but
defeats the override's discoverability purpose, so it still fires.

Per-keyword shape rules (max 5, max 20 chars, regex
`^[a-zA-Z][a-zA-Z0-9_-]*$`) and per-category slug-set membership
(`https://crates.io/category_slugs`) are deliberately **not**
re-validated locally — `cargo publish --dry-run` in the weekly
`crates-io-dry-run.yml` workflow enforces them authoritatively against
crates.io's own validator. Re-implementing them here would duplicate
the source of truth and risk drifting from crates.io's rules.

### Test coverage (7 new tests, 24 total → all pass)

| Test | Coverage |
|---|---|
| `keywords_override_on_allowlisted_crate_is_suppressed` | happy path keywords |
| `categories_override_on_allowlisted_crate_is_suppressed` | happy path categories |
| `keywords_override_on_unlisted_crate_still_fires_3_5` | allow-list is scoped |
| `empty_keywords_array_on_allowlisted_crate_still_fires_3_5` | non-empty-only tightening |
| `empty_categories_array_on_allowlisted_crate_still_fires_3_5` | non-empty-only tightening |
| `keywords_and_categories_workspace_inherit_passes_for_every_member` | inheritance still works on 8 crate ids |
| `is_non_empty_array_distinguishes_shapes` | helper-function unit test (4 cases) |

## Per-crate overrides applied

| Crate | keywords | categories |
|---|---|---|
| `uffs-time` | `["ntfs", "filetime", "datetime", "windows", "no-std"]` | `["date-and-time"]` |
| `uffs-text` | `["unicode", "ntfs", "case-folding", "i18n", "filename"]` | `["text-processing"]` |
| `uffs-client` | `["ipc", "rpc", "client", "uffs", "daemon"]` | `["api-bindings", "filesystem"]` |
| `uffs-mcp` | `["mcp", "ai", "rmcp", "uffs", "protocol"]` | `["api-bindings", "command-line-utilities"]` |

`uffs-mft` and `uffs-cli` are **not** overridden — they ARE the
workspace-app role (`uffs-mft` is the MFT reader the app uses;
`uffs-cli` IS the app's CLI), so workspace defaults remain correct.

Each per-crate `Cargo.toml` change ships with a justification comment
block explaining the override and linking to the allow-list + issue
#241.

## Verification

```bash
cargo test -p uffs-manifest-audit                              # 24 passed, including 7 new
cargo run -p uffs-manifest-audit                               # silent → clean
cargo publish --dry-run -p uffs-time --allow-dirty             # OK (crates.io accepts keywords + category slug)
cargo publish --dry-run -p uffs-text --allow-dirty             # OK
cargo fmt --check -p uffs-manifest-audit                       # OK
cargo clippy -p uffs-manifest-audit --tests --no-deps -- -D warnings   # OK
```

Pre-commit `lint-fast` and pre-push `lint-pre-push` gates both pass.

`uffs-client` and `uffs-mcp` dry-runs still fail on the unrelated
polars-subtree publishability deviation (row 5 of
`docs/architecture/release-automation-plan.md`) — orthogonal to this
PR; they'll start passing automatically once polars upstream publishes
a chrono-compatible release.

## Adherence to the 5 user-mandated rules

1. **No suppression hacks** — the allow-list is the Phase 1 §3.5
   documented escape hatch (`deliberately overridden with
   justification`), scoped tightly (non-empty array, named crates
   only). No `#[allow(...)]`, no skipped tests.
2. **Surgical fix** — mirrors the existing #238 readme-override
   pattern without reshaping the audit's architecture. New helper is
   8 lines.
3. **Preserve behaviour** — non-listed crates still fire identical
   findings; listed crates with workspace inheritance still pass;
   empty-array override still fires for everyone. The 4 existing
   readme tests + every existing invariant test pass unchanged.
4. **Improve tests, don't dodge them** — 7 new tests covering all
   four corners of the new behaviour (suppression, no-suppression,
   empty-still-fires, inheritance-passes), plus the helper unit test.
5. **Documented & atomic** — single signed commit; manifest.rs
   docstrings, audit.rs docstrings, and Phase 1 plan doc (local)
   all updated; PR description explains every decision.

## Scope context

Part of the **crates.io publish-readiness umbrella** tracked in #241,
specifically **gap #1** (per-crate keywords + categories with
allow-list). After this merges, the actionable-now backlog for
crates.io publish prep is **closed** — only publish-day coordination
actions remain (crate-name reservations, flip `FAIL_ON_*=true` in
`crates-io-dry-run.yml`, flip `semver_check=true` in
`release-plz.toml`).

Refs: #238, #241
