### PR TITLE
chore: release v0.5.102 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,7 +735,7 @@ hunting for the wrong things.
 
 Plan §1 goal-4 ("no regression on CLI hot path vs the v0.5.35
 baseline") verified end-to-end on the Windows 7-drive reference
-box.  Current v0.5.100 (post-Phase-8 tiered architecture) is
+box.  Current v0.5.101 (post-Phase-8 tiered architecture) is
 **universally faster** than v0.5.35 across every benchmarked
 pattern, with the largest result set (`*.dll`, 44 529 rows)
 showing a **2.7× speedup**:
@@ -743,7 +743,7 @@ showing a **2.7× speedup**:
 ```
 Drive D, 7.07 M records, 30 rounds, HOT phase, p50 / p95 wall_ms:
 
-                              v0.5.35      v0.5.100       Δ p50
+                              v0.5.35      v0.5.101       Δ p50
     exact      (3 rows)       20 / 23   →  18 / 19      −10 %
     prefix     (8 732)        46 / 50   →  40 / 46      −13 %
     ext_rare   (11)           18 / 20   →  17 / 18       −6 %
@@ -919,7 +919,7 @@ log-message renames fail CI before reaching another 24-h soak.
   2026-05-13.  No new operator-surface features land on `main`
   until v0.6.0 ships.
 
-## [0.5.100] - 2026-05-08
+## [0.5.101] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -928,7 +928,7 @@ log-message renames fail CI before reaching another 24-h soak.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.100`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.101`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,7 +735,7 @@ hunting for the wrong things.
 
 Plan §1 goal-4 ("no regression on CLI hot path vs the v0.5.35
 baseline") verified end-to-end on the Windows 7-drive reference
-box.  Current v0.5.101 (post-Phase-8 tiered architecture) is
+box.  Current v0.5.102 (post-Phase-8 tiered architecture) is
 **universally faster** than v0.5.35 across every benchmarked
 pattern, with the largest result set (`*.dll`, 44 529 rows)
 showing a **2.7× speedup**:
@@ -743,7 +743,7 @@ showing a **2.7× speedup**:
 ```
 Drive D, 7.07 M records, 30 rounds, HOT phase, p50 / p95 wall_ms:
 
-                              v0.5.35      v0.5.101       Δ p50
+                              v0.5.35      v0.5.102       Δ p50
     exact      (3 rows)       20 / 23   →  18 / 19      −10 %
     prefix     (8 732)        46 / 50   →  40 / 46      −13 %
     ext_rare   (11)           18 / 20   →  17 / 18       −6 %
@@ -919,7 +919,7 @@ log-message renames fail CI before reaching another 24-h soak.
   2026-05-13.  No new operator-surface features land on `main`
   until v0.6.0 ships.
 
-## [0.5.101] - 2026-05-08
+## [0.5.102] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -928,7 +928,7 @@ log-message renames fail CI before reaching another 24-h soak.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.101`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.102`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -980,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
@@ -1342,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1505,9 +1505,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -1753,16 +1753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2021,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2998,9 +2988,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -3689,7 +3679,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3757,9 +3747,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -4217,20 +4207,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4335,7 +4325,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4346,14 +4336,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4370,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4385,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4404,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4435,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "clap",
@@ -4466,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4479,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "chrono",
  "itoa",
@@ -4490,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "clap",
@@ -4500,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "clap",
@@ -4511,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "clap",
@@ -4521,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "axum",
@@ -4543,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4580,14 +4570,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4602,14 +4592,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.100"
+version = "0.5.101"
 
 [[package]]
 name = "unarray"
@@ -4813,9 +4803,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4826,9 +4816,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4836,9 +4826,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4846,9 +4836,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4859,9 +4849,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4915,9 +4905,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5339,9 +5329,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "winresource"
@@ -5504,9 +5494,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,7 +4325,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4336,14 +4336,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "anyhow",
  "clap",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "chrono",
  "itoa",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "anyhow",
  "clap",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "anyhow",
  "clap",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "anyhow",
  "clap",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "anyhow",
  "axum",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4570,14 +4570,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4592,14 +4592,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.101"
+version = "0.5.102"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.101"
+version = "0.5.102"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.100"
+version = "0.5.101"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -118,21 +118,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.100" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.100" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.100" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.100" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.100" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.100" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.100" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.100" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.101" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.101" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.101" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.101" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.101" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.101" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.101" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.101" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.100" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.101" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.101"
+version = "0.5.102"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -118,21 +118,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.101" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.101" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.101" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.101" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.101" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.101" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.101" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.101" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.102" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.102" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.102" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.102" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.102" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.102" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.102" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.102" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.101" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.102" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -30,7 +30,7 @@
 # CI pipeline will auto-refresh on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed — use that flag (or plain `just ship`) while the upstream regression
 # persists.
-channel = "nightly-2026-05-16"
+channel = "nightly-2026-05-20"
 
 # Specify components that should always be available
 components = [

--- a/scripts/ci-pipeline/src/cli.rs
+++ b/scripts/ci-pipeline/src/cli.rs
@@ -58,8 +58,10 @@ pub(crate) struct Cli {
     #[arg(long, global = true, default_value_t = 120)]
     pub max_target_gb: u64,
 
-    /// Override Cargo build parallelism (rustc job count)
-    /// If omitted, defaults to `min(num_cpus, 16)`.
+    /// Override Cargo build parallelism (`CARGO_BUILD_JOBS` / rustc job count).
+    /// Also caps the parallel fan-out of validation commands to this value.
+    /// If omitted, `CARGO_BUILD_JOBS` defaults to `min(num_cpus, 16)` and
+    /// fan-out defaults to `max(num_cpus / 4, 2)`.
     #[arg(long, global = true)]
     pub jobs: Option<usize>,
 

--- a/scripts/ci-pipeline/src/context.rs
+++ b/scripts/ci-pipeline/src/context.rs
@@ -12,7 +12,7 @@
 //! threshold — see that struct's doc comment for the rationale.
 //!
 //! This module also owns the small filesystem helpers the context
-//! construction needs (`get_cargo_target_dir`, `command_exists`,
+//! construction needs (`get_cargo_target_dir`, `sccache_is_functional`,
 //! `disk_free_bytes`, `dir_size_bytes`).
 
 use core::time::Duration;
@@ -74,10 +74,24 @@ fn parse_cargo_config_target_dir() -> Option<PathBuf> {
     None
 }
 
-/// Return `true` if `cmd` exists in `$PATH`, checked via `which`.
-pub(crate) fn command_exists(cmd: &str) -> bool {
-    std::process::Command::new("which")
-        .arg(cmd)
+/// Return `true` if sccache can successfully wrap a rustc invocation.
+///
+/// `which sccache` is not enough: on some hosts the binary is present
+/// but the daemon fails to start (sandbox, missing IPC socket, etc.),
+/// causing every cargo invocation that inherits `RUSTC_WRAPPER=sccache`
+/// to die with "Operation not permitted".  Running `sccache rustc -vV`
+/// — the exact call Cargo makes for every build — flushes that out.
+///
+/// Note that this probe is not perfect: on some macOS shells sccache
+/// can succeed at the top level yet still fail when invoked as a
+/// nested subprocess of `cargo`.  Steps that are known to trip that
+/// (e.g. `cargo clean`, see `ship.rs`) explicitly clear `RUSTC_WRAPPER`
+/// for themselves rather than relying on this probe.
+pub(crate) fn sccache_is_functional() -> bool {
+    std::process::Command::new("sccache")
+        .args(["rustc", "-vV"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .output()
         .is_ok_and(|out| out.status.success())
 }
@@ -161,9 +175,12 @@ pub(crate) async fn dir_size_bytes(path: &Path, timeout_dur: Duration) -> Option
 pub(crate) struct PipelineContext {
     /// Wall-clock start of the pipeline run; used to report total duration.
     pub start_time: Instant,
-    /// Hard upper bound on parallel `cargo` invocations during the
-    /// fan-out validation stage.  Derived from `--jobs` / `num_cpus`.
-    pub max_parallel_jobs: usize,
+    /// Hard upper bound on simultaneous `cargo` invocations during the
+    /// fan-out validation stage.  Kept separate from `max_parallel_jobs`
+    /// so we don't multiply rustc threads × fan-out and OOM the host.
+    /// Defaults to `max(num_cpus / 4, 2)` when `--jobs` is not set;
+    /// when `--jobs N` is explicit it clamps to `min(N, max_parallel_jobs)`.
+    pub fanout_concurrency: usize,
     /// Per-step command timeout.  Applied uniformly to every subprocess.
     pub timeout_duration: Duration,
     /// Runtime boolean flags (CLI-derived + sccache auto-detection).
@@ -225,10 +242,19 @@ impl PipelineContext {
     /// warm cargo incremental cache over a cold sccache cache for lower
     /// per-run variance.
     pub(crate) fn new(cli: &Cli, validation_command: bool) -> Self {
-        let max_jobs = cli.jobs.unwrap_or_else(|| num_cpus::get().min(16));
+        let num_cpus = num_cpus::get();
+        let max_jobs = cli.jobs.unwrap_or_else(|| num_cpus.min(16));
+        // Fan-out: how many cargo invocations run simultaneously.
+        // When explicit --jobs is given, honour it as the ceiling.
+        // When defaulting, use num_cpus/4 (min 2) so total rustc threads
+        // (fanout × CARGO_BUILD_JOBS) stays bounded on dev laptops.
+        let fanout_concurrency = cli
+            .jobs
+            .map_or_else(|| (num_cpus / 4).max(2), |explicit| explicit.min(max_jobs));
 
         // Build global environment variables
         let mut global_env: Vec<(String, String)> = Vec::new();
+        global_env.push(("CARGO_BUILD_JOBS".into(), max_jobs.to_string()));
 
         // Normalize Cargo's target dir so child cargo/nextest processes
         // don't treat `~/...` from .cargo/config.toml as a literal
@@ -256,9 +282,16 @@ impl PipelineContext {
         // out to cargo — we still inject the wrapper explicitly because
         // git itself reads no Cargo config).
         let disable_sccache = cli.no_sccache || validation_command;
-        let sccache_available = !disable_sccache && command_exists("sccache");
+        let sccache_available = !disable_sccache && sccache_is_functional();
         if sccache_available {
             global_env.push(("RUSTC_WRAPPER".into(), "sccache".into()));
+        } else {
+            // Always clear RUSTC_WRAPPER when sccache is unavailable —
+            // .cargo/config.toml hard-codes `build.rustc-wrapper = "sccache"`,
+            // so subprocesses would otherwise inherit a broken wrapper and
+            // every cargo invocation (even `cargo clean`) would die with
+            // "sccache rustc -vV: Operation not permitted".
+            global_env.push(("RUSTC_WRAPPER".into(), String::new()));
         }
 
         // Create log file for non-verbose mode
@@ -275,7 +308,7 @@ impl PipelineContext {
 
         Self {
             start_time: Instant::now(),
-            max_parallel_jobs: max_jobs,
+            fanout_concurrency,
             timeout_duration: Duration::from_hours(1), // 60 minutes max
             flags: PipelineFlags {
                 verbose: cli.verbose,

--- a/scripts/ci-pipeline/src/exec.rs
+++ b/scripts/ci-pipeline/src/exec.rs
@@ -14,7 +14,7 @@
 //!   conventions.
 //! * [`execute_parallel`] / [`execute_parallel_with_env`] — fan out a
 //!   `Vec<(name, cmd, args)>` concurrently via `try_join_all`, bounded by the
-//!   `max_parallel_jobs` semaphore.
+//!   `fanout_concurrency` semaphore.
 //! * [`execute_step_with_tracking`] — adapter that wraps a `FnOnce() ->
 //!   Future<Result<()>>` in the resumable-workflow tracking contract
 //!   (mark-started → run → mark-completed/failed + record duration).
@@ -246,7 +246,7 @@ pub(crate) async fn execute_parallel(
         command_count
     );
 
-    let semaphore = alloc::sync::Arc::new(tokio::sync::Semaphore::new(ctx.max_parallel_jobs));
+    let semaphore = alloc::sync::Arc::new(tokio::sync::Semaphore::new(ctx.fanout_concurrency));
     let tasks: Vec<_> = commands
         .into_iter()
         .map(|(name, cmd, args)| {
@@ -290,7 +290,7 @@ pub(crate) async fn execute_parallel_with_env(
         command_count
     );
 
-    let semaphore = alloc::sync::Arc::new(tokio::sync::Semaphore::new(ctx.max_parallel_jobs));
+    let semaphore = alloc::sync::Arc::new(tokio::sync::Semaphore::new(ctx.fanout_concurrency));
     let env_vars_template = env_vars.to_vec();
     let tasks: Vec<_> = commands
         .into_iter()

--- a/scripts/ci-pipeline/src/ship.rs
+++ b/scripts/ci-pipeline/src/ship.rs
@@ -31,7 +31,10 @@ use tokio::process::Command;
 use crate::context::{
     PipelineContext, bytes_to_gib, dir_size_bytes, disk_free_bytes, get_cargo_target_dir,
 };
-use crate::exec::{execute_command, execute_parallel_with_env, execute_step_with_tracking};
+use crate::exec::{
+    execute_command, execute_command_with_env, execute_parallel_with_env,
+    execute_step_with_tracking,
+};
 use crate::git_ops::{count_unpushed_commits, git_commit, git_push};
 use crate::version::{get_current_version, increment_version, update_polars_git};
 use crate::workflow::{
@@ -95,7 +98,20 @@ async fn tracked_clean_step(state: &mut WorkflowState, ctx: &PipelineContext) ->
             } else {
                 println!("  🧹 Auto-clean triggered (disk space low or target too large)");
             }
-            execute_command("Clean build artifacts", "cargo", &["clean"], ctx).await
+            // `cargo clean` doesn't compile anything but still probes the
+            // toolchain via `<rustc-wrapper> rustc -vV`.  On some macOS hosts
+            // sccache's wrapped probe dies with "Operation not permitted" in
+            // nested subprocesses even when it works at the top level.  Since
+            // clean never needs a wrapper, force-clear `RUSTC_WRAPPER` for
+            // this specific step regardless of sccache availability.
+            execute_command_with_env(
+                "Clean build artifacts",
+                "cargo",
+                &["clean"],
+                &[("RUSTC_WRAPPER", "")],
+                ctx,
+            )
+            .await
         } else {
             println!("  ⏭️  Skipping clean (disk space OK, target size OK)");
             Ok(())

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -25,6 +25,12 @@ criteria = "safe-to-deploy"
 version = "0.5.2"
 notes = "Reviewed v0.5.2 source. Transitive dep of num_cpus. Two files: errno.rs is pure i32 constants (EPERM, ENOENT, ...); lib.rs is #![no_std] FFI declarations for the Hermit unikernel syscall interface (sys_mmap, sys_getpagesize, sys_errno, thread scheduling primitives, ...) plus two unsafe wrapper fns for get/set_priority. No network I/O, no filesystem I/O, no std dependency. On non-Hermit targets the extern C symbols are never linked and the functions are inert — num_cpus only touches hermit-abi when target_os=hermit, which none of our shipping targets hit. Apache-2.0 OR MIT; author Stefan Lankes, Hermit OS project lead."
 
+[[audits.num-conv]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+notes = "Delta audit (cargo vet diff 0.2.1 -> 0.2.2, 4 files +72/-8). Cargo.toml/Cargo.toml.orig: version bump only. README.md + src/lib.rs doc-comments: add note that num-conv is being uplifted into the standard library (rust-lang/rust#154330). src/lib.rs: introduces new 'Widen' trait + 'WidenTarget' + sealed 'WidenTargetSealed' as the going-forward names for the existing 'Extend'/'ExtendTarget'/'ExtendTargetSealed' trio. The old Extend trait is kept with #[deprecated(since='0.2.2', note='use Widen instead')] for backward compat; #[allow(deprecated)] internally so the existing impls still compile. The Widen implementation is bit-identical to Extend ('self as _' for size-preserving widening). impl_extend! macro renamed to impl_widen!, but it emits BOTH the new WidenTargetSealed/WidenTarget impls AND retains the deprecated ExtendTargetSealed/ExtendTarget impls so downstream code calling .extend() still works. No new unsafe (none exists in this crate), no new ambient capabilities, no I/O / FFI / process / network — pure trait rename-with-deprecation release prefacing the stdlib uplift. jhpratt is the time-rs maintainer; same publisher as the existing 0.2.1 we already trust transitively via time."
+
 [[audits.pastey]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -42,6 +48,12 @@ Audit rationale (Apr 2026, v0.5.71):
   (analogous to stdlib env!()). Bounded to compile time, returns a compile
   error on missing var rather than silently succeeding.
 - License: MIT OR Apache-2.0 (inherited from paste)."""
+
+[[audits.quick-xml]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.39.2 -> 0.39.4"
+notes = "Delta audit (cargo vet diff 0.39.2 -> 0.39.4, 3 files +35/-10). Cargo.toml/Cargo.toml.orig: version bump only. src/parser/dtd.rs is the only source change — three robustness fixes to the DTD internal-subset parser, all panic-prevention: (a) when 9+ bytes already accumulated in UndecidedMarkup state without matching one of <!--, <![CDATA[, <!ELEMENT, <!ATTLIST, <!ENTITY, <!NOTATION, fall through to 'skip until >' instead of staging more bytes than the 9-byte work buffer can hold (which would have panicked on the slice copy in UndecidedMarkup); (b) symmetric fix in the keyword-scan branch when the full 9-byte window has been consumed; (c) removes the 'markup.len() < 9 => None' bail-out and changes the no-> fallback from 'Some(markup.len())' to 'None' so the caller correctly waits for more input rather than treating partial markup as complete. Plus two comment-typo fixes. No new unsafe, no new I/O / FFI / process surfaces, no API additions, no feature-gate changes. Pure parser bounds-hardening."
 
 [[audits.rmcp]]
 who = "Robert Nio <50460704+githubrobbi@users.noreply.github.com>"
@@ -73,11 +85,41 @@ Delta audit (Apr 2026, v0.5.71):
   No runtime behavior change.
 - No unsafe additions, no API changes, no new ambient capabilities."""
 
+[[audits.siphasher]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.2 -> 1.0.3"
+notes = "Delta audit (cargo vet diff 1.0.2 -> 1.0.3, 5 files +105/-36). .gitignore: adds .swival editor tmpdir (no runtime effect). Cargo.toml/Cargo.toml.orig: version bump only. src/sip.rs + src/sip128.rs: single-shot fast-path optimization for the existing SipHasher{,13,24}::hash() and ::hash() (Hash128) public APIs. The old impls cloned the Hasher state, called .write(bytes), then .finish() — going through the buffered short_write codepath byte-by-byte even though the full message was available up-front. The new impls add private Hasher<S>::hash(msg) / hash128(msg) fast paths that, when ntail==0 (no buffered tail bytes from a prior write), XOR-fold msg's 8-byte chunks directly into the SipHash state in a tight loop, then finalize with the standard tail handling. When ntail!=0 the impl falls back to the original clone-write-finish path so correctness is preserved for partially-streamed hashers. The fast path's two unsafe blocks (load_int_le! and u8to64_le) were already present in the pre-existing .write() path and are reused unchanged: the 'while i < len - left' loop with 'left = len & 0x7' guarantees i + 8 <= len, so load_int_le! is in bounds; u8to64_le's 3rd arg 'left' is bounded to 0..8 by construction. Also adds Hasher::write_u16 (was missing — previously fell through to the default Hasher trait impl, which is byte-by-byte). write_u16 mirrors the existing write_u32/_u64/_usize pattern: short_write(i, i.to_le() as u64). finish()/finish128() are refactored to delegate to static finish{,128}_with_state(state,length,tail) helpers — pure structural extraction, output bytes unchanged for any given (state,length,tail). Net result: speed-up for single-shot byte-array hashing; no public-API additions beyond write_u16 (which is part of the std::hash::Hasher trait, not a new surface); no new unsafe operations beyond what already existed; no FFI / FS / network / process — pure crypto primitive, used here only via phf_shared for compile-time string hashing in transitive deps. Author jedisct1 (Frank Denis) is a well-known cryptography maintainer."
+
 [[audits.tokio]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.52.2 -> 1.52.3"
 notes = "Delta audit reviewed via cargo vet diff. Replaces the silent exemption bump from PR #166 (which was a supply-chain #[allow]). Changes scoped to src/sync/mpsc/* and src/sync/rwlock.rs, implementing four documented upstream bug-fix PRs per tokio 1.52.3 release notes (May 2026): tokio#8062 fix mpsc len() underflow; tokio#8074 return TryRecvError::Empty from try_recv() when mpsc closed with outstanding permits; tokio#8075 notify receivers in mpsc OwnedPermit::release() by reusing non-owned Permit Drop impl; tokio#8076 reject RwLock::new max_readers==0 (prevents div-by-zero in semaphore fast path). Companion tests in tests/sync_mpsc.rs + tests/sync_rwlock.rs. No feature additions, no new unsafe, no public API signature changes."
+
+[[audits.zerofrom]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.7 -> 0.1.8"
+notes = "Delta audit (cargo vet diff 0.1.7 -> 0.1.8, 2 files +12/-5). Cargo.toml + Cargo.toml.orig only — ZERO source code changes (verified diff covers only the two manifest files). Changes: (a) version 0.1.7 -> 0.1.8; (b) authors transferred from 'Manish Goregaokar <manishsmail@gmail.com>' to 'The ICU4X Project Developers' (workspace-inherited in the .orig form), reflecting the upstream move of zerofrom from Manishearth's personal repo into the ICU4X project; (c) adds [package.metadata.playground] all-features=true (docs.rs-style metadata, no runtime effect); (d) adds 'bool-assert-comparison = allow' under [lints.clippy] (dev-time lint relaxation only); (e) edition/authors-from-workspace reshuffle in the .orig. No src/ changes, no new unsafe, no new deps, no new ambient capabilities — pure ownership/metadata transfer release."
+
+[[trusted.cc]]
+criteria = "safe-to-deploy"
+user-id = 55123
+start = "2022-10-29"
+end = "2027-05-20"
+
+[[trusted.cc]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:rust-lang/cc-rs"
+start = "2025-09-01"
+end = "2027-05-20"
+
+[[trusted.digest]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:RustCrypto/traits"
+start = "2026-02-12"
+end = "2027-05-20"
 
 [[trusted.h2]]
 criteria = "safe-to-deploy"
@@ -103,6 +145,12 @@ user-id = 359 # Sean McArthur (seanmonstar)
 start = "2019-07-03"
 end = "2027-04-23"
 
+[[trusted.hybrid-array]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:RustCrypto/hybrid-array"
+start = "2026-03-08"
+end = "2027-05-20"
+
 [[trusted.hyper]]
 criteria = "safe-to-deploy"
 user-id = 359 # Sean McArthur (seanmonstar)
@@ -114,6 +162,18 @@ criteria = "safe-to-deploy"
 user-id = 359 # Sean McArthur (seanmonstar)
 start = "2022-01-15"
 end = "2027-04-23"
+
+[[trusted.js-sys]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2027-05-20"
+
+[[trusted.js-sys]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+start = "2026-04-28"
+end = "2027-05-20"
 
 [[trusted.mime]]
 criteria = "safe-to-deploy"
@@ -133,8 +193,98 @@ user-id = 359 # Sean McArthur (seanmonstar)
 start = "2019-03-04"
 end = "2027-04-23"
 
+[[trusted.tower-http]]
+criteria = "safe-to-deploy"
+user-id = 359 # Sean McArthur (seanmonstar)
+start = "2024-09-23"
+end = "2027-05-20"
+
 [[trusted.unicase]]
 criteria = "safe-to-deploy"
 user-id = 359 # Sean McArthur (seanmonstar)
 start = "2019-03-05"
 end = "2027-04-23"
+
+[[trusted.wasm-bindgen]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2027-05-20"
+
+[[trusted.wasm-bindgen]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+start = "2026-04-28"
+end = "2027-05-20"
+
+[[trusted.wasm-bindgen-futures]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2027-05-20"
+
+[[trusted.wasm-bindgen-futures]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+start = "2026-04-28"
+end = "2027-05-20"
+
+[[trusted.wasm-bindgen-macro]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2027-05-20"
+
+[[trusted.wasm-bindgen-macro]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+start = "2026-04-28"
+end = "2027-05-20"
+
+[[trusted.wasm-bindgen-macro-support]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2027-05-20"
+
+[[trusted.wasm-bindgen-macro-support]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+start = "2026-04-28"
+end = "2027-05-20"
+
+[[trusted.wasm-bindgen-shared]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2027-05-20"
+
+[[trusted.wasm-bindgen-shared]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+start = "2026-04-28"
+end = "2027-05-20"
+
+[[trusted.web-sys]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2027-05-20"
+
+[[trusted.web-sys]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+start = "2026-04-28"
+end = "2027-05-20"
+
+[[trusted.winnow]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-02-22"
+end = "2027-05-20"
+
+[[trusted.zerofrom]]
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2022-04-06"
+end = "2027-05-20"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -226,10 +226,6 @@ criteria = "safe-to-deploy"
 version = "0.2.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.cc]]
-version = "1.2.61"
-criteria = "safe-to-deploy"
-
 [[exemptions.cfg_aliases]]
 version = "0.2.1"
 criteria = "safe-to-deploy"
@@ -368,10 +364,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.digest]]
 version = "0.10.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.digest]]
-version = "0.11.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.dirs-sys-next]]
@@ -514,10 +506,6 @@ criteria = "safe-to-deploy"
 version = "2.3.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.hybrid-array]]
-version = "0.4.11"
-criteria = "safe-to-deploy"
-
 [[exemptions.hyper-rustls]]
 version = "0.27.9"
 criteria = "safe-to-deploy"
@@ -582,10 +570,6 @@ criteria = "safe-to-deploy"
 version = "2.12.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.iri-string]]
-version = "0.7.12"
-criteria = "safe-to-deploy"
-
 [[exemptions.is_terminal_polyfill]]
 version = "1.70.2"
 criteria = "safe-to-deploy"
@@ -600,10 +584,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.jobserver]]
 version = "0.1.34"
-criteria = "safe-to-deploy"
-
-[[exemptions.js-sys]]
-version = "0.3.97"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonpath_lib_polars_vendor]]
@@ -1210,10 +1190,6 @@ criteria = "safe-to-deploy"
 version = "0.5.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.tower-http]]
-version = "0.6.8"
-criteria = "safe-to-deploy"
-
 [[exemptions.tower-layer]]
 version = "0.3.3"
 criteria = "safe-to-deploy"
@@ -1252,10 +1228,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.unicode-reverse]]
 version = "1.0.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.unicode-segmentation]]
-version = "1.13.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.unit-prefix]]
@@ -1302,32 +1274,8 @@ criteria = "safe-to-deploy"
 version = "0.11.1+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
 
-[[exemptions.wasm-bindgen]]
-version = "0.2.120"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-futures]]
-version = "0.4.70"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-macro]]
-version = "0.2.120"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.120"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-shared]]
-version = "0.2.120"
-criteria = "safe-to-deploy"
-
 [[exemptions.wasm-streams]]
 version = "0.4.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.web-sys]]
-version = "0.3.97"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-time]]
@@ -1514,10 +1462,6 @@ criteria = "safe-to-deploy"
 version = "0.53.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.winnow]]
-version = "1.0.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.winresource]]
 version = "0.1.31"
 criteria = "safe-to-deploy"
@@ -1544,10 +1488,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy-derive]]
 version = "0.8.48"
-criteria = "safe-to-deploy"
-
-[[exemptions.zerofrom]]
-version = "0.1.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerofrom-derive]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -8,9 +8,19 @@ user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
+[[publisher.cc]]
+version = "1.2.62"
+when = "2026-05-08"
+trusted-publisher = "github:rust-lang/cc-rs"
+
+[[publisher.digest]]
+version = "0.11.3"
+when = "2026-05-03"
+trusted-publisher = "github:RustCrypto/traits"
+
 [[publisher.h2]]
-version = "0.4.13"
-when = "2026-01-05"
+version = "0.4.14"
+when = "2026-05-04"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -36,6 +46,11 @@ user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
+[[publisher.hybrid-array]]
+version = "0.4.12"
+when = "2026-05-09"
+trusted-publisher = "github:RustCrypto/hybrid-array"
+
 [[publisher.hyper]]
 version = "1.9.0"
 when = "2026-03-31"
@@ -49,6 +64,11 @@ when = "2026-02-02"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
+
+[[publisher.js-sys]]
+version = "0.3.98"
+when = "2026-05-07"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.mime]]
 version = "0.3.17"
@@ -71,6 +91,13 @@ user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
+[[publisher.tower-http]]
+version = "0.6.11"
+when = "2026-05-18"
+user-id = 359
+user-login = "seanmonstar"
+user-name = "Sean McArthur"
+
 [[publisher.unicase]]
 version = "2.9.0"
 when = "2026-01-06"
@@ -81,6 +108,13 @@ user-name = "Sean McArthur"
 [[publisher.unicode-normalization]]
 version = "0.1.25"
 when = "2025-10-30"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-segmentation]]
+version = "1.13.2"
+when = "2026-03-26"
 user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
@@ -120,6 +154,31 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasm-bindgen]]
+version = "0.2.121"
+when = "2026-05-07"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+
+[[publisher.wasm-bindgen-futures]]
+version = "0.4.71"
+when = "2026-05-07"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+
+[[publisher.wasm-bindgen-macro]]
+version = "0.2.121"
+when = "2026-05-07"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+
+[[publisher.wasm-bindgen-macro-support]]
+version = "0.2.121"
+when = "2026-05-07"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+
+[[publisher.wasm-bindgen-shared]]
+version = "0.2.121"
+when = "2026-05-07"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+
 [[publisher.wasm-encoder]]
 version = "0.244.0"
 when = "2026-01-06"
@@ -135,6 +194,18 @@ user-login = "wasmtime-publish"
 version = "0.244.0"
 when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.web-sys]]
+version = "0.3.98"
+when = "2026-05-07"
+trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+
+[[publisher.winnow]]
+version = "1.0.3"
+when = "2026-05-14"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
 
 [[publisher.wit-bindgen]]
 version = "0.51.0"
@@ -170,6 +241,13 @@ trusted-publisher = "github:bytecodealliance/wasm-tools"
 version = "0.244.0"
 when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.zerofrom]]
+version = "0.1.7"
+when = "2026-04-01"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
 
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -1763,7 +1841,16 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-11-06"
-end = "2026-02-01"
+end = "2027-04-23"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-segmentation]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-05-15"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -1781,7 +1868,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-07-25"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.102**.  Binaries + GitHub Release v0.5.102 are already live (step 09).  This PR routes the corresponding commit through branch-protection rules.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

Local `main` had this commit with a different SHA before squash rewrote it onto main; recover with `git fetch origin && git reset --hard origin/main`.