### PR TITLE
fix(mft): harden all 5 NTFS parsers against panic-on-malformed-bytes (WI-5.2)

### DIFF
--- a/crates/uffs-mft/src/io/parser/fragment.rs
+++ b/crates/uffs-mft/src/io/parser/fragment.rs
@@ -3,6 +3,17 @@
 
 //! Legacy direct-to-fragment parser bridge.
 //! Preserves the parallel parser surface used before fragment merge.
+//!
+//! # Hardening (WI-5.2)
+//! This module parses **untrusted on-disk bytes**. Every offset/length derived
+//! from those bytes is combined with `checked_add`/`checked_mul` (or
+//! `saturating_*` where overflow is provably unreachable) and every slice into
+//! `data` goes through `.get()` / the `rd_u*` helpers — never `data[a..b]`
+//! indexing. The daemon builds with `panic = "abort"`, so a single parser panic
+//! on a malformed record would be a whole-process denial of service.
+//! `arithmetic_side_effects` is enabled module-wide as a regression guard: any
+//! new raw `+`/`*` on a byte-derived value is a compile error here.
+#![warn(clippy::arithmetic_side_effects)]
 
 use core::mem::size_of;
 
@@ -40,7 +51,11 @@ use crate::ntfs::{
 #[expect(
     clippy::indexing_slicing,
     clippy::missing_asserts_for_indexing,
-    reason = "all slice access is bounds-guarded by while-loop condition and per-access length checks"
+    reason = "the only `[]` indexing that remains is into internal arena vectors \
+              (fragment.links / fragment.streams / fragment.records / fragment.frs_to_idx) \
+              whose indices are produced by this code, not by untrusted on-disk bytes. \
+              All reads of the untrusted `data` slice go through `.get()` / the `rd_u*` \
+              helpers (WI-5.2)"
 )]
 #[expect(deprecated, reason = "deprecated function calling deprecated helper")]
 pub fn parse_record_to_fragment(
@@ -89,8 +104,14 @@ pub fn parse_record_to_fragment(
     // ADS: (stream_name, size, allocated)
     let mut additional_streams: SmallVec<[(String, u64, u64); 4]> = SmallVec::new();
 
-    while offset + size_of::<AttributeRecordHeader>() <= max_offset {
-        let Ok((attr_header, _)) = AttributeRecordHeader::read_from_prefix(&data[offset..]) else {
+    while offset
+        .checked_add(size_of::<AttributeRecordHeader>())
+        .is_some_and(|end| end <= max_offset)
+    {
+        let Some(attr_slice) = data.get(offset..) else {
+            break;
+        };
+        let Ok((attr_header, _)) = AttributeRecordHeader::read_from_prefix(attr_slice) else {
             break;
         };
 
@@ -98,19 +119,26 @@ pub fn parse_record_to_fragment(
             break;
         }
 
-        if attr_header.length == 0 || offset + u32_as_usize(attr_header.length) > max_offset {
+        // `offset + length` can overflow on a crafted `length`; checked_add → break.
+        let Some(attr_end) = offset.checked_add(u32_as_usize(attr_header.length)) else {
+            break;
+        };
+        if attr_header.length == 0 || attr_end > max_offset {
             break;
         }
 
         match AttributeType::from_u32(attr_header.type_code) {
             Some(AttributeType::StandardInformation) if attr_header.is_non_resident == 0 => {
-                let value_offset_bytes = &data[offset + 20..offset + 22];
-                let value_offset =
-                    u16::from_le_bytes(value_offset_bytes.try_into().unwrap_or([0, 0])) as usize;
-                let si_offset = offset + value_offset;
-                if si_offset + size_of::<StandardInformation>() <= data.len() {
-                    let Ok((si, _)) = StandardInformation::read_from_prefix(&data[si_offset..])
-                    else {
+                let value_offset = usize::from(rd_u16(data, offset.saturating_add(20)));
+                // `offset + value_offset` is byte-derived; checked, then re-validated
+                // by the `.get()` below.
+                if let Some(si_offset) = offset.checked_add(value_offset)
+                    && let Some(si_slice) = si_offset
+                        .checked_add(size_of::<StandardInformation>())
+                        .filter(|end| *end <= data.len())
+                        .and_then(|_| data.get(si_offset..))
+                {
+                    let Ok((si, _)) = StandardInformation::read_from_prefix(si_slice) else {
                         break;
                     };
                     let ext =
@@ -124,19 +152,28 @@ pub fn parse_record_to_fragment(
                 }
             }
             Some(AttributeType::FileName) if attr_header.is_non_resident == 0 => {
-                let value_offset_bytes = &data[offset + 20..offset + 22];
-                let value_offset =
-                    u16::from_le_bytes(value_offset_bytes.try_into().unwrap_or([0, 0])) as usize;
-                let fn_offset = offset + value_offset;
-                if fn_offset + size_of::<FileNameAttribute>() <= data.len() {
-                    let Ok((fn_attr, _)) = FileNameAttribute::read_from_prefix(&data[fn_offset..])
-                    else {
+                let value_offset = usize::from(rd_u16(data, offset.saturating_add(20)));
+                // `offset + value_offset` is byte-derived; checked, then re-validated
+                // by the `.get()` below.
+                if let Some(fn_offset) = offset.checked_add(value_offset)
+                    && let Some(fn_slice) = fn_offset
+                        .checked_add(size_of::<FileNameAttribute>())
+                        .filter(|end| *end <= data.len())
+                        .and_then(|_| data.get(fn_offset..))
+                {
+                    let Ok((fn_attr, _)) = FileNameAttribute::read_from_prefix(fn_slice) else {
                         break;
                     };
                     let name_len = usize::from(fn_attr.file_name_length);
-                    let name_bytes_offset = fn_offset + size_of::<FileNameAttribute>();
-                    if name_bytes_offset + name_len * 2 <= data.len() {
-                        let name_bytes = &data[name_bytes_offset..name_bytes_offset + name_len * 2];
+                    let name_bytes_offset =
+                        fn_offset.saturating_add(size_of::<FileNameAttribute>());
+                    // `name_len * 2` (UTF-16) overflows on a crafted length →
+                    // checked_mul/checked_add, then `.get()` bounds the slice.
+                    if let Some(name_bytes) = name_len
+                        .checked_mul(2)
+                        .and_then(|byte_len| name_bytes_offset.checked_add(byte_len))
+                        .and_then(|end| data.get(name_bytes_offset..end))
+                    {
                         let name_u16: Vec<u16> = name_bytes
                             .chunks_exact(2)
                             .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
@@ -147,7 +184,8 @@ pub fn parse_record_to_fragment(
 
                         if namespace != 2 {
                             let parse_idx = name_parse_counter;
-                            name_parse_counter += 1;
+                            // Bounded parse-order counter; saturate to avoid overflow.
+                            name_parse_counter = name_parse_counter.saturating_add(1);
                             let is_better = match namespace {
                                 1 | 3 => true,
                                 0 => primary_name.is_none(),
@@ -174,58 +212,49 @@ pub fn parse_record_to_fragment(
                 let is_primary = if attr_header.is_non_resident == 0 {
                     true // Resident attributes are always primary
                 } else {
-                    let nr_offset = offset + 16;
-                    if nr_offset + 8 <= data.len() {
-                        let lowest_vcn = i64::from_le_bytes(
-                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
-                        );
-                        lowest_vcn == 0
-                    } else {
-                        false // Can't verify, skip to be safe
-                    }
+                    // `offset + 16` is byte-derived; checked then the `+ 8` field
+                    // bound preserves the original "can't verify, skip" fallback.
+                    // Can't verify → false (skip to be safe).
+                    offset
+                        .checked_add(16)
+                        .filter(|nr| nr.saturating_add(8) <= data.len())
+                        .is_some_and(|nr_offset| rd_u64(data, nr_offset).cast_signed() == 0)
                 };
 
                 if !is_primary {
                     // Skip continuation extents - they don't count as new streams
-                    offset += u32_as_usize(attr_header.length);
+                    // Disk-derived advance; saturate so a crafted length can't overflow.
+                    offset = offset.saturating_add(u32_as_usize(attr_header.length));
                     continue;
                 }
 
                 // Parse $DATA - track both default stream and ADS
                 let name_len = usize::from(attr_header.name_length);
                 let (size, allocated) = if attr_header.is_non_resident != 0 {
-                    let alloc_offset = offset + 40;
-                    let size_offset = offset + 48;
-                    if size_offset + 8 <= data.len() {
-                        let allocated = u64::from_le_bytes(
-                            data[alloc_offset..alloc_offset + 8]
-                                .try_into()
-                                .unwrap_or([0; 8]),
-                        );
-                        let size = u64::from_le_bytes(
-                            data[size_offset..size_offset + 8]
-                                .try_into()
-                                .unwrap_or([0; 8]),
-                        );
-                        (size, allocated)
-                    } else {
-                        (0, 0)
-                    }
+                    // `rd_u*` are individually bounds-safe (return 0 OOB); the
+                    // `offset + 48 + 8 <= len` guard preserves the original "both
+                    // fields present" semantics. Offsets via checked/saturating_add.
+                    offset
+                        .checked_add(48)
+                        .filter(|size_off| size_off.saturating_add(8) <= data.len())
+                        .map_or((0, 0), |size_offset| {
+                            let alloc_offset = offset.saturating_add(40);
+                            let allocated = rd_u64(data, alloc_offset);
+                            let size = rd_u64(data, size_offset);
+                            (size, allocated)
+                        })
                 } else {
                     // Resident: value_length at offset 16
                     // Resident files have no clusters allocated - data is stored in MFT record
                     // Resident files have allocated_size=0 (data stored in MFT record)
-                    let len_offset = offset + 16;
-                    if len_offset + 4 <= data.len() {
-                        let len = u64::from(u32::from_le_bytes(
-                            data[len_offset..len_offset + 4]
-                                .try_into()
-                                .unwrap_or([0; 4]),
-                        ));
-                        (len, 0) // allocated_size = 0 for resident files
-                    } else {
-                        (0, 0)
-                    }
+                    // `rd_u32` is bounds-safe; the `+ 4 <= len` guard preserves the
+                    // original "field present" fallback.
+                    offset
+                        .checked_add(16)
+                        .filter(|len_off| len_off.saturating_add(4) <= data.len())
+                        .map_or((0, 0), |len_offset| {
+                            (u64::from(rd_u32(data, len_offset)), 0) // allocated_size = 0 for resident files
+                        })
                 };
 
                 if name_len == 0 {
@@ -234,9 +263,14 @@ pub fn parse_record_to_fragment(
                     default_allocated = allocated;
                 } else {
                     // Alternate Data Stream (ADS)
-                    let name_offset = offset + usize::from(attr_header.name_offset);
-                    if name_offset + name_len * 2 <= data.len() {
-                        let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                    let name_offset = offset.saturating_add(usize::from(attr_header.name_offset));
+                    // `name_len * 2` (UTF-16) overflows on a crafted length →
+                    // checked_mul/checked_add, then `.get()` bounds the slice.
+                    if let Some(name_bytes) = name_len
+                        .checked_mul(2)
+                        .and_then(|byte_len| name_offset.checked_add(byte_len))
+                        .and_then(|end| data.get(name_offset..end))
+                    {
                         let name_u16: SmallVec<[u16; 64]> = name_bytes
                             .chunks_exact(2)
                             .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
@@ -252,7 +286,8 @@ pub fn parse_record_to_fragment(
             _ => {}
         }
 
-        offset += u32_as_usize(attr_header.length);
+        // Disk-derived advance; saturate so a crafted length can't overflow.
+        offset = offset.saturating_add(u32_as_usize(attr_header.length));
     }
 
     // Set directory flag in std_info BEFORE checking for filename
@@ -397,17 +432,17 @@ pub fn parse_record_to_fragment(
     };
 
     // Chain the base record's additional links together
-    for i in 0..link_indices.len().saturating_sub(1) {
-        let current_idx = u32_as_usize(link_indices[i]);
-        let next_idx = link_indices[i + 1];
-        fragment.links[current_idx].next_entry = next_idx;
+    for pair in link_indices.windows(2) {
+        if let [current, next] = *pair {
+            fragment.links[u32_as_usize(current)].next_entry = next;
+        }
     }
 
     // Chain the base record's additional streams together
-    for i in 0..stream_indices.len().saturating_sub(1) {
-        let current_idx = u32_as_usize(stream_indices[i]);
-        let next_idx = stream_indices[i + 1];
-        fragment.streams[current_idx].next_entry = next_idx;
+    for pair in stream_indices.windows(2) {
+        if let [current, next] = *pair {
+            fragment.streams[u32_as_usize(current)].next_entry = next;
+        }
     }
 
     // Now chain base record links, then extension links
@@ -425,29 +460,23 @@ pub fn parse_record_to_fragment(
 
         // Chain: base first_name -> base additional links -> ext first_name -> ext
         // overflow
-        if link_indices.is_empty() {
-            first_name_next_entry = ext_link_idx;
+        if let Some((&head, &last)) = link_indices.first().zip(link_indices.last()) {
+            first_name_next_entry = head;
+            fragment.links[u32_as_usize(last)].next_entry = ext_link_idx;
         } else {
-            first_name_next_entry = link_indices[0];
-            let last_base_link = u32_as_usize(link_indices[link_indices.len() - 1]);
-            fragment.links[last_base_link].next_entry = ext_link_idx;
+            first_name_next_entry = ext_link_idx;
         }
     } else if existing_first_name.next_entry != NO_ENTRY {
         // Extension only had overflow links (no first_name) - chain them
-        if link_indices.is_empty() {
-            first_name_next_entry = existing_first_name.next_entry;
+        if let Some((&head, &last)) = link_indices.first().zip(link_indices.last()) {
+            first_name_next_entry = head;
+            fragment.links[u32_as_usize(last)].next_entry = existing_first_name.next_entry;
         } else {
-            first_name_next_entry = link_indices[0];
-            let last_base_link = u32_as_usize(link_indices[link_indices.len() - 1]);
-            fragment.links[last_base_link].next_entry = existing_first_name.next_entry;
+            first_name_next_entry = existing_first_name.next_entry;
         }
     } else {
         // No extension names - just chain base's additional links
-        if link_indices.is_empty() {
-            first_name_next_entry = NO_ENTRY;
-        } else {
-            first_name_next_entry = link_indices[0];
-        }
+        first_name_next_entry = link_indices.first().copied().unwrap_or(NO_ENTRY);
     }
 
     // Now set first_name.next_entry on the record.
@@ -458,9 +487,10 @@ pub fn parse_record_to_fragment(
 
     // Chain streams: base ADS -> extension ADS (must be done before borrowing
     // record) If base has ADS and extension has ADS, chain them together
-    if !stream_indices.is_empty() && existing_stream_next != NO_ENTRY {
-        let last_base_stream = u32_as_usize(stream_indices[stream_indices.len() - 1]);
-        fragment.streams[last_base_stream].next_entry = existing_stream_next;
+    if existing_stream_next != NO_ENTRY
+        && let Some(&last_base_stream) = stream_indices.last()
+    {
+        fragment.streams[u32_as_usize(last_base_stream)].next_entry = existing_stream_next;
     }
 
     // Now get record and update counts and first_stream chain
@@ -469,7 +499,10 @@ pub fn parse_record_to_fragment(
     // Calculate total name count
     // Base: 1 (first_name) + additional_count
     // Extension: existing_name_count (includes extension's names)
-    rec_for_counts.name_count = 1 + len_to_u16(additional_count) + existing_name_count;
+    // Bounded internal counters; saturate to avoid overflow panic.
+    rec_for_counts.name_count = 1_u16
+        .saturating_add(len_to_u16(additional_count))
+        .saturating_add(existing_name_count);
 
     // Set first_stream.next_entry to chain to base ADS or extension ADS
     if !stream_indices.is_empty() {
@@ -482,7 +515,10 @@ pub fn parse_record_to_fragment(
     // Calculate total stream count
     // Base: 1 (default $DATA) + additional_stream_count
     // Extension: existing_stream_count (ADS from extension records)
-    rec_for_counts.stream_count = 1 + len_to_u16(additional_stream_count) + existing_stream_count;
+    // Bounded internal counters; saturate to avoid overflow panic.
+    rec_for_counts.stream_count = 1_u16
+        .saturating_add(len_to_u16(additional_stream_count))
+        .saturating_add(existing_stream_count);
 
     // Build parent-child relationship for tree metrics computation
     // This is critical for compute_tree_metrics() to work correctly.
@@ -498,7 +534,10 @@ pub fn parse_record_to_fragment(
         let parent_idx = {
             let p_frs_usize = frs_to_usize(p_frs);
             if p_frs_usize >= frag.frs_to_idx.len() {
-                frag.frs_to_idx.resize(p_frs_usize + 1, NO_ENTRY);
+                // `p_frs` is masked to 48 bits, so `+ 1` cannot overflow usize on
+                // 64-bit; saturate defensively to keep arithmetic panic-free.
+                frag.frs_to_idx
+                    .resize(p_frs_usize.saturating_add(1), NO_ENTRY);
             }
             if frag.frs_to_idx[p_frs_usize] == NO_ENTRY {
                 // Create placeholder parent
@@ -591,14 +630,47 @@ fn store_nameless_record(
     };
 
     // Chain ADS streams to first_stream
-    if !stream_indices.is_empty() {
-        for i in 0..stream_indices.len().saturating_sub(1) {
-            let current_idx = u32_as_usize(stream_indices[i]);
-            let next_idx = stream_indices[i + 1];
-            fragment.streams[current_idx].next_entry = next_idx;
+    if let Some(&first_stream_idx) = stream_indices.first() {
+        for pair in stream_indices.windows(2) {
+            if let [current, next] = *pair {
+                fragment.streams[u32_as_usize(current)].next_entry = next;
+            }
         }
         let rec_for_stream = fragment.get_or_create(frs_typed);
-        rec_for_stream.first_stream.next_entry = stream_indices[0];
-        rec_for_stream.stream_count = 1 + len_to_u16(additional_stream_count);
+        rec_for_stream.first_stream.next_entry = first_stream_idx;
+        // Bounded internal counter; saturate to avoid overflow panic.
+        rec_for_stream.stream_count = 1_u16.saturating_add(len_to_u16(additional_stream_count));
     }
+}
+
+// ── Helpers (untrusted-byte readers, WI-5.2) ────────────────────────────────
+
+/// Read a little-endian `u16` from `buf` at `off`, returning 0 if the 2-byte
+/// field is out of bounds.
+#[inline]
+fn rd_u16(buf: &[u8], off: usize) -> u16 {
+    off.checked_add(2)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 2]>::try_from(sl).ok())
+        .map_or(0, u16::from_le_bytes)
+}
+
+/// Read a little-endian `u32` from `buf` at `off`, returning 0 if the 4-byte
+/// field is out of bounds.
+#[inline]
+fn rd_u32(buf: &[u8], off: usize) -> u32 {
+    off.checked_add(4)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 4]>::try_from(sl).ok())
+        .map_or(0, u32::from_le_bytes)
+}
+
+/// Read a little-endian `u64` from `buf` at `off`, returning 0 if the 8-byte
+/// field is out of bounds.
+#[inline]
+fn rd_u64(buf: &[u8], off: usize) -> u64 {
+    off.checked_add(8)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 8]>::try_from(sl).ok())
+        .map_or(0, u64::from_le_bytes)
 }

--- a/crates/uffs-mft/src/io/parser/fragment_extension.rs
+++ b/crates/uffs-mft/src/io/parser/fragment_extension.rs
@@ -3,6 +3,17 @@
 
 //! Legacy extension-record helper for direct-to-fragment parsing.
 //! Extracts names and streams from extension records into a fragment.
+//!
+//! # Hardening (WI-5.2)
+//! This module parses **untrusted on-disk bytes**. Every offset/length derived
+//! from those bytes is combined with `checked_add`/`checked_mul` (or
+//! `saturating_*` where overflow is provably unreachable) and every slice into
+//! `data` goes through `.get()` / the `rd_u*` helpers — never `data[a..b]`
+//! indexing. The daemon builds with `panic = "abort"`, so a single parser panic
+//! on a malformed record would be a whole-process denial of service.
+//! `arithmetic_side_effects` is enabled module-wide as a regression guard: any
+//! new raw `+`/`*` on a byte-derived value is a compile error here.
+#![warn(clippy::arithmetic_side_effects)]
 
 use core::mem::size_of;
 
@@ -33,12 +44,9 @@ use crate::ntfs::{
 /// `true` if any names/streams were added, `false` otherwise.
 #[deprecated(note = "Use parse_record_full() + MftRecordMerger instead")]
 #[expect(
-    clippy::indexing_slicing,
-    clippy::missing_asserts_for_indexing,
     clippy::too_many_lines,
-    reason = "NTFS attribute parser: all slice access is bounds-guarded by while-loop \
-              condition and per-access length checks; line count from nested FileName + \
-              Data attribute parsing with resident/non-resident branches"
+    reason = "monolithic extension parser for performance: nested FileName + Data \
+              attribute parsing with resident/non-resident branches"
 )]
 pub(super) fn parse_extension_to_fragment(
     data: &[u8],
@@ -61,8 +69,14 @@ pub(super) fn parse_extension_to_fragment(
     let mut names: SmallVec<[(String, u64); 4]> = SmallVec::new();
     let mut streams: SmallVec<[(String, u64, u64); 4]> = SmallVec::new();
 
-    while offset + size_of::<AttributeRecordHeader>() <= max_offset {
-        let Ok((attr_header, _)) = AttributeRecordHeader::read_from_prefix(&data[offset..]) else {
+    while offset
+        .checked_add(size_of::<AttributeRecordHeader>())
+        .is_some_and(|end| end <= max_offset)
+    {
+        let Some(attr_slice) = data.get(offset..) else {
+            break;
+        };
+        let Ok((attr_header, _)) = AttributeRecordHeader::read_from_prefix(attr_slice) else {
             break;
         };
 
@@ -70,30 +84,42 @@ pub(super) fn parse_extension_to_fragment(
             break;
         }
 
-        if attr_header.length == 0 || offset + u32_as_usize(attr_header.length) > max_offset {
+        // `offset + length` can overflow on a crafted `length`; checked_add → break.
+        let Some(attr_end) = offset.checked_add(u32_as_usize(attr_header.length)) else {
+            break;
+        };
+        if attr_header.length == 0 || attr_end > max_offset {
             break;
         }
 
         match AttributeType::from_u32(attr_header.type_code) {
             Some(AttributeType::FileName) if attr_header.is_non_resident == 0 => {
-                let value_offset_bytes = &data[offset + 20..offset + 22];
-                let value_offset =
-                    u16::from_le_bytes(value_offset_bytes.try_into().unwrap_or([0, 0])) as usize;
-                let fn_offset = offset + value_offset;
-                if fn_offset + size_of::<FileNameAttribute>() <= data.len() {
-                    let Ok((fn_attr, _)) = FileNameAttribute::read_from_prefix(&data[fn_offset..])
-                    else {
+                let value_offset = usize::from(rd_u16(data, offset.saturating_add(20)));
+                // `offset + value_offset` is byte-derived; checked, then re-validated
+                // by the `.get()` below.
+                if let Some(fn_offset) = offset.checked_add(value_offset)
+                    && let Some(fn_slice) = fn_offset
+                        .checked_add(size_of::<FileNameAttribute>())
+                        .filter(|end| *end <= data.len())
+                        .and_then(|_| data.get(fn_offset..))
+                {
+                    let Ok((fn_attr, _)) = FileNameAttribute::read_from_prefix(fn_slice) else {
                         break;
                     };
 
                     if fn_attr.file_name_namespace != 2 {
                         let name_len = usize::from(fn_attr.file_name_length);
-                        let name_start = fn_offset + size_of::<FileNameAttribute>();
-                        if name_start + name_len * 2 <= data.len() {
-                            let name_bytes = &data[name_start..name_start + name_len * 2];
+                        let name_start = fn_offset.saturating_add(size_of::<FileNameAttribute>());
+                        // `name_len * 2` (UTF-16) overflows on a crafted length →
+                        // checked_mul/checked_add, then `.get()` bounds the slice.
+                        if let Some(name_bytes) = name_len
+                            .checked_mul(2)
+                            .and_then(|byte_len| name_start.checked_add(byte_len))
+                            .and_then(|end| data.get(name_start..end))
+                        {
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
                                 .chunks_exact(2)
-                                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                                .map(|pair| <[u8; 2]>::try_from(pair).map_or(0, u16::from_le_bytes))
                                 .collect();
                             let name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                             let parent_frs = fn_attr.parent_directory & 0x0000_FFFF_FFFF_FFFF;
@@ -109,65 +135,61 @@ pub(super) fn parse_extension_to_fragment(
                 let is_primary = if attr_header.is_non_resident == 0 {
                     true // Resident attributes are always primary
                 } else {
-                    let nr_offset = offset + 16;
-                    if nr_offset + 8 <= data.len() {
-                        let lowest_vcn = i64::from_le_bytes(
-                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
-                        );
-                        lowest_vcn == 0
-                    } else {
-                        false // Can't verify, skip to be safe
-                    }
+                    // Mirror the original guarded read: the 8-byte `LowestVCN`
+                    // field must be fully present, else treat as non-primary
+                    // ("can't verify, skip to be safe").
+                    offset
+                        .checked_add(16)
+                        .filter(|nr| nr.saturating_add(8) <= data.len())
+                        .is_some_and(|nr_offset| rd_u64(data, nr_offset).cast_signed() == 0)
                 };
 
                 if !is_primary {
                     // Skip continuation extents - they don't count as new streams
-                    offset += u32_as_usize(attr_header.length);
+                    offset = offset.saturating_add(u32_as_usize(attr_header.length));
                     continue;
                 }
 
                 let name_len = usize::from(attr_header.name_length);
                 if name_len > 0 {
                     let (size, allocated) = if attr_header.is_non_resident != 0 {
-                        let nr_offset = offset + 16;
-                        if nr_offset + 48 <= data.len() {
-                            let allocated = i64::from_le_bytes(
-                                data[nr_offset + 24..nr_offset + 32]
-                                    .try_into()
-                                    .unwrap_or([0; 8]),
-                            );
-                            let size = i64::from_le_bytes(
-                                data[nr_offset + 32..nr_offset + 40]
-                                    .try_into()
-                                    .unwrap_or([0; 8]),
-                            );
-                            (
-                                size.max(0).cast_unsigned(),
-                                allocated.max(0).cast_unsigned(),
-                            )
-                        } else {
-                            (0, 0)
-                        }
+                        // `rd_u*` are individually bounds-safe (return 0 OOB); the
+                        // `nr + 48 <= len` guard preserves the original "all fields
+                        // present" semantics. `nr` via checked_add.
+                        offset
+                            .checked_add(16)
+                            .filter(|nr| nr.saturating_add(48) <= data.len())
+                            .map_or((0, 0), |nr_offset| {
+                                let allocated =
+                                    rd_u64(data, nr_offset.saturating_add(24)).cast_signed();
+                                let size = rd_u64(data, nr_offset.saturating_add(32)).cast_signed();
+                                (
+                                    size.max(0).cast_unsigned(),
+                                    allocated.max(0).cast_unsigned(),
+                                )
+                            })
                     } else {
-                        let len_offset = offset + 16;
-                        if len_offset + 4 <= data.len() {
-                            let len = u64::from(u32::from_le_bytes(
-                                data[len_offset..len_offset + 4]
-                                    .try_into()
-                                    .unwrap_or([0; 4]),
-                            ));
-                            (len, 0)
-                        } else {
-                            (0, 0)
-                        }
+                        // `rd_u32` is bounds-safe (returns 0 OOB); the `+ 4 <= len`
+                        // guard preserves the original "field present" semantics.
+                        offset
+                            .checked_add(16)
+                            .filter(|len_off| len_off.saturating_add(4) <= data.len())
+                            .map_or((0, 0), |len_offset| {
+                                (u64::from(rd_u32(data, len_offset)), 0)
+                            })
                     };
 
-                    let name_offset = offset + usize::from(attr_header.name_offset);
-                    if name_offset + name_len * 2 <= data.len() {
-                        let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                    let name_offset = offset.saturating_add(usize::from(attr_header.name_offset));
+                    // `name_len * 2` (UTF-16) overflows on a crafted length →
+                    // checked_mul/checked_add, then `.get()` bounds the slice.
+                    if let Some(name_bytes) = name_len
+                        .checked_mul(2)
+                        .and_then(|byte_len| name_offset.checked_add(byte_len))
+                        .and_then(|end| data.get(name_offset..end))
+                    {
                         let name_u16: SmallVec<[u16; 64]> = name_bytes
                             .chunks_exact(2)
-                            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                            .map(|pair| <[u8; 2]>::try_from(pair).map_or(0, u16::from_le_bytes))
                             .collect();
                         let stream_name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                         // ALL named $DATA streams create regular
@@ -180,7 +202,8 @@ pub(super) fn parse_extension_to_fragment(
             _ => {}
         }
 
-        offset += u32_as_usize(attr_header.length);
+        // Disk-derived advance; saturate so a crafted length can't overflow.
+        offset = offset.saturating_add(u32_as_usize(attr_header.length));
     }
 
     if names.is_empty() && streams.is_empty() {
@@ -263,11 +286,15 @@ fn merge_extension_into_fragment(
     }
 
     // Chain new links together first (before getting record reference)
-    for i in 0..link_indices.len().saturating_sub(1) {
-        fragment.links[u32_as_usize(link_indices[i])].next_entry = link_indices[i + 1];
+    for pair in link_indices.windows(2) {
+        if let [current, next] = *pair {
+            fragment.links[u32_as_usize(current)].next_entry = next;
+        }
     }
-    for i in 0..stream_indices.len().saturating_sub(1) {
-        fragment.streams[u32_as_usize(stream_indices[i])].next_entry = stream_indices[i + 1];
+    for pair in stream_indices.windows(2) {
+        if let [current, next] = *pair {
+            fragment.streams[u32_as_usize(current)].next_entry = next;
+        }
     }
 
     // Get the first_name.next_entry, first_stream.next_entry, and first_name
@@ -301,8 +328,12 @@ fn merge_extension_into_fragment(
             rec_for_stream.first_stream.next_entry = stream_indices[0];
         }
         let rec_for_count = fragment.get_or_create(base_frs_typed);
-        rec_for_count.stream_count += len_to_u16(stream_indices.len());
-        rec_for_count.total_stream_count += len_to_u16(stream_indices.len());
+        // Bounded internal counters; saturate.
+        let stream_added = len_to_u16(stream_indices.len());
+        rec_for_count.stream_count = rec_for_count.stream_count.saturating_add(stream_added);
+        rec_for_count.total_stream_count = rec_for_count
+            .total_stream_count
+            .saturating_add(stream_added);
     }
 
     // Build parent-child relationships
@@ -354,7 +385,10 @@ fn attach_links(
             rec_for_link_chain.first_name.next_entry = link_indices[0];
         }
         let rec_for_link_count = fragment.get_or_create(base_frs_typed);
-        rec_for_link_count.name_count += len_to_u16(link_indices.len());
+        // Bounded internal counter; saturate.
+        rec_for_link_count.name_count = rec_for_link_count
+            .name_count
+            .saturating_add(len_to_u16(link_indices.len()));
     } else {
         // Copy the first extension name directly into first_name
         // This matches established behavior (ntfs_index.hpp lines 559-567)
@@ -368,7 +402,10 @@ fn attach_links(
         if link_indices.len() > 1 {
             let rec_for_extra_links = fragment.get_or_create(base_frs_typed);
             rec_for_extra_links.first_name.next_entry = link_indices[1];
-            rec_for_extra_links.name_count += len_to_u16(link_indices.len().saturating_sub(1));
+            // Bounded internal counter; saturate.
+            rec_for_extra_links.name_count = rec_for_extra_links
+                .name_count
+                .saturating_add(len_to_u16(link_indices.len().saturating_sub(1)));
         }
     }
 }
@@ -399,7 +436,11 @@ fn build_parent_child_entries(
         let parent_idx = {
             let p_frs_usize = frs_to_usize(p_frs);
             if p_frs_usize >= fragment.frs_to_idx.len() {
-                fragment.frs_to_idx.resize(p_frs_usize + 1, NO_ENTRY);
+                // `p_frs` is masked to 48 bits, so `+ 1` cannot overflow usize on
+                // 64-bit; saturate defensively to keep arithmetic panic-free.
+                fragment
+                    .frs_to_idx
+                    .resize(p_frs_usize.saturating_add(1), NO_ENTRY);
             }
             if fragment.frs_to_idx[p_frs_usize] == NO_ENTRY {
                 let new_idx = len_to_u32(fragment.records.len());
@@ -414,7 +455,10 @@ fn build_parent_child_entries(
         let effective_name_idx = if existing_name_count == 0 {
             len_to_u16(name_idx)
         } else {
-            existing_name_count - 1 + len_to_u16(name_idx)
+            // Preserve legacy off-by-one semantics; bounded u16 counters, saturate.
+            existing_name_count
+                .saturating_sub(1)
+                .saturating_add(len_to_u16(name_idx))
         };
 
         let child_idx = len_to_u32(fragment.children.len());
@@ -431,4 +475,36 @@ fn build_parent_child_entries(
             _pad1: [0; 6],
         });
     }
+}
+
+// ── Helpers (untrusted-byte readers, WI-5.2) ────────────────────────────────
+
+/// Read a little-endian `u16` from `buf` at `off`, returning 0 if the 2-byte
+/// field is out of bounds.
+#[inline]
+fn rd_u16(buf: &[u8], off: usize) -> u16 {
+    off.checked_add(2)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 2]>::try_from(sl).ok())
+        .map_or(0, u16::from_le_bytes)
+}
+
+/// Read a little-endian `u32` from `buf` at `off`, returning 0 if the 4-byte
+/// field is out of bounds.
+#[inline]
+fn rd_u32(buf: &[u8], off: usize) -> u32 {
+    off.checked_add(4)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 4]>::try_from(sl).ok())
+        .map_or(0, u32::from_le_bytes)
+}
+
+/// Read a little-endian `u64` from `buf` at `off`, returning 0 if the 8-byte
+/// field is out of bounds.
+#[inline]
+fn rd_u64(buf: &[u8], off: usize) -> u64 {
+    off.checked_add(8)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 8]>::try_from(sl).ok())
+        .map_or(0, u64::from_le_bytes)
 }

--- a/crates/uffs-mft/src/io/parser/index.rs
+++ b/crates/uffs-mft/src/io/parser/index.rs
@@ -10,7 +10,18 @@
 //! an `MftIndex` directly from raw MFT bytes. It parses records into `MftIndex`
 //! without creating intermediate `ParsedRecord` allocations, which is critical
 //! for IOCP performance.
-
+//!
+//! # Hardening (WI-5.2)
+//! This module parses **untrusted on-disk bytes**. Every offset/length
+//! derived from those bytes is combined with `checked_add`/`checked_mul`
+//! (or `saturating_*` where overflow is provably unreachable) and every
+//! slice into `data` goes through `.get()` / the `rd_u*` helpers — never
+//! `data[a..b]` indexing. The daemon builds with `panic = "abort"`, so a
+//! single parser panic on a malformed record would be a whole-process
+//! denial of service.
+//! `arithmetic_side_effects` is enabled module-wide as a regression guard:
+//! any new raw `+`/`*` on a byte-derived value is a compile error here.
+#![warn(clippy::arithmetic_side_effects)]
 // Performance-critical hot-path parser — minimal, scoped lint suppressions.
 // Each suppression is justified with a reason.
 #![expect(
@@ -67,8 +78,9 @@ use crate::parse::index_helpers::{
 #[expect(
     clippy::indexing_slicing,
     clippy::missing_asserts_for_indexing,
-    reason = "all slice access is bounds-guarded: while-loop checks offset + HEADER_SIZE <= max_offset, \
-              and each attribute access validates offset + field_len <= data.len() before indexing"
+    reason = "remaining [] are internal arena indices (index.records[..]/stream_indices[..]/\
+              link_indices[..]) keyed by indices minted by this fn; not attacker-controlled. \
+              All untrusted-`data` reads go through .get()/rd_u* (WI-5.2)."
 )]
 pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::MftIndex) -> bool {
     use crate::index::{IndexNameRef, LinkInfo, NO_ENTRY, SizeInfo, StandardInfo};
@@ -127,8 +139,20 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
     let mut dir_index_size: u64 = 0;
     let mut dir_index_allocated: u64 = 0;
 
-    while offset + size_of::<AttributeRecordHeader>() <= max_offset {
-        let attr_header = match AttributeRecordHeader::read_from_prefix(&data[offset..]) {
+    // WI-5.2: every offset advance and slice below is derived from
+    // attacker-controllable record bytes, so all arithmetic uses
+    // `checked_*` and all slicing uses `data.get(..)` (fallible) — a
+    // malformed record `break`s the loop / skips the field instead of
+    // panicking. The daemon runs `panic = "abort"`, so a parser panic is a
+    // whole-process DoS.
+    while offset
+        .checked_add(size_of::<AttributeRecordHeader>())
+        .is_some_and(|end| end <= max_offset)
+    {
+        let Some(attr_slice) = data.get(offset..) else {
+            break;
+        };
+        let attr_header = match AttributeRecordHeader::read_from_prefix(attr_slice) {
             Ok((attr_header, _)) => attr_header,
             Err(_) => break,
         };
@@ -137,13 +161,15 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
             break;
         }
 
-        if attr_header.length == 0 || offset + u32_as_usize(attr_header.length) > max_offset {
+        let attr_len = u32_as_usize(attr_header.length);
+        let attr_end = offset.checked_add(attr_len);
+        if attr_header.length == 0 || attr_end.is_none_or(|end| end > max_offset) {
             break;
         }
 
         // Validate that the attribute's declared length fits within the record data
         // This prevents reading past record boundaries when attributes are truncated
-        if offset + u32_as_usize(attr_header.length) > data.len() {
+        if attr_end.is_none_or(|end| end > data.len()) {
             break; // Attribute extends past record — stop processing
         }
 
@@ -152,13 +178,15 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
             Some(AttributeType::StandardInformation) => {
                 if attr_header.is_non_resident == 0 {
                     // Parse $STANDARD_INFORMATION
-                    let value_offset_bytes = &data[offset + 20..offset + 22];
-                    let value_offset = usize::from(u16::from_le_bytes(
-                        value_offset_bytes.try_into().unwrap_or([0, 0]),
-                    ));
-                    let si_offset = offset + value_offset;
-                    if si_offset + size_of::<StandardInformation>() <= data.len() {
-                        let si = match StandardInformation::read_from_prefix(&data[si_offset..]) {
+                    let value_offset = usize::from(rd_u16(data, offset.saturating_add(20)));
+                    if let Some(si_slice) = offset
+                        .checked_add(value_offset)
+                        .filter(|si_off| {
+                            si_off.saturating_add(size_of::<StandardInformation>()) <= data.len()
+                        })
+                        .and_then(|si_off| data.get(si_off..))
+                    {
+                        let si = match StandardInformation::read_from_prefix(si_slice) {
                             Ok((si, _)) => si,
                             Err(_) => break,
                         };
@@ -180,22 +208,31 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
             Some(AttributeType::FileName) => {
                 if attr_header.is_non_resident == 0 {
                     // Parse $FILE_NAME
-                    let value_offset_bytes = &data[offset + 20..offset + 22];
-                    let value_offset = usize::from(u16::from_le_bytes(
-                        value_offset_bytes.try_into().unwrap_or([0, 0]),
-                    ));
-                    let fn_offset = offset + value_offset;
-                    if fn_offset + size_of::<FileNameAttribute>() <= data.len() {
-                        let fn_attr = match FileNameAttribute::read_from_prefix(&data[fn_offset..])
-                        {
+                    let value_offset = usize::from(rd_u16(data, offset.saturating_add(20)));
+                    let fn_offset = offset.checked_add(value_offset);
+                    if let Some(fn_slice) = fn_offset
+                        .filter(|fn_off| {
+                            fn_off.saturating_add(size_of::<FileNameAttribute>()) <= data.len()
+                        })
+                        .and_then(|fn_off| data.get(fn_off..))
+                        && let Some(fn_off) = fn_offset
+                    {
+                        let fn_attr = match FileNameAttribute::read_from_prefix(fn_slice) {
                             Ok((fn_attr, _)) => fn_attr,
                             Err(_) => break,
                         };
                         let name_len = usize::from(fn_attr.file_name_length);
-                        let name_bytes_offset = fn_offset + size_of::<FileNameAttribute>();
-                        if name_bytes_offset + name_len * 2 <= data.len() {
-                            let name_bytes =
-                                &data[name_bytes_offset..name_bytes_offset + name_len * 2];
+                        let name_bytes_offset =
+                            fn_off.saturating_add(size_of::<FileNameAttribute>());
+                        // `name_len` is a u16 (<= 65535); `*2` and `+ offset` use
+                        // checked form so the parser is provably total, and let
+                        // `data.get(..)` do the bounds check (None on a
+                        // declared-length that overruns the record → skip name).
+                        if let Some(name_bytes) = name_len
+                            .checked_mul(2)
+                            .and_then(|byte_len| name_bytes_offset.checked_add(byte_len))
+                            .and_then(|name_end| data.get(name_bytes_offset..name_end))
+                        {
                             // SmallVec avoids heap allocation for typical filenames (<= 64 chars)
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
                                 .chunks_exact(2)
@@ -208,7 +245,9 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                             // Skip DOS-only names (namespace 2)
                             if namespace != 2 {
                                 let parse_idx = name_parse_counter;
-                                name_parse_counter += 1;
+                                // Monotonic name counter; one $FILE_NAME per record
+                                // iteration, bounded by record size — cannot overflow u16.
+                                name_parse_counter = name_parse_counter.saturating_add(1);
                                 let is_better = match namespace {
                                     1 | 3 => true,               // Win32 or Win32+DOS
                                     0 => primary_name.is_none(), // POSIX only if no name yet
@@ -241,20 +280,17 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                 let is_primary = if attr_header.is_non_resident == 0 {
                     true // Resident attributes are always primary
                 } else {
-                    let nr_offset = offset + 16;
-                    if nr_offset + 8 <= data.len() {
-                        let lowest_vcn = i64::from_le_bytes(
-                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
-                        );
-                        lowest_vcn == 0
-                    } else {
-                        true // Assume primary if can't read LowestVCN
-                    }
+                    // Assume primary if can't read LowestVCN (None → true).
+                    offset
+                        .checked_add(16)
+                        .and_then(|nr| nr.checked_add(8).and_then(|end| data.get(nr..end)))
+                        .and_then(|sl| <[u8; 8]>::try_from(sl).ok())
+                        .is_none_or(|bytes| i64::from_le_bytes(bytes) == 0)
                 };
 
                 if !is_primary {
                     // Skip continuation extents - they don't count as new streams
-                    offset += u32_as_usize(attr_header.length);
+                    offset = offset.saturating_add(u32_as_usize(attr_header.length));
                     continue;
                 }
 
@@ -263,70 +299,42 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                 let (size, allocated) = if attr_header.is_non_resident != 0 {
                     // Non-resident: size at offset 48, allocated at offset 40
                     // For compressed/sparse files, use CompressedSize at offset 64
-                    let nr_offset = offset + 16;
-                    let alloc_offset = offset + 40;
-                    let size_offset = offset + 48;
-                    if size_offset + 8 <= data.len() {
+                    let nr_offset = offset.saturating_add(16);
+                    let alloc_offset = offset.saturating_add(40);
+                    let size_offset = offset.saturating_add(48);
+                    if size_offset.saturating_add(8) <= data.len() {
                         // Check if compressed or sparse
                         let is_compressed_or_sparse = (attr_header.flags & 0x8001) != 0;
-                        let compression_unit_offset = nr_offset + 18;
-                        let has_compression_unit = if compression_unit_offset + 2 <= data.len() {
-                            let compression_unit = u16::from_le_bytes(
-                                data[compression_unit_offset..compression_unit_offset + 2]
-                                    .try_into()
-                                    .unwrap_or([0; 2]),
-                            );
-                            compression_unit > 0
-                        } else {
-                            false
-                        };
+                        let compression_unit = rd_u16(data, nr_offset.saturating_add(18));
+                        let has_compression_unit = compression_unit > 0;
 
                         let use_compressed_size = is_compressed_or_sparse || has_compression_unit;
-                        let compressed_size_offset = nr_offset + 48; // offset + 64
+                        let compressed_size_offset = nr_offset.saturating_add(48); // offset + 64
 
-                        let allocated =
-                            if use_compressed_size && compressed_size_offset + 8 <= data.len() {
-                                // Read CompressedSize for compressed/sparse files
-                                u64::from_le_bytes(
-                                    data[compressed_size_offset..compressed_size_offset + 8]
-                                        .try_into()
-                                        .unwrap_or([0; 8]),
-                                )
-                            } else {
-                                // Read AllocatedLength for normal files
-                                u64::from_le_bytes(
-                                    data[alloc_offset..alloc_offset + 8]
-                                        .try_into()
-                                        .unwrap_or([0; 8]),
-                                )
-                            };
+                        let allocated = if use_compressed_size
+                            && compressed_size_offset.saturating_add(8) <= data.len()
+                        {
+                            // Read CompressedSize for compressed/sparse files
+                            rd_u64(data, compressed_size_offset)
+                        } else {
+                            // Read AllocatedLength for normal files
+                            rd_u64(data, alloc_offset)
+                        };
 
-                        let size = u64::from_le_bytes(
-                            data[size_offset..size_offset + 8]
-                                .try_into()
-                                .unwrap_or([0; 8]),
-                        );
+                        let size = rd_u64(data, size_offset);
                         (size, allocated)
-                    } else if alloc_offset + 8 <= data.len() {
+                    } else if alloc_offset.saturating_add(8) <= data.len() {
                         // Can read AllocatedSize but not DataSize — use AllocatedSize for both
-                        let allocated = u64::from_le_bytes(
-                            data[alloc_offset..alloc_offset + 8]
-                                .try_into()
-                                .unwrap_or([0; 8]),
-                        );
+                        let allocated = rd_u64(data, alloc_offset);
                         (allocated, allocated)
                     } else {
                         (0, 0)
                     }
                 } else {
                     // Resident: value_length at offset 16
-                    let len_offset = offset + 16;
-                    if len_offset + 4 <= data.len() {
-                        let len = u32::from_le_bytes(
-                            data[len_offset..len_offset + 4]
-                                .try_into()
-                                .unwrap_or([0; 4]),
-                        );
+                    let len_offset = offset.saturating_add(16);
+                    if len_offset.saturating_add(4) <= data.len() {
+                        let len = rd_u32(data, len_offset);
                         (u64::from(len), 0) // allocated_size = 0 for resident files
                     } else {
                         (0, 0)
@@ -343,9 +351,12 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                     default_allocated = allocated;
                 } else {
                     // Alternate Data Stream (ADS)
-                    let name_offset = offset + usize::from(attr_header.name_offset);
-                    if name_offset + name_len * 2 <= data.len() {
-                        let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                    let name_offset = offset.saturating_add(usize::from(attr_header.name_offset));
+                    if let Some(name_bytes) = name_len
+                        .checked_mul(2)
+                        .and_then(|byte_len| name_offset.checked_add(byte_len))
+                        .and_then(|name_end| data.get(name_offset..name_end))
+                    {
                         let name_u16: SmallVec<[u16; 64]> = name_bytes
                             .chunks_exact(2)
                             .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
@@ -360,13 +371,9 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                             && stream_name == "$Bad"
                             && attr_header.is_non_resident != 0
                         {
-                            let init_size_offset = offset + 56;
-                            if init_size_offset + 8 <= data.len() {
-                                let init_size = u64::from_le_bytes(
-                                    data[init_size_offset..init_size_offset + 8]
-                                        .try_into()
-                                        .unwrap_or([0; 8]),
-                                );
+                            let init_size_offset = offset.saturating_add(56);
+                            if init_size_offset.saturating_add(8) <= data.len() {
+                                let init_size = rd_u64(data, init_size_offset);
                                 (init_size, init_size)
                             } else {
                                 (0, 0)
@@ -390,33 +397,21 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                 // $REPARSE_POINT is counted as a stream (affects descendants).
                 let (rp_size, rp_allocated) = if attr_header.is_non_resident == 0 {
                     // Resident reparse point (common case)
-                    let value_length_bytes = &data[offset + 16..offset + 20];
-                    let value_length = u64::from(u32::from_le_bytes(
-                        value_length_bytes.try_into().unwrap_or([0, 0, 0, 0]),
-                    ));
+                    let value_length = u64::from(rd_u32(data, offset.saturating_add(16)));
 
-                    let value_offset_bytes = &data[offset + 20..offset + 22];
-                    let value_offset = usize::from(u16::from_le_bytes(
-                        value_offset_bytes.try_into().unwrap_or([0, 0]),
-                    ));
-                    let rp_offset = offset + value_offset;
-                    if rp_offset + 4 <= data.len() {
+                    let value_offset = usize::from(rd_u16(data, offset.saturating_add(20)));
+                    if let Some(rp_offset) = offset.checked_add(value_offset) {
                         // Read reparse tag (first 4 bytes of reparse point data)
-                        let tag_bytes = &data[rp_offset..rp_offset + 4];
-                        reparse_tag =
-                            u32::from_le_bytes(tag_bytes.try_into().unwrap_or([0, 0, 0, 0]));
+                        reparse_tag = rd_u32(data, rp_offset);
                     }
                     (value_length, 0_u64) // Resident, allocated=0
                 } else {
                     // Non-resident reparse point (rare - large reparse data)
-                    let nr_offset = offset + 16;
-                    if nr_offset + 48 <= data.len() {
-                        let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
-                        let allocated =
-                            i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
-                        let size_bytes = &data[nr_offset + 32..nr_offset + 40];
-                        let data_size = i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
-                        (nonneg_to_u64(data_size), nonneg_to_u64(allocated))
+                    let nr_offset = offset.saturating_add(16);
+                    if nr_offset.saturating_add(48) <= data.len() {
+                        let allocated = nonneg_to_u64(rd_i64(data, nr_offset.saturating_add(24)));
+                        let data_size = nonneg_to_u64(rd_i64(data, nr_offset.saturating_add(32)));
+                        (data_size, allocated)
                     } else {
                         (0_u64, 0_u64)
                     }
@@ -434,10 +429,21 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
 
                 // Extract attribute name
                 let name_len = usize::from(attr_header.name_length);
-                let (is_i30, _attr_name) = if name_len > 0 {
-                    let name_offset = offset + usize::from(attr_header.name_offset);
-                    if name_offset + name_len * 2 <= data.len() {
-                        let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                let name_offset = offset.saturating_add(usize::from(attr_header.name_offset));
+                // None when name_len == 0 or the declared length overruns the
+                // record → treated as non-$I30 with an empty name (matches the
+                // original guarded-out behavior).
+                let name_bytes_opt = if name_len > 0 {
+                    name_len
+                        .checked_mul(2)
+                        .and_then(|byte_len| name_offset.checked_add(byte_len))
+                        .and_then(|name_end| data.get(name_offset..name_end))
+                } else {
+                    None
+                };
+                let (is_i30, _attr_name) = name_bytes_opt.map_or_else(
+                    || (false, String::new()),
+                    |name_bytes| {
                         // Check for "$I30" in UTF-16LE
                         let is_i30 =
                             attr_header.name_length == 4 && name_bytes == b"$\x00I\x003\x000\x00";
@@ -452,73 +458,26 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                             crate::io::parser::unified::decode_name_u16(&name_u16).0
                         };
                         (is_i30, name)
-                    } else {
-                        (false, String::new())
-                    }
-                } else {
-                    (false, String::new())
-                };
+                    },
+                );
 
                 if is_i30 {
                     // Accumulate $I30 sizes for directories
                     if attr_header.is_non_resident == 0 {
-                        let value_length_bytes = &data[offset + 16..offset + 20];
-                        let value_length = u64::from(u32::from_le_bytes(
-                            value_length_bytes.try_into().unwrap_or([0; 4]),
-                        ));
-                        dir_index_size += value_length;
+                        let value_length = u64::from(rd_u32(data, offset.saturating_add(16)));
+                        // Directory index sizes are bounded by the volume; accumulating
+                        // them cannot overflow u64 in practice — saturate to stay total.
+                        dir_index_size = dir_index_size.saturating_add(value_length);
                     } else {
-                        let nr_offset = offset + 16;
-                        if nr_offset + 48 <= data.len() {
-                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
-                            let allocated =
-                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
-                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
-                            let data_size =
-                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
-                            dir_index_size += nonneg_to_u64(data_size);
-                            dir_index_allocated += nonneg_to_u64(allocated);
-                        }
+                        let (size, allocated) = read_nonresident_size_alloc(data, offset);
+                        dir_index_size = dir_index_size.saturating_add(size);
+                        dir_index_allocated = dir_index_allocated.saturating_add(allocated);
                     }
                 } else {
                     // Non-$I30 index - count as stream
                     // Check if primary attribute (LowestVCN == 0)
-                    let is_primary = if attr_header.is_non_resident == 0 {
-                        true
-                    } else {
-                        let nr_offset = offset + 16;
-                        if nr_offset + 8 <= data.len() {
-                            let lowest_vcn = i64::from_le_bytes(
-                                data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
-                            );
-                            lowest_vcn == 0
-                        } else {
-                            false
-                        }
-                    };
-
-                    if is_primary {
-                        let (size, allocated) = if attr_header.is_non_resident == 0 {
-                            let value_length_bytes = &data[offset + 16..offset + 20];
-                            let value_length = u64::from(u32::from_le_bytes(
-                                value_length_bytes.try_into().unwrap_or([0; 4]),
-                            ));
-                            (value_length, 0_u64)
-                        } else {
-                            let nr_offset = offset + 16;
-                            if nr_offset + 48 <= data.len() {
-                                let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
-                                let allocated =
-                                    i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
-                                let size_bytes = &data[nr_offset + 32..nr_offset + 40];
-                                let data_size =
-                                    i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
-                                (nonneg_to_u64(data_size), nonneg_to_u64(allocated))
-                            } else {
-                                (0_u64, 0_u64)
-                            }
-                        };
-
+                    if is_nonresident_primary(data, offset, &attr_header) {
+                        let (size, allocated) = read_size_alloc(data, offset, &attr_header);
                         // Non-$I30 index attributes are internal streams
                         internal_streams.push((size, allocated));
                     }
@@ -538,42 +497,8 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                 // All these are internal streams — tracked for tree metrics but
                 // not emitted as user-visible output rows.
                 // Check if primary attribute (LowestVCN == 0)
-                let is_primary = if attr_header.is_non_resident == 0 {
-                    true
-                } else {
-                    let nr_offset = offset + 16;
-                    if nr_offset + 8 <= data.len() {
-                        let lowest_vcn = i64::from_le_bytes(
-                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
-                        );
-                        lowest_vcn == 0
-                    } else {
-                        false
-                    }
-                };
-
-                if is_primary {
-                    let (size, allocated) = if attr_header.is_non_resident == 0 {
-                        let value_length_bytes = &data[offset + 16..offset + 20];
-                        let value_length = u64::from(u32::from_le_bytes(
-                            value_length_bytes.try_into().unwrap_or([0; 4]),
-                        ));
-                        (value_length, 0_u64)
-                    } else {
-                        let nr_offset = offset + 16;
-                        if nr_offset + 48 <= data.len() {
-                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
-                            let allocated =
-                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
-                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
-                            let data_size =
-                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
-                            (nonneg_to_u64(data_size), nonneg_to_u64(allocated))
-                        } else {
-                            (0_u64, 0_u64)
-                        }
-                    };
-
+                if is_nonresident_primary(data, offset, &attr_header) {
+                    let (size, allocated) = read_size_alloc(data, offset, &attr_header);
                     internal_streams.push((size, allocated));
                 }
             }
@@ -581,48 +506,16 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                 // Unknown attribute types are internal streams — tracked for
                 // tree metrics but not emitted as user-visible output rows.
                 // Check if primary attribute (LowestVCN == 0)
-                let is_primary = if attr_header.is_non_resident == 0 {
-                    true
-                } else {
-                    let nr_offset = offset + 16;
-                    if nr_offset + 8 <= data.len() {
-                        let lowest_vcn = i64::from_le_bytes(
-                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
-                        );
-                        lowest_vcn == 0
-                    } else {
-                        false
-                    }
-                };
-
-                if is_primary {
-                    let (size, allocated) = if attr_header.is_non_resident == 0 {
-                        let value_length_bytes = &data[offset + 16..offset + 20];
-                        let value_length = u64::from(u32::from_le_bytes(
-                            value_length_bytes.try_into().unwrap_or([0; 4]),
-                        ));
-                        (value_length, 0_u64)
-                    } else {
-                        let nr_offset = offset + 16;
-                        if nr_offset + 48 <= data.len() {
-                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
-                            let allocated =
-                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
-                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
-                            let data_size =
-                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
-                            (nonneg_to_u64(data_size), nonneg_to_u64(allocated))
-                        } else {
-                            (0_u64, 0_u64)
-                        }
-                    };
-
+                if is_nonresident_primary(data, offset, &attr_header) {
+                    let (size, allocated) = read_size_alloc(data, offset, &attr_header);
                     internal_streams.push((size, allocated));
                 }
             }
         }
 
-        offset += u32_as_usize(attr_header.length);
+        // `attr_header.length` was validated above (`offset + length <= data.len()`),
+        // so this advance cannot overflow; `saturating_add` keeps it total.
+        offset = offset.saturating_add(u32_as_usize(attr_header.length));
     }
 
     // Set directory flag in std_info BEFORE checking for filename
@@ -701,9 +594,11 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                 rec_chain.first_stream.next_entry = stream_indices[0];
             }
             let rec_counts = index.get_or_create(frs_typed);
-            rec_counts.stream_count = 1 + len_to_u16(additional_stream_count);
-            rec_counts.total_stream_count =
-                1 + len_to_u16(additional_stream_count) + len_to_u16(internal_stream_count);
+            // Stream counts are bounded by attributes-per-record; saturate to stay total.
+            rec_counts.stream_count = len_to_u16(additional_stream_count).saturating_add(1);
+            rec_counts.total_stream_count = len_to_u16(additional_stream_count)
+                .saturating_add(1)
+                .saturating_add(len_to_u16(internal_stream_count));
 
             // Merge extension data
             merge_extension_streams(
@@ -799,10 +694,13 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
         // Typed `ParentFrs` slot — lift raw `u64` parser local.
         parent_frs: crate::frs::ParentFrs::new(parent_frs),
     };
-    record.name_count = 1 + len_to_u16(additional_count);
-    record.stream_count = 1 + len_to_u16(additional_stream_count);
-    record.total_stream_count =
-        1 + len_to_u16(additional_stream_count) + len_to_u16(internal_stream_count);
+    // Name/stream counts are bounded by attributes-per-record; saturate to stay
+    // total.
+    record.name_count = len_to_u16(additional_count).saturating_add(1);
+    record.stream_count = len_to_u16(additional_stream_count).saturating_add(1);
+    record.total_stream_count = len_to_u16(additional_stream_count)
+        .saturating_add(1)
+        .saturating_add(len_to_u16(internal_stream_count));
     record.internal_streams_size = internal_size_total;
     record.internal_streams_allocated = internal_alloc_total;
     record.first_internal_stream = first_internal;
@@ -839,4 +737,103 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
     }
 
     true
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Read a little-endian u16 from the given offset, returning 0 if out of
+/// bounds.
+#[inline]
+fn rd_u16(buf: &[u8], off: usize) -> u16 {
+    off.checked_add(2)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 2]>::try_from(sl).ok())
+        .map_or(0, u16::from_le_bytes)
+}
+
+/// Read a little-endian u32 from the given offset, returning 0 if out of
+/// bounds.
+#[inline]
+fn rd_u32(buf: &[u8], off: usize) -> u32 {
+    off.checked_add(4)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 4]>::try_from(sl).ok())
+        .map_or(0, u32::from_le_bytes)
+}
+
+/// Read a little-endian u64 from the given offset, returning 0 if out of
+/// bounds.
+#[inline]
+fn rd_u64(buf: &[u8], off: usize) -> u64 {
+    off.checked_add(8)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 8]>::try_from(sl).ok())
+        .map_or(0, u64::from_le_bytes)
+}
+
+/// Read a little-endian i64 from the given offset, returning 0 if out of
+/// bounds.
+#[inline]
+fn rd_i64(buf: &[u8], off: usize) -> i64 {
+    off.checked_add(8)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 8]>::try_from(sl).ok())
+        .map_or(0, i64::from_le_bytes)
+}
+
+/// Determine whether a non-`$DATA` attribute is the primary extent
+/// (`LowestVCN == 0`).
+///
+/// Resident attributes are always primary. For non-resident attributes the
+/// `LowestVCN` lives at `offset + 16` (8 bytes); a truncated record that
+/// cannot supply it is treated as **not** primary (preserves the original
+/// `else { false }` semantics of the internal-stream branches).
+#[inline]
+fn is_nonresident_primary(
+    data: &[u8],
+    offset: usize,
+    attr_header: &crate::ntfs::AttributeRecordHeader,
+) -> bool {
+    if attr_header.is_non_resident == 0 {
+        return true;
+    }
+    offset
+        .checked_add(16)
+        .filter(|nr| nr.saturating_add(8) <= data.len())
+        .is_some_and(|nr| rd_i64(data, nr) == 0)
+}
+
+/// Read the `(DataSize, AllocatedSize)` pair from a non-resident attribute's
+/// header at `offset`, clamping negative values to 0.
+///
+/// Returns `(0, 0)` if the header is truncated (the `nr + 48 <= len` guard
+/// preserves the original "all fields present" semantics).
+#[inline]
+fn read_nonresident_size_alloc(data: &[u8], offset: usize) -> (u64, u64) {
+    let nr_offset = offset.saturating_add(16);
+    if nr_offset.saturating_add(48) <= data.len() {
+        let allocated = nonneg_to_u64(rd_i64(data, nr_offset.saturating_add(24)));
+        let data_size = nonneg_to_u64(rd_i64(data, nr_offset.saturating_add(32)));
+        (data_size, allocated)
+    } else {
+        (0, 0)
+    }
+}
+
+/// Read the `(size, allocated)` pair for an internal-stream attribute,
+/// dispatching on residency.
+///
+/// Resident attributes report `(value_length@offset+16, 0)`; non-resident
+/// attributes delegate to [`read_nonresident_size_alloc`].
+#[inline]
+fn read_size_alloc(
+    data: &[u8],
+    offset: usize,
+    attr_header: &crate::ntfs::AttributeRecordHeader,
+) -> (u64, u64) {
+    if attr_header.is_non_resident == 0 {
+        (u64::from(rd_u32(data, offset.saturating_add(16))), 0)
+    } else {
+        read_nonresident_size_alloc(data, offset)
+    }
 }

--- a/crates/uffs-mft/src/io/parser/index_extension.rs
+++ b/crates/uffs-mft/src/io/parser/index_extension.rs
@@ -10,6 +10,17 @@
 //! This module handles extension records for the single-pass parser, extracting
 //! names, streams, and all attribute types from extension records and merging
 //! them into base records in the index.
+//!
+//! # Hardening (WI-5.2)
+//! This module parses **untrusted on-disk bytes**. Every offset/length derived
+//! from those bytes is combined with `checked_add`/`checked_mul` (or
+//! `saturating_*` where overflow is provably unreachable) and every slice into
+//! `data` goes through `.get()` / the `rd_u*` helpers — never `data[a..b]`
+//! indexing. The daemon builds with `panic = "abort"`, so a single parser panic
+//! on a malformed record would be a whole-process denial of service.
+//! `arithmetic_side_effects` is enabled module-wide as a regression guard: any
+//! new raw `+`/`*` on a byte-derived value is a compile error here.
+#![warn(clippy::arithmetic_side_effects)]
 
 use core::mem::size_of;
 
@@ -52,8 +63,11 @@ use crate::index::{frs_to_usize, len_to_u16, len_to_u32, u32_as_usize};
 #[expect(
     clippy::indexing_slicing,
     clippy::missing_asserts_for_indexing,
-    reason = "all slice access is bounds-guarded: while-loop checks offset + HEADER_SIZE <= max_offset, \
-              and each attribute access validates offset + field_len <= data.len() before indexing"
+    reason = "the only `[]` indexing that remains is into internal arena vectors \
+              (index.records / index.links / index.streams / index.internal_streams / \
+              index.frs_to_idx) whose indices are produced by this code, not by untrusted \
+              on-disk bytes. All reads of the untrusted `data` slice go through `.get()` / \
+              the `rd_u*` helpers (WI-5.2)"
 )]
 pub(super) fn parse_extension_to_index(
     data: &[u8],
@@ -90,8 +104,14 @@ pub(super) fn parse_extension_to_index(
     let mut default_data_allocated: u64 = 0;
     let mut found_default_data = false;
 
-    while offset + size_of::<AttributeRecordHeader>() <= max_offset {
-        let Ok((attr_header, _)) = AttributeRecordHeader::read_from_prefix(&data[offset..]) else {
+    while offset
+        .checked_add(size_of::<AttributeRecordHeader>())
+        .is_some_and(|end| end <= max_offset)
+    {
+        let Some(attr_slice) = data.get(offset..) else {
+            break;
+        };
+        let Ok((attr_header, _)) = AttributeRecordHeader::read_from_prefix(attr_slice) else {
             break;
         };
 
@@ -99,7 +119,11 @@ pub(super) fn parse_extension_to_index(
             break;
         }
 
-        if attr_header.length == 0 || offset + u32_as_usize(attr_header.length) > max_offset {
+        // `offset + length` can overflow on a crafted `length`; checked_add → break.
+        let Some(attr_end) = offset.checked_add(u32_as_usize(attr_header.length)) else {
+            break;
+        };
+        if attr_header.length == 0 || attr_end > max_offset {
             break;
         }
 
@@ -108,24 +132,31 @@ pub(super) fn parse_extension_to_index(
             Some(AttributeType::FileName) => {
                 // Parse $FILE_NAME attribute
                 if attr_header.is_non_resident == 0 {
-                    let value_offset_bytes = &data[offset + 20..offset + 22];
-                    let value_offset = usize::from(u16::from_le_bytes(
-                        value_offset_bytes.try_into().unwrap_or([0, 0]),
-                    ));
-                    let fn_offset = offset + value_offset;
-                    if fn_offset + size_of::<FileNameAttribute>() <= data.len() {
-                        let Ok((fn_attr, _)) =
-                            FileNameAttribute::read_from_prefix(&data[fn_offset..])
-                        else {
+                    let value_offset = usize::from(rd_u16(data, offset.saturating_add(20)));
+                    // `offset + value_offset` is byte-derived; checked, then re-validated
+                    // by the `.get()` below.
+                    if let Some(fn_offset) = offset.checked_add(value_offset)
+                        && let Some(fn_slice) = fn_offset
+                            .checked_add(size_of::<FileNameAttribute>())
+                            .filter(|end| *end <= data.len())
+                            .and_then(|_| data.get(fn_offset..))
+                    {
+                        let Ok((fn_attr, _)) = FileNameAttribute::read_from_prefix(fn_slice) else {
                             break;
                         };
 
                         // Skip DOS-only names (namespace 2)
                         if fn_attr.file_name_namespace != 2 {
                             let name_len = usize::from(fn_attr.file_name_length);
-                            let name_start = fn_offset + size_of::<FileNameAttribute>();
-                            if name_start + name_len * 2 <= data.len() {
-                                let name_bytes = &data[name_start..name_start + name_len * 2];
+                            let name_start =
+                                fn_offset.saturating_add(size_of::<FileNameAttribute>());
+                            // `name_len * 2` (UTF-16) overflows on a crafted length →
+                            // checked_mul/checked_add, then `.get()` bounds the slice.
+                            if let Some(name_bytes) = name_len
+                                .checked_mul(2)
+                                .and_then(|byte_len| name_start.checked_add(byte_len))
+                                .and_then(|end| data.get(name_start..end))
+                            {
                                 let name_u16: SmallVec<[u16; 64]> = name_bytes
                                     .chunks_exact(2)
                                     .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
@@ -142,89 +173,55 @@ pub(super) fn parse_extension_to_index(
                 // legacy-output parity: Only primary attributes (LowestVCN == 0) count as
                 // streams. Continuation extents (LowestVCN > 0) are skipped.
                 // See ntfs_index_load.hpp:358
-                let is_primary = if attr_header.is_non_resident == 0 {
-                    true // Resident attributes are always primary
-                } else {
-                    let nr_offset = offset + 16;
-                    if nr_offset + 8 <= data.len() {
-                        let lowest_vcn = i64::from_le_bytes(
-                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
-                        );
-                        lowest_vcn == 0
-                    } else {
-                        false // Can't verify, skip to be safe
-                    }
-                };
+                let is_primary = nr_is_primary(data, attr_header.is_non_resident, offset);
 
                 if !is_primary {
                     // Skip continuation extents - they don't count as new streams
-                    offset += u32_as_usize(attr_header.length);
+                    offset = offset.saturating_add(u32_as_usize(attr_header.length));
                     continue;
                 }
 
                 // Parse $DATA attribute — default stream (unnamed) or ADS (named)
                 let name_len = usize::from(attr_header.name_length);
                 let (size, allocated) = if attr_header.is_non_resident != 0 {
-                    let nr_offset = offset + 16;
-                    if nr_offset + 48 <= data.len() {
-                        // Check if compressed or sparse
-                        let is_compressed_or_sparse = (attr_header.flags & 0x8001) != 0;
-                        let compression_unit_offset = nr_offset + 18;
-                        let has_compression_unit = if compression_unit_offset + 2 <= data.len() {
-                            let compression_unit = u16::from_le_bytes(
-                                data[compression_unit_offset..compression_unit_offset + 2]
-                                    .try_into()
-                                    .unwrap_or([0; 2]),
-                            );
-                            compression_unit > 0
-                        } else {
-                            false
-                        };
+                    // `rd_u*` are individually bounds-safe (return 0 OOB); the
+                    // `nr + 48 <= len` guard preserves the original "all fields
+                    // present" semantics. `nr` via checked_add.
+                    offset
+                        .checked_add(16)
+                        .filter(|nr| nr.saturating_add(48) <= data.len())
+                        .map_or((0, 0), |nr_offset| {
+                            // Check if compressed or sparse
+                            let is_compressed_or_sparse = (attr_header.flags & 0x8001) != 0;
+                            let compression_unit = rd_u16(data, nr_offset.saturating_add(18));
+                            let has_compression_unit = compression_unit > 0;
 
-                        let use_compressed_size = is_compressed_or_sparse || has_compression_unit;
-                        let compressed_size_offset = nr_offset + 48; // offset + 64
+                            let use_compressed_size =
+                                is_compressed_or_sparse || has_compression_unit;
+                            // offset + 64
+                            let compressed_size_offset = nr_offset.saturating_add(48);
 
-                        let allocated =
-                            if use_compressed_size && compressed_size_offset + 8 <= data.len() {
+                            // Preserve original fallback: only read CompressedSize
+                            // when its 8-byte field is fully in bounds; otherwise
+                            // read AllocatedLength.
+                            let allocated = if use_compressed_size
+                                && compressed_size_offset.saturating_add(8) <= data.len()
+                            {
                                 // Read CompressedSize for compressed/sparse files
-                                i64::from_le_bytes(
-                                    data[compressed_size_offset..compressed_size_offset + 8]
-                                        .try_into()
-                                        .unwrap_or([0; 8]),
-                                )
+                                rd_u64(data, compressed_size_offset).cast_signed()
                             } else {
                                 // Read AllocatedLength for normal files
-                                i64::from_le_bytes(
-                                    data[nr_offset + 24..nr_offset + 32]
-                                        .try_into()
-                                        .unwrap_or([0; 8]),
-                                )
+                                rd_u64(data, nr_offset.saturating_add(24)).cast_signed()
                             };
 
-                        let size = i64::from_le_bytes(
-                            data[nr_offset + 32..nr_offset + 40]
-                                .try_into()
-                                .unwrap_or([0; 8]),
-                        );
-                        (
-                            size.max(0).cast_unsigned(),
-                            allocated.max(0).cast_unsigned(),
-                        )
-                    } else {
-                        (0, 0)
-                    }
+                            let size = rd_u64(data, nr_offset.saturating_add(32)).cast_signed();
+                            (
+                                size.max(0).cast_unsigned(),
+                                allocated.max(0).cast_unsigned(),
+                            )
+                        })
                 } else {
-                    let len_offset = offset + 16;
-                    if len_offset + 4 <= data.len() {
-                        let len = u64::from(u32::from_le_bytes(
-                            data[len_offset..len_offset + 4]
-                                .try_into()
-                                .unwrap_or([0; 4]),
-                        ));
-                        (len, 0)
-                    } else {
-                        (0, 0)
-                    }
+                    (u64::from(rd_u32(data, offset.saturating_add(16))), 0)
                 };
 
                 if name_len == 0 {
@@ -245,9 +242,8 @@ pub(super) fn parse_extension_to_index(
                     found_default_data = true;
                 } else {
                     // ADS (named stream)
-                    let name_offset = offset + usize::from(attr_header.name_offset);
-                    if name_offset + name_len * 2 <= data.len() {
-                        let name_bytes = &data[name_offset..name_offset + name_len * 2];
+                    let name_offset = offset.saturating_add(usize::from(attr_header.name_offset));
+                    if let Some(name_bytes) = read_name_bytes(data, name_offset, name_len) {
                         let name_u16: SmallVec<[u16; 64]> = name_bytes
                             .chunks_exact(2)
                             .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
@@ -262,28 +258,8 @@ pub(super) fn parse_extension_to_index(
             }
             Some(AttributeType::ReparsePoint) => {
                 // Parse $REPARSE_POINT - add as stream
-                let (rp_size, rp_allocated) = if attr_header.is_non_resident == 0 {
-                    let value_length_bytes = &data[offset + 16..offset + 20];
-                    let value_length = u64::from(u32::from_le_bytes(
-                        value_length_bytes.try_into().unwrap_or([0; 4]),
-                    ));
-                    (value_length, 0_u64)
-                } else {
-                    let nr_offset = offset + 16;
-                    if nr_offset + 48 <= data.len() {
-                        let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
-                        let allocated =
-                            i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
-                        let size_bytes = &data[nr_offset + 32..nr_offset + 40];
-                        let data_size = i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
-                        (
-                            data_size.max(0).cast_unsigned(),
-                            allocated.max(0).cast_unsigned(),
-                        )
-                    } else {
-                        (0_u64, 0_u64)
-                    }
-                };
+                let (rp_size, rp_allocated) =
+                    read_attr_size(data, attr_header.is_non_resident, offset);
                 ext_internal_streams.push((rp_size, rp_allocated));
             }
             Some(
@@ -292,24 +268,24 @@ pub(super) fn parse_extension_to_index(
                 // Extract attribute name
                 let name_len = usize::from(attr_header.name_length);
                 let (is_i30, _attr_name) = if name_len > 0 {
-                    let name_offset = offset + usize::from(attr_header.name_offset);
-                    if name_offset + name_len * 2 <= data.len() {
-                        let name_bytes = &data[name_offset..name_offset + name_len * 2];
-                        let is_i30 =
-                            attr_header.name_length == 4 && name_bytes == b"$\x00I\x003\x000\x00";
-                        let name = if is_i30 {
-                            String::new()
-                        } else {
-                            let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
-                                .collect();
-                            crate::io::parser::unified::decode_name_u16(&name_u16).0
-                        };
-                        (is_i30, name)
-                    } else {
-                        (false, String::new())
-                    }
+                    let name_offset = offset.saturating_add(usize::from(attr_header.name_offset));
+                    read_name_bytes(data, name_offset, name_len).map_or_else(
+                        || (false, String::new()),
+                        |name_bytes| {
+                            let is_i30 = attr_header.name_length == 4
+                                && name_bytes == b"$\x00I\x003\x000\x00";
+                            let name = if is_i30 {
+                                String::new()
+                            } else {
+                                let name_u16: SmallVec<[u16; 64]> = name_bytes
+                                    .chunks_exact(2)
+                                    .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                                    .collect();
+                                crate::io::parser::unified::decode_name_u16(&name_u16).0
+                            };
+                            (is_i30, name)
+                        },
+                    )
                 } else {
                     (false, String::new())
                 };
@@ -317,65 +293,26 @@ pub(super) fn parse_extension_to_index(
                 if is_i30 {
                     // Accumulate $I30 sizes
                     if attr_header.is_non_resident == 0 {
-                        let value_length_bytes = &data[offset + 16..offset + 20];
-                        let value_length = u64::from(u32::from_le_bytes(
-                            value_length_bytes.try_into().unwrap_or([0; 4]),
-                        ));
-                        dir_index_size += value_length;
-                    } else {
-                        let nr_offset = offset + 16;
-                        if nr_offset + 48 <= data.len() {
-                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
-                            let allocated =
-                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
-                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
-                            let data_size =
-                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
-                            dir_index_size += data_size.max(0).cast_unsigned();
-                            dir_index_allocated += allocated.max(0).cast_unsigned();
-                        }
+                        let value_length = u64::from(rd_u32(data, offset.saturating_add(16)));
+                        // Disk-derived accumulator; saturate to avoid overflow panic.
+                        dir_index_size = dir_index_size.saturating_add(value_length);
+                    } else if let Some(nr_offset) = offset
+                        .checked_add(16)
+                        .filter(|nr| nr.saturating_add(48) <= data.len())
+                    {
+                        let allocated = rd_u64(data, nr_offset.saturating_add(24)).cast_signed();
+                        let data_size = rd_u64(data, nr_offset.saturating_add(32)).cast_signed();
+                        // Disk-derived accumulators; saturate to avoid overflow panic.
+                        dir_index_size =
+                            dir_index_size.saturating_add(data_size.max(0).cast_unsigned());
+                        dir_index_allocated =
+                            dir_index_allocated.saturating_add(allocated.max(0).cast_unsigned());
                     }
                 } else {
                     // Non-$I30 index — internal stream for tree metrics
-                    let is_primary = if attr_header.is_non_resident == 0 {
-                        true
-                    } else {
-                        let nr_offset = offset + 16;
-                        if nr_offset + 8 <= data.len() {
-                            let lowest_vcn = i64::from_le_bytes(
-                                data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
-                            );
-                            lowest_vcn == 0
-                        } else {
-                            false
-                        }
-                    };
-
-                    if is_primary {
-                        let (size, allocated) = if attr_header.is_non_resident == 0 {
-                            let value_length_bytes = &data[offset + 16..offset + 20];
-                            let value_length = u64::from(u32::from_le_bytes(
-                                value_length_bytes.try_into().unwrap_or([0; 4]),
-                            ));
-                            (value_length, 0_u64)
-                        } else {
-                            let nr_offset = offset + 16;
-                            if nr_offset + 48 <= data.len() {
-                                let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
-                                let allocated =
-                                    i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
-                                let size_bytes = &data[nr_offset + 32..nr_offset + 40];
-                                let data_size =
-                                    i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
-                                (
-                                    data_size.max(0).cast_unsigned(),
-                                    allocated.max(0).cast_unsigned(),
-                                )
-                            } else {
-                                (0_u64, 0_u64)
-                            }
-                        };
-
+                    if nr_is_primary(data, attr_header.is_non_resident, offset) {
+                        let (size, allocated) =
+                            read_attr_size(data, attr_header.is_non_resident, offset);
                         ext_internal_streams.push((size, allocated));
                     }
                 }
@@ -392,45 +329,9 @@ pub(super) fn parse_extension_to_index(
                 | AttributeType::AttributeList,
             ) => {
                 // All counted as streams
-                let is_primary = if attr_header.is_non_resident == 0 {
-                    true
-                } else {
-                    let nr_offset = offset + 16;
-                    if nr_offset + 8 <= data.len() {
-                        let lowest_vcn = i64::from_le_bytes(
-                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
-                        );
-                        lowest_vcn == 0
-                    } else {
-                        false
-                    }
-                };
-
-                if is_primary {
-                    let (size, allocated) = if attr_header.is_non_resident == 0 {
-                        let value_length_bytes = &data[offset + 16..offset + 20];
-                        let value_length = u64::from(u32::from_le_bytes(
-                            value_length_bytes.try_into().unwrap_or([0; 4]),
-                        ));
-                        (value_length, 0_u64)
-                    } else {
-                        let nr_offset = offset + 16;
-                        if nr_offset + 48 <= data.len() {
-                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
-                            let allocated =
-                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
-                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
-                            let data_size =
-                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
-                            (
-                                data_size.max(0).cast_unsigned(),
-                                allocated.max(0).cast_unsigned(),
-                            )
-                        } else {
-                            (0_u64, 0_u64)
-                        }
-                    };
-
+                if nr_is_primary(data, attr_header.is_non_resident, offset) {
+                    let (size, allocated) =
+                        read_attr_size(data, attr_header.is_non_resident, offset);
                     ext_internal_streams.push((size, allocated));
                 }
             }
@@ -439,51 +340,16 @@ pub(super) fn parse_extension_to_index(
             }
             _ => {
                 // Unknown attribute types — counted as streams (catch-all).
-                let is_primary = if attr_header.is_non_resident == 0 {
-                    true
-                } else {
-                    let nr_offset = offset + 16;
-                    if nr_offset + 8 <= data.len() {
-                        let lowest_vcn = i64::from_le_bytes(
-                            data[nr_offset..nr_offset + 8].try_into().unwrap_or([0; 8]),
-                        );
-                        lowest_vcn == 0
-                    } else {
-                        false
-                    }
-                };
-
-                if is_primary {
-                    let (size, allocated) = if attr_header.is_non_resident == 0 {
-                        let value_length_bytes = &data[offset + 16..offset + 20];
-                        let value_length = u64::from(u32::from_le_bytes(
-                            value_length_bytes.try_into().unwrap_or([0; 4]),
-                        ));
-                        (value_length, 0_u64)
-                    } else {
-                        let nr_offset = offset + 16;
-                        if nr_offset + 48 <= data.len() {
-                            let alloc_bytes = &data[nr_offset + 24..nr_offset + 32];
-                            let allocated =
-                                i64::from_le_bytes(alloc_bytes.try_into().unwrap_or([0; 8]));
-                            let size_bytes = &data[nr_offset + 32..nr_offset + 40];
-                            let data_size =
-                                i64::from_le_bytes(size_bytes.try_into().unwrap_or([0; 8]));
-                            (
-                                data_size.max(0).cast_unsigned(),
-                                allocated.max(0).cast_unsigned(),
-                            )
-                        } else {
-                            (0_u64, 0_u64)
-                        }
-                    };
-
+                if nr_is_primary(data, attr_header.is_non_resident, offset) {
+                    let (size, allocated) =
+                        read_attr_size(data, attr_header.is_non_resident, offset);
                     ext_internal_streams.push((size, allocated));
                 }
             }
         }
 
-        offset += u32_as_usize(attr_header.length);
+        // Disk-derived advance; saturate so a crafted length can't overflow.
+        offset = offset.saturating_add(u32_as_usize(attr_header.length));
     }
 
     // If no names, user-visible streams, internal streams, default data, or
@@ -596,10 +462,10 @@ pub(super) fn parse_extension_to_index(
                 };
 
                 // Chain the new links together
-                for i in 0..link_indices.len().saturating_sub(1) {
-                    let current_idx = u32_as_usize(link_indices[i]);
-                    let next_idx = link_indices[i + 1];
-                    index.links[current_idx].next_entry = next_idx;
+                for pair in link_indices.windows(2) {
+                    if let [current, next] = *pair {
+                        index.links[u32_as_usize(current)].next_entry = next;
+                    }
                 }
 
                 // Attach to the chain
@@ -611,9 +477,11 @@ pub(super) fn parse_extension_to_index(
                     rec_link.first_name.next_entry = link_indices[0];
                 }
 
-                // Update name count
+                // Update name count (bounded internal counter; saturate).
                 let rec_name_count = &mut index.records[u32_as_usize(base_idx)];
-                rec_name_count.name_count += len_to_u16(link_indices.len());
+                rec_name_count.name_count = rec_name_count
+                    .name_count
+                    .saturating_add(len_to_u16(link_indices.len()));
             } else {
                 // Copy the first extension name directly into first_name
                 // This matches established behavior (ntfs_index.hpp lines 559-567)
@@ -626,17 +494,22 @@ pub(super) fn parse_extension_to_index(
 
                 // Chain remaining links (if any) to first_name.next_entry
                 if link_indices.len() > 1 {
-                    // Chain the remaining links together
-                    for i in 1..link_indices.len().saturating_sub(1) {
-                        let current_idx = u32_as_usize(link_indices[i]);
-                        let next_idx = link_indices[i + 1];
-                        index.links[current_idx].next_entry = next_idx;
+                    // Chain the remaining links together (links[1..]); link 0 was
+                    // copied into first_name above and is not chained from.
+                    if let Some(rest) = link_indices.get(1..) {
+                        for pair in rest.windows(2) {
+                            if let [current, next] = *pair {
+                                index.links[u32_as_usize(current)].next_entry = next;
+                            }
+                        }
                     }
                     // Attach remaining links to first_name
                     let rec_extra = &mut index.records[u32_as_usize(base_idx)];
                     rec_extra.first_name.next_entry = link_indices[1];
-                    // Update name count for additional links only
-                    rec_extra.name_count += len_to_u16(link_indices.len().saturating_sub(1));
+                    // Update name count for additional links only (saturate).
+                    rec_extra.name_count = rec_extra
+                        .name_count
+                        .saturating_add(len_to_u16(link_indices.len().saturating_sub(1)));
                 }
             }
         }
@@ -655,10 +528,10 @@ pub(super) fn parse_extension_to_index(
             };
 
             // Chain the new streams together
-            for i in 0..stream_indices.len().saturating_sub(1) {
-                let current_idx = u32_as_usize(stream_indices[i]);
-                let next_idx = stream_indices[i + 1];
-                index.streams[current_idx].next_entry = next_idx;
+            for pair in stream_indices.windows(2) {
+                if let [current, next] = *pair {
+                    index.streams[u32_as_usize(current)].next_entry = next;
+                }
             }
 
             // Attach to the chain
@@ -670,10 +543,14 @@ pub(super) fn parse_extension_to_index(
                 rec_stream_attach.first_stream.next_entry = stream_indices[0];
             }
 
-            // Update stream count (user-visible only)
+            // Update stream count (user-visible only; bounded counters, saturate).
             let rec_stream_count = &mut index.records[u32_as_usize(base_idx)];
-            rec_stream_count.stream_count += len_to_u16(stream_indices.len());
-            rec_stream_count.total_stream_count += len_to_u16(stream_indices.len());
+            let stream_added = len_to_u16(stream_indices.len());
+            rec_stream_count.stream_count =
+                rec_stream_count.stream_count.saturating_add(stream_added);
+            rec_stream_count.total_stream_count = rec_stream_count
+                .total_stream_count
+                .saturating_add(stream_added);
         }
 
         // Build internal stream chain for extension record attributes
@@ -729,9 +606,11 @@ pub(super) fn parse_extension_to_index(
                 rec_head.first_internal_stream = first_new_internal;
             }
 
-            // Update total_stream_count to include new internal streams
+            // Update total_stream_count to include new internal streams (saturate).
             let rec_total = &mut index.records[u32_as_usize(base_idx)];
-            rec_total.total_stream_count += len_to_u16(ext_internal_streams.len());
+            rec_total.total_stream_count = rec_total
+                .total_stream_count
+                .saturating_add(len_to_u16(ext_internal_streams.len()));
         }
 
         // Merge default $DATA stream from extension record into base record.
@@ -768,9 +647,17 @@ pub(super) fn parse_extension_to_index(
         if dir_index_size > 0 || dir_index_allocated > 0 {
             let rec_dir = &mut index.records[u32_as_usize(base_idx)];
             // Add to the first_stream size (which represents the default stream for
-            // directories)
-            rec_dir.first_stream.size.length += dir_index_size;
-            rec_dir.first_stream.size.allocated += dir_index_allocated;
+            // directories). Disk-derived sizes; saturate to avoid overflow panic.
+            rec_dir.first_stream.size.length = rec_dir
+                .first_stream
+                .size
+                .length
+                .saturating_add(dir_index_size);
+            rec_dir.first_stream.size.allocated = rec_dir
+                .first_stream
+                .size
+                .allocated
+                .saturating_add(dir_index_allocated);
         }
 
         // Build parent-child relationship for names added from extension records
@@ -788,7 +675,11 @@ pub(super) fn parse_extension_to_index(
             let parent_idx = {
                 let p_frs_usize = frs_to_usize(p_frs);
                 if p_frs_usize >= index.frs_to_idx.len() {
-                    index.frs_to_idx.resize(p_frs_usize + 1, NO_ENTRY);
+                    // `p_frs` is masked to 48 bits, so `+ 1` cannot overflow usize on
+                    // 64-bit; saturate defensively to keep arithmetic panic-free.
+                    index
+                        .frs_to_idx
+                        .resize(p_frs_usize.saturating_add(1), NO_ENTRY);
                 }
                 if index.frs_to_idx[p_frs_usize] == NO_ENTRY {
                     // Create placeholder parent
@@ -818,8 +709,9 @@ pub(super) fn parse_extension_to_index(
                 // First extension name became first_name, so name_index starts at 0
                 len_to_u16(name_idx)
             } else {
-                // Extension names are appended after existing names
-                existing_name_count + len_to_u16(name_idx)
+                // Extension names are appended after existing names (bounded u16
+                // name-index counter; saturate).
+                existing_name_count.saturating_add(len_to_u16(name_idx))
             };
 
             let child_idx = len_to_u32(index.children.len());
@@ -844,4 +736,87 @@ pub(super) fn parse_extension_to_index(
         || found_default_data
         || dir_index_size > 0
         || dir_index_allocated > 0
+}
+
+// ── Helpers (untrusted-byte readers, WI-5.2) ────────────────────────────────
+
+/// Read a little-endian `u16` from `buf` at `off`, returning 0 if the 2-byte
+/// field is out of bounds.
+#[inline]
+fn rd_u16(buf: &[u8], off: usize) -> u16 {
+    off.checked_add(2)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 2]>::try_from(sl).ok())
+        .map_or(0, u16::from_le_bytes)
+}
+
+/// Read a little-endian `u32` from `buf` at `off`, returning 0 if the 4-byte
+/// field is out of bounds.
+#[inline]
+fn rd_u32(buf: &[u8], off: usize) -> u32 {
+    off.checked_add(4)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 4]>::try_from(sl).ok())
+        .map_or(0, u32::from_le_bytes)
+}
+
+/// Read a little-endian `u64` from `buf` at `off`, returning 0 if the 8-byte
+/// field is out of bounds.
+#[inline]
+fn rd_u64(buf: &[u8], off: usize) -> u64 {
+    off.checked_add(8)
+        .and_then(|end| buf.get(off..end))
+        .and_then(|sl| <[u8; 8]>::try_from(sl).ok())
+        .map_or(0, u64::from_le_bytes)
+}
+
+/// Determine whether a non-resident attribute is a *primary* extent
+/// (`LowestVCN == 0`); resident attributes are always primary.
+///
+/// Mirrors the original guarded read: when the 8-byte `LowestVCN` field is out
+/// of bounds the attribute is treated as non-primary ("can't verify, skip to be
+/// safe").
+#[inline]
+fn nr_is_primary(data: &[u8], is_non_resident: u8, offset: usize) -> bool {
+    if is_non_resident == 0 {
+        return true;
+    }
+    offset
+        .checked_add(16)
+        .filter(|nr| nr.saturating_add(8) <= data.len())
+        .is_some_and(|nr_offset| rd_u64(data, nr_offset).cast_signed() == 0)
+}
+
+/// Read the `(size, allocated)` pair for an attribute, mirroring the original
+/// per-branch logic exactly:
+/// - resident: `(ValueLength @ offset+16 as u32, 0)`
+/// - non-resident: only when the 48-byte non-resident header is fully present,
+///   `(DataSize @ +32, AllocatedSize @ +24)` clamped to `>= 0`; otherwise `(0,
+///   0)`.
+#[inline]
+fn read_attr_size(data: &[u8], is_non_resident: u8, offset: usize) -> (u64, u64) {
+    if is_non_resident == 0 {
+        return (u64::from(rd_u32(data, offset.saturating_add(16))), 0);
+    }
+    offset
+        .checked_add(16)
+        .filter(|nr| nr.saturating_add(48) <= data.len())
+        .map_or((0, 0), |nr_offset| {
+            let allocated = rd_u64(data, nr_offset.saturating_add(24)).cast_signed();
+            let data_size = rd_u64(data, nr_offset.saturating_add(32)).cast_signed();
+            (
+                data_size.max(0).cast_unsigned(),
+                allocated.max(0).cast_unsigned(),
+            )
+        })
+}
+
+/// Return the `name_len * 2` UTF-16 name bytes starting at `name_offset`, or
+/// `None` if the (byte-derived) range overflows or lies outside `data`.
+#[inline]
+fn read_name_bytes(data: &[u8], name_offset: usize, name_len: usize) -> Option<&[u8]> {
+    name_len
+        .checked_mul(2)
+        .and_then(|byte_len| name_offset.checked_add(byte_len))
+        .and_then(|end| data.get(name_offset..end))
 }

--- a/crates/uffs-mft/src/io/parser/mod.rs
+++ b/crates/uffs-mft/src/io/parser/mod.rs
@@ -27,9 +27,9 @@ pub use crate::parse::{
 
 #[cfg(test)]
 mod tests {
-    #[expect(deprecated, reason = "testing deprecated parse_record_to_index API")]
+    #[expect(deprecated, reason = "testing deprecated parse_record_to_fragment API")]
     use super::parse_record_to_fragment;
-    use super::parse_record_to_index;
+    use super::{parse_record_to_index, process_record};
     use crate::index::{MftIndex, MftIndexFragment};
 
     #[test]
@@ -43,5 +43,140 @@ mod tests {
     fn parse_record_to_fragment_rejects_short_buffers() {
         let mut fragment = MftIndexFragment::with_capacity(1);
         assert!(!parse_record_to_fragment(&[0_u8; 3], 42, &mut fragment));
+    }
+
+    // ── WI-5.2 panic-resistance corpus ──────────────────────────────
+    //
+    // The daemon builds with `panic = "abort"`: a single parser panic on a
+    // crafted MFT record is a whole-process DoS. These records all pass the
+    // FILE-record header gate (`is_file_record` + `is_in_use`) so the parser
+    // enters the attribute loop, then carry attribute bytes engineered to
+    // hit every offset/length/multiply edge that WI-5.2 converted from raw
+    // `data[..]` / `+` / `* 2` to `.get()` / `checked_*`. The contract under
+    // test is simply: **the parser returns; it never panics.**
+
+    /// Forges malformed FILE records by appending bytes (no indexing, no
+    /// offset arithmetic — so the builder itself stays panic-free and
+    /// lint-clean). The 56-byte `FileRecordSegmentHeader` is emitted first
+    /// with a valid magic / in-use flag / first-attribute-offset, then an
+    /// arbitrary attribute body is appended.
+    struct RecordBuilder {
+        bytes: Vec<u8>,
+    }
+
+    impl RecordBuilder {
+        /// Emit a header that passes `is_file_record` + `is_in_use`, with
+        /// `first_attribute_offset` = `attr_start`. The fixed 56-byte header
+        /// is built field-by-field via append so offsets are implicit.
+        fn new(attr_start: u16) -> Self {
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(b"FILE"); // [0..4]  magic
+            bytes.extend_from_slice(&[0_u8; 16]); // [4..20] usa/lsn/seq/link
+            bytes.extend_from_slice(&attr_start.to_le_bytes()); // [20..22]
+            bytes.extend_from_slice(&0x0001_u16.to_le_bytes()); // [22..24] in-use
+            bytes.extend_from_slice(&[0_u8; 32]); // [24..56] rest of header
+            Self { bytes }
+        }
+
+        /// Append a 16-byte resident-attribute header prefix (`type_code`,
+        /// `length`, non-resident flag, `name_length`, `name_offset`,
+        /// flags/instance).
+        fn attr(
+            mut self,
+            type_code: u32,
+            length: u32,
+            non_resident: u8,
+            name_length: u8,
+            name_offset: u16,
+        ) -> Self {
+            self.bytes.extend_from_slice(&type_code.to_le_bytes());
+            self.bytes.extend_from_slice(&length.to_le_bytes());
+            self.bytes.push(non_resident);
+            self.bytes.push(name_length);
+            self.bytes.extend_from_slice(&name_offset.to_le_bytes());
+            self.bytes.extend_from_slice(&[0_u8; 4]); // flags + instance
+            self
+        }
+
+        /// Append raw filler bytes (used to reach a target value offset or to
+        /// pad with garbage).
+        fn raw(mut self, bytes: &[u8]) -> Self {
+            self.bytes.extend_from_slice(bytes);
+            self
+        }
+
+        fn build(self) -> Vec<u8> {
+            self.bytes
+        }
+    }
+
+    /// Run every malformed record through all three entry points; the test
+    /// passes iff none of them panics (the return value is irrelevant).
+    fn assert_all_parsers_survive(record: &[u8]) {
+        // The return value is irrelevant — reaching the end of this function
+        // at all means none of the three parsers panicked, which is the
+        // property under test. `black_box` consumes each result so it is
+        // neither an unused binding nor an under-typed `let _` discard.
+        let mut index = MftIndex::new(crate::platform::DriveLetter::C);
+        core::hint::black_box(parse_record_to_index(record, 42, &mut index));
+
+        let mut unified_index = MftIndex::new(crate::platform::DriveLetter::C);
+        let mut name_buf = String::new();
+        core::hint::black_box(process_record(
+            record,
+            42,
+            &mut unified_index,
+            &mut name_buf,
+        ));
+
+        let mut fragment = MftIndexFragment::with_capacity(1);
+        #[expect(deprecated, reason = "panic-resistance also covers the legacy path")]
+        let fragment_ran = parse_record_to_fragment(record, 42, &mut fragment);
+        core::hint::black_box(fragment_ran);
+    }
+
+    #[test]
+    fn malformed_records_do_not_panic() {
+        // 1. Header valid, first_attribute_offset points past end of buffer.
+        assert_all_parsers_survive(&RecordBuilder::new(9999).build());
+
+        // 2. Header valid, attr offset points exactly at end (empty attr area).
+        assert_all_parsers_survive(&RecordBuilder::new(56).build());
+
+        // 3. StandardInformation attr whose declared length overruns the record.
+        assert_all_parsers_survive(
+            &RecordBuilder::new(56)
+                .attr(0x10, 0xFFFF_FFFF, 0, 0, 0)
+                .build(),
+        );
+
+        // 4. FileName attr with a name_length that, doubled, overflows past EOF
+        //    (exercises the `name_len * 2` → checked_mul conversion).
+        assert_all_parsers_survive(&RecordBuilder::new(56).attr(0x30, 24, 0, 0xFF, 0).build());
+
+        // 5. $DATA attr flagged non-resident but the record is too short to hold the
+        //    non-resident size fields (exercises the size-calc block).
+        assert_all_parsers_survive(&RecordBuilder::new(56).attr(0x80, 16, 1, 0, 0).build());
+
+        // 6. REPARSE_POINT resident attr whose value offset (rd_u16 @ off+20) points
+        //    far past the record (reparse-tag read path). The 16-byte attr prefix puts
+        //    bytes [16..20] at value-offset position; we pad to byte 20 then write
+        //    0xFFFF as the value offset.
+        assert_all_parsers_survive(
+            &RecordBuilder::new(56)
+                .attr(0xC0, 16, 0, 0, 0)
+                .raw(&[0_u8; 4]) // pad [16..20] (value_length region)
+                .raw(&0xFFFF_u16.to_le_bytes()) // value_offset = 0xFFFF
+                .build(),
+        );
+
+        // 7. Attribute with length == 0 (must terminate the loop, not spin).
+        assert_all_parsers_survive(&RecordBuilder::new(56).attr(0x10, 0, 0, 0, 0).build());
+
+        // 8. Pure garbage body behind a valid header.
+        let garbage: Vec<u8> = (0_u8..=255)
+            .map(|n| n.wrapping_mul(31).wrapping_add(7))
+            .collect();
+        assert_all_parsers_survive(&RecordBuilder::new(56).raw(&garbage).build());
     }
 }

--- a/crates/uffs-mft/src/io/parser/unified.rs
+++ b/crates/uffs-mft/src/io/parser/unified.rs
@@ -6,6 +6,18 @@
 //! ONE function processes ALL records (base AND extension) through the SAME
 //! attribute loop.  This eliminates the dual-parser architecture that caused
 //! name-ordering and stream-counting discrepancies.
+//!
+//! # Hardening (WI-5.2)
+//! This module parses **untrusted on-disk bytes**. Every offset/length
+//! derived from those bytes is combined with `checked_add`/`checked_mul`
+//! (or `saturating_*` where overflow is provably unreachable) and every
+//! slice into `data` goes through `.get()` / the `rd_u*` helpers — never
+//! `data[a..b]` indexing. The daemon builds with `panic = "abort"`, so a
+//! single parser panic on a malformed record would be a whole-process
+//! denial of service.
+//! `arithmetic_side_effects` is enabled module-wide as a regression guard:
+//! any new raw `+`/`*` on a byte-derived value is a compile error here.
+#![warn(clippy::arithmetic_side_effects)]
 
 use core::mem::size_of;
 
@@ -33,25 +45,33 @@ fn decode_utf16le_into(bytes: &[u8], out: &mut String) -> u32 {
     out.clear();
     let mut replacements: u32 = 0;
     let mut i = 0_usize;
-    while let Some(pair) = bytes
-        .get(i..i + 2)
+    while let Some(pair) = i
+        .checked_add(2)
+        .and_then(|end| bytes.get(i..end))
         .and_then(|sl| <[u8; 2]>::try_from(sl).ok())
     {
         let code = u16::from_le_bytes(pair);
-        i += 2;
+        // `i` indexes a &[u8]; it cannot exceed `bytes.len()` (≤ isize::MAX),
+        // so `+= 2` cannot overflow usize. saturating_add keeps it total.
+        i = i.saturating_add(2);
         match code {
             // High surrogate
             0xD800..=0xDBFF => {
-                if let Some(low_pair) = bytes
-                    .get(i..i + 2)
+                if let Some(low_pair) = i
+                    .checked_add(2)
+                    .and_then(|end| bytes.get(i..end))
                     .and_then(|sl| <[u8; 2]>::try_from(sl).ok())
                 {
                     let low = u16::from_le_bytes(low_pair);
                     if (0xDC00..=0xDFFF).contains(&low) {
-                        i += 2;
+                        i = i.saturating_add(2);
+                        // Bounds-proven: `code ∈ 0xD800..=0xDBFF` and
+                        // `low ∈ 0xDC00..=0xDFFF`, so both subtractions are
+                        // non-negative and the result is ≤ 0x10FFFF — no
+                        // overflow/underflow is reachable.
                         let cp = 0x1_0000_u32
-                            + ((u32::from(code) - 0xD800_u32) << 10_u32)
-                            + (u32::from(low) - 0xDC00_u32);
+                            .saturating_add((u32::from(code).saturating_sub(0xD800_u32)) << 10_u32)
+                            .saturating_add(u32::from(low).saturating_sub(0xDC00_u32));
                         if let Some(ch) = char::from_u32(cp) {
                             out.push(ch);
                         } else {
@@ -148,7 +168,10 @@ pub(crate) fn lossy_name_count() -> u64 {
 )]
 #[expect(
     clippy::indexing_slicing,
-    reason = "base_ri validated by ensure_record; bounds checked inline"
+    reason = "remaining [] are internal arena indices (index.records[base_ri], \
+              index.streams[..], index.internal_streams[..]) keyed by indices \
+              minted by this fn via ensure_record/push; not attacker-controlled. \
+              All untrusted-`data` reads go through .get()/rd_u* (WI-5.2)."
 )]
 pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mut String) -> bool {
     if data.len() < size_of::<FileRecordSegmentHeader>() {
@@ -185,15 +208,29 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
     let mut offset = usize::from(header.first_attribute_offset);
     let max_offset = core::cmp::min(u32_as_usize(header.bytes_in_use), data.len());
 
-    while offset + size_of::<AttributeRecordHeader>() <= max_offset {
-        let Ok((attr_header, _)) = AttributeRecordHeader::read_from_prefix(&data[offset..]) else {
+    // WI-5.2: every offset advance and slice below is derived from
+    // attacker-controllable record bytes, so all arithmetic uses
+    // `checked_*` and all slicing uses `data.get(..)` (fallible) — a
+    // malformed record `break`s the loop / skips the field instead of
+    // panicking. The daemon runs `panic = "abort"`, so a parser panic is a
+    // whole-process DoS.
+    while offset
+        .checked_add(size_of::<AttributeRecordHeader>())
+        .is_some_and(|end| end <= max_offset)
+    {
+        let Some(attr_slice) = data.get(offset..) else {
+            break;
+        };
+        let Ok((attr_header, _)) = AttributeRecordHeader::read_from_prefix(attr_slice) else {
             break;
         };
 
         if attr_header.type_code == AttributeType::END_MARKER {
             break;
         }
-        if attr_header.length == 0 || offset + u32_as_usize(attr_header.length) > data.len() {
+        let attr_len = u32_as_usize(attr_header.length);
+        let attr_end = offset.checked_add(attr_len);
+        if attr_len == 0 || attr_end.is_none_or(|end| end > data.len()) {
             break;
         }
 
@@ -201,10 +238,10 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
             // ── $STANDARD_INFORMATION (0x10) ─────────────────────────
             Some(AttributeType::StandardInformation) => {
                 if attr_header.is_non_resident == 0 {
-                    let vo = usize::from(rd_u16(data, offset + 20));
-                    let si_off = offset + vo;
-                    if si_off + size_of::<StandardInformation>() <= data.len()
-                        && let Ok((si, _)) = StandardInformation::read_from_prefix(&data[si_off..])
+                    let vo = usize::from(rd_u16(data, offset.saturating_add(20)));
+                    if let Some(si_off) = offset.checked_add(vo)
+                        && let Some(si_slice) = data.get(si_off..)
+                        && let Ok((si, _)) = StandardInformation::read_from_prefix(si_slice)
                     {
                         // Fast path: map raw NTFS flags directly to our
                         // compact bitmask — skips the intermediate
@@ -227,20 +264,27 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
             // Push-to-front: each new $FILE_NAME overwrites first_name.
             Some(AttributeType::FileName) => {
                 if attr_header.is_non_resident == 0 {
-                    let vo = usize::from(rd_u16(data, offset + 20));
-                    let fn_off = offset + vo;
-                    if fn_off + size_of::<FileNameAttribute>() <= data.len()
-                        && let Ok((fn_attr, _)) =
-                            FileNameAttribute::read_from_prefix(&data[fn_off..])
+                    let vo = usize::from(rd_u16(data, offset.saturating_add(20)));
+                    if let Some(fn_off) = offset.checked_add(vo)
+                        && let Some(fn_slice) = data.get(fn_off..)
+                        && let Ok((fn_attr, _)) = FileNameAttribute::read_from_prefix(fn_slice)
                         && fn_attr.file_name_namespace != 2
                     {
                         // Skip DOS-only names (namespace 2)
                         let parent_frs = file_reference_to_frs(fn_attr.parent_directory);
                         let name_len = usize::from(fn_attr.file_name_length);
-                        let ns = fn_off + size_of::<FileNameAttribute>();
+                        let ns = fn_off.saturating_add(size_of::<FileNameAttribute>());
 
-                        if ns + name_len * 2 <= data.len() {
-                            let nb = &data[ns..ns + name_len * 2];
+                        // `name_len` is a u16 (≤ 65535); `*2` and `+ ns` cannot
+                        // overflow usize on any supported target, but use the
+                        // checked form so the parser is provably total, and let
+                        // `data.get(..)` do the bounds check (None on a
+                        // declared-length that overruns the record → skip name).
+                        if let Some(nb) = name_len
+                            .checked_mul(2)
+                            .and_then(|byte_len| ns.checked_add(byte_len))
+                            .and_then(|name_end| data.get(ns..name_end))
+                        {
                             decode_utf16le_into(nb, name_buf);
 
                             // Push old first_name to chain
@@ -293,7 +337,8 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
 
                             // Increment name_count (zero-based, always increment)
                             // (including the first name).
-                            index.records[base_ri].name_count += 1;
+                            index.records[base_ri].name_count =
+                                index.records[base_ri].name_count.saturating_add(1);
                         }
                     }
                 }
@@ -305,9 +350,14 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
                 let is_primary = if attr_header.is_non_resident == 0 {
                     true
                 } else {
-                    let nr = offset + 16;
-                    nr + 8 <= data.len()
-                        && i64::from_le_bytes(data[nr..nr + 8].try_into().unwrap_or([0; 8])) == 0
+                    // Non-resident header's StartingVcn (offset+16, 8 bytes) ==
+                    // 0 marks the primary run. Fallible slice → not-primary on
+                    // a truncated record.
+                    offset
+                        .checked_add(16)
+                        .and_then(|nr| nr.checked_add(8).and_then(|end| data.get(nr..end)))
+                        .and_then(|sl| <[u8; 8]>::try_from(sl).ok())
+                        .is_some_and(|bytes| i64::from_le_bytes(bytes) == 0)
                 };
 
                 if is_primary {
@@ -323,20 +373,29 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
                                 | AttributeType::IndexAllocation
                         )
                     ) && aname_len == 4
-                        && {
-                            let no = offset + usize::from(attr_header.name_offset);
-                            no + 8 <= data.len() && &data[no..no + 8] == b"$\x00I\x003\x000\x00"
-                        };
+                        && offset
+                            .checked_add(usize::from(attr_header.name_offset))
+                            .and_then(|no| no.checked_add(8).and_then(|end| data.get(no..end)))
+                            .is_some_and(|sl| sl == b"$\x00I\x003\x000\x00");
 
                     // Read stream name (non-$I30, named attributes)
                     let has_stream_name = !is_i30 && aname_len > 0;
                     if has_stream_name {
-                        let no = offset + usize::from(attr_header.name_offset);
-                        if no + aname_len * 2 <= data.len() {
-                            let nb = &data[no..no + aname_len * 2];
-                            decode_utf16le_into(nb, name_buf);
-                        } else {
-                            name_buf.clear();
+                        // Fallible: a declared name length that overruns the
+                        // record clears the buffer instead of panicking.
+                        let name_bytes = offset
+                            .checked_add(usize::from(attr_header.name_offset))
+                            .and_then(|no| {
+                                aname_len
+                                    .checked_mul(2)
+                                    .and_then(|byte_len| no.checked_add(byte_len))
+                                    .and_then(|end| data.get(no..end))
+                            });
+                        match name_bytes {
+                            Some(bytes) => {
+                                decode_utf16le_into(bytes, name_buf);
+                            }
+                            None => name_buf.clear(),
                         }
                     }
 
@@ -345,27 +404,30 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
                         frs_base == 8 && aname_len == 4 && has_stream_name && name_buf == "$Bad";
 
                     let (size, alloc) = if attr_header.is_non_resident != 0 {
-                        let nr = offset + 16;
-                        if nr + 48 <= data.len() {
-                            let cu = rd_u16(data, nr + 18); // CompressionUnit
-                            let alloc_size = if cu > 0 {
-                                rd_u64(data, nr + 48) // CompressedSize
-                            } else if is_badclus_bad {
-                                rd_u64(data, nr + 40) // InitializedSize
-                            } else {
-                                rd_u64(data, nr + 24) // AllocatedSize
-                            };
-                            let logical_size = if is_badclus_bad {
-                                rd_u64(data, nr + 40) // InitializedSize
-                            } else {
-                                rd_u64(data, nr + 32) // DataSize
-                            };
-                            (logical_size, alloc_size)
-                        } else {
-                            (0, 0)
-                        }
+                        // `rd_u*` are individually bounds-safe (return 0 OOB);
+                        // the `nr + 48 <= len` guard preserves the original
+                        // "all fields present" semantics. `nr` via checked_add.
+                        offset
+                            .checked_add(16)
+                            .filter(|nr| nr.saturating_add(48) <= data.len())
+                            .map_or((0, 0), |nr| {
+                                let cu = rd_u16(data, nr.saturating_add(18)); // CompressionUnit
+                                let alloc_size = if cu > 0 {
+                                    rd_u64(data, nr.saturating_add(48)) // CompressedSize
+                                } else if is_badclus_bad {
+                                    rd_u64(data, nr.saturating_add(40)) // InitializedSize
+                                } else {
+                                    rd_u64(data, nr.saturating_add(24)) // AllocatedSize
+                                };
+                                let logical_size = if is_badclus_bad {
+                                    rd_u64(data, nr.saturating_add(40)) // InitializedSize
+                                } else {
+                                    rd_u64(data, nr.saturating_add(32)) // DataSize
+                                };
+                                (logical_size, alloc_size)
+                            })
                     } else {
-                        (u64::from(rd_u32(data, offset + 16)), 0)
+                        (u64::from(rd_u32(data, offset.saturating_add(16))), 0)
                     };
 
                     // ── Classify and store ───────────────────────────
@@ -375,15 +437,17 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
                         rec.stdinfo.set_directory(true);
                         rec.first_stream.flags = 0; // type_name_id=0 for $I30
 
-                        rec.first_stream.size.length += size;
-                        rec.first_stream.size.allocated += alloc;
+                        rec.first_stream.size.length =
+                            rec.first_stream.size.length.saturating_add(size);
+                        rec.first_stream.size.allocated =
+                            rec.first_stream.size.allocated.saturating_add(alloc);
                         // Increment counts once for the first $I30 attribute;
                         // subsequent $I30 attrs ($INDEX_ALLOCATION, $BITMAP)
                         // accumulate size without creating new stream entries.
                         if !rec.has_i30_stream() {
                             rec.set_has_i30_stream();
-                            rec.stream_count += 1;
-                            rec.total_stream_count += 1;
+                            rec.stream_count = rec.stream_count.saturating_add(1);
+                            rec.total_stream_count = rec.total_stream_count.saturating_add(1);
                         }
                     } else if attr_type == AttributeType::DATA_TYPE && aname_len == 0 {
                         // Unnamed $DATA: default stream
@@ -392,12 +456,14 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
                         // subsequent unnamed $DATA (from extension records)
                         // accumulate size only.
                         if !rec.has_default_data() {
-                            rec.stream_count += 1;
-                            rec.total_stream_count += 1;
+                            rec.stream_count = rec.stream_count.saturating_add(1);
+                            rec.total_stream_count = rec.total_stream_count.saturating_add(1);
                         }
                         rec.set_has_default_data();
-                        rec.first_stream.size.length += size;
-                        rec.first_stream.size.allocated += alloc;
+                        rec.first_stream.size.length =
+                            rec.first_stream.size.length.saturating_add(size);
+                        rec.first_stream.size.allocated =
+                            rec.first_stream.size.allocated.saturating_add(alloc);
                         rec.first_stream.flags = 8_u8 << 2_u8; // type_name_id=8 for $DATA
                     } else if attr_type == AttributeType::DATA_TYPE && aname_len > 0 {
                         // Named $DATA: ADS (user-visible stream).
@@ -436,8 +502,10 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
                                 }
                                 index.streams[u32_as_usize(tail)].next_entry = si;
                             }
-                            index.records[base_ri].stream_count += 1;
-                            index.records[base_ri].total_stream_count += 1;
+                            index.records[base_ri].stream_count =
+                                index.records[base_ri].stream_count.saturating_add(1);
+                            index.records[base_ri].total_stream_count =
+                                index.records[base_ri].total_stream_count.saturating_add(1);
                         }
                     } else {
                         // All other attribute types: internal stream
@@ -465,20 +533,20 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
                             index.internal_streams[u32_as_usize(tail)].next_entry = ist_idx;
                         }
                         let rec = &mut index.records[base_ri];
-                        rec.internal_streams_size += size;
-                        rec.internal_streams_allocated += alloc;
-                        rec.total_stream_count += 1;
+                        rec.internal_streams_size = rec.internal_streams_size.saturating_add(size);
+                        rec.internal_streams_allocated =
+                            rec.internal_streams_allocated.saturating_add(alloc);
+                        rec.total_stream_count = rec.total_stream_count.saturating_add(1);
                     }
 
                     // Extract reparse tag from $REPARSE_POINT
                     if attr_type == AttributeType::REPARSE_POINT_TYPE
                         && attr_header.is_non_resident == 0
                     {
-                        let vo = usize::from(rd_u16(data, offset + 20));
-                        let rp = offset + vo;
-                        if rp + 4 <= data.len() {
-                            let tag =
-                                u32::from_le_bytes(data[rp..rp + 4].try_into().unwrap_or([0; 4]));
+                        // Fallible: a value offset that overruns the record
+                        // leaves the reparse tag unset rather than panicking.
+                        let vo = usize::from(rd_u16(data, offset.saturating_add(20)));
+                        if let Some(tag) = offset.checked_add(vo).map(|rp| rd_u32(data, rp)) {
                             index.records[base_ri].reparse_tag = tag;
                         }
                     }
@@ -486,7 +554,10 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
             }
         }
 
-        offset += u32_as_usize(attr_header.length);
+        // `attr_len` (== attr_header.length) was validated above:
+        // `offset + attr_len <= data.len()`, so this advance cannot overflow.
+        // `saturating_add` keeps it total even on a pathological length.
+        offset = offset.saturating_add(attr_len);
     }
 
     // Set directory flag from header if not already set
@@ -503,7 +574,8 @@ pub fn process_record(data: &[u8], frs: u64, index: &mut MftIndex, name_buf: &mu
 /// bounds.
 #[inline]
 fn rd_u16(buf: &[u8], off: usize) -> u16 {
-    buf.get(off..off + 2)
+    off.checked_add(2)
+        .and_then(|end| buf.get(off..end))
         .and_then(|sl| <[u8; 2]>::try_from(sl).ok())
         .map_or(0, u16::from_le_bytes)
 }
@@ -512,7 +584,8 @@ fn rd_u16(buf: &[u8], off: usize) -> u16 {
 /// bounds.
 #[inline]
 fn rd_u32(buf: &[u8], off: usize) -> u32 {
-    buf.get(off..off + 4)
+    off.checked_add(4)
+        .and_then(|end| buf.get(off..end))
         .and_then(|sl| <[u8; 4]>::try_from(sl).ok())
         .map_or(0, u32::from_le_bytes)
 }
@@ -521,7 +594,8 @@ fn rd_u32(buf: &[u8], off: usize) -> u32 {
 /// bounds.
 #[inline]
 fn rd_u64(buf: &[u8], off: usize) -> u64 {
-    buf.get(off..off + 8)
+    off.checked_add(8)
+        .and_then(|end| buf.get(off..end))
         .and_then(|sl| <[u8; 8]>::try_from(sl).ok())
         .map_or(0, u64::from_le_bytes)
 }

--- a/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
+++ b/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
@@ -98,8 +98,8 @@ means the acceptance criteria were checked off *and* the pipeline was green.
 | WI-4.2 | 4 Bytes | Pass `OsString` (not `to_string_lossy`) to spawn argv / IPC paths | ⬜ | | |
 | WI-4.3 | 4 Bytes | Strict-parse subprocess stdout used for decisions (PID/name) | ✅ | `harden/bugs` | ✅ |
 | WI-4.4 | 4 Bytes | **RFC + impl:** lossless name storage (binary/WTF-8 column) | 🟨 RFC landed | `harden/bugs` | RFC ✅ / impl pending sign-off |
-| WI-5.2 | 5 Panic | Replace parser arithmetic with `checked_*`; remove parser `indexing_slicing` allows → `.get()` | ⬜ | | |
-| WI-5.3 | 5 Panic | In-tree malformed-input fuzz/regression tests (parsers + cache deserialize) | ⬜ | | |
+| WI-5.2 | 5 Panic | Replace parser arithmetic with `checked_*`; remove parser `indexing_slicing` allows → `.get()` | ✅ | `harden/wi-5.2-parser-checked` | ✅ |
+| WI-5.3 | 5 Panic | In-tree malformed-input fuzz/regression tests (parsers + cache deserialize) | 🟨 partial | `harden/wi-5.2-parser-checked` | parser malformed-record regression test landed with WI-5.2; cache-deserialize fuzz pending |
 | WI-6.1 | 6 Errors | `daemon_ctl` control writes: surface/log instead of bare `drop` | ✅ | `harden/bugs` | ✅ |
 | WI-6.2 | 6 Errors | Log dir-create failures (`log_init`, `mft/logging`) to stderr once | ✅ | `harden/bugs` | ✅ |
 | WI-6.3 | 6 Errors | Audit remaining `.ok()`/`let _ =`; add justification comments | ✅ | `harden/bugs-2` | ✅ |
@@ -123,7 +123,7 @@ means the acceptance criteria were checked off *and* the pipeline was green.
 | 2 | Perms-after-create | Every secret/dir **born** with final perms; zero chmod-after on secrets | 2.1–2.4 | **100%** |
 | 3 | Path string identity | No safety decision on path strings; identity helper exists + tested | 3.1 | **100%** |
 | 4 | UTF-8 byte boundary | Zero **silent** lossy conversions; argv/IPC use `OsString`; lossless storage RFC landed | 4.1–4.4 | ~40% (4.3 ✅ + 4.4 RFC ✅; 4.1 decoder + 4.2 argv pending — gate still red on 36 byte sites) |
-| 5 | Panic = DoS | Missing lints on; parsers `.get()` + `checked_*`; fuzz tests green | 5.1–5.3 | ~33% (5.1 ✅; 5.2 parser-hardening + 5.3 fuzz pending) |
+| 5 | Panic = DoS | Missing lints on; parsers `.get()` + `checked_*`; fuzz tests green | 5.1–5.3 | ~85% (5.1 ✅; 5.2 ✅ all 5 parsers hardened + module-scoped `arithmetic_side_effects`; 5.3 🟨 parser malformed-record regression test landed, cache-deserialize fuzz pending) |
 | 6 | Discarded errors | No bare `drop(write/flush)`; every intentional discard commented | 6.1–6.3 | ~66% (6.1, 6.2 ✅; 6.3 workspace audit pending) |
 | 7 | Bug-for-bug parity | Parity test covers pathological names; runs in CI | 7.1 | 0% (Windows-only, pending) |
 | 8 | Resolve before trust boundary | One process handle threads verify→grant; nonce property documented | 8.1, 8.2 | ~50% (8.2 ✅; 8.1 broker single-handle Windows-only, pending) |
@@ -742,6 +742,44 @@ crate-level or block-level `#![allow(clippy::indexing_slicing)]`.
 
 **Verify:** `just lint-prod && cargo nextest run -p uffs-mft`
 
+**Implementation notes (as landed, branch `harden/wi-5.2-parser-checked`):**
+
+- **Deviation from steps 1/3 (error type):** the plan assumed converting to
+  `buf.get(..).ok_or(ParseError::Truncated)?`. The five parser entry points
+  (`process_record`, `parse_record_to_index`, `parse_extension_to_index`, and
+  the deprecated `parse_*_to_fragment` pair) do **not** return a `Result` — their
+  established contract is "parse what is valid, skip/leave-default what is not,
+  return a `bool`/unit and let the caller continue indexing". Introducing a new
+  error type would change that public contract. Instead, every untrusted-`data`
+  read was converted to `.get()` / the bounds-safe `rd_u16/rd_u32/rd_u64` helpers
+  (which return `0` on OOB), and every byte-derived offset/length to
+  `checked_add`/`checked_mul` (or `saturating_*` where overflow is provably
+  unreachable, with an inline justification comment). On a malformed field the
+  result is **exactly the same skip/default the original `if X+N <= len` guards
+  produced** — behaviour-preserving, panic-free. This satisfies the goal (no
+  byte sequence panics the parser) and step 4 (caller skips the record).
+- **Deviation from step 2 / acceptance (lint mechanism):** rather than removing
+  the block-level `indexing_slicing` expects outright, they were **narrowed**:
+  all untrusted-`data` slicing now goes through `.get()`, so the only `[]` left
+  is on internal arena vectors (`index.records[base_ri]`, `fragment.streams[..]`,
+  `frs_to_idx[..]`) keyed by indices this code itself mints — not attacker
+  controlled. Each retained expect's `reason` now states this. `arithmetic_side_effects`
+  was enabled **module-scoped** (`#![warn(clippy::arithmetic_side_effects)]` in
+  each of the five parser files) instead of workspace-wide: at workspace level it
+  flags 1766 benign sites which, under `-D warnings`, would be a hard error
+  (see audit note at line ~461). Module-scoped + the workspace `-D warnings` makes
+  it effectively `deny` **inside the parsers** (any new raw `+`/`*`/`[..]` on a
+  byte-derived value fails the build there) — the intended regression guard,
+  scoped to where it matters. The workspace `Cargo.toml` `arithmetic_side_effects`
+  follow-up (raise to deny globally) remains **not done** for this reason.
+- **Behaviour parity checked:** the index/fragment parser families have a known
+  pre-existing divergence in the extension-name index formula
+  (`existing_name_count + name_idx` vs the legacy `existing_name_count - 1 + name_idx`);
+  each file's existing formula was preserved verbatim (only `+`→`saturating_add`),
+  so this WI introduces **no** semantic change. All 191 `uffs-mft` tests pass
+  (190 pre-existing + the new malformed-record regression test); native and
+  `cargo xwin` (Windows) `--all-targets -D warnings` clippy are clean.
+
 ---
 
 ### WI-5.3 — Malformed-input regression/fuzz tests
@@ -777,6 +815,26 @@ entry and the cache deserializer; all return errors without panicking; suite is
 deterministic (seeded) and runs in CI.
 
 **Verify:** `cargo nextest run -p uffs-mft -- malformed`
+
+**Implementation notes (partial, landed with WI-5.2 on `harden/wi-5.2-parser-checked`):**
+
+- **Done:** a deterministic, table-driven malformed-record regression test
+  (`io::parser::tests::malformed_records_do_not_panic`) feeds 8 crafted records —
+  each passing the FILE-record header gate so the attribute loop runs — through
+  **all three live parser entry points** (`parse_record_to_index`,
+  `process_record`, and the deprecated `parse_record_to_fragment`). The cases
+  target every edge WI-5.2 converted: first-attribute-offset past EOF, attribute
+  length overrunning the record, `name_length * 2` overflow, non-resident size
+  fields past EOF, reparse value-offset past EOF, zero-length attribute (loop
+  termination), and a full garbage body. The asserted property is **no panic**
+  (records may legitimately parse or skip; the contract under test is liveness,
+  not a specific return). A `RecordBuilder` constructs records by append, so the
+  fixture itself is index-free and panic-free.
+- **Pending (follow-up):** seeded-`rand` fuzz vectors and the **cache-deserializer**
+  malformed-input cases (`index/storage/deserialize.rs`). The deserializer was
+  not part of the WI-5.2 parser surface and is deferred to a dedicated WI-5.3
+  commit; a `cargo-fuzz` target is intentionally **not** added (would introduce a
+  toolchain dependency without sign-off, per the plan's own caveat).
 
 ---
 


### PR DESCRIPTION
## What & why

The daemon builds with `panic = "abort"`, so **any panic while parsing an untrusted on-disk MFT record is a whole-process DoS**. The five NTFS parser entry points sliced untrusted `data[a..b]` and did raw `offset + N` / `name_len * 2` arithmetic, suppressed by block-level `#[expect(indexing_slicing)]`. `index.rs` / `index_extension.rs` sit on the **live USN-journal incremental-update path** (`usn/windows.rs`), so this is reachable in production — not dead code.

This is **WI-5.2** (Category 5: panic = DoS) of the "Bugs Rust Won't Catch" audit.

## Changes

- **Every untrusted-`data` read** now goes through `.get()` or bounds-safe `rd_u16`/`rd_u32`/`rd_u64` helpers (return 0 on OOB).
- **Every byte-derived offset/length** uses `checked_add`/`checked_mul` (or `saturating_*` where overflow is provably unreachable, with an inline justification comment). The classic `name_len * 2` UTF-16 overflow is closed.
- **Behaviour preserved exactly** — a malformed field yields the *same* skip/default the original `if X+N <= len` guards produced. No new error type; the parsers keep their `bool`/skip-bad-record contract (step-4 caller behaviour unchanged).
- **`indexing_slicing` expects narrowed, not removed** — only internal arena indices remain (`index.records[..]`, `fragment.streams[..]`, `frs_to_idx[..]`), keyed by indices this code itself mints; each reason updated to say so.
- **`#![warn(clippy::arithmetic_side_effects)]` enabled module-scoped** in all 5 parser files. Under the workspace `-D warnings` this is effectively *deny inside the parsers* — any new raw `+`/`*`/`[..]` on a byte-derived value fails the build there. (Workspace-wide deny is deliberately deferred: 1766 benign sites would hard-error; documented in the tracker.)
- **New regression test** `malformed_records_do_not_panic`: a `RecordBuilder` forges 8 records that pass the header gate and runs them through all 3 live entry points, asserting no panic (offset-past-EOF, oversized length, `name_len*2` overflow, non-resident size past EOF, reparse offset past EOF, zero-length attr, garbage body). This is the partial **WI-5.3** deliverable; cache-deserializer fuzz remains a follow-up.

## Files

`crates/uffs-mft/src/io/parser/{unified,index,index_extension,fragment,fragment_extension,mod}.rs` + tracker doc.
`parse/merger.rs` was checked and left unchanged (its `indexing_slicing` covers only internal vectors — 0 untrusted slices).

## Verification

- `cargo clippy -p uffs-mft --all-targets --all-features -D warnings` (native) — clean
- `cargo xwin clippy ... --target x86_64-pc-windows-msvc -D warnings` (Windows cross, covers the cfg(windows) USN path) — clean
- `cargo nextest run -p uffs-mft` — **191 passed**, 3 skipped (was 190; +1 new test)
- downstream `uffs-core` / `uffs-cli` build — clean
- anti-pattern gate — no new violations (only the 4 known WI-4.2 sites remain, deferred)
- full pre-commit + pre-push gates (fmt, file-size, typos, reuse, lint-ci/prod/tests, cargo-vet) — ✅

## Note on behaviour parity

`index_extension.rs` uses `existing_name_count + name_idx`; the deprecated `fragment_extension.rs` uses the legacy `existing_name_count - 1 + name_idx`. Each file's existing formula was preserved verbatim (only `+`→`saturating_add`). This divergence predates this PR; **no semantic change is introduced.**