### PR TITLE
docs(lints): cross-reference allocation_policy.md from Cargo.toml + clippy.toml (Phase 6 follow-up, refs #193)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -350,8 +350,8 @@ large_enum_variant = "deny"                        # Optimize enum memory usage
 large_stack_arrays = "deny"                        # Avoid large stack allocations
 large_types_passed_by_value = "deny"               # Pass large types by reference
 trivially_copy_pass_by_ref = "deny"                # Pass small types by value
-clone_on_ref_ptr = "deny"                          # Avoid unnecessary clones
-redundant_clone = "deny"                           # Remove redundant clones
+clone_on_ref_ptr = "deny"                          # Use Arc::clone(&x) form — see allocation_policy.md §3.1 (category α)
+redundant_clone = "deny"                           # Remove redundant clones — see allocation_policy.md §3.4 (category δ)
 unnecessary_wraps = "deny"                         # Remove unnecessary Result/Option wraps
 option_option = "deny"                             # Avoid Option<Option<T>>
 result_unit_err = "deny"                           # Use better error types
@@ -369,14 +369,14 @@ suboptimal_flops = "deny"                          # Optimal floating point oper
 fn_params_excessive_bools = "deny"                 # Avoid too many boolean parameters
 struct_excessive_bools = "deny"                    # Avoid too many boolean fields
 verbose_bit_mask = "deny"                          # Use cleaner bit operations
-inefficient_to_string = "deny"                     # Use efficient string conversions
+inefficient_to_string = "deny"                     # Use efficient string conversions — see allocation_policy.md §2
 string_add = "deny"                                # Use format! instead of string addition
 string_add_assign = "deny"                         # Use format! instead of +=
 string_slice = "deny"                              # Use proper string slicing
-str_to_string = "deny"                             # Use to_owned() instead of to_string()
-implicit_clone = "deny"                            # Make clones explicit
-cloned_instead_of_copied = "deny"                  # Use copy when possible
-map_clone = "deny"                                 # Use copied() instead of map(clone)
+str_to_string = "deny"                             # Use to_owned() instead of to_string() — see allocation_policy.md §2
+implicit_clone = "deny"                            # Make clones explicit — see allocation_policy.md §2
+cloned_instead_of_copied = "deny"                  # Use .copied() for Copy types — see allocation_policy.md §2
+map_clone = "deny"                                 # Use .copied() over .map(Clone::clone) — see allocation_policy.md §2
 filter_map_next = "deny"                           # Use find_map instead
 flat_map_option = "deny"                           # Use filter_map instead
 manual_filter_map = "deny"                         # Use filter_map
@@ -458,9 +458,14 @@ unused_result_ok = "deny"             # Don't call .ok() just to discard — use
 unwrap_in_result = "deny"             # No unwrap/expect inside Result-returning fns
 
 # ───── Memory & allocation ─────
-assigning_clones = "deny"              # Use clone_from instead of clone + assign
-rc_buffer = "deny"                     # Avoid Rc<String> or Rc<Vec>
-rc_mutex = "deny"                      # Avoid Rc<Mutex<T>>
+# Allocation policy: docs/architecture/code-quality/allocation_policy.md
+# defines the five-category taxonomy (α/β/γ/δ/ε) for every prod
+# .clone()/.to_owned()/format!() site and the required per-site
+# justification shape.  Audit script: scripts/dev/clone_alloc_audit.sh.
+# See also docs/architecture/code-quality/lint-posture.md.
+assigning_clones = "deny"              # Use clone_from over .clone() + assign — see allocation_policy.md §2
+rc_buffer = "deny"                     # Avoid Rc<String>/Rc<Vec> — see allocation_policy.md §3.1 (α)
+rc_mutex = "deny"                      # Avoid Rc<Mutex<T>> — see allocation_policy.md §3.1 (α)
 read_zero_byte_vec = "deny"            # Avoid reading into zero-capacity vec
 significant_drop_in_scrutinee = "deny" # Avoid drops in match scrutinee
 significant_drop_tightening = "deny"   # Tighten significant drop scope

--- a/clippy.toml
+++ b/clippy.toml
@@ -33,7 +33,17 @@
 # The panic-family lints (`unwrap_used`, `expect_used`, `panic`) stay at
 # `deny` for prod code; see `docs/architecture/code-quality/panic_policy.md`
 # for the five-category taxonomy (A-E) and the per-site #[expect(...)]
-# annotation contract.  For the broader lint posture see
+# annotation contract.
+#
+# The clone- and allocation-family lints (`redundant_clone`,
+# `clone_on_ref_ptr`, `cloned_instead_of_copied`, `inefficient_to_string`,
+# `unnecessary_to_owned`, `assigning_clones`, `rc_buffer`, `rc_mutex`, …)
+# likewise stay at `deny` for prod code; see
+# `docs/architecture/code-quality/allocation_policy.md` for the
+# five-category taxonomy (α-ε) and the per-site justification contract.
+# Audit script: `scripts/dev/clone_alloc_audit.sh`.
+#
+# For the broader lint posture see
 # `docs/architecture/code-quality/lint-posture.md`.
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true


### PR DESCRIPTION
Phase 6 §11.9 follow-up: parity with the Phase-5e [`panic_policy.md`](../blob/main/docs/architecture/code-quality/panic_policy.md) cross-reference precedent (PR #278).

## The gap this closes

`Cargo.toml` and `clippy.toml` already point at `panic_policy.md` so a contributor running `grep panic_policy Cargo.toml` immediately finds the contract for the deny-level `unwrap_used` / `expect_used` / `panic` lints.

The same shape was **missing** for the allocation contract — a grep for `allocation_policy Cargo.toml` returned nothing before this change, defeating the discoverability that [`docs/architecture/code-quality/allocation_policy.md`](../blob/main/docs/architecture/code-quality/allocation_policy.md) (PR #285) was designed to provide.

## What this changes

Doc-comment-only edits. The `[workspace.lints]` block remains **byte-identical at the TOML-value level** — only trailing comments and the doc-block above `# ───── Memory & allocation ─────` gained content.

### `Cargo.toml` (4 edits, 11 lines net)

1. **New 5-line doc block** above `# ───── Memory & allocation ─────` (line 460) mirroring the panic-policy block at line 322-326. Points at `allocation_policy.md`, the five-category taxonomy (α/β/γ/δ/ε), and the `scripts/dev/clone_alloc_audit.sh` script.

2. **Per-lint trailing comments** added to the relevant deny-level clone-family lints with section refs back into `allocation_policy.md`:

| Lint | Section ref |
|---|---|
| `clone_on_ref_ptr` | §3.1 (category α — Arc clone) |
| `redundant_clone` | §3.4 (category δ — anti-pattern) |
| `inefficient_to_string` | §2 (lint posture) |
| `str_to_string` | §2 |
| `implicit_clone` | §2 |
| `cloned_instead_of_copied` | §2 |
| `map_clone` | §2 |
| `assigning_clones` | §2 |
| `rc_buffer` | §3.1 (α) |
| `rc_mutex` | §3.1 (α) |

### `clippy.toml` (1 edit)

Extended the existing "Test code relaxations" comment block (which already references `panic_policy.md`) with a parallel paragraph referencing `allocation_policy.md` for the eight clone- and allocation-family lints. Lists each family lint explicitly so future contributors can grep on either lint name and find the contract.

## Verification

- **`just lint-pre-push`** ✅ (86s) — every gate green: fmt-check, file-size, gates-drift, hooks-drift, workflow-drift, fast-drift, manifest-drift, commit-subjects, vet, vet-audit-discipline, machete, typos, reuse, cargo-check, lint-ci, lint-prod, lint-tests, rustdoc, doc-tests, tests, smoke, deny, lint-ci-windows.
- **`cargo metadata`** parses cleanly — TOML structure unchanged at value level.
- **`cargo clippy --workspace --all-targets`** emits zero diagnostics (lint values unchanged).
- **Test count unchanged**: 1,833 / 1,833 passing.

## Behavior & contracts

- Zero functional change. The `[workspace.lints]` deny-set is byte-identical at the TOML value level.
- Public API unchanged.
- Doc-comments-only change.

## Strict-lint posture

No suppression hacks. No new `#[allow]` / `#[expect]`. All edits are TOML doc comments.

## Phase 6 closeout reference

Closes the only remaining Phase-6 follow-up item recorded in `phase_6_final_report.md` §11.9 #1 (local-only, gitignored under `/docs/dev/`). Plan §11.5 status moves from "Pending parity follow-up" to "Complete" after this PR lands.

refs #193
