### PR TITLE
docs(soak): close Phase 6 24-h re-run — 9/9 assertions PASS end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -731,6 +731,74 @@ hunting for the wrong things.
   ticks Phase 7 retroactively; Phase 6 stays open pending one
   more 24-h run with the trace-level harness fix.
 
+### Verified — Phase 6 24-h Windows-host soak closes end-to-end (2026-05-14/15)
+
+The last remaining v0.6.0 24-h-soak gate now closes against a
+live Windows-host capture.  `LOG/uffs_soak/phase6-20260514-122946/`
+ran for 24 h on the 7-drive reference box (2026-05-14 12:29:46Z
+→ 2026-05-15 12:29:46Z) against the post-PR-218 harness fix and
+the validator reported **9 of 9 assertions PASS** end-to-end.
+
+The §4.5b adaptive-bonus deferral (recorded in the 2026-05-11
+docs against the May 9-10 reference run, where the
+`RUST_LOG=shard.ttl=debug` filter dropped every `below-ttl`
+TRACE event carrying the bonused `warm_ttl_sec` field) now has
+direct end-to-end evidence:
+
+- **Drive C `min_tier=Warm` floor.**  0 `to=Parked` events on
+  letter=C across 24 h; **2 870** `Demote target clamped by
+  per-drive min_tier` debug events — proving the floor was
+  actively applied thousands of times, not merely coincidentally
+  not-tripped.
+- **Peer-drive demotion.**  D / E / F / G / M / S each fired
+  exactly 2 `Warm → Parked` transitions, confirming the
+  controller drives non-floor drives through the demote ladder
+  on the configured `warm_ttl_base_secs`.
+- **Adaptive TTL bonus.**  `C.max_warm_ttl = 3 786 s` vs
+  peer `max(warm_ttl_sec) = 300 s` — a **12.6× bonus** on the
+  high-rate drive, matching the `+600·log2(rate)` formula in
+  `crate::cache::policy::warm_ttl`.
+
+Memory trajectory across the 24-h window also validates the
+tiering machinery doing real work:
+
+```
+                          00h           23h         post-load
+Working Set (WS) :   6 746 800 128 →    22 888 448 →    69 238 784  (308× WS trim, 3× post-load re-page)
+Private Memory   :   8 293 457 920 → 1 791 188 992 → 1 669 558 272  (78 % real release as drives demoted)
+Virtual Memory   :  28 172 120 064 → 28 168 974 336 → 28 168 974 336 (flat — no address-space leak)
+NPM (non-paged)  :          26 736 →        26 328 →        26 328  (flat)
+```
+
+The 78 % private-memory release is materially different from
+the §4.5d ws-trace soak (where `pm_bytes` stayed within 3 % for
+24 h because the keep-warm worker held all 7 drives Warm).
+Here the controller actively demoted the 6 peer drives, which
+unloaded cold shards from memory and produced the real
+private-bytes release — exactly the intended tiering behavior
+under sustained idle.  The end-of-soak synthetic-load window
+on drive C re-paged recently-needed shards back into WS without
+re-allocating private memory (PM actually continued to fall
+slightly), confirming the page-cache vs. private-bytes split is
+healthy.
+
+No `panic` / `OutOfMemoryError` / `FATAL` log lines across the
+24-h window.  Full breakdown in
+[`docs/architecture/memory-tiering-windows-host-validation.md`](docs/architecture/memory-tiering-windows-host-validation.md)
+§6 sub-section §4.5e.
+
+With this closure, **all three v0.6.0 24-h-soak gates are
+green**:
+
+| Gate | Source | Result | Closed |
+|---|---|---|---|
+| Phase 6 (`min_tier=Warm` floor + adaptive bonus) | `phase6-20260514-122946/` | 9 / 9 PASS | 2026-05-15 |
+| Phase 7 (USN-journal churn) | `phase7-20260510-214412/` | 7 / 7 PASS (regex fix) | 2026-05-13 |
+| ws-trace (Working-Set trajectory) | `wstrace-20260513-113344/` | 4 / 4 PASS | 2026-05-13 |
+
+Only the one-week `main` bake remains per
+[`docs/architecture/memory-tiering-bake-criteria.md`](docs/architecture/memory-tiering-bake-criteria.md).
+
 ### Verified — Phase 7 + ws-trace 24-h Windows-host soaks (2026-05-13/14)
 
 Two of the three v0.6.0 24-h Windows-host soak gates close

--- a/docs/architecture/memory-tiering-bake-criteria.md
+++ b/docs/architecture/memory-tiering-bake-criteria.md
@@ -298,16 +298,22 @@ minor-bump invocation:
       "Consecutive" excludes weekends — 7 weekdays with at least one
       Mac and one Windows check each (full readiness on no-soak days,
       lightweight smoke on soak days).
-- [ ] **Phase 6 24-h soak captured** (§1.5) and `summary.txt` shows all
+- [x] **Phase 6 24-h soak captured** (§1.5) and `summary.txt` shows all
       assertions PASS — closes the master-plan §5.1 Phase 6 row.
 
-      Status (2026-05-13): 8 of 9 assertions PASS end-to-end in
-      `LOG/uffs_soak/phase6-20260509-213122/` (May 9-10 reference-box
-      run); the 9th (adaptive-bonus visibility) is deferred to a
-      re-run after PR #218's harness fix
-      (`shard.ttl=debug` → `shard.ttl=trace`) lands.  See
-      `memory-tiering-windows-host-validation.md` §6 sub-section
-      §4.5b for the root-cause walkthrough.  Daemon-side regression test
+      Status (2026-05-15): **9 of 9 assertions PASS end-to-end** in
+      `LOG/uffs_soak/phase6-20260514-122946/` (2026-05-14 reference-box
+      re-run against the post-PR-218 harness fix).  Drive C held its
+      `min_tier=Warm` floor across 24 h (0 to=Parked events, 2 870
+      `min-tier-clamp` debug events); the six peer drives each fired
+      2 `Warm → Parked` transitions; the adaptive-bonus criterion
+      that was deferred in the 2026-05-09 reference run is now
+      end-to-end verified (`C.max_warm_ttl = 3 786 s` vs peer max
+      300 s — 12.6× bonus).  See
+      `memory-tiering-windows-host-validation.md` §6 sub-sections
+      §4.5b (2026-05-11 deferral root-cause walkthrough) and §4.5e
+      (2026-05-14 closing capture with per-snapshot memory
+      trajectory).  Daemon-side regression test
       `crate::index::tests::shard_ttl_events::
       below_ttl_event_pins_target_level_message_and_reason`
       protects the wire-format contract against future drift.

--- a/docs/architecture/memory-tiering-readiness-validation-2026-05-05.md
+++ b/docs/architecture/memory-tiering-readiness-validation-2026-05-05.md
@@ -261,42 +261,49 @@ This capture closes the validation half of the v0.6.0 Definition of Done
 
 **Remaining items for the v0.6.0 cut (updated 2026-05-15):**
 
-1. **Phase 6 24-h Windows-host soak.**  One re-run pending
-   against the post-PR-218 harness fix (`shard.ttl=debug` →
-   `shard.ttl=trace`, which makes the catch-all `below-ttl`
-   events carrying the bonused `warm_ttl_sec` field visible to
-   the validator).  Pre-fix soak
-   (`LOG/uffs_soak/phase6-20260509-213122/`) verified 8 of 9
-   contracts end-to-end; criterion 3 (adaptive-bonus visibility)
-   was filtered out by the pre-fix log level, not a daemon-side
-   issue.  Daemon-side regression test
-   `crate::index::tests::shard_ttl_events::
-   below_ttl_event_pins_target_level_message_and_reason`
-   protects the wire-format contract against future drift.
+All 24-h-soak gates are now closed.  The remaining work is
+the bake period and the release-mechanics checklist:
 
-   **Phase 7 + ws-trace closed retroactively** (2026-05-13):
-   - **Phase 7**
-     (`LOG/uffs_soak/phase7-20260510-214412/`) — 11
-     `compact-cache save` events captured during the 24-h soak;
-     the pre-fix validator regex did not match the daemon's
-     actual log message.  PR #218 fixed the regex; closes 7 of
-     7 assertions on the existing log, no re-run needed.
-   - **ws-trace**
-     (`LOG/uffs_soak/wstrace-20260513-113344/`) — 4 of 4
-     assertions PASS.  Working Set dropped 30× via
-     `EmptyWorkingSet` page-trim while `pm_bytes` stayed flat
-     (−3 % over 24 h) and all 7 drives held Warm; no leak.
-
-   See
-   [`memory-tiering-windows-host-validation.md`](memory-tiering-windows-host-validation.md)
-   §6 sub-sections §4.5b (Phase 6) · §4.5c (Phase 7) · §4.5d
-   (ws-trace) for the full per-soak capture analysis.
-2. One-week bake on `main` per the criteria in
+1. One-week bake on `main` per the criteria in
    [`memory-tiering-bake-criteria.md`](memory-tiering-bake-criteria.md).
-3. CHANGELOG `Unreleased` → `0.6.0` finalize.
-4. Release notes drafted (this file is the primary input).
-5. Manual review of the diff `v0.5.85..v0.6.0`.
-6. `just ship` with `build/update_all_versions.rs minor`.
+2. CHANGELOG `Unreleased` → `0.6.0` finalize.
+3. Release notes drafted (this file is the primary input).
+4. Manual review of the diff `v0.5.85..v0.6.0`.
+5. `just ship` with `build/update_all_versions.rs minor`.
+
+**24-h-soak gate closures (paper trail):**
+
+- **Phase 6** — `LOG/uffs_soak/phase6-20260514-122946/`,
+  closed 2026-05-15.  9 of 9 assertions PASS end-to-end against
+  the post-PR-218 harness fix.  C held its `min_tier=Warm`
+  floor across 24 h (0 to=Parked events, 2 870 `min-tier-clamp`
+  debug events); the six peer drives each fired 2
+  `Warm → Parked` transitions; adaptive-bonus criterion
+  end-to-end verified (`C.max_warm_ttl=3 786 s` vs peer
+  max=300 s, 12.6×).  Daemon-side regression test
+  `crate::index::tests::shard_ttl_events::
+  below_ttl_event_pins_target_level_message_and_reason`
+  protects the wire-format contract against future drift.
+- **Phase 7** — `LOG/uffs_soak/phase7-20260510-214412/`,
+  closed retroactively 2026-05-13 via PR #218's validator
+  regex fix.  11 `compact-cache save` events captured during
+  the 24-h soak; no re-run needed (pure regex change against
+  the existing log).  Daemon-side regression test
+  `crate::cache::journal_loop::tests::save_log_message::
+  compact_cache_save_log_message_pins_string_target_and_level`
+  pins the literal log-message string.
+- **ws-trace** — `LOG/uffs_soak/wstrace-20260513-113344/`,
+  closed 2026-05-13.  4 of 4 assertions PASS.  Working Set
+  dropped 30× via `EmptyWorkingSet` page-trim while
+  `pm_bytes` stayed flat (−3 % over 24 h) and all 7 drives
+  held Warm; no leak.  Resolves the §4.5c "vacuous pass"
+  footnote.
+
+See
+[`memory-tiering-windows-host-validation.md`](memory-tiering-windows-host-validation.md)
+§6 sub-sections §4.5b (Phase 6 deferral root-cause) · §4.5c
+(Phase 7) · §4.5d (ws-trace) · §4.5e (Phase 6 closing capture)
+for the full per-soak capture analysis.
 
 The bake period now begins.  No new operator-surface features land on
 `main` until `v0.6.0` ships.
@@ -321,7 +328,10 @@ canonical paper trail for the **Phase 8 row flip**.
 | Date closed | 2026-05-05 |
 | Outstanding | None at the operator-surface level. (Phase 9 = "Hot-cold record split" remains explicitly **deferred** per the master-plan §3 Phase 9 GO / NO-GO rule — post-Phase-4 measurement decision, not a v0.6.0 blocker.) |
 
-The remaining gate work for v0.6.0 is the **Phase 6 24-h
-Windows-host soak re-run** (one more capture against the
-post-PR-218 harness fix) and the bake period.  Phase 7 and
-ws-trace are closed; Phase 8 has been closed since 2026-05-05.
+The remaining gate work for v0.6.0 is the **one-week `main` bake**
+per [`memory-tiering-bake-criteria.md`](memory-tiering-bake-criteria.md).
+Phase 6 closed 2026-05-15
+(`LOG/uffs_soak/phase6-20260514-122946/`, 9 of 9 assertions
+PASS), Phase 7 closed retroactively 2026-05-13 via PR #218's
+validator-regex fix, ws-trace closed 2026-05-13, and Phase 8
+has been closed since 2026-05-05.  No 24-h soaks remain.

--- a/docs/architecture/memory-tiering-windows-host-validation.md
+++ b/docs/architecture/memory-tiering-windows-host-validation.md
@@ -665,8 +665,10 @@ daemon's tracing fields, update these patterns in the same commit.
    should exceed the peers' by the `600·log2(rate)` bonus from
    the §5.2 formula (`crate::cache::policy::warm_ttl`).  Per-tick
    evidence requires `shard.ttl=trace` in `RUST_LOG` (see the
-   Setup block above and the 2026-05-11 finding in §6 sub-section
-   §4.5b).
+   Setup block above, the 2026-05-11 deferral analysis in §6
+   sub-section §4.5b, and the 2026-05-14 end-to-end closing
+   capture in §6 sub-section §4.5e — C.max_warm_ttl=3 786 s vs
+   peer max=300 s).
 
 #### Reset
 
@@ -1405,8 +1407,9 @@ The pre-2026-05-13 runbook `RUST_LOG` was
 `crate::cache::shard::tests::decay_ema_integrates_new_queries_into_rate_estimate`
 from PR #146; the field shape is pinned by the new regression
 test above).  **Direct end-to-end evidence of the adaptive bonus
-engaging during a synthetic-load window requires one more 24-h
-run with the harness fix on the Windows host.**
+engaging during a synthetic-load window** was captured in
+the post-PR-218 re-run on 2026-05-14 — see §4.5e below for the
+closing capture.
 
 ### 4.5c 2026-05-11 Phase 7 24-h capture — retroactively ALL GREEN
 
@@ -1548,6 +1551,84 @@ post-v0.6.0; not a blocker because:
 
 **ws-trace closes** — all 4 assertions PASS end-to-end on the
 existing capture; no re-run needed.
+
+### 4.5e 2026-05-14 Phase 6 24-h re-run — ALL GREEN end-to-end
+
+Source: `LOG/uffs_soak/phase6-20260514-122946/` (24-h run on the
+7-drive reference box, 2026-05-14 12:29:46Z → 2026-05-15
+12:29:46Z, against the post-PR-218 harness fix).
+
+Run summary: **9 of 9 harness assertions PASS** — the §4.5b
+deferred adaptive-bonus criterion now has direct end-to-end
+evidence.
+
+| Contract (from §2 above) | 24-h evidence | Status |
+|---|---|---|
+| 1. `C` never demotes below `Warm` | 0 `to=Parked` events for letter=C; **2 870** `Demote target clamped by per-drive min_tier` debug events | ✅ end-to-end verified |
+| 2. Peer drives demote `Warm → Parked` normally | D / E / F / G / M / S each fired **2** Warm→Parked transitions | ✅ end-to-end verified |
+| 3. Adaptive TTL bonus (`+600·log2(rate)`) engages under load | C.max_warm_ttl=**3 786 s** vs max(peers.max_warm_ttl)=**300 s** — bonus = **12.6× peer baseline** | ✅ **end-to-end verified** (was §4.5b ⚠️) |
+
+**Why this re-run was needed.**  The §4.5b deferral was a
+harness-side log-level filter: the `RUST_LOG=shard.ttl=debug`
+filter dropped every `below-ttl` TRACE event, which is the only
+event class that carries the bonused `warm_ttl_sec` field
+during the synthetic-load window (drive C sits in Warm/Hot
+with `idle_secs ≈ 0`, so the demote-eval ladder never reaches
+either DEBUG arm).  PR #218 raised the harness filter to
+`shard.ttl=trace`; this re-run is the first 24-h soak captured
+against that fix.
+
+**Memory trajectory.**  In addition to the 9 contract
+assertions, the hourly process snapshots show the tiering
+machinery doing real work:
+
+```
+                          00h           23h         post-load
+Working Set (WS) :  6 746 800 128  →  22 888 448  →  69 238 784  (308× WS trim, 3× post-load)
+Private Memory   :  8 293 457 920  → 1 791 188 992 → 1 669 558 272 (78 % drop, real release)
+Virtual Memory   : 28 172 120 064  → 28 168 974 336 → 28 168 974 336 (flat — no address-space leak)
+NPM (non-paged)  :         26 736  →        26 328 →         26 328 (flat)
+```
+
+This is materially different from §4.5d's ws-trace
+trajectory, where `pm_bytes` stayed within 3 % over 24 h
+because the keep-warm worker held all 7 drives in Warm.  Here
+the controller actively demoted the 6 peer drives Warm → Parked
+twice each, which unloaded cold shards from memory and produced
+the **78 % private-memory release** — exactly the intended
+tiering-machinery behavior under sustained idle.
+
+The synthetic-load window at end-of-soak then re-paged
+recently-needed shards back into WS (22 MiB → 66 MiB, 3×)
+without growing private memory (which actually continued to
+fall slightly), confirming the page-cache vs. private-bytes
+split is healthy: the daemon brings pages back from standby
+on access rather than re-allocating.
+
+**Operational signals (informational, not gate criteria).**
+
+* `daemon.log` size: 530 454 lines / 78 MiB.  Bulk of the
+  volume is the expected `journal_loop=info` per-tick TRACE on
+  drives whose USN journal isn't active (M and G — non-system
+  drives with no journal enabled, a benign Win32 error 1179
+  surfaced as `WARN Journal poll failed; retrying next tick`).
+  The PR-#218 `shard.ttl=trace` filter added an additional
+  ~23 k events as predicted in §4.5b.
+* `0` `panic` / `OutOfMemoryError` / `FATAL` log lines across
+  24 h — same clean-run shape as §4.5c Phase 7.
+* All 24 hourly snapshots captured (`snapshots/00h-process.json`
+  through `snapshots/23h-process.json` plus
+  `snapshots/post-load-process.json`).
+* All 9 `validation/*.pass` breadcrumb files written.
+
+**Phase 6 closes** — 9 of 9 assertions PASS end-to-end against
+the live Windows host; no further re-runs needed.  The
+`bake-criteria.md` §3 Phase-6 checkbox can now be ticked.
+Combined with §4.5c (Phase 7 closes retroactively), §4.5d
+(ws-trace closes), and the existing Phase 8 closure from
+2026-05-05, this exhausts the v0.6.0 24-h-soak gate slate.
+Only the one-week `main` bake remains per
+[`memory-tiering-bake-criteria.md`](memory-tiering-bake-criteria.md).
 
 ### 4.6 Lifecycle load-stall force-retire at 2 h 11 min (Phase 7 scope)
 


### PR DESCRIPTION
## Summary

The last remaining v0.6.0 24-h-soak gate now closes against a live Windows-host capture.

`LOG/uffs_soak/phase6-20260514-122946/` ran for 24 h on the 7-drive reference box (2026-05-14 12:29:46Z → 2026-05-15 12:29:46Z) against the post-PR-218 harness fix (\`shard.ttl=debug\` → \`shard.ttl=trace\`).  Validator reported **9 of 9 assertions PASS** end-to-end.

## Contract evidence

| Contract | Evidence | Status |
|---|---|---|
| C never demotes below Warm | 0 \`to=Parked\` events for letter=C; **2 870** \`Demote target clamped by per-drive min_tier\` debug events | ✅ end-to-end |
| Peer drives demote Warm → Parked | D / E / F / G / M / S each fired **2** transitions | ✅ end-to-end |
| Adaptive TTL bonus engages | C.max_warm_ttl=**3 786 s** vs peer max=**300 s** (12.6× bonus) | ✅ end-to-end (was §4.5b ⚠️) |

## Memory trajectory

\`\`\`
                          00h            23h          post-load
Working Set (WS) :  6 746 800 128  →   22 888 448  →   69 238 784  (308× WS trim, 3× post-load re-page)
Private Memory   :  8 293 457 920  → 1 791 188 992 → 1 669 558 272 (78 % real release as drives demoted)
Virtual Memory   : 28 172 120 064  → 28 168 974 336 → 28 168 974 336 (flat — no address-space leak)
NPM (non-paged)  :         26 736  →        26 328 →        26 328 (flat)
\`\`\`

The 78 % PM release is **materially different** from §4.5d ws-trace (where pm_bytes stayed within 3 % because the keep-warm worker held all 7 drives Warm).  Here the controller actively demoted the 6 peer drives, which unloaded cold shards from memory — exactly the intended tiering behavior.  The end-of-soak synthetic-load window on C re-paged recently-needed shards back into WS without re-allocating PM (PM actually continued to fall slightly).

No \`panic\` / \`OutOfMemoryError\` / \`FATAL\` log lines across the 24-h window.

## Why the re-run was needed (§4.5b deferral root-cause)

The pre-fix soak (\`phase6-20260509-213122/\`) was filtered by \`RUST_LOG=shard.ttl=debug\`, which dropped every \`below-ttl\` TRACE event — the only event class carrying the bonused \`warm_ttl_sec\` field during the synthetic-load window (because drive C sits in Warm/Hot with \`idle_secs ≈ 0\`, so the demote-eval ladder never reaches either DEBUG arm).

PR #218 raised the harness filter to \`shard.ttl=trace\`.  This re-run is the first 24-h soak captured against that fix.

## Docs updated

| File | Change |
|---|---|
| \`docs/architecture/memory-tiering-windows-host-validation.md\` | New §4.5e closing capture sub-section.  §4.5b's closing paragraph forwards to §4.5e.  §2 criterion 3 cross-ref picks up §4.5e. |
| \`docs/architecture/memory-tiering-bake-criteria.md\` | §3 Phase-6 checkbox ticked \`[x]\`; status text refreshed; cross-refs §4.5b + §4.5e. |
| \`docs/architecture/memory-tiering-readiness-validation-2026-05-05.md\` | Remaining-items list restructured: Phase 6 removed (closed); paper-trail subsection added for Phase 6 / Phase 7 / ws-trace closures; §6 closure note refreshed. |
| \`CHANGELOG.md\` | New \"Verified — Phase 6 24-h Windows-host soak closes end-to-end (2026-05-14/15)\" entry under Unreleased, with gate-status table showing all three v0.6.0 24-h-soak gates green. |

## v0.6.0 gate slate

| Gate | Source | Result | Closed |
|---|---|---|---|
| Phase 6 (\`min_tier=Warm\` floor + adaptive bonus) | \`phase6-20260514-122946/\` | 9 / 9 PASS | **2026-05-15** |
| Phase 7 (USN-journal churn) | \`phase7-20260510-214412/\` | 7 / 7 PASS (regex fix) | 2026-05-13 |
| ws-trace (Working-Set trajectory) | \`wstrace-20260513-113344/\` | 4 / 4 PASS | 2026-05-13 |

**Only the one-week \`main\` bake remains.**

## Discipline notes

- Pure-docs PR; no Rust changes.
- Atomic single-purpose commit, GPG-signed.
- Pre-push gates green locally (lint-fast: 3s; lint-pre-push: 4s).
- No suppression hacks; no tests touched; no public-API changes.