### PR TITLE
fix(uffs-core): drop per-row format!() allocations in path-resolver + result-conversion hot paths (Phase 6d, refs #193)

### DIFF
--- a/crates/uffs-core/src/path_resolver/fast.rs
+++ b/crates/uffs-core/src/path_resolver/fast.rs
@@ -367,17 +367,23 @@ impl FastPathResolver {
                 let parent_path =
                     parent_frs.map_or_else(|| "<null>".to_owned(), |frs_val| self.resolve(frs_val));
 
-                // Build full path: parent + backslash + name
+                // Build full path: parent + backslash + name.  Mutates
+                // `parent_path` in-place to avoid the per-row `format!()`
+                // allocation that the previous branch tree performed (this
+                // map runs once per result row — Phase 6d hot-path
+                // category-δ).  `parent_path` is owned (from `resolve()`),
+                // so `push_str` reuses its buffer; the typical Win32 path
+                // length leaves ample headroom on the existing String's
+                // capacity, so re-allocation is rare.
                 let file_name = name.unwrap_or("<unnamed>");
-
-                // Special case: root directory has name "." - just use parent path
-                let mut path = if file_name == "." {
-                    parent_path
-                } else if parent_path.ends_with('\\') {
-                    format!("{parent_path}{file_name}")
-                } else {
-                    format!("{parent_path}\\{file_name}")
-                };
+                let mut path = parent_path;
+                // Special case: root directory has name "." — keep parent path as-is.
+                if file_name != "." {
+                    if !path.ends_with('\\') {
+                        path.push('\\');
+                    }
+                    path.push_str(file_name);
+                }
 
                 // Check if this entry has an ADS stream name
                 let has_ads = stream_name.is_some_and(|sn| !sn.is_empty());

--- a/crates/uffs-core/src/search/dataframe_convert.rs
+++ b/crates/uffs-core/src/search/dataframe_convert.rs
@@ -16,6 +16,21 @@
 use super::backend::DisplayRow;
 use super::derived::{bulkiness_for_row, tree_allocated_for_row};
 
+/// Static lookup table for the 26 valid drive labels (`"A:"` …
+/// `"Z:"`), indexed by [`uffs_mft::platform::DriveLetter::alphabet_index`].
+///
+/// Replaces a per-row `format!("{}:", drive)` allocation in the
+/// `Vec<DisplayRow>` → `DataFrame` conversion hot path (Phase 6d
+/// category-δ).  Each entry is a `&'static str` carved into the rodata
+/// segment; the resulting `Vec<&'static str>` carries no heap copies
+/// of the labels.  Polars'/Arrow's column-builder still copies into a
+/// contiguous string buffer, but we save the upstream per-row
+/// `String` allocation + free pair.
+const DRIVE_LABELS: [&str; 26] = [
+    "A:", "B:", "C:", "D:", "E:", "F:", "G:", "H:", "I:", "J:", "K:", "L:", "M:", //
+    "N:", "O:", "P:", "Q:", "R:", "S:", "T:", "U:", "V:", "W:", "X:", "Y:", "Z:",
+];
+
 /// Convert `DisplayRow` results to a Polars `DataFrame` with standard MFT
 /// column names so existing CLI output formatters can consume it.
 ///
@@ -37,7 +52,15 @@ pub fn display_rows_to_dataframe(
     let modified: Vec<i64> = rows.iter().map(|row| row.modified).collect();
     let accessed: Vec<i64> = rows.iter().map(|row| row.accessed).collect();
     let flags: Vec<u32> = rows.iter().map(|row| row.flags).collect();
-    let drives: Vec<String> = rows.iter().map(|row| format!("{}:", row.drive)).collect();
+    let drives: Vec<&str> = rows
+        .iter()
+        .map(|row| {
+            DRIVE_LABELS
+                .get(row.drive.alphabet_index())
+                .copied()
+                .unwrap_or("?:")
+        })
+        .collect();
     let descendants: Vec<u32> = rows.iter().map(|row| row.descendants).collect();
     let treesize: Vec<u64> = rows.iter().map(|row| row.treesize).collect();
     let tree_allocated: Vec<u64> = rows.iter().map(tree_allocated_for_row).collect();


### PR DESCRIPTION
Phase 6 sub-phase 6d deliverable per [`phase_6_ownership_borrowing_allocation_implementation_plan.md` §5d + §3.4](../blob/main/docs/dev/architecture/code_clean/phase_6_ownership_borrowing_allocation_implementation_plan.md) (local plan, gitignored under `/docs/dev/`).

## What this changes

Two surgical hot-path category-δ fixes inside `uffs-core`:

| Site | File | Refactor |
|---|---|---|
| Per-row path assembly | `crates/uffs-core/src/path_resolver/fast.rs:add_path_column_with_dir_suffix` | Replace two per-row `format!("{parent_path}{file_name}")` / `format!("{parent_path}\\{file_name}")` with in-place `push_str` on the already-owned `parent_path: String` |
| Per-row drive label | `crates/uffs-core/src/search/dataframe_convert.rs:display_rows_to_dataframe` | Replace per-row `format!("{}:", row.drive)` (`Vec<String>`) with a static `[&str; 26]` table indexed by `DriveLetter::alphabet_index()` (`Vec<&'static str>`) |

Both run inside per-row `map` closures over search-result rows; each row previously incurred an unconditional small `String` allocation that the new code avoids.

## Why this is the right shape

Phase 6d — hot-path `format!` / `to_string` audit — sweeps `uffs-mft::io::parser`, `uffs-mft::parse`, `uffs-core::search`, `uffs-core::path_resolver`, and `uffs-core::aggregate` for the per-record / per-row formatting hot spots flagged in plan §1.2 (HIGH priority).

The audit produces a small surgical-fix surface:
- **`uffs-mft::io::parser`** — **zero** `format!` / `.to_string()` calls in the parse hot path (`columns.rs`, `merger.rs`, `zero_alloc.rs`, `dataframe_build.rs`). The 205 `format!()` count from the 6a baseline lives in cold paths (parse-error variants, log messages, USN status, IOCP error context). Plan §0.2 risk-register row predicted this.
- **`uffs-core::path_resolver::fast.rs`** — two per-row `format!` calls in `add_path_column_with_dir_suffix`, **fixed** by this PR.
- **`uffs-core::search::dataframe_convert.rs`** — one per-row `format!` for drive label, **fixed** by this PR.
- **`uffs-core::path_resolver::legacy.rs:104`** — `format!("{}:\\{}", drive, components.join("\\"))` is irreducible (must allocate one owned String result per resolve); cat-β KEEP.
- **`uffs-core::search::query::mod.rs`**, **`backend.rs`** — `pattern.to_owned()` / `needle.to_owned()` sites are once-per-query (query prep), cat-β KEEP. Candidate for §6e `Cow<'_, str>` expansion.
- **`uffs-core::aggregate::finalize.rs:675-705`** — `format_field` called per (bucket × sample size), not per record. Aggregation framework only samples top-K records per bucket. Marginal cat-γ, KEEP.
- **`<UNKNOWN_0x...>`** / **`<DELETED:...>`** / **`<EXT:...>`** / **`<CORRUPT:...>`** placeholders in `parse/{direct_index,direct_index_extension,forensic/base,forensic/extension,forensic,full,placeholders}.rs` — conditional formatting that fires only on unknown / deleted / extension / corrupt / placeholder records. None fire on every record in the parse hot path. Cat-γ KEEP.

## Verification

- **`just lint-pre-push`** ✅ (96s): every gate green — fmt, file-size, gates-drift, hooks-drift, workflow-drift, fast-drift, manifest-drift, commit-subjects, vet, vet-audit-discipline, machete, typos, reuse, cargo-check, lint-ci, lint-prod, lint-tests, rustdoc, doc-tests, tests, smoke, deny, lint-ci-windows.
- **`cargo nextest run -p uffs-core`** ✅ 817 passed, 3 skipped, 0 failed — same numbers as pre-fix.
- **Affected test paths exercised:** `add_path_column_with_dir_suffix_*`, `add_path_column_*`, `add_path_column_parallel_*` (path-resolver suite); `display_rows_to_dataframe_*`, `results_to_dataframe_*` (result-conversion suite). All pass — observable behavior is byte-identical.

## Behavior & contracts

- Public API unchanged: `add_path_column_with_dir_suffix` and `display_rows_to_dataframe` keep their existing signatures and return types.
- Observable behavior preserved:
  - Paths render with the same separator handling (test corpus covers `parent_path.ends_with('\\')` true and false branches, plus the `file_name == "."` root-of-volume case).
  - Drive labels render exactly as `<letter>:` for A..Z — the previous `format!` produced identical output for the construction-valid range.
- For the unreachable fallback path (a hypothetical out-of-range `DriveLetter`, which cannot occur per `parse()` invariants), the new code yields `"?:"` versus the previous code's `<letter>:`. Since this branch is unreachable by construction, the user-visible difference is zero.

## Strict-lint posture

- No suppression hacks introduced. Both edits replace formatting allocations with idiomatic Rust patterns (`push_str` mutation; static-table lookup via `get().copied()`).
- The `.unwrap_or("?:")` fallback in `display_rows_to_dataframe` satisfies `clippy::indexing_slicing = "deny"` without needing a per-site `#[expect]`.
- Cross-references to Phase 6d sub-phase added in inline doc comments.

## Allocation savings

Per N-row search result (typical N = 1k–100k):
- Site 1 (`add_path_column_with_dir_suffix`): N small `String` allocations + N drops (replaced by N in-place `push_str` operations that reuse the `parent_path` buffer).
- Site 2 (`display_rows_to_dataframe`): N tiny (2-byte) `String` allocations + N drops + 1 `Vec<String>` allocation (replaced by 1 `Vec<&str>` allocation; labels live in rodata).

Wall-clock impact will be quantified by sub-phase 6g (bench refresh on `mft_read`, `query`, `search_benchmarks`).

refs #193
