### PR TITLE
fix(spawn): pass daemon argv as OsString, decode Windows paths losslessly (WI-4.2)

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -22,6 +22,13 @@
 #[cfg(windows)]
 use uffs_broker_protocol::{HandleRequest, HandleResponse, PIPE_NAME, RESPONSE_WIRE_LEN};
 
+// Windows Service registration helpers, split out to keep this file under the
+// 800-LOC ceiling (see `broker/service.rs`).
+#[path = "broker/service.rs"]
+mod service;
+#[cfg(windows)]
+use service::{install_service, uninstall_service};
+
 /// Run the broker (called from main).
 ///
 /// Scope is `pub(crate)` because `broker` is a private module of the
@@ -312,6 +319,9 @@ fn get_client_exe_path(pid: u32) -> Option<String> {
     }
     // u32→usize lossless on 64-bit; use get() to satisfy indexing_slicing.
     let len = size as usize;
+    // AUDIT-OK(bytes): display only — used solely for `audit_log`, never a
+    // trust decision (the real check is `verify_client(pid)`, queried
+    // independently), so a lossy name cannot weaken security (WI-4.2).
     buf.get(..len).map(String::from_utf16_lossy)
 }
 
@@ -330,68 +340,6 @@ fn audit_log(action: &str, pid: u32, exe: Option<&str>, drive: Option<char>, det
         "AUDIT"
     );
     // Future: also write to Windows Event Log via ReportEventW
-}
-
-// ── Windows Service Install/Uninstall ───────────────────────────────────
-
-/// Register the broker as a Windows Service via `sc create`.
-///
-/// Writes a one-line result to stdout — this is a CLI admin command whose
-/// user-facing output is its only observable product, so `println!` is the
-/// idiomatic sink rather than the `tracing` subscriber used by the
-/// long-running service modes.
-#[cfg(windows)]
-#[expect(
-    clippy::print_stdout,
-    reason = "CLI admin command — stdout is the user-visible result channel"
-)]
-fn install_service() -> anyhow::Result<()> {
-    let exe = std::env::current_exe()?;
-    let output = std::process::Command::new("sc")
-        .args([
-            "create",
-            "UffsAccessBroker",
-            &format!("binPath= \"{}\"", exe.display()),
-            "start=",
-            "demand",
-            "DisplayName=",
-            "UFFS Access Broker",
-        ])
-        .output()?;
-
-    if output.status.success() {
-        println!("Service installed. Start with: sc start UffsAccessBroker");
-    } else {
-        // AUDIT-OK(bytes): `sc` command stderr surfaced verbatim in an
-        // error message for the operator — display only, no decision.
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Install failed: {stderr}");
-    }
-    Ok(())
-}
-
-/// Deregister the broker Windows Service via `sc delete`.
-///
-/// See [`install_service`] for why stdout is the output channel.
-#[cfg(windows)]
-#[expect(
-    clippy::print_stdout,
-    reason = "CLI admin command — stdout is the user-visible result channel"
-)]
-fn uninstall_service() -> anyhow::Result<()> {
-    let output = std::process::Command::new("sc")
-        .args(["delete", "UffsAccessBroker"])
-        .output()?;
-
-    if output.status.success() {
-        println!("Service uninstalled.");
-    } else {
-        // AUDIT-OK(bytes): `sc` command stderr surfaced verbatim in an
-        // error message for the operator — display only, no decision.
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Uninstall failed: {stderr}");
-    }
-    Ok(())
 }
 
 // ── D7.3: Named Pipe Operations ─────────────────────────────────────────
@@ -504,6 +452,8 @@ fn get_pipe_client_pid(pipe: windows::Win32::Foundation::HANDLE) -> Option<u32> 
     reason = "Win32 process-image-name query requires unsafe FFI"
 )]
 fn verify_client(pid: u32) -> bool {
+    use std::os::windows::ffi::OsStringExt as _;
+
     use windows::Win32::Foundation::CloseHandle;
     use windows::Win32::System::Threading::{
         OpenProcess, PROCESS_NAME_FORMAT, PROCESS_QUERY_LIMITED_INFORMATION,
@@ -542,7 +492,11 @@ fn verify_client(pid: u32) -> bool {
     let Some(slice) = buf.get(..len) else {
         return false;
     };
-    let exe_name = String::from_utf16_lossy(slice);
+    // Lossless `from_wide` (not `from_utf16_lossy`): this exe path drives a
+    // daemon-identity decision, so a non-UTF-8/WTF-8 component must not be
+    // mangled to U+FFFD first. Daemon names are ASCII; a non-UTF-8 name simply
+    // fails `to_str()` below and is rejected (WI-4.2).
+    let exe_name = std::ffi::OsString::from_wide(slice);
 
     let name = std::path::Path::new(&exe_name)
         .file_name()

--- a/crates/uffs-broker/src/broker/service.rs
+++ b/crates/uffs-broker/src/broker/service.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Windows Service registration helpers for the access broker.
+//!
+//! Extracted from `broker.rs` (which sits at the 800-LOC file-size ceiling) as
+//! a self-contained, behavior-neutral unit: `install_service` /
+//! `uninstall_service` shell out to `sc` and share no state with the
+//! pipe-serving or client-verification logic. Both are admin-only CLI commands
+//! invoked from `broker::run`.
+
+/// Register the broker as a Windows Service via `sc create`.
+#[cfg(windows)]
+#[expect(
+    clippy::print_stdout,
+    reason = "CLI admin command — stdout is the user-visible result channel"
+)]
+pub(super) fn install_service() -> anyhow::Result<()> {
+    let exe = std::env::current_exe()?;
+    let output = std::process::Command::new("sc")
+        .args([
+            "create",
+            "UffsAccessBroker",
+            &format!("binPath= \"{}\"", exe.display()),
+            "start=",
+            "demand",
+            "DisplayName=",
+            "UFFS Access Broker",
+        ])
+        .output()?;
+
+    if output.status.success() {
+        println!("Service installed. Start with: sc start UffsAccessBroker");
+    } else {
+        // AUDIT-OK(bytes): `sc` command stderr surfaced verbatim in an
+        // error message for the operator — display only, no decision.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Install failed: {stderr}");
+    }
+    Ok(())
+}
+
+/// Deregister the broker Windows Service via `sc delete`.
+///
+/// See [`install_service`] for why stdout is the output channel.
+#[cfg(windows)]
+#[expect(
+    clippy::print_stdout,
+    reason = "CLI admin command — stdout is the user-visible result channel"
+)]
+pub(super) fn uninstall_service() -> anyhow::Result<()> {
+    let output = std::process::Command::new("sc")
+        .args(["delete", "UffsAccessBroker"])
+        .output()?;
+
+    if output.status.success() {
+        println!("Service uninstalled.");
+    } else {
+        // AUDIT-OK(bytes): `sc` command stderr surfaced verbatim in an
+        // error message for the operator — display only, no decision.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Uninstall failed: {stderr}");
+    }
+    Ok(())
+}

--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -145,21 +145,23 @@ fn daemon_start(
     );
 
     // Build spawn args — forward raw, let daemon handle discovery.
-    let mut spawn_args = Vec::new();
+    // Use `OsString` so non-UTF-8 / WTF-8 paths survive losslessly to the
+    // spawned daemon's argv (WI-4.2).
+    let mut spawn_args: Vec<std::ffi::OsString> = Vec::new();
     if let Some(dir) = data_dir {
-        spawn_args.push("--data-dir".to_owned());
-        spawn_args.push(dir.to_string_lossy().into_owned());
+        spawn_args.push(std::ffi::OsString::from("--data-dir"));
+        spawn_args.push(dir.as_os_str().to_os_string());
     }
     for mft_path in mft_files {
-        spawn_args.push("--mft-file".to_owned());
-        spawn_args.push(mft_path.to_string_lossy().into_owned());
+        spawn_args.push(std::ffi::OsString::from("--mft-file"));
+        spawn_args.push(mft_path.as_os_str().to_os_string());
     }
     for letter in drives {
-        spawn_args.push("--drive".to_owned());
-        spawn_args.push(letter.to_string());
+        spawn_args.push(std::ffi::OsString::from("--drive"));
+        spawn_args.push(std::ffi::OsString::from(letter.to_string()));
     }
     if no_cache {
-        spawn_args.push("--no-cache".to_owned());
+        spawn_args.push(std::ffi::OsString::from("--no-cache"));
     }
 
     // ── Env-var forwarding ────────────────────────────────────────────────
@@ -193,8 +195,8 @@ fn daemon_start(
         log_level.to_owned()
     };
     if effective_log_level != "info" {
-        spawn_args.push("--log-level".to_owned());
-        spawn_args.push(effective_log_level.clone());
+        spawn_args.push(std::ffi::OsString::from("--log-level"));
+        spawn_args.push(std::ffi::OsString::from(effective_log_level.clone()));
     }
 
     // Effective log file: CLI arg wins; fall back to $UFFS_LOG_DIR/uffsd.log.
@@ -210,8 +212,8 @@ fn daemon_start(
         .map(std::path::Path::to_path_buf)
         .or(derived_log_file);
     if let Some(path) = &effective_log_file {
-        spawn_args.push("--log-file".to_owned());
-        spawn_args.push(path.to_string_lossy().into_owned());
+        spawn_args.push(std::ffi::OsString::from("--log-file"));
+        spawn_args.push(path.as_os_str().to_os_string());
     }
 
     // [diag] Print every diagnostic variable so we can trace the full chain.
@@ -567,11 +569,11 @@ fn daemon_restart() -> Result<()> {
             .drives()
             .with_context(|| "Failed to query drives before restart")?;
 
-        let mut args = Vec::new();
+        let mut args: Vec<std::ffi::OsString> = Vec::new();
         for dr in &drives_resp.drives {
             if let Some(path) = dr.source.strip_prefix("file:") {
-                args.push("--mft-file".to_owned());
-                args.push(path.to_owned());
+                args.push(std::ffi::OsString::from("--mft-file"));
+                args.push(std::ffi::OsString::from(path));
             }
         }
 
@@ -599,7 +601,7 @@ fn daemon_restart() -> Result<()> {
         "Restarting daemon with {} data source(s)...",
         spawn_args
             .iter()
-            .filter(|arg| *arg == "--mft-file" || *arg == "--data-dir")
+            .filter(|arg| arg.as_os_str() == "--mft-file" || arg.as_os_str() == "--data-dir")
             .count()
     );
 

--- a/crates/uffs-cli/src/commands/search/args.rs
+++ b/crates/uffs-cli/src/commands/search/args.rs
@@ -24,14 +24,14 @@
 ///
 /// The daemon auto-start needs `--data-dir`, `--mft-file`, `--no-cache`,
 /// `--drive`, and log env vars. Everything else is irrelevant for spawn.
-pub(crate) fn extract_spawn_args(args: &[String]) -> Vec<String> {
-    let mut spawn = Vec::new();
+pub(crate) fn extract_spawn_args(args: &[String]) -> Vec<std::ffi::OsString> {
+    let mut spawn: Vec<std::ffi::OsString> = Vec::new();
     let mut iter = args.iter().peekable();
     while let Some(arg) = iter.next() {
         let flag = arg.split('=').next().unwrap_or(arg.as_str());
         match flag {
             "--data-dir" | "--mft-file" | "--drive" | "--drives" | "--log-level" | "--log-file" => {
-                spawn.push(arg.clone());
+                spawn.push(std::ffi::OsString::from(arg));
                 // If not `--flag=val` form, consume the next token as value.
                 if !arg.contains('=')
                     && iter.peek().is_some_and(|peeked| {
@@ -39,22 +39,25 @@ pub(crate) fn extract_spawn_args(args: &[String]) -> Vec<String> {
                     })
                 {
                     // peek() confirmed the value exists, so next() is safe.
-                    spawn.push(iter.next().map_or_else(String::new, String::clone));
+                    spawn.push(
+                        iter.next()
+                            .map_or_else(std::ffi::OsString::new, std::ffi::OsString::from),
+                    );
                 }
             }
-            "--no-cache" => spawn.push(arg.clone()),
+            "--no-cache" => spawn.push(std::ffi::OsString::from(arg)),
             _ => {}
         }
     }
 
     // Forward log env vars.
     if let Ok(ll) = std::env::var("UFFS_LOG") {
-        spawn.push("--log-level".to_owned());
-        spawn.push(ll);
+        spawn.push(std::ffi::OsString::from("--log-level"));
+        spawn.push(std::ffi::OsString::from(ll));
     }
     if let Ok(lf) = std::env::var("UFFS_LOG_FILE") {
-        spawn.push("--log-file".to_owned());
-        spawn.push(lf);
+        spawn.push(std::ffi::OsString::from("--log-file"));
+        spawn.push(std::ffi::OsString::from(lf));
     }
 
     spawn

--- a/crates/uffs-client/src/connect.rs
+++ b/crates/uffs-client/src/connect.rs
@@ -172,7 +172,7 @@ impl UffsClient {
     /// Returns `ConnectionFailed`, `DaemonStartFailed`, or
     /// `DaemonNeedsElevation` (Windows, non-admin shell only).
     pub async fn connect_with_args(
-        spawn_args: &[String],
+        spawn_args: &[std::ffi::OsString],
     ) -> Result<Self, crate::error::ClientError> {
         Self::connect_with_args_inner(spawn_args, resolve_elevation_policy(false)).await
     }
@@ -190,7 +190,7 @@ impl UffsClient {
     /// Same as [`Self::connect_with_args`], minus
     /// `DaemonNeedsElevation` (which is turned into a UAC prompt).
     pub async fn connect_with_elevation(
-        spawn_args: &[String],
+        spawn_args: &[std::ffi::OsString],
     ) -> Result<Self, crate::error::ClientError> {
         Self::connect_with_args_inner(spawn_args, ElevationPolicy::AllowUacPrompt).await
     }
@@ -202,7 +202,7 @@ impl UffsClient {
     /// point can decide whether a missing elevated context is a
     /// hard error (the default) or a prompt request.
     async fn connect_with_args_inner(
-        spawn_args: &[String],
+        spawn_args: &[std::ffi::OsString],
         policy: ElevationPolicy,
     ) -> Result<Self, crate::error::ClientError> {
         let sock = socket_path();
@@ -264,24 +264,20 @@ impl UffsClient {
     /// executable cannot be found, the spawn fails, or the policy
     /// forbids elevation in the current context.
     fn auto_start_daemon(
-        spawn_args: &[String],
+        spawn_args: &[std::ffi::OsString],
         policy: ElevationPolicy,
     ) -> Result<(), crate::error::ClientError> {
         tracing::info!(?policy, "Daemon not running, auto-starting via `uffsd`...");
 
         let daemon_exe = find_daemon_exe();
-        let mut cmd_args: Vec<&str> = Vec::new();
-        for arg in spawn_args {
-            cmd_args.push(arg.as_str());
-        }
-        log_spawn_details(&daemon_exe, &cmd_args);
+        log_spawn_details(&daemon_exe, spawn_args);
 
         // On Windows, reading the MFT requires Administrator privileges.
         // The default policy is `RequireExistingElevation` — if we are
         // not already elevated, we return `DaemonNeedsElevation` and let
         // the CLI render an actionable message.  Callers opt in to a
         // UAC prompt via `connect_with_elevation` or `UFFS_ELEVATE=1`.
-        spawn_daemon(&daemon_exe, &cmd_args, policy)?;
+        spawn_daemon(&daemon_exe, spawn_args, policy)?;
         tracing::debug!("auto_start_daemon: spawn returned OK");
         Ok(())
     }

--- a/crates/uffs-client/src/connect_logging.rs
+++ b/crates/uffs-client/src/connect_logging.rs
@@ -11,10 +11,11 @@
 //! 800-LOC ceiling once the v0.5.36 UAC work added the elevation
 //! entry points.
 
+use std::ffi::OsString;
 use std::path::Path;
 
 /// Log daemon spawn details (exe path, existence, command args).
-pub(crate) fn log_spawn_details(uffs_exe: &Path, cmd_args: &[&str]) {
+pub(crate) fn log_spawn_details(uffs_exe: &Path, cmd_args: &[OsString]) {
     tracing::debug!(
         uffs_exe = %uffs_exe.display(),
         uffs_exe_exists = uffs_exe.exists(),

--- a/crates/uffs-client/src/connect_sync.rs
+++ b/crates/uffs-client/src/connect_sync.rs
@@ -169,7 +169,7 @@ impl UffsClientSync {
     ///
     /// Returns `ConnectionFailed`, `DaemonStartFailed`, or
     /// `DaemonNeedsElevation` (Windows, non-admin shell only).
-    pub fn connect_with_args(spawn_args: &[String]) -> Result<Self, ClientError> {
+    pub fn connect_with_args(spawn_args: &[std::ffi::OsString]) -> Result<Self, ClientError> {
         Self::connect_with_args_inner(spawn_args, resolve_elevation_policy(false))
     }
 
@@ -183,7 +183,7 @@ impl UffsClientSync {
     ///
     /// Same as [`Self::connect_with_args`], minus
     /// `DaemonNeedsElevation` (converted into a UAC prompt).
-    pub fn connect_with_elevation(spawn_args: &[String]) -> Result<Self, ClientError> {
+    pub fn connect_with_elevation(spawn_args: &[std::ffi::OsString]) -> Result<Self, ClientError> {
         Self::connect_with_args_inner(spawn_args, ElevationPolicy::AllowUacPrompt)
     }
 
@@ -194,7 +194,7 @@ impl UffsClientSync {
     /// point can decide whether a missing elevated context is a
     /// hard error (the default) or a prompt request.
     fn connect_with_args_inner(
-        spawn_args: &[String],
+        spawn_args: &[std::ffi::OsString],
         policy: ElevationPolicy,
     ) -> Result<Self, ClientError> {
         let sock = socket_path();
@@ -220,10 +220,15 @@ impl UffsClientSync {
         #[cfg(not(windows))]
         {
             let has_data_source = spawn_args.iter().any(|arg| {
-                arg == "--data-dir"
-                    || arg == "--mft-file"
-                    || arg.starts_with("--data-dir=")
-                    || arg.starts_with("--mft-file=")
+                // A data-source flag is always ASCII; a non-UTF-8 `OsString`
+                // (e.g. a raw path arg) is by definition not one of these
+                // flags, so `to_str()` → `None` → `false` is correct.
+                arg.to_str().is_some_and(|flag| {
+                    flag == "--data-dir"
+                        || flag == "--mft-file"
+                        || flag.starts_with("--data-dir=")
+                        || flag.starts_with("--mft-file=")
+                })
             });
             if !has_data_source {
                 return Err(ClientError::ConnectionFailed(

--- a/crates/uffs-client/src/connect_sync_autostart.rs
+++ b/crates/uffs-client/src/connect_sync_autostart.rs
@@ -24,7 +24,7 @@ use crate::error::ClientError;
 ///
 /// Propagates spawn failures from [`spawn_daemon`].
 pub(crate) fn auto_start_daemon(
-    spawn_args: &[String],
+    spawn_args: &[std::ffi::OsString],
     policy: ElevationPolicy,
 ) -> Result<Option<crate::daemon_child::DaemonChildHandle>, ClientError> {
     let pid_path = pid_file_path();
@@ -44,8 +44,7 @@ pub(crate) fn auto_start_daemon(
     }
 
     let daemon_exe = find_daemon_exe();
-    let str_args: Vec<&str> = spawn_args.iter().map(String::as_str).collect();
-    let handle = spawn_daemon(&daemon_exe, &str_args, policy)?;
+    let handle = spawn_daemon(&daemon_exe, spawn_args, policy)?;
     Ok(Some(handle))
 }
 

--- a/crates/uffs-client/src/daemon_spawn.rs
+++ b/crates/uffs-client/src/daemon_spawn.rs
@@ -114,7 +114,7 @@ pub(crate) fn resolve_elevation_policy(force_allow: bool) -> ElevationPolicy {
 #[cfg(unix)]
 pub(crate) fn spawn_daemon(
     exe: &std::path::Path,
-    args: &[&str],
+    args: &[std::ffi::OsString],
     _policy: ElevationPolicy,
 ) -> Result<DaemonChildHandle, crate::error::ClientError> {
     // `policy` is Windows-only; the Unix spawn never prompts for
@@ -140,7 +140,7 @@ pub(crate) fn spawn_daemon(
 #[cfg(windows)]
 pub(crate) fn spawn_daemon(
     exe: &std::path::Path,
-    args: &[&str],
+    args: &[std::ffi::OsString],
     policy: ElevationPolicy,
 ) -> Result<DaemonChildHandle, crate::error::ClientError> {
     spawn_daemon_windows(exe, args, policy)
@@ -160,7 +160,7 @@ pub(crate) fn spawn_daemon(
 )]
 fn spawn_daemon_unix(
     exe: &std::path::Path,
-    args: &[&str],
+    args: &[std::ffi::OsString],
 ) -> Result<DaemonChildHandle, crate::error::ClientError> {
     let child = std::process::Command::new(exe)
         .args(args)
@@ -185,7 +185,7 @@ fn spawn_daemon_unix(
 )]
 fn spawn_daemon_windows(
     exe: &std::path::Path,
-    args: &[&str],
+    args: &[std::ffi::OsString],
     policy: ElevationPolicy,
 ) -> Result<DaemonChildHandle, crate::error::ClientError> {
     let elevated = is_elevated();
@@ -222,7 +222,7 @@ fn spawn_daemon_windows(
 #[cfg(windows)]
 fn spawn_via_uac_prompt(
     exe: &std::path::Path,
-    args: &[&str],
+    args: &[std::ffi::OsString],
 ) -> Result<DaemonChildHandle, crate::error::ClientError> {
     tracing::debug!("NOT elevated, using ShellExecuteW runas (policy allows UAC)");
     tracing::info!("Not elevated — requesting elevation via UAC prompt");
@@ -252,54 +252,104 @@ fn spawn_via_uac_prompt(
 ///   backslashes just before the closing `"` must also be doubled so the
 ///   closing quote is not interpreted as escaped.
 ///
-/// This function is pure string manipulation and is compiled (and unit
-/// tested) on every platform, even though it is only *called* from
+/// This function operates on **UTF-16 code units** (`&[u16]`), the native
+/// width of a `CreateProcessW` command line, and appends the escaped result
+/// to `out` (also `&mut Vec<u16>`).  Working in UTF-16 — rather than the old
+/// `&str` → `String` form — means a path containing unpaired surrogates or
+/// other non-UTF-8 (WTF-8) sequences survives **losslessly** from the caller's
+/// `OsStr` all the way to the child's argv (Category 4, WI-4.2).  The caller
+/// derives the `&[u16]` via `OsStr::encode_wide`.
+///
+/// It is pure code-unit manipulation and is compiled (and unit tested) on
+/// every platform even though it is only *called* from
 /// [`spawn_detached_no_inherit`] on Windows.  We gate the item on
 /// `any(windows, test)` so macOS/Linux release builds don't emit a
 /// `dead_code` warning, while `cargo test` still compiles it everywhere
 /// and the unit tests run on the ship box.
 #[cfg(any(windows, test))]
-#[must_use]
-fn quote_arg_for_createprocess(arg: &str) -> String {
+fn quote_arg_for_createprocess(arg: &[u16], out: &mut Vec<u16>) {
+    // UTF-16 code units for the ASCII metacharacters we test against.
+    const SPACE: u16 = b' ' as u16;
+    const TAB: u16 = b'\t' as u16;
+    const NEWLINE: u16 = b'\n' as u16;
+    const VTAB: u16 = 0x000B; // vertical tab (\x0b)
+    const QUOTE: u16 = b'"' as u16;
+    const BACKSLASH: u16 = b'\\' as u16;
+
     if arg.is_empty() {
-        return "\"\"".to_owned();
+        // An empty argument must become `""` — otherwise it collapses into the
+        // separating space and disappears from the child's argv.
+        out.push(QUOTE);
+        out.push(QUOTE);
+        return;
     }
-    // Fast path: nothing that needs escaping.
+    // Fast path: nothing that needs escaping — emit the code units verbatim.
     let needs_quoting = arg
-        .chars()
-        .any(|chr| chr == ' ' || chr == '\t' || chr == '\n' || chr == '\x0b' || chr == '"');
+        .iter()
+        .any(|&unit| matches!(unit, SPACE | TAB | NEWLINE | VTAB | QUOTE));
     if !needs_quoting {
-        return arg.to_owned();
+        out.extend_from_slice(arg);
+        return;
     }
 
-    let mut out = String::with_capacity(arg.len() + 2);
-    out.push('"');
+    out.push(QUOTE);
     let mut pending_backslashes: usize = 0;
-    for chr in arg.chars() {
-        if chr == '\\' {
+    for &unit in arg {
+        if unit == BACKSLASH {
             pending_backslashes += 1;
-        } else if chr == '"' {
+        } else if unit == QUOTE {
             // Double the pending backslashes, then escape the quote.
             for _ in 0..=(pending_backslashes * 2) {
-                out.push('\\');
+                out.push(BACKSLASH);
             }
-            out.push('"');
+            out.push(QUOTE);
             pending_backslashes = 0;
         } else {
             for _ in 0..pending_backslashes {
-                out.push('\\');
+                out.push(BACKSLASH);
             }
-            out.push(chr);
+            out.push(unit);
             pending_backslashes = 0;
         }
     }
     // Trailing backslashes must be doubled so the closing quote is not
     // swallowed as an escape target.
     for _ in 0..(pending_backslashes * 2) {
-        out.push('\\');
+        out.push(BACKSLASH);
     }
-    out.push('"');
-    out
+    out.push(QUOTE);
+}
+
+/// Build a space-separated, MSVCRT-quoted, **null-terminated** UTF-16 command
+/// line from an optional leading program token followed by `args`.
+///
+/// Each token is run through [`quote_arg_for_createprocess`] so the result is
+/// safe to hand to `CreateProcessW` (`lead = Some(exe)`) or to
+/// `ShellExecuteW` as the parameter list (`lead = None`). Building from
+/// `OsStr` code units keeps non-UTF-8/WTF-8 path bytes intact (WI-4.2).
+#[cfg(windows)]
+fn build_wide_command_line(
+    lead: Option<&std::ffi::OsStr>,
+    args: &[std::ffi::OsString],
+) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt as _;
+
+    let mut wide: Vec<u16> = Vec::new();
+    if let Some(program) = lead {
+        let program_wide: Vec<u16> = program.encode_wide().collect();
+        quote_arg_for_createprocess(&program_wide, &mut wide);
+    }
+    for arg in args {
+        // A space separates tokens; emit one before every token except the
+        // very first written (i.e. when `wide` is still empty).
+        if !wide.is_empty() {
+            wide.push(u16::from(b' '));
+        }
+        let arg_wide: Vec<u16> = arg.encode_wide().collect();
+        quote_arg_for_createprocess(&arg_wide, &mut wide);
+    }
+    wide.push(0); // CreateProcessW / ShellExecuteW require null termination.
+    wide
 }
 
 // ── CreateProcessW spawn ──────────────────────────────────────────────────
@@ -318,25 +368,21 @@ fn quote_arg_for_createprocess(arg: &str) -> String {
 #[cfg(windows)]
 fn spawn_detached_no_inherit(
     exe: &std::path::Path,
-    args: &[&str],
+    args: &[std::ffi::OsString],
 ) -> Result<DaemonChildHandle, crate::error::ClientError> {
     use windows::Win32::Foundation::CloseHandle;
     use windows::Win32::System::Threading::{
         CreateProcessW, DETACHED_PROCESS, PROCESS_INFORMATION, STARTUPINFOW,
     };
 
-    // Build the command-line string using full MSVCRT-compatible escaping.
-    // The previous naive implementation dropped empty args entirely and
+    // Build the command-line as UTF-16 directly, using full MSVCRT-compatible
+    // escaping (the program token leads). Working in UTF-16 — rather than
+    // `to_string_lossy()` → `String` — preserves non-UTF-8/WTF-8 path bytes
+    // losslessly through to the child's argv (Category 4, WI-4.2). The
+    // previous naive implementation also dropped empty args entirely and
     // mangled any arg containing spaces or quotes — see
     // `quote_arg_for_createprocess` for the gory details.
-    let mut cmd_line = String::new();
-    cmd_line.push_str(&quote_arg_for_createprocess(&exe.to_string_lossy()));
-    for arg in args {
-        cmd_line.push(' ');
-        cmd_line.push_str(&quote_arg_for_createprocess(arg));
-    }
-
-    let mut cmd_wide: Vec<u16> = cmd_line.encode_utf16().chain(core::iter::once(0)).collect();
+    let mut cmd_wide: Vec<u16> = build_wide_command_line(Some(exe.as_os_str()), args);
 
     let si = STARTUPINFOW {
         cb: u32::try_from(size_of::<STARTUPINFOW>()).unwrap_or(u32::MAX),
@@ -451,21 +497,27 @@ fn is_elevated() -> bool {
 #[cfg(windows)]
 fn shell_execute_elevated(
     exe: &std::path::Path,
-    args: &[&str],
+    args: &[std::ffi::OsString],
 ) -> Result<(), crate::error::ClientError> {
+    use std::os::windows::ffi::OsStrExt as _;
+
     use windows::Win32::UI::Shell::ShellExecuteW;
     use windows::core::PCWSTR;
 
     let verb: Vec<u16> = "runas\0".encode_utf16().collect();
-    let exe_str = exe.to_string_lossy();
-    let file: Vec<u16> = format!("{exe_str}\0").encode_utf16().collect();
-    let params_str = args.join(" ");
-    let params: Vec<u16> = format!("{params_str}\0").encode_utf16().collect();
+    // Build `file` and `params` as UTF-16 directly so non-UTF-8/WTF-8 path
+    // bytes survive losslessly (Category 4, WI-4.2). `params` reuses the same
+    // MSVCRT-compatible quoting as the CreateProcessW path so args with spaces
+    // or quotes are not mangled by the elevated re-parse.
+    let mut file: Vec<u16> = exe.as_os_str().encode_wide().collect();
+    file.push(0); // null terminator
+
+    // No leading program token: `file` is the program; `params` is the args.
+    let params: Vec<u16> = build_wide_command_line(None, args);
 
     tracing::debug!(
         verb = "runas",
-        file = %exe_str,
-        params = %params_str,
+        file = %exe.display(),
         "ShellExecuteW"
     );
 
@@ -583,6 +635,17 @@ mod elevation_policy_tests {
 mod quote_arg_tests {
     use super::quote_arg_for_createprocess;
 
+    /// Ergonomic wrapper: quote a `&str` argument and return the result as a
+    /// `String`, so the UTF-16 `quote_arg_for_createprocess` can be asserted
+    /// against readable string literals. Encodes input to UTF-16, runs the
+    /// real quoting routine, then decodes the produced code units back.
+    fn quote_str(arg: &str) -> String {
+        let wide: Vec<u16> = arg.encode_utf16().collect();
+        let mut out: Vec<u16> = Vec::new();
+        quote_arg_for_createprocess(&wide, &mut out);
+        String::from_utf16(&out).expect("ASCII quoting output is always valid UTF-16")
+    }
+
     /// **Regression (silent `daemon start` failure, `LOG/Output`):** an
     /// empty argument must round-trip as `""` so `CreateProcessW`'s child
     /// sees it as a zero-length argv entry instead of skipping it
@@ -594,7 +657,7 @@ mod quote_arg_tests {
     /// its IPC transports.
     #[test]
     fn empty_arg_becomes_explicit_empty_quotes() {
-        assert_eq!(quote_arg_for_createprocess(""), "\"\"");
+        assert_eq!(quote_str(""), "\"\"");
     }
 
     /// Plain alphanumeric / punctuation arguments pass through unquoted.
@@ -602,12 +665,9 @@ mod quote_arg_tests {
     /// `tracing::debug!` consumers.
     #[test]
     fn plain_arg_passes_through_unquoted() {
-        assert_eq!(quote_arg_for_createprocess("debug"), "debug");
-        assert_eq!(quote_arg_for_createprocess("--log-level"), "--log-level");
-        assert_eq!(
-            quote_arg_for_createprocess("C:\\Users\\rnio"),
-            "C:\\Users\\rnio"
-        );
+        assert_eq!(quote_str("debug"), "debug");
+        assert_eq!(quote_str("--log-level"), "--log-level");
+        assert_eq!(quote_str("C:\\Users\\rnio"), "C:\\Users\\rnio");
     }
 
     /// Arguments containing whitespace must be wrapped in double quotes.
@@ -616,8 +676,8 @@ mod quote_arg_tests {
     #[test]
     fn whitespace_arg_gets_quoted() {
         assert_eq!(
-            quote_arg_for_createprocess(r"C:\Program Files\uffs"),
-            "\"C:\\Program Files\\uffs\"",
+            quote_str(r"C:\Program Files\uffs"),
+            "\"C:\\Program Files\\uffs\""
         );
     }
 
@@ -626,10 +686,7 @@ mod quote_arg_tests {
     /// terminator.
     #[test]
     fn embedded_quote_is_escaped() {
-        assert_eq!(
-            quote_arg_for_createprocess(r#"he said "hi""#),
-            r#""he said \"hi\"""#
-        );
+        assert_eq!(quote_str(r#"he said "hi""#), r#""he said \"hi\"""#);
     }
 
     /// MSVCRT rule: each backslash that precedes a quote must be
@@ -639,10 +696,10 @@ mod quote_arg_tests {
     fn backslashes_before_quote_are_doubled() {
         // Single backslash followed by a quote → two backslashes then an
         // escaped quote inside the quoted string.
-        assert_eq!(quote_arg_for_createprocess(r#"a\"b"#), r#""a\\\"b""#);
+        assert_eq!(quote_str(r#"a\"b"#), r#""a\\\"b""#);
         // Two backslashes followed by a quote → four backslashes then an
         // escaped quote.
-        assert_eq!(quote_arg_for_createprocess(r#"a\\"b"#), r#""a\\\\\"b""#);
+        assert_eq!(quote_str(r#"a\\"b"#), r#""a\\\\\"b""#);
     }
 
     /// Trailing backslashes inside a quoted arg must be doubled so the
@@ -653,10 +710,7 @@ mod quote_arg_tests {
     fn trailing_backslash_in_quoted_arg_is_doubled() {
         // "path has\" → needs quoting (space), and the trailing \
         // must be doubled so the closing " stands on its own.
-        assert_eq!(
-            quote_arg_for_createprocess("path with\\"),
-            "\"path with\\\\\"",
-        );
+        assert_eq!(quote_str("path with\\"), "\"path with\\\\\"");
     }
 
     /// End-to-end: simulate the exact args list that caused the bug.
@@ -668,9 +722,30 @@ mod quote_arg_tests {
         let args = ["--log-level", "", "--log-file", "uffsd.log"];
         let cmd: String = args
             .iter()
-            .map(|arg| quote_arg_for_createprocess(arg))
+            .map(|arg| quote_str(arg))
             .collect::<Vec<_>>()
             .join(" ");
         assert_eq!(cmd, "--log-level \"\" --log-file uffsd.log");
+    }
+
+    /// **WI-4.2 lossless round-trip:** a UTF-16 argument containing an
+    /// unpaired surrogate (0xD800) — i.e. a Windows path that is *not*
+    /// representable in UTF-8 — must survive quoting verbatim. The old
+    /// `to_string_lossy()` path would have replaced 0xD800 with U+FFFD,
+    /// silently mangling the path before it reached the child's argv. The
+    /// surrogate is not a metacharacter, so it passes through the fast path
+    /// unchanged, code unit for code unit.
+    #[test]
+    fn lone_surrogate_arg_survives_losslessly() {
+        let arg: Vec<u16> = vec![
+            u16::from(b'C'),
+            u16::from(b':'),
+            0xD800, // lone high surrogate — not valid UTF-8/UTF-16 scalar
+            u16::from(b'x'),
+        ];
+        let mut out: Vec<u16> = Vec::new();
+        quote_arg_for_createprocess(&arg, &mut out);
+        // No metacharacters → emitted verbatim, surrogate preserved.
+        assert_eq!(out, arg, "lone surrogate must round-trip unchanged");
     }
 }

--- a/crates/uffs-client/src/verify.rs
+++ b/crates/uffs-client/src/verify.rs
@@ -179,6 +179,8 @@ fn get_process_exe_path(pid: u32) -> Option<PathBuf> {
 /// Windows: uses `QueryFullProcessImageNameW()`.
 #[cfg(target_os = "windows")]
 fn get_process_exe_path(pid: u32) -> Option<PathBuf> {
+    use std::os::windows::ffi::OsStringExt as _;
+
     use windows::Win32::Foundation::CloseHandle;
     use windows::Win32::System::Threading::{
         OpenProcess, PROCESS_NAME_FORMAT, PROCESS_QUERY_LIMITED_INFORMATION,
@@ -218,7 +220,11 @@ fn get_process_exe_path(pid: u32) -> Option<PathBuf> {
     // `QueryFullProcessImageNameW` and is always ≤ `buf.len()` on success.
     // Use `.get()` to stay panic-free against any future reallocation.
     let slice = buf.get(..size as usize)?;
-    Some(PathBuf::from(String::from_utf16_lossy(slice)))
+    // Decode losslessly via `OsString::from_wide` (not `from_utf16_lossy`):
+    // this path is compared for process-identity verification, so a
+    // non-UTF-8/WTF-8 exe path must not be silently mangled to U+FFFD before
+    // the comparison (Category 4, WI-4.2).
+    Some(PathBuf::from(std::ffi::OsString::from_wide(slice)))
 }
 
 // ── Fallback for other platforms ────────────────────────────────────────

--- a/crates/uffs-mcp/src/bin/http_gateway.rs
+++ b/crates/uffs-mcp/src/bin/http_gateway.rs
@@ -138,7 +138,11 @@ async fn main() -> anyhow::Result<()> {
     let config = uffs_mcp::http::HttpGatewayConfig {
         bind_addr: args.bind,
         auth_token: args.auth_token,
-        daemon_spawn_args: args.daemon_args,
+        daemon_spawn_args: args
+            .daemon_args
+            .into_iter()
+            .map(std::ffi::OsString::from)
+            .collect(),
     };
 
     uffs_mcp::http::run_gateway(config).await

--- a/crates/uffs-mcp/src/handler/mod.rs
+++ b/crates/uffs-mcp/src/handler/mod.rs
@@ -67,7 +67,7 @@ enum ClientSlot {
     /// [`UffsClient::connect_with_args`] on every daemon-backed call.
     Active {
         /// Args forwarded to `uffs daemon run` on auto-start.
-        spawn_args: Vec<String>,
+        spawn_args: Vec<std::ffi::OsString>,
     },
     /// No daemon — metadata-only / testing.
     None,
@@ -112,7 +112,7 @@ impl UffsMcpServer {
     /// connection.  See the private `ClientSlot` enum for the
     /// rationale behind the per-call connection model.
     #[must_use]
-    pub fn new(spawn_args: Vec<String>) -> Self {
+    pub fn new(spawn_args: Vec<std::ffi::OsString>) -> Self {
         Self::with_stats(
             ClientSlot::Active { spawn_args },
             Arc::new(McpStats::default()),
@@ -125,13 +125,16 @@ impl UffsMcpServer {
     /// connection model; retained as a distinct constructor because the
     /// HTTP gateway factory closure calls it explicitly.
     #[must_use]
-    pub fn new_lazy(spawn_args: Vec<String>) -> Self {
+    pub fn new_lazy(spawn_args: Vec<std::ffi::OsString>) -> Self {
         Self::new_lazy_with_stats(spawn_args, Arc::new(McpStats::default()))
     }
 
     /// Create a lazy server with shared stats (for HTTP gateway).
     #[must_use]
-    pub(crate) fn new_lazy_with_stats(spawn_args: Vec<String>, stats: Arc<McpStats>) -> Self {
+    pub(crate) fn new_lazy_with_stats(
+        spawn_args: Vec<std::ffi::OsString>,
+        stats: Arc<McpStats>,
+    ) -> Self {
         stats.session_started();
         Self::with_stats(ClientSlot::Active { spawn_args }, stats)
     }

--- a/crates/uffs-mcp/src/http.rs
+++ b/crates/uffs-mcp/src/http.rs
@@ -45,7 +45,7 @@ pub(crate) struct AppState {
     boot: Instant,
     /// Daemon spawn args forwarded to lazy `UffsClient` connections.
     #[expect(dead_code, reason = "reserved for lazy UffsClient connection init")]
-    spawn_args: Arc<[String]>,
+    spawn_args: Arc<[std::ffi::OsString]>,
     /// Shared MCP stats across all sessions.
     stats: Arc<McpStats>,
 }
@@ -57,7 +57,7 @@ pub(crate) struct AppState {
 /// All three fields are `pub` because this is a **configuration DTO**.
 /// `bind_addr` is a required parameter (no default that makes sense);
 /// `auth_token` is genuinely optional; `daemon_spawn_args` is a
-/// forwarded vector with no invariants to protect.
+/// forwarded `Vec<OsString>` with no invariants to protect.
 ///
 /// # `#[non_exhaustive]` decision (Phase 3b §3.6)
 ///
@@ -72,14 +72,14 @@ pub struct HttpGatewayConfig {
     /// Optional bearer token for authenticating MCP requests.
     pub auth_token: Option<String>,
     /// Extra CLI args forwarded to `uffs daemon run` on auto-start.
-    pub daemon_spawn_args: Vec<String>,
+    pub daemon_spawn_args: Vec<std::ffi::OsString>,
 }
 
 /// Build the axum [`Router`] with MCP, health, and status endpoints.
 ///
 /// The router is returned without binding — call [`run_gateway`] to serve.
 pub(crate) fn build_router(config: &HttpGatewayConfig) -> Router {
-    let spawn_args: Arc<[String]> = config.daemon_spawn_args.clone().into();
+    let spawn_args: Arc<[std::ffi::OsString]> = config.daemon_spawn_args.clone().into();
     let spawn_args_clone = Arc::clone(&spawn_args);
     let stats = Arc::new(McpStats::default());
     let stats_for_factory = Arc::clone(&stats);

--- a/crates/uffs-mcp/src/lib.rs
+++ b/crates/uffs-mcp/src/lib.rs
@@ -209,7 +209,7 @@ use tracing::info;
 /// # Field discipline (Phase 3b §3.4)
 ///
 /// Both fields are `pub` because this is a **configuration DTO**.
-/// `daemon_spawn_args` is a forwarded `Vec<String>` (no invariants to
+/// `daemon_spawn_args` is a forwarded `Vec<OsString>` (no invariants to
 /// protect); `idle_timeout_secs == 0` is the documented sentinel for
 /// "no timeout" and is validated at the call site, not in a setter.
 ///
@@ -226,7 +226,7 @@ use tracing::info;
 pub struct McpConfig {
     /// Extra CLI args forwarded to `uffs daemon run` when auto-starting
     /// (e.g. `["--data-dir", "/path"]`).
-    pub daemon_spawn_args: Vec<String>,
+    pub daemon_spawn_args: Vec<std::ffi::OsString>,
     /// Idle timeout in seconds.  The MCP server will auto-exit if no
     /// MCP messages are received within this period.  `0` = no timeout.
     pub idle_timeout_secs: u64,

--- a/crates/uffs-mcp/src/main.rs
+++ b/crates/uffs-mcp/src/main.rs
@@ -274,7 +274,7 @@ async fn mcp_start(
     let daemon_args = {
         let mut args = process::build_daemon_args(mft_files, data_dir);
         if no_cache {
-            args.push("--no-cache".to_owned());
+            args.push(std::ffi::OsString::from("--no-cache"));
         }
         args
     };
@@ -357,7 +357,11 @@ async fn port_is_occupied(bind: &str, port: u16) -> bool {
 
 /// Deep health check when target port is occupied.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
-async fn preflight_reclaim_or_reuse(bind: &str, port: u16, daemon_args: &[String]) -> Result<bool> {
+async fn preflight_reclaim_or_reuse(
+    bind: &str,
+    port: u16,
+    daemon_args: &[std::ffi::OsString],
+) -> Result<bool> {
     let health_url = format!("http://{bind}:{port}/health");
     let gateway_ok = process::reqwest_lite_get(&health_url)
         .await

--- a/crates/uffs-mcp/src/process.rs
+++ b/crates/uffs-mcp/src/process.rs
@@ -8,19 +8,24 @@
 use anyhow::Result;
 
 /// Build `--mft-file` / `--data-dir` args for daemon auto-start.
+///
+/// Returns `OsString` entries so a path containing non-UTF-8 / WTF-8 bytes is
+/// forwarded to the spawned daemon verbatim, never `to_string_lossy`-mangled
+/// (Category 4, WI-4.2). Flag literals are ASCII; only the path values carry
+/// the OS-native bytes.
 #[must_use]
 pub(crate) fn build_daemon_args(
     mft_files: &[std::path::PathBuf],
     data_dir: Option<&std::path::Path>,
-) -> Vec<String> {
+) -> Vec<std::ffi::OsString> {
     let mut args = Vec::new();
     if let Some(dir) = data_dir {
-        args.push("--data-dir".to_owned());
-        args.push(dir.to_string_lossy().into_owned());
+        args.push(std::ffi::OsString::from("--data-dir"));
+        args.push(dir.as_os_str().to_os_string());
     }
     for path in mft_files {
-        args.push("--mft-file".to_owned());
-        args.push(path.to_string_lossy().into_owned());
+        args.push(std::ffi::OsString::from("--mft-file"));
+        args.push(path.as_os_str().to_os_string());
     }
     args
 }
@@ -276,10 +281,12 @@ pub(crate) async fn mcp_reload() -> Result<()> {
                     &config.port.to_string(),
                 ]);
                 if let Some(dir) = &config.data_dir {
-                    cmd.args(["--data-dir", &dir.to_string_lossy()]);
+                    cmd.arg("--data-dir");
+                    cmd.arg(dir.as_os_str());
                 }
                 for mft in &config.mft_files {
-                    cmd.args(["--mft-file", &mft.to_string_lossy()]);
+                    cmd.arg("--mft-file");
+                    cmd.arg(mft.as_os_str());
                 }
                 if config.no_cache {
                     cmd.arg("--no-cache");

--- a/crates/uffs-security/src/pipe.rs
+++ b/crates/uffs-security/src/pipe.rs
@@ -562,6 +562,10 @@ unsafe fn pwstr_to_string(ptr: PWSTR) -> String {
     // SAFETY: `ptr.0 .. ptr.0 + len` is contiguous valid UTF-16 per the
     // caller's contract; we do not include the trailing null.
     let slice = unsafe { core::slice::from_raw_parts(ptr.0, len) };
+    // AUDIT-OK(bytes): the only caller decodes a SID string from
+    // `ConvertSidToStringSidW`, whose output is by specification pure ASCII
+    // (`S-1-5-21-...`). Lossy and lossless decoding are therefore identical
+    // here; `from_utf16_lossy` cannot alter a valid SID (Category 4, WI-4.2).
     String::from_utf16_lossy(slice)
 }
 

--- a/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
+++ b/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
@@ -95,7 +95,7 @@ means the acceptance criteria were checked off *and* the pipeline was green.
 | WI-5.1 | 5 Panic | Enable `arithmetic_side_effects`; `overflow-checks=true` for `dist` | ✅ | `harden/bugs` | ✅ |
 | WI-G.1 | Guard | CI grep-gate script forbidding the anti-patterns from returning | ✅ | `harden/bugs` | ✅ |
 | WI-4.1 | 4 Bytes | Single instrumented UTF-16 decoder; per-index `lossy_name_count` stat + warn | ✅ | `harden/bugs-2` | ✅ |
-| WI-4.2 | 4 Bytes | Pass `OsString` (not `to_string_lossy`) to spawn argv / IPC paths | ⬜ | | |
+| WI-4.2 | 4 Bytes | Pass `OsString` (not `to_string_lossy`) to spawn argv / IPC paths | ✅ | `harden/wi-4.2-osstring-argv` | full `&[OsString]` spawn chain (incl. Windows `CreateProcessW`/`ShellExecuteW` via `encode_wide`) + 4 `from_utf16_lossy` decode sites (2 lossless, 2 AUDIT-OK); gate now fully green |
 | WI-4.3 | 4 Bytes | Strict-parse subprocess stdout used for decisions (PID/name) | ✅ | `harden/bugs` | ✅ |
 | WI-4.4 | 4 Bytes | **RFC + impl:** lossless name storage (binary/WTF-8 column) | 🟨 RFC landed | `harden/bugs` | RFC ✅ / impl pending sign-off |
 | WI-5.2 | 5 Panic | Replace parser arithmetic with `checked_*`; remove parser `indexing_slicing` allows → `.get()` | ✅ | PR #349 (merged) | ✅ |
@@ -127,7 +127,7 @@ means the acceptance criteria were checked off *and* the pipeline was green.
 | 6 | Discarded errors | No bare `drop(write/flush)`; every intentional discard commented | 6.1–6.3 | ~66% (6.1, 6.2 ✅; 6.3 workspace audit pending) |
 | 7 | Bug-for-bug parity | Parity test covers pathological names; runs in CI | 7.1 | 0% (Windows-only, pending) |
 | 8 | Resolve before trust boundary | One process handle threads verify→grant; nonce property documented | 8.1, 8.2 | ~50% (8.2 ✅; 8.1 broker single-handle Windows-only, pending) |
-| G | Regression guard | Grep-gate in CI blocks reintroduction of all anti-patterns | G.1 | Gate built ✅; **not yet wired into the pipeline** (still red on the 36 byte sites until WI-4.1/4.2 land) |
+| G | Regression guard | Grep-gate in CI blocks reintroduction of all anti-patterns | G.1 | Gate built ✅ and **now fully green** (all byte sites resolved by WI-4.1/4.2/4.3); pipeline-wiring (`just audit-gate` into the `go`/ship lane in `uffs-ci-pipeline`) is the remaining follow-up |
 
 > **Note on WI-4.4 (🟨 Deferred-but-tracked):** literal *lossless* name handling
 > requires a binary/WTF-8 name column that ripples through the Polars query
@@ -628,6 +628,44 @@ containing a non-UTF-8 byte (Unix: `OsString::from_vec(vec![0x66, 0x80, 0x66])`)
 preserves the exact bytes in the resulting `OsString` argv entry.
 
 **Verify:** `cargo nextest run -p uffs-cli -p uffs-client -p uffs-mcp`
+
+**Implementation notes (landed on `harden/wi-4.2-osstring-argv`):**
+
+- **Full `&[&str]`/`&[String]` → `&[OsString]` spawn chain.** The spawn argv now
+  carries OS-native bytes end to end: `process::build_daemon_args` (mcp) and the
+  two `daemon_mgmt.rs` builders + `extract_spawn_args` (cli) produce
+  `Vec<OsString>` (flag literals via `OsString::from`, path values via
+  `path.as_os_str().to_os_string()` — no `to_string_lossy`); the public client
+  API `UffsClient`/`UffsClientSync::connect_with_args`/`connect_with_elevation`,
+  `auto_start_daemon`, `log_spawn_details`, and the whole `daemon_spawn.rs`
+  chain (`spawn_daemon`, `spawn_daemon_unix`/`_windows`, `spawn_via_uac_prompt`,
+  `spawn_detached_no_inherit`, `shell_execute_elevated`) all take `&[OsString]`.
+  The `McpConfig`/`HttpGatewayConfig`/`UffsMcpServer` `daemon_spawn_args` fields
+  and the handler `ClientSlot` became `Vec<OsString>` too.
+- **Windows `CreateProcessW` / `ShellExecuteW` rewritten to UTF-16.**
+  `quote_arg_for_createprocess` now operates on `&[u16]` (was `&str → String`)
+  and a shared `build_wide_command_line` builds the command line from
+  `OsStr::encode_wide`, so a path with unpaired surrogates / non-UTF-8 bytes
+  reaches the child's argv **losslessly** instead of being `to_string_lossy`
+  mangled to U+FFFD. The MSVCRT backslash/quote/empty-arg escaping rules are
+  preserved (now expressed over code units). The `process.rs` `uffsmcp`-restart
+  spawn args switched from `cmd.args(["--data-dir", &dir.to_string_lossy()])` to
+  `cmd.arg("--data-dir"); cmd.arg(dir.as_os_str())`.
+- **The 4 `from_utf16_lossy` decode sites (clears the gate):** `verify.rs`
+  (process exe path → identity check) and `broker.rs` exe-name identity check
+  now decode **losslessly** via `OsString::from_wide`; `broker.rs`
+  `get_client_exe_path` (audit-log display only — the real check is
+  `verify_client`) and `pipe.rs` `pwstr_to_string` (decodes an ASCII-by-spec SID
+  string) are marked `// AUDIT-OK(bytes)` with rationale.
+- **Verification:** native + `cargo xwin` (Windows) `--all-targets -D warnings`
+  clippy clean across uffs-broker/client/security/cli/mcp; 390 tests pass; the
+  anti-pattern gate is now **fully green** (no remaining byte sites). New
+  `lone_surrogate_arg_survives_losslessly` test proves a 0xD800-bearing arg
+  round-trips through the quoting routine unchanged.
+- **Deviation from the suggested test:** the plan suggested a Unix
+  `OsString::from_vec` non-UTF-8 argv test; the lossless property was instead
+  proven at the Windows quoting layer (the platform whose `to_string_lossy`
+  path was the actual bug), which is where the conversion logic lives.
 
 ---
 


### PR DESCRIPTION
## What & why

**Category 4** ("Bugs Rust Won't Catch"), **WI-4.2**. Spawning the daemon mangled non-UTF-8 / WTF-8 paths: argv was built as `String` via `path.to_string_lossy()`, and the Windows `CreateProcessW`/`ShellExecuteW` command line was assembled as a `String` then `encode_utf16`'d — so a path with an unpaired surrogate reached the child's argv as **U+FFFD**. Four `from_utf16_lossy` sites also decoded Windows-API UTF-16 lossily, two of them feeding process-identity decisions.

This is the last work item that was blocking the anti-pattern gate; **the gate is now fully green.**

## Changes

- **Whole spawn chain `&[&str]`/`&[String]` → `&[std::ffi::OsString]`:** the arg-builders (`build_daemon_args`, the two `daemon_mgmt.rs` builders, `extract_spawn_args`), the public client API (`UffsClient`/`UffsClientSync` `connect_with_args`/`connect_with_elevation`, `auto_start_daemon`, `log_spawn_details`), and all of `daemon_spawn.rs`. Flag literals via `OsString::from`; path values via `as_os_str().to_os_string()` (no `to_string_lossy`). The `McpConfig`/`HttpGatewayConfig`/`UffsMcpServer`/handler `daemon_spawn_args` fields became `Vec<OsString>`.
- **Windows FFI rewritten to UTF-16:** `quote_arg_for_createprocess` now operates on `&[u16]` (was `&str → String`); a new shared `build_wide_command_line` builds the command line from `OsStr::encode_wide`, so surrogate/WTF-8 paths reach the child **losslessly**. The MSVCRT backslash/quote/empty-arg escaping rules are preserved (over code units). The `process.rs` `uffsmcp`-restart spawn switched to `cmd.arg(dir.as_os_str())`.
- **4 `from_utf16_lossy` decode sites (clears the gate):** `verify.rs` exe path + `broker.rs` exe-name identity check → lossless `OsString::from_wide`; `broker.rs` audit-log name (display only — the real check is `verify_client`) and `pipe.rs` SID string (ASCII by spec) → `AUDIT-OK(bytes)` with rationale.
- **New test** `lone_surrogate_arg_survives_losslessly`: a `0xD800`-bearing arg round-trips through the quoting routine unchanged.
- **`broker/service.rs`:** extracted `install_service`/`uninstall_service` (behavior-neutral) to keep `broker.rs` under the 800-LOC file-size ceiling after the added rationale comments.

## Scope note

Search-query `Vec<String>` (env args, query text passed to `run_search`/`search_cli_raw`) is intentionally **not** converted — those are query text, not spawn paths. Only the vecs feeding `connect_with_args`/`connect_with_elevation` became `Vec<OsString>`.

## Verification

- native + `cargo xwin` (Windows) `--all-targets -D warnings` clippy clean across uffs-broker/client/security/cli/mcp
- `cargo nextest run` (those crates) → **390 passed**
- **anti-pattern gate fully green** (no remaining byte sites)
- full pre-commit + pre-push gates (fmt, file-size, typos, reuse, lint-ci, lint-prod, lint-tests, lint-ci-windows, cargo-vet) — ✅

## Follow-up (separate PR)

Now that the gate is green, wire `just audit-gate` into the `go`/ship lane in the `uffs-ci-pipeline` crate.