### PR TITLE
fix(just): replace Unicode in Windows PowerShell recipe strings

### DIFF
--- a/just/build.just
+++ b/just/build.just
@@ -531,7 +531,7 @@ sync:
     $ErrorActionPreference = 'Stop'
     $branch = (git rev-parse --abbrev-ref HEAD).Trim()
     if ($branch -ne 'main') {
-        Write-Host "❌ just sync only runs on main (current: $branch)" -ForegroundColor Red
+        Write-Host "[FAIL] just sync only runs on main (current: $branch)" -ForegroundColor Red
         Write-Host "   Use 'git pull --rebase' (or commit the WIP first) on feature branches."
         exit 1
     }
@@ -541,19 +541,19 @@ sync:
     $after = (git rev-parse --short FETCH_HEAD).Trim()
     $dirty = (git status --porcelain)
     if ($dirty) {
-        Write-Host "⚠️  Discarding uncommitted edits to:" -ForegroundColor Yellow
+        Write-Host "[WARN] Discarding uncommitted edits to:" -ForegroundColor Yellow
         (git diff --name-only HEAD) -split "`n" | Where-Object { $_ } | ForEach-Object { Write-Host "   $_" }
     }
     if ($before -eq $after -and -not $dirty) {
-        Write-Host "✅ Already at origin/main ($before) — nothing to do" -ForegroundColor Green
+        Write-Host "[OK] Already at origin/main ($before) - nothing to do" -ForegroundColor Green
     } else {
         if ($before -ne $after) {
-            Write-Host "⚠️  Resetting $before -> $after" -ForegroundColor Yellow
+            Write-Host "[WARN] Resetting $before -> $after" -ForegroundColor Yellow
         }
         git reset --hard FETCH_HEAD
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         $head = (git rev-parse --short HEAD).Trim()
-        Write-Host "✅ Synced to $head" -ForegroundColor Green
+        Write-Host "[OK] Synced to $head" -ForegroundColor Green
     }
 
 # Force-pull main (discarding local edits) and reinstall release binaries

--- a/just/dev.just
+++ b/just/dev.just
@@ -224,7 +224,7 @@ bake-day:
     $BakeDir = Join-Path $HOME 'uffs_bake'
     $Log = Join-Path $BakeDir "$Date-$Platform.log"
     New-Item -ItemType Directory -Path $BakeDir -Force | Out-Null
-    Write-Host "🎂 Bake-day check — $Platform — $Date" -ForegroundColor Blue
+    Write-Host "[bake-day] check - $Platform - $Date" -ForegroundColor Blue
     Write-Host "   Log: $Log`n" -ForegroundColor Blue
     just readiness *>&1 | Tee-Object -FilePath $Log
     $ReadinessExit = $LASTEXITCODE
@@ -243,25 +243,25 @@ bake-day:
     if ($RedFlags) {
         $Pass = $false
         $Reasons += "red-flag patterns found"
-        Write-Host "`n❌ Red-flag patterns:" -ForegroundColor Red
+        Write-Host "`n[FAIL] Red-flag patterns:" -ForegroundColor Red
         $RedFlags | ForEach-Object { Write-Host $_.Line }
     }
     if ($BgIoFail) {
         $Pass = $false
         $Reasons += "BackgroundIoPriority begin failed"
-        Write-Host "`n❌ BackgroundIoPriority:" -ForegroundColor Red
+        Write-Host "`n[FAIL] BackgroundIoPriority:" -ForegroundColor Red
         $BgIoFail | ForEach-Object { Write-Host $_.Line }
     }
-    Write-Host "`n── Bake-day summary ─────────────────────────────────" -ForegroundColor Blue
+    Write-Host "`n--- Bake-day summary ---------------------------------" -ForegroundColor Blue
     if ($Pass) {
-        Write-Host "✅ $Platform $Date — ALL GREEN (150/150)" -ForegroundColor Green
-        $Result = '150/150 ✅'
+        Write-Host "[OK] $Platform $Date - ALL GREEN (150/150)" -ForegroundColor Green
+        $Result = '150/150 OK'
     } else {
-        Write-Host "❌ $Platform $Date — FAILED: $($Reasons -join ', ')" -ForegroundColor Red
+        Write-Host "[FAIL] $Platform $Date - FAILED: $($Reasons -join ', ')" -ForegroundColor Red
         Write-Host "   Full log: $Log" -ForegroundColor Red
         $Result = 'FAIL'
     }
-    Write-Host "`n── Paste row into docs/architecture/memory-tiering-bake-criteria.md §4 ─" -ForegroundColor Blue
+    Write-Host "`n--- Paste row into docs/architecture/memory-tiering-bake-criteria.md Section 4 ---" -ForegroundColor Blue
     Write-Host "|  ?  | $Date | full readiness | (pending) | full readiness | $Result |       |"
     if (-not $Pass) { exit 1 }
 
@@ -408,18 +408,18 @@ update-tools:
 [windows]
 update-tools:
     #!powershell
-    Write-Host "`n🔄 Updating all development tools" -ForegroundColor Blue
+    Write-Host "`n[update-tools] Updating all development tools" -ForegroundColor Blue
     Write-Host "========================================================"
 
-    # ── 1. Rust toolchain ──────────────────────────────────────
-    Write-Host "`n🦀 Step 1/3: Rust toolchain" -ForegroundColor Blue
+    # --- 1. Rust toolchain ------------------------------------
+    Write-Host "`n[Rust] Step 1/3: Rust toolchain" -ForegroundColor Blue
     rustup self update 2>$null
     rustup update
     just toolchain-sync
-    Write-Host "  ✅ Rust toolchain up to date" -ForegroundColor Green
+    Write-Host "  [OK] Rust toolchain up to date" -ForegroundColor Green
 
-    # ── 2. Cargo tools ─────────────────────────────────────────
-    Write-Host "`n📦 Step 2/3: Cargo tools" -ForegroundColor Blue
+    # --- 2. Cargo tools ---------------------------------------
+    Write-Host "`n[Pkg] Step 2/3: Cargo tools" -ForegroundColor Blue
     $tools = @(
         "cargo-nextest"
         "cargo-llvm-cov"
@@ -434,27 +434,27 @@ update-tools:
     )
     $toolList = $tools -join " "
     if (Get-Command cargo-binstall -ErrorAction SilentlyContinue) {
-        Write-Host "  → Using cargo-binstall (fast, pre-built binaries)"
+        Write-Host "  -> Using cargo-binstall (fast, pre-built binaries)"
         Invoke-Expression "cargo binstall -y --no-confirm $toolList"
     } else {
-        Write-Host "  → Using cargo install (compiling from source — slower)"
-        Write-Host "  💡 Install cargo-binstall for faster updates:" -ForegroundColor Yellow
+        Write-Host "  -> Using cargo install (compiling from source - slower)"
+        Write-Host "  [TIP] Install cargo-binstall for faster updates:" -ForegroundColor Yellow
         Invoke-Expression "cargo install $toolList"
     }
-    Write-Host "  ✅ Cargo tools up to date" -ForegroundColor Green
+    Write-Host "  [OK] Cargo tools up to date" -ForegroundColor Green
 
-    # ── 3. System packages ─────────────────────────────────────
-    Write-Host "`n📦 Step 3/3: System packages" -ForegroundColor Blue
+    # --- 3. System packages -----------------------------------
+    Write-Host "`n[Pkg] Step 3/3: System packages" -ForegroundColor Blue
     if (Get-Command winget -ErrorAction SilentlyContinue) {
         winget upgrade Casey.Just 2>$null
     } elseif (Get-Command scoop -ErrorAction SilentlyContinue) {
         scoop update just 2>$null
     } else {
-        Write-Host "  → No winget/scoop detected, skipping system packages"
+        Write-Host "  -> No winget/scoop detected, skipping system packages"
     }
-    Write-Host "  ✅ System packages up to date" -ForegroundColor Green
+    Write-Host "  [OK] System packages up to date" -ForegroundColor Green
 
-    Write-Host "`n🎉 All tools updated!" -ForegroundColor Green
+    Write-Host "`n[DONE] All tools updated!" -ForegroundColor Green
     Write-Host "  rustc:    $(rustc --version)"
     Write-Host "  nextest:  $(cargo nextest --version 2>$null | Select-Object -First 1)"
 

--- a/just/shared.just
+++ b/just/shared.just
@@ -5,6 +5,25 @@
 # Updated: April 2026 — Nightly (1.96+) / Edition 2024
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
+# Windows PowerShell 5.1 (powershell.exe) reads files without a BOM as the
+# system ANSI code page (typically CP1252) — NOT as UTF-8.  `just` writes
+# shebang recipe bodies (`#!powershell`) as UTF-8 without a BOM, so any
+# multi-byte Unicode codepoint whose UTF-8 continuation byte lands in
+# 0x91-0x94 decodes to a smart quotation mark (U+2018-U+201D) which the
+# PowerShell tokenizer treats as a string delimiter.  This silently
+# terminates string literals mid-line and surfaces downstream as
+# "Unexpected token" / "Missing closing '}'" errors far from the real
+# cause.  Known offenders that hit this trap:
+#   em-dash (—)        UTF-8 E2 80 94  -> 0x94 = U+201D right double quote
+#   box-drawing (─)    UTF-8 E2 94 80  -> 0x94 = U+201D right double quote
+#   right arrow (→)    UTF-8 E2 86 92  -> 0x92 = U+2019 right single quote
+#   package emoji (📦) UTF-8 F0 9F 93 A6 -> 0x93 = U+201C left double quote
+#   bulb emoji   (💡) UTF-8 F0 9F 92 A1 -> 0x92 = U+2019 right single quote
+# RULE: Keep all `[windows]` `#!powershell` recipe strings ASCII-only.
+# Unicode inside `#` comments is safe (tokenizer skips comment bodies).
+# Migrating to PowerShell 7 (`pwsh`) would also fix this — pwsh reads
+# scripts as UTF-8 by default — but that requires every operator to have
+# PS Core installed, which the Windows-host CI baseline does not.
 set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-Command"]
 
 export FORCE_COLOR := "1"


### PR DESCRIPTION
## Root cause

Windows PowerShell 5.1 (`powershell.exe`) reads UTF-8-no-BOM files as the system ANSI code page (CP1252). `just` writes `#!powershell` recipe bodies as UTF-8 without a BOM, so any multi-byte Unicode codepoint whose UTF-8 continuation byte lands in `0x91`-`0x94` decodes as a **smart quotation mark** (U+2018-U+201D), which the PowerShell tokenizer treats as a string delimiter. This silently terminates string literals mid-line and surfaces downstream as `Unexpected token` / `Missing closing }` errors far from the real cause.

## Reported failure

```
> just bake-day
At C:\Users\rnio\AppData\Local\Temp\just-8Y4WhE\bake-day.ps1:259 char:1
+ } else {
+ ~
Unexpected token "}" in expression or statement.
error: Recipe `bake-day` failed with exit code 1
```

Line 259 of `just/dev.just` contains `} else {`. The actual breakage is upstream: the em-dash `—` (UTF-8 `E2 80 94`) on line 227 decodes to `â€"` under CP1252; the trailing `0x94` byte is U+201D (right double quote) which terminates the surrounding `"..."` string early, leaving PowerShell to mis-parse everything until it gives up at the next `}`.

## Affected recipes

- `just/dev.just::bake-day` (the reported failure)
- `just/dev.just::update-tools` (same trap, same file)
- `just/build.just::sync` (em-dash on line 548)

## Fix

Replaced all Unicode in `[windows]` `#!powershell` string literals with ASCII tags (`[OK]`, `[FAIL]`, `[WARN]`, `[TIP]`, `[DONE]`, `[Rust]`, `[Pkg]`, etc.). Unicode in `#` comments was left intact — the tokenizer skips comment bodies. Unix recipe variants are unchanged.

Added a comment block above `set windows-shell` in `just/shared.just` documenting:
- The CP1252/UTF-8 trap with the exact byte sequences
- The ASCII-only rule for future Windows recipes
- Why we can't just switch to PowerShell 7 (operator baseline)

## Verification

- `just --evaluate` parses clean on Mac
- Byte-scanner confirms **0 dangerous bytes (`0x91`-`0x94`) in any PowerShell string** across all `just/*.just` files
- Full pre-push gate (22 jobs, including `lint-ci-windows`) passed locally

## Test plan

- [ ] `just bake-day` runs to completion on Windows (was the reported failure)
- [ ] `just update-tools` parses on Windows
- [ ] `just sync` parses on Windows