### PR TITLE
refactor(uffs-core): demote DirCacheExt to free fn dir_cache_with_capacity (Phase 7b, refs #287)

### DIFF
--- a/crates/uffs-core/src/search/query/mod.rs
+++ b/crates/uffs-core/src/search/query/mod.rs
@@ -21,7 +21,7 @@ use super::backend::{DisplayRow, FilterMode, PhaseTimings};
 use super::field::FieldId;
 use super::filters::SearchFilters;
 use crate::compact::{CompactRecord, DriveCompactIndex};
-use crate::search::tree::{self, DirCacheExt as _};
+use crate::search::tree;
 
 /// Whether cache profiling is enabled (`UFFS_CACHE_PROFILE` env var).
 ///
@@ -475,7 +475,7 @@ pub(crate) fn search_compact_drive_tree(
     let match_count = match_indices.len();
 
     let t_resolve = std::time::Instant::now();
-    let mut dir_cache = tree::DirCache::with_capacity(256);
+    let mut dir_cache = tree::dir_cache_with_capacity(256);
     let rows: Vec<DisplayRow> = match_indices
         .iter()
         .filter_map(|&record_idx| {
@@ -584,7 +584,7 @@ fn indices_to_rows(
     indices: &[u32],
     volume_prefix: &str,
 ) -> Vec<DisplayRow> {
-    let mut dir_cache = tree::DirCache::with_capacity(256);
+    let mut dir_cache = tree::dir_cache_with_capacity(256);
     indices
         .iter()
         .filter_map(|&record_idx| {

--- a/crates/uffs-core/src/search/query/numeric_top_n.rs
+++ b/crates/uffs-core/src/search/query/numeric_top_n.rs
@@ -11,7 +11,7 @@ use super::super::backend::{self, DisplayRow, FilterMode, PhaseTimings};
 use super::super::derived::bulkiness_for_record;
 use super::super::field::FieldId;
 use super::super::filters::SearchFilters;
-use super::super::tree::{self, DirCacheExt as _};
+use super::super::tree;
 use super::{HeapEntry, heap_push_capped, make_display_row, stack_volume_prefix};
 use crate::compact::{CompactRecord, DriveCompactIndex};
 
@@ -528,7 +528,7 @@ fn resolve_chunk<D: AsRef<DriveCompactIndex>>(
         let volume_prefix = stack_volume_prefix(&mut vp_buf, drive.letter);
         let cache = local_caches
             .entry(drive_idx)
-            .or_insert_with(|| tree::DirCache::with_capacity(256));
+            .or_insert_with(|| tree::dir_cache_with_capacity(256));
         let t_resolve = std::time::Instant::now();
         let path = tree::resolve_path_cached(drive, rec_idx as usize, volume_prefix, cache);
         resolve_fn_ns += t_resolve.elapsed().as_nanos();

--- a/crates/uffs-core/src/search/query/path_only_top_n.rs
+++ b/crates/uffs-core/src/search/query/path_only_top_n.rs
@@ -63,7 +63,7 @@ use rayon::prelude::*;
 use super::super::backend::{self, DisplayRow, FilterMode, PhaseTimings};
 use super::super::field::FieldId;
 use super::super::filters::{SearchFilters, row_passes_filters};
-use super::super::tree::{self, DirCache, DirCacheExt as _};
+use super::super::tree::{self, DirCache};
 use super::numeric_top_n::sort_indices_by_name;
 use super::{make_display_row, passes_filter_mode, stack_volume_prefix};
 use crate::compact::DriveCompactIndex;
@@ -160,7 +160,7 @@ pub(super) fn collect_path_only_sorted_top_n<D: AsRef<DriveCompactIndex> + Sync>
         let drive = drive_ref.as_ref();
         let mut vp_buf = [0_u8; 4];
         let volume_prefix = stack_volume_prefix(&mut vp_buf, drive.letter);
-        let mut dir_cache = DirCache::with_capacity(256);
+        let mut dir_cache = tree::dir_cache_with_capacity(256);
 
         // Roots = records whose parent is `u32::MAX` (typically the
         // drive root "." at FRS 5, though stray orphans are possible).
@@ -587,7 +587,7 @@ fn collect_path_only_via_ext_index<D: AsRef<DriveCompactIndex> + Sync>(
                 let volume_prefix = stack_volume_prefix(&mut vp_buf, drive.letter);
                 let cache = local_caches
                     .entry(drive_idx)
-                    .or_insert_with(|| DirCache::with_capacity(256));
+                    .or_insert_with(|| tree::dir_cache_with_capacity(256));
                 let path = tree::resolve_path_cached(drive, rec_idx as usize, volume_prefix, cache);
                 local_rows.push(make_display_row(rec_idx, drive.letter, rec, name, path));
                 local_candidates += 1;

--- a/crates/uffs-core/src/search/query/path_sorted_top_n.rs
+++ b/crates/uffs-core/src/search/query/path_sorted_top_n.rs
@@ -31,7 +31,7 @@ use rayon::prelude::*;
 use super::super::backend::{self, DisplayRow, FilterMode};
 use super::super::field::FieldId;
 use super::super::filters::{SearchFilters, row_passes_filters};
-use super::super::tree::{self, DirCache, DirCacheExt as _};
+use super::super::tree::{self, DirCache};
 use super::numeric_top_n::sort_indices_by_name;
 use super::{make_display_row, passes_filter_mode, stack_volume_prefix};
 use crate::compact::DriveCompactIndex;
@@ -145,7 +145,7 @@ fn walk_tree_path_sorted<D: AsRef<DriveCompactIndex>>(
             .collect();
         sort_indices_by_name(&mut roots, drive, sort_desc);
 
-        let mut dir_cache = DirCache::with_capacity(256);
+        let mut dir_cache = tree::dir_cache_with_capacity(256);
         let mut stack: Vec<u32> = roots.into_iter().rev().collect();
         while let Some(idx) = stack.pop() {
             if path_results.len() >= limit {
@@ -319,7 +319,7 @@ fn collect_path_via_ext_index<D: AsRef<DriveCompactIndex> + Sync>(
                 let volume_prefix = stack_volume_prefix(&mut vp_buf, drive.letter);
                 let cache = local_caches
                     .entry(drive_idx)
-                    .or_insert_with(|| DirCache::with_capacity(256));
+                    .or_insert_with(|| tree::dir_cache_with_capacity(256));
                 let path = tree::resolve_path_cached(drive, rec_idx as usize, volume_prefix, cache);
                 local_rows.push(make_display_row(rec_idx, drive.letter, rec, name, path));
             }

--- a/crates/uffs-core/src/search/tree.rs
+++ b/crates/uffs-core/src/search/tree.rs
@@ -20,16 +20,19 @@ use crate::compact::DriveCompactIndex;
 /// walks.  Uses `FxHashMap` (3–5× faster than `HashMap` for integer keys).
 pub type DirCache = FxHashMap<u32, String>;
 
-/// Trait extension to add `with_capacity` to `DirCache` (`FxHashMap`).
-pub(crate) trait DirCacheExt {
-    /// Create a new `DirCache` with the given capacity.
-    fn with_capacity(capacity: usize) -> Self;
-}
-
-impl DirCacheExt for DirCache {
-    fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity_and_hasher(capacity, FxBuildHasher)
-    }
+/// Construct a [`DirCache`] with the given capacity, pre-wired with the
+/// crate's `FxBuildHasher`.
+///
+/// Replaces the former `DirCacheExt::with_capacity` extension trait
+/// (Phase 7b refactor playbook §879-886).  The trait satisfied none of
+/// the J1/J2/J3/J4 justification criteria — single impl, no test fakes,
+/// `pub(crate)` (no extension surface), no infrastructure decoupling —
+/// and forced every caller to bring a `DirCacheExt as _` import into
+/// scope just to write `DirCache::with_capacity(n)`.  A free function
+/// carries the same intent without the implicit trait import.
+#[must_use]
+pub(crate) fn dir_cache_with_capacity(capacity: usize) -> DirCache {
+    DirCache::with_capacity_and_hasher(capacity, FxBuildHasher)
 }
 
 /// Resolve a record's full path by walking the parent chain in the compact


### PR DESCRIPTION
Phase 7b — the only trait demotion from the Phase 7 justification audit (issue #287).

## Background

The Phase 7 trait justification audit classified 13 prod traits against the playbook §879-886 J1/J2/J3/J4 taxonomy:

- **12 KEEP** (J1 / J2 / J3): `FileReader`, `FormatRow`, `RuntimeDir`, `JournalSource`, plus 9 `uffs-daemon::cache` lifecycle hooks (`BodyLoader`, `CacheCleaner`, `PatchSink`, `CursorStore`, `Prefetch`, `PressureSignal`, `WorkingSetTrim`, `BackgroundIoPriority`).
- **1 DEMOTE**: `DirCacheExt`.

## The demotion

`DirCacheExt` was a single-method `pub(crate)` extension trait providing `with_capacity(n) -> Self` over the `DirCache = FxHashMap<u32, String>` type alias.  It satisfied none of the four justification criteria:

| Criterion | Verdict |
|---|---|
| **J1** multiple meaningful impls | ❌ 1 impl (for `DirCache` only) |
| **J2** test-substitution boundary | ❌ no test fakes |
| **J3** stable extension surface | ❌ `pub(crate)`; rustdoc claims no extensibility |
| **J4** high-level/infra decoupling | ❌ single-method ergonomic constructor |

The trait forced every caller to write `use … DirCacheExt as _;` just to spell `DirCache::with_capacity(n)`, and the indirection made the call site easy to misread as an inherent method on the `DirCache` type alias (which is not legal — type aliases cannot have inherent methods).

## What changed

- `crates/uffs-core/src/search/tree.rs`: deleted the trait + impl (15 LOC); added a free `pub(crate) fn dir_cache_with_capacity(capacity: usize) -> DirCache` with the same body (`FxHashMap::with_capacity_and_hasher(n, FxBuildHasher)`).  Doc-comment documents the playbook §879-886 rationale inline.
- `crates/uffs-core/src/search/query/mod.rs`: dropped `DirCacheExt as _` from the `use` line; switched 2 call sites.
- `crates/uffs-core/src/search/query/numeric_top_n.rs`: same — 1 call site.
- `crates/uffs-core/src/search/query/path_only_top_n.rs`: same — 2 call sites.
- `crates/uffs-core/src/search/query/path_sorted_top_n.rs`: same — 2 call sites.

Behavior preserved bit-for-bit; the function body is the exact same expression the trait impl had.

## API impact

Zero.  `DirCacheExt` was `pub(crate)`; no external code could reference it.

## Verification

- `cargo check -p uffs-core` — ✅ clean
- `cargo clippy -p uffs-core --all-targets -- -D warnings` — ✅ clean
- `cargo nextest run -p uffs-core` — ✅ **817/817 passing**, 3 skipped (2.7 s)
- Pre-push gate (`lint-pre-push`) — ✅ green (94 s)
- Commit signed: `3628BD817A687030E83025A8E406D32B4736D09F`

## Diff summary

```
 5 files changed, 24 insertions(+), 21 deletions(-)
```

## Findings doc (local-only, gitignored)

`docs/dev/baseline/2026-05-19/phase_7_trait_justification_findings.md` records every J1-J4 verdict for all 13 prod traits, with full per-trait justification text.

## Next: 7c — generic-function audit (129 prod-path `fn<…>` sites).

Refs: #287