### PR TITLE
feat(release): min/normal/full bundle tiers + bundled uffs-tui demo (+ winget alias seed)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -584,98 +584,151 @@ jobs:
           echo "📦 Packaged binaries:"
           ls -la
 
-      - name: Stage release bundle
+      - name: Stage release bundles (min / normal / full)
         shell: bash
+        env:
+          # `gh release download` reads the public githubrobbi/uffs-demo
+          # repo.  The default GITHUB_TOKEN can read public release assets,
+          # so no extra secret is needed.  The demo is versioned
+          # INDEPENDENTLY of the engine — we fetch its latest TUI build and
+          # bundle it as the zero-friction front door (`uffs-tui`) so a new
+          # user can launch a UI on their own data without touching the CLI.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "🎁 Staging release bundle for ${{ matrix.target }}..."
+          set -euo pipefail
+          echo "🎁 Staging release bundles (min / normal / full) for ${{ matrix.target }}..."
 
-          STAGE_DIR="release-staging/${{ matrix.artifact-name }}"
-          mkdir -p "$STAGE_DIR/assets"
+          ARTIFACT="${{ matrix.artifact-name }}"   # e.g. uffs-windows-x64
+          TRIPLE="${{ matrix.target }}"
+          OS="${{ matrix.os }}"
+          BINDIR="target/${TRIPLE}/release"
+          PLAT="${ARTIFACT#uffs-}"                 # windows-x64 / macos-arm64 / linux-x64
+          if [[ "$OS" == "windows-latest" ]]; then EXT=".exe"; else EXT=""; fi
 
-          # ── Binaries ───────────────────────────────────────────────────────
-          # Same shipping set as `Package binaries` above.  Diagnostic
-          # binaries (uffs-diag) stay workspace-only and are not shipped.
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            for bin in uffs.exe uffsd.exe uffsmcp.exe uffs-mft.exe; do
-              if [[ -f "target/${{ matrix.target }}/release/$bin" ]]; then
-                cp "target/${{ matrix.target }}/release/$bin" "$STAGE_DIR/"
-              fi
-            done
+          # Diagnostic tools (uffs-diag) — built by `--workspace --bins`
+          # above; shipped ONLY in the `full` tier.  Kept in lockstep with
+          # ALL_BINARIES in scripts/ci/build-cross-all.rs.
+          DIAG_BINS=(analyze-mft-parents dump-mft-records scan-mft-magic \
+                     dump-mft-extents cross-check-mft-reference compare-raw-mft \
+                     inspect-mft-record-flow analyze-diff compare-scan-parity \
+                     verify-iocp-capture)
+
+          # ── Fetch the free demo TUI (non-fatal) ────────────────────────────
+          # Bundled into EVERY tier so `uffs-tui` works straight out of the
+          # zip.  If the asset is missing or the download fails, we emit a
+          # warning and ship the engine bundles WITHOUT the demo — a
+          # demo-repo hiccup must never block an engine release.
+          mkdir -p demo
+          DEMO_ASSET="uffs_tui-demo-${PLAT}${EXT}"
+          DEMO_BIN=""
+          if gh release download --repo githubrobbi/uffs-demo \
+               --pattern "$DEMO_ASSET" --dir demo --clobber; then
+            DEMO_BIN="demo/${DEMO_ASSET}"
+            chmod +x "$DEMO_BIN" 2>/dev/null || true
+            echo "✅ Fetched demo TUI: ${DEMO_ASSET}"
           else
-            for bin in uffs uffsd uffsmcp uffs-mft; do
-              if [[ -f "target/${{ matrix.target }}/release/$bin" ]]; then
-                cp "target/${{ matrix.target }}/release/$bin" "$STAGE_DIR/"
-              fi
-            done
+            echo "::warning title=Demo TUI unavailable::Could not fetch ${DEMO_ASSET} from githubrobbi/uffs-demo — shipping engine bundles without the bundled TUI demo."
           fi
 
-          # ── Documentation (common across every platform) ─────────────────────
-          cp README.md LICENSE TRADEMARK.md CHANGELOG.md "$STAGE_DIR/"
+          # ── Tier staging helper ────────────────────────────────────────────
+          #   $1 = zip basename (also the archive's single root dir)
+          #   $2 = tier: min | normal | full
+          stage_bundle() {
+            local zipbase="$1" tier="$2"
+            local stage="release-staging/${zipbase}"
+            rm -rf "$stage"; mkdir -p "$stage/assets"
 
-          # ── Platform-specific brand assets + packaging helpers ──────────────
-          case "${{ matrix.target }}" in
-            *-windows-*)
-              cp assets/brand/icons/uffs.ico     "$STAGE_DIR/assets/"
-              cp assets/brand/uffs-hero-1024.png "$STAGE_DIR/assets/"
-              ;;
-            *-apple-*)
-              cp assets/brand/icons/uffs.icns    "$STAGE_DIR/assets/"
-              cp assets/brand/uffs-hero-1024.png "$STAGE_DIR/assets/"
-              mkdir -p "$STAGE_DIR/packaging/macos"
-              cp packaging/macos/Info.plist.in   "$STAGE_DIR/packaging/macos/"
-              cp packaging/macos/bundle.sh       "$STAGE_DIR/packaging/macos/"
-              chmod +x "$STAGE_DIR/packaging/macos/bundle.sh"
+            # Engine binaries per tier.  ALL tiers include uffs + uffsd:
+            # the CLI auto-spawns the SEPARATE uffsd binary (find_daemon_exe
+            # in uffs-client) — `uffs` alone cannot search.
+            local engine_bins=()
+            case "$tier" in
+              min)    engine_bins=(uffs uffsd) ;;
+              normal) engine_bins=(uffs uffsd uffsmcp uffs-mft) ;;
+              full)   engine_bins=(uffs uffsd uffsmcp uffs-mft "${DIAG_BINS[@]}") ;;
+            esac
+            for b in "${engine_bins[@]}"; do
+              if [[ -f "${BINDIR}/${b}${EXT}" ]]; then
+                cp "${BINDIR}/${b}${EXT}" "$stage/"
+              fi
+            done
 
-              # Pre-build a ready-to-run UFFS.app inside the bundle so
-              # end users don't need to run bundle.sh themselves.  Runs
-              # the committed script from the repo root (not the staged
-              # copy) since bundle.sh expects repo-root-relative paths.
-              chmod +x packaging/macos/bundle.sh
-              packaging/macos/bundle.sh \
-                "target/${{ matrix.target }}/release/uffs" \
-                "$STAGE_DIR/UFFS.app"
-              ;;
-            *-linux-*)
-              cp -r assets/brand/icons/hicolor   "$STAGE_DIR/assets/"
-              cp assets/brand/uffs-hero-1024.png "$STAGE_DIR/assets/"
-              mkdir -p "$STAGE_DIR/packaging/linux"
-              cp packaging/linux/install.sh      "$STAGE_DIR/packaging/linux/"
-              cp packaging/linux/uffs.desktop    "$STAGE_DIR/packaging/linux/"
-              chmod +x "$STAGE_DIR/packaging/linux/install.sh"
-              ;;
-          esac
+            # Demo TUI — every tier, renamed to a clean `uffs-tui` command.
+            if [[ -n "$DEMO_BIN" && -f "$DEMO_BIN" ]]; then
+              cp "$DEMO_BIN" "$stage/uffs-tui${EXT}"
+            fi
 
-          echo "📂 Staging tree:"
-          find "$STAGE_DIR" -maxdepth 4 -type f | sort
+            # Licenses — engine (MPL-2.0) always; the demo notice is added
+            # only when the demo is actually present, so the mixed-license
+            # zip stays unambiguous.
+            cp LICENSE "$stage/"
+            if [[ -n "$DEMO_BIN" && -f packaging/DEMO-NOTICE.txt ]]; then
+              cp packaging/DEMO-NOTICE.txt "$stage/DEMO-LICENSE.txt"
+            fi
 
-          # ── ZIP the bundle ─────────────────────────────────────────────────
-          # 7z on Windows (pre-installed, no Git-Bash zip dependency);
-          # `zip` on macOS/Linux.  The ZIP goes straight into
-          # release-artifacts/ so the existing Upload step picks it up
-          # alongside the raw binaries.
-          #
-          # Both branches `cd release-staging` first so the archive's
-          # root entry is `${{ matrix.artifact-name }}/`, not
-          # `release-staging/${{ matrix.artifact-name }}/` — fixes #92,
-          # where the Windows ZIP previously contained the staging
-          # directory as a wrapper folder.
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            (cd release-staging && \
-             7z a -tzip \
-               "../release-artifacts/${{ matrix.artifact-name }}.zip" \
-               "${{ matrix.artifact-name }}" > /dev/null)
-          else
-            (cd release-staging && \
-             zip -rq "../release-artifacts/${{ matrix.artifact-name }}.zip" \
-                     "${{ matrix.artifact-name }}")
-          fi
+            # Docs + brand + packaging helpers — normal/full only; `min`
+            # stays a lean engine + TUI payload.
+            if [[ "$tier" != "min" ]]; then
+              cp README.md TRADEMARK.md CHANGELOG.md "$stage/"
+              case "$TRIPLE" in
+                *-windows-*)
+                  cp assets/brand/icons/uffs.ico     "$stage/assets/"
+                  cp assets/brand/uffs-hero-1024.png "$stage/assets/"
+                  ;;
+                *-apple-*)
+                  cp assets/brand/icons/uffs.icns    "$stage/assets/"
+                  cp assets/brand/uffs-hero-1024.png "$stage/assets/"
+                  mkdir -p "$stage/packaging/macos"
+                  cp packaging/macos/Info.plist.in   "$stage/packaging/macos/"
+                  cp packaging/macos/bundle.sh       "$stage/packaging/macos/"
+                  chmod +x "$stage/packaging/macos/bundle.sh"
+                  # Pre-build a ready-to-run UFFS.app inside the bundle so
+                  # end users don't need to run bundle.sh themselves.
+                  chmod +x packaging/macos/bundle.sh
+                  packaging/macos/bundle.sh \
+                    "${BINDIR}/uffs" "$stage/UFFS.app"
+                  ;;
+                *-linux-*)
+                  cp -r assets/brand/icons/hicolor   "$stage/assets/"
+                  cp assets/brand/uffs-hero-1024.png "$stage/assets/"
+                  mkdir -p "$stage/packaging/linux"
+                  cp packaging/linux/install.sh      "$stage/packaging/linux/"
+                  cp packaging/linux/uffs.desktop    "$stage/packaging/linux/"
+                  chmod +x "$stage/packaging/linux/install.sh"
+                  ;;
+              esac
+            fi
 
-          echo "📦 Bundle ZIP:"
-          ls -la "release-artifacts/${{ matrix.artifact-name }}.zip"
+            # ── ZIP the bundle ───────────────────────────────────────────────
+            # 7z on Windows (pre-installed, no Git-Bash zip dependency);
+            # `zip` on macOS/Linux.  `cd release-staging` first so the
+            # archive's root entry is `${zipbase}/`, not
+            # `release-staging/${zipbase}/` (fixes #92).
+            if [[ "$OS" == "windows-latest" ]]; then
+              (cd release-staging && \
+               7z a -tzip "../release-artifacts/${zipbase}.zip" "${zipbase}" > /dev/null)
+            else
+              (cd release-staging && \
+               zip -rq "../release-artifacts/${zipbase}.zip" "${zipbase}")
+            fi
+            echo "📦 ${zipbase}.zip:"; ls -la "release-artifacts/${zipbase}.zip"
+          }
 
-          # Clean up staging; only the ZIP needs to survive into the
-          # uploaded artifact.
-          rm -rf release-staging
+          # ── Emit the three tiers ────────────────────────────────────────────
+          # The `normal` zip keeps the bare `${ARTIFACT}.zip` name so the
+          # winget package (SkyLLC.UFFS, installers-regex
+          # `uffs-windows-x64\.zip$`) and backwards-compat download URLs are
+          # unchanged.  `min` and `full` are additive.
+          stage_bundle "${ARTIFACT}-min"  min
+          stage_bundle "${ARTIFACT}"      normal
+          stage_bundle "${ARTIFACT}-full" full
+
+          echo "📂 normal-tier staging tree:"
+          find "release-staging/${ARTIFACT}" -maxdepth 4 -type f | sort
+
+          # Clean up staging + downloaded demo; only the ZIPs survive into
+          # the uploaded artifact.
+          rm -rf release-staging demo
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -896,32 +949,48 @@ jobs:
           cross-platform, so macOS and Linux builds are shipped for
           **offline MFT analysis** from captured `.mft` / `.bin` snapshots.
 
-          Each platform ships as a **one-download ZIP bundle** with the
-          binaries, the UFFS brand assets, the full documentation set
-          (`README.md`, `LICENSE`, `TRADEMARK.md`, `CHANGELOG.md`), and
-          the platform's packaging helper.  Individual binaries are also
-          attached for automation that `wget`s a single file.
+          Each platform ships as a **one-download ZIP bundle** in three
+          tiers — pick the one that matches how much you need:
+
+          | Tier | Zip suffix | Contents |
+          |------|-----------|----------|
+          | **min** | `-min.zip` | `uffs` + `uffsd` + `uffs-tui` demo. Lean engine for CI/scripting. |
+          | **normal** | *(no suffix)* | min + `uffsmcp` + `uffs-mft` + docs + brand + packaging helper. **Recommended.** |
+          | **full** | `-full.zip` | normal + the `uffs-diag` diagnostic tools. |
+
+          > 🖥️ **Every tier bundles the free `uffs-tui` demo** — the
+          > zero-setup front door.  After unzipping, just run `uffs-tui`
+          > to browse your own drives in a UI (the daemon auto-starts).
+          > The demo has capped result counts and disabled exports; see
+          > `DEMO-LICENSE.txt` in the zip.  Full TUI/GUI are commercial.
+
+          Individual binaries are also attached for automation that
+          `wget`s a single file.
 
           ### 🟦 Windows x86_64 — primary live-indexing target
-          - **`uffs-windows-x64.zip`** — recommended: CLI + daemon + MCP
-            + MFT tooling + icon + docs.  The `.exe`s ship with the UFFS
-            icon and `asInvoker` manifest embedded.
+          - **`uffs-windows-x64.zip`** — recommended (normal tier): CLI +
+            daemon + MCP + MFT tooling + `uffs-tui` demo + icon + docs.
+            The `.exe`s ship with the UFFS icon and `asInvoker` manifest
+            embedded.  Also: `uffs-windows-x64-min.zip`,
+            `uffs-windows-x64-full.zip`.
           - Raw binaries: `uffs-windows-x64.exe`, `uffsd-windows-x64.exe`,
             `uffsmcp-windows-x64.exe`, `uffs-mft-windows-x64.exe`.
 
           ### 🍏 macOS Apple Silicon — offline MFT analysis
-          - **`uffs-macos-arm64.zip`** — recommended: raw binaries + a
-            ready-to-run `UFFS.app` bundle + icns + docs +
-            `packaging/macos/bundle.sh` for rebuilding.
+          - **`uffs-macos-arm64.zip`** — recommended (normal tier): raw
+            binaries + `uffs-tui` demo + a ready-to-run `UFFS.app` bundle
+            + icns + docs + `packaging/macos/bundle.sh` for rebuilding.
+            Also: `uffs-macos-arm64-min.zip`, `uffs-macos-arm64-full.zip`.
           - Raw binaries: `uffs-macos-arm64`, `uffsd-macos-arm64`,
             `uffsmcp-macos-arm64`, `uffs-mft-macos-arm64`.
           - Intel Macs: run the arm64 build under Rosetta 2.
 
           ### 🐧 Linux x86_64 — offline MFT analysis
-          - **`uffs-linux-x64.zip`** — recommended: binaries + full
-            hicolor icon tree + `packaging/linux/install.sh` (drops the
-            `.desktop` entry and icons under `/usr/local` with one
-            `sudo` invocation) + docs.
+          - **`uffs-linux-x64.zip`** — recommended (normal tier): binaries
+            + `uffs-tui` demo + full hicolor icon tree +
+            `packaging/linux/install.sh` (drops the `.desktop` entry and
+            icons under `/usr/local` with one `sudo` invocation) + docs.
+            Also: `uffs-linux-x64-min.zip`, `uffs-linux-x64-full.zip`.
           - Raw binaries: `uffs-linux-x64`, `uffsd-linux-x64`,
             `uffsmcp-linux-x64`, `uffs-mft-linux-x64`.
           - Use with `--mft-file` to analyse captured MFT snapshots on servers, forensics VMs, or in Docker.

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -13,8 +13,18 @@
 # The action clones the *previous* version's manifest as a template and
 # updates only the version, installer URL, SHA256, and release date — so
 # the nested-installer structure (InstallerType: zip / NestedInstallerType:
-# portable, the four PortableCommandAliases uffs/uffsd/uffsmcp/uffs-mft)
-# carries over automatically with no manifest authoring on our side.
+# portable, the PortableCommandAliases uffs/uffsd/uffsmcp/uffs-mft + the
+# bundled uffs-tui demo) carries over automatically with no manifest
+# authoring on our side.
+#
+# ── uffs-tui alias contract ──────────────────────────────────────────
+# komac PRESERVES NestedInstallerFiles across version bumps but does NOT
+# auto-add executables it finds in the zip.  The `uffs-tui` alias must be
+# SEEDED into the manifest ONCE — into the auto-generated PR for the first
+# release whose uffs-windows-x64.zip actually contains uffs-tui.exe — after
+# which every auto-release carries all five aliases forward.  Procedure +
+# idempotent patcher: packaging/winget/README.md and
+# scripts/dev/winget_add_tui_alias.sh.
 #
 # ── Required secret ──────────────────────────────────────────────────
 # `WINGET_TOKEN` — a **classic** Personal Access Token with the

--- a/README.md
+++ b/README.md
@@ -80,9 +80,13 @@ Each release ships pre-built binaries, a `CHECKSUMS.txt` (SHA256), per-crate SBO
 
 | Platform | Download | Notes |
 |---|---|---|
-| **Windows x64** | [`uffs-windows-x64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | CLI + daemon + MCP + MFT tools. Recommended. |
-| **macOS Apple Silicon** | [`uffs-macos-arm64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | Offline MFT analysis only. Includes `UFFS.app` bundle. |
-| **Linux x64** | [`uffs-linux-x64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | Offline MFT analysis only. Includes `install.sh`. |
+| **Windows x64** | [`uffs-windows-x64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | CLI + daemon + MCP + MFT tools + `uffs-tui` demo. Recommended. |
+| **macOS Apple Silicon** | [`uffs-macos-arm64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | Offline MFT analysis only. Includes `UFFS.app` bundle + `uffs-tui` demo. |
+| **Linux x64** | [`uffs-linux-x64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | Offline MFT analysis only. Includes `install.sh` + `uffs-tui` demo. |
+
+> 📦 **Three tiers per platform** — `…-min.zip` (just `uffs` + `uffsd` + the `uffs-tui` demo, for CI/scripting), the bare `….zip` (**recommended**: adds MCP + MFT tooling + docs), and `…-full.zip` (adds the `uffs-diag` diagnostic tools). Every tier bundles the free `uffs-tui` demo.
+
+> 🖥️ **Fastest way to try it — no CLI required.** Unzip any tier and run **`uffs-tui`**: the daemon auto-starts and you're browsing your own drives in a UI within seconds. The bundled TUI is the free demo (capped result counts, exports disabled — see `DEMO-LICENSE.txt`); full TUI/GUI are commercial.
 
 **Windows quick-install (one command) — via [WinGet](https://learn.microsoft.com/windows/package-manager/):**
 ```powershell
@@ -111,7 +115,7 @@ cargo build --release
 
 > 📖 **[Full installation guide](docs/user-manual/installation.md)** — WinGet, PATH setup, daemon autostart, Scoop (coming)
 
-> 🖥️ **Prefer a UI?** Free **demo** builds of the UFFS TUI and GUI (macOS, Linux, Windows) are at **[uffs-demo/releases](https://github.com/githubrobbi/uffs-demo/releases/latest)** — limited result counts, exports disabled. They drive this same open-source daemon. Full versions are commercial (see [Maintainership & Commercial](#maintainership--commercial)).
+> 🖥️ **Prefer a UI?** The free **`uffs-tui` demo is bundled in every release ZIP** above — just run `uffs-tui`. Standalone demo builds of the TUI **and GUI** (macOS, Linux, Windows) also live at **[uffs-demo/releases](https://github.com/githubrobbi/uffs-demo/releases/latest)** — limited result counts, exports disabled. They drive this same open-source daemon. Full versions are commercial (see [Maintainership & Commercial](#maintainership--commercial)).
 
 ---
 

--- a/packaging/DEMO-NOTICE.txt
+++ b/packaging/DEMO-NOTICE.txt
@@ -1,0 +1,44 @@
+UFFS TUI — DEMO BUILD: LICENSE & NOTICE
+=======================================
+
+This archive bundles a binary named `uffs-tui` (uffs-tui.exe on Windows).
+It is the FREE DEMO build of the UFFS terminal UI, provided for convenience
+as a zero-setup front door to the engine.
+
+WHAT IS COVERED BY THE MPL-2.0
+------------------------------
+Everything in this archive EXCEPT `uffs-tui` is part of UFFS Core — the
+open-source engine, daemon, CLI, MCP server, and MFT tooling — and is
+licensed under the Mozilla Public License 2.0 (see the accompanying
+`LICENSE` file). UFFS Core will never be made less open.
+
+WHAT THIS NOTICE COVERS
+-----------------------
+The `uffs-tui` demo binary is a SEPARATE, proprietary product. It is NOT
+part of UFFS Core and is NOT licensed under the MPL-2.0. It is distributed
+free of charge as a closed-source demonstration build with the following
+limitations:
+
+  * result counts are capped, and
+  * exports are disabled.
+
+The demo drives the same open-source UFFS daemon over the public IPC
+protocol; it adds no hidden functionality to the engine.
+
+  Copyright (c) 2025-2026 SKY, LLC. All rights reserved.
+
+  - Source repository for the demo: https://github.com/githubrobbi/uffs-demo
+  - The demo is versioned independently of the engine and may be built
+    against a specific UFFS core commit.
+
+REMOVING THE DEMO
+-----------------
+If you only want the open-source engine, delete the `uffs-tui` binary (and
+this `DEMO-LICENSE.txt`); the remaining files are entirely MPL-2.0. The
+`min` download tier ships the same engine without docs/brand assets.
+
+FULL / COMMERCIAL VERSIONS
+--------------------------
+Full-featured UFFS TUI and GUI products (no result caps, exports enabled)
+are commercial. See the project README ("Maintainership & Commercial") for
+details: https://github.com/skyllc-ai/UltraFastFileSearch

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,73 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 SKY, LLC.
+SPDX-License-Identifier: MPL-2.0
+-->
+# WinGet manifest — `uffs-tui` alias contract
+
+The `SkyLLC.UFFS` WinGet package is **auto-submitted** to `microsoft/winget-pkgs`
+by [`.github/workflows/winget-publish.yml`](../../.github/workflows/winget-publish.yml)
+on every release, via `winget-releaser` (komac under the hood). The package is a
+**zip → portable** installer that exposes its bundled binaries as typed commands
+through `NestedInstallerFiles` / `PortableCommandAlias`.
+
+The `normal`-tier zip (`uffs-windows-x64.zip`) now also bundles the free
+**`uffs-tui` demo**, and we want `winget install SkyLLC.UFFS` to expose it as a
+typed `uffs-tui` command alongside `uffs`, `uffsd`, `uffsmcp`, and `uffs-mft`.
+
+## Why this needs a one-time seed
+
+komac **preserves** the previous version's `NestedInstallerFiles` list when it
+bumps the package to a new version (komac v2.14.0 — *"Preserve nested installer
+metadata during version updates to preserve existing PortableCommandAlias"*).
+
+It does **not** scan the zip and auto-add newly-bundled executables. So the
+`uffs-tui` alias will never appear on its own — it must be added to the manifest
+**once**. After that, komac carries all five aliases forward on every
+auto-submitted release, and nothing further is required.
+
+## Hard precondition
+
+Only add the alias to a release whose `uffs-windows-x64.zip` **actually contains**
+`uffs-windows-x64/uffs-tui.exe` — i.e. the **first release built after** the
+min/normal/full tiering landed in `release.yml`. Adding it to an earlier version
+(whose zip has no `uffs-tui.exe`) makes the winget validation pipeline fail the
+install test.
+
+Confirm before seeding:
+
+```bash
+TAG=v0.5.XXX   # the first TUI-bundled release
+curl -fsSL -o /tmp/uffs.zip \
+  "https://github.com/skyllc-ai/UltraFastFileSearch/releases/download/${TAG}/uffs-windows-x64.zip"
+unzip -l /tmp/uffs.zip | grep -F 'uffs-windows-x64/uffs-tui.exe'   # must print a line
+```
+
+## One-time procedure
+
+1. After the first TUI-bundled release, `winget-publish.yml` dispatches
+   `winget-releaser`, which opens a PR to `microsoft/winget-pkgs` from the
+   `githubrobbi/winget-pkgs` fork bumping `SkyLLC.UFFS` to the new version (with
+   the existing four aliases).
+2. Check out that PR branch on the fork and run the idempotent patcher against
+   the new version's installer manifest:
+
+   ```bash
+   ./scripts/dev/winget_add_tui_alias.sh \
+     manifests/s/SkyLLC/UFFS/0.5.XXX/SkyLLC.UFFS.installer.yaml
+   ```
+
+   (Or hand-add the block from [`uffs-tui-nested-file.yaml`](uffs-tui-nested-file.yaml).)
+3. Commit + push to the PR branch, let the winget validation bot pass, and merge.
+4. Verify once the package indexes:
+
+   ```powershell
+   winget install --id SkyLLC.UFFS
+   uffs-tui --help
+   ```
+
+From then on, every release auto-keeps all five aliases — no manual step.
+
+## Future: `uffs-gui`
+
+When the GUI demo is bundled into the zip, repeat the same one-time seed with a
+`uffs-windows-x64/uffs-gui.exe` → `uffs-gui` entry.

--- a/packaging/winget/uffs-tui-nested-file.yaml
+++ b/packaging/winget/uffs-tui-nested-file.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025-2026 SKY, LLC.
+# SPDX-License-Identifier: MPL-2.0
+#
+# Canonical NestedInstallerFiles entry that exposes the bundled `uffs-tui`
+# demo as a typed WinGet command (`uffs-tui`).
+#
+# This is the SINGLE source of truth for the alias.  It must be SEEDED ONCE
+# into the SkyLLC.UFFS installer manifest (see ./README.md); thereafter komac
+# preserves it across every auto-submitted release.
+#
+# RelativeFilePath is rooted at the zip's single top-level directory
+# (`uffs-windows-x64/`), which is unchanged by the min/normal/full tiering —
+# the winget package always points at the `normal` zip (`uffs-windows-x64.zip`).
+
+- RelativeFilePath: uffs-windows-x64/uffs-tui.exe
+  PortableCommandAlias: uffs-tui

--- a/scripts/dev/winget_add_tui_alias.sh
+++ b/scripts/dev/winget_add_tui_alias.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025-2026 SKY, LLC.
+# SPDX-License-Identifier: MPL-2.0
+#
+# Idempotently insert the `uffs-tui` PortableCommandAlias into a WinGet
+# `SkyLLC.UFFS.installer.yaml` manifest.
+#
+# WHY THIS EXISTS
+# ---------------
+# `winget-publish.yml` auto-submits the SkyLLC.UFFS manifest via
+# winget-releaser (komac).  komac PRESERVES the previous version's
+# NestedInstallerFiles/PortableCommandAlias list across updates
+# (komac v2.14.0: "Preserve nested installer metadata"), but it does NOT
+# auto-add new executables it finds in the zip.  So the `uffs-tui` alias
+# must be seeded into the manifest exactly ONCE — into the auto-generated
+# PR for the first release whose `uffs-windows-x64.zip` actually contains
+# `uffs-windows-x64/uffs-tui.exe`.  After that, every auto-release carries
+# all five aliases forward and this script is no longer needed.
+#
+# USAGE
+# -----
+#   scripts/dev/winget_add_tui_alias.sh <path/to/SkyLLC.UFFS.installer.yaml>
+#
+# Typical flow (one-time):
+#   1. After the first TUI-bundled release, winget-releaser opens a PR to
+#      microsoft/winget-pkgs from the githubrobbi/winget-pkgs fork.
+#   2. Check out that PR branch on the fork.
+#   3. Run this script against the new version's installer manifest, e.g.:
+#        ./scripts/dev/winget_add_tui_alias.sh \
+#          manifests/s/SkyLLC/UFFS/0.5.108/SkyLLC.UFFS.installer.yaml
+#   4. Commit + push to the PR branch; let validation pass; merge.
+#   5. Verify:  winget install --id SkyLLC.UFFS  &&  uffs-tui --help
+#
+# The script is safe to re-run: if the alias is already present it exits 0
+# without modifying the file.
+set -euo pipefail
+
+MANIFEST="${1:-}"
+if [[ -z "$MANIFEST" ]]; then
+  echo "Usage: $0 <path/to/SkyLLC.UFFS.installer.yaml>" >&2
+  exit 2
+fi
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "❌ Manifest not found: $MANIFEST" >&2
+  exit 1
+fi
+
+# Already seeded? Nothing to do.
+if grep -q 'uffs-tui\.exe' "$MANIFEST"; then
+  echo "✅ uffs-tui alias already present in $MANIFEST — nothing to do."
+  exit 0
+fi
+
+# Sanity: this must be the SkyLLC.UFFS portable-in-zip installer manifest.
+if ! grep -q '^NestedInstallerFiles:' "$MANIFEST"; then
+  echo "❌ $MANIFEST has no 'NestedInstallerFiles:' section — wrong file?" >&2
+  exit 1
+fi
+if ! grep -q 'PackageIdentifier: SkyLLC.UFFS' "$MANIFEST"; then
+  echo "❌ $MANIFEST is not the SkyLLC.UFFS manifest." >&2
+  exit 1
+fi
+
+# Insert the two-line nested-file block immediately after the
+# `NestedInstallerFiles:` key so it joins the existing alias list.
+tmp="$(mktemp)"
+awk '
+  /^NestedInstallerFiles:[[:space:]]*$/ {
+    print
+    print "- RelativeFilePath: uffs-windows-x64/uffs-tui.exe"
+    print "  PortableCommandAlias: uffs-tui"
+    next
+  }
+  { print }
+' "$MANIFEST" > "$tmp"
+mv "$tmp" "$MANIFEST"
+
+echo "✅ Added uffs-tui PortableCommandAlias to $MANIFEST"
+echo "   Review the diff, commit, and push to the winget-pkgs PR branch."


### PR DESCRIPTION
## Summary

Make UFFS installs front-door friendly: every release ZIP now bundles the free **`uffs-tui` demo**, and each platform ships in three tiers.

### Release bundles (`release.yml`)
- **min** (`uffs-<plat>-min.zip`): `uffs` + `uffsd` + `uffs-tui` — lean engine for CI/scripting.
- **normal** (`uffs-<plat>.zip`, **unchanged name/contents superset**): adds `uffsmcp` + `uffs-mft` + docs + brand + packaging helper. Recommended.
- **full** (`uffs-<plat>-full.zip`): adds the `uffs-diag` diagnostic tools.
- The demo TUI is fetched **non-fatally** from public `githubrobbi/uffs-demo` (`uffs_tui-demo-<plat>`) and bundled as `uffs-tui` in **every** tier. A demo-repo hiccup warns but never blocks an engine release.
- `packaging/DEMO-NOTICE.txt` → `DEMO-LICENSE.txt` in each zip keeps the MPL-2.0 / proprietary-demo boundary unambiguous.

### WinGet (`winget-publish.yml` + tooling)
- komac **preserves** `NestedInstallerFiles`/`PortableCommandAlias` across version bumps but does **not** auto-add new zip executables, so the `uffs-tui` alias must be **seeded once**; thereafter all five aliases carry forward automatically.
- `scripts/dev/winget_add_tui_alias.sh` — idempotent, validated patcher.
- `packaging/winget/README.md` — one-time seed procedure + hard precondition (the release zip must already contain `uffs-tui.exe`).

## Compatibility
- `normal` zip name (`uffs-windows-x64.zip`), root dir, and its 4 binaries are **unchanged**, so the winget installer regex and backwards-compat download URLs keep working. `min`/`full` are purely additive.

## Notes
- No Rust touched (CI/docs/packaging only). Pre-push gate passed all checks incl. the full Rust suite.
- The winget alias seed is a **one-time** manual step **after** the first release built from this branch ships a TUI-containing zip — see `packaging/winget/README.md`.