### PR TITLE
docs: link the free TUI/GUI demo downloads in Download & Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ cargo build --release
 
 > 📖 **[Full installation guide](docs/user-manual/installation.md)** — WinGet, PATH setup, daemon autostart, Scoop (coming)
 
+> 🖥️ **Prefer a UI?** Free **demo** builds of the UFFS TUI and GUI (macOS, Linux, Windows) are at **[uffs-demo/releases](https://github.com/githubrobbi/uffs-demo/releases/latest)** — limited result counts, exports disabled. They drive this same open-source daemon. Full versions are commercial (see [Maintainership & Commercial](#maintainership--commercial)).
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
Adds a discoverable download line for the free UFFS TUI/GUI demo (githubrobbi/uffs-demo/releases) in the Download & Install section, cross-linked to Maintainership & Commercial. The demo drives this same open-source daemon; full versions are commercial. Docs only (2-line addition).