### PR TITLE
refactor: Phase 5d — typed error enums replace Result<_, String> across workspace (closes #192)

### DIFF
--- a/crates/uffs-cli/src/args.rs
+++ b/crates/uffs-cli/src/args.rs
@@ -7,7 +7,64 @@
 //! (see [`uffs_client::protocol::cli_args`]).  This module only handles
 //! subcommands that run client-side (daemon, mcp, stats, aggregate).
 
+use core::fmt;
 use std::path::PathBuf;
+
+use uffs_mft::platform::{DriveLetter, DriveLetterError};
+
+/// Typed error returned by [`parse_drive_letter`].
+///
+/// Phase 5d migration of the previous `Result<DriveLetter, String>`
+/// return type: the Display strings stay byte-identical with the
+/// pre-migration messages so end-user CLI output is unchanged, while
+/// [`std::error::Error::source`] now chains through to the underlying
+/// [`DriveLetterError`] for the `Inner` case (a real improvement over
+/// the previous `String` that flattened the source out).
+///
+/// `#[non_exhaustive]` per Phase 5c discipline so future variants don't
+/// require a semver bump on the (workspace-internal) consumer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum ParseDriveLetterError {
+    /// Input was not a single ASCII letter (optionally followed by `:`).
+    BadShape {
+        /// The original, untrimmed input (echoed back in Display).
+        input: String,
+    },
+    /// The single character was not in `A..=Z` (case-insensitive).
+    ///
+    /// `source` preserves the underlying [`DriveLetterError`] so callers
+    /// that walk [`std::error::Error::source`] keep the typed chain.
+    Inner {
+        /// The original, untrimmed input (echoed back in Display).
+        input: String,
+        /// The underlying [`DriveLetter::parse`] failure.
+        source: DriveLetterError,
+    },
+}
+
+impl fmt::Display for ParseDriveLetterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadShape { input } => write!(
+                f,
+                "Invalid drive letter '{input}': expected single letter like 'C' or 'C:'"
+            ),
+            Self::Inner { input, source } => {
+                write!(f, "Invalid drive letter '{input}': {source}")
+            }
+        }
+    }
+}
+
+impl core::error::Error for ParseDriveLetterError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Inner { source, .. } => Some(source),
+            Self::BadShape { .. } => None,
+        }
+    }
+}
 
 /// Parse a drive letter from common CLI input formats.
 ///
@@ -15,24 +72,30 @@ use std::path::PathBuf;
 ///
 /// # Errors
 ///
-/// Returns an error if the input is not a valid drive letter.
-pub(crate) fn parse_drive_letter(input: &str) -> Result<uffs_mft::platform::DriveLetter, String> {
+/// Returns [`ParseDriveLetterError`] when `input` is not a single
+/// ASCII letter (optionally with a `:` suffix and surrounding
+/// whitespace) in `A..=Z`.
+pub(crate) fn parse_drive_letter(input: &str) -> Result<DriveLetter, ParseDriveLetterError> {
     let trimmed = input.trim();
     let letter_str = trimmed.strip_suffix(':').unwrap_or(trimmed);
 
     if letter_str.len() != 1 {
-        return Err(format!(
-            "Invalid drive letter '{input}': expected single letter like 'C' or 'C:'"
-        ));
+        return Err(ParseDriveLetterError::BadShape {
+            input: input.to_owned(),
+        });
     }
 
     let ch = letter_str
         .chars()
         .next()
-        .ok_or_else(|| format!("Invalid drive letter '{input}'"))?;
+        .ok_or_else(|| ParseDriveLetterError::BadShape {
+            input: input.to_owned(),
+        })?;
 
-    uffs_mft::platform::DriveLetter::parse(ch)
-        .map_err(|err| format!("Invalid drive letter '{input}': {err}"))
+    DriveLetter::parse(ch).map_err(|source| ParseDriveLetterError::Inner {
+        input: input.to_owned(),
+        source,
+    })
 }
 
 // ── Subcommand types ───────────────────────────────────────────────────
@@ -60,7 +123,7 @@ pub(crate) enum DaemonAction {
         /// Data directory.
         data_dir: Option<PathBuf>,
         /// Drive letter(s) to load (filters `--data-dir` discovery).
-        drives: Vec<uffs_mft::platform::DriveLetter>,
+        drives: Vec<DriveLetter>,
         /// Skip file cache.
         no_cache: bool,
         /// Log level.
@@ -95,7 +158,7 @@ pub(crate) enum DaemonAction {
         /// Data directory — discover and load a specific drive from it.
         data_dir: Option<PathBuf>,
         /// Drive letter(s) to load (Windows live only).
-        drives: Vec<uffs_mft::platform::DriveLetter>,
+        drives: Vec<DriveLetter>,
         /// Skip cache when loading.
         no_cache: bool,
     },
@@ -105,7 +168,7 @@ pub(crate) enum DaemonAction {
     /// hibernate --help`.
     Hibernate {
         /// Drive letter(s) to hibernate; empty = all loaded drives.
-        drives: Vec<uffs_mft::platform::DriveLetter>,
+        drives: Vec<DriveLetter>,
     },
     /// Promote drive(s) to `Hot` and pin the tier (Phase 8-C).
     ///
@@ -113,7 +176,7 @@ pub(crate) enum DaemonAction {
     /// (matches the daemon's `DEFAULT_PRELOAD_PIN_MINUTES`).
     Preload {
         /// Drive letter(s) to preload (must be non-empty).
-        drives: Vec<uffs_mft::platform::DriveLetter>,
+        drives: Vec<DriveLetter>,
         /// Override the default 30-min pin window.
         pin_minutes: Option<u32>,
     },
@@ -125,7 +188,7 @@ pub(crate) enum DaemonAction {
     /// (clearing pins) before unlinking the cache files.
     Forget {
         /// Drive letter(s) to forget (must be non-empty).
-        drives: Vec<uffs_mft::platform::DriveLetter>,
+        drives: Vec<DriveLetter>,
         /// Force-forget non-`Cold` drives by auto-hibernating first.
         force: bool,
     },
@@ -194,7 +257,7 @@ fn parse_daemon_start(rest: &[String]) -> DaemonAction {
             "--drive" => {
                 if let Some(val) = iter.next() {
                     for ch in val.chars() {
-                        if let Ok(letter) = uffs_mft::platform::DriveLetter::parse(ch) {
+                        if let Ok(letter) = DriveLetter::parse(ch) {
                             drives.push(letter);
                         }
                     }
@@ -384,7 +447,7 @@ fn parse_daemon_forget(rest: &[String]) -> Result<DaemonAction, anyhow::Error> {
 /// values, and whitespace.  Silently skips entries that don't parse
 /// as ASCII letters - mirrors the lenient parsing already used by
 /// `parse_daemon_load`.
-fn extend_drives_from_csv(drives: &mut Vec<uffs_mft::platform::DriveLetter>, value: &str) {
+fn extend_drives_from_csv(drives: &mut Vec<DriveLetter>, value: &str) {
     for part in value.split(',') {
         if let Ok(letter) = parse_drive_letter(part) {
             drives.push(letter);
@@ -555,4 +618,66 @@ USAGE:  uffs status
 #[expect(clippy::print_stdout, reason = "intentional help output")]
 pub(crate) fn print_status_help() {
     print!("{STATUS_HELP}");
+}
+
+#[cfg(test)]
+mod tests {
+    use core::error::Error as _;
+
+    use super::{ParseDriveLetterError, parse_drive_letter};
+
+    /// `BadShape` carries the original input and its Display matches the
+    /// byte-for-byte format the previous `Result<_, String>` produced.
+    /// Locks the user-visible CLI error message in place across the
+    /// Phase 5d migration so operators don't see a renderer change.
+    #[test]
+    fn bad_shape_preserves_legacy_display_format() {
+        let err = parse_drive_letter("CD").expect_err("multi-char input must error");
+        assert!(
+            matches!(&err, ParseDriveLetterError::BadShape { input } if input == "CD"),
+            "expected BadShape('CD'), got {err:?}",
+        );
+        assert_eq!(
+            err.to_string(),
+            "Invalid drive letter 'CD': expected single letter like 'C' or 'C:'",
+        );
+        assert!(err.source().is_none(), "BadShape has no underlying source");
+    }
+
+    /// `Inner` preserves the original input AND chains the underlying
+    /// [`DriveLetterError`] via [`Error::source`].
+    /// The Display string keeps the pre-migration shape; the chain is
+    /// the real improvement over the previous flattened `String`.
+    #[test]
+    fn inner_preserves_source_chain() {
+        let err = parse_drive_letter("1:").expect_err("non-letter input must error");
+        let ParseDriveLetterError::Inner { input, source } = &err else {
+            panic!("expected Inner variant, got {err:?}");
+        };
+        assert_eq!(input, "1:");
+        assert_eq!(source.raw, '1');
+        assert_eq!(
+            err.to_string(),
+            "Invalid drive letter '1:': drive letter must be ASCII A..=Z (case insensitive); got '1'",
+        );
+        // The error chain must include the typed source — this is the
+        // observable improvement over the pre-Phase-5d `String` return.
+        let chained = err.source().expect("Inner exposes its source");
+        assert_eq!(
+            chained.to_string(),
+            "drive letter must be ASCII A..=Z (case insensitive); got '1'",
+        );
+    }
+
+    /// Empty input takes the `BadShape` branch and round-trips the empty
+    /// `input` field — defensive coverage for the `chars().next()` arm
+    /// which is otherwise unreachable after the `len() != 1` guard.
+    #[test]
+    fn bad_shape_handles_empty_input() {
+        let err = parse_drive_letter("").expect_err("empty input must error");
+        assert!(
+            matches!(&err, ParseDriveLetterError::BadShape { input } if input.is_empty()),
+            "expected BadShape(''), got {err:?}",
+        );
+    }
 }

--- a/crates/uffs-client/src/format.rs
+++ b/crates/uffs-client/src/format.rs
@@ -260,6 +260,33 @@ pub fn parse_month_spec(spec: &str) -> Vec<u32> {
     months
 }
 
+/// Typed error returned by [`parse_size`].
+///
+/// Phase 5d migration of the previous `Result<u64, String>` return
+/// type: the [`core::fmt::Display`] strings stay byte-identical with
+/// the pre-migration messages so any operator-facing CLI error output
+/// is unchanged, while callers can now match on variants instead of
+/// parsing the string.
+///
+/// `#[non_exhaustive]` per Phase 5c discipline so a future failure
+/// mode (e.g. overflow on the saturating-mul, or a negative-prefix
+/// rejection) can grow a variant without a semver bump.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ParseSizeError {
+    /// Input was empty after trimming.
+    #[error("empty size specification")]
+    Empty,
+    /// The numeric portion failed [`u64::from_str`].  The original
+    /// untrimmed spec is echoed back so the operator sees what they
+    /// typed.
+    #[error("invalid size: {spec}")]
+    InvalidNumber {
+        /// The original, untrimmed input.
+        spec: String,
+    },
+}
+
 /// Parse a human-readable size spec into bytes.
 ///
 /// Accepts: `1024`, `10KB`, `5MB`, `2GB`, `1TB`, `100B`.
@@ -267,8 +294,12 @@ pub fn parse_month_spec(spec: &str) -> Vec<u32> {
 ///
 /// # Errors
 ///
-/// Returns an error string if the input is empty or not a valid number.
-pub fn parse_size(spec: &str) -> Result<u64, String> {
+/// Returns [`ParseSizeError::Empty`] when the input is empty after
+/// trimming, or [`ParseSizeError::InvalidNumber`] when the digit
+/// portion fails [`u64::from_str`].  The Display strings stay
+/// byte-identical with the pre-Phase-5d output so any operator-facing
+/// CLI output is unchanged.
+pub fn parse_size(spec: &str) -> Result<u64, ParseSizeError> {
     const SUFFIXES: &[(&str, u64)] = &[
         ("TB", 1024 * 1024 * 1024 * 1024),
         ("GB", 1024 * 1024 * 1024),
@@ -279,7 +310,7 @@ pub fn parse_size(spec: &str) -> Result<u64, String> {
 
     let trimmed = spec.trim();
     if trimmed.is_empty() {
-        return Err("empty size specification".to_owned());
+        return Err(ParseSizeError::Empty);
     }
 
     let upper = trimmed.to_ascii_uppercase();
@@ -292,7 +323,9 @@ pub fn parse_size(spec: &str) -> Result<u64, String> {
     let count: u64 = digits
         .trim()
         .parse()
-        .map_err(|_parse_err| format!("invalid size: {spec}"))?;
+        .map_err(|_parse_err| ParseSizeError::InvalidNumber {
+            spec: spec.to_owned(),
+        })?;
 
     Ok(count.saturating_mul(multiplier))
 }
@@ -358,4 +391,88 @@ pub fn extract_drive_letter(pattern: &str) -> Option<uffs_mft::platform::DriveLe
         return None;
     }
     uffs_mft::platform::DriveLetter::parse(first as char).ok()
+}
+
+#[cfg(test)]
+mod parse_size_error_tests {
+    //! Phase 5d regression tests for [`ParseSizeError`].
+    //!
+    //! Locks each variant's Display string at the byte-identical text
+    //! the pre-Phase-5d `Result<u64, String>` returns produced, so any
+    //! operator-facing CLI error output stays unchanged through the
+    //! migration.
+
+    use super::{ParseSizeError, parse_size};
+
+    /// Empty input is rejected with the `Empty` variant whose Display
+    /// is byte-identical to the pre-Phase-5d `"empty size specification"`
+    /// message.
+    #[test]
+    fn empty_input_returns_empty_variant_with_locked_display() {
+        let err = parse_size("").expect_err("empty input must error");
+        assert_eq!(err, ParseSizeError::Empty);
+        assert_eq!(err.to_string(), "empty size specification");
+    }
+
+    /// Whitespace-only input also walks the `Empty` branch (the
+    /// pre-trim guard catches it).  Locks the operator-friendly
+    /// behaviour rather than a stricter
+    /// "looks-like-no-digits" alternative.
+    #[test]
+    fn whitespace_only_input_returns_empty_variant() {
+        let err = parse_size("   ").expect_err("whitespace-only input must error");
+        assert_eq!(err, ParseSizeError::Empty);
+    }
+
+    /// Non-numeric input is rejected with `InvalidNumber` whose
+    /// Display interpolates the original (untrimmed) spec verbatim —
+    /// byte-identical to the pre-Phase-5d
+    /// `"invalid size: {spec}"` message.
+    #[test]
+    fn non_numeric_input_returns_invalid_number_with_locked_display() {
+        let err = parse_size("abc").expect_err("non-numeric input must error");
+        assert_eq!(err, ParseSizeError::InvalidNumber {
+            spec: "abc".to_owned(),
+        },);
+        assert_eq!(err.to_string(), "invalid size: abc");
+    }
+
+    /// A bare suffix with no digits (e.g. `MB`) is also rejected via
+    /// `InvalidNumber` — the suffix-strip leaves an empty digit slot,
+    /// which fails [`u64::from_str`].  The spec field echoes the
+    /// original input untouched.
+    #[test]
+    fn bare_suffix_returns_invalid_number_echoing_original_spec() {
+        let err = parse_size("MB").expect_err("bare suffix input must error");
+        assert_eq!(err, ParseSizeError::InvalidNumber {
+            spec: "MB".to_owned(),
+        },);
+        assert_eq!(err.to_string(), "invalid size: MB");
+    }
+
+    /// Negative inputs (e.g. `-1KB`) are rejected — `u64::from_str`
+    /// refuses the leading minus.  Locks the existing behaviour that
+    /// the CLI rejects negative sizes rather than silently treating
+    /// them as zero.
+    #[test]
+    fn negative_input_returns_invalid_number() {
+        let err = parse_size("-1KB").expect_err("negative input must error");
+        assert_eq!(err, ParseSizeError::InvalidNumber {
+            spec: "-1KB".to_owned(),
+        },);
+    }
+
+    /// Happy-path lock — typed return value must round-trip the
+    /// expected byte count for the canonical suffixes.  Guards against
+    /// accidental regression of the success arm during the migration.
+    #[test]
+    fn happy_path_round_trips_canonical_suffixes() {
+        assert_eq!(parse_size("0"), Ok(0));
+        assert_eq!(parse_size("1024"), Ok(1024));
+        assert_eq!(parse_size("1KB"), Ok(1024));
+        assert_eq!(parse_size("1MB"), Ok(1024 * 1024));
+        assert_eq!(parse_size("1GB"), Ok(1024 * 1024 * 1024));
+        assert_eq!(parse_size("1TB"), Ok(1024_u64 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size("  1MB  "), Ok(1024 * 1024));
+    }
 }

--- a/crates/uffs-client/src/format.rs
+++ b/crates/uffs-client/src/format.rs
@@ -277,7 +277,7 @@ pub enum ParseSizeError {
     /// Input was empty after trimming.
     #[error("empty size specification")]
     Empty,
-    /// The numeric portion failed [`u64::from_str`].  The original
+    /// The numeric portion failed `u64::from_str`.  The original
     /// untrimmed spec is echoed back so the operator sees what they
     /// typed.
     #[error("invalid size: {spec}")]
@@ -296,7 +296,7 @@ pub enum ParseSizeError {
 ///
 /// Returns [`ParseSizeError::Empty`] when the input is empty after
 /// trimming, or [`ParseSizeError::InvalidNumber`] when the digit
-/// portion fails [`u64::from_str`].  The Display strings stay
+/// portion fails `u64::from_str`.  The Display strings stay
 /// byte-identical with the pre-Phase-5d output so any operator-facing
 /// CLI output is unchanged.
 pub fn parse_size(spec: &str) -> Result<u64, ParseSizeError> {

--- a/crates/uffs-client/src/protocol/cli_args.rs
+++ b/crates/uffs-client/src/protocol/cli_args.rs
@@ -9,8 +9,13 @@
 //! (`--begins-with`, `--between`, `--exact-size`, `--word`, etc.)
 //! happens here.
 
+// `CliArgsError` is re-exported at the `cli_args` module path so the
+// public API of `from_cli_args` has a stable, canonically-named typed
+// error.  Phase 5d migration: see the type's doc-comment in
+// `cli_args_helpers.rs` for the full rationale.
+pub use super::cli_args_helpers::CliArgsError as Error;
 use super::cli_args_helpers::{
-    drives_csv, extract_extensions_from_regex, flag_val, is_pure_ext_glob, non_empty,
+    CliArgsError, drives_csv, extract_extensions_from_regex, flag_val, is_pure_ext_glob, non_empty,
     parse_bare_drive_prefix, parse_bool, parse_i32, parse_size, parse_u16, parse_u32, parse_u64,
 };
 use super::{SearchFilterMode, SearchParams, SearchResponseMode};
@@ -26,12 +31,15 @@ impl SearchParams {
     ///
     /// # Errors
     ///
-    /// Returns a descriptive error string on malformed arguments.
+    /// Returns a [`CliArgsError`] variant on malformed arguments.  The
+    /// [`core::fmt::Display`] strings stay byte-identical with the
+    /// pre-Phase-5d `Result<_, String>` payloads so operator-facing CLI
+    /// error output is unchanged.
     #[expect(
         clippy::too_many_lines,
         reason = "mechanical 1:1 flag-to-field mapping"
     )]
-    pub fn from_cli_args(args: &[String]) -> Result<Self, String> {
+    pub fn from_cli_args(args: &[String]) -> Result<Self, CliArgsError> {
         let mut raw = RawCliArgs::default();
         let mut iter = args.iter().cloned().peekable();
 
@@ -251,10 +259,14 @@ impl SearchParams {
                 }
                 other => {
                     if other.starts_with('-') {
-                        return Err(format!("Unknown flag: '{other}'"));
+                        return Err(CliArgsError::UnknownFlag {
+                            flag: other.to_owned(),
+                        });
                     }
                     if raw.pattern.is_some() {
-                        return Err(format!("Unexpected argument: '{other}'"));
+                        return Err(CliArgsError::UnexpectedArgument {
+                            arg: other.to_owned(),
+                        });
                     }
                     raw.pattern = Some(arg);
                 }
@@ -365,7 +377,7 @@ impl RawCliArgs {
         clippy::cognitive_complexity,
         reason = "three composable sugar rewrites (drive-prefix, ext-glob, regex-ext) plus filter normalisation; splitting further would fragment the parse pipeline"
     )]
-    fn into_search_params(mut self) -> Result<SearchParams, String> {
+    fn into_search_params(mut self) -> Result<SearchParams, CliArgsError> {
         // ── Pattern sugar: --begins-with / --ends-with / --contains ─
         let raw_pattern = self
             .pattern
@@ -418,9 +430,7 @@ impl RawCliArgs {
             && (pattern.contains('\\') || pattern.contains('/'))
             && !pattern.starts_with('>')
         {
-            return Err(
-                "--name-only cannot be used with path patterns containing '\\' or '/'".to_owned(),
-            );
+            return Err(CliArgsError::NameOnlyWithPathPattern);
         }
 
         // ── --exact-size / --exact-descendants ─────────────────────

--- a/crates/uffs-client/src/protocol/cli_args_helpers.rs
+++ b/crates/uffs-client/src/protocol/cli_args_helpers.rs
@@ -10,9 +10,119 @@
 //! costs nothing at call sites and buys generous head-room in the
 //! main file.
 
+use core::num::ParseIntError;
+
+use uffs_mft::platform::{DriveLetter, DriveLetterError};
+
+use crate::format::ParseSizeError;
 // `parse_size` is re-exported so the importer can glob-import every
 // parsing helper the main file needs in a single `use` statement.
 pub(super) use crate::format::parse_size;
+
+/// Typed error produced by every CLI-argument parsing helper in this
+/// module and by [`super::cli_args::SearchParams::from_cli_args`].
+///
+/// Phase 5d migration of the previous `Result<_, String>` return
+/// types: every [`core::fmt::Display`] string stays byte-identical
+/// with the pre-migration `format!()` payloads so any operator-facing
+/// CLI error output is unchanged, while callers can now match on
+/// variants and walk the [`core::error::Error::source`] chain.
+///
+/// `#[non_exhaustive]` per Phase 5c discipline so future CLI flags
+/// can grow a variant without a semver bump on the
+/// (workspace-internal) consumers.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum CliArgsError {
+    /// `take_next` / `flag_val` ran out of tokens before consuming a
+    /// value for `flag`.
+    #[error("Missing value for {flag}")]
+    MissingValue {
+        /// The CLI flag name that was awaiting a value.
+        flag: String,
+    },
+    /// `parse_u16` / `parse_u32` / `parse_u64` / `parse_i32` failed
+    /// to convert `flag`'s text to the target integer type.  The
+    /// underlying [`ParseIntError`] is exposed via
+    /// [`core::error::Error::source`] for callers that want the typed
+    /// chain.
+    #[error("Bad {flag}: {source}")]
+    BadInt {
+        /// The CLI flag name whose value failed to parse.
+        flag: String,
+        /// The underlying [`u*::from_str`] / [`i*::from_str`] failure.
+        #[source]
+        source: ParseIntError,
+    },
+    /// `parse_bool` rejected `value` for `flag` — accepted forms are
+    /// `true|1|yes` and `false|0|no`.
+    #[error("Bad bool for {flag}: '{value}'")]
+    BadBool {
+        /// The CLI flag name whose value failed to parse.
+        flag: String,
+        /// The offending value as supplied by the operator.
+        value: String,
+    },
+    /// `drives_csv` encountered an empty segment (e.g. `--drives ,C`
+    /// or `--drives C,`).
+    #[error("empty drive")]
+    EmptyDrive,
+    /// `drives_csv` saw a segment whose shape is not a single ASCII
+    /// alphabetic letter (optionally with a trailing `:`).  Examples:
+    /// `12`, `CD`, `??`.
+    #[error("Bad drive: '{input}'")]
+    BadDrive {
+        /// The offending segment (original, untrimmed).
+        input: String,
+    },
+    /// `drives_csv` accepted the shape but [`DriveLetter::parse`]
+    /// rejected the letter — this branch is currently unreachable
+    /// (the `is_ascii_alphabetic` guard makes it impossible), but we
+    /// keep the variant so the error path stays expressible if the
+    /// invariant ever changes.  The underlying [`DriveLetterError`]
+    /// is exposed via [`core::error::Error::source`].
+    #[error("Bad drive: '{input}' ({source})")]
+    BadDriveParse {
+        /// The offending segment (original, untrimmed).
+        input: String,
+        /// The underlying [`DriveLetter::parse`] failure.
+        #[source]
+        source: DriveLetterError,
+    },
+    /// [`crate::format::parse_size`] rejected one of the
+    /// `--{min,max,exact}-size*` / `--{min,max}-treesize` /
+    /// `--{min,max}-tree-allocated` operands.  The underlying
+    /// [`ParseSizeError`] is exposed via
+    /// [`core::error::Error::source`] AND `#[from]` so call sites can
+    /// keep the `?` propagation shape.
+    #[error("{source}")]
+    BadSize {
+        /// The underlying [`crate::format::parse_size`] failure.
+        #[source]
+        #[from]
+        source: ParseSizeError,
+    },
+    /// `from_cli_args` encountered a leading-dash token that did not
+    /// match any known flag.
+    #[error("Unknown flag: '{flag}'")]
+    UnknownFlag {
+        /// The unrecognised flag (as supplied on the command line).
+        flag: String,
+    },
+    /// `from_cli_args` encountered a second positional argument after
+    /// the pattern slot was already filled.
+    #[error("Unexpected argument: '{arg}'")]
+    UnexpectedArgument {
+        /// The extra positional argument.
+        arg: String,
+    },
+    /// `into_search_params` saw `--name-only` combined with a pattern
+    /// that contains `\` or `/` (without the `>` regex prefix), which
+    /// is semantically inconsistent — name-only matches against the
+    /// file name, not the path.
+    #[error("--name-only cannot be used with path patterns containing '\\' or '/'")]
+    NameOnlyWithPathPattern,
+}
 
 /// Returns `Some(val)` if `val` is non-empty, otherwise `None`.
 /// Used for optional output-config fields that should fall back to
@@ -25,9 +135,10 @@ pub(super) fn non_empty(val: String) -> Option<String> {
 pub(super) fn take_next(
     flag: &str,
     iter: &mut impl Iterator<Item = String>,
-) -> Result<String, String> {
-    iter.next()
-        .ok_or_else(|| format!("Missing value for {flag}"))
+) -> Result<String, CliArgsError> {
+    iter.next().ok_or_else(|| CliArgsError::MissingValue {
+        flag: flag.to_owned(),
+    })
 }
 
 /// Handle `--flag=val` or `--flag <val>`.
@@ -35,58 +146,75 @@ pub(super) fn flag_val(
     cur: &str,
     flag: &str,
     iter: &mut impl Iterator<Item = String>,
-) -> Result<String, String> {
+) -> Result<String, CliArgsError> {
     cur.strip_prefix(&format!("{flag}="))
         .map_or_else(|| take_next(flag, iter), |rest| Ok(rest.to_owned()))
 }
 
 /// Parse comma-separated drive letters.
-pub(super) fn drives_csv(input: &str) -> Result<Vec<uffs_mft::platform::DriveLetter>, String> {
+pub(super) fn drives_csv(input: &str) -> Result<Vec<DriveLetter>, CliArgsError> {
     input
         .split(',')
         .map(|part| {
             let stripped = part.trim();
             let trimmed = stripped.strip_suffix(':').unwrap_or(stripped);
-            let ch = trimmed
-                .chars()
-                .next()
-                .ok_or_else(|| "empty drive".to_owned())?;
+            let ch = trimmed.chars().next().ok_or(CliArgsError::EmptyDrive)?;
             if trimmed.len() != 1 || !ch.is_ascii_alphabetic() {
-                return Err(format!("Bad drive: '{part}'"));
+                return Err(CliArgsError::BadDrive {
+                    input: part.to_owned(),
+                });
             }
-            // `is_ascii_alphabetic` proves the parse succeeds; we
-            // forward the `DriveLetterError` text for the (impossible)
-            // failure case so the error path is still readable if the
+            // `is_ascii_alphabetic` proves the parse succeeds; the
+            // `BadDriveParse` variant chains the typed
+            // `DriveLetterError` for the (unreachable today) failure
+            // case so the error path is still expressible if the
             // invariant ever changes.
-            uffs_mft::platform::DriveLetter::parse(ch)
-                .map_err(|err| format!("Bad drive: '{part}' ({err})"))
+            DriveLetter::parse(ch).map_err(|source| CliArgsError::BadDriveParse {
+                input: part.to_owned(),
+                source,
+            })
         })
         .collect()
 }
 
 /// Parse string to `u16`.
-pub(super) fn parse_u16(flag: &str, text: &str) -> Result<u16, String> {
-    text.parse().map_err(|err| format!("Bad {flag}: {err}"))
+pub(super) fn parse_u16(flag: &str, text: &str) -> Result<u16, CliArgsError> {
+    text.parse().map_err(|source| CliArgsError::BadInt {
+        flag: flag.to_owned(),
+        source,
+    })
 }
 /// Parse string to `u32`.
-pub(super) fn parse_u32(flag: &str, text: &str) -> Result<u32, String> {
-    text.parse().map_err(|err| format!("Bad {flag}: {err}"))
+pub(super) fn parse_u32(flag: &str, text: &str) -> Result<u32, CliArgsError> {
+    text.parse().map_err(|source| CliArgsError::BadInt {
+        flag: flag.to_owned(),
+        source,
+    })
 }
 /// Parse string to `u64`.
-pub(super) fn parse_u64(flag: &str, text: &str) -> Result<u64, String> {
-    text.parse().map_err(|err| format!("Bad {flag}: {err}"))
+pub(super) fn parse_u64(flag: &str, text: &str) -> Result<u64, CliArgsError> {
+    text.parse().map_err(|source| CliArgsError::BadInt {
+        flag: flag.to_owned(),
+        source,
+    })
 }
 /// Parse string to `i32`.
-pub(super) fn parse_i32(flag: &str, text: &str) -> Result<i32, String> {
-    text.parse().map_err(|err| format!("Bad {flag}: {err}"))
+pub(super) fn parse_i32(flag: &str, text: &str) -> Result<i32, CliArgsError> {
+    text.parse().map_err(|source| CliArgsError::BadInt {
+        flag: flag.to_owned(),
+        source,
+    })
 }
 
 /// Parse boolean value.
-pub(super) fn parse_bool(flag: &str, text: &str) -> Result<bool, String> {
+pub(super) fn parse_bool(flag: &str, text: &str) -> Result<bool, CliArgsError> {
     match text {
         "true" | "1" | "yes" => Ok(true),
         "false" | "0" | "no" => Ok(false),
-        _ => Err(format!("Bad bool for {flag}: '{text}'")),
+        _ => Err(CliArgsError::BadBool {
+            flag: flag.to_owned(),
+            value: text.to_owned(),
+        }),
     }
 }
 
@@ -206,9 +334,7 @@ pub(super) fn extract_extensions_from_regex(pattern: &str) -> Option<Vec<String>
 /// Mirrored by `uffs_core::search::backend::parse_bare_drive_prefix`
 /// (the daemon's belt-and-suspenders safety net at dispatch time).
 /// Keep the two definitions in sync.
-pub(super) fn parse_bare_drive_prefix(
-    pattern: &str,
-) -> Option<(uffs_mft::platform::DriveLetter, &str)> {
+pub(super) fn parse_bare_drive_prefix(pattern: &str) -> Option<(DriveLetter, &str)> {
     let bytes = pattern.as_bytes();
     let letter = *bytes.first()?;
     if !letter.is_ascii_alphabetic() {
@@ -225,6 +351,236 @@ pub(super) fn parse_bare_drive_prefix(
     // The `is_ascii_alphabetic` guard above proves the `try_from`
     // cannot fail; using `?` keeps the API a `Option` and avoids an
     // unwrap.
-    let drive_letter = uffs_mft::platform::DriveLetter::try_from(letter).ok()?;
+    let drive_letter = DriveLetter::try_from(letter).ok()?;
     Some((drive_letter, rest))
+}
+
+#[cfg(test)]
+mod cli_args_error_tests {
+    //! Phase 5d regression tests for [`CliArgsError`] and the typed
+    //! return types of every helper in this module.
+    //!
+    //! Each test locks one variant of [`CliArgsError`] at the
+    //! byte-identical Display string the pre-Phase-5d
+    //! `Result<_, String>` produced, so operator-facing CLI error
+    //! output is unchanged through the migration.  Variants that
+    //! chain an underlying error (`BadInt`, `BadDriveParse`,
+    //! `BadSize`) additionally walk [`core::error::Error::source`]
+    //! to assert the typed chain is intact — the real improvement
+    //! over the previous flattened `String`.
+
+    use core::error::Error as _;
+
+    use super::{
+        CliArgsError, drives_csv, parse_bool, parse_i32, parse_size, parse_u16, parse_u32,
+        parse_u64, take_next,
+    };
+    use crate::format::ParseSizeError;
+
+    #[test]
+    fn take_next_missing_value_locks_display() {
+        let mut empty = core::iter::empty::<String>();
+        let err = take_next("--drive", &mut empty).expect_err("missing value must error");
+        assert_eq!(err, CliArgsError::MissingValue {
+            flag: "--drive".to_owned(),
+        },);
+        assert_eq!(err.to_string(), "Missing value for --drive");
+        assert!(err.source().is_none(), "MissingValue has no chained source");
+    }
+
+    #[test]
+    fn parse_u16_bad_int_locks_display_and_chains_source() {
+        let err =
+            parse_u16("--agg-page-size", "not-a-number").expect_err("non-numeric input must error");
+        let CliArgsError::BadInt { flag, source } = &err else {
+            panic!("expected BadInt variant, got {err:?}");
+        };
+        assert_eq!(flag, "--agg-page-size");
+        // Display matches the pre-Phase-5d `"Bad {flag}: {err}"` shape.
+        assert_eq!(err.to_string(), format!("Bad --agg-page-size: {source}"));
+        // The typed source chain is the migration's actual improvement
+        // over the flattened `String`.
+        let chained = err.source().expect("BadInt exposes its ParseIntError");
+        assert_eq!(chained.to_string(), source.to_string());
+    }
+
+    #[test]
+    fn parse_u32_bad_int_locks_display() {
+        let err = parse_u32("--max-descendants", "abc").expect_err("must error");
+        assert!(matches!(&err, CliArgsError::BadInt { flag, .. } if flag == "--max-descendants"));
+        assert!(err.to_string().starts_with("Bad --max-descendants: "));
+    }
+
+    #[test]
+    fn parse_u64_bad_int_locks_display() {
+        let err = parse_u64("--min-bulkiness", "xyz").expect_err("must error");
+        assert!(matches!(&err, CliArgsError::BadInt { flag, .. } if flag == "--min-bulkiness"));
+        assert!(err.to_string().starts_with("Bad --min-bulkiness: "));
+    }
+
+    #[test]
+    fn parse_i32_bad_int_locks_display() {
+        let err = parse_i32("--tz-offset", "qux").expect_err("must error");
+        assert!(matches!(&err, CliArgsError::BadInt { flag, .. } if flag == "--tz-offset"));
+        assert!(err.to_string().starts_with("Bad --tz-offset: "));
+    }
+
+    #[test]
+    fn parse_bool_locks_display() {
+        let err = parse_bool("--header", "maybe").expect_err("must error");
+        assert_eq!(err, CliArgsError::BadBool {
+            flag: "--header".to_owned(),
+            value: "maybe".to_owned(),
+        },);
+        assert_eq!(err.to_string(), "Bad bool for --header: 'maybe'");
+    }
+
+    #[test]
+    fn parse_bool_accepts_canonical_forms() {
+        assert_eq!(parse_bool("--header", "true"), Ok(true));
+        assert_eq!(parse_bool("--header", "1"), Ok(true));
+        assert_eq!(parse_bool("--header", "yes"), Ok(true));
+        assert_eq!(parse_bool("--header", "false"), Ok(false));
+        assert_eq!(parse_bool("--header", "0"), Ok(false));
+        assert_eq!(parse_bool("--header", "no"), Ok(false));
+    }
+
+    /// Empty segment in the CSV (e.g. `,C`) takes the `EmptyDrive`
+    /// branch.  Locks the Display at `"empty drive"`.
+    #[test]
+    fn drives_csv_empty_segment_locks_display() {
+        let err = drives_csv(",C").expect_err("empty leading segment must error");
+        assert_eq!(err, CliArgsError::EmptyDrive);
+        assert_eq!(err.to_string(), "empty drive");
+    }
+
+    /// Multi-character segment walks the `BadDrive` branch (it's not
+    /// a single ASCII letter).  Display echoes the original part.
+    #[test]
+    fn drives_csv_multi_char_segment_locks_display() {
+        let err = drives_csv("CD").expect_err("multi-char segment must error");
+        assert_eq!(err, CliArgsError::BadDrive {
+            input: "CD".to_owned(),
+        },);
+        assert_eq!(err.to_string(), "Bad drive: 'CD'");
+    }
+
+    /// Non-alphabetic segment walks `BadDrive` (digits, punctuation).
+    #[test]
+    fn drives_csv_non_alpha_segment_locks_display() {
+        let err = drives_csv("1").expect_err("digit segment must error");
+        assert_eq!(err, CliArgsError::BadDrive {
+            input: "1".to_owned(),
+        },);
+        assert_eq!(err.to_string(), "Bad drive: '1'");
+    }
+
+    /// Happy-path lock — `drives_csv` must accept comma-separated
+    /// letters with optional `:` suffix and surrounding whitespace.
+    #[test]
+    fn drives_csv_accepts_canonical_forms() {
+        let parsed = drives_csv("C,D:,E").expect("canonical CSV must parse");
+        assert_eq!(parsed.len(), 3);
+    }
+
+    /// `?`-propagation via `#[from]` lifts a `ParseSizeError` into
+    /// `CliArgsError::BadSize` without losing the chain.  This is the
+    /// path `from_cli_args` takes for `--min-size` / etc.
+    #[test]
+    fn parse_size_propagates_via_from_into_bad_size() {
+        // Direct construction of the error path the `?` operator
+        // would synthesise in `from_cli_args`.
+        let inner = parse_size("abc").expect_err("must error");
+        let outer: CliArgsError = inner.clone().into();
+        assert_eq!(outer, CliArgsError::BadSize {
+            source: inner.clone(),
+        },);
+        // Display delegates to the inner `ParseSizeError` ("invalid
+        // size: abc"), matching the pre-Phase-5d byte sequence which
+        // came directly from `parse_size`'s String return.
+        assert_eq!(outer.to_string(), inner.to_string());
+        // Chained source is the typed inner.
+        let chained = outer.source().expect("BadSize exposes its ParseSizeError");
+        let chained_size: &ParseSizeError = chained
+            .downcast_ref()
+            .expect("source must downcast to ParseSizeError");
+        assert_eq!(chained_size, &inner);
+    }
+
+    #[test]
+    fn unknown_flag_display_locked() {
+        let err = CliArgsError::UnknownFlag {
+            flag: "--nope".to_owned(),
+        };
+        assert_eq!(err.to_string(), "Unknown flag: '--nope'");
+    }
+
+    #[test]
+    fn unexpected_argument_display_locked() {
+        let err = CliArgsError::UnexpectedArgument {
+            arg: "extra".to_owned(),
+        };
+        assert_eq!(err.to_string(), "Unexpected argument: 'extra'");
+    }
+
+    #[test]
+    fn name_only_with_path_pattern_display_locked() {
+        let err = CliArgsError::NameOnlyWithPathPattern;
+        assert_eq!(
+            err.to_string(),
+            "--name-only cannot be used with path patterns containing '\\' or '/'",
+        );
+    }
+
+    /// End-to-end: feeding `from_cli_args` an unknown flag must
+    /// surface as the typed `UnknownFlag` variant.  This is the
+    /// boundary where `cli_args.rs` raises the inline error.
+    #[test]
+    fn from_cli_args_surfaces_unknown_flag() {
+        use crate::protocol::SearchParams;
+        let args = vec!["--bogus-flag".to_owned()];
+        let err = SearchParams::from_cli_args(&args).expect_err("unknown flag must error");
+        assert_eq!(err, CliArgsError::UnknownFlag {
+            flag: "--bogus-flag".to_owned(),
+        },);
+    }
+
+    /// End-to-end: a second positional argument after the pattern
+    /// surfaces as `UnexpectedArgument`.
+    #[test]
+    fn from_cli_args_surfaces_unexpected_argument() {
+        use crate::protocol::SearchParams;
+        let args = vec!["pattern1".to_owned(), "pattern2".to_owned()];
+        let err = SearchParams::from_cli_args(&args).expect_err("second positional must error");
+        assert_eq!(err, CliArgsError::UnexpectedArgument {
+            arg: "pattern2".to_owned(),
+        },);
+    }
+
+    /// End-to-end: `--name-only` plus a path pattern surfaces as
+    /// `NameOnlyWithPathPattern`.
+    #[test]
+    fn from_cli_args_surfaces_name_only_with_path_pattern() {
+        use crate::protocol::SearchParams;
+        let args = vec!["foo/bar".to_owned(), "--name-only".to_owned()];
+        let err = SearchParams::from_cli_args(&args).expect_err("name-only+path must error");
+        assert_eq!(err, CliArgsError::NameOnlyWithPathPattern);
+    }
+
+    /// End-to-end: `--min-size abc` surfaces a typed `BadSize` after
+    /// the `?` From-conversion in `from_cli_args`.  Display matches
+    /// the pre-Phase-5d `"invalid size: abc"` text.
+    #[test]
+    fn from_cli_args_surfaces_bad_size() {
+        use crate::protocol::SearchParams;
+        let args = vec!["*".to_owned(), "--min-size".to_owned(), "abc".to_owned()];
+        let err = SearchParams::from_cli_args(&args).expect_err("bad size must error");
+        let CliArgsError::BadSize { source } = &err else {
+            panic!("expected BadSize variant, got {err:?}");
+        };
+        assert_eq!(source, &ParseSizeError::InvalidNumber {
+            spec: "abc".to_owned(),
+        },);
+        assert_eq!(err.to_string(), "invalid size: abc");
+    }
 }

--- a/crates/uffs-client/src/protocol/cli_args_helpers.rs
+++ b/crates/uffs-client/src/protocol/cli_args_helpers.rs
@@ -20,7 +20,7 @@ use crate::format::ParseSizeError;
 pub(super) use crate::format::parse_size;
 
 /// Typed error produced by every CLI-argument parsing helper in this
-/// module and by [`super::cli_args::SearchParams::from_cli_args`].
+/// module and by [`crate::protocol::SearchParams::from_cli_args`].
 ///
 /// Phase 5d migration of the previous `Result<_, String>` return
 /// types: every [`core::fmt::Display`] string stays byte-identical
@@ -50,7 +50,7 @@ pub enum CliArgsError {
     BadInt {
         /// The CLI flag name whose value failed to parse.
         flag: String,
-        /// The underlying [`u*::from_str`] / [`i*::from_str`] failure.
+        /// The underlying `u*::from_str` / `i*::from_str` failure.
         #[source]
         source: ParseIntError,
     },

--- a/crates/uffs-core/src/aggregate/mod.rs
+++ b/crates/uffs-core/src/aggregate/mod.rs
@@ -28,6 +28,7 @@ pub mod export;
 pub mod finalize;
 pub mod pagination;
 pub mod parser;
+pub mod parser_error;
 pub(crate) mod planner;
 pub mod presets;
 pub mod rollup;
@@ -48,6 +49,7 @@ pub use finalize::{
 };
 pub use pagination::{AggregateCursor, PaginatedBuckets, paginate_result};
 pub use parser::{parse_agg_spec, parse_and_expand_agg_specs};
+pub use parser_error::ParseAggSpecError;
 pub use planner::AggregatePlan;
 pub use presets::AggregatePreset;
 use rayon::prelude::*;

--- a/crates/uffs-core/src/aggregate/parser.rs
+++ b/crates/uffs-core/src/aggregate/parser.rs
@@ -16,18 +16,43 @@
 //! - `missing:extension`
 //! - `distinct:extension`
 
+use core::num::ParseIntError;
+
+use super::parser_error::ParseAggSpecError;
 use super::spec::{
     AggregateKind, AggregateSpec, BucketMetric, CalendarInterval, DuplicateVerify, RollupMode,
     ScalarMetric, TopHitsSpec,
 };
 use crate::search::field::FieldId;
 
+/// Build a closure that lifts a [`ParseIntError`] into the typed
+/// [`ParseAggSpecError::InvalidIntOption`] variant.
+///
+/// Keeps every `val.parse().map_err(...)` call site to a single line
+/// so the file stays under the 800-LOC policy ceiling without
+/// shedding any of the typed-variant information.  `option` is the
+/// static label rendered into the pre-Phase-5d Display string
+/// (e.g. `"top"`, `"sample"`, `"range boundary"`).
+fn invalid_int(
+    option: &'static str,
+    value: String,
+) -> impl FnOnce(ParseIntError) -> ParseAggSpecError {
+    move |source| ParseAggSpecError::InvalidIntOption {
+        option,
+        value,
+        source,
+    }
+}
+
 /// Parse a single `--agg` specification string into an `AggregateSpec`.
 ///
 /// # Errors
 ///
-/// Returns an error string if the spec is malformed.
-pub fn parse_agg_spec(input: &str) -> Result<AggregateSpec, String> {
+/// Returns a [`ParseAggSpecError`] variant when the spec is
+/// malformed.  Display strings stay byte-identical with the
+/// pre-Phase-5d `Result<_, String>` payloads so any operator-facing
+/// log output (daemon `tracing::warn!` and CLI stderr) is unchanged.
+pub fn parse_agg_spec(input: &str) -> Result<AggregateSpec, ParseAggSpecError> {
     let trimmed = input.trim();
 
     // Split on first ':'
@@ -56,7 +81,9 @@ pub fn parse_agg_spec(input: &str) -> Result<AggregateSpec, String> {
 
         "distinct" => parse_distinct(rest),
 
-        _ => Err(format!("Unknown aggregate kind: `{kind_str}`")),
+        _ => Err(ParseAggSpecError::UnknownKind {
+            kind: kind_str.to_owned(),
+        }),
     }
 }
 
@@ -75,12 +102,14 @@ fn split_field_and_options(input: &str) -> (&str, &str) {
 }
 
 /// Parse a field name to `FieldId`.
-fn parse_field(name: &str) -> Result<FieldId, String> {
-    FieldId::parse(name).ok_or_else(|| format!("Unknown field: `{name}`"))
+fn parse_field(name: &str) -> Result<FieldId, ParseAggSpecError> {
+    FieldId::parse(name).ok_or_else(|| ParseAggSpecError::UnknownField {
+        name: name.to_owned(),
+    })
 }
 
 /// Parse "field,metrics=M+M" → Stats spec.
-fn parse_stats(rest: &str) -> Result<AggregateSpec, String> {
+fn parse_stats(rest: &str) -> Result<AggregateSpec, ParseAggSpecError> {
     let (field_str, opts_str) = split_field_and_options(rest);
     let field = parse_field(field_str)?;
     let opts = parse_options(opts_str);
@@ -107,7 +136,7 @@ fn parse_stats(rest: &str) -> Result<AggregateSpec, String> {
 }
 
 /// Parse "field,top=N,metrics=M+M" → Terms spec.
-fn parse_terms(rest: &str) -> Result<AggregateSpec, String> {
+fn parse_terms(rest: &str) -> Result<AggregateSpec, ParseAggSpecError> {
     let (field_str, opts_str) = split_field_and_options(rest);
     let field = parse_field(field_str)?;
     let opts = parse_options(opts_str);
@@ -117,11 +146,7 @@ fn parse_terms(rest: &str) -> Result<AggregateSpec, String> {
 
     for (key, val) in &opts {
         match *key {
-            "top" => {
-                top = val
-                    .parse()
-                    .map_err(|err| format!("Invalid top: `{val}`: {err}"))?;
-            }
+            "top" => top = val.parse().map_err(invalid_int("top", (*val).to_owned()))?,
             "metrics" => {
                 for metric in val.split('+') {
                     metrics.push(parse_bucket_metric(metric)?);
@@ -130,7 +155,7 @@ fn parse_terms(rest: &str) -> Result<AggregateSpec, String> {
             "sample" => {
                 sample_count = val
                     .parse()
-                    .map_err(|err| format!("Invalid sample: `{val}`: {err}"))?;
+                    .map_err(invalid_int("sample", (*val).to_owned()))?;
             }
             _ => {}
         }
@@ -151,7 +176,7 @@ fn parse_terms(rest: &str) -> Result<AggregateSpec, String> {
 }
 
 /// Parse "field,interval=N" → Histogram spec.
-fn parse_histogram(rest: &str) -> Result<AggregateSpec, String> {
+fn parse_histogram(rest: &str) -> Result<AggregateSpec, ParseAggSpecError> {
     let (field_str, opts_str) = split_field_and_options(rest);
     let field = parse_field(field_str)?;
     let opts = parse_options(opts_str);
@@ -163,7 +188,7 @@ fn parse_histogram(rest: &str) -> Result<AggregateSpec, String> {
             "interval" => {
                 interval = val
                     .parse()
-                    .map_err(|err| format!("Invalid interval: `{val}`: {err}"))?;
+                    .map_err(invalid_int("interval", (*val).to_owned()))?;
             }
             "metrics" => {
                 metrics.clear();
@@ -183,7 +208,7 @@ fn parse_histogram(rest: &str) -> Result<AggregateSpec, String> {
 }
 
 /// Parse "field,calendar=INTERVAL" → `DateHistogram` spec.
-fn parse_date_histogram(rest: &str) -> Result<AggregateSpec, String> {
+fn parse_date_histogram(rest: &str) -> Result<AggregateSpec, ParseAggSpecError> {
     let (field_str, opts_str) = split_field_and_options(rest);
     let field = parse_field(field_str)?;
     let opts = parse_options(opts_str);
@@ -193,8 +218,11 @@ fn parse_date_histogram(rest: &str) -> Result<AggregateSpec, String> {
     for (key, val) in &opts {
         match *key {
             "calendar" | "interval" => {
-                calendar = CalendarInterval::parse(val)
-                    .ok_or_else(|| format!("Invalid calendar interval: `{val}`"))?;
+                calendar = CalendarInterval::parse(val).ok_or_else(|| {
+                    ParseAggSpecError::InvalidCalendar {
+                        val: (*val).to_owned(),
+                    }
+                })?;
             }
             "metrics" => {
                 metrics.clear();
@@ -214,7 +242,7 @@ fn parse_date_histogram(rest: &str) -> Result<AggregateSpec, String> {
 }
 
 /// Parse "field,bins=A..B+C..D+E.." → Range spec.
-fn parse_range(rest: &str) -> Result<AggregateSpec, String> {
+fn parse_range(rest: &str) -> Result<AggregateSpec, ParseAggSpecError> {
     let (field_str, opts_str) = split_field_and_options(rest);
     let field = parse_field(field_str)?;
     let opts = parse_options(opts_str);
@@ -228,9 +256,9 @@ fn parse_range(rest: &str) -> Result<AggregateSpec, String> {
                     // Each bin can be "A..B" or just "A". Extract the boundary values.
                     for part in boundary_str.split("..") {
                         if !part.is_empty() {
-                            let boundary_val: u64 = part.parse().map_err(|err| {
-                                format!("Invalid range boundary: `{part}`: {err}")
-                            })?;
+                            let boundary_val: u64 = part
+                                .parse()
+                                .map_err(invalid_int("range boundary", part.to_owned()))?;
                             if !boundaries.contains(&boundary_val) {
                                 boundaries.push(boundary_val);
                             }
@@ -261,7 +289,7 @@ fn parse_range(rest: &str) -> Result<AggregateSpec, String> {
 /// spec.
 ///
 /// Nested sub-aggregation syntax: `rollup:drive,sub=terms:type`
-fn parse_rollup(rest: &str) -> Result<AggregateSpec, String> {
+fn parse_rollup(rest: &str) -> Result<AggregateSpec, ParseAggSpecError> {
     let (mode_str, opts_str) = split_field_and_options(rest);
     let opts = parse_options(opts_str);
     let mut depth: u32 = 1;
@@ -276,17 +304,13 @@ fn parse_rollup(rest: &str) -> Result<AggregateSpec, String> {
             "depth" => {
                 depth = val
                     .parse()
-                    .map_err(|err| format!("Invalid depth: `{val}`: {err}"))?;
+                    .map_err(invalid_int("depth", (*val).to_owned()))?;
             }
-            "top" => {
-                top = val
-                    .parse()
-                    .map_err(|err| format!("Invalid top: `{val}`: {err}"))?;
-            }
+            "top" => top = val.parse().map_err(invalid_int("top", (*val).to_owned()))?,
             "record" | "frs" | "ancestor" => {
                 record_idx = Some(
                     val.parse()
-                        .map_err(|err| format!("Invalid record index: `{val}`: {err}"))?,
+                        .map_err(invalid_int("record index", (*val).to_owned()))?,
                 );
             }
             "metrics" => {
@@ -298,7 +322,7 @@ fn parse_rollup(rest: &str) -> Result<AggregateSpec, String> {
             "sample" => {
                 sample_count = val
                     .parse()
-                    .map_err(|err| format!("Invalid sample: `{val}`: {err}"))?;
+                    .map_err(invalid_int("sample", (*val).to_owned()))?;
             }
             "sub" => {
                 // Parse nested sub-aggregation spec (e.g. "terms:type").
@@ -313,14 +337,13 @@ fn parse_rollup(rest: &str) -> Result<AggregateSpec, String> {
         "drive" => RollupMode::Drive,
         "path" | "folder" | "dir" => RollupMode::Path { depth },
         "ancestor" | "drilldown" => {
-            let idx = record_idx
-                .ok_or_else(|| "rollup:ancestor requires record=<idx> option".to_owned())?;
+            let idx = record_idx.ok_or(ParseAggSpecError::AncestorRequiresRecord)?;
             RollupMode::Ancestor { record_idx: idx }
         }
         _ => {
-            return Err(format!(
-                "Unknown rollup mode: `{mode_str}`. Use 'path', 'drive', or 'ancestor'."
-            ));
+            return Err(ParseAggSpecError::UnknownRollupMode {
+                mode: mode_str.to_owned(),
+            });
         }
     };
 
@@ -336,7 +359,7 @@ fn parse_rollup(rest: &str) -> Result<AggregateSpec, String> {
 }
 
 /// Parse "size+name,verify=MODE,top=N,sample=N" → Duplicates spec.
-fn parse_duplicates(rest: &str) -> Result<AggregateSpec, String> {
+fn parse_duplicates(rest: &str) -> Result<AggregateSpec, ParseAggSpecError> {
     let (keys_str, opts_str) = split_field_and_options(rest);
     let opts = parse_options(opts_str);
 
@@ -360,23 +383,23 @@ fn parse_duplicates(rest: &str) -> Result<AggregateSpec, String> {
                     "none" => DuplicateVerify::None,
                     "first_bytes" | "first" => DuplicateVerify::FirstBytes { count: 4096 },
                     "sha256" | "hash" => DuplicateVerify::Sha256,
-                    _ => return Err(format!("Unknown verify mode: `{val}`")),
+                    _ => {
+                        return Err(ParseAggSpecError::UnknownVerifyMode {
+                            val: (*val).to_owned(),
+                        });
+                    }
                 };
             }
-            "top" => {
-                top = val
-                    .parse()
-                    .map_err(|err| format!("Invalid top: `{val}`: {err}"))?;
-            }
+            "top" => top = val.parse().map_err(invalid_int("top", (*val).to_owned()))?,
             "sample" => {
                 sample_count = val
                     .parse()
-                    .map_err(|err| format!("Invalid sample: `{val}`: {err}"))?;
+                    .map_err(invalid_int("sample", (*val).to_owned()))?;
             }
             "max_groups" => {
                 max_groups = val
                     .parse()
-                    .map_err(|err| format!("Invalid max_groups: `{val}`: {err}"))?;
+                    .map_err(invalid_int("max_groups", (*val).to_owned()))?;
             }
             _ => {}
         }
@@ -394,13 +417,13 @@ fn parse_duplicates(rest: &str) -> Result<AggregateSpec, String> {
 }
 
 /// Parse "NAME" → Preset expansion.
-fn parse_preset(rest: &str) -> Result<AggregateSpec, String> {
+fn parse_preset(rest: &str) -> Result<AggregateSpec, ParseAggSpecError> {
     let name = rest.trim();
     if super::presets::AggregatePreset::parse(name).is_none() {
-        return Err(format!(
-            "Unknown preset: `{name}`. Available: {}",
-            super::presets::AggregatePreset::ALL_NAMES.join(", ")
-        ));
+        return Err(ParseAggSpecError::UnknownPreset {
+            name: name.to_owned(),
+            available: super::presets::AggregatePreset::ALL_NAMES.join(", "),
+        });
     }
     // Return a Count as placeholder — the caller should expand the preset.
     // For now, we signal via label that this is a preset.
@@ -411,19 +434,19 @@ fn parse_preset(rest: &str) -> Result<AggregateSpec, String> {
 }
 
 /// Parse "field" → Missing spec.
-fn parse_missing(rest: &str) -> Result<AggregateSpec, String> {
+fn parse_missing(rest: &str) -> Result<AggregateSpec, ParseAggSpecError> {
     let field = parse_field(rest.trim())?;
     Ok(AggregateSpec::new(AggregateKind::Missing { field }))
 }
 
 /// Parse "field" → Distinct spec.
-fn parse_distinct(rest: &str) -> Result<AggregateSpec, String> {
+fn parse_distinct(rest: &str) -> Result<AggregateSpec, ParseAggSpecError> {
     let field = parse_field(rest.trim())?;
     Ok(AggregateSpec::new(AggregateKind::Distinct { field }))
 }
 
 /// Parse a scalar metric name.
-fn parse_scalar_metric(name: &str) -> Result<ScalarMetric, String> {
+fn parse_scalar_metric(name: &str) -> Result<ScalarMetric, ParseAggSpecError> {
     match name {
         "sum" => Ok(ScalarMetric::Sum),
         "min" => Ok(ScalarMetric::Min),
@@ -431,12 +454,14 @@ fn parse_scalar_metric(name: &str) -> Result<ScalarMetric, String> {
         "avg" | "mean" => Ok(ScalarMetric::Avg),
         "value_count" | "count" => Ok(ScalarMetric::ValueCount),
         "missing_count" | "missing" => Ok(ScalarMetric::MissingCount),
-        _ => Err(format!("Unknown scalar metric: `{name}`")),
+        _ => Err(ParseAggSpecError::UnknownScalarMetric {
+            name: name.to_owned(),
+        }),
     }
 }
 
 /// Parse a bucket metric name.
-fn parse_bucket_metric(name: &str) -> Result<BucketMetric, String> {
+fn parse_bucket_metric(name: &str) -> Result<BucketMetric, ParseAggSpecError> {
     match name {
         "count" => Ok(BucketMetric::Count),
         "total_bytes" | "bytes" | "size" => Ok(BucketMetric::TotalBytes),
@@ -448,7 +473,9 @@ fn parse_bucket_metric(name: &str) -> Result<BucketMetric, String> {
         "max_size" | "max" => Ok(BucketMetric::MaxSize),
         "share_count" | "share_of_count" => Ok(BucketMetric::ShareOfTotalCount),
         "share_bytes" | "share_of_bytes" => Ok(BucketMetric::ShareOfTotalBytes),
-        _ => Err(format!("Unknown bucket metric: `{name}`")),
+        _ => Err(ParseAggSpecError::UnknownBucketMetric {
+            name: name.to_owned(),
+        }),
     }
 }
 
@@ -459,7 +486,9 @@ fn parse_bucket_metric(name: &str) -> Result<BucketMetric, String> {
 /// # Errors
 ///
 /// Returns errors for any malformed spec.
-pub fn parse_and_expand_agg_specs(inputs: &[&str]) -> Result<Vec<AggregateSpec>, String> {
+pub fn parse_and_expand_agg_specs(
+    inputs: &[&str],
+) -> Result<Vec<AggregateSpec>, ParseAggSpecError> {
     let mut result = Vec::new();
 
     for input in inputs {
@@ -480,302 +509,10 @@ pub fn parse_and_expand_agg_specs(inputs: &[&str]) -> Result<Vec<AggregateSpec>,
     Ok(result)
 }
 
+// Tests live in a sibling file via `#[path]` to keep this file under
+// the 800-line policy ceiling.  The attached child sees this module's
+// scope (private items, `use super::*;`) exactly as it did when the
+// tests lived inline.
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_count() {
-        let spec = parse_agg_spec("count").unwrap();
-        assert!(matches!(spec.kind, AggregateKind::Count));
-    }
-
-    #[test]
-    fn parse_stats_size() {
-        let spec = parse_agg_spec("stats:size").unwrap();
-        if let AggregateKind::Stats { field, metrics } = &spec.kind {
-            assert_eq!(*field, FieldId::Size);
-            assert_eq!(metrics.len(), 4); // default: sum/min/max/avg
-        } else {
-            panic!("expected Stats");
-        }
-    }
-
-    #[test]
-    fn parse_terms_extension_with_top() {
-        let spec = parse_agg_spec("terms:extension,top=100").unwrap();
-        if let AggregateKind::Terms { field, top, .. } = &spec.kind {
-            assert_eq!(*field, FieldId::Extension);
-            assert_eq!(*top, 100);
-        } else {
-            panic!("expected Terms");
-        }
-    }
-
-    #[test]
-    fn parse_facet_alias() {
-        let spec = parse_agg_spec("facet:extension").unwrap();
-        assert!(matches!(spec.kind, AggregateKind::Terms { .. }));
-    }
-
-    #[test]
-    fn parse_date_histogram() {
-        let spec = parse_agg_spec("datehist:modified,calendar=month").unwrap();
-        if let AggregateKind::DateHistogram {
-            field, calendar, ..
-        } = &spec.kind
-        {
-            assert_eq!(*field, FieldId::Modified);
-            assert_eq!(*calendar, CalendarInterval::Month);
-        } else {
-            panic!("expected DateHistogram");
-        }
-    }
-
-    #[test]
-    fn parse_range_with_bins() {
-        let spec = parse_agg_spec("range:size,bins=1024+1048576+1073741824").unwrap();
-        if let AggregateKind::Range { boundaries, .. } = &spec.kind {
-            assert_eq!(boundaries.len(), 3);
-        } else {
-            panic!("expected Range");
-        }
-    }
-
-    #[test]
-    fn parse_rollup_path() {
-        let spec = parse_agg_spec("rollup:path,depth=2,top=20").unwrap();
-        if let AggregateKind::Rollup { mode, top, .. } = &spec.kind {
-            assert_eq!(*mode, RollupMode::Path { depth: 2 });
-            assert_eq!(*top, 20);
-        } else {
-            panic!("expected Rollup");
-        }
-    }
-
-    #[test]
-    fn parse_duplicates() {
-        let spec = parse_agg_spec("duplicates:size+name,verify=none,top=50").unwrap();
-        if let AggregateKind::Duplicates { keys, top, .. } = &spec.kind {
-            assert_eq!(keys.len(), 2);
-            assert_eq!(*top, 50);
-        } else {
-            panic!("expected Duplicates");
-        }
-    }
-
-    #[test]
-    fn parse_missing() {
-        let spec = parse_agg_spec("missing:extension").unwrap();
-        assert!(matches!(spec.kind, AggregateKind::Missing { .. }));
-    }
-
-    #[test]
-    fn parse_distinct() {
-        let spec = parse_agg_spec("distinct:extension").unwrap();
-        assert!(matches!(spec.kind, AggregateKind::Distinct { .. }));
-    }
-
-    #[test]
-    fn parse_preset() {
-        let spec = parse_agg_spec("preset:overview").unwrap();
-        assert!(spec.label.as_deref().unwrap().starts_with("__preset__"));
-    }
-
-    #[test]
-    fn parse_and_expand_preset() {
-        let specs = parse_and_expand_agg_specs(&["preset:overview"]).unwrap();
-        assert!(specs.len() >= 5); // overview has 5+ specs
-    }
-
-    #[test]
-    fn parse_unknown_kind() {
-        let result = parse_agg_spec("foobar:thing");
-        result.unwrap_err();
-    }
-
-    #[test]
-    fn parse_histogram() {
-        let spec = parse_agg_spec("hist:size,interval=1024").unwrap();
-        if let AggregateKind::Histogram {
-            field, interval, ..
-        } = &spec.kind
-        {
-            assert_eq!(*field, FieldId::Size);
-            assert_eq!(*interval, 1024);
-        } else {
-            panic!("expected Histogram");
-        }
-    }
-
-    // ── Stage 2 gap-fill tests ────────────────────────────────────
-
-    #[test]
-    fn parse_terms_with_sample() {
-        let spec = parse_agg_spec("terms:extension,top=10,sample=3").unwrap();
-        if let AggregateKind::Terms {
-            field, top, sample, ..
-        } = &spec.kind
-        {
-            assert_eq!(*field, FieldId::Extension);
-            assert_eq!(*top, 10);
-            let sample_spec = sample.as_ref().expect("sample should be Some");
-            assert_eq!(sample_spec.count, 3);
-        } else {
-            panic!("expected Terms");
-        }
-    }
-
-    #[test]
-    fn parse_terms_without_sample() {
-        let spec = parse_agg_spec("terms:extension,top=5").unwrap();
-        if let AggregateKind::Terms { sample, .. } = &spec.kind {
-            assert!(sample.is_none(), "no sample= → None");
-        } else {
-            panic!("expected Terms");
-        }
-    }
-
-    #[test]
-    fn parse_rollup_drive() {
-        let spec = parse_agg_spec("rollup:drive,top=10").unwrap();
-        if let AggregateKind::Rollup { mode, top, .. } = &spec.kind {
-            assert_eq!(*mode, RollupMode::Drive);
-            assert_eq!(*top, 10);
-        } else {
-            panic!("expected Rollup");
-        }
-    }
-
-    #[test]
-    fn parse_rollup_with_sample() {
-        let spec = parse_agg_spec("rollup:path,depth=2,sample=2").unwrap();
-        if let AggregateKind::Rollup { mode, sample, .. } = &spec.kind {
-            assert_eq!(*mode, RollupMode::Path { depth: 2 });
-            let sample_spec = sample.as_ref().expect("sample should be Some");
-            assert_eq!(sample_spec.count, 2);
-        } else {
-            panic!("expected Rollup");
-        }
-    }
-
-    #[test]
-    fn parse_duplicates_with_sample() {
-        let spec = parse_agg_spec("duplicates:size+name,sample=5,top=50").unwrap();
-        if let AggregateKind::Duplicates {
-            keys, top, sample, ..
-        } = &spec.kind
-        {
-            assert_eq!(keys.len(), 2);
-            assert_eq!(*top, 50);
-            let sample_spec = sample.as_ref().expect("sample should be Some");
-            assert_eq!(sample_spec.count, 5);
-        } else {
-            panic!("expected Duplicates");
-        }
-    }
-
-    #[test]
-    fn parse_rollup_folder_alias() {
-        let spec = parse_agg_spec("rollup:folder,depth=3").unwrap();
-        if let AggregateKind::Rollup { mode, .. } = &spec.kind {
-            assert_eq!(*mode, RollupMode::Path { depth: 3 });
-        } else {
-            panic!("expected Rollup");
-        }
-    }
-
-    #[test]
-    fn parse_rollup_dir_alias() {
-        let spec = parse_agg_spec("rollup:dir").unwrap();
-        if let AggregateKind::Rollup { mode, .. } = &spec.kind {
-            assert_eq!(*mode, RollupMode::Path { depth: 1 });
-        } else {
-            panic!("expected Rollup");
-        }
-    }
-
-    #[test]
-    fn parse_rollup_ancestor_mode() {
-        let spec = parse_agg_spec("rollup:ancestor,record=42,top=10").unwrap();
-        if let AggregateKind::Rollup { mode, top, .. } = &spec.kind {
-            assert_eq!(*mode, RollupMode::Ancestor { record_idx: 42 });
-            assert_eq!(*top, 10);
-        } else {
-            panic!("expected Rollup");
-        }
-    }
-
-    #[test]
-    fn parse_rollup_ancestor_frs_alias() {
-        let spec = parse_agg_spec("rollup:ancestor,frs=100").unwrap();
-        if let AggregateKind::Rollup { mode, .. } = &spec.kind {
-            assert_eq!(*mode, RollupMode::Ancestor { record_idx: 100 });
-        } else {
-            panic!("expected Rollup");
-        }
-    }
-
-    #[test]
-    fn parse_rollup_ancestor_missing_record_errors() {
-        let err = parse_agg_spec("rollup:ancestor,top=10");
-        assert!(err.is_err(), "ancestor without record= should fail");
-    }
-
-    #[test]
-    fn parse_rollup_drilldown_alias() {
-        let spec = parse_agg_spec("rollup:drilldown,record=5").unwrap();
-        if let AggregateKind::Rollup { mode, .. } = &spec.kind {
-            assert_eq!(*mode, RollupMode::Ancestor { record_idx: 5 });
-        } else {
-            panic!("expected Rollup");
-        }
-    }
-
-    #[test]
-    fn parse_rollup_with_nested_sub() {
-        let spec = parse_agg_spec("rollup:drive,sub=terms:extension").unwrap();
-        if let AggregateKind::Rollup { mode, sub, .. } = &spec.kind {
-            assert_eq!(*mode, RollupMode::Drive);
-            let sub_spec = sub.as_ref().expect("sub should be present");
-            assert!(
-                matches!(&sub_spec.kind, AggregateKind::Terms { .. }),
-                "sub should be a terms aggregation"
-            );
-        } else {
-            panic!("expected Rollup");
-        }
-    }
-
-    #[test]
-    fn parse_rollup_no_sub_by_default() {
-        let spec = parse_agg_spec("rollup:drive,top=5").unwrap();
-        if let AggregateKind::Rollup { sub, .. } = &spec.kind {
-            assert!(sub.is_none(), "sub should be None when not specified");
-        } else {
-            panic!("expected Rollup");
-        }
-    }
-
-    #[test]
-    fn parse_nested_rollup_path_with_terms_type() {
-        let spec = parse_agg_spec("rollup:path,depth=1,sub=terms:type,top=20").unwrap();
-        if let AggregateKind::Rollup { mode, sub, top, .. } = &spec.kind {
-            assert_eq!(*mode, RollupMode::Path { depth: 1 });
-            assert_eq!(*top, 20);
-            let sub_spec = sub.as_ref().expect("sub should be present");
-            assert!(matches!(&sub_spec.kind, AggregateKind::Terms { .. }));
-        } else {
-            panic!("expected Rollup");
-        }
-    }
-    #[test]
-    fn parse_terms_sample_zero_is_none() {
-        let spec = parse_agg_spec("terms:extension,sample=0").unwrap();
-        if let AggregateKind::Terms { sample, .. } = &spec.kind {
-            assert!(sample.is_none(), "sample=0 should produce None");
-        } else {
-            panic!("expected Terms");
-        }
-    }
-}
+#[path = "parser_tests.rs"]
+mod tests;

--- a/crates/uffs-core/src/aggregate/parser_error.rs
+++ b/crates/uffs-core/src/aggregate/parser_error.rs
@@ -65,7 +65,7 @@ pub enum ParseAggSpecError {
         option: &'static str,
         /// The offending value as supplied on the wire / command line.
         value: String,
-        /// The underlying [`u*::from_str`] failure.
+        /// The underlying `u*::from_str` failure.
         #[source]
         source: ParseIntError,
     },
@@ -96,7 +96,7 @@ pub enum ParseAggSpecError {
         val: String,
     },
     /// The preset name did not match any of
-    /// [`crate::aggregate::presets::AggregatePreset::ALL_NAMES`].
+    /// `AggregatePreset::ALL_NAMES`.
     ///
     /// `available` is the comma-joined list of accepted names,
     /// preserved verbatim from the pre-Phase-5d Display message so

--- a/crates/uffs-core/src/aggregate/parser_error.rs
+++ b/crates/uffs-core/src/aggregate/parser_error.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Typed error returned by [`super::parser::parse_agg_spec`] and
+//! [`super::parser::parse_and_expand_agg_specs`].
+//!
+//! Lifted out of `parser.rs` purely to keep that file under the
+//! 800-line policy ceiling.  The enum is `pub` and re-exported at
+//! `uffs_core::aggregate::ParseAggSpecError` via the parent module's
+//! glob re-export of `parser::*`.
+//!
+//! Phase 5d migration of the previous `Result<_, String>` return
+//! types: every [`core::fmt::Display`] string stays byte-identical
+//! with the pre-migration `format!()` payloads so operator-facing
+//! daemon logs (`tracing::warn!("skipping malformed aggregate spec:
+//! {e}")` in `uffs-daemon/src/index/aggregation.rs`) and CLI error
+//! output are unchanged, while callers can now match on variants and
+//! walk [`core::error::Error::source`] for the typed integer-parse
+//! chain.
+//!
+//! `#[non_exhaustive]` per Phase 5c discipline so future aggregate
+//! kinds / option keys can grow a variant without a semver bump on
+//! the (workspace-internal) consumers.
+
+use core::num::ParseIntError;
+
+/// Typed error returned by [`super::parser::parse_agg_spec`] and
+/// [`super::parser::parse_and_expand_agg_specs`].
+///
+/// See the module-level docs in `parser_error.rs` for the migration
+/// rationale.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ParseAggSpecError {
+    /// The top-level `kind:` segment did not match any known
+    /// aggregate kind (`count`, `stats`, `terms`, `facet`, `hist`,
+    /// `histogram`, `datehist`, `date_histogram`, `range`, `rollup`,
+    /// `duplicates`, `dups`, `preset`, `missing`, `distinct`).
+    #[error("Unknown aggregate kind: `{kind}`")]
+    UnknownKind {
+        /// The unrecognised kind token (as supplied on the command line).
+        kind: String,
+    },
+    /// A `field` slot named a column that
+    /// [`crate::search::field::FieldId::parse`] does not recognise.
+    #[error("Unknown field: `{name}`")]
+    UnknownField {
+        /// The unrecognised field name.
+        name: String,
+    },
+    /// One of the integer-valued option keys (`top`, `sample`,
+    /// `interval`, `range boundary`, `depth`, `record index`,
+    /// `max_groups`) failed to parse as the target integer type.
+    ///
+    /// The `option` field carries the lower-case label used in the
+    /// pre-Phase-5d Display message so the byte sequence is
+    /// unchanged.  The underlying [`ParseIntError`] is exposed via
+    /// [`core::error::Error::source`] for callers that want the typed
+    /// chain — net-new coverage over the previous `String` return.
+    #[error("Invalid {option}: `{value}`: {source}")]
+    InvalidIntOption {
+        /// The option label as rendered in the pre-Phase-5d Display
+        /// message (`"top"`, `"sample"`, `"interval"`, `"range
+        /// boundary"`, `"depth"`, `"record index"`, `"max_groups"`).
+        option: &'static str,
+        /// The offending value as supplied on the wire / command line.
+        value: String,
+        /// The underlying [`u*::from_str`] failure.
+        #[source]
+        source: ParseIntError,
+    },
+    /// `calendar=` named a value that
+    /// [`crate::aggregate::spec::CalendarInterval::parse`] does not
+    /// recognise.
+    #[error("Invalid calendar interval: `{val}`")]
+    InvalidCalendar {
+        /// The unrecognised calendar identifier.
+        val: String,
+    },
+    /// `rollup:ancestor` was supplied without the required
+    /// `record=<idx>` option (also known as `frs=` / `ancestor=`).
+    #[error("rollup:ancestor requires record=<idx> option")]
+    AncestorRequiresRecord,
+    /// The rollup mode did not match `path` / `folder` / `dir` /
+    /// `drive` / `ancestor` / `drilldown`.
+    #[error("Unknown rollup mode: `{mode}`. Use 'path', 'drive', or 'ancestor'.")]
+    UnknownRollupMode {
+        /// The unrecognised rollup mode.
+        mode: String,
+    },
+    /// The duplicates `verify=` mode did not match `none` /
+    /// `first_bytes` / `first` / `sha256` / `hash`.
+    #[error("Unknown verify mode: `{val}`")]
+    UnknownVerifyMode {
+        /// The unrecognised verify mode.
+        val: String,
+    },
+    /// The preset name did not match any of
+    /// [`crate::aggregate::presets::AggregatePreset::ALL_NAMES`].
+    ///
+    /// `available` is the comma-joined list of accepted names,
+    /// preserved verbatim from the pre-Phase-5d Display message so
+    /// operators see the same help text.
+    #[error("Unknown preset: `{name}`. Available: {available}")]
+    UnknownPreset {
+        /// The unrecognised preset name.
+        name: String,
+        /// Comma-joined list of accepted preset names.
+        available: String,
+    },
+    /// A `metrics=` segment in a `stats:*` spec named a scalar metric
+    /// that did not match `sum` / `min` / `max` / `avg` / `mean` /
+    /// `value_count` / `count` / `missing_count` / `missing`.
+    #[error("Unknown scalar metric: `{name}`")]
+    UnknownScalarMetric {
+        /// The unrecognised scalar metric name.
+        name: String,
+    },
+    /// A `metrics=` segment in a bucket-valued spec named a bucket
+    /// metric that did not match `count` / `total_bytes` / `bytes` /
+    /// `size` / `total_allocated` / `allocated` / `waste_bytes` /
+    /// `waste` / `waste_pct` / `waste_percent` / `avg_size` / `avg` /
+    /// `min_size` / `min` / `max_size` / `max` / `share_count` /
+    /// `share_of_count` / `share_bytes` / `share_of_bytes`.
+    #[error("Unknown bucket metric: `{name}`")]
+    UnknownBucketMetric {
+        /// The unrecognised bucket metric name.
+        name: String,
+    },
+}

--- a/crates/uffs-core/src/aggregate/parser_tests.rs
+++ b/crates/uffs-core/src/aggregate/parser_tests.rs
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Tests for the `--agg` power-syntax parser.
+//!
+//! Lifted out of `parser.rs` to keep that file under the 800-line
+//! policy ceiling.  Attached via `#[path]` in `parser.rs` so the
+//! `use super::*;` continues to resolve against the production
+//! module exactly as it did when the tests lived inline.
+
+use super::*;
+
+#[test]
+fn parse_count() {
+    let spec = parse_agg_spec("count").unwrap();
+    assert!(matches!(spec.kind, AggregateKind::Count));
+}
+
+#[test]
+fn parse_stats_size() {
+    let spec = parse_agg_spec("stats:size").unwrap();
+    if let AggregateKind::Stats { field, metrics } = &spec.kind {
+        assert_eq!(*field, FieldId::Size);
+        assert_eq!(metrics.len(), 4); // default: sum/min/max/avg
+    } else {
+        panic!("expected Stats");
+    }
+}
+
+#[test]
+fn parse_terms_extension_with_top() {
+    let spec = parse_agg_spec("terms:extension,top=100").unwrap();
+    if let AggregateKind::Terms { field, top, .. } = &spec.kind {
+        assert_eq!(*field, FieldId::Extension);
+        assert_eq!(*top, 100);
+    } else {
+        panic!("expected Terms");
+    }
+}
+
+#[test]
+fn parse_facet_alias() {
+    let spec = parse_agg_spec("facet:extension").unwrap();
+    assert!(matches!(spec.kind, AggregateKind::Terms { .. }));
+}
+
+#[test]
+fn parse_date_histogram() {
+    let spec = parse_agg_spec("datehist:modified,calendar=month").unwrap();
+    if let AggregateKind::DateHistogram {
+        field, calendar, ..
+    } = &spec.kind
+    {
+        assert_eq!(*field, FieldId::Modified);
+        assert_eq!(*calendar, CalendarInterval::Month);
+    } else {
+        panic!("expected DateHistogram");
+    }
+}
+
+#[test]
+fn parse_range_with_bins() {
+    let spec = parse_agg_spec("range:size,bins=1024+1048576+1073741824").unwrap();
+    if let AggregateKind::Range { boundaries, .. } = &spec.kind {
+        assert_eq!(boundaries.len(), 3);
+    } else {
+        panic!("expected Range");
+    }
+}
+
+#[test]
+fn parse_rollup_path() {
+    let spec = parse_agg_spec("rollup:path,depth=2,top=20").unwrap();
+    if let AggregateKind::Rollup { mode, top, .. } = &spec.kind {
+        assert_eq!(*mode, RollupMode::Path { depth: 2 });
+        assert_eq!(*top, 20);
+    } else {
+        panic!("expected Rollup");
+    }
+}
+
+#[test]
+fn parse_duplicates() {
+    let spec = parse_agg_spec("duplicates:size+name,verify=none,top=50").unwrap();
+    if let AggregateKind::Duplicates { keys, top, .. } = &spec.kind {
+        assert_eq!(keys.len(), 2);
+        assert_eq!(*top, 50);
+    } else {
+        panic!("expected Duplicates");
+    }
+}
+
+#[test]
+fn parse_missing() {
+    let spec = parse_agg_spec("missing:extension").unwrap();
+    assert!(matches!(spec.kind, AggregateKind::Missing { .. }));
+}
+
+#[test]
+fn parse_distinct() {
+    let spec = parse_agg_spec("distinct:extension").unwrap();
+    assert!(matches!(spec.kind, AggregateKind::Distinct { .. }));
+}
+
+#[test]
+fn parse_preset() {
+    let spec = parse_agg_spec("preset:overview").unwrap();
+    assert!(spec.label.as_deref().unwrap().starts_with("__preset__"));
+}
+
+#[test]
+fn parse_and_expand_preset() {
+    let specs = parse_and_expand_agg_specs(&["preset:overview"]).unwrap();
+    assert!(specs.len() >= 5); // overview has 5+ specs
+}
+
+#[test]
+fn parse_unknown_kind() {
+    let result = parse_agg_spec("foobar:thing");
+    result.unwrap_err();
+}
+
+#[test]
+fn parse_histogram() {
+    let spec = parse_agg_spec("hist:size,interval=1024").unwrap();
+    if let AggregateKind::Histogram {
+        field, interval, ..
+    } = &spec.kind
+    {
+        assert_eq!(*field, FieldId::Size);
+        assert_eq!(*interval, 1024);
+    } else {
+        panic!("expected Histogram");
+    }
+}
+
+// ── Stage 2 gap-fill tests ────────────────────────────────────
+
+#[test]
+fn parse_terms_with_sample() {
+    let spec = parse_agg_spec("terms:extension,top=10,sample=3").unwrap();
+    if let AggregateKind::Terms {
+        field, top, sample, ..
+    } = &spec.kind
+    {
+        assert_eq!(*field, FieldId::Extension);
+        assert_eq!(*top, 10);
+        let sample_spec = sample.as_ref().expect("sample should be Some");
+        assert_eq!(sample_spec.count, 3);
+    } else {
+        panic!("expected Terms");
+    }
+}
+
+#[test]
+fn parse_terms_without_sample() {
+    let spec = parse_agg_spec("terms:extension,top=5").unwrap();
+    if let AggregateKind::Terms { sample, .. } = &spec.kind {
+        assert!(sample.is_none(), "no sample= → None");
+    } else {
+        panic!("expected Terms");
+    }
+}
+
+#[test]
+fn parse_rollup_drive() {
+    let spec = parse_agg_spec("rollup:drive,top=10").unwrap();
+    if let AggregateKind::Rollup { mode, top, .. } = &spec.kind {
+        assert_eq!(*mode, RollupMode::Drive);
+        assert_eq!(*top, 10);
+    } else {
+        panic!("expected Rollup");
+    }
+}
+
+#[test]
+fn parse_rollup_with_sample() {
+    let spec = parse_agg_spec("rollup:path,depth=2,sample=2").unwrap();
+    if let AggregateKind::Rollup { mode, sample, .. } = &spec.kind {
+        assert_eq!(*mode, RollupMode::Path { depth: 2 });
+        let sample_spec = sample.as_ref().expect("sample should be Some");
+        assert_eq!(sample_spec.count, 2);
+    } else {
+        panic!("expected Rollup");
+    }
+}
+
+#[test]
+fn parse_duplicates_with_sample() {
+    let spec = parse_agg_spec("duplicates:size+name,sample=5,top=50").unwrap();
+    if let AggregateKind::Duplicates {
+        keys, top, sample, ..
+    } = &spec.kind
+    {
+        assert_eq!(keys.len(), 2);
+        assert_eq!(*top, 50);
+        let sample_spec = sample.as_ref().expect("sample should be Some");
+        assert_eq!(sample_spec.count, 5);
+    } else {
+        panic!("expected Duplicates");
+    }
+}
+
+#[test]
+fn parse_rollup_folder_alias() {
+    let spec = parse_agg_spec("rollup:folder,depth=3").unwrap();
+    if let AggregateKind::Rollup { mode, .. } = &spec.kind {
+        assert_eq!(*mode, RollupMode::Path { depth: 3 });
+    } else {
+        panic!("expected Rollup");
+    }
+}
+
+#[test]
+fn parse_rollup_dir_alias() {
+    let spec = parse_agg_spec("rollup:dir").unwrap();
+    if let AggregateKind::Rollup { mode, .. } = &spec.kind {
+        assert_eq!(*mode, RollupMode::Path { depth: 1 });
+    } else {
+        panic!("expected Rollup");
+    }
+}
+
+#[test]
+fn parse_rollup_ancestor_mode() {
+    let spec = parse_agg_spec("rollup:ancestor,record=42,top=10").unwrap();
+    if let AggregateKind::Rollup { mode, top, .. } = &spec.kind {
+        assert_eq!(*mode, RollupMode::Ancestor { record_idx: 42 });
+        assert_eq!(*top, 10);
+    } else {
+        panic!("expected Rollup");
+    }
+}
+
+#[test]
+fn parse_rollup_ancestor_frs_alias() {
+    let spec = parse_agg_spec("rollup:ancestor,frs=100").unwrap();
+    if let AggregateKind::Rollup { mode, .. } = &spec.kind {
+        assert_eq!(*mode, RollupMode::Ancestor { record_idx: 100 });
+    } else {
+        panic!("expected Rollup");
+    }
+}
+
+#[test]
+fn parse_rollup_ancestor_missing_record_errors() {
+    let err = parse_agg_spec("rollup:ancestor,top=10");
+    assert!(err.is_err(), "ancestor without record= should fail");
+}
+
+#[test]
+fn parse_rollup_drilldown_alias() {
+    let spec = parse_agg_spec("rollup:drilldown,record=5").unwrap();
+    if let AggregateKind::Rollup { mode, .. } = &spec.kind {
+        assert_eq!(*mode, RollupMode::Ancestor { record_idx: 5 });
+    } else {
+        panic!("expected Rollup");
+    }
+}
+
+#[test]
+fn parse_rollup_with_nested_sub() {
+    let spec = parse_agg_spec("rollup:drive,sub=terms:extension").unwrap();
+    if let AggregateKind::Rollup { mode, sub, .. } = &spec.kind {
+        assert_eq!(*mode, RollupMode::Drive);
+        let sub_spec = sub.as_ref().expect("sub should be present");
+        assert!(
+            matches!(&sub_spec.kind, AggregateKind::Terms { .. }),
+            "sub should be a terms aggregation"
+        );
+    } else {
+        panic!("expected Rollup");
+    }
+}
+
+#[test]
+fn parse_rollup_no_sub_by_default() {
+    let spec = parse_agg_spec("rollup:drive,top=5").unwrap();
+    if let AggregateKind::Rollup { sub, .. } = &spec.kind {
+        assert!(sub.is_none(), "sub should be None when not specified");
+    } else {
+        panic!("expected Rollup");
+    }
+}
+
+#[test]
+fn parse_nested_rollup_path_with_terms_type() {
+    let spec = parse_agg_spec("rollup:path,depth=1,sub=terms:type,top=20").unwrap();
+    if let AggregateKind::Rollup { mode, sub, top, .. } = &spec.kind {
+        assert_eq!(*mode, RollupMode::Path { depth: 1 });
+        assert_eq!(*top, 20);
+        let sub_spec = sub.as_ref().expect("sub should be present");
+        assert!(matches!(&sub_spec.kind, AggregateKind::Terms { .. }));
+    } else {
+        panic!("expected Rollup");
+    }
+}
+#[test]
+fn parse_terms_sample_zero_is_none() {
+    let spec = parse_agg_spec("terms:extension,sample=0").unwrap();
+    if let AggregateKind::Terms { sample, .. } = &spec.kind {
+        assert!(sample.is_none(), "sample=0 should produce None");
+    } else {
+        panic!("expected Terms");
+    }
+}
+
+// ───────────────────────── Phase 5d typed-error tests ─────────────────────
+//
+// Each of these locks the Display string of one `ParseAggSpecError`
+// variant at the byte-identical text the pre-Phase-5d `Result<_, String>`
+// returns produced, so daemon `tracing::warn!` lines and CLI stderr
+// stay unchanged through the migration.  Variants that chain an
+// underlying `ParseIntError` additionally walk `Error::source` to
+// assert the typed chain is intact — net-new coverage over the
+// flattened `String` return.
+
+#[test]
+fn unknown_kind_display_locked() {
+    use core::error::Error as _;
+    let err = parse_agg_spec("bogus:thing").expect_err("unknown kind must error");
+    assert_eq!(err, ParseAggSpecError::UnknownKind {
+        kind: "bogus".to_owned(),
+    });
+    assert_eq!(err.to_string(), "Unknown aggregate kind: `bogus`");
+    assert!(err.source().is_none());
+}
+
+#[test]
+fn unknown_field_display_locked() {
+    let err = parse_agg_spec("stats:not_a_field").expect_err("unknown field must error");
+    assert_eq!(err, ParseAggSpecError::UnknownField {
+        name: "not_a_field".to_owned(),
+    });
+    assert_eq!(err.to_string(), "Unknown field: `not_a_field`");
+}
+
+#[test]
+fn invalid_int_option_top_chains_source() {
+    use core::error::Error as _;
+    let err = parse_agg_spec("terms:extension,top=abc").expect_err("non-numeric top must error");
+    let ParseAggSpecError::InvalidIntOption {
+        option,
+        value,
+        source,
+    } = &err
+    else {
+        panic!("expected InvalidIntOption, got {err:?}");
+    };
+    assert_eq!(*option, "top");
+    assert_eq!(value, "abc");
+    // Display: byte-identical with the pre-Phase-5d
+    // `format!("Invalid top: `{val}`: {err}")` payload.
+    assert_eq!(err.to_string(), format!("Invalid top: `abc`: {source}"));
+    // Source chain walks to the underlying ParseIntError — the typed
+    // improvement over the previous flattened String.
+    let chained = err
+        .source()
+        .expect("InvalidIntOption exposes ParseIntError");
+    assert_eq!(chained.to_string(), source.to_string());
+}
+
+#[test]
+fn invalid_int_option_interval_locked() {
+    let err = parse_agg_spec("hist:size,interval=xyz").expect_err("must error");
+    assert!(
+        matches!(&err, ParseAggSpecError::InvalidIntOption { option, value, .. }
+        if *option == "interval" && value == "xyz")
+    );
+    assert!(err.to_string().starts_with("Invalid interval: `xyz`: "));
+}
+
+#[test]
+fn invalid_int_option_range_boundary_locked() {
+    let err = parse_agg_spec("range:size,bins=abc").expect_err("must error");
+    assert!(
+        matches!(&err, ParseAggSpecError::InvalidIntOption { option, value, .. }
+        if *option == "range boundary" && value == "abc")
+    );
+    assert!(
+        err.to_string()
+            .starts_with("Invalid range boundary: `abc`: ")
+    );
+}
+
+#[test]
+fn invalid_int_option_depth_locked() {
+    let err = parse_agg_spec("rollup:path,depth=xx").expect_err("must error");
+    assert!(
+        matches!(&err, ParseAggSpecError::InvalidIntOption { option, .. }
+        if *option == "depth")
+    );
+}
+
+#[test]
+fn invalid_int_option_record_index_locked() {
+    let err = parse_agg_spec("rollup:ancestor,record=qq").expect_err("must error");
+    assert!(
+        matches!(&err, ParseAggSpecError::InvalidIntOption { option, value, .. }
+        if *option == "record index" && value == "qq")
+    );
+}
+
+#[test]
+fn invalid_int_option_sample_locked() {
+    let err = parse_agg_spec("terms:extension,sample=qq").expect_err("must error");
+    assert!(
+        matches!(&err, ParseAggSpecError::InvalidIntOption { option, .. }
+        if *option == "sample")
+    );
+}
+
+#[test]
+fn invalid_int_option_max_groups_locked() {
+    let err = parse_agg_spec("duplicates:size+name,max_groups=qq").expect_err("must error");
+    assert!(
+        matches!(&err, ParseAggSpecError::InvalidIntOption { option, .. }
+        if *option == "max_groups")
+    );
+}
+
+#[test]
+fn invalid_calendar_display_locked() {
+    let err = parse_agg_spec("datehist:modified,calendar=fortnight")
+        .expect_err("unknown calendar must error");
+    assert_eq!(err, ParseAggSpecError::InvalidCalendar {
+        val: "fortnight".to_owned(),
+    });
+    assert_eq!(err.to_string(), "Invalid calendar interval: `fortnight`");
+}
+
+#[test]
+fn ancestor_requires_record_display_locked() {
+    let err = parse_agg_spec("rollup:ancestor,top=10").expect_err("must error");
+    assert_eq!(err, ParseAggSpecError::AncestorRequiresRecord);
+    assert_eq!(
+        err.to_string(),
+        "rollup:ancestor requires record=<idx> option"
+    );
+}
+
+#[test]
+fn unknown_rollup_mode_display_locked() {
+    let err = parse_agg_spec("rollup:bogus").expect_err("must error");
+    assert_eq!(err, ParseAggSpecError::UnknownRollupMode {
+        mode: "bogus".to_owned(),
+    });
+    assert_eq!(
+        err.to_string(),
+        "Unknown rollup mode: `bogus`. Use 'path', 'drive', or 'ancestor'.",
+    );
+}
+
+#[test]
+fn unknown_verify_mode_display_locked() {
+    let err = parse_agg_spec("duplicates:size+name,verify=bogus").expect_err("must error");
+    assert_eq!(err, ParseAggSpecError::UnknownVerifyMode {
+        val: "bogus".to_owned(),
+    });
+    assert_eq!(err.to_string(), "Unknown verify mode: `bogus`");
+}
+
+#[test]
+fn unknown_preset_display_locked() {
+    let err = parse_agg_spec("preset:nonsense").expect_err("must error");
+    let ParseAggSpecError::UnknownPreset { name, available } = &err else {
+        panic!("expected UnknownPreset, got {err:?}");
+    };
+    assert_eq!(name, "nonsense");
+    assert!(
+        !available.is_empty(),
+        "Available preset list must be non-empty",
+    );
+    // Display: byte-identical with the pre-Phase-5d format.
+    assert_eq!(
+        err.to_string(),
+        format!("Unknown preset: `nonsense`. Available: {available}")
+    );
+}
+
+#[test]
+fn unknown_scalar_metric_display_locked() {
+    let err = parse_agg_spec("stats:size,metrics=bogus").expect_err("must error");
+    assert_eq!(err, ParseAggSpecError::UnknownScalarMetric {
+        name: "bogus".to_owned(),
+    });
+    assert_eq!(err.to_string(), "Unknown scalar metric: `bogus`");
+}
+
+#[test]
+fn unknown_bucket_metric_display_locked() {
+    let err = parse_agg_spec("terms:extension,metrics=bogus").expect_err("must error");
+    assert_eq!(err, ParseAggSpecError::UnknownBucketMetric {
+        name: "bogus".to_owned(),
+    });
+    assert_eq!(err.to_string(), "Unknown bucket metric: `bogus`");
+}

--- a/crates/uffs-core/src/aggregate/spec.rs
+++ b/crates/uffs-core/src/aggregate/spec.rs
@@ -268,7 +268,7 @@ impl TopHitsSpec {
     /// # Errors
     ///
     /// Returns a [`TopHitsValidateError`] variant if `count` is zero,
-    /// exceeds [`MAX_SAMPLE_COUNT`], or [`Self::sort_field`] is not
+    /// exceeds `MAX_SAMPLE_COUNT`, or [`Self::sort_field`] is not
     /// sortable.  Display strings stay byte-identical with the
     /// pre-Phase-5d `Result<_, String>` payloads.
     pub const fn validate(&self) -> Result<(), TopHitsValidateError> {
@@ -307,7 +307,7 @@ pub enum TopHitsValidateError {
     /// emit anything meaningful.
     #[error("TopHitsSpec count must be ≥ 1")]
     ZeroCount,
-    /// `count` exceeded [`MAX_SAMPLE_COUNT`].  The offending value is
+    /// `count` exceeded `MAX_SAMPLE_COUNT`.  The offending value is
     /// echoed for the operator.
     #[error("TopHitsSpec count {count} exceeds maximum {max}", max = MAX_SAMPLE_COUNT)]
     CountExceedsMax {

--- a/crates/uffs-core/src/aggregate/spec.rs
+++ b/crates/uffs-core/src/aggregate/spec.rs
@@ -267,30 +267,61 @@ impl TopHitsSpec {
     ///
     /// # Errors
     ///
-    /// Returns `Err` with a human-readable message if the sort field is
-    /// not numeric/timestamp (i.e. cannot be meaningfully ordered), or if
-    /// `count` is zero.
-    pub fn validate(&self) -> Result<(), String> {
+    /// Returns a [`TopHitsValidateError`] variant if `count` is zero,
+    /// exceeds [`MAX_SAMPLE_COUNT`], or [`Self::sort_field`] is not
+    /// sortable.  Display strings stay byte-identical with the
+    /// pre-Phase-5d `Result<_, String>` payloads.
+    pub const fn validate(&self) -> Result<(), TopHitsValidateError> {
         if self.count == 0 {
-            return Err("TopHitsSpec count must be ≥ 1".to_owned());
+            return Err(TopHitsValidateError::ZeroCount);
         }
         if self.count > MAX_SAMPLE_COUNT {
-            return Err(format!(
-                "TopHitsSpec count {} exceeds maximum {}",
-                self.count, MAX_SAMPLE_COUNT
-            ));
+            return Err(TopHitsValidateError::CountExceedsMax { count: self.count });
         }
         // sort_field should be something orderable — we accept any field
         // that the sort pipeline accepts (numeric, timestamp, boolean).
         let meta = self.sort_field.metadata();
         if !meta.sortable {
-            return Err(format!(
-                "TopHitsSpec sort_field {:?} is not sortable",
-                self.sort_field
-            ));
+            return Err(TopHitsValidateError::UnsortableField {
+                field: self.sort_field,
+            });
         }
         Ok(())
     }
+}
+
+/// Typed error returned by [`TopHitsSpec::validate`].
+///
+/// Phase 5d migration of the previous `Result<(), String>` return
+/// type: the [`core::fmt::Display`] strings stay byte-identical with
+/// the pre-migration `format!()` payloads so any operator-facing
+/// validation message is unchanged.
+///
+/// `#[non_exhaustive]` per Phase 5c discipline so a future validation
+/// rule (e.g. duplicate-projection-field check) can grow a variant
+/// without a semver bump on the (workspace-internal) consumer.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum TopHitsValidateError {
+    /// `count` was zero — the sample size must be at least 1 to
+    /// emit anything meaningful.
+    #[error("TopHitsSpec count must be ≥ 1")]
+    ZeroCount,
+    /// `count` exceeded [`MAX_SAMPLE_COUNT`].  The offending value is
+    /// echoed for the operator.
+    #[error("TopHitsSpec count {count} exceeds maximum {max}", max = MAX_SAMPLE_COUNT)]
+    CountExceedsMax {
+        /// The offending count.
+        count: u8,
+    },
+    /// [`TopHitsSpec::sort_field`] is not declared sortable in its
+    /// metadata — typically a non-numeric / non-timestamp field like
+    /// `FieldId::Attributes`.
+    #[error("TopHitsSpec sort_field {field:?} is not sortable")]
+    UnsortableField {
+        /// The offending field id.
+        field: FieldId,
+    },
 }
 
 /// A scalar metric computed over a set of records.
@@ -578,10 +609,45 @@ mod tests {
     #[test]
     fn top_hits_validate_unsortable_field() {
         let spec = TopHitsSpec::new(2, FieldId::Attributes, true, vec![]);
-        let result = spec.validate();
-        assert!(result.is_err(), "Attributes is not sortable");
-        let msg = result.unwrap_err();
-        assert!(msg.contains("not sortable"), "error: {msg}");
+        let err = spec.validate().expect_err("Attributes is not sortable");
+        assert!(
+            matches!(&err, TopHitsValidateError::UnsortableField { field } if *field == FieldId::Attributes),
+            "expected UnsortableField(Attributes), got {err:?}",
+        );
+        // Display contract preserved from the pre-Phase-5d `String` return.
+        assert!(err.to_string().contains("not sortable"), "error: {err}");
+    }
+
+    #[test]
+    fn top_hits_validate_zero_count() {
+        // Construct directly to bypass `new`'s validation (if any) so we
+        // can exercise the `ZeroCount` arm.
+        let spec = TopHitsSpec {
+            count: 0,
+            sort_field: FieldId::Size,
+            sort_desc: true,
+            projection: vec![],
+        };
+        let err = spec.validate().expect_err("zero count must error");
+        assert_eq!(err, TopHitsValidateError::ZeroCount);
+        assert_eq!(err.to_string(), "TopHitsSpec count must be ≥ 1");
+    }
+
+    #[test]
+    fn top_hits_validate_count_exceeds_max() {
+        let over = MAX_SAMPLE_COUNT + 1;
+        let spec = TopHitsSpec {
+            count: over,
+            sort_field: FieldId::Size,
+            sort_desc: true,
+            projection: vec![],
+        };
+        let err = spec.validate().expect_err("over-max count must error");
+        assert_eq!(err, TopHitsValidateError::CountExceedsMax { count: over });
+        assert_eq!(
+            err.to_string(),
+            format!("TopHitsSpec count {over} exceeds maximum {MAX_SAMPLE_COUNT}"),
+        );
     }
 
     #[test]

--- a/crates/uffs-core/src/search/filters/time_parsing.rs
+++ b/crates/uffs-core/src/search/filters/time_parsing.rs
@@ -93,7 +93,7 @@ pub enum ParseSizeError {
     /// Input was empty after trimming.
     #[error("empty size specification")]
     Empty,
-    /// The numeric portion failed [`u64::from_str`].  The original
+    /// The numeric portion failed `u64::from_str`.  The original
     /// untrimmed spec is echoed back so the operator sees what they
     /// typed.
     #[error("invalid size: {spec}")]

--- a/crates/uffs-core/src/search/filters/time_parsing.rs
+++ b/crates/uffs-core/src/search/filters/time_parsing.rs
@@ -67,6 +67,50 @@ pub fn parse_month_spec(spec: &str) -> Vec<u32> {
 // Size parsing helpers
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// Typed error returned by [`parse_size`].
+///
+/// Phase 5d migration of the previous `Result<u64, String>` return
+/// type: the [`core::fmt::Display`] strings stay byte-identical with
+/// the pre-migration `format!()` payloads so any operator-facing CLI
+/// error output is unchanged, while callers can now match on
+/// variants instead of parsing the string.
+///
+/// `#[non_exhaustive]` per Phase 5c discipline so future failure
+/// modes (e.g. negative-prefix rejection, unit-overflow with a
+/// suffix-larger-than-`u64` policy) can grow a variant without a
+/// semver bump.
+///
+/// Note: this is an independent copy of `uffs_client::format::ParseSizeError`
+/// — the two `parse_size` functions live in different crates with a
+/// subtle behaviour difference (this `uffs-core` variant rejects
+/// overflow explicitly via `Overflow`, while the `uffs-client` variant
+/// saturates).  Both keep the same Display text for the shared
+/// variants so operator output is consistent regardless of which
+/// crate's helper renders the error.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ParseSizeError {
+    /// Input was empty after trimming.
+    #[error("empty size specification")]
+    Empty,
+    /// The numeric portion failed [`u64::from_str`].  The original
+    /// untrimmed spec is echoed back so the operator sees what they
+    /// typed.
+    #[error("invalid size: {spec}")]
+    InvalidNumber {
+        /// The original, untrimmed input.
+        spec: String,
+    },
+    /// `count * multiplier` overflowed [`u64`] (e.g. `9999TB`).  The
+    /// original untrimmed spec is echoed back for the same reason as
+    /// [`Self::InvalidNumber`].
+    #[error("size overflows u64: {spec}")]
+    Overflow {
+        /// The original, untrimmed input.
+        spec: String,
+    },
+}
+
 /// Parse a human-readable size string into bytes.
 ///
 /// Accepts plain integers (bytes) and suffixes: `B`, `KB`, `MB`, `GB`, `TB`.
@@ -75,8 +119,10 @@ pub fn parse_month_spec(spec: &str) -> Vec<u32> {
 ///
 /// # Errors
 ///
-/// Returns `Err` if the spec is empty, contains non-numeric characters
-/// (after stripping the suffix), or the result overflows `u64`.
+/// Returns a [`ParseSizeError`] variant when the spec is empty,
+/// contains non-numeric characters (after stripping the suffix), or
+/// the result overflows [`u64`].  Display strings stay byte-identical
+/// with the pre-Phase-5d output.
 ///
 /// # Examples
 ///
@@ -90,7 +136,7 @@ pub fn parse_month_spec(spec: &str) -> Vec<u32> {
 /// assert_eq!(parse_size("0"), Ok(0));
 /// assert!(parse_size("abc").is_err());
 /// ```
-pub fn parse_size(spec: &str) -> Result<u64, String> {
+pub fn parse_size(spec: &str) -> Result<u64, ParseSizeError> {
     // Suffix table: longest-first to avoid prefix ambiguity.
     const SUFFIXES: &[(&str, u64)] = &[
         ("TB", 1024 * 1024 * 1024 * 1024),
@@ -102,7 +148,7 @@ pub fn parse_size(spec: &str) -> Result<u64, String> {
 
     let trimmed = spec.trim();
     if trimmed.is_empty() {
-        return Err("empty size specification".to_owned());
+        return Err(ParseSizeError::Empty);
     }
 
     let upper = trimmed.to_ascii_uppercase();
@@ -115,11 +161,15 @@ pub fn parse_size(spec: &str) -> Result<u64, String> {
     let count: u64 = digits
         .trim()
         .parse()
-        .map_err(|_parse_err| format!("invalid size: {spec}"))?;
+        .map_err(|_parse_err| ParseSizeError::InvalidNumber {
+            spec: spec.to_owned(),
+        })?;
 
     count
         .checked_mul(multiplier)
-        .ok_or_else(|| format!("size overflows u64: {spec}"))
+        .ok_or_else(|| ParseSizeError::Overflow {
+            spec: spec.to_owned(),
+        })
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/uffs-daemon/src/handler.rs
+++ b/crates/uffs-daemon/src/handler.rs
@@ -28,6 +28,16 @@ use crate::lifecycle::LifecycleHandle;
 // `Self::try_pack_paths_blob(...)` method syntax — no call-site changes.
 #[path = "handler_blob.rs"]
 mod blob;
+
+// `ParseSearchParamsError` lives in its own sibling file for the same
+// 800-LOC policy reason and to keep the typed-error introduction
+// physically separate from the dispatcher.  Re-exporting the type
+// here lets every call site (and the co-located test module) refer
+// to it unqualified.
+#[path = "handler_parse_search_params.rs"]
+mod parse_search_params;
+use parse_search_params::ParseSearchParamsError;
+
 /// Request handler holding shared daemon state.
 pub(crate) struct RequestHandler {
     /// Shared index manager.
@@ -81,9 +91,9 @@ impl RequestHandler {
 
     /// Handle `search` method.
     async fn handle_search(&self, id: u64, req: &RpcRequest) -> String {
-        let search_params = match Self::parse_and_validate_search_params(id, req) {
+        let search_params = match Self::parse_and_validate_search_params(req) {
             Ok(params) => params,
-            Err(error_json) => return error_json,
+            Err(parse_err) => return parse_err.to_rpc_error_json(id),
         };
 
         // Auto-load missing drives from data_dir before searching.
@@ -148,34 +158,40 @@ impl RequestHandler {
     }
 
     /// Decode `req.params` into a [`SearchParams`] and enforce
-    /// [`MAX_PATTERN_LENGTH`].  Returns the parsed params on success
-    /// or a fully-formed JSON-RPC error response on failure so the
-    /// caller can return it directly.
-    fn parse_and_validate_search_params(id: u64, req: &RpcRequest) -> Result<SearchParams, String> {
+    /// [`MAX_PATTERN_LENGTH`].
+    ///
+    /// Phase 5d migration: previously this returned
+    /// `Result<SearchParams, String>` where the `String` was a
+    /// pre-serialised JSON-RPC error body.  The serialisation concern
+    /// has been hoisted to [`ParseSearchParamsError::to_rpc_error_json`]
+    /// at the wire boundary so the parser expresses only the domain
+    /// concern ("did the params parse?") and the request `id` no
+    /// longer threads through this private helper.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseSearchParamsError::MissingOrInvalidParams`] when
+    /// `req.params` is absent or fails to deserialise as
+    /// [`SearchParams`]; returns
+    /// [`ParseSearchParamsError::PatternTooLong`] when
+    /// `search_params.pattern` exceeds [`MAX_PATTERN_LENGTH`] (S4.4.3
+    /// regex-DoS guard).  The wire bytes produced by
+    /// [`ParseSearchParamsError::to_rpc_error_json`] are byte-identical
+    /// with the pre-Phase-5d output so clients see no change.
+    fn parse_and_validate_search_params(
+        req: &RpcRequest,
+    ) -> Result<SearchParams, ParseSearchParamsError> {
         let search_params: SearchParams = req
             .params
             .as_ref()
             .and_then(|val| serde_json::from_value::<SearchParams>(val.clone()).ok())
-            .ok_or_else(|| {
-                serde_json::to_string(&RpcErrorResponse::error(
-                    Some(id),
-                    ERR_INVALID_PARAMS,
-                    "Missing or invalid search params",
-                ))
-                .unwrap_or_default()
-            })?;
+            .ok_or(ParseSearchParamsError::MissingOrInvalidParams)?;
 
         // S4.4.3: Reject overly long patterns (regex DoS prevention).
         if search_params.pattern.len() > MAX_PATTERN_LENGTH {
-            return Err(serde_json::to_string(&RpcErrorResponse::error(
-                Some(id),
-                ERR_INVALID_PARAMS,
-                &format!(
-                    "Pattern too long ({} chars, max {MAX_PATTERN_LENGTH})",
-                    search_params.pattern.len()
-                ),
-            ))
-            .unwrap_or_default());
+            return Err(ParseSearchParamsError::PatternTooLong {
+                len: search_params.pattern.len(),
+            });
         }
 
         Ok(search_params)
@@ -730,3 +746,7 @@ mod paths_blob_tests;
 #[cfg(test)]
 #[path = "handler_csv_blob_tests.rs"]
 mod csv_blob_tests;
+
+#[cfg(test)]
+#[path = "handler_parse_search_params_tests.rs"]
+mod parse_search_params_tests;

--- a/crates/uffs-daemon/src/handler.rs
+++ b/crates/uffs-daemon/src/handler.rs
@@ -298,13 +298,19 @@ impl RequestHandler {
         };
 
         // Parse into SearchParams using the shared CLI parser.
+        //
+        // Phase 5d: `from_cli_args` now returns a typed
+        // `uffs_client::protocol::cli_args::Error` (alias of
+        // `CliArgsError`) whose Display string is byte-identical with
+        // the pre-Phase-5d `String` payload, so the JSON-RPC error
+        // message stays unchanged.
         let search_params = match SearchParams::from_cli_args(&args) {
             Ok(params) => params,
-            Err(msg) => {
+            Err(err) => {
                 return serde_json::to_string(&RpcErrorResponse::error(
                     Some(id),
                     ERR_INVALID_PARAMS,
-                    &msg,
+                    &err.to_string(),
                 ))
                 .unwrap_or_default();
             }

--- a/crates/uffs-daemon/src/handler_parse_search_params.rs
+++ b/crates/uffs-daemon/src/handler_parse_search_params.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Typed error for [`super::RequestHandler::parse_and_validate_search_params`].
+//!
+//! Phase 5d migration of the previous `Result<SearchParams, String>`
+//! return type: the `String` used to be a pre-serialised JSON-RPC
+//! error body, conflating two concerns (parsing vs. wire-output) in
+//! one signature.  Splitting them out yields a domain-only error type
+//! here and a single boundary call at
+//! [`super::RequestHandler::handle_search`] — same wire bytes,
+//! sharper types.
+//!
+//! Lifted out of `handler.rs` to keep that file under the 800-line
+//! policy ceiling.  Re-attached via
+//! `#[path = "handler_parse_search_params.rs"] mod parse_search_params;`
+//! in `handler.rs`, which then re-exports the type with
+//! `use parse_search_params::ParseSearchParamsError;` so every call
+//! site (and the co-located test module at
+//! `handler_parse_search_params_tests.rs`) keeps the unqualified name.
+
+use alloc::borrow::Cow;
+
+use uffs_client::protocol::{ERR_INVALID_PARAMS, RpcErrorResponse};
+
+use super::MAX_PATTERN_LENGTH;
+
+/// Typed error produced by
+/// [`super::RequestHandler::parse_and_validate_search_params`].
+///
+/// `#[non_exhaustive]` per Phase 5c discipline so a future validation
+/// branch (e.g. drive-letter-allowlist enforcement) can grow a variant
+/// without a semver bump on the (workspace-internal) consumer.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub(super) enum ParseSearchParamsError {
+    /// `req.params` was absent, malformed JSON, or failed to
+    /// deserialise as `SearchParams`.
+    #[error("Missing or invalid search params")]
+    MissingOrInvalidParams,
+    /// `search_params.pattern.len()` exceeded [`MAX_PATTERN_LENGTH`]
+    /// — the S4.4.3 regex-DoS guard rail.
+    #[error("Pattern too long ({len} chars, max {MAX_PATTERN_LENGTH})")]
+    PatternTooLong {
+        /// The offending pattern's length in bytes.
+        len: usize,
+    },
+}
+
+impl ParseSearchParamsError {
+    /// Render this error as a fully-formed JSON-RPC error response
+    /// body, using `id` as the request correlation id.
+    ///
+    /// The wire bytes produced here are byte-identical with the
+    /// pre-Phase-5d output (same JSON-RPC version, same
+    /// [`ERR_INVALID_PARAMS`] code, same message text, same encoder),
+    /// so clients see no change.  When serialisation itself fails
+    /// (which would be a `serde_json` defect on a fixed-shape error
+    /// payload), we fall back to the empty-string default exactly as
+    /// the previous code did — preserving the existing observable
+    /// behaviour without silently swallowing a panic.
+    pub(super) fn to_rpc_error_json(&self, id: u64) -> String {
+        // Build the message as `&str` where possible to avoid a
+        // throw-away heap allocation for the static-text variant.
+        let message: Cow<'_, str> = match *self {
+            Self::MissingOrInvalidParams => "Missing or invalid search params".into(),
+            Self::PatternTooLong { len } => {
+                format!("Pattern too long ({len} chars, max {MAX_PATTERN_LENGTH})").into()
+            }
+        };
+        serde_json::to_string(&RpcErrorResponse::error(
+            Some(id),
+            ERR_INVALID_PARAMS,
+            &message,
+        ))
+        .unwrap_or_default()
+    }
+}

--- a/crates/uffs-daemon/src/handler_parse_search_params_tests.rs
+++ b/crates/uffs-daemon/src/handler_parse_search_params_tests.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Regression tests for [`super::ParseSearchParamsError`].
+//!
+//! Phase 5d migration of `parse_and_validate_search_params` from
+//! `Result<SearchParams, String>` to a typed error.  These tests lock
+//! the wire-byte equivalence of the error JSON-RPC body so external
+//! callers see no change, and pin the Display contract of the typed
+//! variants for future maintainers.
+//!
+//! Sibling-file layout (`#[path]` attached) matches the established
+//! `handler_blob.rs` / `handler_paths_blob_tests.rs` /
+//! `handler_csv_blob_tests.rs` pattern — keeps `handler.rs` under
+//! the 800-line policy ceiling without sacrificing test coverage.
+
+use core::error::Error as _;
+
+use uffs_client::protocol::{ERR_INVALID_PARAMS, RpcRequest};
+
+use super::{MAX_PATTERN_LENGTH, ParseSearchParamsError};
+
+/// Build the wire bytes the **pre-Phase-5d** code emitted for the
+/// `MissingOrInvalidParams` path — used as the byte-equivalence
+/// reference for the new typed-error route.
+fn legacy_missing_or_invalid_json(id: u64) -> String {
+    serde_json::to_string(&uffs_client::protocol::RpcErrorResponse::error(
+        Some(id),
+        ERR_INVALID_PARAMS,
+        "Missing or invalid search params",
+    ))
+    .expect("fixed-shape RpcErrorResponse must always serialise")
+}
+
+/// Build the wire bytes the **pre-Phase-5d** code emitted for the
+/// `PatternTooLong` path — used as the byte-equivalence reference.
+fn legacy_pattern_too_long_json(id: u64, len: usize) -> String {
+    serde_json::to_string(&uffs_client::protocol::RpcErrorResponse::error(
+        Some(id),
+        ERR_INVALID_PARAMS,
+        &format!("Pattern too long ({len} chars, max {MAX_PATTERN_LENGTH})"),
+    ))
+    .expect("fixed-shape RpcErrorResponse must always serialise")
+}
+
+/// The `MissingOrInvalidParams` variant Display matches the legacy
+/// message text exactly — operator logs are unchanged.
+#[test]
+fn missing_or_invalid_params_display_locked() {
+    let err = ParseSearchParamsError::MissingOrInvalidParams;
+    assert_eq!(err.to_string(), "Missing or invalid search params");
+    assert!(
+        err.source().is_none(),
+        "MissingOrInvalidParams has no underlying source",
+    );
+}
+
+/// The `PatternTooLong` variant Display interpolates `len` and the
+/// `MAX_PATTERN_LENGTH` constant exactly the way the previous code did.
+#[test]
+fn pattern_too_long_display_locked() {
+    let err = ParseSearchParamsError::PatternTooLong { len: 9_999 };
+    assert_eq!(
+        err.to_string(),
+        format!("Pattern too long (9999 chars, max {MAX_PATTERN_LENGTH})"),
+    );
+}
+
+/// `to_rpc_error_json` for `MissingOrInvalidParams` must produce the
+/// **byte-identical** JSON-RPC error body the pre-Phase-5d path
+/// produced — same id, same code, same message, same encoder.
+#[test]
+fn missing_or_invalid_params_wire_bytes_locked() {
+    let err = ParseSearchParamsError::MissingOrInvalidParams;
+    for id in [0_u64, 1, 42, u64::MAX] {
+        assert_eq!(
+            err.to_rpc_error_json(id),
+            legacy_missing_or_invalid_json(id),
+            "wire bytes drifted for MissingOrInvalidParams at id={id}",
+        );
+    }
+}
+
+/// `to_rpc_error_json` for `PatternTooLong` must produce the
+/// **byte-identical** JSON-RPC error body the pre-Phase-5d path
+/// produced for the same `id` and `len`.
+#[test]
+fn pattern_too_long_wire_bytes_locked() {
+    for len in [MAX_PATTERN_LENGTH + 1, MAX_PATTERN_LENGTH * 2, 1_000_000] {
+        let err = ParseSearchParamsError::PatternTooLong { len };
+        for id in [0_u64, 1, u64::MAX] {
+            assert_eq!(
+                err.to_rpc_error_json(id),
+                legacy_pattern_too_long_json(id, len),
+                "wire bytes drifted for PatternTooLong at id={id}, len={len}",
+            );
+        }
+    }
+}
+
+/// End-to-end: an `RpcRequest` with `params = null` exercises the
+/// `MissingOrInvalidParams` path through
+/// [`super::RequestHandler::parse_and_validate_search_params`].
+#[test]
+fn parse_and_validate_rejects_missing_params() {
+    let req = RpcRequest {
+        jsonrpc: "2.0".to_owned(),
+        id: Some(7),
+        method: "search".to_owned(),
+        params: None,
+    };
+    let err = super::RequestHandler::parse_and_validate_search_params(&req)
+        .expect_err("missing params must error");
+    assert_eq!(err, ParseSearchParamsError::MissingOrInvalidParams);
+}
+
+/// End-to-end: an `RpcRequest` carrying a `SearchParams` with a
+/// `pattern` over the [`MAX_PATTERN_LENGTH`] guard exercises the
+/// `PatternTooLong` path through
+/// [`super::RequestHandler::parse_and_validate_search_params`].
+#[test]
+fn parse_and_validate_rejects_overlong_pattern() {
+    let oversized = "a".repeat(MAX_PATTERN_LENGTH + 1);
+    let req = RpcRequest {
+        jsonrpc: "2.0".to_owned(),
+        id: Some(11),
+        method: "search".to_owned(),
+        params: Some(serde_json::json!({ "pattern": oversized })),
+    };
+    let err = super::RequestHandler::parse_and_validate_search_params(&req)
+        .expect_err("overlong pattern must error");
+    assert_eq!(err, ParseSearchParamsError::PatternTooLong {
+        len: MAX_PATTERN_LENGTH + 1
+    },);
+}
+
+/// End-to-end happy path: a well-formed `SearchParams` round-trips
+/// through `parse_and_validate_search_params` unchanged.  Locks the
+/// contract that the migration did not introduce a spurious failure
+/// mode for valid input.
+#[test]
+fn parse_and_validate_accepts_valid_params() {
+    let req = RpcRequest {
+        jsonrpc: "2.0".to_owned(),
+        id: Some(13),
+        method: "search".to_owned(),
+        params: Some(serde_json::json!({ "pattern": "*.rs" })),
+    };
+    let params = super::RequestHandler::parse_and_validate_search_params(&req)
+        .expect("valid params must parse");
+    assert_eq!(params.pattern, "*.rs");
+}

--- a/crates/uffs-daemon/src/index/wire_spec.rs
+++ b/crates/uffs-daemon/src/index/wire_spec.rs
@@ -18,6 +18,82 @@ use uffs_core::aggregate::TopHitsSpec;
 
 use crate::index::IndexManager;
 
+/// Typed errors produced by [`IndexManager::convert_wire_spec`] and
+/// its helpers.
+///
+/// Phase 5d migration of the previous `Result<_, String>` return type:
+/// the [`core::fmt::Display`] strings stay byte-identical with the
+/// pre-migration messages so the
+/// `tracing::warn!("skipping malformed aggregate spec: {e}")` line in
+/// `aggregation.rs` keeps rendering the exact same operator-facing
+/// text.  The typed variants give downstream tooling (and future
+/// aggregation-level RPC error handlers) something to match on without
+/// parsing strings.
+///
+/// `#[non_exhaustive]` per Phase 5c discipline so a future wire-kind
+/// can grow a variant without a semver bump on the
+/// (workspace-internal) consumer.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub(crate) enum WireSpecError {
+    /// `kind == "preset"` but the `preset` field was absent.
+    #[error("preset kind requires 'preset' field")]
+    PresetFieldMissing,
+    /// `preset` named a value that [`AggregatePreset::parse`] does not
+    /// recognise.
+    ///
+    /// [`AggregatePreset::parse`]: uffs_core::aggregate::presets::AggregatePreset::parse
+    #[error("unknown preset: `{name}`")]
+    UnknownPreset {
+        /// The unrecognised preset name as supplied on the wire.
+        name: String,
+    },
+    /// The wire spec's `field` slot was absent for a kind that requires
+    /// it (`stats`, `terms`, `histogram`, `range`, `missing`,
+    /// `distinct`, `date_histogram`).
+    #[error("missing 'field'")]
+    FieldMissing,
+    /// `field` named a column that [`FieldId::parse`] does not
+    /// recognise.
+    ///
+    /// [`FieldId::parse`]: uffs_core::search::field::FieldId::parse
+    #[error("unknown field: `{name}`")]
+    UnknownField {
+        /// The unrecognised field name as supplied on the wire.
+        name: String,
+    },
+    /// `calendar` named a value that [`CalendarInterval::parse`] does
+    /// not recognise.
+    ///
+    /// [`CalendarInterval::parse`]: uffs_core::aggregate::spec::CalendarInterval::parse
+    #[error("unknown calendar interval: `{name}`")]
+    UnknownCalendar {
+        /// The unrecognised calendar identifier as supplied on the wire.
+        name: String,
+    },
+    /// `kind == "raw"` but the syntax slot (the wire `label` field)
+    /// was absent.
+    #[error("raw kind requires syntax in 'label' field")]
+    RawSyntaxMissing,
+    /// [`parse_agg_spec`] rejected the raw spec syntax.
+    ///
+    /// **Phase 5d transitional:** `parse_agg_spec` itself returns
+    /// `Result<_, String>` (uffs-core, scheduled for a separate PR in
+    /// the same sub-phase).  Once that migration lands, this variant
+    /// will be tightened to carry the typed `uffs-core` error directly
+    /// and the `String` payload retired.
+    ///
+    /// [`parse_agg_spec`]: uffs_core::aggregate::parser::parse_agg_spec
+    #[error("{0}")]
+    RawSyntax(String),
+    /// `kind` did not match any of the supported aggregate kinds.
+    #[error("unknown aggregate kind: `{kind}`")]
+    UnknownKind {
+        /// The unrecognised kind identifier as supplied on the wire.
+        kind: String,
+    },
+}
+
 impl IndexManager {
     /// Convert a wire-protocol [`AggregateSpecWire`] into one or more
     /// core [`AggregateSpec`]s.
@@ -27,9 +103,12 @@ impl IndexManager {
     ///
     /// # Errors
     ///
-    /// Returns a human-readable error string when the wire spec is
-    /// missing a required field, names an unknown preset / calendar
-    /// / kind, or fails the inner `parse_agg_spec` (for `kind: "raw"`).
+    /// Returns [`WireSpecError`] when the wire spec is missing a
+    /// required field, names an unknown preset / calendar / kind, or
+    /// fails the inner `parse_agg_spec` (for `kind: "raw"`).  The
+    /// [`core::fmt::Display`] string stays byte-identical with the
+    /// pre-Phase-5d `String` payload so operator-facing log lines are
+    /// unchanged.
     ///
     /// [`AggregateSpec`]: uffs_core::aggregate::spec::AggregateSpec
     /// [`AggregateSpecWire`]: uffs_client::protocol::AggregateSpecWire
@@ -39,7 +118,7 @@ impl IndexManager {
     )]
     pub(crate) fn convert_wire_spec(
         ws: &uffs_client::protocol::AggregateSpecWire,
-    ) -> Result<Vec<uffs_core::aggregate::spec::AggregateSpec>, String> {
+    ) -> Result<Vec<uffs_core::aggregate::spec::AggregateSpec>, WireSpecError> {
         use uffs_core::aggregate::parser::parse_agg_spec;
         use uffs_core::aggregate::presets::AggregatePreset;
         use uffs_core::aggregate::spec::{
@@ -58,9 +137,11 @@ impl IndexManager {
                 let name = ws
                     .preset
                     .as_deref()
-                    .ok_or_else(|| "preset kind requires 'preset' field".to_owned())?;
-                let preset = AggregatePreset::parse(name)
-                    .ok_or_else(|| format!("unknown preset: `{name}`"))?;
+                    .ok_or(WireSpecError::PresetFieldMissing)?;
+                let preset =
+                    AggregatePreset::parse(name).ok_or_else(|| WireSpecError::UnknownPreset {
+                        name: name.to_owned(),
+                    })?;
                 Ok(preset.expand())
             }
             "count" => Ok(make(AggregateKind::Count)),
@@ -93,8 +174,11 @@ impl IndexManager {
             "date_histogram" | "datehist" => {
                 let field = require_field(ws)?;
                 let cal_str = ws.calendar.as_deref().unwrap_or("month");
-                let calendar = CalendarInterval::parse(cal_str)
-                    .ok_or_else(|| format!("unknown calendar interval: `{cal_str}`"))?;
+                let calendar = CalendarInterval::parse(cal_str).ok_or_else(|| {
+                    WireSpecError::UnknownCalendar {
+                        name: cal_str.to_owned(),
+                    }
+                })?;
                 let metrics = parse_bucket_metrics(&ws.metrics);
                 Ok(make(AggregateKind::DateHistogram {
                     field,
@@ -171,28 +255,29 @@ impl IndexManager {
                 }))
             }
             "raw" => {
-                let syntax = ws
-                    .label
-                    .as_deref()
-                    .ok_or_else(|| "raw kind requires syntax in 'label' field".to_owned())?;
-                let spec = parse_agg_spec(syntax)?;
+                let syntax = ws.label.as_deref().ok_or(WireSpecError::RawSyntaxMissing)?;
+                let spec = parse_agg_spec(syntax).map_err(WireSpecError::RawSyntax)?;
                 Ok(vec![spec])
             }
-            other => Err(format!("unknown aggregate kind: `{other}`")),
+            other => Err(WireSpecError::UnknownKind {
+                kind: other.to_owned(),
+            }),
         }
     }
 }
 
 /// Parse the wire spec's `field` slot into a [`FieldId`], producing a
-/// human-readable error when it is absent or names an unknown column.
+/// typed [`WireSpecError`] when it is absent or names an unknown
+/// column.
+///
+/// [`FieldId`]: uffs_core::search::field::FieldId
 fn require_field(
     ws: &uffs_client::protocol::AggregateSpecWire,
-) -> Result<uffs_core::search::field::FieldId, String> {
-    let name = ws
-        .field
-        .as_deref()
-        .ok_or_else(|| "missing 'field'".to_owned())?;
-    uffs_core::search::field::FieldId::parse(name).ok_or_else(|| format!("unknown field: `{name}`"))
+) -> Result<uffs_core::search::field::FieldId, WireSpecError> {
+    let name = ws.field.as_deref().ok_or(WireSpecError::FieldMissing)?;
+    uffs_core::search::field::FieldId::parse(name).ok_or_else(|| WireSpecError::UnknownField {
+        name: name.to_owned(),
+    })
 }
 
 /// Parse wire metric strings to [`BucketMetric`]s.
@@ -265,4 +350,120 @@ fn build_sample(ws: &uffs_client::protocol::AggregateSpecWire) -> Option<TopHits
         }
         th
     })
+}
+
+#[cfg(test)]
+mod tests {
+    //! Phase 5d regression tests for [`WireSpecError`].
+    //!
+    //! Locks the Display message of every variant at the byte-identical
+    //! string the pre-Phase-5d `Result<_, String>` returns produced.
+    //! The `tracing::warn!("skipping malformed aggregate spec: {e}")`
+    //! line in `aggregation.rs` interpolates Display, so operator-facing
+    //! daemon logs are guaranteed unchanged by this lock.
+
+    use uffs_client::protocol::AggregateSpecWire;
+
+    use super::{IndexManager, WireSpecError};
+
+    /// Make an empty wire spec with the given `kind` for happy-path
+    /// rejection tests.
+    fn ws(kind: &str) -> AggregateSpecWire {
+        AggregateSpecWire {
+            kind: kind.to_owned(),
+            ..AggregateSpecWire::default()
+        }
+    }
+
+    #[test]
+    fn preset_field_missing_display_locked() {
+        let err = IndexManager::convert_wire_spec(&ws("preset"))
+            .expect_err("preset kind without 'preset' field must error");
+        assert_eq!(err, WireSpecError::PresetFieldMissing);
+        assert_eq!(err.to_string(), "preset kind requires 'preset' field");
+    }
+
+    #[test]
+    fn unknown_preset_display_locked() {
+        let mut spec = ws("preset");
+        spec.preset = Some("does-not-exist".to_owned());
+        let err =
+            IndexManager::convert_wire_spec(&spec).expect_err("unknown preset name must error");
+        assert_eq!(err, WireSpecError::UnknownPreset {
+            name: "does-not-exist".to_owned(),
+        },);
+        assert_eq!(err.to_string(), "unknown preset: `does-not-exist`");
+    }
+
+    #[test]
+    fn field_missing_display_locked() {
+        // `stats` requires a `field`; omitting it walks the
+        // `require_field` → `FieldMissing` path.
+        let err = IndexManager::convert_wire_spec(&ws("stats"))
+            .expect_err("stats kind without 'field' must error");
+        assert_eq!(err, WireSpecError::FieldMissing);
+        assert_eq!(err.to_string(), "missing 'field'");
+    }
+
+    #[test]
+    fn unknown_field_display_locked() {
+        let mut spec = ws("stats");
+        spec.field = Some("not-a-column".to_owned());
+        let err =
+            IndexManager::convert_wire_spec(&spec).expect_err("unknown field name must error");
+        assert_eq!(err, WireSpecError::UnknownField {
+            name: "not-a-column".to_owned(),
+        },);
+        assert_eq!(err.to_string(), "unknown field: `not-a-column`");
+    }
+
+    #[test]
+    fn unknown_calendar_display_locked() {
+        let mut spec = ws("date_histogram");
+        spec.field = Some("modified".to_owned());
+        spec.calendar = Some("fortnight".to_owned());
+        let err = IndexManager::convert_wire_spec(&spec)
+            .expect_err("unknown calendar interval must error");
+        assert_eq!(err, WireSpecError::UnknownCalendar {
+            name: "fortnight".to_owned(),
+        },);
+        assert_eq!(err.to_string(), "unknown calendar interval: `fortnight`");
+    }
+
+    #[test]
+    fn raw_syntax_missing_display_locked() {
+        let err = IndexManager::convert_wire_spec(&ws("raw"))
+            .expect_err("raw kind without label must error");
+        assert_eq!(err, WireSpecError::RawSyntaxMissing);
+        assert_eq!(err.to_string(), "raw kind requires syntax in 'label' field");
+    }
+
+    #[test]
+    fn raw_syntax_passthrough_preserves_inner_message() {
+        // `parse_agg_spec("")` returns `Err(<some message>)`; the
+        // typed variant must echo that string verbatim through
+        // Display so the existing operator-facing message is intact.
+        let mut spec = ws("raw");
+        spec.label = Some(String::new());
+        let err = IndexManager::convert_wire_spec(&spec).expect_err("empty raw spec must error");
+        let WireSpecError::RawSyntax(msg) = &err else {
+            panic!("expected RawSyntax, got {err:?}");
+        };
+        assert!(
+            !msg.is_empty(),
+            "passthrough message must not collapse to empty",
+        );
+        // Display equals the raw passthrough string.
+        assert_eq!(err.to_string(), *msg);
+    }
+
+    #[test]
+    fn unknown_kind_display_locked() {
+        let err = IndexManager::convert_wire_spec(&ws("bogus-kind"))
+            .expect_err("unknown kind must error");
+        assert_eq!(err, WireSpecError::UnknownKind {
+            kind: "bogus-kind".to_owned(),
+        },);
+        assert_eq!(err.to_string(), "unknown aggregate kind: `bogus-kind`");
+    }
 }

--- a/crates/uffs-daemon/src/index/wire_spec.rs
+++ b/crates/uffs-daemon/src/index/wire_spec.rs
@@ -77,15 +77,17 @@ pub(crate) enum WireSpecError {
     RawSyntaxMissing,
     /// [`parse_agg_spec`] rejected the raw spec syntax.
     ///
-    /// **Phase 5d transitional:** `parse_agg_spec` itself returns
-    /// `Result<_, String>` (uffs-core, scheduled for a separate PR in
-    /// the same sub-phase).  Once that migration lands, this variant
-    /// will be tightened to carry the typed `uffs-core` error directly
-    /// and the `String` payload retired.
+    /// Phase 5d (post-`uffs-core` migration): tightened from the
+    /// pre-migration `RawSyntax(String)` to carry the typed
+    /// [`uffs_core::aggregate::ParseAggSpecError`] directly.  Display
+    /// stays byte-identical with the pre-Phase-5d payload because
+    /// `ParseAggSpecError`'s `Display` impl preserves the original
+    /// `format!()` text from `parse_agg_spec`.  Source-chain is now
+    /// walkable via [`core::error::Error::source`].
     ///
     /// [`parse_agg_spec`]: uffs_core::aggregate::parser::parse_agg_spec
     #[error("{0}")]
-    RawSyntax(String),
+    RawSyntax(#[source] uffs_core::aggregate::ParseAggSpecError),
     /// `kind` did not match any of the supported aggregate kinds.
     #[error("unknown aggregate kind: `{kind}`")]
     UnknownKind {
@@ -440,21 +442,33 @@ mod tests {
 
     #[test]
     fn raw_syntax_passthrough_preserves_inner_message() {
-        // `parse_agg_spec("")` returns `Err(<some message>)`; the
-        // typed variant must echo that string verbatim through
-        // Display so the existing operator-facing message is intact.
+        // `parse_agg_spec("")` returns
+        // `Err(ParseAggSpecError::UnknownKind { kind: "" })`; the
+        // typed variant must echo the inner Display verbatim through
+        // its own Display so the existing operator-facing message is
+        // intact.  Post-`uffs-core` Phase 5d the inner is now a typed
+        // `ParseAggSpecError` rather than a `String` — the source
+        // chain is walkable via `Error::source`.
+        use core::error::Error as _;
+
         let mut spec = ws("raw");
         spec.label = Some(String::new());
         let err = IndexManager::convert_wire_spec(&spec).expect_err("empty raw spec must error");
-        let WireSpecError::RawSyntax(msg) = &err else {
+        let WireSpecError::RawSyntax(inner) = &err else {
             panic!("expected RawSyntax, got {err:?}");
         };
+        // Display equals the inner ParseAggSpecError Display, which
+        // for the empty-spec path expands to "Unknown aggregate kind:
+        // ``" — byte-identical with the pre-Phase-5d String payload.
+        let inner_display = inner.to_string();
         assert!(
-            !msg.is_empty(),
-            "passthrough message must not collapse to empty",
+            !inner_display.is_empty(),
+            "passthrough display must not collapse to empty",
         );
-        // Display equals the raw passthrough string.
-        assert_eq!(err.to_string(), *msg);
+        assert_eq!(err.to_string(), inner_display);
+        // The source chain walks to the inner typed error.
+        let chained = err.source().expect("RawSyntax exposes its inner source");
+        assert_eq!(chained.to_string(), inner_display);
     }
 
     #[test]


### PR DESCRIPTION
## Phase 5d — `Result<_, String>` migration (final)

Closes the last item of #192 §5d ("typed error enums replace `Result<_, String>` across the workspace").

All **32 prod call-sites** identified in the playbook audit are now typed error enums with `#[non_exhaustive]`, `thiserror::Error`, and `core::error::Error::source` chaining where applicable. **Display strings are byte-identical** with the pre-migration `format!()` payloads so any operator-facing CLI / JSON-RPC error output is unchanged.

### Crate-by-crate breakdown

| Crate | Commit | Sites | New error types |
|---|---|---:|---|
| `uffs-cli` | `4c6ba663` | 1 | `ParseDriveLetterError` |
| `uffs-daemon` | `4be0d0d0` | 3 | `WireSpecError`, `ParseSearchParamsError` |
| `uffs-client` | `6a338669` | 11 | `CliArgsError`, `ParseSizeError` |
| `uffs-core` | `e1a6f62e` | 17 | `ParseAggSpecError`, `TopHitsValidateError`, `ParseSizeError` |
| docs follow-up | `4e92d9a2` | — | (rustdoc intra-doc-link cleanup) |

### Design highlights

- **Error chaining**: `CliArgsError::BadInt` carries `#[source] ParseIntError`; `WireSpecError::RawSyntax` was tightened from `String` to `#[source] ParseAggSpecError` so the typed chain flows all the way through the daemon boundary.
- **`const fn` upgrade**: `TopHitsSpec::validate` is now a `const fn` returning `TopHitsValidateError`, enabling future compile-time validation.
- **Wire-byte preservation**: `ParseSearchParamsError::to_rpc_error_json` serializes at the JSON-RPC boundary so the daemon's reply bytes are byte-identical with the pre-migration `Result<_, String>` formatting.
- **800-LOC policy**: `parser.rs` decomposed into sibling `parser_error.rs` + `parser_tests.rs` (519 LOC after, down from 781).
- **`#[non_exhaustive]` discipline**: every new error enum carries the attribute per Phase 5c forward-compat rules so future validation rules can grow a variant without a semver bump.

### Verification

- `cargo test --workspace --lib`: **1658 passed, 0 failed, 10 ignored**
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings -D clippy::pedantic -D clippy::nursery`: clean
- `cargo fmt --check`: clean
- `bash scripts/ci/check_file_size_policy.sh`: clean
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`: clean
- `rg 'Result<[^,>]+,\s*String>' crates/ -t rust`: **zero function-signature matches workspace-wide**; all 18 remaining hits are doc-comment references to the pre-migration type for traceability.
- Local pre-push lint gate (rustdoc, lint-ci-windows, smoke, tests, file-size, gates-drift, hooks-drift, workflow-drift, fast-drift, manifest-drift, commit-subjects, vet-audit-discipline, machete, typos, reuse): **green** (146s).

### Regression coverage

Net-new tests lock the Display string of every error variant byte-for-byte against the pre-migration text, plus `Error::source` chain checks where chaining was added.  End-to-end tests exercise the typed errors through public API boundaries (`SearchParams::from_cli_args`, `convert_wire_spec`, `parse_and_validate_search_params`).

### No public-API breakage

`uffs-client::protocol::cli_args::Error` is the public re-export of `CliArgsError`, preserving the previous `Error` alias.  All other crates are workspace-internal consumers.
