### PR TITLE
fix(ci): move cargo-mutants to windows-latest so cfg(windows) code is reachable (refs #267)

### DIFF
--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -436,10 +436,10 @@ jobs:
   #
   # Why scoped to `uffs-security` (and not `--workspace`):
   #
-  #   `cargo-mutants` is O(mutations × test-suite-runtime).  At ~198
+  #   `cargo-mutants` is O(mutations × test-suite-runtime).  At ~209
   #   generated mutations for `uffs-security` × ~5 s baseline tests,
-  #   the warm-cache full run lands at 10-15 min with `--jobs 4` on
-  #   `ubuntu-latest` (4 cores).  Extending to `uffs-mft` would add
+  #   the warm-cache full run lands at 15-25 min with `--jobs 4` on
+  #   `windows-latest` (4 cores).  Extending to `uffs-mft` would add
   #   ~600 mutations × ~30 s tests ≈ another 60-90 min — beyond a
   #   reasonable Tier 2 weekly budget without batching across days.
   #
@@ -450,32 +450,46 @@ jobs:
   #   measurable test-quality signal there that no other tool in
   #   this pipeline produces.
   #
+  # Why `windows-latest` (not `ubuntu-latest`):
+  #
+  #   The single highest-value file in `uffs-security` for
+  #   mutation testing is `src/pipe.rs` (Windows named-pipe
+  #   security helpers — the privilege-elevation IPC surface).
+  #   That file is `#![cfg(windows)]` at file level, so its tests
+  #   only compile on Windows.  On `ubuntu-latest` the inaugural
+  #   run (commit `e8b6bdf`, 2026-05-18 nightly, refs issue #267)
+  #   produced 153 MISSED mutations — all inside `pipe.rs`,
+  #   because the Linux runner cannot compile the test code that
+  #   would catch them.  This was a structural false-negative,
+  #   not a real test-quality signal.
+  #
+  #   The other ~56 cross-platform mutations (keystore, runtime-
+  #   dir, FNV hashing) compile on both platforms; moving the
+  #   whole job to Windows keeps that coverage *and* unlocks the
+  #   pipe.rs coverage that's the actual mutation-testing prize.
+  #   Running both platforms in parallel would test the cross-
+  #   platform 56 twice for marginal additional signal at
+  #   ~2× the Windows-runner $/min cost — single-Windows is the
+  #   honest cost-benefit choice.
+  #
   # Why advisory (job allowed to fail without breaking the workflow):
   #
   #   We have NO baseline of "expected missed mutations" yet — this
   #   is the first run.  The initial post-merge run will produce a
-  #   numerical baseline (e.g. "12 missed out of 198"); a follow-up
+  #   numerical baseline (e.g. "12 missed out of 209"); a follow-up
   #   PR can then promote the gate to hard-fail-on-regression once
   #   that baseline is recorded in `mutants.out/`.
   #
-  # Tier R3-04 of `docs/dev/architecture/code_clean/CLIPPY_POSTURE.md`.
+  # Tier R3-04 of `docs/architecture/code-quality/lint-posture.md`.
   mutants:
     name: Tier 2 / cargo-mutants (uffs-security)
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     timeout-minutes: 60
     # Advisory in the initial rollout — see header comment.  Promote
     # to a hard gate via a follow-up PR once we have a baseline of
     # "expected missed mutations" and can fail on regression.
     continue-on-error: true
     steps:
-      - name: Free up disk space
-        # cargo-mutants copies the workspace into a temp dir for
-        # each mutant test run, so disk usage spikes briefly.  Same
-        # prelude as miri / careful for consistency.
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -488,8 +502,11 @@ jobs:
           # Dedicated cache key — cargo-mutants does many short
           # per-mutant rebuilds and benefits from its own cache so
           # the regular workspace builds don't evict mutation-test
-          # artifacts (and vice-versa).
-          shared-key: tier-2-mutants
+          # artifacts (and vice-versa).  `-windows` suffix scopes
+          # the cache to the Windows runner (rust-cache already
+          # includes the OS in its prefix, but the explicit suffix
+          # makes the platform pin visible in the cache UI).
+          shared-key: tier-2-mutants-windows
           cache-on-failure: 'true'
 
       - name: Install cargo-mutants
@@ -498,12 +515,18 @@ jobs:
           tool: cargo-mutants
 
       - name: Run cargo-mutants on uffs-security
-        # `--jobs 4` matches `ubuntu-latest`'s 4-core capacity.
+        # `--jobs 4` matches `windows-latest`'s 4-core capacity.
         # `--no-shuffle` gives deterministic mutant ordering, which
         # is useful when comparing successive runs.
         # `mutants.toml` at repo root supplies `additional_cargo_args
         # = ["--locked"]`, `timeout_multiplier = 2.0`, and exclusion
         # globs / regexes — see that file for justification of each.
+        #
+        # Explicit `shell: bash` because GitHub-Actions' default
+        # shell on Windows runners is PowerShell, which does NOT
+        # honour the `\` line-continuation; bash on Windows runners
+        # (provided by Git-for-Windows) does.
+        shell: bash
         run: |
           cargo mutants \
             --package uffs-security \


### PR DESCRIPTION
# Move cargo-mutants to `windows-latest` so `#[cfg(windows)]` code is reachable

Closes the `cargo-mutants` half of issue #267. (The MSRV half shipped in PR #269; the cargo-fuzz half shipped in PR #270.)

## Why

The `Tier 2 / cargo-mutants (uffs-security)` job produced **153 MISSED mutations** on its inaugural run (commit `e8b6bdf`, 2026-05-18 nightly). Every single missed mutation is inside `@/crates/uffs-security/src/pipe.rs:1-50`.

**Root cause.** `pipe.rs` carries `#![cfg(windows)]` at file level (`@/crates/uffs-security/src/pipe.rs:49`) — it's the Windows named-pipe security helpers for the privilege-elevation IPC surface (UAC-aware DACL construction). The `#[cfg(test)]` test module inside the file inherits that gate, so the tests only compile on Windows.

On `ubuntu-latest`, cargo-mutants behaves correctly:
- It parses the source AST (cfg-agnostic) and generates mutations for every function it finds.
- It then runs `cargo test` against each mutant.

But on Linux, `pipe.rs` is excluded from compilation entirely, so:
- The mutated source is never compiled.
- The tests that would catch it never run.
- cargo-mutants records every mutation as MISSED.

This is a **structural false-negative**. The Linux job was testing **zero** of the workspace's actual pipe-IPC security logic and reporting it as "153 test-quality gaps".

## What

Move the job from `ubuntu-latest` to `windows-latest` in `@/.github/workflows/tier-2.yml`. On Windows:
- `pipe.rs` compiles → its mutations exercise real code paths → its tests (which DO assert the elevated-token branch behaviour) determine caught vs missed.
- The other ~56 cross-platform mutations (keystore, runtime-dir, FNV hashing) compile on Windows just as on Linux and keep their existing signal.

Five concrete edits, all in the `mutants:` job block:

1. **`runs-on: ubuntu-latest` → `runs-on: windows-latest`**.
2. **Drop the `Free up disk space` step** (Linux-only commands; Windows runners have ~14 GB free vs cargo-mutants' ~5-10 GB worktree-copy spike → no cleanup needed).
3. **`shared-key: tier-2-mutants` → `tier-2-mutants-windows`** (`Swatinem/rust-cache` already includes the OS in its prefix, but the explicit suffix makes the platform pin visible in the cache UI).
4. **Add `shell: bash`** to the cargo-mutants run step because the GitHub-Actions default shell on Windows runners is PowerShell, which does NOT honour `\` line-continuation; Git-for-Windows bash on the runner does.
5. **Updated header rationale block** explaining WHY Windows (full audit of the 153 false-negatives, why single-Windows beats dual-platform on cost-benefit), bumping mutation-count claim from ~198 to ~209 (Windows-visible total includes the 153 pipe.rs ones), and bumping expected runtime from 10-15 min to 15-25 min.

I also corrected a stale pointer in the same header block: `docs/dev/architecture/code_clean/CLIPPY_POSTURE.md` (under the **gitignored** `docs/dev/` tree) → `docs/architecture/code-quality/lint-posture.md` (the actual committed document).

## Why this over the alternatives

- **`exclude_globs += ["**/pipe.rs"]` in `mutants.toml`** — would drop the false-negatives but ALSO drop all real coverage of the security-critical Windows IPC surface. Net signal: negative.
- **Dual matrix** (Linux for cross-platform code + Windows for `pipe.rs`) — would test the ~56 cross-platform mutations twice for marginal signal, at ~2× Windows-runner $/min cost. Single-Windows captures both surfaces in one job.
- **Stay on Linux + accept the baseline** — would record "153 expected misses" as the baseline, which encodes the structural blind spot into the gate and makes future promotion to hard-fail-on-regression impossible without a confusing baseline-rebase.

## Validation

- `actionlint .github/workflows/tier-2.yml` — clean.
- Cannot verify end-to-end on the macOS dev host (the fix is a Windows-runner pin); next Tier-2 cycle on 2026-05-25 will exercise the new platform.
- Advisory rollout (`continue-on-error: true`) preserved so any Windows-specific surprises don't block the workflow.
- `mutants.toml` config is Windows-portable as-is (no platform-specific paths or shell commands).

## Rules adherence

1. **No suppression hacks** — false-negative misses are *fixed* at root (move to a platform where the code compiles), not silenced via `exclude_globs` or a baseline-accept ratchet.
2. **Surgical root-cause fix** — runner platform swap + companion adjustments (cache key, shell, drop Linux-only cleanup, header comment). No source changes; no test changes.
3. **Preserves behavior & contracts** — same scope (`--package uffs-security`), same `--jobs 4 --no-shuffle` flags, same `mutants.toml` config, same advisory posture, same 60-min timeout budget, same artifact-upload path.
4. **Tests improved, not dodged** — the test suite that guards `pipe.rs` is now genuinely under mutation-quality measurement instead of bypassed by a cfg gate. No test skipped, no test relaxed.
5. **Atomic signed commit** — single concern (cargo-mutants runner platform) in a single file.

## With this merged, issue #267 closes completely

All three Tier-2 advisory failures from the 2026-05-18 nightly are now addressed via three sequenced atomic PRs:

- **MSRV** — dropped (PR #269, merged).
- **cargo-fuzz** — pinned to glibc target (PR #270, merged).
- **cargo-mutants** — moved to Windows runner (this PR).

The next Tier-2 cycle on 2026-05-25 will be the first weekly run with all three repairs in place.
