### PR TITLE
refactor(uffs-core): extract fold_needle helper returning Cow<'_, str> (Phase 6e, refs #193)

### DIFF
--- a/crates/uffs-core/src/search/backend.rs
+++ b/crates/uffs-core/src/search/backend.rs
@@ -568,12 +568,7 @@ impl MultiDriveBackend {
             .map_or_else(uffs_text::case_fold::CaseFold::default_table, |drive| {
                 drive.fold
             });
-        let needle = if case_sensitive {
-            pattern.to_owned()
-        } else {
-            let mut buf = Vec::with_capacity(pattern.len());
-            fold.fold_into(pattern, &mut buf).to_owned()
-        };
+        let needle = super::dispatch::fold_needle(case_sensitive, pattern, fold);
         let is_path = !is_match_all && !is_regex && crate::search::tree::is_path_pattern(&needle);
 
         if is_match_all {
@@ -836,12 +831,7 @@ pub fn search_index(
         .map_or_else(uffs_text::case_fold::CaseFold::default_table, |drive| {
             drive.fold
         });
-    let needle = if case_sensitive {
-        pattern.to_owned()
-    } else {
-        let mut buf = Vec::with_capacity(pattern.len());
-        fold.fold_into(pattern, &mut buf).to_owned()
-    };
+    let needle = super::dispatch::fold_needle(case_sensitive, pattern, fold);
     let is_path = !is_match_all && !is_regex && crate::search::tree::is_path_pattern(&needle);
 
     tracing::debug!(

--- a/crates/uffs-core/src/search/dispatch.rs
+++ b/crates/uffs-core/src/search/dispatch.rs
@@ -24,6 +24,8 @@
 //!    [`dispatch_trigram_or_tree`]) — the three leaf dispatch paths +
 //!    [`pick_mode_label`] for tracing.
 
+use alloc::borrow::Cow;
+
 use rayon::prelude::*;
 
 use super::backend::{DisplayRow, FilterMode, PhaseTimings, SortSpec};
@@ -31,6 +33,34 @@ use super::filters::SearchFilters;
 use super::sorting::sort_rows;
 use crate::compact::DriveCompactIndex;
 use crate::search::field::FieldId;
+
+/// Build the search needle from `pattern`, applying case-folding when
+/// case-insensitive matching is requested.
+///
+/// Returns [`Cow::Borrowed`] for the case-sensitive path (zero
+/// allocation — the needle reuses the caller's `&str`) and
+/// [`Cow::Owned`] for the case-insensitive path (one allocation for
+/// the folded result).
+///
+/// Replaces a previous duplicated `if … pattern.to_owned() … else …
+/// .to_owned()` pattern in both [`super::backend::MultiDriveBackend::search`]
+/// and [`super::backend::search_index`]; the deduplication is the
+/// Phase 6e (`Cow<'_, str>` expansion) deliverable per the phase-6
+/// ownership/borrowing/allocation plan §3.5.  Downstream call sites
+/// already accept `&str` (via [`Cow`]'s `Deref<Target = str>`), so
+/// this is a behavior-preserving refactor.
+pub(super) fn fold_needle(
+    case_sensitive: bool,
+    pattern: &str,
+    fold: uffs_text::case_fold::CaseFold,
+) -> Cow<'_, str> {
+    if case_sensitive {
+        Cow::Borrowed(pattern)
+    } else {
+        let mut buf = Vec::with_capacity(pattern.len());
+        Cow::Owned(fold.fold_into(pattern, &mut buf).to_owned())
+    }
+}
 
 // ─── Pattern-rewrite safety nets ───────────────────────────────────────
 


### PR DESCRIPTION
Phase 6 sub-phase 6e deliverable per the phase-6 ownership/borrowing/allocation plan §5e + §3.5 (local plan, gitignored under `/docs/dev/`).

## What this changes

Deduplicates the per-query needle-fold block previously duplicated between `MultiDriveBackend::search` (line ~571) and the free `search_index` function (line ~839) in `crates/uffs-core/src/search/backend.rs`. The new helper `super::dispatch::fold_needle` returns `Cow<'_, str>` so the case-sensitive path avoids the per-query `String` allocation:

| Case-sensitivity | Result | Allocation |
|---|---|---|
| `case_sensitive == true` | `Cow::Borrowed(pattern)` | **zero** — reuses the caller's `&str` |
| `case_sensitive == false` | `Cow::Owned(fold.fold_into(pattern, &mut buf).to_owned())` | one — irreducible (folded data must be owned) |

Downstream consumers (`is_path_pattern`, `strip_prefix`, `search_compact_drive`, `search_compact_drive_tree`, `search_compact_drive_regex`) already accept `&str` and rely on `Cow`'s `Deref<Target = str>` impl for transparent coercion — no call-site changes needed beyond the binding site.

## Why this is the right shape

Phase 6e plan rule (§3.5): *"Introduce `Cow<'_, str>` ONLY where genuinely ambiguous ownership exists (e.g. function takes `&str` but sometimes needs an owned variant for case-folding)."*

This is the textbook case:
- The function takes `pattern: &str` (borrowed).
- The case-sensitive branch can keep the borrow.
- The case-insensitive branch must own the fold buffer's contents.
- Downstream call sites only ever read `&str`.

The 6d audit surfaced this as the highest-value cat-β → Cow conversion opportunity in the `uffs-core::search` hot path (per plan §3.4). Two other candidate sites (`extract_trigram_needle` in `query/mod.rs:223`, `format_field` in `aggregate/finalize.rs:668`) were considered but rejected:
- `extract_trigram_needle` already returns the value via `String` storage in the caller's per-query scratch — Cow gains nothing since the caller stores it owned regardless.
- `format_field` returns `String` for aggregation bucket sample formatting; the static-literal branches (`"directory"`, `"file"`, `"true"`, `"false"`) could be Cow but the savings are bucket-count × sample-size, not per-record. Cat-γ, KEEP.

## Verification

- **`just lint-pre-push`** ✅ (87s): every gate green — fmt, file-size, gates-drift, hooks-drift, workflow-drift, fast-drift, manifest-drift, commit-subjects, vet, vet-audit-discipline, machete, typos, reuse, cargo-check, lint-ci, lint-prod, lint-tests, rustdoc, doc-tests, tests, smoke, deny, lint-ci-windows.
- **`cargo nextest run -p uffs-core`** ✅ 817 passed, 3 skipped, 0 failed — same numbers as pre-fix.
- **Search-suite coverage:** exercises both `MultiDriveBackend::search` (interactive TUI path) and `search_index` (daemon path) across case-sensitive, case-insensitive, glob, regex, tree, and match-all branches. All pass — `Cow`'s `Deref<Target = str>` impl gives byte-identical behavior to the prior `String` shape.

## Behavior & contracts

- Public API unchanged: both `search` and `search_index` keep their existing signatures.
- Observable behavior preserved: `needle` produces byte-identical content for every `(case_sensitive, pattern)` input. All downstream `needle.strip_prefix`, `&needle` slice borrows, and pattern matches retain their semantics under `Cow`'s `Deref<Target = str>` impl.
- Helper is `pub(super)` — internal to the `search` module tree, not part of the public surface.

## Strict-lint posture

- No suppression hacks introduced.
- Helper uses idiomatic `Cow` pattern with elided lifetimes (per `clippy::elidable_lifetime_names` pedantic guidance).
- `alloc::borrow::Cow` import matches the workspace convention (`compact_cache.rs:28` precedent) and satisfies `clippy::std_instead_of_alloc = "deny"`.
- No new `#[allow]` / `#[expect]` reasons added anywhere.

## Allocation savings

One `String` allocation (≈ 10–100 bytes typical pattern) per case-sensitive search query. Per-query overhead is small but real, and the helper now centralises the fold logic so any future refinement (e.g. taking ownership of the fold buffer directly via `String::from_utf8` to skip the second copy in the case-insensitive path) lands in one place rather than two.

Wall-clock impact will be quantified by sub-phase 6g (bench refresh on `mft_read`, `query`, `search_benchmarks`).

refs #193
