### PR TITLE
fix(ci): sign cargo-vet refresh PR commits via GITHUB_TOKEN REST API (refs #272)

### DIFF
--- a/.github/workflows/cargo-vet-refresh.yml
+++ b/.github/workflows/cargo-vet-refresh.yml
@@ -27,12 +27,20 @@
 #
 # Why we keep it a PR instead of pushing to `main` directly:
 #
-#   Branch protection on `main` requires signed commits.  GitHub
-#   Actions cannot sign commits with the project's GPG key
-#   without storing the private key as a secret (bad).  Routing
-#   the refresh through a PR lets the maintainer's normal workflow
-#   (signed merge commit via squash or rebase) produce a signed
-#   artifact on `main`.
+#   Branch protection on `main` requires reviewer sign-off (the
+#   `main-protection` ruleset's `PULL_REQUEST` rule).  Direct
+#   pushes by automation would bypass that review surface.
+#   Routing the refresh through a PR keeps the maintainer's
+#   usual review + squash-merge flow intact.
+#
+#   The matching `REQUIRED_SIGNATURES` rule used to make the
+#   intermediate bot commit on the PR branch unsignable without
+#   storing a GPG private key as a secret, which forced the
+#   maintainer to amend + force-push every refresh just to satisfy
+#   branch protection.  Resolved by `sign-commits: true` on the
+#   `peter-evans/create-pull-request` step below (Phase
+#   cargo-vet-refresh-signed-commits, refs #272 force-push).
+#   See that step's comment for the mechanism.
 #
 # Operational note — CI won't auto-run on this PR:
 #
@@ -158,12 +166,29 @@ jobs:
         #   • branch creation (reuses if the same branch is still open)
         #   • commit authoring (GitHub Actions bot)
         #   • PR open OR update (idempotent across weekly runs)
+        #
+        # `sign-commits: true` switches the action from `git` to the
+        # GitHub REST API (`PUT /repos/{owner}/{repo}/contents/{path}`)
+        # for commit creation.  REST-API commits authored by
+        # `GITHUB_TOKEN` are auto-signed by GitHub's `web-flow` key, so
+        # the resulting bot commit satisfies the `main-protection`
+        # ruleset's `REQUIRED_SIGNATURES` rule without us ever provisioning
+        # a private GPG key as a secret.  See `action.yml` of
+        # `peter-evans/create-pull-request@v7` for the input docs
+        # ("Sign commits as `github-actions[bot]` when using `GITHUB_TOKEN`").
+        #
+        # Without this flag the action commits via `git` with the bot's
+        # email but no signature, producing an `unsigned` commit that
+        # branch protection rejects on merge (manifested as PR #272
+        # being `BLOCKED` until the maintainer rebased + force-pushed a
+        # signed copy by hand).
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "chore/cargo-vet-refresh"
           base: main
           delete-branch: true
+          sign-commits: true
           commit-message: |
             chore(security): refresh cargo-vet imports
 


### PR DESCRIPTION
# Sign cargo-vet refresh PR commits via `GITHUB_TOKEN` REST API

## Why

The weekly cargo-vet auto-refresh PR keeps landing with an **unsigned** bot commit. This week (#272), commit `53f95cae8` produced `verified: false`, and the `main-protection` ruleset's `REQUIRED_SIGNATURES` rule turned the PR's `mergeStateStatus` to `BLOCKED` even after CI was green. The maintainer had to manually rebase + force-push a signed copy before squash-merge would proceed — ~5 min of human work every Monday.

## Root cause

`peter-evans/create-pull-request@v7` (the action pinned at `@/.github/workflows/cargo-vet-refresh.yml:185`) defaults to creating commits via `git`, which produces unsigned commits when the runner doesn't have a configured signing key. The workflow's own preamble at lines 28-35 acknowledged the limitation and reasoned that storing a GPG private key as a CI secret would be worse — which it would.

## Fix

The same action supports `sign-commits: true`, which switches its commit-creation path from `git` to the GitHub REST API (`PUT /repos/{owner}/{repo}/contents/{path}`). REST-API commits authored by `GITHUB_TOKEN` are **auto-signed by GitHub's `web-flow` key** — the same key GitHub uses to sign squash-merge commits created via the web UI. Branch protection treats those as verified.

Two surgical edits in `@/.github/workflows/cargo-vet-refresh.yml`:

1. Add `sign-commits: true` to the `peter-evans/create-pull-request` step inputs (line 191).
2. Rewrite the now-stale rationale block (lines 28-43) to:
   - keep the "why PR instead of direct push" reason (still valid: we need maintainer review),
   - explain that `REQUIRED_SIGNATURES` is now satisfied by the REST-API + web-flow mechanism,
   - leave a forward-pointing comment so the next reader of the action step finds the full mechanism inline.

## Why this over alternatives

| Alternative | Cost | Verdict |
|---|---|---|
| **GitHub App + installation token** | Provision App, rotate tokens, store App private key as a secret | Heavier setup for the same signing outcome |
| **Self-hosted GPG key as CI secret** | Long-lived signing key in CI = real risk in case of secret leakage | Rejected by the original workflow design for the same reason |
| **Switch to a different action** | Churn an already-mature, hash-pinned dependency | No upside |
| **`sign-commits: true` (this PR)** | One new input on a step we already use | **Selected** |

## Validation

- `actionlint .github/workflows/cargo-vet-refresh.yml` clean ✓
- Verified the pinned version (`5f6978faf089d4d20b00c7766989d076bb2fc7f1` = v7) supports the `sign-commits` input by reading `action.yml` at that ref via `gh api`. Description: *"Sign commits as `github-actions[bot]` when using `GITHUB_TOKEN`, or your own bot when using GitHub App tokens."*
- Pre-push hook green on all 17 checks (cargo-check, lint-ci, lint-prod, lint-tests, rustdoc, doc-tests, tests, smoke, lint-ci-windows, …) ✓
- Cannot end-to-end verify until next Monday's scheduled run (or a manual `workflow_dispatch`); the action's own test suite covers the REST-API commit path so regression risk is low.

## Out of scope

Anti-recursion CI suppression on `GITHUB_TOKEN`-opened PRs is **orthogonal** to signing and remains a separate concern, still documented in the workflow's `Operational note` comment and in the auto-generated PR body. Fixing that would require either close+reopen automation or switching to a fine-grained PAT, both of which are larger changes than this PR's scope.

## Rules adherence

1. **No suppression hacks** — doesn't disable `REQUIRED_SIGNATURES`, doesn't sidestep branch protection, doesn't store a secret.
2. **Surgical, correct fix** — one new input on a step we already use + a comment refresh, contained in a single workflow file.
3. **Preserves the existing contract** — same review surface, same schedule, same human squash-merge flow on `main`.
4. **Tests improved, not dodged** — this is infra, no test changes apply; the action's own upstream test suite covers the new path.
5. **Atomic signed commit** — single concern (sign the bot commit) in a single file.

Refs PR #272 (this week's manual workaround).
