### PR TITLE
fix(ci): keep release 'Show binary sizes' green on non-Windows targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,9 +370,11 @@ jobs:
         shell: bash
         run: |
           echo "📐 Release binary sizes:"
-          # Glob over the shipping-set names instead of `ls | grep` (SC2010);
-          # `nullglob` keeps the loop silent when a target dir hasn't built.
-          shopt -s nullglob
+          # Iterate the explicit shipping-set names (avoids `ls | grep`, SC2010).
+          # Use `if … then … fi` rather than `[[ -f $bin ]] && ls …` so a missing
+          # file on the final iteration does not propagate exit-1 out of the
+          # loop under `bash -e` (e.g. uffs-mft.exe is absent on non-Windows
+          # targets, which broke release pipeline #96 / v0.5.97).
           for bin in target/${{ matrix.target }}/release/uffs \
                      target/${{ matrix.target }}/release/uffsd \
                      target/${{ matrix.target }}/release/uffsmcp \
@@ -381,7 +383,9 @@ jobs:
                      target/${{ matrix.target }}/release/uffsd.exe \
                      target/${{ matrix.target }}/release/uffsmcp.exe \
                      target/${{ matrix.target }}/release/uffs-mft.exe; do
-            [[ -f "$bin" ]] && ls -lh "$bin"
+            if [[ -f "$bin" ]]; then
+              ls -lh "$bin"
+            fi
           done
 
       - name: Package binaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,7 +735,7 @@ hunting for the wrong things.
 
 Plan §1 goal-4 ("no regression on CLI hot path vs the v0.5.35
 baseline") verified end-to-end on the Windows 7-drive reference
-box.  Current v0.5.96 (post-Phase-8 tiered architecture) is
+box.  Current v0.5.97 (post-Phase-8 tiered architecture) is
 **universally faster** than v0.5.35 across every benchmarked
 pattern, with the largest result set (`*.dll`, 44 529 rows)
 showing a **2.7× speedup**:
@@ -743,7 +743,7 @@ showing a **2.7× speedup**:
 ```
 Drive D, 7.07 M records, 30 rounds, HOT phase, p50 / p95 wall_ms:
 
-                              v0.5.35      v0.5.96       Δ p50
+                              v0.5.35      v0.5.97       Δ p50
     exact      (3 rows)       20 / 23   →  18 / 19      −10 %
     prefix     (8 732)        46 / 50   →  40 / 46      −13 %
     ext_rare   (11)           18 / 20   →  17 / 18       −6 %
@@ -919,7 +919,7 @@ log-message renames fail CI before reaching another 24-h soak.
   2026-05-13.  No new operator-surface features land on `main`
   until v0.6.0 ships.
 
-## [0.5.96] - 2026-05-08
+## [0.5.97] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -928,7 +928,7 @@ log-message renames fail CI before reaching another 24-h soak.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.96`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.97`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,7 +735,7 @@ hunting for the wrong things.
 
 Plan §1 goal-4 ("no regression on CLI hot path vs the v0.5.35
 baseline") verified end-to-end on the Windows 7-drive reference
-box.  Current v0.5.97 (post-Phase-8 tiered architecture) is
+box.  Current v0.5.98 (post-Phase-8 tiered architecture) is
 **universally faster** than v0.5.35 across every benchmarked
 pattern, with the largest result set (`*.dll`, 44 529 rows)
 showing a **2.7× speedup**:
@@ -743,7 +743,7 @@ showing a **2.7× speedup**:
 ```
 Drive D, 7.07 M records, 30 rounds, HOT phase, p50 / p95 wall_ms:
 
-                              v0.5.35      v0.5.97       Δ p50
+                              v0.5.35      v0.5.98       Δ p50
     exact      (3 rows)       20 / 23   →  18 / 19      −10 %
     prefix     (8 732)        46 / 50   →  40 / 46      −13 %
     ext_rare   (11)           18 / 20   →  17 / 18       −6 %
@@ -919,7 +919,7 @@ log-message renames fail CI before reaching another 24-h soak.
   2026-05-13.  No new operator-surface features land on `main`
   until v0.6.0 ships.
 
-## [0.5.97] - 2026-05-08
+## [0.5.98] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -928,7 +928,7 @@ log-message renames fail CI before reaching another 24-h soak.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.97`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.98`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,14 +4346,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "clap",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "chrono",
  "itoa",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "clap",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "clap",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "clap",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "axum",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4581,14 +4581,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4603,14 +4603,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.96"
+version = "0.5.97"
 
 [[package]]
 name = "unarray"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,14 +4346,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "clap",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "chrono",
  "itoa",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "clap",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "clap",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "clap",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "axum",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4581,14 +4581,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4603,14 +4603,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.97"
+version = "0.5.98"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.97"
+version = "0.5.98"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires
@@ -116,21 +116,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.97" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.97" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.97" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.97" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.97" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.97" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.97" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.97" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.98" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.98" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.98" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.98" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.98" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.98" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.98" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.98" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.97" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.98" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.96"
+version = "0.5.97"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires
@@ -116,21 +116,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.96" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.96" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.96" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.96" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.96" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.96" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.96" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.96" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.97" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.97" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.97" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.97" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.97" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.97" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.97" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.97" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.96" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.97" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -30,7 +30,7 @@
 # CI pipeline will auto-refresh on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed — use that flag (or plain `just ship`) while the upstream regression
 # persists.
-channel = "nightly-2026-05-14"
+channel = "nightly-2026-05-15"
 
 # Specify components that should always be available
 components = [


### PR DESCRIPTION
## What

Release pipeline **#96 (v0.5.97)** failed on the `x86_64-unknown-linux-gnu` and `aarch64-apple-darwin` matrix legs at the **Show binary sizes** step.  Only `x86_64-pc-windows-msvc` passed, so **Create GitHub Release** was skipped and **no v0.5.97 assets shipped** — \`gh release view v0.5.97\` returns \"release not found\" even though the \`v0.5.97\` tag exists on \`main\`.

## Root cause

\`\`\`yaml
for bin in target/.../uffs \\
           ...
           target/.../uffs-mft.exe; do
  [[ -f \"\$bin\" ]] && ls -lh \"\$bin\"
done
\`\`\`

GitHub Actions runs \`shell: bash\` as \`bash --noprofile --norc -e -o pipefail\`.

- The loop iterates **literal** paths (not globs), so the preceding \`shopt -s nullglob\` did nothing — the comment was misleading.
- On Linux/macOS the **final** iterated path is \`uffs-mft.exe\`, which never exists for those targets.
- \`[[ -f \$bin ]]\` returns false → the trailing \`&&\` short-circuit makes the iteration exit \`1\`.
- The exit status of a \`for\` loop is the exit status of its **last** command.  Because the failure lands on the final iteration, the whole loop returns \`1\`, and \`set -e\` propagates that as a step failure.
- On Windows-MSVC the final path *does* exist, so the loop returns \`0\` there.  That is why only two of three targets broke.

Regression introduced in \`0202b5496\` (PR #227 — \"Phase 1-2 follow-up trifecta\").

## Fix

- Replace \`[[ -f \"\$bin\" ]] && ls -lh \"\$bin\"\` with an explicit \`if [[ -f \"\$bin\" ]]; then ls -lh \"\$bin\"; fi\` so a missing file is a clean no-op rather than a non-zero exit.
- Drop the misleading \`shopt -s nullglob\` line and its comment — the loop iterates literal strings.
- Inline a regression-anchored comment so the next refactor does not re-introduce the pattern.

## Verification

- \`bash -e\` reproduction on macOS confirms the fix:
  \`\`\`bash
  set -e
  for f in /etc/hosts /nope.exe; do [[ -f \$f ]] && ls \$f; done; echo \"loop exit: \$?\"   # → exits the script
  for f in /etc/hosts /nope.exe; do if [[ -f \$f ]]; then ls \$f; fi; done; echo \"loop exit: \$?\"   # → loop exit: 0
  \`\`\`
- Local pre-push gate (\`lint-pre-push\`) green: file-size, drift gates, vet, machete, clippy (CI/prod/tests), rustdoc, doc-tests, tests, smoke, deny, lint-ci-windows — 281s.

## Out of scope (not changed in this PR)

- v0.5.97 itself: the \`v0.5.97\` git tag is already on \`main\`.  After this PR lands, the next ship cycle should bump to **v0.5.98** rather than retroactively publishing v0.5.97, so the tag and the release stay in lockstep.
- The same \`[[ -f \$x ]] && cmd\` pattern does *not* appear elsewhere in \`.github/workflows/release.yml\` (grep clean).