### PR TITLE
docs(readme): wire live sponsor channels + add no-telemetry trust bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
   <a href="https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest"><img src="https://img.shields.io/github/downloads/skyllc-ai/UltraFastFileSearch/total?label=downloads" alt="Total Downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg" alt="License: MPL 2.0"></a>
   <a href="https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest"><img src="https://img.shields.io/badge/platform-Windows-blue.svg" alt="Platform: Windows"></a>
+  <a href="https://opencollective.com/uffs-search"><img src="https://img.shields.io/badge/Sponsor-Open%20Collective-3385FF?logo=opencollective&logoColor=white" alt="Sponsor on Open Collective"></a>
+  <a href="https://ko-fi.com/ufffssearch"><img src="https://img.shields.io/badge/Tip-Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Tip on Ko-fi"></a>
 </p>
 
 **A benchmark-driven NTFS search engine for Windows.** UFFS reads the Master File Table directly, builds a compact persisted index, and keeps large NTFS estates searchable through a background daemon.
@@ -41,6 +43,7 @@ UFFS is built for **exact filename, path, and metadata search** at scales where 
 - 🔍 **40+ filters** — size, date, extension, type, attributes, path length, tree size, regex
 - 🧩 **One engine, multiple interfaces** — CLI, TUI, daemon, API, and MCP share the same index
 - 🧭 **Deterministic local scope** — built for exact NTFS filename/path/metadata search, not fuzzy ranking
+- 🔒 **No telemetry, fully local** — UFFS makes no outbound network calls; your index and queries never leave your machine (the optional MCP gateway binds a local-only port you explicitly enable)
 - 🖥️ **Cross-platform offline analysis** — live NTFS on Windows; offline MFT analysis on macOS and Linux
 
 ---
@@ -274,7 +277,7 @@ UFFS is developed and maintained by **[Sky, LLC](https://github.com/skyllc-ai)**
 
 - **Commercial UFFS frontends** (polished GUI / premium TUI) are in development on top of this open-source engine. For waitlist or partnership inquiries: [`uffs@nios.net`](mailto:uffs@nios.net) or open a [discussion](https://github.com/skyllc-ai/UltraFastFileSearch/discussions) with the `commercial-interest` label.
 - **Hiring / collaboration.** This repository is also the public engineering portfolio of its maintainer; see the [Sky, LLC org page](https://github.com/skyllc-ai) for the full pitch and contact details.
-- **Sponsorship.** Formal sponsor channels (GitHub Sponsors, Ko-fi) are being set up. Star the repo and watch for the sponsor CTA to appear here once approvals land.
+- **Sponsorship.** UFFS is free and MPL-2.0 forever; sponsorships fund Windows code-signing, benchmark hardware, and release engineering. **Companies** (invoice / receipt via Sky, LLC): [Open Collective](https://opencollective.com/uffs-search). **One-time tip:** [Ko-fi](https://ko-fi.com/ufffssearch). Individual recurring tiers via **GitHub Sponsors** are being enrolled — the repo "Sponsor" button already lists the live channels above.
 
 ## Acknowledgments
 


### PR DESCRIPTION
## What
- Replace the stale `Sponsorship` placeholder ("channels are being set up") with the **live** channels: Open Collective (companies, invoiced via Sky, LLC) + Ko-fi (one-time tips).
- Add matching **Open Collective** + **Ko-fi** badges to the README header.
- Add a grounded **"No telemetry, fully local"** bullet to *Why UFFS?*.

## Why
Open Collective + Ko-fi are already live in `.github/FUNDING.yml` and on the repo Sponsor button, but the README still told readers funding wasn't set up. GitHub Sponsors (individual recurring tiers) is still enrolling and is noted as such.

## Grounding for the privacy claim
Verified no HTTP-client deps (`reqwest`/`hyper`/`ureq`/`sentry`/etc.) in the product crates. The only sockets are the **opt-in, local-only** MCP gateway (`uffs-mcp` binds localhost; the CLI `/status` probe is feature-gated and off by default). No outbound network, no analytics.

## Scope
Docs only. No code or behavior changes.