### PR TITLE
docs(daemon): document task ownership at fire-and-forget spawn sites

### DIFF
--- a/crates/uffs-daemon/src/handler.rs
+++ b/crates/uffs-daemon/src/handler.rs
@@ -499,6 +499,31 @@ impl RequestHandler {
 
     /// Handle `refresh` method — spawns refresh in background, returns
     /// immediate ack.
+    ///
+    /// # Task ownership
+    ///
+    /// The spawned refresh task is **fire-and-forget** — the
+    /// `JoinHandle` is intentionally discarded.  The closure captures
+    /// an `Arc<IndexManager>` clone, keeping the manager alive for the
+    /// refresh duration even if the original client connection drops.
+    ///
+    /// * **Owner:** none held; the runtime owns the task.
+    /// * **Shutdown:** none — [`IndexManager::refresh`] runs to completion
+    ///   regardless of daemon shutdown signal.  Acceptable because refresh is
+    ///   short-lived (seconds), and the daemon's
+    ///   `await_shutdown_then_force_exit` watchdog will `process::exit` after
+    ///   the load-task timeout, terminating any in-flight refresh with the
+    ///   runtime.
+    /// * **Error obs.:** [`IndexManager::refresh`] logs internally; no upward
+    ///   propagation.  The immediate ack returned to the client asserts only
+    ///   that the refresh was scheduled, not that it succeeded — clients poll
+    ///   `status` for completion.
+    /// * **Cancel behavior:** not cancellable; runs to completion or process
+    ///   exit.
+    ///
+    /// See Phase 10c task-ownership inventory.
+    ///
+    /// [`IndexManager::refresh`]: crate::index::IndexManager::refresh
     fn handle_refresh(&self, id: u64, req: &RpcRequest) -> String {
         let refresh_params: RefreshParams = req
             .params

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -689,6 +689,26 @@ fn spawn_ipc_servers(
     });
     tracing::info!("IPC server task spawned");
 
+    // Task ownership (Phase 10c): the Windows named-pipe IPC server is
+    // **fire-and-forget** — the `_pipe_task` `JoinHandle` is bound but
+    // never `.abort()`-ed.  Rationale (mirrors the parent fn rustdoc):
+    //
+    //   * **Owner:** the binding `_pipe_task` lives until end-of-scope in
+    //     `spawn_ipc_servers`; the task itself outlives the binding (Tokio detaches
+    //     a spawned task once its `JoinHandle` drops).
+    //   * **Shutdown:** none cooperative — the pipe `accept` loop has no
+    //     cancellation hook; the `await_shutdown_then_force_exit` watchdog
+    //     `process::exit`s the daemon, terminating the task with the runtime.
+    //   * **Error obs.:** body logs via `tracing::error!`; outer `JoinHandle` drop
+    //     discards the result.
+    //   * **Cancel behavior:** process-exit only.
+    //
+    // The sibling AF_UNIX task IS returned + held + `.abort()`-ed —
+    // that's the "primary" IPC transport on Unix.  On Windows, both
+    // transports coexist (AF_UNIX for tools using the cross-platform
+    // socket path; named-pipe for native Windows tooling); aborting
+    // just one and letting the other ride out process exit is a
+    // deliberate asymmetry.
     #[cfg(windows)]
     let _pipe_task = {
         let pipe_index = Arc::clone(idx);


### PR DESCRIPTION
## What

Phase 10c task-ownership inventory closure.  Hand-audit of all 18 prod `tokio::spawn(` sites found 16 already textbook-clean (named `spawn_*` constructor with rustdoc, OR inline comments answering all four required facets: owner / shutdown / error obs. / cancel behavior).  This PR fills in the remaining 2 gaps with minimal `# Task ownership` rustdoc additions.

## Why

Phase 10 acceptance criterion #2 (playbook §1142) requires that every `tokio::spawn(` call-site has, at the call-site or enclosing named-spawner function, a comment / rustdoc block answering "who owns / how it's shut down / how errors are observed / what happens on cancellation."

Per-site inventory (all 18 prod sites with full verdicts) lives in `docs/dev/baseline/2026-05-19/phase_10_task_ownership_inventory.md` (local-only; `docs/dev/baseline/` is gitignored).

## Sites augmented in this PR

### `crates/uffs-daemon/src/handler.rs:510` (`handle_refresh`)

Previously a one-line rustdoc: *"spawns refresh in background, returns immediate ack."*

That didn't explain:

- The spawned task is **intentionally detached** \u2014 the `JoinHandle` is discarded; the closure captures `Arc<IndexManager>` to keep the manager alive.
- The task **runs to completion regardless of daemon shutdown** \u2014 it has no cooperative cancellation; the watchdog `process::exit` is the only termination mechanism.
- The immediate ack **asserts scheduling, not refresh success** \u2014 clients must poll `status` for completion.

Added a full `# Task ownership` block enumerating those.

### `crates/uffs-daemon/src/lib.rs:697` (Windows named-pipe IPC spawn)

Inline spawn inside `spawn_ipc_servers` whose asymmetric ownership wasn't called out next to the call-site:

- The sibling AF_UNIX task IS returned + held + `.abort()`-ed during graceful shutdown.
- The named-pipe task is fire-and-forget \u2014 `_pipe_task` binding drops at end-of-scope; the task itself outlives via Tokio's auto-detach.

Added a `// Task ownership (Phase 10c):` block explaining the deliberate asymmetry.

## Rule-1 adherence

- **Zero behavior change.**  Documentation-only PR.
- **Zero `#[allow(...)]` introductions.**
- **No suppression hacks**, no disabled lints, no skipped tests.
- **Surgical** \u2014 minimum text needed to enumerate the four required facets at each site (owner, shutdown, error obs., cancel behavior).

## Verification

Local:

- `cargo check -p uffs-daemon` \u2014 clean.
- `cargo clippy -p uffs-daemon --all-targets -- -D warnings` \u2014 0 warnings.
- `cargo test -p uffs-daemon --lib` \u2014 **298 passed / 0 failed**.
- `scripts/hooks/_lint_fast.sh` (pre-commit) \u2014 all 7 stages passed.
- `scripts/hooks/_lint_pre_push.sh` \u2014 all 17 stages passed in 83s.

## Acceptance against playbook §1142-1146 (Phase 10 §2)

> **§1142 #2 \u2014 Task lifecycle is explicit.**

\u2705 **CLOSED for Phase 10c.**  All 18 prod `tokio::spawn(` sites now have, at the call-site or enclosing named-spawner function, a comment / rustdoc block answering the four required facets.  Inventory will be folded into `concurrency_policy.md §'Spawn-site registry'` in Phase 10g.

## Tracking

Refs #302 (Phase 10 umbrella).  Follow-on PRs:

- 10d (backpressure) \u2014 audit of 4 unbounded channels.
- 10e (timeouts) \u2014 per-boundary timeout coverage.
- 10f (blocking-IO-in-async) \u2014 `std::fs::*` inside `async fn` outside `spawn_blocking`.
- 10g (policy doc) \u2014 `concurrency_policy.md` + per-crate `# Concurrency` rustdoc.
- 10h \u2014 CONTRIBUTING cross-link + final report (folded into 10g).