### PR TITLE
chore: ship v0.5.104 (version bump + supply-chain vet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,7 +735,7 @@ hunting for the wrong things.
 
 Plan §1 goal-4 ("no regression on CLI hot path vs the v0.5.35
 baseline") verified end-to-end on the Windows 7-drive reference
-box.  Current v0.5.103 (post-Phase-8 tiered architecture) is
+box.  Current v0.5.104 (post-Phase-8 tiered architecture) is
 **universally faster** than v0.5.35 across every benchmarked
 pattern, with the largest result set (`*.dll`, 44 529 rows)
 showing a **2.7× speedup**:
@@ -743,7 +743,7 @@ showing a **2.7× speedup**:
 ```
 Drive D, 7.07 M records, 30 rounds, HOT phase, p50 / p95 wall_ms:
 
-                              v0.5.35      v0.5.103       Δ p50
+                              v0.5.35      v0.5.104       Δ p50
     exact      (3 rows)       20 / 23   →  18 / 19      −10 %
     prefix     (8 732)        46 / 50   →  40 / 46      −13 %
     ext_rare   (11)           18 / 20   →  17 / 18       −6 %
@@ -919,7 +919,7 @@ log-message renames fail CI before reaching another 24-h soak.
   2026-05-13.  No new operator-surface features land on `main`
   until v0.6.0 ships.
 
-## [0.5.103] - 2026-05-08
+## [0.5.104] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -928,7 +928,7 @@ log-message renames fail CI before reaching another 24-h soak.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.103`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.104`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,7 +37,7 @@ license-url: "https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/LICENSE
 # Keep this in sync with [workspace.package].version in Cargo.toml.
 # The release pipeline (release-plz / just ship) should bump this automatically
 # once Pattern 5 in build/update_all_versions.rs is extended to cover CITATION.cff.
-version: "0.5.103"
+version: "0.5.104"
 date-released: "2026-05-29"
 
 # ── Classification ───────────────────────────────────────────────────────────

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,9 +1841,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2892ae4ea6fa2cb7acb0e236a6880d39523239cd9089de71d220910ccc806790"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
  "cty",
@@ -1948,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebca48a43116bc25f18a61360f1be98412f50cc218f5e52c823086b999a4a21a"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -4325,7 +4325,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4336,14 +4336,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "clap",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "chrono",
  "itoa",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "clap",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "clap",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "clap",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "axum",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4570,14 +4570,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4592,14 +4592,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.103"
+version = "0.5.104"
 
 [[package]]
 name = "unarray"
@@ -4709,9 +4709,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.103"
+version = "0.5.104"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -118,21 +118,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.103" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.103" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.103" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.103" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.103" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.103" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.103" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.103" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.104" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.104" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.104" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.104" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.104" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.104" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.104" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.104" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.103" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.104" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace
@@ -197,7 +197,7 @@ winresource = "0.1.31"
 
 # ───── Serialization ─────
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde_json = "1.0.150"
 # Phase 6 of memory-tiering: parse `daemon.toml` for per-drive
 # tier overrides + adaptive-TTL knobs in `uffs-daemon::config`.
 # Pinned to v1.1.2 to match the supply-chain exemption already on
@@ -248,7 +248,7 @@ colored = "3.1.1"
 
 # ───── Pattern Matching ─────
 regex = "1.12.3"
-memchr = "2.8.0"
+memchr = "2.8.1"
 aho-corasick = "1.1.4"
 globset = "0.4.18"
 
@@ -276,7 +276,7 @@ rayon = "1.12.0"
 crossbeam-channel = "0.5.15"
 
 # ───── Memory ─────
-mimalloc = "0.1.50"
+mimalloc = "0.1.52"
 memmap2 = "0.9.10"
 
 # ───── System ─────
@@ -289,7 +289,7 @@ hostname = "0.4.2"
 num_cpus = "1.17.0"
 # Random unique identifiers.  Only the `v4` (random) feature is enabled
 # workspace-wide; consumers that need v1/v5/v7 etc. re-add the feature.
-uuid = { version = "1.23.1", features = ["v4"] }
+uuid = { version = "1.23.2", features = ["v4"] }
 
 # ───── Security / Crypto ─────
 aes-gcm = "0.10"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -43,11 +43,23 @@ criteria = "safe-to-deploy"
 delta = "0.1.47 -> 0.1.48"
 notes = "Delta audit (cargo vet diff 0.1.47 -> 0.1.48). build.rs: restructured MSVC path to compile the vendored mimalloc via a generated OUT_DIR C++17 wrapper (mimalloc-static.cc that #includes static.c) because mimalloc needs the C++ atomics path under MSVC/clang-cl; non-MSVC keeps the direct C build. All paths derive from CARGO_MANIFEST_DIR/OUT_DIR (no untrusted input); fs::write only emits the #include wrapper into OUT_DIR (standard build-script practice). Vendored C is an upstream point-release SYNC of official microsoft/mimalloc: v2 MI_MALLOC_VERSION 20301->20302 (2.3.1->2.3.2) and v3 30301->30302 (3.3.1->3.3.2). Reviewed the 3272-line C delta for injected logic: no network/socket, no system/exec/popen, no LD_/DYLD_ env hijack, no exfil/base64/eval introduced; changes are confined to the version-pinned v2/ and v3/ trees and match upstream patch releases. extended.rs: no functional code change. Audited at the level appropriate for a vendored-allocator upstream sync (verify provenance + capability surface), not a line-by-line review of allocator C internals."
 
+[[audits.libmimalloc-sys]]
+who = "Robert Nio <robert_nio@intuit.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.48 -> 0.1.49"
+notes = "Delta audit (cargo vet diff 0.1.48 -> 0.1.49). ZERO vendored-C files changed (no v2/v3 tree edits this release). build.rs unchanged. src/extended.rs adds exactly one new FFI binding: 'pub fn mi_stats_get_json(buf_size: usize, buf: *mut c_char) -> *mut c_char' (#[cfg(not(feature=v2))], v3-only) backing mimalloc's stats-to-JSON feature, plus a test 'use super::super::mi_malloc'. The C implementation already existed upstream; this is just the Rust extern declaration. No new ambient capability / I/O / process / network / env access."
+
 [[audits.mimalloc]]
 who = "Robert Nio <robert_nio@intuit.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.50 -> 0.1.51"
 notes = "Delta audit (cargo vet diff 0.1.50 -> 0.1.51). Only .gitignore, Cargo.toml, Cargo.toml.orig changed: version bump 0.1.50->0.1.51, libmimalloc-sys dep 0.1.47->0.1.48, and one new passthrough feature 'win_direct_tls = [libmimalloc-sys/win_direct_tls]'. ZERO .rs source changes. No new unsafe / FFI / I/O / capability in this wrapper crate."
+
+[[audits.mimalloc]]
+who = "Robert Nio <robert_nio@intuit.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.51 -> 0.1.52"
+notes = "Delta audit (cargo vet diff 0.1.51 -> 0.1.52). Cargo.toml(.orig): version bump + libmimalloc-sys dep 0.1.48->0.1.49. src/lib.rs + src/extended.rs add a v3-only (#[cfg(not(feature=v2))]) 'stats_json() -> Result<StatsJson, &str>' wrapper plus a StatsJson newtype with Deref/Drop. The unsafe blocks are allocator FFI into mimalloc's own functions (the new mi_stats_get_json getter and mi_free for the returned buffer) — standard mimalloc-sys FFI, no new ambient capability / I/O / network."
 
 [[audits.num-conv]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -120,6 +132,12 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.52.2 -> 1.52.3"
 notes = "Delta audit reviewed via cargo vet diff. Replaces the silent exemption bump from PR #166 (which was a supply-chain #[allow]). Changes scoped to src/sync/mpsc/* and src/sync/rwlock.rs, implementing four documented upstream bug-fix PRs per tokio 1.52.3 release notes (May 2026): tokio#8062 fix mpsc len() underflow; tokio#8074 return TryRecvError::Empty from try_recv() when mpsc closed with outstanding permits; tokio#8075 notify receivers in mpsc OwnedPermit::release() by reusing non-owned Permit Drop impl; tokio#8076 reject RwLock::new max_readers==0 (prevents div-by-zero in semaphore fast path). Companion tests in tests/sync_mpsc.rs + tests/sync_rwlock.rs. No feature additions, no new unsafe, no public API signature changes."
+
+[[audits.uuid]]
+who = "Robert Nio <robert_nio@intuit.com>"
+criteria = "safe-to-deploy"
+delta = "1.23.1 -> 1.23.2"
+notes = "Delta audit (cargo vet diff 1.23.1 -> 1.23.2). Files: Cargo.toml(.orig) version bump, README, src/{error,fmt,parser,lib,external/serde_support}.rs. Patch release by KodrAus (uuid maintainer): formatting/parser refinements + serde tweak. The single unsafe is std::str::from_utf8_unchecked(self.0) on the crate's own fixed-size format buffer, which uuid populates exclusively with ASCII hex digits + hyphens before formatting — sound zero-copy formatting (same pattern as the vetted 1.23.1). No new I/O / FFI / process / network / ambient capability."
 
 [[audits.zerofrom]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"


### PR DESCRIPTION
## Summary

`just ship-fresh` bumped the workspace to **v0.5.104** and `cargo update` advanced 3 transitive deps past their vetted versions. This PR carries the bump + the real delta audits. (Routed via PR because branch protection rejects the ship's direct push to `main`.)

## Vetted deltas (real audits, `Vet-Reviewed-Diff:` trailers)

| Crate | Transition | Finding |
|---|---|---|
| `libmimalloc-sys` | 0.1.48→0.1.49 | **Zero** vendored-C changes; build.rs unchanged; adds one v3-only FFI binding `mi_stats_get_json` (C impl already upstream) |
| `mimalloc` | 0.1.51→0.1.52 | v3-only `stats_json()` wrapper + `StatsJson` newtype; `unsafe` = standard allocator FFI (`mi_stats_get_json`/`mi_free`) |
| `uuid` | 1.23.1→1.23.2 | KodrAus patch (fmt/parser/serde); lone `unsafe` is `from_utf8_unchecked` on uuid's own ASCII-only format buffer — sound zero-copy, same as vetted 1.23.1 |

`cargo vet` passes. Local `lint-pre-push` green incl. `vet` ✅, `vet-audit-discipline` ✅, clippy Linux+Windows, tests.