### PR TITLE
chore: release v0.5.98 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,7 +735,7 @@ hunting for the wrong things.
 
 Plan §1 goal-4 ("no regression on CLI hot path vs the v0.5.35
 baseline") verified end-to-end on the Windows 7-drive reference
-box.  Current v0.5.97 (post-Phase-8 tiered architecture) is
+box.  Current v0.5.98 (post-Phase-8 tiered architecture) is
 **universally faster** than v0.5.35 across every benchmarked
 pattern, with the largest result set (`*.dll`, 44 529 rows)
 showing a **2.7× speedup**:
@@ -743,7 +743,7 @@ showing a **2.7× speedup**:
 ```
 Drive D, 7.07 M records, 30 rounds, HOT phase, p50 / p95 wall_ms:
 
-                              v0.5.35      v0.5.97       Δ p50
+                              v0.5.35      v0.5.98       Δ p50
     exact      (3 rows)       20 / 23   →  18 / 19      −10 %
     prefix     (8 732)        46 / 50   →  40 / 46      −13 %
     ext_rare   (11)           18 / 20   →  17 / 18       −6 %
@@ -919,7 +919,7 @@ log-message renames fail CI before reaching another 24-h soak.
   2026-05-13.  No new operator-surface features land on `main`
   until v0.6.0 ships.
 
-## [0.5.97] - 2026-05-08
+## [0.5.98] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -928,7 +928,7 @@ log-message renames fail CI before reaching another 24-h soak.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.97`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.98`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,14 +4346,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "clap",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "chrono",
  "itoa",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "clap",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "clap",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "clap",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "axum",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4581,14 +4581,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4603,14 +4603,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.97"
+version = "0.5.98"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.97"
+version = "0.5.98"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires
@@ -116,21 +116,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.97" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.97" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.97" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.97" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.97" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.97" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.97" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.97" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.98" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.98" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.98" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.98" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.98" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.98" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.98" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.98" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.97" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.98" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.98**.  Binaries + GitHub Release v0.5.98 are already live (step 09).  This PR routes the corresponding commit through branch-protection rules.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

Local `fix/ci-release-show-binary-sizes-eof` had this commit with a different SHA before squash rewrote it onto main; recover with `git fetch origin && git reset --hard origin/fix/ci-release-show-binary-sizes-eof`.