### PR TITLE
fix(toolchain): correct stale rust-toolchain.toml comment drift

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,30 +6,32 @@
 # and prevents issues caused by switching between stable/nightly toolchains
 
 [toolchain]
-# Latest known-good nightly — re-pinned 2026-04-20 after the toolchain-sync bump
-# to nightly-2026-04-20 surfaced the ethnum regression on `just ship-fresh`.
-# CI must NOT override this with `@nightly`; this file is the single source of truth.
+# Pinned nightly — single source of truth for every environment.
+# CI must NOT override this with `@nightly`; workflows install via
+# `rustup show` (which reads this file) so the pin is always honored.
 #
-# History note: previously pinned to nightly-2026-04-11 because nightly-2026-04-13
-# broke tokio 1.51.1 via unresolved imports in tokio::io::util.  Tokio 1.52.1 (which
-# the workspace now depends on) resolves the interaction, so the original trigger is
-# gone.  Pinned to nightly-2026-04-17 — the last nightly that compiles the workspace
-# cleanly.  Every nightly from 2026-04-18 onward (incl. 04-20) regresses with
+# Current pin: nightly-2026-05-20.  Requires ethnum >= 1.5.3 (the
+# workspace Cargo.lock resolves 1.5.3 transitively via polars-compute +
+# parquet — verify with `grep -A1 'name = "ethnum"' Cargo.lock`).
 #
-#   error[E0512]: cannot transmute between types of different sizes
-#    --> ethnum-1.5.2/src/error.rs:16  `mem::transmute::<(), TryFromIntError>(())`
+# Resolved-history note (kept so a future bump does not re-tread this):
+#   * nightly-2026-04-13 broke tokio 1.51.1 (unresolved imports in
+#     tokio::io::util).  Tokio 1.52.1 resolved it; trigger is gone.
+#   * nightlies 2026-04-18 .. (the 04-17→05-xx window) regressed any
+#     build still pinning ethnum 1.5.2 with:
+#         error[E0512]: cannot transmute between types of different sizes
+#          --> ethnum-1.5.2/src/error.rs:16
+#             `mem::transmute::<(), TryFromIntError>(())`
+#     because std's `TryFromIntError` private field grew 0 -> 8 bits.
+#     ethnum 1.5.3 removed that zero-sized transmute, so the regression
+#     is fixed at the dependency level — NOT by holding an old nightly.
+#     If you bump the channel and hit E0512, the fix is
+#     `cargo update -p ethnum --precise 1.5.3` (or newer), never a
+#     toolchain downgrade.
 #
-# `TryFromIntError`'s private field grew from 0 to 8 bits on nightly, and ethnum's
-# upstream main branch has NOT published a fix (verified 2026-04-20 against
-# https://raw.githubusercontent.com/nlordell/ethnum-rs/main/src/error.rs).  Since
-# ethnum is pulled in transitively by polars-compute + parquet, we cannot drop it,
-# and maintaining our own ethnum fork is out of scope — so we hold the pin at 04-17
-# until a new ethnum release removes the zero-sized `TryFromIntError` hack.
-#
-# Run `just toolchain-sync` to re-attempt a bump once upstream ships the fix; the
-# CI pipeline will auto-refresh on `ship --fresh` unless `--skip-toolchain-sync`
-# is passed — use that flag (or plain `just ship`) while the upstream regression
-# persists.
+# Run `just toolchain-sync` to re-attempt a channel bump; the CI
+# pipeline auto-refreshes on `ship --fresh` unless `--skip-toolchain-sync`
+# is passed.
 channel = "nightly-2026-05-20"
 
 # Specify components that should always be available


### PR DESCRIPTION
## Summary

Fixes the one genuine OSS finding from the `uffs-products` sync report (`docs/OSS_SYNC_FINDINGS.md` §1).

`rust-toolchain.toml`'s comment block claimed the channel **must stay pinned at `nightly-2026-04-17`** to avoid the `ethnum 1.5.2` E0512 transmute regression — but the file actually ships `channel = "nightly-2026-05-20"` (since v0.5.102, commit `d4e40baa2`) and the workspace `Cargo.lock` resolves the **fixed `ethnum 1.5.3`**. The comment was stale and actively misleading.

**Real-world cost:** it sent the products repo chasing a toolchain *downgrade* before they found the actual fix (bump ethnum, not the channel).

## Change

Comment-only rewrite of the `[toolchain]` block:
- States the current reality: pin `05-20` requires `ethnum >= 1.5.3`, with a verify command.
- Keeps the tokio 1.51→1.52 and ethnum history as **resolved** notes (so a future bump doesn't re-tread it).
- Documents the correct remedy if E0512 recurs on a bump: `cargo update -p ethnum --precise 1.5.3`, **never** a toolchain downgrade.

`channel` and all other settings are **unchanged** — this touches comments only.

## Other findings in the report (validated, no action needed)

| § | Finding | OSS status |
|---|---|---|
| 3 | rustls-webpki / rand advisories | Clean — OSS has `rustls-webpki 0.103.13`, `rand 0.9.4`/`0.10.1` (no vulnerable 0.8.x); Dependabot enabled (`dependabot-auto-merge.yml`) |
| 4 | CI `@nightly` float vs pin | OSS CI installs via `rustup show` (honors the pin) — products-only mistake |
| 5 | duplicate `setup` recipe | OSS has exactly one `setup:` in `shared.just` — no collision |