### PR TITLE
fix(uffs-core): drop defensive Vec<u16> clone in path-only / path-sorted top-N hot path (Phase 6c, refs #193)

### DIFF
--- a/crates/uffs-core/src/search/query/path_only_top_n.rs
+++ b/crates/uffs-core/src/search/query/path_only_top_n.rs
@@ -511,9 +511,14 @@ fn collect_path_only_via_ext_index<D: AsRef<DriveCompactIndex> + Sync>(
             continue;
         }
         let drive_idx_u16 = uffs_mft::len_to_u16(drive_idx);
-        // Clone the resolved ids so we can reborrow `search_filters`
-        // later if a future filter pushes more predicates.
-        for &ext_id in &search_filters.resolved_ext_ids.clone() {
+        // Borrow `resolved_ext_ids` immutably for the inner loop's
+        // lifetime: the body never touches `search_filters`, so the
+        // borrow is released when the inner loop ends, freeing the
+        // next outer iteration's call to `resolve_ext_ids_for_drive`
+        // (which needs `&mut search_filters`).  Replaces a defensive
+        // `.clone()` (Phase 6c category-δ) that was anticipating a
+        // future filter push that never landed.
+        for &ext_id in &search_filters.resolved_ext_ids {
             for &rec_idx_u32 in drive.ext_index.get(ext_id) {
                 let rec_idx = rec_idx_u32 as usize;
                 let Some(rec) = drive.records.get(rec_idx) else {

--- a/crates/uffs-core/src/search/query/path_sorted_top_n.rs
+++ b/crates/uffs-core/src/search/query/path_sorted_top_n.rs
@@ -247,9 +247,14 @@ fn collect_path_via_ext_index<D: AsRef<DriveCompactIndex> + Sync>(
             continue;
         }
         let drive_idx_u16 = uffs_mft::len_to_u16(drive_idx);
-        // Clone the resolved ids so we can reborrow `search_filters`
-        // for the next drive without re-aliasing the loop body.
-        for &ext_id in &search_filters.resolved_ext_ids.clone() {
+        // Borrow `resolved_ext_ids` immutably for the inner loop's
+        // lifetime: the body never touches `search_filters`, so the
+        // borrow is released when the inner loop ends, freeing the
+        // next outer iteration's call to `resolve_ext_ids_for_drive`
+        // (which needs `&mut search_filters`).  Replaces a defensive
+        // `.clone()` (Phase 6c category-δ) that was anticipating a
+        // re-aliasing scenario that the current code doesn't hit.
+        for &ext_id in &search_filters.resolved_ext_ids {
             for &rec_idx_u32 in drive.ext_index.get(ext_id) {
                 let rec_idx = rec_idx_u32 as usize;
                 let Some(rec) = drive.records.get(rec_idx) else {


### PR DESCRIPTION
Phase 6 sub-phase 6c deliverable per [`phase_6_ownership_borrowing_allocation_implementation_plan.md` §5c + §3.2](../blob/main/docs/dev/architecture/code_clean/phase_6_ownership_borrowing_allocation_implementation_plan.md) (local plan, gitignored under `/docs/dev/`).

## What this changes

Two surgical fixes inside the per-drive top-N execution path of `uffs-core::search`:

| Site | File | Refactor |
|---|---|---|
| `path_only_top_n` inner-loop ext-id iteration | `crates/uffs-core/src/search/query/path_only_top_n.rs:516` | Drop `search_filters.resolved_ext_ids.clone()` → borrow immutably |
| `path_sorted_top_n` inner-loop ext-id iteration | `crates/uffs-core/src/search/query/path_sorted_top_n.rs:252` | Drop `search_filters.resolved_ext_ids.clone()` → borrow immutably |

Both sites had a defensive `.clone()` justified by an inline comment anticipating a future re-borrow of `search_filters` inside the loop body.  That re-borrow never landed — the inner-loop body reads only `drive.*`, `hide_system`, `hide_ads`, and writes to local `candidates`, never touching `search_filters`.  The immutable borrow of `resolved_ext_ids` is naturally released when the inner loop ends, so the next outer iteration's call to `resolve_ext_ids_for_drive` (which needs `&mut search_filters`) compiles without conflict.

## Why this is the right shape

Phase 6c — the clone taxonomy audit — classifies all 253 prod `.clone()` sites by:
- **α** — Arc clone for actor-model task dispatch (KEEP — `Cargo.toml [workspace.lints.clippy] clone_on_ref_ptr = "deny"` already enforces the explicit `Arc::clone(&x)` form)
- **β** — genuine ownership-fence (KEEP — caller has `&T`, API needs `T`)
- **γ** — error / log context carry-along (KEEP — error paths are cold)
- **δ** — hot-path anti-pattern (FIX — restructure ownership)
- **ε** — `#[cfg(test)]` only (out of scope)

These two sites are the only cat-δ candidates surfaced by the audit that are surgically fixable without an API redesign.  Two larger cat-δ opportunities are documented in the findings doc as follow-up phases:

- **Future-A** — `ParsedColumns::push_record(_expanded)` taking `&ParsedRecord` forces a `String` clone per record in the MFT parse hot path. Refactor to consume by value would change a `pub` signature; deferred to a dedicated sub-phase gated on the §6g bench numbers.
- **Future-B** — `FastResolver::resolve_cached` returns `String`; migrating the path cache to `Arc<str>` would replace per-cache-hit String clones with refcount bumps. API-level change; deferred.

The remaining 251 sites are legitimate by construction and documented in the per-crate breakdown of the (gitignored) findings doc at `docs/dev/baseline/2026-05-12/phase_6_clone_taxonomy_findings.md`.

## Verification

- **`just lint-pre-push`** ✅ (89s): every gate green — fmt, file-size, gates-drift, hooks-drift, workflow-drift, fast-drift, manifest-drift, commit-subjects, vet, vet-audit-discipline, machete, typos, reuse, cargo-check, lint-ci, lint-prod, lint-tests, rustdoc, doc-tests, tests, smoke, deny, lint-ci-windows.
- **`cargo nextest run -p uffs-core`** ✅ 817 passed, 3 skipped, 0 failed — same numbers as pre-fix.
- **Search-suite coverage:** 374 search-tests pass; the affected paths are exercised by `parallel_drive_scan_merges_global_top_n_across_drives`, `parallel_drive_scan_respects_limit_smaller_than_per_drive_count`, `match_all_explicit_limit_caps_results`, `unlimited_returns_more_than_capped`, `match_all_none_limit_is_unlimited`, `top_n_sort_by_system_flag`.
- **Strict-clippy posture unchanged.**  No new `#[allow]` / `#[expect]` introduced; `cargo clippy --workspace --all-targets --message-format=json` emits zero diagnostics for the 9 clone-family lints across the workspace.

## Behavior & contracts

- Both affected functions are `pub(crate)` (`select_path_only_top_n` / `select_path_sorted_top_n`).  Zero public-API surface change.
- Observable behavior — top-N rows, ordering, candidate selection, filter precedence — is unchanged. Only the per-query allocation count drops by one `Vec<u16>` per participating drive (~7 small allocs per query in typical 7-drive configurations).
- Comment text at each site is replaced with a multi-line block documenting the new (correct) borrow invariant and cross-referencing Phase 6c so the reason-text survives future code review.

## Allocation savings

Per top-N query with extension filtering active:
- Before: `N_drives × Vec<u16>::with_capacity(N_ext_ids)` allocations per query (7 small allocs in the typical 7-drive case)
- After: zero — the per-drive `Vec<u16>` lives in `search_filters.resolved_ext_ids` and is borrowed immutably

The per-query overhead is small but real, and the `Vec` was long enough lived (the full inner-loop scan duration) to defeat the small-block allocator's fast path.  §6g bench refresh will quantify the wall-clock delta.

## Strict-lint posture

- No suppression hacks.
- Both edits are 8-line comment blocks + a single-character source change (drop `.clone()`).
- No new `#[allow]` / `#[expect]` reasons added anywhere.

refs #193
