### PR TITLE
fix(ci): fail-fast pre-flight + per-job permissions on release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,114 @@ jobs:
           echo "🏷️ Tag: $VERSION"
           echo "🚀 Triggered by: ${{ inputs.triggered_by || 'tag-push' }}"
 
+      - name: Pre-flight — verify Actions token can create releases
+        # Belt-and-suspenders guard against a silent repo-level
+        # permissions clamp.
+        #
+        # The workflow's top-level `permissions:` block (and the
+        # `create-github-release` job's per-job override) both declare
+        # `contents: write`, which softprops/action-gh-release needs
+        # in order to POST the v* git tag and release row.  However,
+        # the repository-level toggle at "Settings → Actions →
+        # General → Workflow permissions" can clamp every job's
+        # GITHUB_TOKEN to read-only at runtime regardless of what
+        # the workflow declares.  When that happens, the build
+        # matrix burns ~30 minutes and then `create-github-release`
+        # dies with the cryptic:
+        #
+        #   HTTP 403 — Resource not accessible by integration
+        #
+        # The failure mode is silent until that step is reached.
+        # See release pipeline #98 / v0.5.99 — three platforms built
+        # for 32 min each, then the publish step failed in 1 s with
+        # the 403, and we had to drop the run and re-dispatch after
+        # flipping the setting.
+        #
+        # This step exercises the EXACT REST path that the failing
+        # action uses, but with a throwaway draft release that is
+        # immediately deleted.  A read-only-clamped token fails the
+        # `gh release create --draft` call in ~1 s with the same 403,
+        # at which point we surface a precise actionable error
+        # pointing at the toggle that needs flipping.
+        #
+        # Why a draft release and not a direct `actions/permissions`
+        # API probe: reading `/repos/.../actions/permissions/workflow`
+        # requires the `administration: read` scope, which neither
+        # this workflow nor the repo-default GITHUB_TOKEN carries.
+        # The synthetic create-draft-then-delete probe uses the
+        # `contents: write` scope this job already declares, so it
+        # works without widening the workflow's permission surface.
+        #
+        # Draft releases do not create the underlying git tag (only
+        # published releases do), so cleanup is just the release-row
+        # delete — no orphaned tags can leak even if the cleanup
+        # step itself fails.  The throwaway tag name includes both
+        # `run_id` and `run_attempt` so concurrent / retried
+        # invocations cannot collide.
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          TEST_TAG="preflight-permcheck-run${{ github.run_id }}-attempt${{ github.run_attempt }}"
+          echo "Probing release-create permissions with synthetic draft: $TEST_TAG"
+
+          if ! gh release create "$TEST_TAG" \
+                 --repo "${{ github.repository }}" \
+                 --draft \
+                 --notes "Preflight permissions check; auto-deleted within seconds." \
+                 --title "permcheck (auto-deleted)" 2>/tmp/perm-err.log; then
+              ERR=$(cat /tmp/perm-err.log)
+              echo "::error title=Workflow permissions block release publish::Failed to create a draft release as a preflight permissions probe — see annotation below."
+              cat <<EOF
+          ❌ Pre-flight permissions probe FAILED.
+
+          The probe attempted to create a draft release ($TEST_TAG)
+          and \`gh release create\` returned:
+
+          ${ERR}
+
+          Most common cause: the repository's "Workflow permissions"
+          setting is "Read repository contents and packages
+          permissions", which clamps the per-job GITHUB_TOKEN to
+          read-only at runtime regardless of what the workflow file
+          declares.  softprops/action-gh-release in the
+          create-github-release job would fail with HTTP 403
+          ("Resource not accessible by integration") after the build
+          matrix (~30 min).  Catching it here saves the ~30 min.
+
+          To fix, flip the toggle to "Read and write permissions":
+            https://github.com/${{ github.repository }}/settings/actions
+
+          Or via CLI (requires repo admin):
+            gh api -X PUT /repos/${{ github.repository }}/actions/permissions/workflow \\
+              -f default_workflow_permissions=write
+
+          If the repo-level setting is already "Read and write" but
+          the probe still fails, the organization's default at
+            https://github.com/organizations/<org>/settings/actions
+          may be set to read-only and is cascading down to every repo.
+          Fix it at the org level (or have an org admin do it), then
+          re-dispatch this workflow.
+
+          Regression history: pipeline #98 / v0.5.99.
+          EOF
+              exit 1
+          fi
+
+          # Cleanup: delete the draft release row.  Best-effort — if
+          # delete fails, the draft is orphaned but harmless (drafts
+          # do not create git tags, are not surfaced on the public
+          # /releases page, and the unique tag name per
+          # run_id+attempt prevents cross-run collisions).
+          if ! gh release delete "$TEST_TAG" \
+                 --repo "${{ github.repository }}" --yes; then
+              echo "::warning::Failed to clean up preflight draft release $TEST_TAG; orphan is harmless but visible to repo admins via /releases?per_page=100."
+          fi
+
+          echo "✅ Workflow permissions allow release publish"
+
       - name: Check if tag or release already exists (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch'
         shell: bash
@@ -565,6 +673,36 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release-preparation, build-release-binaries]
     timeout-minutes: 15
+    # Explicit per-job permissions matrix.  Documents the intent at the
+    # point of use rather than relying on inheritance from the workflow-
+    # level `permissions:` block ~520 lines up.  Note: a per-job block
+    # only NARROWS the workflow-level grant — it cannot grant a scope
+    # the workflow level didn't already declare.  More importantly, BOTH
+    # are still clamped at runtime by the repo-level "Settings → Actions
+    # → General → Workflow permissions" toggle.  If that toggle is set
+    # to "Read repository contents and packages permissions", every
+    # scope below is silently downgraded to read regardless of what is
+    # written here.  The `Pre-flight — verify Actions token …` step in
+    # `release-preparation` fails fast in that case so we don't burn
+    # ~30 min of build time before discovering it.
+    #
+    #   contents: write       — softprops/action-gh-release creates the
+    #                            v* git tag AND the release row via the
+    #                            REST API.  Without this scope, the
+    #                            create-release step fails with HTTP
+    #                            403 "Resource not accessible by
+    #                            integration" (see release pipeline
+    #                            #98 / v0.5.99 for the regression).
+    #   id-token: write       — OIDC token issuance for the SLSA
+    #                            build-provenance attestation via
+    #                            Sigstore Fulcio.
+    #   attestations: write   — posts the resulting attestation to
+    #                            this repo via GitHub's Attestations
+    #                            API.
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What

Release pipeline **#98 (v0.5.99)** built binaries on all three platforms for ~32 minutes and then died in <1 second at the `📦 Create GitHub Release` step with:

\`\`\`
HTTP 403 — Resource not accessible by integration
\`\`\`

Root cause was a **repo-level setting flip**: \`Settings → Actions → General → Workflow permissions\` had been switched from *\"Read and write\"* to *\"Read-only\"*.  That toggle **clamps every job's \`GITHUB_TOKEN\` to read scope at runtime regardless of what the workflow file declares** — so the workflow's top-level \`permissions: contents: write\` was silently downgraded to read.  v0.5.96 (the previous successful release ~16 h earlier) ran with the *same* workflow file and succeeded, confirming the file was never the problem.

The org's audit log is not retrievable (Free-tier org — \`gh api /orgs/skyllc-ai/audit-log\` returns 404), so the actor/timestamp of the flip is unrecoverable.

## Why this PR is needed even though the immediate symptom can be fixed by re-flipping the toggle

A repo-level toggle that bypasses every safeguard in YAML is a perfect silent-rot vector: the next time it's flipped (intentionally or accidentally — by you, a co-maintainer, an org admin, or a GitHub-side policy nudge), the next release will silently burn ~30 minutes of build time before dying at the publish step.  This PR makes that scenario fail in ~1 second with a precise error message.

## The two belt-and-suspenders changes

### 1. Pre-flight permissions probe in \`release-preparation\`

Creates a draft release with a throwaway tag (\`preflight-permcheck-run<run_id>-attempt<run_attempt>\`) and immediately deletes it on success.  Exercises the EXACT REST path that \`softprops/action-gh-release\` uses 30+ minutes later in \`create-github-release\`, so a permissions clamp surfaces here in ~1 s with an actionable error message pointing at the toggle that needs flipping (repo level, with an org-level fallback note for free-tier orgs where the cascade can come from the org).

\`\`\`yaml
- name: Pre-flight — verify Actions token can create releases
  shell: bash
  env:
    GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
  run: |
    set -euo pipefail
    TEST_TAG=\"preflight-permcheck-run\${{ github.run_id }}-attempt\${{ github.run_attempt }}\"
    if ! gh release create \"\$TEST_TAG\" --repo \"\${{ github.repository }}\" --draft …; then
        # ::error annotation + heredoc with full remediation steps
        exit 1
    fi
    gh release delete \"\$TEST_TAG\" --repo \"\${{ github.repository }}\" --yes || \\
        echo \"::warning::orphan is harmless\"
\`\`\`

**Why a synthetic-release probe rather than a direct \`/repos/.../actions/permissions/workflow\` API call:** that endpoint requires the \`administration: read\` scope, which neither this workflow nor the default \`GITHUB_TOKEN\` carries.  Widening to add it would expand the permission surface.  The create-draft probe stays inside \`contents: write\` which the job already declares (no new scope grants).

**Cleanup safety:** Draft releases do **not** create the underlying git tag (only published releases do), so a failed cleanup leaks at worst an invisible draft row — never an orphan tag.  The throwaway tag name includes both \`run_id\` and \`run_attempt\` so concurrent or retried invocations cannot collide.

### 2. Explicit per-job \`permissions:\` block on \`create-github-release\`

Pins \`contents: write\`, \`id-token: write\`, \`attestations: write\` at the point of use rather than relying on inheritance from the workflow-level block ~520 lines up.

Does **NOT** change runtime behaviour by itself — the repo-level clamp still wins.  But it pairs with the pre-flight to make the failure mode self-documenting from the YAML alone: a reader doesn't have to scroll 500 lines to learn which scopes this job needs.

\`\`\`yaml
create-github-release:
  name: 📦 Create GitHub Release
  …
  permissions:
    contents: write       # action-gh-release: create v* tag + release row
    id-token: write       # SLSA build-provenance: OIDC for Sigstore Fulcio
    attestations: write   # SLSA build-provenance: post attestation to repo
\`\`\`

## Verification

- \`actionlint .github/workflows/release.yml .github/workflows/release-cache-warm.yml\` — clean.
- Local \`lint-pre-push\` gate (22 stages, including \`workflow-drift\`) — ✅ all green in 51s.
- The probe itself will be exercised on the next release dispatch.  On the current repo state (workflow permissions = \"read\"), it will fail with the precise error message it's designed to surface; once the repo-level toggle is flipped back to \"write\", subsequent runs will pass the probe in ~1 s.

## What it does NOT do

- It does not flip the repo-level workflow-permissions toggle (that's a repo-admin action that should be done deliberately, not as a code change).
- It does not change behaviour on the existing failing run — that one is permanently failed and needs a fresh dispatch.
- It does not widen the workflow's permission surface — no new \`administration:read\` scope, no new tokens.

## Recommended next steps after merge

1. Flip the toggle: \`Settings → Actions → General → Workflow permissions → Read and write permissions → Save\` (or via API as documented in the probe's failure message).
2. Re-dispatch \`🚀 UFFS Release Pipeline\` for \`v0.5.99\` (no version bump needed — Cargo.toml is already at 0.5.99, no \`v0.5.99\` tag exists yet, and the release workflow creates the tag atomically).
3. The pre-flight probe will pass in <2 s; the rest of the pipeline proceeds.

Regression history: pipeline #98 / v0.5.99.  Related prior PRs in the same release-stability sweep: #251 (show-binary-sizes shell bug), #254 (macOS rustup proxy post-cache-restore).