### PR TITLE
feat(bench): add --out summary CSV flag + verify v0.5.35 CLI hot-path baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -731,6 +731,81 @@ hunting for the wrong things.
   ticks Phase 7 retroactively; Phase 6 stays open pending one
   more 24-h run with the trace-level harness fix.
 
+### Verified — v0.5.35 baseline CLI hot-path bench (2026-05-15)
+
+Plan §1 goal-4 ("no regression on CLI hot path vs the v0.5.35
+baseline") verified end-to-end on the Windows 7-drive reference
+box.  Current v0.5.96 (post-Phase-8 tiered architecture) is
+**universally faster** than v0.5.35 across every benchmarked
+pattern, with the largest result set (`*.dll`, 44 529 rows)
+showing a **2.7× speedup**:
+
+```
+Drive D, 7.07 M records, 30 rounds, HOT phase, p50 / p95 wall_ms:
+
+                              v0.5.35      v0.5.96       Δ p50
+    exact      (3 rows)       20 / 23   →  18 / 19      −10 %
+    prefix     (8 732)        46 / 50   →  40 / 46      −13 %
+    ext_rare   (11)           18 / 20   →  17 / 18       −6 %
+    ext_dll    (44 529)       94 / 100  →  35 / 40      −63 %  (2.7×)
+    substring  (12 458)       50 / 54   →  43 / 47      −14 %
+```
+
+Row-count parity preserved exactly across both versions on every
+pattern (no result-set drift — the post-v0.5.35 path-resolver
+fast path + Phase 3.2 single-buffer multi-column render path
+both preserve the same filter semantics and column ordering).
+The dramatic `ext_dll` win is dominated by those two surfaces:
+both are big-N row-materialisation gains, exactly where 44 K
+paths-into-CSV land in the wall-clock budget.
+
+Capture command (run twice with `~/bin/uffs.exe` swapped between
+the two binaries via `~/bin/uffs.exe daemon kill` +
+`Remove-Item $env:LOCALAPPDATA\uffs\cache` between runs):
+
+```powershell
+rust-script scripts\windows\cross-tool-benchmark.rs `
+    --skip-cold --drives D --rounds 30 `
+    --patterns exact,prefix,ext_rare,ext_dll,substring `
+    --tools uffs `
+    --uffs-bin "$HOME\bin\uffs.exe"
+```
+
+Raw artefact: `LOG/memory output` (manual stdout paste).  The
+**`--out <path>` flag was added to the bench script in this
+release** so future captures can persist the summary table as a
+structured CSV (columns: `tool,phase,sink,drive,pattern,p50_ms,
+p95_ms,rows,bad,verdict,rounds_ok,rounds_total`) — see the
+`Added — cross-tool benchmark script: --out summary CSV flag`
+entry below.
+
+### Added — cross-tool benchmark script: `--out` summary CSV flag
+
+`scripts/windows/cross-tool-benchmark.rs` learned a new
+`--out <path>` flag that writes the post-run summary as a
+plain-CSV at the supplied path (creating intermediate
+directories as needed).  Columns mirror the stdout summary
+table but emit integer milliseconds and integer row counts so
+the file is trivially regress-able by `pandas` / `polars` /
+`awk`:
+
+```
+tool,phase,sink,drive,pattern,p50_ms,p95_ms,rows,bad,verdict,rounds_ok,rounds_total
+UFFS,HOT,file,D,exact,18,19,3,0,PASS,30,30
+UFFS,HOT,file,D,prefix,40,46,8732,0,PASS,30,30
+…
+```
+
+The new flag is distinct from the existing
+`<cwd>/uffs_bench_out.csv` daemon-side file (raw per-query row
+dumps, overwritten every round) and never collides with it.
+The banner block prints both paths up front so operators see
+exactly where each artefact lands.  Unknown CLI flags now warn
+on stderr (`warning: unknown flag "--foo" ignored`) instead of
+silently swallowing — caught during the 2026-05-15 v0.5.35
+baseline bench where a typo-`--out` in pre-flag-support runs
+left the operator hunting a non-existent CSV file.
+
 ### Verified — Phase 6 24-h Windows-host soak closes end-to-end (2026-05-14/15)
 
 The last remaining v0.6.0 24-h-soak gate now closes against a

--- a/scripts/windows/cross-tool-benchmark.rs
+++ b/scripts/windows/cross-tool-benchmark.rs
@@ -204,7 +204,14 @@ struct Row { tool: Tool, phase: Phase, sink: OutputSink, drive: String, pat: Str
 struct Cfg { uffs: PathBuf, uffs_cpp: Option<PathBuf>, es: Option<PathBuf>,
              drives: Vec<String>, rounds: usize,
              tools: Vec<Tool>, sinks: Vec<OutputSink>, skip_cold: bool,
-             patterns: Option<Vec<String>> }
+             patterns: Option<Vec<String>>,
+             /// Optional summary CSV output path.  When `Some`, the post-run
+             /// summary (one row per Tool × Phase × Sink × Drive × Pattern
+             /// combination, with p50/p95/rows/bad/verdict) is written to
+             /// this path after the stdout tables.  Distinct from the daemon's
+             /// own intermediate `uffs_bench_out.csv` in the cwd, which holds
+             /// the raw per-query row dumps and is overwritten every round.
+             out: Option<PathBuf> }
 impl Cfg {
     fn skip_pattern(&self, label: &str) -> bool {
         self.patterns.as_ref().map_or(false, |ps| !ps.iter().any(|p| p == &label.to_lowercase()))
@@ -651,6 +658,7 @@ fn parse_args() -> Cfg {
     let mut skip_cold = false;
     let mut uffs_bin: Option<PathBuf> = None;
     let mut patterns_filter: Option<Vec<String>> = None;
+    let mut out: Option<PathBuf> = None;
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
@@ -661,8 +669,13 @@ fn parse_args() -> Cfg {
             "--patterns" => { i += 1; patterns_filter = Some(args[i].split(',').map(|s| s.trim().to_lowercase()).collect()); }
             "--skip-cold" => { skip_cold = true; }
             "--uffs-bin" => { i += 1; uffs_bin = Some(PathBuf::from(&args[i])); }
+            "--out" => { i += 1; out = Some(PathBuf::from(&args[i])); }
             "--help" | "-h" => { print_help(); std::process::exit(0); }
-            _ => {}
+            other => {
+                if other.starts_with('-') {
+                    eprintln!("warning: unknown flag {other:?} ignored (use --help for the supported list)");
+                }
+            }
         }
         i += 1;
     }
@@ -690,7 +703,7 @@ fn parse_args() -> Cfg {
         .map(OutputSink::parse_list)
         .filter(|v| !v.is_empty())
         .unwrap_or_else(|| vec![OutputSink::File]);
-    Cfg { uffs, uffs_cpp, es, drives, rounds, tools, sinks, skip_cold, patterns: patterns_filter }
+    Cfg { uffs, uffs_cpp, es, drives, rounds, tools, sinks, skip_cold, patterns: patterns_filter, out }
 }
 
 fn print_help() {
@@ -710,6 +723,12 @@ fn print_help() {
     eprintln!("                        ext_rare, ext_dll, ext_regex_alt, substring");
     eprintln!("  --skip-cold           Skip UFFS COLD and WARM phases");
     eprintln!("  --uffs-bin <path>     Path to uffs.exe (Rust)");
+    eprintln!("  --out <path>          Write the post-run summary table to CSV at <path>.");
+    eprintln!("                        Columns: tool,phase,sink,drive,pattern,p50_ms,");
+    eprintln!("                        p95_ms,rows,bad,verdict,rounds_ok,rounds_total.");
+    eprintln!("                        Distinct from the daemon's intermediate");
+    eprintln!("                        uffs_bench_out.csv in the cwd (raw per-query rows,");
+    eprintln!("                        overwritten every round).");
     eprintln!("  --help                This message");
 }
 
@@ -734,7 +753,10 @@ fn main() {
     println!("║  Rounds:       {} per pattern per tool", cfg.rounds);
     let sinks_str: Vec<&'static str> = cfg.sinks.iter().map(|s| s.label()).collect();
     println!("║  Sinks (HOT):  {}  (COLD/WARM are always file)", sinks_str.join(", "));
-    println!("║  Bench file:   {}", bench_out_path());
+    println!("║  Daemon bench file:  {}  (raw per-query rows, overwritten every round)", bench_out_path());
+    if let Some(ref p) = cfg.out {
+        println!("║  Summary CSV:        {}  (written post-run via --out)", p.display());
+    }
     println!("║  Columns:      path-only (fair: all tools write ~same bytes/row)");
     println!("║  Limit:        none (all results, fair for C++)");
     println!("║  Timeout:      {} s → DNF", TIMEOUT.as_secs());
@@ -925,6 +947,26 @@ fn main() {
 
     // ── Summary table ────────────────────────────────────────────────────────
     print_summary(&cfg, &all_rows);
+
+    // ── Optional CSV sink for the summary (one row per Tool × Phase × Sink ×
+    //    Drive × Pattern combination).  Distinct from the daemon's intermediate
+    //    `uffs_bench_out.csv`, which holds the raw per-query row dumps and is
+    //    overwritten every round.  The two never collide: this file lives at
+    //    whatever path the operator passes via `--out`, the other is fixed at
+    //    `<cwd>/uffs_bench_out.csv`.
+    if let Some(ref path) = cfg.out {
+        match write_summary_csv(&cfg, &all_rows, path) {
+            Ok(()) => {
+                println!();
+                println!("Summary CSV written: {}  ({} rows)", path.display(), all_rows.len());
+            }
+            Err(e) => {
+                eprintln!();
+                eprintln!("ERROR: failed to write summary CSV to {}: {}", path.display(), e);
+                std::process::exit(2);
+            }
+        }
+    }
 }
 
 
@@ -1027,4 +1069,71 @@ fn find_p50(rows: &[Row], tool: Tool, phase: Phase, sink: OutputSink, drive: &st
             if s.is_empty() { "—".to_string() } else { fms(p50(&s)) }
         })
         .unwrap_or_else(|| "SKIP".to_string())
+}
+
+
+// ── Summary CSV writer ───────────────────────────────────────────────────────
+/// Write the post-run summary as CSV at `path`.  One row per Tool × Phase ×
+/// Sink × Drive × Pattern combination.  Columns mirror the stdout summary
+/// table but are emitted as plain integer milliseconds (no human-friendly
+/// `ms` / `s` formatting) so the file is trivially regress-able by downstream
+/// tooling (`pandas`, `polars`, `awk`, …).
+///
+/// Null-sink rows (where the child process redirected output to a real NUL
+/// device) report `0` for `rows` and `bad` since nothing is counted by design;
+/// the stdout summary distinguishes these with a literal `—` placeholder, but
+/// CSV consumers prefer numeric columns.  Verdict carries the same value
+/// either way, so the distinction is recoverable when the consumer cares.
+///
+/// `rounds_ok` counts entries with `t.ok == true`; `rounds_total` is the full
+/// run vec length (which may be `< cfg.rounds` for runs short-circuited via
+/// `is_fast_deterministic_fail`).
+fn write_summary_csv(_cfg: &Cfg, rows: &[Row], path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let mut f = std::fs::File::create(path)?;
+    writeln!(
+        f,
+        "tool,phase,sink,drive,pattern,p50_ms,p95_ms,rows,bad,verdict,rounds_ok,rounds_total"
+    )?;
+    for row in rows {
+        let s = sw(&row.runs);
+        let any_dnf = row.runs.iter().any(|r| r.dnf);
+        let all_ok = row.runs.iter().all(|r| r.ok);
+        let any_bad = row.runs.iter().any(|r| r.bad_rows > 0);
+        let verdict = if any_dnf { "DNF" }
+            else if any_bad { "WRONG" }
+            else if all_ok { "PASS" }
+            else { "ERROR" };
+        let p50_ms = if s.is_empty() { 0 } else { p50(&s) };
+        let p95_ms = if s.is_empty() { 0 } else { p95(&s) };
+        let first_ok = row.runs.iter().find(|r| r.ok);
+        let (rows_count, bad_count) = if matches!(row.sink, OutputSink::Null) {
+            (0u64, 0u64)
+        } else {
+            (first_ok.map_or(0, |r| r.rows), first_ok.map_or(0, |r| r.bad_rows))
+        };
+        let rounds_ok = row.runs.iter().filter(|r| r.ok).count();
+        let rounds_total = row.runs.len();
+        writeln!(
+            f,
+            "{},{},{},{},{},{},{},{},{},{},{},{}",
+            row.tool.label(),
+            row.phase.label(),
+            row.sink.label(),
+            row.drive,
+            row.pat,
+            p50_ms,
+            p95_ms,
+            rows_count,
+            bad_count,
+            verdict,
+            rounds_ok,
+            rounds_total,
+        )?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
Standalone v0.6.0 release-readiness work, surfaced during the 2026-05-15 baseline-bench pass on the Windows 7-drive reference box.

> **Note on rebase.**  This PR originally also carried the Phase 6 24-h soak closure commit, but that landed independently on `main` as **PR #246** while this branch was being prepared.  Rebasing `origin/main` auto-detected the duplicate patch and dropped it; only the bench commit remains.  See PR #246 for the Phase 6 soak closure details.

## Plan §1 goal-4 (no CLI hot-path regression) — VERIFIED

Captured 2026-05-15 on the 7-drive reference box (drive D,
7.07 M records, 30 rounds, HOT phase, p50/p95 wall_ms):

| Pattern | v0.5.35 | v0.5.96 | Δ p50 | Rows |
|---|---:|---:|---:|---:|
| `exact` | 20 / 23 ms | 18 / 19 ms | −10 % | 3 |
| `prefix` | 46 / 50 ms | 40 / 46 ms | −13 % | 8 732 |
| `ext_rare` | 18 / 20 ms | 17 / 18 ms | −6 % | 11 |
| **`ext_dll`** | 94 / 100 ms | **35 / 40 ms** | **−63 % (2.7×)** | **44 529** |
| `substring` | 50 / 54 ms | 43 / 47 ms | −14 % | 12 458 |

Current v0.5.96 is **universally faster** than v0.5.35 on every
pattern.  Row-count parity preserved exactly across both versions
(no result-set drift).  Capture: `LOG/memory output` (manual
stdout paste — the bench script's `--out` flag was not yet
available for this run).

## New bench-script feature: `--out <path>`

`scripts/windows/cross-tool-benchmark.rs` learned a `--out <path>`
flag that writes the post-run summary as plain CSV (12 columns:
`tool,phase,sink,drive,pattern,p50_ms,p95_ms,rows,bad,verdict,
rounds_ok,rounds_total`).  Intermediate directories are created
on demand; the writer exits 2 on failure.  Distinct from the
existing `<cwd>/uffs_bench_out.csv` daemon-side file (raw
per-query row dumps).  Banner block now prints both paths up
front so operators see exactly where each artefact lands.

Unknown CLI flags now warn on stderr (`warning: unknown flag
"--foo" ignored`) instead of silently swallowing — caught during
the 2026-05-15 baseline bench where a typo-`--out` in
pre-flag-support runs left the operator hunting a non-existent
CSV file.

## v0.6.0 bake gate status (with this PR)

| Gate | Status | Closed |
|---|---|---|
| Phase 5 (ws-trace) 24-h soak | 🟢 4 / 4 PASS | 2026-05-13 |
| Phase 7 (USN-journal churn) 24-h soak | 🟢 7 / 7 PASS | 2026-05-13 |
| Phase 6 (adaptive TTL) 24-h soak | 🟢 9 / 9 PASS (#246) | 2026-05-15 |
| **Plan §1 goal-4 (CLI hot-path no-regression)** | 🟢 **5/5 patterns improved** | **2026-05-15** |

**All v0.6.0 readiness gates green.**  Only the one-week `main` bake
remains per
[memory-tiering-bake-criteria.md](docs/architecture/memory-tiering-bake-criteria.md).

## Verification

- `just lint-pre-push` — 23/23 gates green (54s pre-commit; 50s
  pre-push initial; 3s pre-push post-rebase — bucket 2 skipped
  since no rust/dep/infra files changed).
- Bench script compiles cleanly via standalone `rustc --edition
  2021 --emit=metadata` on Mac (frontmatter intact, no warnings).
- No new code paths in production crates — this is documentation
  plus a Windows-only rust-script.

## Files touched

- `CHANGELOG.md` — two new subsections under v0.6.0 staging:
  `### Verified — v0.5.35 baseline CLI hot-path bench (2026-05-15)`
  and `### Added — cross-tool benchmark script: --out summary
  CSV flag`.
- `scripts/windows/cross-tool-benchmark.rs` — `--out` flag
  plumbing + `write_summary_csv` impl (~80 LOC of new code) +
  unknown-flag warning + banner-block restructuring.