### PR TITLE
feat(ci): auto-submit winget manifest on release + promote winget install

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# WinGet Publish — auto-submit the winget-pkgs manifest on every release.
+#
+# When `release.yml` finishes and publishes a non-draft, non-prerelease
+# GitHub Release (it sets `draft: false`, `prerelease: false`), GitHub
+# emits a `release: released` event.  This workflow reacts to that event
+# and uses `winget-releaser` (komac under the hood) to open a pull
+# request against microsoft/winget-pkgs that bumps `SkyLLC.UFFS` to the
+# new version.
+#
+# The action clones the *previous* version's manifest as a template and
+# updates only the version, installer URL, SHA256, and release date — so
+# the nested-installer structure (InstallerType: zip / NestedInstallerType:
+# portable, the four PortableCommandAliases uffs/uffsd/uffsmcp/uffs-mft)
+# carries over automatically with no manifest authoring on our side.
+#
+# ── Required secret ──────────────────────────────────────────────────
+# `WINGET_TOKEN` — a **classic** Personal Access Token with the
+# `public_repo` scope (fine-grained tokens that can fork + push to
+# microsoft/winget-pkgs also work).  The default `GITHUB_TOKEN` CANNOT
+# be used: it has no permission to fork an external repo or push the
+# manifest branch.  Create it under the maintainer account that owns the
+# winget-pkgs fork (the same account that hand-submitted PR
+# microsoft/winget-pkgs#378294 for v0.5.102), then add it at
+# Settings → Secrets and variables → Actions → New repository secret.
+
+name: 📦 WinGet Publish
+
+run-name: 📦 WinGet ${{ github.event.release.tag_name || inputs.release-tag }}
+
+on:
+  release:
+    types: [released]
+  # Manual fallback: re-submit a specific tag if the release-triggered
+  # run failed (e.g. the token expired) or a release predates this
+  # workflow.  Provide the git tag, e.g. `v0.5.102`.
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: 'Git tag to publish to WinGet (e.g. v0.5.102)'
+        required: true
+        type: string
+
+# Serialise submissions so two releases landing close together queue
+# cleanly instead of racing to open competing winget-pkgs PRs.
+concurrency:
+  group: winget-publish-${{ github.event.release.tag_name || inputs.release-tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Submit winget-pkgs manifest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Never run from forks — only the canonical repo holds WINGET_TOKEN.
+    if: github.repository_owner == 'skyllc-ai'
+    steps:
+      - name: Submit manifest to winget-pkgs
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        with:
+          identifier: SkyLLC.UFFS
+          # Match the Windows ZIP asset uploaded by release.yml. The
+          # action derives the package version from the release tag,
+          # stripping the leading `v` (v0.5.102 → 0.5.102).
+          installers-regex: 'uffs-windows-x64\.zip$'
+          release-tag: ${{ github.event.release.tag_name || inputs.release-tag }}
+          # The account that owns the microsoft/winget-pkgs fork komac
+          # pushes the manifest branch to.  MUST match the account that
+          # owns WINGET_TOKEN — i.e. the maintainer who submitted the
+          # original PR microsoft/winget-pkgs#378294, NOT the `skyllc-ai`
+          # org (the action's default `github.repository_owner`, which
+          # has no winget-pkgs fork).
+          fork-user: githubrobbi
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — WinGet distribution: live install docs + auto-submission pipeline
+
+`SkyLLC.UFFS` is published on the Windows Package Manager community
+repository (microsoft/winget-pkgs#378294, v0.5.102), so `winget install
+SkyLLC.UFFS` now works.
+
+- **Docs promote WinGet as the recommended Windows install.** `README.md`
+  Download section gains the `winget install SkyLLC.UFFS` one-liner and
+  the stale "WinGet (coming)" note is removed;
+  `docs/user-manual/installation.md` gains a new §1 *WinGet (Windows —
+  Recommended)* and renumbers the downstream sections (Pre-Built Binaries
+  → §2 … Verify Installation → §6).
+- **`.github/workflows/winget-publish.yml`** — on every published
+  release (`release: released`), `winget-releaser` (komac under the hood)
+  opens a winget-pkgs PR bumping the manifest. The prior version's
+  nested-installer structure (`InstallerType: zip` /
+  `NestedInstallerType: portable`, the four `uffs`/`uffsd`/`uffsmcp`/
+  `uffs-mft` command aliases) carries over automatically. A
+  `workflow_dispatch` fallback re-submits a specific tag by hand.
+  - **One-time setup required:** add a `WINGET_TOKEN` repository secret —
+    a classic PAT with `public_repo` scope owned by the maintainer
+    account that holds the winget-pkgs fork (the action's `fork-user` is
+    pinned to `githubrobbi`, not the `skyllc-ai` org). The default
+    `GITHUB_TOKEN` cannot fork an external repo, so the workflow no-ops
+    until this secret exists.
+
 ### Added — Phase 8: operator-driven memory tiering (v0.6.0 staging)
 
 The full operator-facing memory-tiering surface — every command end-to-end

--- a/README.md
+++ b/README.md
@@ -84,9 +84,13 @@ Each release ships pre-built binaries, a `CHECKSUMS.txt` (SHA256), per-crate SBO
 | **macOS Apple Silicon** | [`uffs-macos-arm64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | Offline MFT analysis only. Includes `UFFS.app` bundle. |
 | **Linux x64** | [`uffs-linux-x64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | Offline MFT analysis only. Includes `install.sh`. |
 
-**Windows quick-install (one command):**
+**Windows quick-install (one command) — via [WinGet](https://learn.microsoft.com/windows/package-manager/):**
 ```powershell
-# Extract the ZIP anywhere, add the folder to PATH, then:
+winget install SkyLLC.UFFS
+```
+
+Or grab the ZIP above, extract it anywhere, add the folder to PATH, then:
+```powershell
 uffs --version
 ```
 
@@ -105,7 +109,7 @@ gh attestation verify uffs-windows-x64.exe --owner skyllc-ai
 cargo build --release
 ```
 
-> 📖 **[Full installation guide](docs/user-manual/installation.md)** — PATH setup, daemon autostart, WinGet (coming), Scoop (coming)
+> 📖 **[Full installation guide](docs/user-manual/installation.md)** — WinGet, PATH setup, daemon autostart, Scoop (coming)
 
 ---
 

--- a/docs/user-manual/installation.md
+++ b/docs/user-manual/installation.md
@@ -1,7 +1,8 @@
 # Installation
 
-Pre-built Windows binaries are available from
-[GitHub Releases](https://github.com/skyllc-ai/UltraFastFileSearch/releases).
+On Windows, the fastest path is [WinGet](https://learn.microsoft.com/windows/package-manager/)
+(§1).  Pre-built binaries for all platforms are also available from
+[GitHub Releases](https://github.com/skyllc-ai/UltraFastFileSearch/releases) (§2).
 Most users do not need to build from source.
 
 > **See also:** [Getting Started](getting-started.md) ·
@@ -10,7 +11,34 @@ Most users do not need to build from source.
 
 ---
 
-## 1  Pre-Built Binaries (Recommended)
+## 1  WinGet (Windows — Recommended)
+
+If you have the [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/)
+(bundled with Windows 11 and modern Windows 10), install in one command:
+
+```powershell
+winget install SkyLLC.UFFS
+```
+
+This installs the `uffs` CLI (daemon + MCP + MFT tools) and puts it on
+your PATH automatically.  Upgrade later with:
+
+```powershell
+winget upgrade SkyLLC.UFFS
+```
+
+Confirm the install:
+
+```powershell
+uffs --version
+```
+
+> Live NTFS search still requires an **Administrator** terminal — see
+> [§3 Platform Requirements](#3--platform-requirements).
+
+---
+
+## 2  Pre-Built Binaries
 
 Download the latest Windows x64 binaries from the
 [GitHub Releases page](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest).
@@ -71,7 +99,7 @@ Get-FileHash uffs-windows-x64.exe -Algorithm SHA256
 
 ---
 
-## 2  Platform Requirements
+## 3  Platform Requirements
 
 | Platform | Data source | Privileges |
 |----------|------------|------------|
@@ -106,7 +134,7 @@ See [Cache & Data Sources](cache-and-data.md) for how to set up the
 
 ---
 
-## 3  Add to PATH
+## 4  Add to PATH
 
 ### Windows (PowerShell)
 
@@ -128,7 +156,7 @@ uffs --version
 uffs "*.txt" --limit 5
 ```
 
-### macOS / Linux (build from source — see §4)
+### macOS / Linux (build from source — see §5)
 
 ```bash
 ln -s "$(pwd)/target/release/uffs" /usr/local/bin/uffs
@@ -136,7 +164,7 @@ ln -s "$(pwd)/target/release/uffs" /usr/local/bin/uffs
 
 ---
 
-## 4  Build from Source
+## 5  Build from Source
 
 Building from source is needed for development, contributing, or
 running on macOS/Linux.
@@ -211,7 +239,7 @@ for details on the `xwin-dev` profile and COFF archive size limits.
 
 ---
 
-## 5  Verify Installation
+## 6  Verify Installation
 
 ```bash
 # Check version


### PR DESCRIPTION
## Summary

`SkyLLC.UFFS` is live on the Windows Package Manager (microsoft/winget-pkgs#378294, v0.5.102), so `winget install SkyLLC.UFFS` now works. This promotes WinGet in the docs and automates future manifest submissions.

## Changes

- **`README.md`** — Download section leads with `winget install SkyLLC.UFFS`; removed the stale *"WinGet (coming)"* note.
- **`docs/user-manual/installation.md`** — new **§1 WinGet (Recommended)**; downstream sections renumbered §2–§6 with cross-refs fixed.
- **`.github/workflows/winget-publish.yml`** *(new)* — on `release: released`, `winget-releaser` (komac) opens a winget-pkgs PR bumping the manifest. The prior version's nested `zip`/`portable` structure and the four command aliases (`uffs`/`uffsd`/`uffsmcp`/`uffs-mft`) carry over automatically. A `workflow_dispatch` fallback re-submits a specific tag.
- **`CHANGELOG.md`** — `[Unreleased]` entry documenting the above.

## ⚠️ One-time setup required

Add a **`WINGET_TOKEN`** repository secret — a **classic** PAT with `public_repo` scope, owned by the account that holds the winget-pkgs fork (`fork-user` is pinned to `githubrobbi`, not the `skyllc-ai` org). The default `GITHUB_TOKEN` cannot fork an external repo, so the workflow no-ops until this secret exists.

## Verification

- Action pinned to a full commit SHA (`winget-releaser@4ffc7888…` = v2); input names verified against the action's `action.yml` at that SHA.
- `workflow-drift` gate green; pre-push suite (fmt, clippy, tests, windows-lint, reuse, typos, …) all green — no `--no-verify` bypass.