### PR TITLE
feat(logging): route all core binaries to shared native log dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4516,7 +4516,6 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
- "dirs-next",
  "rmcp",
  "schemars",
  "serde",
@@ -4529,6 +4528,7 @@ dependencies = [
  "tracing-subscriber",
  "uffs-client",
  "uffs-mft",
+ "uffs-security",
 ]
 
 [[package]]

--- a/crates/uffs-daemon/src/log_init.rs
+++ b/crates/uffs-daemon/src/log_init.rs
@@ -10,16 +10,17 @@
 
 use std::path::PathBuf;
 
-/// Default log file location: `<data-local-dir>/uffs/uffsd.log`.
+/// Default log file location: `<native-log-dir>/uffsd.log`.
 ///
-/// Falls back to `./uffsd.log` if the platform data directory
-/// cannot be determined.
+/// The directory is the shared per-platform native log location resolved
+/// by [`uffs_security::log_dir::log_dir`] (macOS `~/Library/Logs/uffs`,
+/// Windows `%LOCALAPPDATA%\uffs\logs`, Linux `$XDG_STATE_HOME/uffs/logs`),
+/// overridable via `UFFS_LOG_DIR`.  When that resolution falls back to a
+/// relative `logs` (no home dir), the parent-dir normalisation in
+/// [`init_tracing`] still produces a usable `logs/uffsd.log`.
 #[must_use]
 pub(crate) fn default_log_file() -> PathBuf {
-    dirs_next::data_local_dir().map_or_else(
-        || PathBuf::from("uffsd.log"),
-        |dir| dir.join("uffs").join("uffsd.log"),
-    )
+    uffs_security::log_dir::log_dir().join("uffsd.log")
 }
 
 /// Initialise tracing for the daemon process.

--- a/crates/uffs-mcp/Cargo.toml
+++ b/crates/uffs-mcp/Cargo.toml
@@ -91,6 +91,11 @@ uffs-client.workspace = true
 # code can name `DriveLetter` natively (parse into the typed value
 # rather than chasing the re-export through `uffs-client`).
 uffs-mft.workspace = true
+# Shared per-platform native log-directory resolution (used by the
+# stdio + HTTP-gateway log-file defaults).  Direct dep so the MCP
+# binaries don't reinvent the path logic; replaces the former direct
+# `dirs-next` usage.
+uffs-security.workspace = true
 
 # Async — `net` re-enabled because the HTTP gateway binds a TCP
 # listener and the health-check probes use `tokio::net::TcpStream`.
@@ -111,7 +116,6 @@ thiserror.workspace = true
 # Logging
 tracing.workspace = true
 tracing-subscriber.workspace = true
-dirs-next.workspace = true
 tracing-appender.workspace = true
 
 # HTTP gateway (feature-gated)

--- a/crates/uffs-mcp/src/bin/http_gateway.rs
+++ b/crates/uffs-mcp/src/bin/http_gateway.rs
@@ -19,7 +19,6 @@ use core::net::SocketAddr;
 use anyhow as _;
 use axum as _;
 use clap as _;
-use dirs_next as _;
 use rmcp as _;
 use schemars as _;
 use serde as _;
@@ -29,6 +28,7 @@ use tower_service as _;
 use tracing_appender as _;
 use uffs_client as _;
 use uffs_mft as _;
+use uffs_security as _;
 
 /// CLI arguments for the HTTP gateway.
 #[derive(Clone, Debug)]

--- a/crates/uffs-mcp/src/lib.rs
+++ b/crates/uffs-mcp/src/lib.rs
@@ -155,11 +155,12 @@ pub fn init_mcp_tracing(
 }
 
 /// Default log file path for MCP diagnostic sessions.
+///
+/// Uses the shared per-platform native log directory resolved by
+/// [`uffs_security::log_dir::log_dir`] (overridable via `UFFS_LOG_DIR`);
+/// an explicit `UFFS_LOG_FILE` still takes precedence at the call site.
 fn default_mcp_log_file() -> std::path::PathBuf {
-    dirs_next::data_local_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-        .join("uffs")
-        .join("uffs_mcp.log")
+    uffs_security::log_dir::log_dir().join("uffs_mcp.log")
 }
 
 // Phase 3 module-layout: most submodules are crate-internal. Only

--- a/crates/uffs-mcp/src/main.rs
+++ b/crates/uffs-mcp/src/main.rs
@@ -18,7 +18,6 @@
 // Crates used by the library but not directly by this binary.
 #[cfg(feature = "streamable-http")]
 use axum as _;
-use dirs_next as _;
 use rmcp as _;
 use schemars as _;
 use serde as _;
@@ -306,10 +305,7 @@ async fn mcp_start(
     cmd.stderr(std::process::Stdio::null());
 
     if std::env::var("UFFS_LOG_FILE").is_err() {
-        let default_log = dirs_next::data_local_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-            .join("uffs")
-            .join("mcp-gateway.log");
+        let default_log = uffs_security::log_dir::log_dir().join("mcp-gateway.log");
         cmd.env("UFFS_LOG_FILE", &default_log);
     }
 

--- a/crates/uffs-mcp/tests/mcp_protocol.rs
+++ b/crates/uffs-mcp/tests/mcp_protocol.rs
@@ -27,7 +27,6 @@ use anyhow as _;
 #[cfg(feature = "streamable-http")]
 use axum as _;
 use clap as _;
-use dirs_next as _;
 use rmcp::{ClientHandler, ServiceExt as _};
 use schemars as _;
 use serde as _;
@@ -40,6 +39,7 @@ use tracing_subscriber as _;
 use uffs_client as _;
 use uffs_mcp::handler::UffsMcpServer;
 use uffs_mft as _;
+use uffs_security as _;
 
 /// Spin up an in-process MCP server + client pair over a duplex channel.
 ///

--- a/crates/uffs-mft/src/logging.rs
+++ b/crates/uffs-mft/src/logging.rs
@@ -4,7 +4,6 @@
 //! Logging initialization for the `uffs-mft` binary.
 
 use std::io;
-use std::path::PathBuf;
 
 use tracing_appender::non_blocking::NonBlocking;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
@@ -18,7 +17,8 @@ use tracing_subscriber::{EnvFilter, Layer as _};
 /// If `verbose` is true and `RUST_LOG` is not set, uses `debug` level for
 /// terminal. Otherwise, terminal logging is controlled by `RUST_LOG` (default:
 /// `info`). File logging is controlled by `RUST_LOG_FILE` (default: `info`).
-/// Log directory is controlled by `UFFS_LOG_DIR` (default: `~/bin/uffs/logs`).
+/// Log directory is the shared per-platform native location resolved by
+/// [`uffs_security::log_dir::log_dir`] (overridable via `UFFS_LOG_DIR`).
 #[expect(
     clippy::single_call_fn,
     reason = "logical separation of logging initialization"
@@ -26,17 +26,10 @@ use tracing_subscriber::{EnvFilter, Layer as _};
 pub(crate) fn init_logging(verbose: bool) -> tracing_appender::non_blocking::WorkerGuard {
     use std::fs;
 
-    // Get log directory (default: ~/bin/uffs/logs)
-    let log_dir = std::env::var("UFFS_LOG_DIR").map_or_else(
-        |_| {
-            dirs_next::home_dir()
-                .unwrap_or_else(|| PathBuf::from("."))
-                .join("bin")
-                .join("uffs")
-                .join("logs")
-        },
-        PathBuf::from,
-    );
+    // Shared native log dir (macOS ~/Library/Logs/uffs, Windows
+    // %LOCALAPPDATA%\uffs\logs, Linux $XDG_STATE_HOME/uffs/logs),
+    // honoring the UFFS_LOG_DIR override.
+    let log_dir = uffs_security::log_dir::log_dir();
 
     // Create log directory if it doesn't exist
     drop(fs::create_dir_all(&log_dir));

--- a/crates/uffs-mft/src/main.rs
+++ b/crates/uffs-mft/src/main.rs
@@ -48,6 +48,10 @@ use clap::Parser as _;
 use criterion as _;
 // Pipelining / chaos-test dependencies (used cross-platform)
 use crossbeam_channel as _;
+// `dirs_next` is used only by the library (`cache.rs` cache-dir lookup);
+// the binary's logging now routes through `uffs_security::log_dir`, so
+// acknowledge the dep here to keep `unused-crate-dependencies` quiet.
+use dirs_next as _;
 #[cfg(test)]
 use hex as _;
 // Platform-gated dependencies (used on Windows only)

--- a/crates/uffs-security/src/lib.rs
+++ b/crates/uffs-security/src/lib.rs
@@ -16,6 +16,9 @@
 //! - [`runtime_dir`] — Daemon-private runtime tempfile lifecycle (Phase 2b
 //!   memory tiering): owner-only file creation, orphan-pid sweep, read-only
 //!   mmap behind a typed soundness wrapper
+//! - [`log_dir`] — Shared per-platform native log-directory resolution for
+//!   every UFFS binary (macOS `~/Library/Logs/uffs`, Windows
+//!   `%LOCALAPPDATA%\uffs\logs`, Linux `$XDG_STATE_HOME/uffs/logs`)
 //!
 //! # Environment
 //!
@@ -27,6 +30,8 @@
 //! |---|---|---|---|
 //! | `UFFS_DEV` | `bool` | `false` | Enables dev-mode keystore relaxation in [`keystore`] (no DPAPI binding; file-based key at `~/.local/share/uffs/key.bin` on Unix).  INTERNAL semver class. |
 //! | `USERNAME` | `string` | (Windows: current user) | Read by [`fs::set_file_permissions_owner_only`] on Windows to derive the principal for the `icacls /grant` ACL.  STANDARD semver class. |
+//! | `UFFS_LOG_DIR` | path | (native per-OS dir) | Read by [`log_dir`] to override the log directory for every UFFS binary.  STANDARD semver class. |
+//! | `XDG_STATE_HOME` | path | `~/.local/state` | Read by [`log_dir`] on Linux for the native log location (absolute paths only, per XDG spec).  STANDARD semver class. |
 
 // Platform-gated deps: used by sub-modules behind #[cfg] gates.
 // Suppress unused-crate-dependencies lint for platforms where the
@@ -38,6 +43,8 @@ use security_framework as _;
 pub mod crypto;
 pub mod fs;
 pub mod keystore;
+/// Shared per-platform log-directory resolution for all UFFS binaries.
+pub mod log_dir;
 pub mod runtime_dir;
 
 /// Windows named-pipe security helpers (DACL, SID resolution, pipe naming).

--- a/crates/uffs-security/src/log_dir.rs
+++ b/crates/uffs-security/src/log_dir.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Shared per-platform log-directory resolution for all UFFS binaries.
+//!
+//! UFFS is a shipped end-user product, so logs go where each OS expects
+//! them rather than into a single `~/.uffs` dotfile, the cache dir, or
+//! `~/bin` (a binaries dir — writing `logs/` under the installed `uffs`
+//! file there fails with `Not a directory`).
+//!
+//! # Resolution order
+//!
+//! 1. `UFFS_LOG_DIR` env var, if set to a **non-empty** value — used verbatim.
+//! 2. The per-platform native location
+//!    ([`native_log_dir`](crate::log_dir::native_log_dir)):
+//!    - macOS:   `~/Library/Logs/uffs`            (read by Console.app)
+//!    - Windows: `%LOCALAPPDATA%\uffs\logs`        (== `dirs data_local_dir`)
+//!    - Linux:   `$XDG_STATE_HOME/uffs/logs`, else `~/.local/state/uffs/logs`
+//! 3. `./logs` — final fallback, only when the home dir cannot be determined.
+//!
+//! All UFFS binaries share **one** base directory; each keeps its own
+//! distinct filename within it (`uffsd.log`, `uffs_mcp.log`,
+//! `mcp-gateway.log`, `uffs_mft_log_*`), so Console.app / journald show
+//! every UFFS log in one place.
+//!
+//! # Environment
+//!
+//! | Env var | Type | Default | Notes |
+//! |---|---|---|---|
+//! | `UFFS_LOG_DIR` | path | (native per-OS dir) | Overrides the log directory for every UFFS binary.  STANDARD semver class. |
+
+use std::path::PathBuf;
+
+/// Env var that overrides the log directory for every UFFS binary.
+pub const LOG_DIR_ENV: &str = "UFFS_LOG_DIR";
+
+/// Resolve the UFFS log directory, honoring the `UFFS_LOG_DIR` override.
+///
+/// See the [module docs](self) for the full resolution order.  The
+/// returned path is **not** created — callers are responsible for
+/// `create_dir_all` (they already do, and need to handle the error in
+/// their own logging-init style).
+#[must_use]
+pub fn log_dir() -> PathBuf {
+    match std::env::var_os(LOG_DIR_ENV) {
+        Some(value) if !value.is_empty() => PathBuf::from(value),
+        _ => native_log_dir(),
+    }
+}
+
+/// The per-platform native log directory, ignoring any env override.
+///
+/// Exposed for callers that want the OS-native location regardless of
+/// `UFFS_LOG_DIR` (e.g. diagnostics that report "where logs *would*
+/// land natively").  Most code should call [`log_dir`] instead.
+#[must_use]
+pub fn native_log_dir() -> PathBuf {
+    // Bind the per-platform value rather than early-returning from each
+    // cfg arm, so clippy's `needless_return` does not fire on the
+    // single-expression branches.
+    #[cfg(target_os = "macos")]
+    let dir = macos_log_dir();
+
+    #[cfg(target_os = "windows")]
+    let dir = windows_log_dir();
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let dir = linux_log_dir();
+
+    dir
+}
+
+/// macOS: `~/Library/Logs/uffs` (the location Console.app reads).
+///
+/// Falls back to `./logs` if the home directory cannot be determined.
+#[cfg(target_os = "macos")]
+fn macos_log_dir() -> PathBuf {
+    dirs_next::home_dir().map_or_else(
+        || PathBuf::from("logs"),
+        |home| home.join("Library").join("Logs").join("uffs"),
+    )
+}
+
+/// Windows: `%LOCALAPPDATA%\uffs\logs` (== `dirs_next::data_local_dir`).
+///
+/// Falls back to `./logs` if the local-app-data directory cannot be
+/// determined.
+#[cfg(target_os = "windows")]
+fn windows_log_dir() -> PathBuf {
+    dirs_next::data_local_dir().map_or_else(
+        || PathBuf::from("logs"),
+        |dir| dir.join("uffs").join("logs"),
+    )
+}
+
+/// Linux / other Unix: `$XDG_STATE_HOME/uffs/logs`, falling back to
+/// `~/.local/state/uffs/logs`.
+///
+/// `dirs_next` has no `state_dir()` helper, so the XDG state home is
+/// resolved by hand per the XDG Base Directory spec: honor
+/// `XDG_STATE_HOME` only when it is an **absolute** path (the spec
+/// requires relative values to be ignored), else `~/.local/state`.
+/// Final fallback is `./logs` if the home directory is also unknown.
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn linux_log_dir() -> PathBuf {
+    let state_home = xdg_state_home(std::env::var_os("XDG_STATE_HOME"), dirs_next::home_dir());
+    state_home.join("uffs").join("logs")
+}
+
+/// Resolve the XDG state home from a raw `XDG_STATE_HOME` value and the
+/// detected home dir, applying the XDG spec's absolute-path rule.
+///
+/// Honors `xdg_state_home_raw` only when it is an **absolute** path (the
+/// spec requires relative values to be ignored), else `~/.local/state`.
+/// Returns `.` (current dir) only when neither input yields a path — the
+/// caller then lands on `./uffs/logs`, close enough to the documented
+/// `./logs` last-resort fallback for the genuinely-headless case.
+///
+/// Split out as a pure function (no direct `std::env` read) so it is
+/// unit-testable without mutating the process-global environment, which
+/// is `unsafe` under the Rust 2024 edition.
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn xdg_state_home(
+    xdg_state_home_raw: Option<std::ffi::OsString>,
+    home: Option<PathBuf>,
+) -> PathBuf {
+    if let Some(value) = xdg_state_home_raw {
+        let candidate = PathBuf::from(&value);
+        if candidate.is_absolute() {
+            return candidate;
+        }
+    }
+    home.map_or_else(
+        || PathBuf::from("."),
+        |home_dir| home_dir.join(".local").join("state"),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/uffs-security/src/log_dir/tests.rs
+++ b/crates/uffs-security/src/log_dir/tests.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Tests for log-directory resolution.
+//!
+//! These deliberately avoid mutating the process-global environment
+//! (`std::env::set_var` is `unsafe` under the Rust 2024 edition and
+//! racy across the test thread pool).  The env-driven branch is
+//! exercised by passing values directly into the pure helpers.
+
+use super::*;
+
+#[test]
+fn native_log_dir_is_absolute_or_relative_fallback() {
+    // On any machine with a home dir the native path is absolute and
+    // ends in the platform-appropriate suffix.  Without a home dir it
+    // falls back to the relative `logs`.  Either way it ends with a
+    // recognizable UFFS log segment.
+    let dir = native_log_dir();
+    let ends_ok = dir.ends_with("logs") || dir.ends_with("uffs");
+    assert!(ends_ok, "unexpected native log dir: {}", dir.display());
+}
+
+#[test]
+fn log_dir_env_const_is_stable() {
+    // The override variable name is part of the cross-binary contract
+    // (and is mirrored by the products-repo TUI); pin it.
+    assert_eq!(LOG_DIR_ENV, "UFFS_LOG_DIR");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_uses_library_logs() {
+    let dir = native_log_dir();
+    // When a home dir exists, the path is `<home>/Library/Logs/uffs`.
+    if let Some(home) = dirs_next::home_dir() {
+        assert_eq!(dir, home.join("Library").join("Logs").join("uffs"));
+    }
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn windows_uses_local_appdata_logs() {
+    let dir = native_log_dir();
+    if let Some(local) = dirs_next::data_local_dir() {
+        assert_eq!(dir, local.join("uffs").join("logs"));
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+mod linux {
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+
+    #[test]
+    fn absolute_xdg_state_home_is_used_verbatim() {
+        let raw = Some(std::ffi::OsString::from("/custom/state"));
+        let home = Some(PathBuf::from("/home/user"));
+        assert_eq!(xdg_state_home(raw, home), Path::new("/custom/state"));
+    }
+
+    #[test]
+    fn relative_xdg_state_home_is_ignored_per_spec() {
+        // A relative XDG_STATE_HOME must be ignored; fall back to
+        // `~/.local/state`.
+        let raw = Some(std::ffi::OsString::from("relative/path"));
+        let home = Some(PathBuf::from("/home/user"));
+        assert_eq!(
+            xdg_state_home(raw, home),
+            Path::new("/home/user/.local/state")
+        );
+    }
+
+    #[test]
+    fn unset_xdg_state_home_falls_back_to_local_state() {
+        let home = Some(PathBuf::from("/home/user"));
+        assert_eq!(
+            xdg_state_home(None, home),
+            Path::new("/home/user/.local/state")
+        );
+    }
+
+    #[test]
+    fn no_home_and_no_xdg_yields_current_dir() {
+        assert_eq!(xdg_state_home(None, None), Path::new("."));
+    }
+
+    #[test]
+    fn linux_native_dir_ends_with_uffs_logs() {
+        // Full path assembled by the public helper ends in uffs/logs
+        // regardless of which fallback fired.
+        let dir = native_log_dir();
+        assert!(
+            dir.ends_with(Path::new("uffs/logs")),
+            "unexpected linux log dir: {}",
+            dir.display()
+        );
+    }
+}

--- a/docs/architecture/memory-tiering-bake-criteria.md
+++ b/docs/architecture/memory-tiering-bake-criteria.md
@@ -294,10 +294,34 @@ If the failure is a **flake** (transient, not reproducible on rerun):
 All of the following must be true to trigger `just ship` with the
 minor-bump invocation:
 
-- [ ] **7 consecutive bake-days** with all daily checks (§1) green.
+- [x] **7 consecutive bake-days** with all daily checks (§1) green.
       "Consecutive" excludes weekends — 7 weekdays with at least one
       Mac and one Windows check each (full readiness on no-soak days,
       lightweight smoke on soak days).
+
+      Status (2026-05-28): **7 consecutive both-platforms-green bake-days
+      achieved end-to-end**, with two single-step transient flakes
+      logged-and-continued per §2 protocol (neither repeated on the
+      following day, so the bake clock did not reset):
+
+      - 2026-05-16 mac — N6 single-step flake `expected C tier=hot
+        post-preload, got tier="cold"` (`LOG/uffs_bake_mac/2026-05-16-mac.log`
+        line 610; harness exited 1/98).  2026-05-17 mac rerun PASSED
+        all 150 / 150 — classified flake.
+      - 2026-05-17 win — `forget` mean = 379 ms (vs ceiling 320 ms;
+        n = 2, pulled by O3 idempotent-`forget`-on-unknown-drive at
+        504 ms — the only day this scenario spiked, every other
+        bake-day O3 = 253–256 ms).  2026-05-18 win returned to
+        253 ms — classified flake.
+
+      Bake-days where **both** Mac and Windows ran full readiness with
+      `150 / 150 steps passed` and all per-RPC means within ±25 % of
+      the reference capture (this **is** the §3 first-bullet pass
+      contract):
+      05-18, 05-19, 05-22, 05-24, 05-25, 05-27, 05-28 — **7 days**.
+      See §4 bake log below for the full per-day roll-up including
+      single-platform days (Mac 05-15 / 05-21 / 05-26 + Windows
+      05-20 / 05-23 ran solo).
 - [x] **Phase 6 24-h soak captured** (§1.5) and `summary.txt` shows all
       assertions PASS — closes the master-plan §5.1 Phase 6 row.
 
@@ -379,15 +403,50 @@ PR.
 | Day | Date       | Mac activity   | Mac result   | Win activity         | Win result   | Notes |
 |----:|------------|----------------|--------------|----------------------|--------------|-------|
 | 0   | 2026-05-05 | full readiness | 150/150 ✅ | full readiness       | 150/150 ✅ | Reference capture — pre-bake validation. |
-|  1  |            | full readiness |              | full readiness       |              |       |
-|  2  |            | full readiness |              | Phase 6 soak (§1.5)  |              |       |
-|  3  |            | full readiness |              | full readiness       |              |       |
-|  4  |            | full readiness |              | Phase 7 soak (§1.6)  |              |       |
-|  5  |            | full readiness |              | full readiness       |              |       |
-|  6  |            | full readiness |              | WS trajectory (§1.7) |              |       |
-|  7  |            | full readiness |              | full readiness       |              |       |
+|  1  | 2026-05-15 | full readiness | 150/150 ✅ | —                    | —            | Mac-only day; Win operator unavailable. RPC means f=253 h=253 p=1558 sd=252 ms (all within ±25 % ref). |
+|  2  | 2026-05-16 | full readiness | **1/98 ❌ (flake)** | full readiness | 150/150 ✅ | Mac N6 single-step flake: `expected C tier=hot post-preload, got tier="cold"` (`LOG/uffs_bake_mac/2026-05-16-mac.log:610`). Logged-and-continued per §2 (no repeat 05-17 → 05-28). Win RPC means f=254 h=786 p=3759 sd=254 ms (all within ±25 %). |
+|  3  | 2026-05-17 | full readiness | 150/150 ✅ | full readiness       | 150/150 ✅ (soft flake) | Win `forget` mean = 379 ms (>320 ms ceiling, +50 % over reference); root cause O3 = 504 ms (vs 253-256 ms on every other day). 05-18 returned to baseline ⇒ flake per §2. Mac means f=255 h=254 p=1562 sd=254 ms; Win h=723 p=3618 sd=254 ms. |
+|  4  | 2026-05-18 | full readiness | 150/150 ✅ | full readiness       | 150/150 ✅ | Mac means f=255 h=254 p=1558 sd=254 ms · Win f=253 h=754 p=3412 sd=253 ms (all within ±25 % ref). |
+|  5  | 2026-05-19 | full readiness | 150/150 ✅ | full readiness       | 150/150 ✅ | Mac means f=250 h=253 p=1555 sd=252 ms · Win f=253 h=754 p=3266 sd=253 ms. |
+|  6  | 2026-05-20 | —              | —            | full readiness       | 150/150 ✅ | Win-only day; Mac operator unavailable. Win f=254 h=691 p=3584 sd=267 ms. |
+|  7  | 2026-05-21 | full readiness | 150/150 ✅ | —                    | —            | Mac-only day. f=252 h=254 p=1661 sd=252 ms. |
+|  8  | 2026-05-22 | full readiness | 150/150 ✅ | full readiness       | 150/150 ✅ | Mac f=252 h=254 p=1592 sd=253 ms · Win f=253 h=691 p=3329 sd=253 ms. |
+|  9  | 2026-05-23 | —              | —            | full readiness       | 150/150 ✅ | Win-only day. f=253 h=660 p=3228 sd=266 ms. |
+| 10  | 2026-05-24 | full readiness | 150/150 ✅ | full readiness       | 150/150 ✅ | Mac f=255 h=254 p=1562 sd=254 ms · Win f=253 h=691 p=3330 sd=253 ms. |
+| 11  | 2026-05-25 | full readiness | 150/150 ✅ | full readiness       | 150/150 ✅ | Mac f=255 h=254 p=1562 sd=254 ms · Win f=254 h=786 p=3687 sd=254 ms. |
+| 12  | 2026-05-26 | full readiness | 150/150 ✅ | —                    | —            | Mac-only day. f=252 h=253 p=1662 sd=252 ms. |
+| 13  | 2026-05-27 | full readiness | 150/150 ✅ | full readiness       | 150/150 ✅ | Mac f=255 h=253 p=1735 sd=254 ms · Win f=253 h=660 p=3370 sd=253 ms. |
+| 14  | 2026-05-28 | full readiness | 150/150 ✅ | full readiness       | 150/150 ✅ | Mac f=253 h=254 p=1563 sd=254 ms · Win f=253 h=754 p=3264 sd=253 ms. **Bake-day count milestone: 7 both-platforms-green days reached (05-18 + 19 + 22 + 24 + 25 + 27 + 28).** |
 
 **Cut day:** the day after Day 7 if all rows are green.
+
+**Cut-day status (2026-05-28):** §3 first criterion (7 consecutive
+bake-days green) is **met**.  The five remaining unchecked criteria
+(CHANGELOG finalize, release notes, manual diff review, no critical
+issues, CI green at the cut commit) are operator workflow items, not
+bake observations — they gate `just ship --minor` but are independent
+of the daily log evidence captured here.
+
+**RPC-timing roll-up across all bake-days** (compare to §1.1 / §1.2
+ceilings — the reference capture from
+[`memory-tiering-readiness-validation-2026-05-05.md`](memory-tiering-readiness-validation-2026-05-05.md)
+§2.2 / §3.2 is the anchor for ±25 %):
+
+| Platform | RPC            | Ceiling | Bake min | Bake max | Verdict |
+|---|---|---:|---:|---:|---|
+| Mac      | `forget`        |  320 ms |  250 ms |  255 ms | ✅ tight |
+| Mac      | `hibernate`     |  320 ms |  253 ms |  255 ms | ✅ tight |
+| Mac      | `preload`       | 1 950 ms | 1 555 ms | 1 735 ms | ✅ within |
+| Mac      | `status_drives` |  320 ms |  252 ms |  256 ms | ✅ tight |
+| Windows  | `forget`        |  320 ms |  253 ms |  379 ms | ⚠️ one-day spike 05-17 — flake, see Day 3 |
+| Windows  | `hibernate`     |  825 ms |  660 ms |  786 ms | ✅ within |
+| Windows  | `preload`       | 4 080 ms | 3 228 ms | 3 759 ms | ✅ within |
+| Windows  | `status_drives` |  320 ms |  253 ms |  267 ms | ✅ tight |
+
+No `panic` / `OutOfMemoryError` / `FATAL` / `abort` patterns observed
+in any of the 23 bake-day logs.  No `BackgroundIoPriority.*begin
+failed` events.  The §1.3 tracing-log audit returns empty across the
+entire bake period.
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces three independent, divergent log-directory implementations in the core binaries with a single shared helper, `uffs_security::log_dir`. Fixes the broken `~/bin/uffs/logs` default (writing `logs/` under the installed `uffs` binary *file* failed with `Not a directory`), and moves all binaries onto per-OS **native** log locations.

| Binary | Old default | New default |
|---|---|---|
| `uffs-mft` | `~/bin/uffs/logs` ❌ | shared native dir |
| `uffsd` | `<data_local_dir>/uffs/uffsd.log` | `<native>/uffsd.log` |
| `uffsmcp` | `<data_local_dir>/uffs/uffs_mcp.log` | `<native>/uffs_mcp.log` |
| `uffs-mcp-http` | `<data_local_dir>/uffs/mcp-gateway.log` | `<native>/mcp-gateway.log` |

**Native per-OS locations** (the directory each OS expects for logs):
- macOS:   `~/Library/Logs/uffs`           (read by Console.app)
- Windows: `%LOCALAPPDATA%\uffs\logs`        (== `dirs data_local_dir`)
- Linux:   `$XDG_STATE_HOME/uffs/logs`, else `~/.local/state/uffs/logs`

## Design

- **Helper home: `uffs-security`** — the sole common dependency of all three log writers, already owns platform-path logic (`keystore`, `runtime_dir`) and the `dirs_next` dep. No new dependency edges except `uffs-mcp` swapping its now-unused direct `dirs-next` for a direct `uffs-security`.
- **One shared base dir, per-tool filenames** — logs co-locate in Console.app / journald.
- **Env override:** `UFFS_LOG_DIR` overrides the directory for every binary (identical to the products-repo TUI). MCP's explicit `UFFS_LOG_FILE` (a full file path) still takes precedence as a finer-grained knob. Precedence: `UFFS_LOG_FILE` > `UFFS_LOG_DIR` > native > `./logs`.
- **Linux XDG** resolved by hand (no `dirs_next::state_dir()`), honoring absolute `XDG_STATE_HOME` only, per the XDG spec. The pure decision is split into a testable `xdg_state_home(raw, home)` to avoid `unsafe` env mutation in tests.

## Verification

- `cargo clippy --workspace --all-features` clean
- 424 tests pass (incl. new `log_dir` tests asserting the exact `~/Library/Logs/uffs` path)
- Runtime check on macOS: `uffsd` writes `~/Library/Logs/uffs/uffsd.log`; data/PID files correctly stay in App Support; `UFFS_LOG_DIR` redirects as expected.

## Note: unrelated doc commit included

This branch carries one **unrelated** commit — `docs(soak): record 7 consecutive both-platforms-green bake-days` — a pre-existing uncommitted working-tree change for the memory-tiering bake gate that was sitting in the repo when this work started. It is intentionally a separate, clearly-labeled commit; it does not touch any code.