### PR TITLE
chore: release v0.5.106 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -784,7 +784,7 @@ hunting for the wrong things.
 
 Plan §1 goal-4 ("no regression on CLI hot path vs the v0.5.35
 baseline") verified end-to-end on the Windows 7-drive reference
-box.  Current v0.5.105 (post-Phase-8 tiered architecture) is
+box.  Current v0.5.106 (post-Phase-8 tiered architecture) is
 **universally faster** than v0.5.35 across every benchmarked
 pattern, with the largest result set (`*.dll`, 44 529 rows)
 showing a **2.7× speedup**:
@@ -792,7 +792,7 @@ showing a **2.7× speedup**:
 ```
 Drive D, 7.07 M records, 30 rounds, HOT phase, p50 / p95 wall_ms:
 
-                              v0.5.35      v0.5.105       Δ p50
+                              v0.5.35      v0.5.106       Δ p50
     exact      (3 rows)       20 / 23   →  18 / 19      −10 %
     prefix     (8 732)        46 / 50   →  40 / 46      −13 %
     ext_rare   (11)           18 / 20   →  17 / 18       −6 %
@@ -968,7 +968,7 @@ log-message renames fail CI before reaching another 24-h soak.
   2026-05-13.  No new operator-surface features land on `main`
   until v0.6.0 ships.
 
-## [0.5.105] - 2026-05-08
+## [0.5.106] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -977,7 +977,7 @@ log-message renames fail CI before reaching another 24-h soak.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.105`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.106`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,8 +37,8 @@ license-url: "https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/LICENSE
 # Keep this in sync with [workspace.package].version in Cargo.toml.
 # The release pipeline (release-plz / just ship) should bump this automatically
 # once Pattern 5 in build/update_all_versions.rs is extended to cover CITATION.cff.
-version: "0.5.105"
-date-released: "2026-05-29"
+version: "0.5.106"
+date-released: "2026-05-31"
 
 # ── Classification ───────────────────────────────────────────────────────────
 type: software

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,7 +4325,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4336,14 +4336,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "clap",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "chrono",
  "itoa",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "clap",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "clap",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "clap",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "axum",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4570,14 +4570,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4592,14 +4592,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.105"
+version = "0.5.106"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.105"
+version = "0.5.106"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -118,21 +118,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.105" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.105" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.105" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.105" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.105" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.105" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.105" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.105" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.106" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.106" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.106" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.106" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.106" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.106" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.106" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.106" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.105" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.106" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -252,10 +252,6 @@ fn run_search(args: &[String]) -> Result<()> {
 
     let t_ready = std::time::Instant::now();
     // 2 minutes — `from_mins` is nightly-only as of 2026-04.
-    #[expect(
-        clippy::duration_suboptimal_units,
-        reason = "Duration::from_mins is nightly-only"
-    )]
     let ready_timeout = core::time::Duration::from_secs(120);
     client
         .await_ready(ready_timeout)

--- a/crates/uffs-daemon/src/index/loading.rs
+++ b/crates/uffs-daemon/src/index/loading.rs
@@ -202,10 +202,6 @@ impl IndexManager {
     /// daemon.  Raw NTFS volume reads can hang indefinitely when a
     /// drive is unresponsive (bad sectors, sleep, USB disconnect).
     #[cfg(windows)]
-    #[expect(
-        clippy::duration_suboptimal_units,
-        reason = "Duration::from_mins is unstable (rust-lang/rust#120301); cannot migrate yet"
-    )]
     const DRIVE_LOAD_TIMEOUT: core::time::Duration = core::time::Duration::from_secs(300);
 
     /// Load live Windows drives — **all drives in parallel**.

--- a/crates/uffs-mcp/src/handler/mod.rs
+++ b/crates/uffs-mcp/src/handler/mod.rs
@@ -368,6 +368,10 @@ impl ServerHandler for UffsMcpServer {
         }
     }
 
+    #[expect(
+        clippy::unused_async_trait_impl,
+        reason = "rmcp ServerHandler trait mandates an async signature; this handler returns precomputed data and has no .await"
+    )]
     async fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,
@@ -456,6 +460,10 @@ impl ServerHandler for UffsMcpServer {
         final_result.map_err(McpError::from)
     }
 
+    #[expect(
+        clippy::unused_async_trait_impl,
+        reason = "rmcp ServerHandler trait mandates an async signature; this handler returns precomputed data and has no .await"
+    )]
     async fn list_resources(
         &self,
         _request: Option<PaginatedRequestParams>,
@@ -513,6 +521,10 @@ impl ServerHandler for UffsMcpServer {
         })
     }
 
+    #[expect(
+        clippy::unused_async_trait_impl,
+        reason = "rmcp ServerHandler trait mandates an async signature; this handler returns precomputed data and has no .await"
+    )]
     async fn list_resource_templates(
         &self,
         _request: Option<PaginatedRequestParams>,
@@ -614,6 +626,10 @@ impl ServerHandler for UffsMcpServer {
         )]))
     }
 
+    #[expect(
+        clippy::unused_async_trait_impl,
+        reason = "rmcp ServerHandler trait mandates an async signature; this handler returns precomputed data and has no .await"
+    )]
     async fn list_prompts(
         &self,
         _request: Option<PaginatedRequestParams>,
@@ -627,6 +643,10 @@ impl ServerHandler for UffsMcpServer {
         })
     }
 
+    #[expect(
+        clippy::unused_async_trait_impl,
+        reason = "rmcp ServerHandler trait mandates an async signature; this handler builds prompt messages synchronously with no .await"
+    )]
     async fn get_prompt(
         &self,
         request: GetPromptRequestParams,

--- a/crates/uffs-mft/src/reader/index_cache.rs
+++ b/crates/uffs-mft/src/reader/index_cache.rs
@@ -245,7 +245,11 @@ impl MftReader {
     /// Always returns `MftError::PlatformNotSupported` on non-Windows
     /// platforms.
     #[cfg(not(windows))]
-    #[expect(clippy::unused_async, reason = "async for API parity with windows")]
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "async signature mirrors the Windows impl for cross-cfg API parity"
+    )]
     pub async fn read_index_cached(&self, _ttl_seconds: u64) -> Result<crate::index::MftIndex> {
         Err(MftError::PlatformNotSupported)
     }

--- a/crates/uffs-mft/src/reader/index_read.rs
+++ b/crates/uffs-mft/src/reader/index_read.rs
@@ -274,7 +274,11 @@ impl MftReader {
     /// Always returns `MftError::PlatformNotSupported` on non-Windows
     /// platforms.
     #[cfg(not(windows))]
-    #[expect(clippy::unused_async, reason = "async for API parity with windows")]
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "async signature and by-value callback mirror the Windows impl for cross-cfg API parity"
+    )]
     pub async fn read_index_with_progress<F>(&self, _callback: F) -> Result<crate::index::MftIndex>
     where
         F: Fn(MftProgress) + Send + 'static,

--- a/crates/uffs-mft/src/reader/index_timing.rs
+++ b/crates/uffs-mft/src/reader/index_timing.rs
@@ -83,7 +83,11 @@ impl MftReader {
     /// Always returns `MftError::PlatformNotSupported` on non-Windows
     /// platforms.
     #[cfg(not(windows))]
-    #[expect(clippy::unused_async, reason = "async for API parity with windows")]
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "async signature mirrors the Windows impl for cross-cfg API parity"
+    )]
     pub async fn read_all_index_with_timing(
         &self,
     ) -> Result<(crate::index::MftIndex, BenchmarkResult)> {

--- a/crates/uffs-mft/src/reader/multi_drive/mod.rs
+++ b/crates/uffs-mft/src/reader/multi_drive/mod.rs
@@ -104,7 +104,11 @@ impl MultiDriveMftReader {
     /// Always returns `MftError::PlatformNotSupported` on non-Windows
     /// platforms.
     #[cfg(not(windows))]
-    #[expect(clippy::unused_async, reason = "async for API parity with windows")]
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "async signature mirrors the Windows impl for cross-cfg API parity"
+    )]
     pub async fn read_all(&self) -> Result<DataFrame> {
         Err(MftError::PlatformNotSupported)
     }
@@ -116,7 +120,11 @@ impl MultiDriveMftReader {
     /// Always returns `MftError::PlatformNotSupported` on non-Windows
     /// platforms.
     #[cfg(not(windows))]
-    #[expect(clippy::unused_async, reason = "async for API parity with windows")]
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "async signature and by-value callback mirror the Windows impl for cross-cfg API parity"
+    )]
     pub async fn read_with_progress<F>(&self, _callback: F) -> Result<DataFrame>
     where
         F: Fn(crate::platform::DriveLetter, MftProgress) + Send + Sync + Clone + 'static,
@@ -131,7 +139,11 @@ impl MultiDriveMftReader {
     /// Always returns `MftError::PlatformNotSupported` on non-Windows
     /// platforms.
     #[cfg(not(windows))]
-    #[expect(clippy::unused_async, reason = "async for API parity with windows")]
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "async signature mirrors the Windows impl for cross-cfg API parity"
+    )]
     pub async fn read_all_detailed(&self) -> Result<Vec<DriveReadResult>> {
         Err(MftError::PlatformNotSupported)
     }
@@ -143,7 +155,11 @@ impl MultiDriveMftReader {
     /// Always returns `MftError::PlatformNotSupported` on non-Windows
     /// platforms.
     #[cfg(not(windows))]
-    #[expect(clippy::unused_async, reason = "async for API parity with windows")]
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "async signature mirrors the Windows impl for cross-cfg API parity"
+    )]
     pub async fn read_all_index(&self) -> Result<Vec<crate::index::MftIndex>> {
         Err(MftError::PlatformNotSupported)
     }
@@ -155,7 +171,11 @@ impl MultiDriveMftReader {
     /// Always returns `MftError::PlatformNotSupported` on non-Windows
     /// platforms.
     #[cfg(not(windows))]
-    #[expect(clippy::unused_async, reason = "async for API parity with windows")]
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "async signature and by-value callback mirror the Windows impl for cross-cfg API parity"
+    )]
     pub async fn read_all_index_with_progress<F>(
         &self,
         _callback: F,
@@ -173,7 +193,11 @@ impl MultiDriveMftReader {
     /// Always returns `MftError::PlatformNotSupported` on non-Windows
     /// platforms.
     #[cfg(not(windows))]
-    #[expect(clippy::unused_async, reason = "async for API parity with windows")]
+    #[expect(
+        clippy::unused_async,
+        clippy::unused_async_trait_impl,
+        reason = "async signature mirrors the Windows impl for cross-cfg API parity"
+    )]
     pub async fn read_all_index_cached(
         &self,
         _ttl_seconds: u64,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -10,7 +10,7 @@
 # CI must NOT override this with `@nightly`; workflows install via
 # `rustup show` (which reads this file) so the pin is always honored.
 #
-# Current pin: nightly-2026-05-20.  Requires ethnum >= 1.5.3 (the
+# Current pin: nightly-2026-05-31.  Requires ethnum >= 1.5.3 (the
 # workspace Cargo.lock resolves 1.5.3 transitively via polars-compute +
 # parquet — verify with `grep -A1 'name = "ethnum"' Cargo.lock`).
 #

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -32,7 +32,7 @@
 # Run `just toolchain-sync` to re-attempt a channel bump; the CI
 # pipeline auto-refreshes on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed.
-channel = "nightly-2026-05-29"
+channel = "nightly-2026-05-31"
 
 # Specify components that should always be available
 components = [


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.106** — the `[workspace.package].version` bump in `Cargo.toml`.  This PR routes that commit through branch-protection rules.  Once it merges to `main`, `auto-tag-release.yml` tags the commit and invokes `release.yml`, which builds the cross-platform binaries and publishes GitHub Release v0.5.106.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

The auto-commit lived only on `release/v0.5.106`, so local `main` never drifted — sync it with a plain `git pull --ff-only origin main` (no `reset --hard` needed).