### PR TITLE
fix(security): unwrap FACILITY_WIN32 HRESULT so create_owner_only honors AlreadyExists contract (refs #267)

### DIFF
--- a/crates/uffs-security/src/runtime_dir.rs
+++ b/crates/uffs-security/src/runtime_dir.rs
@@ -423,7 +423,40 @@ mod windows_impl {
                     None,
                 )
             };
-            let handle = handle_result.map_err(io::Error::other)?;
+            // Unwrap the FACILITY_WIN32 envelope so std can map the
+            // raw Win32 code to the documented `ErrorKind`
+            // (`AlreadyExists` / `PermissionDenied` per the trait
+            // contract at `RuntimeDir::create_owner_only`).
+            //
+            // `windows::core::Error::code()` returns an HRESULT.  Win32
+            // failures arrive wrapped via `HRESULT_FROM_WIN32`, which
+            // sets facility = 7 (`FACILITY_WIN32`, severity = 1) and
+            // stuffs `GetLastError()` into the low 16 bits:
+            //
+            //     0x8007_XXXX  ← XXXX = GetLastError()
+            //
+            // `io::Error::from_raw_os_error` expects the bare Win32
+            // code (not the wrapped HRESULT) — its internal
+            // `decode_error_kind` table is keyed on `ERROR_FILE_EXISTS`
+            // (80), `ERROR_ACCESS_DENIED` (5), etc., NOT on their
+            // HRESULT envelopes.  Passing the raw HRESULT instead
+            // would degrade every error to `ErrorKind::Other`, which
+            // is exactly what produced the nightly cargo-mutants
+            // baseline failure on Windows runners (`gh run 26037964594`,
+            // `runtime_dir::tests::create_owner_only_rejects_existing_file`).
+            //
+            // Non-WIN32-facility HRESULTs fall through unchanged —
+            // std has no portable kind mapping for them anyway, and
+            // `from_raw_os_error` will just preserve them verbatim.
+            let handle = handle_result.map_err(|err| {
+                let hresult = err.code().0;
+                let win32_code = if (hresult.cast_unsigned() & 0xFFFF_0000_u32) == 0x8007_0000_u32 {
+                    hresult & 0xFFFF_i32
+                } else {
+                    hresult
+                };
+                io::Error::from_raw_os_error(win32_code)
+            })?;
             #[expect(
                 unsafe_code,
                 reason = "transfer ownership Win32 HANDLE → std::fs::File"


### PR DESCRIPTION
# Unwrap `FACILITY_WIN32` HRESULT so `create_owner_only` honors `AlreadyExists` contract

## Why

`WindowsRuntimeDir::create_owner_only` wrapped every `CreateFileW` error with `io::Error::other`, destroying the `ErrorKind` mapping that the `RuntimeDir::create_owner_only` trait contract at `@/crates/uffs-security/src/runtime_dir.rs:128-134` documents:

* `AlreadyExists` — path already exists
* `PermissionDenied` — parent dir is unwriteable

The nightly `cargo-mutants(uffs-security)` job on `windows-latest` — freshly enabled by #271 (refs #267) — surfaced the latent bug as a **hard baseline-test failure**:

```
thread 'runtime_dir::tests::create_owner_only_rejects_existing_file' panicked at
crates\uffs-security\src\runtime_dir\tests.rs:67:5:
expected AlreadyExists/PermissionDenied, got Other: The file exists. (0x80070050)
```

That panic returned `cargo test` → `Failure(101)` → cargo-mutants exit code 4 (`"cargo test failed in an unmutated tree, so no mutants were tested"`), which is what tripped run [`26037964594`](https://github.com/skyllc-ai/UltraFastFileSearch/actions/runs/26037964594) in the nightly Tier-2 sweep.

On Linux the bug was invisible because the entire Windows impl is `#[cfg(windows)]`-gated. PR #271 moving the job to `windows-latest` was the right call — it surfaced exactly the kind of latent platform-specific contract violation that "compile-only Linux" was masking.

## Root cause

`windows::core::Error::code()` returns an **HRESULT**, but `io::Error::from_raw_os_error`'s internal `decode_error_kind` table is keyed on **bare Win32 codes** (`ERROR_FILE_EXISTS=80`, `ERROR_ACCESS_DENIED=5`, ...), NOT on their FACILITY_WIN32 HRESULT envelopes (`0x8007_0050`, `0x8007_0005`, ...).

The previous `io::Error::other` codepath dropped the code entirely, so the only way to honor the trait contract is to **unwrap `HRESULT_FROM_WIN32`** before forwarding to std.

HRESULT layout (Win32-routed errors):

```
  31           24           16            0
  ┌─┬─┬─┬─┬───┴─┬───────────┴────────────┐
  │1│R│C│N│ Fac │     GetLastError()     │
  └─┴─┴─┴─┴─────┴────────────────────────┘
  severity=1 (failure)
  facility=7 (FACILITY_WIN32)
  → 0x8007_XXXX
```

## What

One callsite in `@/crates/uffs-security/src/runtime_dir.rs:451-459` — when the HRESULT carries facility = 7 (`FACILITY_WIN32`), extract the low 16 bits and feed those to `io::Error::from_raw_os_error` so std can resolve the canonical `ErrorKind`. Non-WIN32-facility HRESULTs fall through unchanged (std has no portable kind mapping for them anyway).

```rust
let handle = handle_result.map_err(|err| {
    let hresult = err.code().0;
    let win32_code = if (hresult.cast_unsigned() & 0xFFFF_0000_u32) == 0x8007_0000_u32 {
        hresult & 0xFFFF_i32
    } else {
        hresult
    };
    io::Error::from_raw_os_error(win32_code)
})?;
```

The existing assertion at `@/crates/uffs-security/src/runtime_dir/tests.rs:67-73` already asserts `kind() ∈ {AlreadyExists, PermissionDenied}`, so **no test changes are needed** — the existing oracle just gets to actually pass on Windows. The same assertion remains the regression test for this fix.

## Out of scope

`@/crates/uffs-mft/src/platform/volume.rs` has the same HRESULT-vs-Win32 confusion at five call sites (`io::Error::from_raw_os_error(err.code().0)` on lines 215, 326, 369, 410, …), but **no current test asserts `ErrorKind` on those paths** so the bug is latent and non-blocking. Tracked separately to keep this commit atomic per the small-commits rule.

## Validation

* `cargo check -p uffs-security --all-targets` on macOS ✓
* `cargo test -p uffs-security --lib runtime_dir` → **12/12 pass** on Unix ✓
* `cargo clippy -p uffs-security --all-targets -- -D warnings` ✓
* `just lint-ci-windows` (`cargo xwin clippy --target x86_64-pc-windows-msvc -D warnings`) ✓
* Pre-push hook `lint-pre-push` — all 12 checks green including cross-compiled Windows clippy ✓
* End-to-end Windows behaviour will be confirmed by the next `cargo-mutants(uffs-security)` cycle on `windows-latest` (cannot be exercised on the macOS dev host — the fixed code path is `#[cfg(windows)]`-gated).

## Rules adherence

1. **No suppression hacks** — no `#[allow]`, no test relaxation, no cfg-gating away the issue. The fix is at the source layer, not the assertion layer.
2. **Surgical, root-cause fix** — 1 callsite, +34/-1 lines, contained within the `#[cfg(windows)]` module.
3. **Preserves the documented contract** — in fact this commit is what makes the implementation finally match the contract that's existed since the trait was authored.
4. **Tests improved, not dodged** — the trait-contract oracle now actually exercises the contract on Windows, instead of failing the baseline. Zero tests skipped or relaxed.
5. **Atomic signed commit** — Conventional-Commits style, root cause + rationale + scope-exclusion all in the commit body.

Refs #267 (cargo-mutants Windows rollout).
Refs nightly run [`26037964594`](https://github.com/skyllc-ai/UltraFastFileSearch/actions/runs/26037964594) (regression surfaced here).
