### PR TITLE
fix(ci): pin cargo-fuzz to glibc target so sanitizer can link (refs #267)

### DIFF
--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -650,18 +650,35 @@ jobs:
         # 60-min job timeout.  No corpus seed yet — the very first
         # run starts from random bytes and discovers coverage
         # organically.
+        #
+        # `--target x86_64-unknown-linux-gnu` is required because
+        # cargo-fuzz ≥0.13 defaults to `x86_64-unknown-linux-musl`,
+        # and musl's statically-linked libc is incompatible with
+        # `-Zsanitizer=address` (libfuzzer-sys's default RUSTFLAGS),
+        # which manifests as `error: sanitizer is incompatible with
+        # statically linked libc` + `error[E0463]: can't find crate
+        # for \`core\`` for `libc`.  The glibc target is pre-installed
+        # via `rust-toolchain.toml::targets` (the workspace's native
+        # Linux build triple); pinning it here makes the sanitizer
+        # work without sweeping `-C target-feature=-crt-static` into
+        # RUSTFLAGS (which would still leave us on the musl runtime
+        # for everything except the libc link — a partial workaround,
+        # not a root fix).  Refs issue #267.
         run: |
           cd crates/uffs-mft
-          cargo +nightly fuzz run fuzz_parse_record -- -max_total_time=900
+          cargo +nightly fuzz run --target x86_64-unknown-linux-gnu \
+            fuzz_parse_record -- -max_total_time=900
 
       - name: Run cargo-fuzz fuzz_apply_fixup (15 min budget)
         # Same shape as above.  `if: always()` so a crash in the
         # first target still lets the second target run — advisory
-        # rollout values coverage over fail-fast.
+        # rollout values coverage over fail-fast.  `--target` pin
+        # required for the same musl/sanitizer reason as above.
         if: always()
         run: |
           cd crates/uffs-mft
-          cargo +nightly fuzz run fuzz_apply_fixup -- -max_total_time=900
+          cargo +nightly fuzz run --target x86_64-unknown-linux-gnu \
+            fuzz_apply_fixup -- -max_total_time=900
 
       - name: Upload fuzz artifacts (crashes + corpus)
         # Keep both `crashes/` (any reproducer libfuzzer found) and


### PR DESCRIPTION
# Pin cargo-fuzz to glibc target so sanitizer can link

Closes the `cargo-fuzz` half of issue #267 (the other half — MSRV — already shipped in PR #269).

## Why

The `Tier 2 / cargo-fuzz (uffs-mft)` job failed on its inaugural run (commit `e8b6bdf`, 2026-05-18 nightly) at the BUILD step — both fuzz targets, identical signature:

```
error: sanitizer is incompatible with statically linked libc,
       disable it using `-C target-feature=-crt-static`
error[E0463]: can't find crate for `core`
error: could not compile `libc` (lib) due to 2 previous errors
```

**Root cause.** cargo-fuzz 0.13.x changed its default build target from the host triple (historically `x86_64-unknown-linux-gnu` on `ubuntu-latest`) to `x86_64-unknown-linux-musl`. The full failing build command reproduced from the run log:

```
cargo build --manifest-path .../fuzz/Cargo.toml \
            --target x86_64-unknown-linux-musl \
            --release \
            <RUSTFLAGS includes -Zsanitizer=address>
```

musl's libc is statically linked by default; ASAN (which `libfuzzer-sys` enables via `-Zsanitizer=address` in its default RUSTFLAGS) requires a *dynamically*-linked libc to interpose malloc/free etc. Structurally incompatible.

## What

Pin both `cargo fuzz run` invocations in `@/.github/workflows/tier-2.yml` to the glibc target:

```yaml
cargo +nightly fuzz run --target x86_64-unknown-linux-gnu \
      fuzz_parse_record -- -max_total_time=900
```

`x86_64-unknown-linux-gnu` is already pre-installed via `@/rust-toolchain.toml:49` (the workspace's canonical Linux build triple), so no `rustup target add` step or cache-key change is needed.

## Why this over the RUSTFLAGS workaround

The error message hints at `-C target-feature=-crt-static` as an alternative. Rejected because:

- It only disables the static-libc *link* — the rest of the std runtime would still be musl, which is a partial workaround rather than a root fix.
- It's RUSTFLAGS-level magic; target-pinning is configuration-level and self-documenting.
- The cargo-fuzz upstream issue tracker recommends target-pinning when sanitizer use is intended.

The workflow comment block records all of this so a future maintainer bumping cargo-fuzz doesn't have to re-litigate.

## Validation

- `actionlint .github/workflows/tier-2.yml` — clean.
- The fix cannot be verified end-to-end on the macOS dev host (cargo-fuzz is Linux-only); next nightly Tier-2 run on 2026-05-25 will exercise the new invocation.
- Time budgets (15 min × 2 targets) and job-level (60 min) are preserved.
- Advisory rollout (`continue-on-error: true`) preserved — this PR fixes the **build**, not the gate posture; promoting to hard-gate is a separate follow-up after a corpus baseline exists.

## Rules adherence

1. **No suppression hacks** — failing build is *fixed*, not silenced. `continue-on-error: true` was pre-existing and intentional per the advisory-rollout phasing in `@/.github/workflows/tier-2.yml:580-591`.
2. **Surgical root-cause fix** — one CLI flag per invocation; addresses the structural musl/sanitizer incompat at its actual layer.
3. **Preserves contracts** — the two fuzz targets, their time budgets, their artifact-upload paths, and the advisory-rollout posture are all unchanged.
4. **Tests not dodged** — fuzz harness code (`@/crates/uffs-mft/fuzz/fuzz_targets/`) untouched.
5. **Atomic signed commit** — single concern (cargo-fuzz target pin) in a single file.

## What this does NOT address

The `cargo-mutants` half of #267 (153 missed mutations because Linux runner can't exercise `#[cfg(windows)]` paths in `crates/uffs-security/src/pipe.rs`). That's its own structural concern — moving the job to `windows-latest` is the right shape — and will land in a separate sequenced PR after this one passes its Tier-2 verification cycle.
