### PR TITLE
chore(broker-protocol): add #[non_exhaustive] to ProtocolError (Phase 5b, refs #192)

### DIFF
--- a/crates/uffs-broker-protocol/src/lib.rs
+++ b/crates/uffs-broker-protocol/src/lib.rs
@@ -71,7 +71,18 @@ pub const RESPONSE_WIRE_LEN: usize = 9;
 /// surface them as a structured error to the user, log them, and
 /// continue serving subsequent requests.  Encoding never fails: it's a
 /// pure byte-layout operation.
+///
+/// `#[non_exhaustive]` is applied per Phase 5 §5c: future protocol
+/// extensions (e.g. a `Truncated { expected, got }` variant when a
+/// reader supplies fewer than `REQUEST_WIRE_LEN` / `RESPONSE_WIRE_LEN`
+/// bytes, or a `RateLimited` variant once the wire format gains an
+/// out-of-band error channel) can land as additive minor-version
+/// bumps without breaking downstream exhaustive matchers.  Downstream
+/// crates (`uffs-broker`, `uffs-daemon::broker_client`) currently
+/// treat this error opaquely — verified zero exhaustive-match sites
+/// workspace-wide at the Phase 5b audit (refs #192).
 #[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ProtocolError {
     /// Drive-letter byte was outside the ASCII range (high bit set or
     /// otherwise non-ASCII).  The broker should respond with


### PR DESCRIPTION
## Summary

**Phase 5 sub-phase 5b** — per-crate audit of `uffs-broker-protocol`,
the smallest crate in the Phase-5a authoritative work queue (10 sites
out of 104 workspace-wide).

Refs issue 192.

## Audit result

Surprise outcome: **9 of the 10 surfaced sites are test code** that the
strict-clippy `allow-{unwrap,expect,panic}-in-tests = true` setting
correctly protects.  The actionable finding is a Phase-3b oversight on
the error enum's semver hygiene.

| Plan §3 dimension | sites | action |
|---|---:|---|
| §3.1 `Result<_, String>` in lib boundaries | 0 | — |
| §3.2 `Box<dyn Error>` in public APIs       | 0 | — |
| §3.3 Prod `unwrap()` / `expect()`          | 0 | — *(all 10 surfaced sites are inside `#[cfg(test)] mod tests`, plan §3.3 category D)* |
| §3.4 `panic!` / `todo!` / `unimplemented!` | 0 | — |
| §3.5 Lossy `From<X>` error-conversion      | 0 | — |
| §3.6 Error enums missing `#[non_exhaustive]` | **1** | **this PR** |

## What changed

11-line patch to `crates/uffs-broker-protocol/src/lib.rs`:

- Added `#[non_exhaustive]` to `ProtocolError`.
- Added 9 doc lines describing the rationale, the additive variants a
  future contributor might want to add (`Truncated { expected, got }`,
  `RateLimited`), and the audit evidence (zero exhaustive-match sites
  workspace-wide).

## Safety / semver

Workspace-wide grep confirmed:

- `uffs-broker` consumer: 0 references to `ProtocolError`.
- `uffs-daemon::broker_client` consumer: 0 references to `ProtocolError`.
- Owner crate: construction sites + intra-doc links + test assertions only.

The two real consumers propagate `ProtocolError` opaquely via `From`-ed
source errors, never matching on its variants.  `#[non_exhaustive]` is
therefore a zero-impact change today and a forward-compatible safety
net for tomorrow.

## Validation

| Gate | Result |
|---|---|
| `cargo check -p uffs-broker-protocol --all-targets` | clean |
| `cargo test -p uffs-broker-protocol --all-targets`  | **16/16 passing** (zero existing-test regression) |
| `cargo clippy -p uffs-broker-protocol --all-targets` | clean against workspace strict-clippy |
| `cargo check --workspace --all-targets`             | clean (no downstream breakage) |
| `cargo clippy --workspace --all-targets`            | clean |
| `cargo doc -p uffs-broker-protocol --no-deps -D warnings -D rustdoc::broken_intra_doc_links` | clean |
| `just lint-fast` (commit-time)                       | 7/7 gates passed (24s) |
| `just lint-pre-push`                                | 12/12 gates passed (57s) |

## Rules adherence

1. **No suppression hacks** — added a forward-compat attribute with full
   justification.  Did NOT touch `clippy.toml`, did NOT add `#[allow]` to
   any unwrap/expect, did NOT relax any lint.  The 10 test-block sites
   stay as-is because the existing strict-gate posture already classifies
   them correctly.
2. **Surgical** — 11 lines, one attribute + its rationale docstring.
3. **Preserves behavior & contracts** — no behavior change.  Public API
   surface stays binary-compatible.
4. **No test changes** — N/A; all 16 existing tests pass unchanged.
5. **Atomic signed commit** — single-purpose deliverable.

## Stat

```
1 file changed, 11 insertions(+)
```
