### PR TITLE
fix(concurrency): snapshot lock state before awaits in status RPC + MCP dispatch

### DIFF
--- a/crates/uffs-daemon/src/index/stats.rs
+++ b/crates/uffs-daemon/src/index/stats.rs
@@ -74,8 +74,25 @@ impl IndexManager {
     /// Get current daemon status.
     ///
     /// Includes `has_drives` and `total_records` for completeness.
+    ///
+    /// # Concurrency
+    ///
+    /// Snapshots the `DaemonStatus` upfront via `.read().await.clone()`
+    /// rather than holding the read guard across the inner awaits
+    /// below.  Without the snapshot, the guard would be held across
+    /// [`Self::has_drives`], [`Self::total_records`], and
+    /// [`Self::snapshot`] — three independent `self.index.read().await`
+    /// acquisitions — blocking any concurrent
+    /// [`Self::set_ready`] / [`Self::set_loading_progress`] /
+    /// [`crate::index::refresh::IndexManager::refresh`] writer on
+    /// `self.status` for the duration of the status RPC (which on a
+    /// many-drive box with a slow snapshot path can be tens of
+    /// milliseconds).  `DaemonStatus` is a small `Clone` enum
+    /// (`Loading { usize, usize }` or `Refreshing { Vec<DriveLetter> }`
+    /// in the worst case), so the snapshot is microseconds and never
+    /// crosses an inner `.await`.  See Phase 10b audit findings.
     pub(crate) async fn status(&self, connections: usize) -> StatusResponse {
-        let status = self.status.read().await;
+        let status_snapshot = self.status.read().await.clone();
         let loaded = self.has_drives().await;
         let records = self.total_records().await;
         tracing::trace!(
@@ -115,7 +132,7 @@ impl IndexManager {
             });
 
         StatusResponse {
-            status: status.clone(),
+            status: status_snapshot,
             uptime_secs: self.start_time.elapsed().as_secs(),
             connections,
             pid: std::process::id(),

--- a/crates/uffs-mcp/src/handler/mod.rs
+++ b/crates/uffs-mcp/src/handler/mod.rs
@@ -239,6 +239,23 @@ impl UffsMcpServer {
     ///
     /// Separated from `call_tool` so the retry-on-reconnect logic can
     /// call it a second time with the same arguments.
+    ///
+    /// # Concurrency
+    ///
+    /// Snapshots the [`RootsState`] upfront via `.read().await.clone()`
+    /// rather than holding the read guard across the daemon-RPC tool
+    /// dispatch awaits below.  Without the snapshot, the guard would
+    /// be held for the duration of every tool call (potentially
+    /// seconds for a large `uffs_search` / `uffs_aggregate`), blocking
+    /// any concurrent [`ServerHandler::on_roots_list_changed`] writer
+    /// — which acquires `self.roots.write().await` to refresh the
+    /// state — for the duration of every in-flight tool call across
+    /// the whole MCP session.  Cloning `RootsState` is cheap (small
+    /// `Vec<RootScope>` of typically `< 10` short-string entries; see
+    /// the type's rustdoc).  See Phase 10b audit findings.
+    ///
+    /// [`RootsState`]: crate::roots::RootsState
+    /// [`ServerHandler::on_roots_list_changed`]: rmcp::handler::server::ServerHandler::on_roots_list_changed
     async fn dispatch_tool(
         &self,
         tool_name: &str,
@@ -253,7 +270,7 @@ impl UffsMcpServer {
             Self::readiness_gate(&mut client).await?;
         }
 
-        let roots_state = self.roots.read().await;
+        let roots_state = self.roots.read().await.clone();
 
         match tool_name {
             "uffs_search" => {

--- a/crates/uffs-mcp/src/roots.rs
+++ b/crates/uffs-mcp/src/roots.rs
@@ -33,7 +33,14 @@ pub struct RootScope {
 }
 
 /// Shared roots state held by the MCP server.
-#[derive(Debug, Default)]
+///
+/// `Clone` is derived so the MCP handler can snapshot the current
+/// state under a brief read guard and then release the lock before
+/// dispatching tools that await on the daemon RPC.  Cloning is cheap:
+/// the `roots` and `warnings` `Vec`s are typically `< 10` short
+/// `String`s each (one per workspace root).  See Phase 10b audit
+/// findings and `crate::handler::UffsMcpServer::call_tool_with_args`.
+#[derive(Debug, Default, Clone)]
 pub struct RootsState {
     /// Whether the client has advertised roots at least once.
     pub advertised: bool,


### PR DESCRIPTION
## What

Phase 10b hand-audit fixes for the 2 of 36 lock-across-await candidate sites that held a guard across long-running inner awaits.  Neither was a deadlock (no lock-acquisition cycle), but both caused unnecessary contention with concurrent writers on the same lock.

## Why

Phase 10b of the workspace refactor playbook (#302) requires that every lock-across-await site identified by `scripts/dev/concurrency_audit.sh` (added in #303) is either proven safe by hand-audit or fixed.  Hand-audit of all 36 candidate sites found:

- **34 sites: already textbook-clean.**  Dominant patterns: block-scoped extract-then-await returning owned values, explicit `drop(guard);` before next `.await`, single-statement guards with no inner await.
- **2 sites: fix required.**  Both fixed in this PR via the extract-then-clone-then-await snapshot pattern.

## Fix 1 — `uffs-daemon/src/index/stats.rs:78` (status RPC)

`IndexManager::status()` held `self.status.read().await` across three inner awaits (`has_drives`, `total_records`, `snapshot`) and the allocator-mem snapshot call.  The guard was only used to clone the `DaemonStatus` into the response at the very end.  This blocked any concurrent `set_ready` / `set_loading_progress` / `refresh` writer on `self.status` for the full duration of the status RPC (tens of ms on many-drive boxes).

**Fix:** snapshot via `let status_snapshot = self.status.read().await.clone();` upfront.  `DaemonStatus` is already `Clone` (small enum).  Snapshot is microseconds.

## Fix 2 — `uffs-mcp/src/handler/mod.rs:256` + `uffs-mcp/src/roots.rs:43` (MCP dispatch)

`UffsMcpServer::dispatch_tool` held `self.roots.read().await` across the entire tool dispatch chain — `tools::search::run(..., &roots_state).await` can run for seconds against the daemon RPC for large queries.  Any concurrent `on_roots_list_changed` notification (which takes `self.roots.write().await`) blocked for the duration of every in-flight tool call across the whole MCP session.

**Fix:**
- Derive `Clone` on `RootsState` (cheap: typically `<10` short-string `RootScope` entries).
- Snapshot via `let roots_state = self.roots.read().await.clone();` and pass the owned value by reference to the tool runners.  Tool signatures unchanged (they already took `&RootsState`).

## Rule-1 adherence

- Zero `#[allow(...)]` introductions.
- No suppression hacks, no disabled lints, no skipped tests.
- Both fixes are minimal extract-then-await snapshots.
- Full rustdoc justification at each modified site (`# Concurrency` section explaining the invariant + the failure mode the snapshot prevents).
- Behavior preserved: status response shape unchanged; tool dispatch shape unchanged.

## Verification

Local:
- `cargo check -p uffs-daemon -p uffs-mcp` — clean.
- `cargo clippy -p uffs-daemon -p uffs-mcp --all-targets -- -W clippy::await_holding_lock -D warnings` — 0 warnings.
- `cargo test -p uffs-daemon --lib` — **298 passed / 0 failed**.
- `cargo test -p uffs-mcp` — **12 passed / 0 failed + 1 doctest passed**.
- `scripts/dev/lint-fast` (pre-commit) — all 7 stages passed in 25s.
- `scripts/dev/lint-pre-push` — all 17 stages passed in 92s.

CI: see check suite below.

## Audit verdict for the remaining 34 sites

Per-site verdict tables for all 36 candidate sites are documented in `docs/dev/baseline/2026-05-19/phase_10_lock_across_await_audit.md` (local-only; `docs/dev/baseline/` is gitignored).  This PR closes the lock-across-await hazard ledger for Phase 10b.

## Tracking

Refs #302 (Phase 10 umbrella).  Follow-on PRs for sub-phases 10c (task ownership), 10d (backpressure), 10e (timeouts), 10f (blocking IO), 10g (policy doc), 10h (CONTRIBUTING) will come in separate diffs.