### PR TITLE
fix(daemon): wrap sync search file-output in block_in_place

### DIFF
--- a/crates/uffs-daemon/src/index/search.rs
+++ b/crates/uffs-daemon/src/index/search.rs
@@ -347,8 +347,20 @@ impl IndexManager {
             let output_config = build_output_config(&effective_params);
 
             let t_write = profiling.then(Instant::now);
-            let write_result =
-                Self::write_rows_to_file(&filtered_rows, output_path, &output_config);
+            // Phase 10f: `write_rows_to_file` does sync `File::create` +
+            // buffered `write_all` + `rename` on the tokio runtime
+            // thread.  For large result sets (10⁵+ rows × ~200 bytes ≈
+            // tens of MB), the write blocks for tens-to-hundreds of ms;
+            // `block_in_place` tells the multi-threaded runtime to move
+            // other tasks off this worker for the duration so the IPC
+            // accept loop, stats heartbeat, and per-shard journal loops
+            // keep making progress.  Cheaper than `spawn_blocking` here
+            // because the `Err` arm falls through to the IPC path and
+            // reuses `filtered_rows` — `spawn_blocking` would force an
+            // expensive clone or an `Arc<Vec<DisplayRow>>` refactor.
+            let write_result = tokio::task::block_in_place(|| {
+                Self::write_rows_to_file(&filtered_rows, output_path, &output_config)
+            });
             let write_us = t_write.map_or(0, |ts| ts.elapsed().as_micros());
 
             match write_result {


### PR DESCRIPTION
## What

Phase 10f blocking-IO-in-async audit surfaced exactly **1 real prod hazard**: `async fn search` (`crates/uffs-daemon/src/index/search.rs:351` pre-fix) calls `Self::write_rows_to_file(&filtered_rows, output_path, &output_config)` **synchronously** after the spawn_blocking search join, doing `std::fs::File::create` + `BufWriter::write_all` + `std::fs::rename` on the tokio runtime worker thread.

## Hazard scale

For `--out=<path>` exports with 10⁵+ rows × ~200 bytes ≈ tens of MB (and worst-case multi-million-row exports at hundreds of MB), the write blocks the worker for **100-500 ms**.  During that window, the IPC accept loop, stats heartbeat, per-shard journal loops, idle-demote controller, and memory-pressure subscriber all stall on the same worker.

## Fix

Wrap `write_rows_to_file` in `tokio::task::block_in_place`.

**Why `block_in_place` and not `spawn_blocking`:** the `Err` arm of `write_result` falls through to the IPC payload-building path and reuses `filtered_rows` — `spawn_blocking` would force either an expensive clone of the (potentially millions-of-rows) `Vec<DisplayRow>` or an invasive `Arc<Vec<DisplayRow>>` refactor.  `block_in_place` keeps the existing borrow shape, just tells the multi-threaded runtime to migrate other tasks off this worker for the duration.

**Runtime safety:** the daemon uses `#[tokio::main]` (default multi-threaded runtime; see `crates/uffs-daemon/src/main.rs:119`).  `block_in_place` requires multi-threaded and panics on `current_thread`.  The two `new_current_thread` instances in `crates/uffs-daemon/src/ipc/windows_unix_bridge.rs:183,237` are separate helper threads driving bridge I/O — not the main runtime hosting `async fn search`.

```rust
// Phase 10f: `write_rows_to_file` does sync `File::create` +
// buffered `write_all` + `rename` on the tokio runtime
// thread.  For large result sets (10⁵+ rows × ~200 bytes ≈
// tens of MB), the write blocks for tens-to-hundreds of ms;
// `block_in_place` tells the multi-threaded runtime to move
// other tasks off this worker for the duration so the IPC
// accept loop, stats heartbeat, and per-shard journal loops
// keep making progress.  Cheaper than `spawn_blocking` here
// because the `Err` arm falls through to the IPC path and
// reuses `filtered_rows` — `spawn_blocking` would force an
// expensive clone or an `Arc<Vec<DisplayRow>>` refactor.
let write_result = tokio::task::block_in_place(|| {
    Self::write_rows_to_file(&filtered_rows, output_path, &output_config)
});
```

## Hand-audit summary

14 candidate files flagged by `scripts/dev/concurrency_audit.sh §8`.  Hand-audit classification:

  * **13 sites justified** as (b) sync helper / startup-once / `Drop` / CLI one-shot — PID-file ops in `lifecycle.rs`; stale-socket cleanup in `ipc.rs` / `windows_unix_bridge.rs`; tracing dir setup; CLI command handlers in `uffs-mft/src/commands/windows/*.rs` and `uffs-mcp/src/process.rs`; `std::thread::sleep` in a dedicated `std::thread::spawn` watchdog (not async).
  * **1 real prod hazard** — fixed here.

Soft stylistic notes (not fixed; deferred):

  * `windows_unix_bridge.rs:43` — could move stale-socket cleanup into a sync helper for consistency with the Unix path.
  * `connect.rs:736` — could swap `std::fs::read_to_string` → `tokio::fs::read_to_string(...).await` on the client `shutdown` path.
  * `mcp/process.rs:229,255` — could swap `std::thread::sleep` → `tokio::time::sleep(...).await` in `async fn mcp_reload`.

Per-site inventory in `docs/dev/baseline/2026-05-19/phase_10_blocking_io_in_async_audit.md` (local; `docs/dev/baseline/` is gitignored).

## Rule-1 adherence

  * **Zero `#[allow(...)]` introductions.**
  * **No suppression hacks**, no disabled lints, no skipped tests.
  * **Observable behavior preserved** — return value, file contents, error semantics identical (the wrapper only changes runtime isolation, not the I/O operation itself).
  * **Surgical** — single-call-site fix + inline rationale comment.

## Verification

Local:

  * `cargo fmt -p uffs-daemon` — clean.
  * `cargo clippy -p uffs-daemon --all-targets -- -D warnings` — 0 warnings.
  * `cargo test -p uffs-daemon` — **298 lib + 0 integration (4 ignored, require pre-built daemon binary) + 0 doctest passed**.
  * Pre-commit `lint-fast` — all 7 stages passed.
  * Pre-push `lint-pre-push` — all 17 stages passed in 88 s.

## Acceptance against playbook §1142-1146

> No `async fn` performs unbounded sync I/O without `spawn_blocking` / `block_in_place`.

✅ **CLOSED for Phase 10f.**  The single prod hazard is fixed with `block_in_place`.  All other candidate sites are classified as sync helpers, startup-once, `Drop`, or CLI one-shot context.

Will be folded into `concurrency_policy.md §"Blocking-I/O rule"` in Phase 10g.

## Tracking

Refs #302 (Phase 10 umbrella).  Sub-phases remaining:

  * 10g — `concurrency_policy.md` + per-crate `# Concurrency` rustdoc.
  * 10h — CONTRIBUTING cross-link + final report (folded into 10g).
