### PR TITLE
chore(lints): activate 4 Phase-7 trait/generic/dispatch lints (Phase 7f, refs #287)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,12 +340,17 @@ unnecessary_safety_comment = "deny"    # Accurate safety comments
 # ───── DENY level lints — safety, correctness, discipline ─────
 # These MUST be clean in production code. clippy.toml relaxes test code
 # automatically via allow-*-in-tests settings.
-missing_errors_doc = "deny"                        # Document error conditions
-missing_panics_doc = "deny"                        # Document panic conditions
-missing_safety_doc = "deny"                        # Document safety requirements
-cognitive_complexity = "deny"                      # Keep functions simple (default threshold=25; violations get scoped #[expect])
-too_many_lines = "deny"                            # Keep functions short (default threshold=100; violations get scoped #[expect])
-type_complexity = "deny"                           # Keep types simple (default threshold=250; violations get scoped #[expect])
+missing_errors_doc = "deny"   # Document error conditions
+missing_panics_doc = "deny"   # Document panic conditions
+missing_safety_doc = "deny"   # Document safety requirements
+cognitive_complexity = "deny" # Keep functions simple (default threshold=25; violations get scoped #[expect])
+too_many_lines = "deny"       # Keep functions short (default threshold=100; violations get scoped #[expect])
+type_complexity = "deny"      # Keep types simple (default threshold=250; violations get scoped #[expect]) — see trait_policy.md §2
+# ── Phase 7f trait/generic/dispatch discipline lints — see trait_policy.md §2 ──
+too_many_arguments = "deny"                        # Keep fn signatures lean (default threshold=7; violations get scoped #[expect]) — see trait_policy.md §2
+trait_duplication_in_bounds = "deny"               # Disallow `T: Foo + Foo + Bar` duplicate bounds — see trait_policy.md §8 anti-patterns
+wrong_self_convention = "deny"                     # Enforce as_*/into_*/to_*/from_* method-name conventions — see trait_policy.md §2
+multiple_bound_locations = "warn"                  # Discourage split `<T: …>` + `where T: …` on the same `T` — see trait_policy.md §2
 large_enum_variant = "deny"                        # Optimize enum memory usage
 large_stack_arrays = "deny"                        # Avoid large stack allocations
 large_types_passed_by_value = "deny"               # Pass large types by reference

--- a/clippy.toml
+++ b/clippy.toml
@@ -43,6 +43,16 @@
 # five-category taxonomy (α-ε) and the per-site justification contract.
 # Audit script: `scripts/dev/clone_alloc_audit.sh`.
 #
+# The trait / generic / dispatch lints (`type_complexity`,
+# `too_many_arguments`, `trait_duplication_in_bounds`,
+# `wrong_self_convention`, `multiple_bound_locations`) likewise stay at
+# `deny` / `warn` for prod code; see
+# `docs/architecture/code-quality/trait_policy.md` for the four-criterion
+# trait justification taxonomy (J1-J4), the generic-function categories
+# (G1-LOCAL / G2-USEFUL / G3-SPREAD / G4-CASCADING / G5-CLOSURE), the
+# dispatch matrix (D1-D4 + S1-S3), and the seal/open decision tree.
+# Audit script: `scripts/dev/trait_generic_audit.sh`.
+#
 # For the broader lint posture see
 # `docs/architecture/code-quality/lint-posture.md`.
 allow-unwrap-in-tests = true


### PR DESCRIPTION
Phase 7f — promote 4 clippy lints to active enforcement under the trait/generic/dispatch policy doc landing in PR #290.

## What changes

| Lint | Level | Default | Diagnostics on `main` |
|---|---|---|---:|
| `clippy::too_many_arguments` | `deny` (was default `warn`) | warn | 0 (19 pre-existing `#[expect]` sites) |
| `clippy::trait_duplication_in_bounds` | `deny` (was default `allow`) | allow | 0 |
| `clippy::wrong_self_convention` | `deny` (was default `warn`) | warn | 0 |
| `clippy::multiple_bound_locations` | `warn` (was default `warn`) | warn | 0 |

Each gets a trailing-comment cross-reference to the relevant section of `docs/architecture/code-quality/trait_policy.md`.

## Files

- **`Cargo.toml`** — 4 new lint entries under a Phase-7f banner, between the existing `type_complexity` (Phase 6) and `large_enum_variant` lines.
- **`clippy.toml`** — extends the test-relaxations comment block with a paragraph documenting the trait/generic/dispatch lint set + audit script, mirroring the existing panic/allocation policy paragraphs.

## Verification

- `cargo clippy --workspace --all-targets --message-format=short` — ✅ **0 diagnostics** from any of the 4 lints.
- Pre-push gate: ✅ `lint-pre-push` passed (163 s — includes full workspace clippy with the new lints active).
- Commit signed: `3628BD817A687030E83025A8E406D32B4736D09F`.

## Diff

```
 Cargo.toml  |  7 ++++++- (4 new lints + 1 trailing-comment ref on type_complexity)
 clippy.toml | 10 ++++++++++
 2 files changed, 21 insertions(+), 6 deletions(-)
```

## API impact

Zero.  No source-code change anywhere except 2 config files.

## Companion PRs (Phase 7 sequence)

- #288 — 7a baseline script (merged)
- #289 — 7b `DirCacheExt` demotion (in CI auto-merge)
- #290 — 7g `trait_policy.md` + CONTRIBUTING.md
- **#this** — 7f activate the 4 lints with cross-references to #290

7c/7d/7e are findings-only (no PRs); 7h is next (bench refresh).

Refs: #287