### PR TITLE
refactor(uffs-mft): Frs / ParentFrs newtypes — parse layer (Phase 4 sub-phase 5d.1, refs #191)

### DIFF
--- a/crates/uffs-diag/src/bin/dump_mft_records.rs
+++ b/crates/uffs-diag/src/bin/dump_mft_records.rs
@@ -321,8 +321,10 @@ fn test_merge(raw_path: &str, base_frs: u64, ext_frs: u64) -> Result<()> {
     let merged_records = record_merger.merge();
     println!("  merged.len(): {}", merged_records.len());
 
-    // Find the base record in merged results
-    if let Some(record) = merged_records.iter().find(|rec| rec.frs == base_frs) {
+    // Find the base record in merged results.  `base_frs` is the
+    // CLI-parsed `u64`; lift to the typed `Frs` for the equality check.
+    let base_frs_typed = uffs_mft::Frs::new(base_frs);
+    if let Some(record) = merged_records.iter().find(|rec| rec.frs == base_frs_typed) {
         println!("\n=== FRS {base_frs} after merge ===");
         println!("  name: {:?}", record.name);
         println!("  parent_frs: {}", record.parent_frs);

--- a/crates/uffs-mft/src/frs.rs
+++ b/crates/uffs-mft/src/frs.rs
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! File Record Segment (FRS) newtypes.
+//!
+//! NTFS identifies every record in the Master File Table by its
+//! **File Record Segment number** — a 0-based index into the `$MFT`
+//! file.  The on-disk and FFI representations are an unsigned 64-bit
+//! integer, but the workspace has historically threaded raw `u64`
+//! values through parse, index, query, and wire surfaces.  That made
+//! two real correctness hazards open-coded:
+//!
+//! * **own-FRS vs parent-FRS swap** — closures, struct literals, and function
+//!   calls accept `(parent_frs: u64, own_frs: u64)` and the compiler cannot
+//!   tell when a caller transposes them.
+//! * **sentinel ambiguity** — `0` means *"root of the filesystem metadata; no
+//!   base record"* in some contexts and *"unset / null reference"* in others.
+//!   Predicates spelled `frs == 0` mix both meanings.
+//!
+//! This module introduces two newtypes that close both gaps without
+//! touching the wire format:
+//!
+//! * [`Frs`] — a typed FRS value.  Wraps `u64` byte-identically; carries `ZERO`
+//!   (the `$MFT` self-record / "null reference") and `ROOT` (FRS 5 — the `.`
+//!   root directory) sentinels; exposes [`Frs::is_zero`] / [`Frs::is_root`] so
+//!   predicates read at the semantic level callers actually mean.
+//! * [`ParentFrs`] — a typed *parent-directory* FRS.  Composed over [`Frs`] so
+//!   the type system makes a parent-vs-child swap a compile error.  Convert via
+//!   [`ParentFrs::as_frs`] when looking the parent record up in the index.
+//!
+//! # Invariants
+//!
+//! Carried by the type system:
+//!
+//! * `Copy + Eq + Hash + Ord` — both newtypes slot into `HashMap` / `BTreeMap`
+//!   keys, compare cheaply, and pass by value.
+//! * `ParentFrs` cannot be silently coerced to `Frs` (or vice versa) without an
+//!   explicit `as_frs()` / `ParentFrs::of()` call.
+//!
+//! Not carried by the type system (kernel-issued / format-defined):
+//!
+//! * The numeric range is `0..=2^48-1` on real NTFS volumes; the newtype
+//!   accepts any `u64` so we keep round-trip parity with the on-disk
+//!   `MFT_SEGMENT_REFERENCE.segment_number_low_part + segment_number_high_part`
+//!   48-bit encoding without rejecting FFI-sourced values defensively.
+
+use core::fmt;
+
+/// Typed File Record Segment number.
+///
+/// Newtype wrapper around the raw `u64` FRS used in `MFT_SEGMENT_REFERENCE`,
+/// the on-disk `$FILE_NAME.parent_directory` field, and every parse /
+/// index / query API.  We preserve the bit pattern byte-for-byte so
+/// on-disk + on-wire formats are unchanged.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct Frs(u64);
+
+impl Frs {
+    /// FRS `0` — the `$MFT` self-record on a real volume, and the
+    /// canonical *"null reference"* sentinel for fields like
+    /// `ParsedRecord.base_frs` on base (non-extension) records.
+    ///
+    /// Use [`Self::is_zero`] for the predicate.
+    pub const ZERO: Self = Self(0);
+
+    /// FRS `5` — the NTFS root directory (`.`).
+    ///
+    /// Every other directory's path traversal terminates at this
+    /// record; exposing it as a constant keeps the magic number out
+    /// of parent-chain walkers.
+    pub const ROOT: Self = Self(5);
+
+    /// Wrap a raw `u64` from a Win32 FFI buffer, on-disk parser, or
+    /// serde wire decode.
+    ///
+    /// FRS values are kernel-issued — there is no client-side
+    /// validation we can perform on a single value in isolation.
+    #[must_use]
+    pub const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    /// Underlying raw `u64`.
+    ///
+    /// Use this **only** at FFI / serialization boundaries or when
+    /// indexing into a `Vec<FileRecord>` keyed by FRS.  Internal
+    /// logic should compare [`Frs`] values directly via the derived
+    /// [`Ord`] / [`PartialEq`] impls.
+    #[must_use]
+    pub const fn raw(self) -> u64 {
+        self.0
+    }
+
+    /// `true` when this value equals [`Frs::ZERO`].
+    ///
+    /// Mirrors the historic `frs == 0` / `base_frs == 0` predicate
+    /// used throughout the parse layer to detect *"no base record"*
+    /// (i.e. this IS the base) and *"null parent reference"*.
+    #[must_use]
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+
+    /// `true` when this value equals [`Frs::ROOT`] (FRS 5 — `.`).
+    #[must_use]
+    pub const fn is_root(self) -> bool {
+        self.0 == Self::ROOT.0
+    }
+}
+
+impl From<u64> for Frs {
+    fn from(raw: u64) -> Self {
+        Self(raw)
+    }
+}
+
+impl From<Frs> for u64 {
+    fn from(value: Frs) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Display for Frs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Typed *parent-directory* FRS.
+///
+/// Composed over [`Frs`] so a parent reference and the record's own
+/// reference are not interchangeable at the type level — fixing the
+/// historic `(parent_frs: u64, own_frs: u64)` swap hazard.
+///
+/// To look the parent record up in the index, convert explicitly via
+/// [`ParentFrs::as_frs`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct ParentFrs(Frs);
+
+impl ParentFrs {
+    /// Parent reference of `0` — the *"no parent"* sentinel used by
+    /// the `$MFT` self-record and any record whose `$FILE_NAME`
+    /// attribute was lost.
+    pub const ZERO: Self = Self(Frs::ZERO);
+
+    /// The root directory's parent — also FRS `5`, since the root is
+    /// its own parent in NTFS.  Useful for parent-chain termination
+    /// predicates.
+    pub const ROOT: Self = Self(Frs::ROOT);
+
+    /// Wrap a raw `u64` from the on-disk `$FILE_NAME.parent_directory`
+    /// field or an FFI / wire buffer.
+    #[must_use]
+    pub const fn new(raw: u64) -> Self {
+        Self(Frs::new(raw))
+    }
+
+    /// Promote a typed [`Frs`] to a [`ParentFrs`] — used when the
+    /// caller is *deliberately* asserting that an [`Frs`] value
+    /// represents a parent directory (e.g. building a synthetic
+    /// `$FILE_NAME` for a placeholder record).
+    #[must_use]
+    pub const fn of(frs: Frs) -> Self {
+        Self(frs)
+    }
+
+    /// Extract the underlying [`Frs`] so this parent reference can be
+    /// used as an index lookup key.  The conversion is intentionally
+    /// explicit — it documents *"I am now looking up the parent
+    /// record"* at the call site.
+    #[must_use]
+    pub const fn as_frs(self) -> Frs {
+        self.0
+    }
+
+    /// Underlying raw `u64` — same caller-contract notes as
+    /// [`Frs::raw`].
+    #[must_use]
+    pub const fn raw(self) -> u64 {
+        self.0.raw()
+    }
+
+    /// `true` when this parent reference equals [`ParentFrs::ZERO`].
+    #[must_use]
+    pub const fn is_zero(self) -> bool {
+        self.0.is_zero()
+    }
+
+    /// `true` when this parent reference equals [`ParentFrs::ROOT`]
+    /// (FRS 5 — parent-chain termination on real NTFS volumes).
+    #[must_use]
+    pub const fn is_root(self) -> bool {
+        self.0.is_root()
+    }
+}
+
+impl From<u64> for ParentFrs {
+    fn from(raw: u64) -> Self {
+        Self::new(raw)
+    }
+}
+
+impl From<Frs> for ParentFrs {
+    fn from(frs: Frs) -> Self {
+        Self::of(frs)
+    }
+}
+
+impl From<ParentFrs> for Frs {
+    fn from(parent: ParentFrs) -> Self {
+        parent.as_frs()
+    }
+}
+
+impl From<ParentFrs> for u64 {
+    fn from(parent: ParentFrs) -> Self {
+        parent.raw()
+    }
+}
+
+impl fmt::Display for ParentFrs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Frs, ParentFrs};
+
+    #[test]
+    fn frs_raw_roundtrip_preserves_u64_exactly() {
+        // Wire-format contract: any `u64` the kernel hands us must come
+        // back byte-identical via `raw()`.  Keeps the on-disk MFT
+        // segment-reference decode path bit-for-bit compatible after
+        // the newtype migration.
+        for raw in [0_u64, 1, 5, 42, 1_u64 << 47_u32, u64::MAX] {
+            assert_eq!(Frs::new(raw).raw(), raw, "Frs round-trip drift for {raw}");
+        }
+    }
+
+    #[test]
+    fn frs_sentinels_match_literal_values() {
+        assert_eq!(Frs::ZERO, Frs::new(0));
+        assert_eq!(Frs::ROOT, Frs::new(5));
+        assert!(Frs::ZERO.is_zero());
+        assert!(!Frs::ZERO.is_root());
+        assert!(Frs::ROOT.is_root());
+        assert!(!Frs::ROOT.is_zero());
+    }
+
+    #[test]
+    fn frs_from_into_u64_symmetry() {
+        let raw: u64 = 0x0123_4567_89AB_CDEF;
+        let frs: Frs = raw.into();
+        let back: u64 = frs.into();
+        assert_eq!(back, raw);
+    }
+
+    #[test]
+    fn frs_display_matches_raw_u64() {
+        for raw in [0_u64, 1, 5, 1_234_567, u64::MAX] {
+            assert_eq!(format!("{}", Frs::new(raw)), raw.to_string());
+        }
+    }
+
+    #[test]
+    fn frs_ord_matches_underlying_u64() {
+        assert!(Frs::ZERO < Frs::new(1));
+        assert!(Frs::new(1) < Frs::new(2));
+        assert!(Frs::ROOT < Frs::new(6));
+        assert!(Frs::ZERO < Frs::new(u64::MAX));
+    }
+
+    #[test]
+    fn parent_frs_raw_roundtrip_preserves_u64_exactly() {
+        for raw in [0_u64, 1, 5, 42, 1_u64 << 47_u32, u64::MAX] {
+            assert_eq!(
+                ParentFrs::new(raw).raw(),
+                raw,
+                "ParentFrs round-trip drift for {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn parent_frs_of_and_as_frs_roundtrip() {
+        // `ParentFrs::of(frs)` followed by `.as_frs()` must yield the
+        // original [`Frs`] byte-identically — this is the documented
+        // promotion / demotion path between own-record and
+        // parent-record references.
+        for raw in [0_u64, 5, 42, 1_u64 << 47_u32] {
+            let frs = Frs::new(raw);
+            let parent = ParentFrs::of(frs);
+            assert_eq!(parent.as_frs(), frs);
+            assert_eq!(parent.raw(), raw);
+        }
+    }
+
+    #[test]
+    fn parent_frs_sentinels_match_literal_values() {
+        assert_eq!(ParentFrs::ZERO, ParentFrs::new(0));
+        assert_eq!(ParentFrs::ROOT, ParentFrs::new(5));
+        assert!(ParentFrs::ZERO.is_zero());
+        assert!(!ParentFrs::ZERO.is_root());
+        assert!(ParentFrs::ROOT.is_root());
+        assert!(!ParentFrs::ROOT.is_zero());
+    }
+
+    #[test]
+    fn parent_frs_display_matches_raw_u64() {
+        for raw in [0_u64, 1, 5, 1_234_567, u64::MAX] {
+            assert_eq!(format!("{}", ParentFrs::new(raw)), raw.to_string());
+        }
+    }
+
+    #[test]
+    fn parent_frs_into_frs_via_from() {
+        // The `From<ParentFrs> for Frs` impl documents the *"I am
+        // looking up the parent record now"* boundary.  Verify it
+        // produces the same value as the explicit `.as_frs()` method.
+        for raw in [0_u64, 5, 1_234_567] {
+            let parent = ParentFrs::new(raw);
+            let via_method = parent.as_frs();
+            let via_from: Frs = parent.into();
+            assert_eq!(via_method, via_from);
+        }
+    }
+
+    #[test]
+    fn parent_frs_does_not_coerce_to_frs_silently() {
+        // Compile-time contract: this test exists primarily as
+        // documentation.  The body asserts that the two newtypes are
+        // distinct nominal types — any silent coercion would let the
+        // assertion compile against the wrong side.
+        let frs = Frs::new(42);
+        let parent = ParentFrs::new(42);
+        // Equality check is only available after explicit demotion.
+        assert_eq!(parent.as_frs(), frs);
+    }
+}

--- a/crates/uffs-mft/src/index/builder.rs
+++ b/crates/uffs-mft/src/index/builder.rs
@@ -77,11 +77,23 @@ impl MftIndex {
                 continue;
             }
 
+            // Parse → index typed-to-raw boundary.  The parse layer
+            // (sub-phase 5d.1) hands us typed `Frs` / `ParentFrs`
+            // values; the index storage (`FileRecord.frs`,
+            // `ChildInfo.child_frs`, `LinkInfo.parent_frs`, …) is
+            // still `u64`.  Sub-phase 5d.2 will migrate the index
+            // side; until then we demote once at loop entry so the
+            // body keeps a single typed→raw boundary point with a
+            // clear citation.
+            let parsed_frs = parsed.frs.raw();
+            let parsed_parent_frs = parsed.parent_frs.raw();
+            let parsed_base_frs = parsed.base_frs.raw();
+
             // === Collect stats (cheap - just incrementing counters) ===
             index.stats.record_count += 1;
             index.stats.total_name_bytes += parsed.name.len() as u64;
-            if parsed.frs > index.stats.max_frs {
-                index.stats.max_frs = parsed.frs;
+            if parsed_frs > index.stats.max_frs {
+                index.stats.max_frs = parsed_frs;
             }
             if parsed.is_directory {
                 index.stats.dir_count += 1;
@@ -95,11 +107,11 @@ impl MftIndex {
                 index.stats.ads_count += 1;
             }
             // System metafile detection
-            if parsed.frs <= SYSTEM_METAFILE_MAX_FRS && parsed.frs != ROOT_FRS_LOCAL {
+            if parsed_frs <= SYSTEM_METAFILE_MAX_FRS && parsed_frs != ROOT_FRS_LOCAL {
                 index.stats.system_metafile_count += 1;
             }
             // Child of system metafile detection
-            if parsed.parent_frs <= SYSTEM_METAFILE_MAX_FRS && parsed.parent_frs != ROOT_FRS_LOCAL {
+            if parsed_parent_frs <= SYSTEM_METAFILE_MAX_FRS && parsed_parent_frs != ROOT_FRS_LOCAL {
                 index.stats.system_child_count += 1;
             }
 
@@ -114,7 +126,7 @@ impl MftIndex {
             // Get or create the record and set all basic fields in a block scope
             // to end the mutable borrow before adding additional names/streams
             {
-                let record = index.get_or_create(parsed.frs);
+                let record = index.get_or_create(parsed_frs);
 
                 // Set sequence number, LSN, and namespace (raw MFT fields)
                 record.sequence_number = parsed.sequence_number;
@@ -135,7 +147,7 @@ impl MftIndex {
                 // Set name info (offset and extension_id were computed before borrowing record)
                 record.first_name.name =
                     IndexNameRef::new(name_offset, name_len, is_ascii, extension_id);
-                record.first_name.parent_frs = parsed.parent_frs;
+                record.first_name.parent_frs = parsed_parent_frs;
                 // Note: name_count is set AFTER filtering additional names to avoid
                 // counting duplicates. See the code after this block.
 
@@ -148,7 +160,7 @@ impl MftIndex {
                     parsed.is_corrupt,
                     parsed.is_extension,
                 );
-                record.base_frs = parsed.base_frs;
+                record.base_frs = parsed_base_frs;
 
                 // Set size and flags
                 // For directories, use parsed.size/allocated_size which includes
@@ -189,11 +201,14 @@ impl MftIndex {
                 .iter()
                 .filter(|n| !(n.name == parsed.name && n.parent_frs == parsed.parent_frs))
                 .collect();
+            // (`n.parent_frs == parsed.parent_frs` compares two `ParentFrs`
+            // values — the typed equality is a structural compile-time win
+            // over the prior raw `u64` comparison.)
 
             // Update name_count to reflect actual stored names (1 primary + additional)
             // This must be done AFTER filtering to avoid counting duplicates
             let actual_name_count = len_to_u16((1 + additional_names.len()).max(1));
-            index.get_or_create(parsed.frs).name_count = actual_name_count;
+            index.get_or_create(parsed_frs).name_count = actual_name_count;
 
             if !additional_names.is_empty() {
                 let mut prev_link_idx = NO_ENTRY;
@@ -209,12 +224,13 @@ impl MftIndex {
                         next_entry: prev_link_idx,
                         name: IndexNameRef::new(extra_offset, extra_len, extra_ascii, extra_ext_id),
                         _pad0: [0; 4],
-                        parent_frs: extra_name.parent_frs,
+                        // `LinkInfo.parent_frs` is still `u64` (migrated in 5d.2).
+                        parent_frs: extra_name.parent_frs.raw(),
                     });
                     prev_link_idx = link_idx;
                 }
                 // Link first_name to the chain
-                let record = index.get_or_create(parsed.frs);
+                let record = index.get_or_create(parsed_frs);
                 record.first_name.next_entry = prev_link_idx;
             }
 
@@ -283,7 +299,7 @@ impl MftIndex {
             // named) This is used for user-facing output (DataFrame export)
             let actual_stream_count = len_to_u16((1 + named_streams.len()).max(1));
 
-            let record = index.get_or_create(parsed.frs);
+            let record = index.get_or_create(parsed_frs);
             record.total_stream_count = total_stream_count;
             record.stream_count = actual_stream_count;
             record.internal_streams_size = internal_streams_size;
@@ -326,7 +342,7 @@ impl MftIndex {
                     prev_stream_idx = stream_idx;
                 }
                 // Link first_stream to the chain
-                let file_record = index.get_or_create(parsed.frs);
+                let file_record = index.get_or_create(parsed_frs);
                 file_record.first_stream.next_entry = prev_stream_idx;
             }
 
@@ -336,8 +352,13 @@ impl MftIndex {
             // Each child entry stores its name_index so we can calculate proportional
             // shares.
             for (name_idx, name_info) in parsed.names.iter().enumerate() {
-                let parent_frs = name_info.parent_frs;
-                if parent_frs == parsed.frs || parent_frs == u64::from(NO_ENTRY) {
+                // Per-name boundary: `NameInfo.parent_frs` is typed
+                // (`ParentFrs`); the parent walker below indexes the
+                // `frs_to_idx` Vec by `usize` and stores `u64` in
+                // `ChildInfo` / `FileRecord` — all 5d.2-scope u64
+                // surfaces.
+                let parent_frs = name_info.parent_frs.raw();
+                if parent_frs == parsed_frs || parent_frs == u64::from(NO_ENTRY) {
                     continue;
                 }
 
@@ -369,7 +390,7 @@ impl MftIndex {
                 index.children.push(ChildInfo {
                     next_entry: old_first_child,
                     _pad0: [0; 4],
-                    child_frs: parsed.frs,
+                    child_frs: parsed_frs,
                     name_index: len_to_u16(name_idx),
                     _pad1: [0; 6],
                 });
@@ -377,18 +398,18 @@ impl MftIndex {
 
             // Handle case where names is empty (shouldn't happen, but be safe)
             if parsed.names.is_empty()
-                && parsed.parent_frs != parsed.frs
-                && parsed.parent_frs != u64::from(NO_ENTRY)
+                && parsed_parent_frs != parsed_frs
+                && parsed_parent_frs != u64::from(NO_ENTRY)
             {
                 let parent_idx = {
-                    let parent_frs_usize = frs_to_usize(parsed.parent_frs);
+                    let parent_frs_usize = frs_to_usize(parsed_parent_frs);
                     if parent_frs_usize >= index.frs_to_idx.len() {
                         index.frs_to_idx.resize(parent_frs_usize + 1, NO_ENTRY);
                     }
                     if index.frs_to_idx[parent_frs_usize] == NO_ENTRY {
                         let new_idx = len_to_u32(index.records.len());
                         index.frs_to_idx[parent_frs_usize] = new_idx;
-                        index.records.push(FileRecord::new(parsed.parent_frs));
+                        index.records.push(FileRecord::new(parsed_parent_frs));
                     }
                     index.frs_to_idx[parent_frs_usize]
                 };
@@ -401,7 +422,7 @@ impl MftIndex {
                 index.children.push(ChildInfo {
                     next_entry: old_first_child,
                     _pad0: [0; 4],
-                    child_frs: parsed.frs,
+                    child_frs: parsed_frs,
                     name_index: 0,
                     _pad1: [0; 6],
                 });

--- a/crates/uffs-mft/src/lib.rs
+++ b/crates/uffs-mft/src/lib.rs
@@ -199,6 +199,8 @@ pub mod platform;
 
 pub mod usn;
 
+pub mod frs;
+
 pub mod cache;
 
 mod reader;
@@ -221,6 +223,8 @@ pub use cache::{
 };
 pub use error::{MftError, Result};
 pub use flags::FileFlags;
+// Re-export FRS newtypes — typed alternatives to raw `u64` FRS values.
+pub use frs::{Frs, ParentFrs};
 // Re-export lean index types
 pub use index::{
     ChildInfo, FileRecord, IndexBuildTiming, IndexNameRef, IndexStreamInfo, LinkInfo, MftIndex,

--- a/crates/uffs-mft/src/ntfs/metadata.rs
+++ b/crates/uffs-mft/src/ntfs/metadata.rs
@@ -239,7 +239,7 @@ pub struct NameInfo {
     /// The file name.
     pub name: String,
     /// Parent directory FRS.
-    pub parent_frs: u64,
+    pub parent_frs: crate::frs::ParentFrs,
     /// Namespace (0=POSIX, 1=Win32, 2=DOS, 3=Win32+DOS).
     pub namespace: u8,
     /// Creation time from `$FILE_NAME` (Unix microseconds).
@@ -251,7 +251,7 @@ pub struct NameInfo {
     /// MFT change time from `$FILE_NAME` (Unix microseconds).
     pub fn_mft_changed: i64,
     /// FRS of the MFT record this name was parsed from (base or extension).
-    pub source_frs: u64,
+    pub source_frs: crate::frs::Frs,
 }
 
 /// Information about a single data stream.

--- a/crates/uffs-mft/src/parse/attribute_helpers.rs
+++ b/crates/uffs-mft/src/parse/attribute_helpers.rs
@@ -114,13 +114,17 @@ pub(super) fn parse_file_name_full(
 
     Some(NameInfo {
         name,
-        parent_frs: file_reference_to_frs(fn_attr.parent_directory),
+        // On-disk → typed boundary: `file_reference_to_frs` keeps its
+        // `u64` ABI (it decodes the 48-bit `parent_directory` field of
+        // `MFT_SEGMENT_REFERENCE`); we lift into `ParentFrs` here so
+        // every downstream consumer reads a typed parent reference.
+        parent_frs: crate::frs::ParentFrs::new(file_reference_to_frs(fn_attr.parent_directory)),
         namespace: fn_attr.file_name_namespace,
         fn_created: fn_attr.creation_time,
         fn_modified: fn_attr.modification_time,
         fn_accessed: fn_attr.access_time,
         fn_mft_changed: fn_attr.mft_change_time,
-        source_frs,
+        source_frs: crate::frs::Frs::new(source_frs),
     })
 }
 

--- a/crates/uffs-mft/src/parse/columns.rs
+++ b/crates/uffs-mft/src/parse/columns.rs
@@ -161,8 +161,10 @@ impl ParsedColumns {
     /// This is the hot path for accumulation - keep it fast!
     #[inline]
     pub fn push_record(&mut self, record: &ParsedRecord) {
-        self.frs.push(record.frs);
-        self.parent_frs.push(record.parent_frs);
+        // Columnar storage is `Vec<u64>` — it backs the Polars dataframe
+        // surface whose schema is u64.  Downcast at the push boundary.
+        self.frs.push(record.frs.raw());
+        self.parent_frs.push(record.parent_frs.raw());
         // legacy-output parity: directories have empty name
         if record.is_directory {
             self.name.push(String::new());
@@ -250,8 +252,9 @@ impl ParsedColumns {
                 if crate::ntfs::is_internal_windows_stream(&stream_info.name) {
                     continue;
                 }
-                self.frs.push(record.frs);
-                self.parent_frs.push(name_info.parent_frs);
+                // Polars-bound `Vec<u64>` columns — downcast at the push boundary.
+                self.frs.push(record.frs.raw());
+                self.parent_frs.push(name_info.parent_frs.raw());
                 // legacy-output parity: directories have empty name
                 if record.is_directory {
                     self.name.push(String::new());

--- a/crates/uffs-mft/src/parse/forensic.rs
+++ b/crates/uffs-mft/src/parse/forensic.rs
@@ -47,7 +47,7 @@ pub fn parse_record_forensic(
             return ParseResult::Skip;
         }
         return ParseResult::Base(ParsedRecord {
-            frs,
+            frs: crate::frs::Frs::new(frs),
             name: format!("<CORRUPT:{frs}>"),
             is_corrupt: true,
             ..Default::default()

--- a/crates/uffs-mft/src/parse/forensic/base.rs
+++ b/crates/uffs-mft/src/parse/forensic/base.rs
@@ -552,7 +552,7 @@ pub(super) fn parse_base_record(
     };
 
     ParseResult::Base(ParsedRecord {
-        frs,
+        frs: crate::frs::Frs::new(frs),
         sequence_number,
         lsn,
         parent_frs: primary.parent_frs,
@@ -574,6 +574,6 @@ pub(super) fn parse_base_record(
         is_deleted,
         is_corrupt: false,
         is_extension: is_extension_record,
-        base_frs: base_frs_value,
+        base_frs: crate::frs::Frs::new(base_frs_value),
     })
 }

--- a/crates/uffs-mft/src/parse/forensic/extension.rs
+++ b/crates/uffs-mft/src/parse/forensic/extension.rs
@@ -381,8 +381,8 @@ pub(super) fn parse_extension_record(
     }
 
     ParseResult::Extension(ExtensionAttributes {
-        base_frs: base_frs_value,
-        extension_frs: frs,
+        base_frs: crate::frs::Frs::new(base_frs_value),
+        extension_frs: crate::frs::Frs::new(frs),
         names,
         streams,
         dir_index_size,

--- a/crates/uffs-mft/src/parse/full.rs
+++ b/crates/uffs-mft/src/parse/full.rs
@@ -74,12 +74,15 @@ pub fn parse_record_full(data: &[u8], frs: u64) -> ParseResult {
         return ParseResult::Skip;
     }
 
-    // Check if this is an extension record
+    // Check if this is an extension record.  On-disk → typed boundary:
+    // `file_reference_to_frs` decodes the 48-bit `MFT_SEGMENT_REFERENCE`
+    // back to a raw `u64`; we lift to `Frs` here so the rest of the
+    // function (and every downstream consumer) handles a typed value.
     let is_extension = !header.is_base_record();
     let base_frs = if is_extension {
-        file_reference_to_frs(header.base_file_record_segment)
+        crate::frs::Frs::new(file_reference_to_frs(header.base_file_record_segment))
     } else {
-        frs
+        crate::frs::Frs::new(frs)
     };
 
     // Extract sequence number and LSN from header
@@ -584,7 +587,7 @@ pub fn parse_record_full(data: &[u8], frs: u64) -> ParseResult {
     if is_extension {
         return ParseResult::Extension(ExtensionAttributes {
             base_frs,
-            extension_frs: frs,
+            extension_frs: crate::frs::Frs::new(frs),
             names,
             streams,
             dir_index_size,
@@ -654,7 +657,7 @@ pub fn parse_record_full(data: &[u8], frs: u64) -> ParseResult {
     };
 
     ParseResult::Base(ParsedRecord {
-        frs,
+        frs: crate::frs::Frs::new(frs),
         sequence_number,
         lsn,
         parent_frs: primary.parent_frs,
@@ -676,7 +679,8 @@ pub fn parse_record_full(data: &[u8], frs: u64) -> ParseResult {
         is_deleted: false,
         is_corrupt: false,
         is_extension: false,
-        base_frs: 0,
+        // Base records carry the documented "no base record" sentinel.
+        base_frs: crate::frs::Frs::ZERO,
     })
 }
 

--- a/crates/uffs-mft/src/parse/merger.rs
+++ b/crates/uffs-mft/src/parse/merger.rs
@@ -87,7 +87,7 @@ impl MftRecordMerger {
     pub fn add_result(&mut self, result: ParseResult) {
         match result {
             ParseResult::Base(record) => {
-                let frs = frs_to_usize(record.frs);
+                let frs = frs_to_usize(record.frs.raw());
                 // Expand if needed (rare - only if FRS exceeds initial capacity)
                 if frs >= self.base_records.len() {
                     self.base_records.resize(frs + 1, None);
@@ -113,7 +113,7 @@ impl MftRecordMerger {
     pub fn merge(mut self) -> Vec<ParsedRecord> {
         // Merge all extensions into their base records
         for ext in self.extensions {
-            let base_frs = frs_to_usize(ext.base_frs);
+            let base_frs = frs_to_usize(ext.base_frs.raw());
             if base_frs < self.base_records.len()
                 && let Some(ref mut base) = self.base_records[base_frs]
             {
@@ -269,7 +269,7 @@ impl MftRecordMerger {
         // Merge all extensions into their base records
         for ext in self.extensions {
             // FRS values are bounded by MFT size, always < 2^32 on real systems
-            let base_frs = usize::try_from(ext.base_frs).unwrap_or(usize::MAX);
+            let base_frs = usize::try_from(ext.base_frs.raw()).unwrap_or(usize::MAX);
             if base_frs < self.base_records.len()
                 && let Some(ref mut base) = self.base_records[base_frs]
             {

--- a/crates/uffs-mft/src/parse/name_tracker.rs
+++ b/crates/uffs-mft/src/parse/name_tracker.rs
@@ -3,6 +3,7 @@
 
 //! Helpers for selecting the preferred primary file name during parsing.
 
+use crate::frs::ParentFrs;
 use crate::ntfs::NameInfo;
 
 /// Tracks the best primary name during parsing.
@@ -11,7 +12,7 @@ pub(super) struct PrimaryNameTracker {
     /// Primary filename.
     pub(super) name: String,
     /// Parent FRS of the primary name.
-    pub(super) parent_frs: u64,
+    pub(super) parent_frs: ParentFrs,
     /// Namespace of the primary name (255 = invalid/unset).
     pub(super) namespace: u8,
     /// `$FILE_NAME` creation timestamp.
@@ -49,7 +50,7 @@ impl Default for PrimaryNameTracker {
     fn default() -> Self {
         Self {
             name: String::new(),
-            parent_frs: 0,
+            parent_frs: ParentFrs::ZERO,
             namespace: Self::INVALID_NAMESPACE,
             fn_created: 0,
             fn_modified: 0,

--- a/crates/uffs-mft/src/parse/placeholders.rs
+++ b/crates/uffs-mft/src/parse/placeholders.rs
@@ -6,6 +6,7 @@
 use tracing::{debug, info, warn};
 
 use super::ParsedRecord;
+use crate::frs::{Frs, ParentFrs};
 use crate::ntfs::ExtendedStandardInfo;
 
 /// Creates a placeholder record for a missing parent directory.
@@ -26,10 +27,12 @@ use crate::ntfs::ExtendedStandardInfo;
 #[must_use]
 pub fn create_placeholder_record(frs: u64) -> ParsedRecord {
     ParsedRecord {
-        frs,
+        frs: Frs::new(frs),
         sequence_number: 0,
         lsn: 0,
-        parent_frs: 5, // Assume root as parent (FRS 5 is root directory)
+        // Synthetic placeholders default their parent to the NTFS root
+        // directory so path resolution terminates cleanly.
+        parent_frs: ParentFrs::ROOT,
         name: format!("<dir:{frs}>"),
         namespace: 1, // Win32 namespace
         names: Vec::new(),
@@ -47,7 +50,8 @@ pub fn create_placeholder_record(frs: u64) -> ParsedRecord {
         is_deleted: false,
         is_corrupt: false,
         is_extension: false,
-        base_frs: 0,
+        // Base records carry the documented "no base record" sentinel.
+        base_frs: Frs::ZERO,
     }
 }
 
@@ -108,8 +112,12 @@ pub fn add_missing_parent_placeholders_to_vec(records: &mut Vec<ParsedRecord>) -
 fn insert_missing_parents(records: &mut Vec<ParsedRecord>) -> usize {
     use rustc_hash::FxHashSet;
 
-    let known_frs: FxHashSet<u64> = records.iter().map(|rec| rec.frs).collect();
-    let referenced: FxHashSet<u64> = records.iter().map(|rec| rec.parent_frs).collect();
+    // Hash-set bookkeeping is keyed on the raw `u64` view because we need
+    // to compare own-FRS values against parent-FRS values for set
+    // membership, and the two newtypes are intentionally non-coercible.
+    // The `.raw()` boundary is the standard down-cast for this case.
+    let known_frs: FxHashSet<u64> = records.iter().map(|rec| rec.frs.raw()).collect();
+    let referenced: FxHashSet<u64> = records.iter().map(|rec| rec.parent_frs.raw()).collect();
 
     let missing: Vec<u64> = referenced
         .difference(&known_frs)

--- a/crates/uffs-mft/src/parse/tests.rs
+++ b/crates/uffs-mft/src/parse/tests.rs
@@ -4,6 +4,7 @@
 //! Tests for parse-module helpers, record decoding, and regressions.
 
 use super::*;
+use crate::frs::{Frs, ParentFrs};
 use crate::ntfs::{AttributeType, ExtendedStandardInfo, FILE_RECORD_MAGIC, NameInfo, ReparseTag};
 
 fn write_u16_le(buffer: &mut [u8], offset: usize, value: u16) {
@@ -287,13 +288,13 @@ fn parse_file_name_full_reads_unaligned_payload() {
 
     if let Some(name_info) = result {
         assert_eq!(name_info.name, name);
-        assert_eq!(name_info.parent_frs, 42);
+        assert_eq!(name_info.parent_frs, ParentFrs::new(42));
         assert_eq!(name_info.namespace, 1);
         assert_eq!(name_info.fn_created, creation_time);
         assert_eq!(name_info.fn_modified, modification_time);
         assert_eq!(name_info.fn_accessed, access_time);
         assert_eq!(name_info.fn_mft_changed, mft_change_time);
-        assert_eq!(name_info.source_frs, 99);
+        assert_eq!(name_info.source_frs, Frs::new(99));
     }
 }
 
@@ -307,7 +308,7 @@ fn parse_record_forensic_reads_unaligned_record_slice() {
     assert!(matches!(&result, ParseResult::Base(_)));
 
     if let ParseResult::Base(parsed_record) = result {
-        assert_eq!(parsed_record.frs, 5);
+        assert_eq!(parsed_record.frs, Frs::ROOT);
         assert_eq!(parsed_record.sequence_number, 1);
         assert!(parsed_record.in_use);
     }
@@ -334,11 +335,11 @@ fn parse_record_forensic_reads_unaligned_extension_record_slice() {
     assert!(matches!(&merge_result, ParseResult::Extension(_)));
 
     if let ParseResult::Extension(extension) = merge_result {
-        assert_eq!(extension.base_frs, base_frs);
-        assert_eq!(extension.extension_frs, extension_frs);
+        assert_eq!(extension.base_frs, Frs::new(base_frs));
+        assert_eq!(extension.extension_frs, Frs::new(extension_frs));
         assert_eq!(extension.names.len(), 1);
         assert_eq!(extension.names[0].name, "ext-name.txt");
-        assert_eq!(extension.names[0].parent_frs, 42);
+        assert_eq!(extension.names[0].parent_frs, ParentFrs::new(42));
     }
 
     let forensic_result =
@@ -347,7 +348,7 @@ fn parse_record_forensic_reads_unaligned_extension_record_slice() {
 
     if let ParseResult::Base(parsed_record) = forensic_result {
         assert!(parsed_record.is_extension);
-        assert_eq!(parsed_record.base_frs, base_frs);
+        assert_eq!(parsed_record.base_frs, Frs::new(base_frs));
         assert_eq!(parsed_record.name, "ext-name.txt");
     }
 }
@@ -380,8 +381,9 @@ fn parse_record_forensic_reads_unaligned_resident_reparse_tag() {
 fn create_placeholder_record_works() {
     let record = create_placeholder_record(12345);
 
-    assert_eq!(record.frs, 12345);
-    assert_eq!(record.parent_frs, 5); // Root directory
+    assert_eq!(record.frs, Frs::new(12345));
+    // Placeholder records terminate path resolution at the NTFS root.
+    assert_eq!(record.parent_frs, ParentFrs::ROOT);
     assert_eq!(record.name, "<dir:12345>");
     assert!(record.is_directory);
     assert!(record.in_use);
@@ -396,8 +398,8 @@ fn parse_result_variants() {
     assert!(matches!(base, ParseResult::Base(_)));
 
     let ext = ParseResult::Extension(ExtensionAttributes {
-        base_frs: 100,
-        extension_frs: 101,
+        base_frs: Frs::new(100),
+        extension_frs: Frs::new(101),
         names: Vec::new(),
         streams: Vec::new(),
         dir_index_size: 0,
@@ -429,9 +431,11 @@ fn parse_options_forensic() {
 #[test]
 fn parsed_record_default() {
     let record = ParsedRecord::default();
-    assert_eq!(record.frs, 0);
+    // `Frs::default()` / `ParentFrs::default()` are the documented ZERO
+    // sentinels — a default `ParsedRecord` has no own / parent FRS.
+    assert_eq!(record.frs, Frs::ZERO);
     assert_eq!(record.sequence_number, 0);
-    assert_eq!(record.parent_frs, 0);
+    assert_eq!(record.parent_frs, ParentFrs::ZERO);
     assert!(record.name.is_empty());
     assert!(!record.in_use);
     assert!(!record.is_directory);
@@ -449,12 +453,12 @@ fn add_missing_parent_placeholders_no_missing() {
     let mut records = vec![
         {
             let mut r = create_placeholder_record(5);
-            r.parent_frs = 5; // Root references itself
+            r.parent_frs = ParentFrs::ROOT; // Root references itself
             r
         },
         {
             let mut r = create_placeholder_record(100);
-            r.parent_frs = 5; // References root
+            r.parent_frs = ParentFrs::ROOT; // References root
             r
         },
     ];
@@ -467,7 +471,7 @@ fn add_missing_parent_placeholders_no_missing() {
 fn add_missing_parent_placeholders_with_missing() {
     let mut records = vec![{
         let mut r = create_placeholder_record(100);
-        r.parent_frs = 50; // References non-existent parent
+        r.parent_frs = ParentFrs::new(50); // References non-existent parent
         r
     }];
 
@@ -475,7 +479,7 @@ fn add_missing_parent_placeholders_with_missing() {
     assert!(added >= 1, "Should add placeholder for missing parent 50");
 
     // Verify placeholder was added
-    let has_50 = records.iter().any(|r| r.frs == 50);
+    let has_50 = records.iter().any(|r| r.frs == Frs::new(50));
     assert!(has_50, "Placeholder for FRS 50 should exist");
 }
 
@@ -504,10 +508,10 @@ mod proptest_tests {
         #[test]
         fn placeholder_record_always_valid(frs in 0_u64..1_000_000) {
             let record = create_placeholder_record(frs);
-            prop_assert_eq!(record.frs, frs);
+            prop_assert_eq!(record.frs, Frs::new(frs));
             prop_assert!(record.is_directory);
             prop_assert!(record.in_use);
-            prop_assert_eq!(record.parent_frs, 5); // Always root
+            prop_assert_eq!(record.parent_frs, ParentFrs::ROOT); // Always root
         }
 
         /// ParseOptions should have consistent is_forensic behavior
@@ -563,13 +567,13 @@ fn extension_merge_with_empty_base_name() {
 
     // Add base record with empty name
     let base = ParsedRecord {
-        frs: 100,
+        frs: Frs::new(100),
         sequence_number: 1,
         lsn: 0,
-        parent_frs: 0,       // Wrong - should be updated from extension
-        name: String::new(), // Empty - should be updated from extension
-        namespace: 255,      // Invalid
-        names: Vec::new(),   // No names in base record
+        parent_frs: ParentFrs::ZERO, // Wrong - should be updated from extension
+        name: String::new(),         // Empty - should be updated from extension
+        namespace: 255,              // Invalid
+        names: Vec::new(),           // No names in base record
         streams: Vec::new(),
         size: 0,
         allocated_size: 0,
@@ -584,23 +588,23 @@ fn extension_merge_with_empty_base_name() {
         is_deleted: false,
         is_corrupt: false,
         is_extension: false,
-        base_frs: 0,
+        base_frs: Frs::ZERO,
     };
     record_merger.add_result(ParseResult::Base(base));
 
     // Add extension record with the actual name
     let ext = ExtensionAttributes {
-        base_frs: 100,
-        extension_frs: 200,
+        base_frs: Frs::new(100),
+        extension_frs: Frs::new(200),
         names: vec![NameInfo {
             name: "test_directory".to_owned(),
-            parent_frs: 5, // Root
-            namespace: 1,  // Win32
+            parent_frs: ParentFrs::ROOT, // Root
+            namespace: 1,                // Win32
             fn_created: 0,
             fn_modified: 0,
             fn_accessed: 0,
             fn_mft_changed: 0,
-            source_frs: 200,
+            source_frs: Frs::new(200),
         }],
         streams: Vec::new(),
         dir_index_size: 0,
@@ -614,13 +618,14 @@ fn extension_merge_with_empty_base_name() {
     // Check that the base record now has the name from extension
     assert_eq!(result.len(), 1, "Should have exactly 1 merged record");
     let rec = &result[0];
-    assert_eq!(rec.frs, 100);
+    assert_eq!(rec.frs, Frs::new(100));
     assert_eq!(
         rec.name, "test_directory",
         "Name should be merged from extension"
     );
     assert_eq!(
-        rec.parent_frs, 5,
+        rec.parent_frs,
+        ParentFrs::ROOT,
         "parent_frs should be merged from extension"
     );
     assert_eq!(
@@ -637,17 +642,17 @@ fn extension_before_base_merge() {
 
     // Add extension record FIRST (before base record)
     let ext = ExtensionAttributes {
-        base_frs: 100,
-        extension_frs: 200,
+        base_frs: Frs::new(100),
+        extension_frs: Frs::new(200),
         names: vec![NameInfo {
             name: "test_directory".to_owned(),
-            parent_frs: 5,
+            parent_frs: ParentFrs::ROOT,
             namespace: 1,
             fn_created: 0,
             fn_modified: 0,
             fn_accessed: 0,
             fn_mft_changed: 0,
-            source_frs: 200,
+            source_frs: Frs::new(200),
         }],
         streams: Vec::new(),
         dir_index_size: 0,
@@ -657,10 +662,10 @@ fn extension_before_base_merge() {
 
     // Add base record AFTER extension
     let base = ParsedRecord {
-        frs: 100,
+        frs: Frs::new(100),
         sequence_number: 1,
         lsn: 0,
-        parent_frs: 0,
+        parent_frs: ParentFrs::ZERO,
         name: String::new(),
         namespace: 255,
         names: Vec::new(),
@@ -678,7 +683,7 @@ fn extension_before_base_merge() {
         is_deleted: false,
         is_corrupt: false,
         is_extension: false,
-        base_frs: 0,
+        base_frs: Frs::ZERO,
     };
     record_merger.add_result(ParseResult::Base(base));
 
@@ -688,13 +693,14 @@ fn extension_before_base_merge() {
     // Check that the base record now has the name from extension
     assert_eq!(result.len(), 1, "Should have exactly 1 merged record");
     let rec = &result[0];
-    assert_eq!(rec.frs, 100);
+    assert_eq!(rec.frs, Frs::new(100));
     assert_eq!(
         rec.name, "test_directory",
         "Name should be merged from extension"
     );
     assert_eq!(
-        rec.parent_frs, 5,
+        rec.parent_frs,
+        ParentFrs::ROOT,
         "parent_frs should be merged from extension"
     );
 }

--- a/crates/uffs-mft/src/parse/types.rs
+++ b/crates/uffs-mft/src/parse/types.rs
@@ -22,13 +22,13 @@ use crate::ntfs::{ExtendedStandardInfo, NameInfo, StreamInfo};
 )]
 pub struct ParsedRecord {
     /// File Record Segment number.
-    pub frs: u64,
+    pub frs: crate::frs::Frs,
     /// Sequence number (incremented when FRS is reused).
     pub sequence_number: u16,
     /// Log File Sequence Number - correlates with `$LogFile` journal.
     pub lsn: u64,
     /// Primary parent directory FRS (from best name).
-    pub parent_frs: u64,
+    pub parent_frs: crate::frs::ParentFrs,
     /// Primary file name (Win32 or Win32+DOS preferred).
     pub name: String,
     /// Primary filename namespace (0=POSIX, 1=Win32, 2=DOS, 3=Win32+DOS).
@@ -71,9 +71,9 @@ pub struct ParsedRecord {
     /// True if this is an extension record (not a base record).
     /// Only populated when parsing with `ParseOptions::include_extensions`.
     pub is_extension: bool,
-    /// Base FRS for extension records (0 for base records).
+    /// Base FRS for extension records (`Frs::ZERO` for base records).
     /// Only meaningful when `is_extension` is true.
-    pub base_frs: u64,
+    pub base_frs: crate::frs::Frs,
 }
 
 impl ParsedRecord {
@@ -127,9 +127,9 @@ impl ParsedRecord {
 #[derive(Debug, Clone, Default)]
 pub struct ExtensionAttributes {
     /// The base FRS this extension belongs to.
-    pub base_frs: u64,
+    pub base_frs: crate::frs::Frs,
     /// The extension's own FRS.
-    pub extension_frs: u64,
+    pub extension_frs: crate::frs::Frs,
     /// File names found in this extension.
     pub names: Vec<NameInfo>,
     /// Streams found in this extension.

--- a/crates/uffs-mft/src/reader/dataframe_build.rs
+++ b/crates/uffs-mft/src/reader/dataframe_build.rs
@@ -62,8 +62,10 @@ impl MftReader {
             let name_count = parsed.name_count();
             let stream_count = parsed.stream_count();
 
-            frs_vec.push(parsed.frs);
-            parent_frs_vec.push(parsed.parent_frs);
+            // Polars-bound `Vec<u64>` columns — downcast typed FRS values at the push
+            // boundary.
+            frs_vec.push(parsed.frs.raw());
+            parent_frs_vec.push(parsed.parent_frs.raw());
             name_vec.push(parsed.name);
             size_vec.push(parsed.size);
             allocated_size_vec.push(parsed.allocated_size);
@@ -436,8 +438,9 @@ impl MftReader {
 
                 for name_info in &names {
                     for stream_info in &streams {
-                        frs_vec.push(parsed.frs);
-                        parent_frs_vec.push(name_info.parent_frs);
+                        // Polars-bound `Vec<u64>` columns — typed → raw at the push boundary.
+                        frs_vec.push(parsed.frs.raw());
+                        parent_frs_vec.push(name_info.parent_frs.raw());
                         name_vec.push(name_info.name.clone());
                         let (size, alloc) = if stream_info.name.is_empty() {
                             (parsed.size, parsed.allocated_size)
@@ -474,8 +477,9 @@ impl MftReader {
                     }
                 }
             } else {
-                frs_vec.push(parsed.frs);
-                parent_frs_vec.push(parsed.parent_frs);
+                // Polars-bound `Vec<u64>` columns — typed → raw at the push boundary.
+                frs_vec.push(parsed.frs.raw());
+                parent_frs_vec.push(parsed.parent_frs.raw());
                 name_vec.push(parsed.name);
                 size_vec.push(parsed.size);
                 allocated_size_vec.push(parsed.allocated_size);
@@ -626,8 +630,10 @@ impl MftReader {
             let name_count = parsed.name_count();
             let stream_count = parsed.stream_count();
 
-            frs_vec.push(parsed.frs);
-            parent_frs_vec.push(parsed.parent_frs);
+            // Polars-bound `Vec<u64>` columns — downcast typed FRS values at the push
+            // boundary.
+            frs_vec.push(parsed.frs.raw());
+            parent_frs_vec.push(parsed.parent_frs.raw());
             name_vec.push(parsed.name);
             size_vec.push(parsed.size);
             allocated_size_vec.push(parsed.allocated_size);


### PR DESCRIPTION
## Summary

Phase 4 sub-phase **5d.1** — first slice of the FRS migration along
the playbook's data-flow split (5d.1 parse → 5d.2 index → 5d.3 query
→ 5d.4 wire).

Introduces **two** typed newtypes that close the historic *own-FRS vs
parent-FRS swap* hazard and the *sentinel-meaning ambiguity*
(`frs == 0` meaning both "null reference" and "$MFT self-record")
without touching the on-disk or wire format.

## Newtypes (`crates/uffs-mft/src/frs.rs`)

- `Frs(u64)` — typed FRS value with documented sentinels
  `Frs::ZERO` / `Frs::ROOT` and predicates `is_zero` / `is_root`.
- `ParentFrs(Frs)` — composed-over-`Frs` newtype for parent-directory
  references; the type system makes parent-vs-child swaps a compile
  error.  Convert via `ParentFrs::of(Frs)` / `ParentFrs::as_frs()`
  at the explicit promotion / demotion sites.

Both are `#[repr(transparent)]` (byte-identical to `u64`) and derive
`Copy + Eq + Ord + Hash + Default` so they slot into `HashMap` /
`BTreeMap` keys and tracing fields.

## Migrated parse-layer surface

| Field | Before | After |
|---|---|---|
| `NameInfo.parent_frs` | `u64` | `ParentFrs` |
| `NameInfo.source_frs` | `u64` | `Frs` |
| `ParsedRecord.frs` | `u64` | `Frs` |
| `ParsedRecord.parent_frs` | `u64` | `ParentFrs` |
| `ParsedRecord.base_frs` | `u64` | `Frs` |
| `ExtensionAttributes.base_frs` | `u64` | `Frs` |
| `ExtensionAttributes.extension_frs` | `u64` | `Frs` |
| `PrimaryNameTracker.parent_frs` | `u64` | `ParentFrs` |

The `parse_record* (data, frs: u64)` public input signatures stay
`u64` because the FRS is derived arithmetically from chunk offsets in
the read loop; the typed surface is the *output* contract.

## Boundary down-casts (5d.2 will erase these)

The index storage, Polars `Vec<u64>` columns, and the `uffs-diag` CLI
are still `u64`.  Each crossing point uses an explicit `.raw()` /
`Frs::new()` lift with a citation comment:

- `index/builder.rs::from_parsed_records` — single typed→raw demote
  at loop entry (`parsed_frs`, `parsed_parent_frs`, `parsed_base_frs`
  locals) with a doc-comment naming sub-phase 5d.2 as the eraser.
- `parse/columns.rs::push_record{,_expanded}` — Polars-bound columns.
- `reader/dataframe_build.rs` (4 sites) — same pattern.
- `parse/merger.rs` (3 sites) — `frs_to_usize` / `TryFrom<u64>`
  index-arithmetic boundaries.
- `uffs-diag/src/bin/dump_mft_records.rs` — wraps the CLI-parsed
  `u64` for the merged-record lookup.

## Wire format unchanged

Pinned by:

- `frs::tests::frs_raw_roundtrip_preserves_u64_exactly` /
  `parent_frs_raw_roundtrip_preserves_u64_exactly` — any `u64`
  survives `Frs::new` → `.raw()` byte-identically (covers `0`, `1`,
  `5`, `42`, `1 << 47`, `u64::MAX`).
- `frs::tests::frs_sentinels_match_literal_values` /
  `parent_frs_sentinels_match_literal_values` — `ZERO` / `ROOT` are
  the documented `0` / `5` literals exactly.
- `frs::tests::parent_frs_of_and_as_frs_roundtrip` — promotion /
  demotion across the `Frs` ↔ `ParentFrs` boundary is bit-identical.
- Updated `parse::tests::*` — every existing parse regression test
  compares against the typed surface (`Frs::new(...)`, `Frs::ROOT`,
  `ParentFrs::ROOT`, etc.) preserving the prior numeric expectations.

## Verification

- ✅ `cargo check --workspace --all-targets`
- ✅ `cargo xwin check --target x86_64-pc-windows-msvc --workspace --all-targets`
- ✅ `cargo test --workspace --lib --bins` — 180 `uffs-mft` lib tests
  pass (was 169; +11 new `Frs` / `ParentFrs` regression tests).
- ✅ `just lint-pre-push` — all 23 gates green (fmt, file-size,
  drift, vet, machete, typos, reuse, cargo-check, lint-ci,
  lint-prod, lint-tests, rustdoc, doc-tests, tests, smoke, deny,
  lint-ci-windows).

## Out of scope (follow-up sub-phases)

- `index::types::FileRecord.{frs, base_frs}`,
  `index::types::FILE_NAME.parent_frs`,
  `index::model::ChildEntry.child_frs`, `index::*` lookup APIs — **5d.2**.
- Query / search surfaces — **5d.3**.
- USN / wire DTOs (`UsnRecord`, `FileChange`, broker-protocol rows) — **5d.4**.

Refs #191