### PR TITLE
fix(winget): preserve CRLF line endings in uffs-tui alias patcher

### DIFF
--- a/scripts/dev/winget_add_tui_alias.sh
+++ b/scripts/dev/winget_add_tui_alias.sh
@@ -61,14 +61,24 @@ if ! grep -q 'PackageIdentifier: SkyLLC.UFFS' "$MANIFEST"; then
   exit 1
 fi
 
+# winget-pkgs manifests use CRLF line endings; mixing LF into them trips
+# the pipeline's "Validation-Line-Endings-Error".  Detect the manifest's
+# convention and emit the two inserted lines with a matching terminator so
+# the file stays uniform.  (awk preserves the trailing CR on existing
+# lines because the default record separator is LF.)
+cr=''
+if grep -q $'\r$' "$MANIFEST"; then
+  cr=$'\r'
+fi
+
 # Insert the two-line nested-file block immediately after the
 # `NestedInstallerFiles:` key so it joins the existing alias list.
 tmp="$(mktemp)"
-awk '
+awk -v cr="$cr" '
   /^NestedInstallerFiles:[[:space:]]*$/ {
     print
-    print "- RelativeFilePath: uffs-windows-x64/uffs-tui.exe"
-    print "  PortableCommandAlias: uffs-tui"
+    printf "%s%s\n", "- RelativeFilePath: uffs-windows-x64/uffs-tui.exe", cr
+    printf "%s%s\n", "  PortableCommandAlias: uffs-tui", cr
     next
   }
   { print }


### PR DESCRIPTION
## Problem

`scripts/dev/winget_add_tui_alias.sh` inserted the `uffs-tui` alias lines via `awk`, which emits **LF**. winget-pkgs manifests are **CRLF**, so the patched file had mixed line endings and tripped the validation pipeline's **`Validation-Line-Endings-Error`**.

Hit live while seeding the alias on **microsoft/winget-pkgs#382689** (SkyLLC.UFFS 0.5.109): 30 CRLF lines + the 2 LF-only inserted lines. Already fixed *on that PR* by re-normalizing the manifest to uniform CRLF; this PR fixes the **tool** so it can't recur.

## Fix

Detect the manifest's existing line ending and emit the two inserted lines with a matching terminator (`awk` already preserves the trailing CR on existing records since `RS=LF`).

## Verification

- CRLF fixture in -> uniform CRLF out (32/32 lines, 0 LF-only).
- LF input stays LF.
- Still idempotent; `shellcheck` clean.

No Rust touched.