### PR TITLE
test(mft): malformed-input corpus for cache deserializer (WI-5.3)

### DIFF
--- a/crates/uffs-mft/src/index/tests_storage.rs
+++ b/crates/uffs-mft/src/index/tests_storage.rs
@@ -50,3 +50,150 @@ fn deserialize_rejects_links_count_beyond_remaining_bytes() {
         Err("Links section exceeds remaining data")
     ));
 }
+
+// ── WI-5.3 malformed-input corpus (cache deserializer) ───────────────
+//
+// The cache deserializer parses **untrusted on-disk bytes** (a persisted
+// index reloaded at startup). The daemon runs `panic = "abort"`, so a panic
+// here on a truncated/corrupt cache file is a whole-process DoS. The
+// deserializer already returns `Result<_, &'static str>` and reads via
+// `.get(..).ok_or(..)?` + `checked_*` (WI-5.2 era); this corpus locks that
+// in. The contract under test for arbitrary input is: **`deserialize`
+// returns `Ok` or `Err` — it never panics.**
+
+/// Build a *populated* index (records, names, several sections) and serialize
+/// it, so the mutation/fuzz corpus exercises every section, not just the
+/// header of an empty index.
+fn populated_serialized_index() -> Vec<u8> {
+    let mut index = MftIndex::new(crate::platform::DriveLetter::C);
+    for (frs, name) in [
+        (100_u64, "alpha.txt"),
+        (101, "beta.rs"),
+        (102, "gamma"),
+        (103, "delta.log"),
+    ] {
+        let offset = index.add_name(name);
+        let ext = index.intern_extension(name);
+        let len = u16::try_from(name.len()).unwrap_or(u16::MAX);
+        let record = index.get_or_create(frs.into());
+        record.first_name.name = IndexNameRef::new(offset, len, true, ext);
+    }
+    index.build_extension_index();
+    index.serialize(123, 456, crate::usn::Usn::new(789))
+}
+
+/// A valid blob must round-trip (sanity baseline for the mutation tests).
+#[test]
+fn deserialize_accepts_a_valid_roundtrip() {
+    let data = populated_serialized_index();
+    MftIndex::deserialize(&data).expect("a freshly serialized index must deserialize cleanly");
+}
+
+/// Truncating a valid blob at *every* length must never panic. The
+/// deserializer is lenient about some trailing/optional sections, so a
+/// near-complete prefix may legitimately deserialize `Ok`; the guarantee
+/// WI-5.3 locks in is **liveness** (Ok or Err, never a panic/abort), not
+/// that every prefix is rejected. Truncation into a *length-bearing header*
+/// field, however, must always be an error (checked separately below).
+#[test]
+fn deserialize_survives_truncation_at_every_boundary() {
+    let full = populated_serialized_index();
+    let full_len = full.len();
+
+    for cut in 0..full_len {
+        let truncated = full.get(..cut).unwrap_or(&[]);
+        // Property under test: returns (Ok or Err) without panicking.
+        let _outcome = MftIndex::deserialize(truncated);
+    }
+
+    // A blob truncated inside the fixed header (before all section lengths are
+    // even readable) is always rejected — never silently accepted.
+    let header_cut = full.get(..LINKS_COUNT_OFFSET).unwrap_or(&[]);
+    MftIndex::deserialize(header_cut)
+        .expect_err("a blob cut inside the fixed header must be rejected");
+
+    // The complete blob still round-trips.
+    MftIndex::deserialize(&full).expect("the complete blob must round-trip");
+}
+
+/// Empty and 1-byte inputs are rejected without panic.
+#[test]
+fn deserialize_rejects_tiny_inputs() {
+    MftIndex::deserialize(&[]).expect_err("empty input must be rejected");
+    MftIndex::deserialize(&[0_u8]).expect_err("1-byte input must be rejected");
+    MftIndex::deserialize(&[0xFF_u8]).expect_err("1-byte input must be rejected");
+}
+
+/// Writing an out-of-range count/size into each length-bearing header field
+/// must produce a clean error (no overflow panic, no OOB slice).
+#[test]
+fn deserialize_rejects_oversized_section_fields() {
+    for offset in [RECORD_COUNT_OFFSET, NAMES_SIZE_OFFSET, LINKS_COUNT_OFFSET] {
+        let mut data = populated_serialized_index();
+        if data.len() >= offset + 8 {
+            write_u64(&mut data, offset, u64::MAX);
+            let result = MftIndex::deserialize(&data);
+            assert!(
+                result.is_err(),
+                "u64::MAX in the section-length field at offset {offset} must be rejected, got {result:?}"
+            );
+        }
+    }
+}
+
+/// Seeded, deterministic fuzz: thousands of mutated/random blobs through the
+/// deserializer, asserting it always returns (Ok or Err) and never panics.
+/// `ChaCha8Rng::seed_from_u64` makes the corpus reproducible in CI.
+#[test]
+fn deserialize_never_panics_on_seeded_fuzz() {
+    use rand::{Rng as _, RngExt as _, SeedableRng as _};
+    use rand_chacha::ChaCha8Rng;
+
+    let baseline = populated_serialized_index();
+    let mut rng = ChaCha8Rng::seed_from_u64(0x0053_F0FF_u64);
+
+    for _ in 0..5_000 {
+        let blob = match rng.random_range(0_u8..4) {
+            // (a) flip a handful of bytes in an otherwise-valid blob.
+            0 => {
+                let mut data = baseline.clone();
+                let flips = rng.random_range(1_usize..=8);
+                for _ in 0..flips {
+                    if !data.is_empty() {
+                        let idx = rng.random_range(0..data.len());
+                        if let Some(byte) = data.get_mut(idx) {
+                            *byte = rng.random::<u8>();
+                        }
+                    }
+                }
+                data
+            }
+            // (b) truncate a valid blob at a random length.
+            1 => {
+                let cut = rng.random_range(0..=baseline.len());
+                baseline.get(..cut).unwrap_or(&[]).to_vec()
+            }
+            // (c) valid blob with random trailing garbage appended.
+            2 => {
+                let mut data = baseline.clone();
+                let extra = rng.random_range(0_usize..64);
+                let mut tail = vec![0_u8; extra];
+                rng.fill_bytes(&mut tail);
+                data.extend_from_slice(&tail);
+                data
+            }
+            // (d) fully random bytes of random length.
+            _ => {
+                let len = rng.random_range(0_usize..256);
+                let mut data = vec![0_u8; len];
+                rng.fill_bytes(&mut data);
+                data
+            }
+        };
+
+        // The property: returns Ok or Err, never panics. We deliberately
+        // ignore which — corrupt input legitimately may or may not parse;
+        // liveness (no panic / no abort) is what WI-5.3 guarantees.
+        let _outcome = MftIndex::deserialize(&blob);
+    }
+}

--- a/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
+++ b/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
@@ -98,8 +98,8 @@ means the acceptance criteria were checked off *and* the pipeline was green.
 | WI-4.2 | 4 Bytes | Pass `OsString` (not `to_string_lossy`) to spawn argv / IPC paths | ⬜ | | |
 | WI-4.3 | 4 Bytes | Strict-parse subprocess stdout used for decisions (PID/name) | ✅ | `harden/bugs` | ✅ |
 | WI-4.4 | 4 Bytes | **RFC + impl:** lossless name storage (binary/WTF-8 column) | 🟨 RFC landed | `harden/bugs` | RFC ✅ / impl pending sign-off |
-| WI-5.2 | 5 Panic | Replace parser arithmetic with `checked_*`; remove parser `indexing_slicing` allows → `.get()` | ✅ | `harden/wi-5.2-parser-checked` | ✅ |
-| WI-5.3 | 5 Panic | In-tree malformed-input fuzz/regression tests (parsers + cache deserialize) | 🟨 partial | `harden/wi-5.2-parser-checked` | parser malformed-record regression test landed with WI-5.2; cache-deserialize fuzz pending |
+| WI-5.2 | 5 Panic | Replace parser arithmetic with `checked_*`; remove parser `indexing_slicing` allows → `.get()` | ✅ | PR #349 (merged) | ✅ |
+| WI-5.3 | 5 Panic | In-tree malformed-input fuzz/regression tests (parsers + cache deserialize) | ✅ | `harden/wi-5.3-malformed-tests` | parser malformed-record test (PR #349) + deserializer truncation/boundary/seeded-fuzz corpus |
 | WI-6.1 | 6 Errors | `daemon_ctl` control writes: surface/log instead of bare `drop` | ✅ | `harden/bugs` | ✅ |
 | WI-6.2 | 6 Errors | Log dir-create failures (`log_init`, `mft/logging`) to stderr once | ✅ | `harden/bugs` | ✅ |
 | WI-6.3 | 6 Errors | Audit remaining `.ok()`/`let _ =`; add justification comments | ✅ | `harden/bugs-2` | ✅ |
@@ -123,7 +123,7 @@ means the acceptance criteria were checked off *and* the pipeline was green.
 | 2 | Perms-after-create | Every secret/dir **born** with final perms; zero chmod-after on secrets | 2.1–2.4 | **100%** |
 | 3 | Path string identity | No safety decision on path strings; identity helper exists + tested | 3.1 | **100%** |
 | 4 | UTF-8 byte boundary | Zero **silent** lossy conversions; argv/IPC use `OsString`; lossless storage RFC landed | 4.1–4.4 | ~40% (4.3 ✅ + 4.4 RFC ✅; 4.1 decoder + 4.2 argv pending — gate still red on 36 byte sites) |
-| 5 | Panic = DoS | Missing lints on; parsers `.get()` + `checked_*`; fuzz tests green | 5.1–5.3 | ~85% (5.1 ✅; 5.2 ✅ all 5 parsers hardened + module-scoped `arithmetic_side_effects`; 5.3 🟨 parser malformed-record regression test landed, cache-deserialize fuzz pending) |
+| 5 | Panic = DoS | Missing lints on; parsers `.get()` + `checked_*`; fuzz tests green | 5.1–5.3 | ✅ 100% (5.1 ✅; 5.2 ✅ all 5 parsers hardened + module-scoped `arithmetic_side_effects`; 5.3 ✅ parser malformed-record test + deserializer truncation/boundary/seeded-fuzz corpus) |
 | 6 | Discarded errors | No bare `drop(write/flush)`; every intentional discard commented | 6.1–6.3 | ~66% (6.1, 6.2 ✅; 6.3 workspace audit pending) |
 | 7 | Bug-for-bug parity | Parity test covers pathological names; runs in CI | 7.1 | 0% (Windows-only, pending) |
 | 8 | Resolve before trust boundary | One process handle threads verify→grant; nonce property documented | 8.1, 8.2 | ~50% (8.2 ✅; 8.1 broker single-handle Windows-only, pending) |
@@ -816,9 +816,9 @@ deterministic (seeded) and runs in CI.
 
 **Verify:** `cargo nextest run -p uffs-mft -- malformed`
 
-**Implementation notes (partial, landed with WI-5.2 on `harden/wi-5.2-parser-checked`):**
+**Implementation notes (landed on `harden/wi-5.2-parser-checked`):**
 
-- **Done:** a deterministic, table-driven malformed-record regression test
+- **Parsers** — a deterministic, table-driven malformed-record regression test
   (`io::parser::tests::malformed_records_do_not_panic`) feeds 8 crafted records —
   each passing the FILE-record header gate so the attribute loop runs — through
   **all three live parser entry points** (`parse_record_to_index`,
@@ -826,15 +826,26 @@ deterministic (seeded) and runs in CI.
   target every edge WI-5.2 converted: first-attribute-offset past EOF, attribute
   length overrunning the record, `name_length * 2` overflow, non-resident size
   fields past EOF, reparse value-offset past EOF, zero-length attribute (loop
-  termination), and a full garbage body. The asserted property is **no panic**
-  (records may legitimately parse or skip; the contract under test is liveness,
-  not a specific return). A `RecordBuilder` constructs records by append, so the
-  fixture itself is index-free and panic-free.
-- **Pending (follow-up):** seeded-`rand` fuzz vectors and the **cache-deserializer**
-  malformed-input cases (`index/storage/deserialize.rs`). The deserializer was
-  not part of the WI-5.2 parser surface and is deferred to a dedicated WI-5.3
-  commit; a `cargo-fuzz` target is intentionally **not** added (would introduce a
-  toolchain dependency without sign-off, per the plan's own caveat).
+  termination), and a full garbage body. A `RecordBuilder` constructs records by
+  append, so the fixture itself is index-free and panic-free.
+- **Cache deserializer** (`index/storage/deserialize.rs`, `index/tests_storage.rs`)
+  — five tests: a valid-blob round-trip baseline; a **truncation sweep** over a
+  *populated* serialized index at every length; empty / 1-byte rejection;
+  out-of-range section-length header fields (`u64::MAX` in record-count /
+  names-size / links-count → clean error, no overflow/OOB); and a **seeded,
+  deterministic fuzz loop** (`ChaCha8Rng::seed_from_u64`, 5 000 iterations)
+  mixing bit-flips, random truncation, trailing garbage, and fully random blobs.
+- **Property under test** is **liveness** — `deserialize` returns `Ok` *or* `Err`
+  but never panics/aborts — except where a specific rejection is provable (tiny
+  inputs, a cut inside the fixed header, oversized length fields). The truncation
+  sweep deliberately does **not** assert "every prefix is an error": the
+  deserializer is intentionally lenient about some trailing/optional sections, so
+  a near-complete prefix may legitimately parse `Ok`; asserting otherwise would
+  encode a false contract. This was found empirically (a 1570/1610-byte prefix
+  parsed) and the test was corrected to match the real, safe behaviour.
+- A `cargo-fuzz` target is intentionally **not** added — it would introduce a
+  toolchain dependency without sign-off (per the plan's own caveat); the seeded
+  `ChaCha8Rng` corpus gives deterministic, CI-friendly fuzz coverage instead.
 
 ---
 


### PR DESCRIPTION
## What & why

Completes **WI-5.3** (Category 5: panic = DoS) of the "Bugs Rust Won't Catch" audit. The parser malformed-record test already landed in #349 (WI-5.2); this PR adds the **cache-deserializer** half.

The deserializer (`index/storage/deserialize.rs`) parses **untrusted on-disk bytes** — a persisted index reloaded at startup. The daemon runs `panic = "abort"`, so a panic on a truncated/corrupt cache file is a whole-process DoS.

**The deserializer was already hardened** (returns `Result<_, &'static str>`, slices via `.get(..).ok_or(..)?`, sizes sections with `checked_mul`/`checked_add`). This PR is **purely additive tests** that lock that in — no production code change.

## Added (`crates/uffs-mft/src/index/tests_storage.rs`)

- valid-blob round-trip baseline (sanity for the mutation tests)
- **truncation sweep** over a *populated* serialized index at every length
- empty / 1-byte / single-`0xFF` rejection
- **oversized section-length header fields** (`u64::MAX` in record-count / names-size / links-count) → clean error, no overflow/OOB
- **seeded deterministic fuzz loop** (`ChaCha8Rng::seed_from_u64`, 5 000 iterations: bit-flips, random truncation, trailing garbage, fully random blobs)

## Property under test

**Liveness** — `deserialize` returns `Ok` *or* `Err` but never panics/aborts — except where a specific rejection is provable (tiny inputs, a cut inside the fixed header, oversized length fields).

The truncation sweep deliberately does **not** assert "every prefix is an error": the deserializer is intentionally lenient about some trailing/optional sections, so a near-complete prefix may legitimately parse `Ok` (found empirically — a 1570/1610-byte prefix parsed). Asserting otherwise would encode a false contract; the test was corrected to match the real, safe behaviour.

No `cargo-fuzz` target added (would introduce a toolchain dependency without sign-off, per the plan's own caveat); the seeded `ChaCha8Rng` corpus gives deterministic, CI-friendly fuzz coverage instead.

## Verification

- `cargo clippy -p uffs-mft --all-targets --all-features -D warnings` (native) — clean
- `cargo xwin clippy ... --target x86_64-pc-windows-msvc -D warnings` (Windows cross) — clean
- `cargo nextest run -p uffs-mft` — **196 passed**, 3 skipped (was 191; +5 deserializer tests)
- full pre-commit + pre-push gates (fmt, file-size, typos, reuse, lint-ci, lint-prod, lint-tests, lint-ci-windows, cargo-vet) — ✅

With this, **Category 5 is 100%** (5.1 ✅, 5.2 ✅ via #349, 5.3 ✅).