### PR TITLE
docs(demo): add reproducible demo-capture kit for TUI + CLI GIFs

### DIFF
--- a/scripts/dev/demo/README.md
+++ b/scripts/dev/demo/README.md
@@ -1,0 +1,116 @@
+# UFFS demo capture kit
+
+Tooling and shot lists for the two Phase 1 launch GIFs:
+
+1. **TUI quick-start** — the zero-friction "front door" (hero on README + site).
+2. **CLI speed** — raw query latency across a real NTFS estate (proof clip for HN / Reddit / Rust).
+
+Everything here is built so the clips are **reproducible**, **honest**, and **re-renderable** each release. Capture must run on the Windows box with live NTFS (the only place `uffs` reads the MFT directly); macOS/Linux can only show offline-MFT analysis.
+
+---
+
+## TL;DR
+
+```powershell
+# 1. Put the machine in a known, honest recording state (Windows, elevated)
+pwsh -File scripts/dev/demo/record_demo_prep.ps1 -Mode hot
+
+# 2a. Scripted, reproducible CLI GIF (recommended — re-render every release):
+vhs scripts/dev/demo/cli-demo.tape      # -> uffs-cli.gif
+
+# 2b. TUI GIF — record interactively with ScreenToGif (see "TUI capture") ,
+#     or try the VHS skeleton once keybindings are filled in:
+vhs scripts/dev/demo/tui-demo.tape       # -> uffs-tui.gif
+
+# 3. Drop outputs into both repos and wire them in (see "Where the GIFs go")
+```
+
+---
+
+## Recorders
+
+| Tool | Use for | Why | Platform |
+|---|---|---|---|
+| **[VHS](https://github.com/charmbracelet/vhs)** (`charmbracelet/vhs`) | CLI clip (primary) | Scripted `.tape` files → deterministic, pixel-stable GIF/MP4/WebM you can re-render every release. Drives the **real** binary, so all timings are genuine. | Best on Linux/macOS; Windows support is best-effort (needs `ttyd` + `ffmpeg`). If VHS misbehaves on Windows, record the CLI with ScreenToGif using the same shot list. |
+| **[ScreenToGif](https://www.screentogif.com/)** | TUI clip (primary), CLI fallback | Free, Windows-native, captures a real interactive TUI session faithfully; built-in crop/trim/optimize + palette reduction. | Windows |
+| `ffmpeg` | post-processing | Trim, scale, palette-optimize any capture (snippets below). | All |
+
+Install on Windows: `winget install charmbracelet.vhs` (if available) and `winget install NickeManarin.ScreenToGif`.
+
+---
+
+## Honesty guardrails (non-negotiable)
+
+These clips are marketing for a **benchmark-honest** project. Do not undermine that.
+
+- **Never fake or speed-edit latency.** VHS runs the real binary; with ScreenToGif, do not cut frames to make a query look faster than it is.
+- **State the daemon tier.** The "instant" story is a **hot/warm daemon**. `record_demo_prep.ps1 -Mode hot` warms it first; the caption must say so (e.g. "hot daemon, 25.9M records"). If you want to show the cold build, use `-Mode cold` and label it COLD.
+- **Show real counts.** Don't trim the result count or the "N results in X ms" line out of frame.
+- **Match the published numbers.** Latency on screen should be consistent with `docs/benchmarks/`. If it drifts, update the benchmark hub too — don't cherry-pick.
+- **No doctored prompt.** Use a clean but real shell; don't hand-edit the recorded text.
+
+---
+
+## CLI shot list (`cli-demo.tape`)
+
+Target ~18–22 s. Commands mirror the README Quick Start so the clip and docs agree.
+
+1. `uffs "*.rs"` — whole-machine search, all drives, returns immediately.
+2. `uffs "*.log" --min-size 100MB --newer 7d --files-only` — filtered hunt for big recent logs.
+3. `uffs "*.dll" --drive C` — single-drive scope.
+4. `uffs daemon status_drives` — show the per-drive tier/telemetry table (proves the hot-daemon architecture).
+
+Caption to burn in or use as alt text: **"UFFS — targeted NTFS queries in single-digit ms on a hot daemon (25.9M records, 7 drives)."**
+
+---
+
+## TUI capture (`tui-demo.tape` / ScreenToGif)
+
+Target ~15–20 s. The story is **"unzip → run → browsing your own drives in seconds."**
+
+Shot list:
+1. Terminal in an unzipped release folder. Type `uffs-tui` and Enter.
+2. Daemon auto-starts; the TUI comes up populated with the real drives.
+3. Type a query (e.g. `*.pdf`), show the results list filtering live.
+4. Arrow through a couple of results / toggle a filter.
+5. Quit cleanly.
+
+> The bundled `uffs-tui` is the **free demo** (capped result counts, exports disabled — `DEMO-LICENSE.txt`). That's fine and honest for the front-door clip; don't imply uncapped/export features.
+
+**Why ScreenToGif for the TUI:** interactive navigation reads more authentically when a human drives it, and the demo TUI's keybindings live in the separate [`githubrobbi/uffs-demo`](https://github.com/githubrobbi/uffs-demo) repo (not vendored here), so the VHS tape ships as a **skeleton** — fill in the real keystrokes once, then it's reproducible too.
+
+---
+
+## Where the GIFs go
+
+Keep the heavy binaries out of git history where possible; prefer the smallest optimized GIF (< ~3 MB) or an MP4/WebM.
+
+| Output | Location | Wires into |
+|---|---|---|
+| `uffs-tui.gif` | `assets/demo/uffs-tui.gif` (this repo) **and** `skyllc-ai.github.io/assets/demo/uffs-tui.gif` | README hero block; site hero/section |
+| `uffs-cli.gif` | `assets/demo/uffs-cli.gif` (this repo) | README "Benchmark snapshot" area; HN/Reddit posts |
+
+README wiring (hero):
+
+```markdown
+<p align="center">
+  <img src="assets/demo/uffs-tui.gif" alt="UFFS TUI: unzip, run uffs-tui, and browse your real NTFS drives in seconds (hot daemon, 25.9M records).">
+</p>
+```
+
+Site wiring: add an `<img>` in the hero or a dedicated demo section of `index.html`, served from `assets/demo/`.
+
+---
+
+## Post-processing snippets
+
+```bash
+# Trim to a clean window (start 00:02, length 18s) from an MP4 capture
+ffmpeg -ss 00:00:02 -t 18 -i raw.mp4 -an trimmed.mp4
+
+# MP4 -> optimized GIF (palette pass keeps it crisp + small)
+ffmpeg -i trimmed.mp4 -vf "fps=15,scale=1200:-1:flags=lanczos,palettegen" palette.png
+ffmpeg -i trimmed.mp4 -i palette.png -vf "fps=15,scale=1200:-1:flags=lanczos,paletteuse" uffs-cli.gif
+```
+
+Aim for: 1200px wide, 12–15 fps, < 3 MB. If a clip won't fit under ~5 MB as a GIF, ship an MP4/WebM and let GitHub/the site autoplay it.

--- a/scripts/dev/demo/cli-demo.tape
+++ b/scripts/dev/demo/cli-demo.tape
@@ -1,0 +1,54 @@
+# UFFS CLI speed demo — VHS tape (charmbracelet/vhs)
+# Render:  vhs scripts/dev/demo/cli-demo.tape   ->  uffs-cli.gif
+#
+# Runs the REAL `uffs` binary, so every latency on screen is genuine.
+# Prereqs:
+#   - `uffs` (and `uffsd`) on PATH
+#   - daemon WARMED before recording:  pwsh -File scripts/dev/demo/record_demo_prep.ps1 -Mode hot
+#   - VHS + ffmpeg installed
+#
+# Honesty: this clip shows the HOT-DAEMON path. Keep the "hot daemon" caption
+# in README/site alt text. Do not edit frames to alter timings.
+
+Output uffs-cli.gif
+
+Set Shell "pwsh"
+Set FontSize 20
+Set Width 1200
+Set Height 640
+Set Padding 24
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 45ms
+Set PlaybackSpeed 1.0
+
+# Settle on a clean prompt
+Hide
+Type "clear" Enter
+Show
+Sleep 600ms
+
+# 1) Whole-machine search across every drive — returns immediately
+Type "uffs ""*.rs"""
+Sleep 400ms
+Enter
+Sleep 2500ms
+
+# 2) Filtered hunt: big, recent log files only
+Type "uffs ""*.log"" --min-size 100MB --newer 7d --files-only"
+Sleep 400ms
+Enter
+Sleep 2800ms
+
+# 3) Single-drive scope
+Type "uffs ""*.dll"" --drive C"
+Sleep 400ms
+Enter
+Sleep 2500ms
+
+# 4) Prove the architecture: per-drive tier + telemetry table (the hot daemon)
+Type "uffs daemon status_drives"
+Sleep 400ms
+Enter
+Sleep 3500ms
+
+Sleep 1s

--- a/scripts/dev/demo/record_demo_prep.ps1
+++ b/scripts/dev/demo/record_demo_prep.ps1
@@ -1,0 +1,115 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Put a Windows box into a known, HONEST state before recording a UFFS demo clip.
+
+.DESCRIPTION
+    The launch demo GIFs (see scripts/dev/demo/README.md) must show real,
+    reproducible behaviour. This script warms (or, on request, cools) the UFFS
+    daemon and prints the exact recorder settings so every capture is consistent
+    and the on-screen latency matches docs/benchmarks/.
+
+    It only calls DOCUMENTED `uffs` commands. It is non-destructive by default;
+    the cold path (which deletes on-disk caches) is gated behind -ConfirmDestructive.
+
+.PARAMETER Mode
+    hot   (default) Restart the daemon and warm it so targeted queries answer from
+                    memory. This is the "instant" story — caption your clip
+                    "hot daemon, <N> records".
+    cold            Show the cold MFT build path. DESTRUCTIVE: evicts caches for the
+                    target drives so the next search rebuilds from raw MFT
+                    (tens of seconds). Requires -ConfirmDestructive.
+
+.PARAMETER Drives
+    Drive letters to warm/preload (hot) or forget (cold). Default: C.
+
+.PARAMETER ConfirmDestructive
+    Required to actually run Mode=cold (which deletes on-disk caches).
+
+.EXAMPLE
+    pwsh -File scripts/dev/demo/record_demo_prep.ps1 -Mode hot -Drives C,D
+
+.EXAMPLE
+    pwsh -File scripts/dev/demo/record_demo_prep.ps1 -Mode cold -Drives D -ConfirmDestructive
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('hot', 'cold')]
+    [string]$Mode = 'hot',
+
+    [string[]]$Drives = @('C'),
+
+    [switch]$ConfirmDestructive
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+function Write-Warn($msg) { Write-Host "!!  $msg" -ForegroundColor Yellow }
+
+# --- locate uffs ------------------------------------------------------------
+$uffs = Get-Command uffs -ErrorAction SilentlyContinue
+if (-not $uffs) {
+    throw "'uffs' is not on PATH. Unzip a release and add its folder to PATH, then re-run."
+}
+Write-Step "Using uffs: $($uffs.Source)"
+& uffs --version
+
+# --- recorder settings (print, don't enforce) -------------------------------
+Write-Host ""
+Write-Step "Recommended recorder settings (keep every clip consistent):"
+Write-Host @"
+  Terminal      : Windows Terminal, single tab, no split panes
+  Window size   : 1200 x 640 (CLI)  /  1280 x 720 (TUI)
+  Font          : Cascadia Mono / Cascadia Code, size 18-20
+  Theme         : dark, high-contrast (e.g. One Half Dark / Catppuccin Mocha)
+  FPS / width   : 12-15 fps, export at 1200px wide, target < 3 MB GIF
+  Recorder      : ScreenToGif (TUI + fallback) | VHS tapes (CLI, reproducible)
+"@ -ForegroundColor DarkGray
+
+# --- mode -------------------------------------------------------------------
+switch ($Mode) {
+    'hot' {
+        Write-Host ""
+        Write-Step "Mode=hot — warming the daemon so targeted queries answer from memory."
+        Write-Step "Restarting daemon for a clean, known state..."
+        & uffs daemon restart
+
+        foreach ($d in $Drives) {
+            Write-Step "Preloading drive $d and pinning it for the recording window..."
+            & uffs daemon preload $d --pin-minutes 60
+        }
+
+        Write-Step "Priming the query path (these warm-up results are NOT part of the clip)..."
+        & uffs "*.rs"            | Out-Null
+        & uffs "*.dll" --drive ($Drives[0]) | Out-Null
+
+        Write-Host ""
+        Write-Step "Current tier / telemetry (this is the table the CLI clip shows):"
+        & uffs daemon status_drives
+
+        Write-Host ""
+        Write-Host "READY (hot). Caption the clip as a HOT daemon over your real record count." -ForegroundColor Green
+        Write-Warn "Honesty: do not edit frames to alter latency; the numbers on screen must stand."
+    }
+
+    'cold' {
+        Write-Host ""
+        Write-Warn "Mode=cold is DESTRUCTIVE: it evicts on-disk caches for: $($Drives -join ', ')"
+        Write-Warn "The next search rebuilds from raw MFT (tens of seconds). Indexes are re-buildable, but this is not instant."
+        if (-not $ConfirmDestructive) {
+            throw "Refusing to run cold mode without -ConfirmDestructive. Re-run with that switch if you really want the cold-build clip."
+        }
+        foreach ($d in $Drives) {
+            Write-Step "Forgetting drive $d (evict + delete on-disk caches)..."
+            & uffs daemon forget $d --force
+        }
+        Write-Host ""
+        Write-Host "READY (cold). Your next 'uffs' query will now show the COLD build path." -ForegroundColor Green
+        Write-Warn "Label the clip COLD and show the full build time honestly."
+    }
+}
+
+Write-Host ""
+Write-Step "Next: render the CLI clip with  vhs scripts/dev/demo/cli-demo.tape"
+Write-Step "      record the TUI clip per scripts/dev/demo/README.md (ScreenToGif)."

--- a/scripts/dev/demo/tui-demo.tape
+++ b/scripts/dev/demo/tui-demo.tape
@@ -1,0 +1,54 @@
+# UFFS TUI quick-start demo — VHS tape SKELETON (charmbracelet/vhs)
+# Render:  vhs scripts/dev/demo/tui-demo.tape   ->  uffs-tui.gif
+#
+# STATUS: skeleton. The bundled `uffs-tui` is the free demo binary built in the
+# separate githubrobbi/uffs-demo repo, so its exact keybindings are not vendored
+# here. Fill in the `# TODO` keystrokes ONCE (confirm against the running TUI),
+# then this clip is reproducible too.
+#
+# If filling keybindings is fiddly, just record the TUI interactively with
+# ScreenToGif using the shot list in README.md — that is the supported path.
+#
+# Prereqs:
+#   - `uffs-tui` (and `uffs`/`uffsd`) on PATH, ideally from an unzipped release
+#   - daemon warmed:  pwsh -File scripts/dev/demo/record_demo_prep.ps1 -Mode hot
+#
+# Honesty: the demo TUI caps result counts and disables exports (DEMO-LICENSE.txt).
+# Don't imply uncapped/export behaviour in this clip.
+
+Output uffs-tui.gif
+
+Set Shell "pwsh"
+Set FontSize 18
+Set Width 1280
+Set Height 720
+Set Padding 20
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 45ms
+
+# Story: "unzip -> run -> browsing your real drives in seconds"
+Hide
+Type "clear" Enter
+Show
+Sleep 600ms
+
+# Launch the TUI; the daemon auto-starts and the UI populates with real drives
+Type "uffs-tui"
+Sleep 400ms
+Enter
+Sleep 3500ms          # let the daemon attach + the UI render
+
+# TODO: type a query into the TUI's search field (confirm focus behaviour)
+Type "*.pdf"
+Sleep 2500ms          # results filter live
+
+# TODO: navigate results — replace with the demo TUI's real keys
+Down
+Down
+Sleep 1500ms
+
+# TODO: optionally toggle a filter / panel here
+
+# TODO: quit cleanly — replace with the demo TUI's real quit key (often q or Ctrl+C)
+Type "q"
+Sleep 1500ms


### PR DESCRIPTION
## What
Adds a tracked, Windows-first capture kit (in `scripts/dev/demo/`, since `docs/dev` is gitignored) for the two Phase 1 launch GIFs the marketing plan calls for:

- **TUI quick-start** clip (hero on README + site)
- **CLI speed** clip (proof for HN / Reddit / Rust)

## Contents
- `README.md` — recorder choices (VHS for the CLI, ScreenToGif for the interactive TUI), exact shot lists, **honesty guardrails**, output paths + README/site wiring, and ffmpeg optimize snippets.
- `cli-demo.tape` — VHS tape that drives the **real** `uffs` binary through the README Quick Start queries + `daemon status_drives`, so every on-screen latency is genuine.
- `tui-demo.tape` — VHS **skeleton** for the unzip→run→browse story (keystrokes marked TODO because the demo TUI lives in `githubrobbi/uffs-demo`, not vendored here).
- `record_demo_prep.ps1` — puts the Windows box in a known state: non-destructive **hot** warm-up (real `daemon restart` / `preload` / `status_drives`) and a `-ConfirmDestructive`-gated **cold** path; prints consistent recorder settings.

## Honesty
The kit forbids frame-edited timings, requires labelling the daemon tier (hot vs cold), and ties on-screen numbers to `docs/benchmarks/`. Uses only documented `uffs daemon` subcommands (verified in `crates/uffs-cli`).

## Follow-up (not in this PR — needs your Windows box)
Record the two clips, drop them at `assets/demo/uffs-{tui,cli}.gif`, and wire the hero `<img>` into README + site.