### PR TITLE
docs(trait-policy): backfill row 194 PR ID (this PR -> #290)

### DIFF
--- a/docs/architecture/code-quality/trait_policy.md
+++ b/docs/architecture/code-quality/trait_policy.md
@@ -191,4 +191,4 @@ Append-only.  Each entry: date, sub-phase, decision, PR.
 | 2026-05-19 | 7d | Audit 40 true dispatch sites — all D1/D2; zero refactor PRs | findings-only |
 | 2026-05-19 | 7e | Keep all 3 surviving `pub trait`s OPEN — `FileReader` (J3), `FormatRow` (J3), `RuntimeDir` (structurally sealed by private fields of `RuntimeFile`) | findings-only |
 | 2026-05-19 | 7f | Add 4 clippy lints: `too_many_arguments`, `trait_duplication_in_bounds`, `wrong_self_convention` (deny) + `multiple_bound_locations` (warn) | #291 |
-| 2026-05-19 | 7g | Add this `trait_policy.md` + `CONTRIBUTING.md` cross-link | this PR |
+| 2026-05-19 | 7g | Add this `trait_policy.md` + `CONTRIBUTING.md` cross-link | #290 |


### PR DESCRIPTION
Closes the last cosmetic placeholder in the Phase 7 decisions-log table.

The Phase 7g row in `docs/architecture/code-quality/trait_policy.md:194` read 'this PR' at the time PR #290 was open.  After #290 merged the literal needed backfilling to '#290' to match the surrounding rows (#288/#289/#291).

Companion to PR #296 (Phase 8e), which already backfilled the sibling 'TBD' placeholder on row 193 (Phase 7f -> #291) as part of the additivity-gap fix.  This 1-line edit completes the decisions-log hygiene pass for Phase 7.

No code change; no behavior change.  After this merges, Phase 7 + Phase 8 closeouts are fully complete with zero stale placeholders in any tracked policy doc.