### PR TITLE
chore: release v0.5.100 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,7 +735,7 @@ hunting for the wrong things.
 
 Plan §1 goal-4 ("no regression on CLI hot path vs the v0.5.35
 baseline") verified end-to-end on the Windows 7-drive reference
-box.  Current v0.5.99 (post-Phase-8 tiered architecture) is
+box.  Current v0.5.100 (post-Phase-8 tiered architecture) is
 **universally faster** than v0.5.35 across every benchmarked
 pattern, with the largest result set (`*.dll`, 44 529 rows)
 showing a **2.7× speedup**:
@@ -743,7 +743,7 @@ showing a **2.7× speedup**:
 ```
 Drive D, 7.07 M records, 30 rounds, HOT phase, p50 / p95 wall_ms:
 
-                              v0.5.35      v0.5.99       Δ p50
+                              v0.5.35      v0.5.100       Δ p50
     exact      (3 rows)       20 / 23   →  18 / 19      −10 %
     prefix     (8 732)        46 / 50   →  40 / 46      −13 %
     ext_rare   (11)           18 / 20   →  17 / 18       −6 %
@@ -919,7 +919,7 @@ log-message renames fail CI before reaching another 24-h soak.
   2026-05-13.  No new operator-surface features land on `main`
   until v0.6.0 ships.
 
-## [0.5.99] - 2026-05-08
+## [0.5.100] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -928,7 +928,7 @@ log-message renames fail CI before reaching another 24-h soak.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.99`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.100`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1719,7 +1719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -4335,7 +4335,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,14 +4346,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "clap",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "chrono",
  "itoa",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "clap",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "clap",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "clap",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "axum",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4581,14 +4581,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4603,14 +4603,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.99"
+version = "0.5.100"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.99"
+version = "0.5.100"
 edition = "2024"
 # MSRV: Pure Rust code compiles on stable 1.91+ (Duration::from_mins),
 # but Polars is built with features = ["nightly", "simd"] which requires
@@ -116,21 +116,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.99" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.99" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.99" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.99" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.99" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.99" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.99" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.99" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.100" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.100" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.100" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.100" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.100" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.100" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.100" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.100" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.99" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.100" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -30,7 +30,7 @@
 # CI pipeline will auto-refresh on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed — use that flag (or plain `just ship`) while the upstream regression
 # persists.
-channel = "nightly-2026-05-15"
+channel = "nightly-2026-05-16"
 
 # Specify components that should always be available
 components = [

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -13,6 +13,12 @@ criteria = "safe-to-deploy"
 version = "3.1.1"
 notes = "Reviewed v3.1.1 source. Scope: ANSI terminal coloring. One unsafe block in control.rs (Windows Console FFI via windows-sys: GetStdHandle / GetConsoleMode / SetConsoleMode) — standard Win32 terminal setup, properly cfg(windows)-gated. No network I/O, no filesystem writes, no process spawning. Only std types plus windows-sys on Windows. Dev-deps (rspec, insta, ansiterm) are standard testing crates. MPL-2.0 licensed, same as our workspace."
 
+[[audits.hashbrown]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.17.1"
+notes = "Reviewed 0.17.0 -> 0.17.1 source diff (6 files, +106/-28). (1) CHANGELOG / Cargo.toml{,.orig} / README — version bump (drops redundant 'authors' field) + markdown line-wrap reformat. (2) src/control/group/lsx.rs — 3-line LoongArch SX SIMD micro-opt inside an existing unsafe block: lsx_vslt_b(self.0, zero) -> lsx_vslti_b::<0>(self.0) and lsx_vor_v(special, lsx_vreplgr2vr_b(imm)) -> lsx_vori_b::<imm>(special). Replaces materialized-zero compare with the immediate-compare intrinsic. No new unsafe blocks, no new intrinsics outside the 0.17.0 set, no behavior change to SwissTable special-tag construction. LoongArch is not a shipping target for UFFS (x86_64 + aarch64 only). (3) src/rustc_entry.rs — additive: new HashMap::rustc_try_insert (PR #722) returning Result<&mut V, RustcOccupiedError> for collision-aware insertion, plus the RustcOccupiedError struct. Built on the existing self.table.find / self.table.insert_entry primitives; no new unsafe, no FFI / FS / network / process surfaces. The 'rustc_*' prefix marks it for upstream rustc consumption (hashbrown backs std::collections::HashMap). MIT OR Apache-2.0 (unchanged)."
+
 [[audits.hermit-abi]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.100**.  Binaries + GitHub Release v0.5.100 are already live (step 09).  This PR routes the corresponding commit through branch-protection rules.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

Local `main` had this commit with a different SHA before squash rewrote it onto main; recover with `git fetch origin && git reset --hard origin/main`.