### PR TITLE
fix(ci): auto-trigger winget submission from the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,12 @@ concurrency:
 
 permissions:
   contents: write
-  actions: read
+  # `actions: write` (was `read`) so the `submit-winget` job can dispatch
+  # `winget-publish.yml` via `gh workflow run` after the release lands.
+  # Per-job blocks can only NARROW this, so it must be granted here; every
+  # other job re-declares a narrower per-job `permissions:` set and does
+  # not inherit write.
+  actions: write
   issues: write
   # SLSA build-provenance attestation flow (P1 hardening):
   #   - `id-token: write` lets the runner mint an OIDC token
@@ -82,6 +87,15 @@ jobs:
     name: 📋 Release Preparation
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Explicit per-job scopes so this job does NOT inherit the
+    # workflow-level `actions: write` (granted only for the
+    # `submit-winget` dispatch).  This job needs `contents: write` for
+    # its `gh release create --draft` preflight; `actions` stays read —
+    # the rollback-attack guard below deliberately must NOT run with
+    # `actions: write`.
+    permissions:
+      contents: write
+      actions: read
     outputs:
       version: ${{ steps.validate.outputs.version }}
       tag: ${{ steps.validate.outputs.tag }}
@@ -317,6 +331,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: release-preparation
     timeout-minutes: ${{ matrix.timeout }}
+    # Explicit read-only scope so this job does NOT inherit the
+    # workflow-level `actions: write` (granted only for `submit-winget`).
+    # The build only checks out + compiles + uploads artifacts — no
+    # write scope is needed.
+    permissions:
+      contents: read
     env:
       RUSTFLAGS: ${{ matrix.rustflags }}
     strategy:
@@ -1029,6 +1049,51 @@ jobs:
             echo "- [📦 Release Page](https://github.com/${{ github.repository }}/releases/tag/${{ needs.release-preparation.outputs.tag }})"
             echo "- [📋 Full Changelog](https://github.com/${{ github.repository }}/commits/${{ needs.release-preparation.outputs.version }})"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # WinGet submission — dispatch winget-publish.yml after the release lands
+  # ═══════════════════════════════════════════════════════════════════════════
+  #
+  # Why dispatch instead of relying on `on: release` in winget-publish.yml:
+  # the Release above is created with the default GITHUB_TOKEN, and GitHub
+  # suppresses event cascades from GITHUB_TOKEN-authored actions — so a
+  # `release: released` trigger would never fire.  Triggering another
+  # workflow via `gh workflow run` (workflow_dispatch) IS a permitted
+  # GITHUB_TOKEN action, so this is the robust path.
+  #
+  # Non-blocking: `continue-on-error: true` plus the job being outside every
+  # other job's `needs:` graph means a winget hiccup (rate limit, token
+  # rotation, microsoft/winget-pkgs outage) can never fail or roll back an
+  # otherwise-successful release.
+  submit-winget:
+    name: 📦 Submit to WinGet
+    runs-on: ubuntu-latest
+    needs: [release-preparation, create-github-release]
+    if: github.repository_owner == 'skyllc-ai'
+    continue-on-error: true
+    permissions:
+      actions: write # required to dispatch winget-publish.yml via the API
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch winget-publish workflow for the release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.release-preparation.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Dispatching winget-publish.yml for ${RELEASE_TAG}"
+          # Dispatch against the repo's default branch: `gh workflow run
+          # --ref` resolves the workflow definition from that ref, and
+          # winget-publish.yml always lives on the default branch.  Using
+          # the default branch (not github.ref_name, which is the tag on a
+          # `push: tags: v*` run) keeps the dispatch ref stable.
+          default_branch="$(gh repo view "${GH_REPO}" --json defaultBranchRef -q .defaultBranchRef.name)"
+          gh workflow run winget-publish.yml \
+            --ref "${default_branch}" \
+            -f "release-tag=${RELEASE_TAG}"
+          echo "✅ winget-publish.yml dispatched for ${RELEASE_TAG} on ${default_branch} (runs independently; check the Actions tab)."
 
   # ═══════════════════════════════════════════════════════════════════════════
   # Failure Notification — opens a GitHub Issue on release failure

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -28,14 +28,23 @@
 
 name: 📦 WinGet Publish
 
-run-name: 📦 WinGet ${{ github.event.release.tag_name || inputs.release-tag }}
+run-name: 📦 WinGet ${{ inputs.release-tag }}
 
+# `workflow_dispatch` ONLY — deliberately NOT `on: release`.
+#
+# A GitHub Release published by `release.yml` using the default
+# `GITHUB_TOKEN` does **not** emit a `release` event: GitHub suppresses
+# event cascades from `GITHUB_TOKEN`-authored actions to prevent
+# workflow-trigger loops.  So an `on: release:` trigger here would
+# NEVER fire from our release pipeline — it was dead config.
+#
+# Instead, `release.yml`'s `submit-winget` job explicitly dispatches
+# this workflow via `gh workflow run` once the release is published
+# (the documented `GITHUB_TOKEN` → `workflow_dispatch` exception, which
+# IS permitted).  `release-tag` is therefore always supplied; this is
+# also the manual re-submit entry point if a release predates the
+# automation or a previous run failed (e.g. expired token).
 on:
-  release:
-    types: [released]
-  # Manual fallback: re-submit a specific tag if the release-triggered
-  # run failed (e.g. the token expired) or a release predates this
-  # workflow.  Provide the git tag, e.g. `v0.5.102`.
   workflow_dispatch:
     inputs:
       release-tag:
@@ -46,7 +55,7 @@ on:
 # Serialise submissions so two releases landing close together queue
 # cleanly instead of racing to open competing winget-pkgs PRs.
 concurrency:
-  group: winget-publish-${{ github.event.release.tag_name || inputs.release-tag }}
+  group: winget-publish-${{ inputs.release-tag }}
   cancel-in-progress: false
 
 permissions:
@@ -60,7 +69,26 @@ jobs:
     # Never run from forks — only the canonical repo holds WINGET_TOKEN.
     if: github.repository_owner == 'skyllc-ai'
     steps:
+      # Graceful no-op when the token is absent: warn (not ❌) so a
+      # missing/rotated secret never shows as a hard failure.  The
+      # weekly `winget-token-expiry-check.yml` is the durable alarm for
+      # this condition; here we just skip cleanly.  `outputs.present`
+      # gates the submit step below.
+      - name: Check WINGET_TOKEN is configured
+        id: token
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -z "${WINGET_TOKEN:-}" ]]; then
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=WINGET_TOKEN missing::Skipping winget-pkgs submission for ${{ inputs.release-tag }} — set the WINGET_TOKEN secret, then re-run this workflow manually."
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Submit manifest to winget-pkgs
+        if: steps.token.outputs.present == 'true'
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: SkyLLC.UFFS
@@ -68,7 +96,7 @@ jobs:
           # action derives the package version from the release tag,
           # stripping the leading `v` (v0.5.102 → 0.5.102).
           installers-regex: 'uffs-windows-x64\.zip$'
-          release-tag: ${{ github.event.release.tag_name || inputs.release-tag }}
+          release-tag: ${{ inputs.release-tag }}
           # The account that owns the microsoft/winget-pkgs fork komac
           # pushes the manifest branch to.  MUST match the account that
           # owns WINGET_TOKEN — i.e. the maintainer who submitted the


### PR DESCRIPTION
## Summary

Closes the real WinGet trigger gap. WinGet auto-publish **never actually fired**: `winget-publish.yml` used `on: release: [released]`, but `release.yml` publishes the GitHub Release with the default `GITHUB_TOKEN` — and GitHub **suppresses event cascades from `GITHUB_TOKEN`-authored actions**, so the `release` event was never emitted. The trigger was dead config; winget-pkgs stayed stuck at 0.5.102 until we manually dispatched it.

## Fix (robust, non-blocking)

**`release.yml`:**
- New `submit-winget` job (`needs: create-github-release`) that dispatches `winget-publish.yml` via `gh workflow run` once the release is published — the documented, *permitted* `GITHUB_TOKEN` → `workflow_dispatch` path.
- `continue-on-error: true` + outside every other job's `needs:` graph → a winget hiccup (rate limit, token rotation, winget-pkgs outage) can **never** fail or roll back a release.
- Dispatches against the default branch (where the workflow lives), passing the release tag.
- Bumped workflow-level `actions: read → write` (required to dispatch). **Least-privilege preserved:** added explicit per-job `permissions` to `release-preparation` (`contents:write, actions:read`) and `build-release-binaries` (`contents:read`) so neither inherits the broadened scope. Audited — all 5 jobs now pin their own block; only `submit-winget` gets `actions: write`.

**`winget-publish.yml`:**
- Dropped the dead `on: release` trigger; `workflow_dispatch` is now the single entry (`release-tag` always supplied by the dispatcher, or manually for re-submits).
- Added a graceful no-op: warns (not ❌) when `WINGET_TOKEN` is unset, so a missing/rotated secret never shows as a hard failure. The weekly `winget-token-expiry-check.yml` (#326) remains the durable alarm.

## Result
Every `just ship` release now auto-submits to winget-pkgs, end to end — no manual dispatch.

> Note: the pre-push hit a transient E0514 stale-rustc-cache error (the exact class #325 fixes for the ship path); a `cargo clean` cleared it and the full gate passed. YAML-only change.