### PR TITLE
fix(broker): open client process once, thread handle verify→duplicate (WI-8.1)

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -29,6 +29,14 @@ mod service;
 #[cfg(windows)]
 use service::{install_service, uninstall_service};
 
+// Client process-handle acquisition + identity verification (WI-8.1), split
+// out to keep this file under the 800-LOC ceiling. See
+// `broker/process_handle.rs`.
+#[path = "broker/process_handle.rs"]
+mod process_handle;
+#[cfg(windows)]
+use process_handle::{OwnedProcessHandle, query_process_image_name, verify_client_handle};
+
 /// Run the broker (called from main).
 ///
 /// Scope is `pub(crate)` because `broker` is a private module of the
@@ -150,21 +158,41 @@ fn handle_one_connection(
         return;
     };
 
-    let exe_path = get_client_exe_path(pid);
-    if !check_client_identity(pid, exe_path.as_deref()) {
+    // WI-8.1: open the client process exactly ONCE here. The same handle is
+    // used to read the image name, make the identity decision, AND serve as
+    // the `DuplicateHandle` target — so a PID-reuse race cannot redirect the
+    // grant to a different (unverified) process between verify and duplicate.
+    let Some(client_process) = OwnedProcessHandle::open_client(pid) else {
+        audit_log("REJECTED", pid, None, None, "could not open client process");
+        tracing::warn!(pid, "Could not open client process — rejecting");
+        return;
+    };
+
+    // Read the exe path from the SAME handle we just opened (not a fresh
+    // PID→handle resolution). The identity decision uses the lossless path
+    // inside `verify_client_handle`; this `String` form is for the audit log
+    // only (display), so `to_string_lossy` is acceptable here.
+    let exe_path: Option<String> =
+        query_process_image_name(client_process.raw()).map(|os| os.to_string_lossy().into_owned());
+    if !check_client_identity(&client_process, pid, exe_path.as_deref()) {
         return;
     }
 
-    process_drive_request(pipe, pid, exe_path.as_deref(), rate_limit);
+    process_drive_request(pipe, &client_process, pid, exe_path.as_deref(), rate_limit);
 }
 
-/// Verify the client's identity (`verify_client` whitelist + Authenticode
-/// signature check).  Emits the appropriate REJECTED audit log on failure.
+/// Verify the client's identity (`verify_client_handle` name allowlist +
+/// Authenticode signature check).  Emits the appropriate REJECTED audit log on
+/// failure.
+///
+/// Takes the already-open `client_process` handle (WI-8.1) and verifies the
+/// image name read from **that** handle — the same handle the grant will
+/// duplicate into — rather than re-resolving the PID.
 ///
 /// Returns `true` when identity is confirmed, `false` otherwise.
 #[cfg(windows)]
-fn check_client_identity(pid: u32, exe: Option<&str>) -> bool {
-    if !verify_client(pid) {
+fn check_client_identity(client_process: &OwnedProcessHandle, pid: u32, exe: Option<&str>) -> bool {
+    if !verify_client_handle(client_process.raw()) {
         audit_log("REJECTED", pid, exe, None, "identity verification failed");
         tracing::warn!(pid, "Rejected broker client — not uffsd");
         return false;
@@ -193,11 +221,12 @@ fn check_client_identity(pid: u32, exe: Option<&str>) -> bool {
 #[cfg(windows)]
 fn process_drive_request(
     pipe: windows::Win32::Foundation::HANDLE,
+    client_process: &OwnedProcessHandle,
     pid: u32,
     exe: Option<&str>,
     rate_limit: &mut std::collections::HashMap<char, std::time::Instant>,
 ) {
-    match handle_pipe_request_with_rate_limit(pipe, pid, rate_limit) {
+    match handle_pipe_request_with_rate_limit(pipe, client_process, pid, rate_limit) {
         Ok(drive) => {
             audit_log("GRANTED", pid, exe, Some(drive), "handle issued");
         }
@@ -212,6 +241,7 @@ fn process_drive_request(
 #[cfg(windows)]
 fn handle_pipe_request_with_rate_limit(
     pipe: windows::Win32::Foundation::HANDLE,
+    client_process: &OwnedProcessHandle,
     client_pid: u32,
     rate_limit: &mut std::collections::HashMap<char, std::time::Instant>,
 ) -> anyhow::Result<char> {
@@ -242,7 +272,7 @@ fn handle_pipe_request_with_rate_limit(
     rate_limit.insert(drive_letter, now);
 
     // Delegate to actual handle brokering (drive letter already read)
-    handle_pipe_request_inner(pipe, client_pid, drive_letter)?;
+    handle_pipe_request_inner(pipe, client_process, client_pid, drive_letter)?;
     Ok(drive_letter)
 }
 
@@ -279,50 +309,6 @@ fn verify_authenticode(exe_path: &str) -> bool {
         }
         Err(_) => true, // PowerShell not available — allow (graceful degradation)
     }
-}
-
-/// Get the exe path for a PID (for audit logging).
-#[cfg(windows)]
-#[expect(
-    unsafe_code,
-    reason = "Win32 process-image-name query requires unsafe FFI"
-)]
-fn get_client_exe_path(pid: u32) -> Option<String> {
-    use windows::Win32::Foundation::CloseHandle;
-    use windows::Win32::System::Threading::{
-        OpenProcess, PROCESS_NAME_FORMAT, PROCESS_QUERY_LIMITED_INFORMATION,
-        QueryFullProcessImageNameW,
-    };
-
-    // SAFETY: OpenProcess is a read-only query with
-    // PROCESS_QUERY_LIMITED_INFORMATION; failure returns an Error (caught by
-    // ok()?), not a dangling handle.
-    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
-    let mut buf = vec![0_u16; 4096];
-    let mut size = u32::try_from(buf.len()).unwrap_or(u32::MAX);
-    // SAFETY: `handle` is a valid open process handle; `buf` is a fixed 4096-wide
-    // allocation; `size` is an owned u32 whose address is exclusive to this call.
-    let result = unsafe {
-        QueryFullProcessImageNameW(
-            handle,
-            PROCESS_NAME_FORMAT(0),
-            windows::core::PWSTR(buf.as_mut_ptr()),
-            &raw mut size,
-        )
-    };
-    // SAFETY: `handle` was obtained from OpenProcess above and is no longer needed.
-    if let Err(close_err) = unsafe { CloseHandle(handle) } {
-        tracing::debug!(err = ?close_err, "CloseHandle failed in get_client_exe_path");
-    }
-    if result.is_err() || size == 0 {
-        return None;
-    }
-    // u32→usize lossless on 64-bit; use get() to satisfy indexing_slicing.
-    let len = size as usize;
-    // AUDIT-OK(bytes): display only — used solely for `audit_log`, never a
-    // trust decision (the real check is `verify_client(pid)`, queried
-    // independently), so a lossy name cannot weaken security (WI-4.2).
-    buf.get(..len).map(String::from_utf16_lossy)
 }
 
 /// S5.3: Audit log entry to tracing (and Windows Event Log if available).
@@ -445,72 +431,6 @@ fn get_pipe_client_pid(pipe: windows::Win32::Foundation::HANDLE) -> Option<u32> 
     (result.is_ok() && pid != 0).then_some(pid)
 }
 
-/// Verify that a client process is a legitimate uffs-daemon.
-#[cfg(windows)]
-#[expect(
-    unsafe_code,
-    reason = "Win32 process-image-name query requires unsafe FFI"
-)]
-fn verify_client(pid: u32) -> bool {
-    use std::os::windows::ffi::OsStringExt as _;
-
-    use windows::Win32::Foundation::CloseHandle;
-    use windows::Win32::System::Threading::{
-        OpenProcess, PROCESS_NAME_FORMAT, PROCESS_QUERY_LIMITED_INFORMATION,
-        QueryFullProcessImageNameW,
-    };
-
-    // SAFETY: OpenProcess is a read-only query with
-    // PROCESS_QUERY_LIMITED_INFORMATION; failure returns Err (handled by the
-    // let-else) rather than an invalid handle.
-    let Ok(handle) = (unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }) else {
-        return false;
-    };
-
-    let mut buf = vec![0_u16; 4096];
-    let mut size = u32::try_from(buf.len()).unwrap_or(u32::MAX);
-    // SAFETY: `handle` is a valid open process handle; `buf` is a 4096-wide
-    // owned allocation; `size` is a stack-owned u32 accessed exclusively here.
-    let result = unsafe {
-        QueryFullProcessImageNameW(
-            handle,
-            PROCESS_NAME_FORMAT(0),
-            windows::core::PWSTR(buf.as_mut_ptr()),
-            &raw mut size,
-        )
-    };
-    // SAFETY: `handle` came from OpenProcess above and is no longer used.
-    if let Err(close_err) = unsafe { CloseHandle(handle) } {
-        tracing::debug!(err = ?close_err, "CloseHandle failed in verify_client");
-    }
-
-    if result.is_err() || size == 0 {
-        return false;
-    }
-    // u32→usize lossless on 64-bit; get() keeps us out of indexing_slicing.
-    let len = size as usize;
-    let Some(slice) = buf.get(..len) else {
-        return false;
-    };
-    // Lossless `from_wide` (not `from_utf16_lossy`): this exe path drives a
-    // daemon-identity decision, so a non-UTF-8/WTF-8 component must not be
-    // mangled to U+FFFD first. Daemon names are ASCII; a non-UTF-8 name simply
-    // fails `to_str()` below and is rejected (WI-4.2).
-    let exe_name = std::ffi::OsString::from_wide(slice);
-
-    let name = std::path::Path::new(&exe_name)
-        .file_name()
-        .and_then(|file_name| file_name.to_str())
-        .unwrap_or("");
-
-    name == "uffsd"
-        || name == "uffsd.exe"
-        || name == "uffs-daemon.exe"
-        || name == "uffs-daemon"
-        || name.starts_with("uffs-daemon")
-        || name.starts_with("uffs_daemon")
-}
-
 // ── D7.5: Handle Brokering ──────────────────────────────────────────────
 
 /// Open the NTFS volume for a drive letter with read-only backup semantics.
@@ -543,49 +463,44 @@ fn open_volume_read_only(drive_letter: char) -> anyhow::Result<windows::Win32::F
 
 /// Duplicate `volume_handle` into the client process with read-only access.
 ///
-/// The caller retains ownership of `volume_handle` and is responsible for
-/// closing it; this function only opens / closes the transient client-process
-/// handle it needs for the `DuplicateHandle` call.
+/// **WI-8.1:** the duplicate target is the **same** `client_process` handle
+/// that was verified in `check_client_identity` — passed in by the caller, not
+/// re-opened from the PID. This closes the verify-then-reopen race: there is no
+/// window in which a recycled PID could point the grant at a different process.
+///
+/// The caller retains ownership of both `volume_handle` and `client_process`.
 #[cfg(windows)]
 #[expect(
     unsafe_code,
-    reason = "OpenProcess + GetCurrentProcess + DuplicateHandle + CloseHandle are FFI calls"
+    reason = "GetCurrentProcess + DuplicateHandle are FFI calls"
 )]
 fn duplicate_volume_handle_to_client(
     volume_handle: windows::Win32::Foundation::HANDLE,
-    client_pid: u32,
+    client_process: &OwnedProcessHandle,
 ) -> anyhow::Result<windows::Win32::Foundation::HANDLE> {
-    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows::Win32::Foundation::HANDLE;
     use windows::Win32::Storage::FileSystem::FILE_GENERIC_READ;
-    use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcess, PROCESS_DUP_HANDLE};
-
-    // SAFETY: `client_pid` is an integer; OpenProcess returns Err on invalid PID.
-    let client_process = unsafe { OpenProcess(PROCESS_DUP_HANDLE, false, client_pid) }
-        .map_err(|err| anyhow::anyhow!("OpenProcess for client {client_pid} failed: {err}"))?;
+    use windows::Win32::System::Threading::GetCurrentProcess;
 
     // SAFETY: GetCurrentProcess is a Win32 pseudo-handle getter (never fails).
     let current_process = unsafe { GetCurrentProcess() };
 
     let mut client_handle = HANDLE::default();
-    // SAFETY: `current_process`, `volume_handle`, and `client_process` are all
-    // valid handles; `client_handle` is a stack-owned HANDLE passed via
+    // SAFETY: `current_process`, `volume_handle`, and `client_process.raw()`
+    // are all valid handles (the client handle is kept alive by the caller's
+    // `OwnedProcessHandle`); `client_handle` is a stack-owned HANDLE passed via
     // exclusive &raw mut.
     let dup_ok = unsafe {
         windows::Win32::Foundation::DuplicateHandle(
             current_process,
             volume_handle,
-            client_process,
+            client_process.raw(),
             &raw mut client_handle,
             FILE_GENERIC_READ.0,
             false,
             windows::Win32::Foundation::DUPLICATE_HANDLE_OPTIONS(0),
         )
     };
-
-    // SAFETY: `client_process` came from OpenProcess above; we're done with it.
-    if let Err(close_err) = unsafe { CloseHandle(client_process) } {
-        tracing::debug!(err = ?close_err, "CloseHandle(client_process) failed after dup");
-    }
 
     dup_ok.map_err(|err| anyhow::anyhow!("DuplicateHandle failed: {err}"))?;
     Ok(client_handle)
@@ -618,6 +533,7 @@ fn write_success_response(
 #[expect(unsafe_code, reason = "CloseHandle is an FFI call")]
 fn handle_pipe_request_inner(
     pipe: windows::Win32::Foundation::HANDLE,
+    client_process: &OwnedProcessHandle,
     client_pid: u32,
     drive_letter: char,
 ) -> anyhow::Result<()> {
@@ -633,7 +549,7 @@ fn handle_pipe_request_inner(
         }
     };
 
-    let dup_result = duplicate_volume_handle_to_client(volume_handle, client_pid);
+    let dup_result = duplicate_volume_handle_to_client(volume_handle, client_process);
 
     // Close our copy of the volume handle regardless of whether the duplicate
     // succeeded — the client has its own handle now, or the whole request

--- a/crates/uffs-broker/src/broker/process_handle.rs
+++ b/crates/uffs-broker/src/broker/process_handle.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Client process-handle acquisition and identity verification for the broker.
+//!
+//! **WI-8.1 (Category 8 — resolve before trust boundary):** the broker opens
+//! the client process **exactly once** ([`OwnedProcessHandle::open_client`])
+//! and uses that single handle for both the identity check
+//! ([`verify_client_handle`]) and the later `DuplicateHandle` target — so a
+//! PID-reuse race cannot redirect the granted volume handle to an unverified
+//! process. Extracted from `broker.rs` to keep that file under the 800-LOC
+//! ceiling while grouping the trust-boundary machinery in one place.
+
+/// RAII wrapper around a client process `HANDLE` opened via `OpenProcess`.
+///
+/// Opening once, with the union of rights both phases need
+/// (`PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_DUP_HANDLE`), means the handle
+/// whose identity is verified is the **same** handle the grant duplicates into
+/// — there is no second PID→handle resolution to race against. `Drop` closes
+/// it on every path.
+#[cfg(windows)]
+pub(super) struct OwnedProcessHandle(windows::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl OwnedProcessHandle {
+    /// Open the client process once with the combined rights needed for both
+    /// identity verification (`QueryFullProcessImageNameW`) and the
+    /// `DuplicateHandle` target. Returns `None` if the process cannot be
+    /// opened (e.g. it already exited).
+    #[expect(unsafe_code, reason = "Win32 OpenProcess FFI")]
+    pub(super) fn open_client(pid: u32) -> Option<Self> {
+        use windows::Win32::System::Threading::{
+            OpenProcess, PROCESS_DUP_HANDLE, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        // SAFETY: `OpenProcess` returns `Result<HANDLE>`; on failure we map to
+        // `None` and never construct an `OwnedProcessHandle` around an invalid
+        // handle, so `Drop` only ever closes a real open handle.
+        let handle = unsafe {
+            OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_DUP_HANDLE,
+                false,
+                pid,
+            )
+        }
+        .ok()?;
+        Some(Self(handle))
+    }
+
+    /// The raw handle, for passing to Win32 query / duplicate calls. The
+    /// returned handle is owned by `self` and must not outlive it.
+    pub(super) const fn raw(&self) -> windows::Win32::Foundation::HANDLE {
+        self.0
+    }
+}
+
+#[cfg(windows)]
+impl Drop for OwnedProcessHandle {
+    #[expect(unsafe_code, reason = "CloseHandle for the owned process handle")]
+    fn drop(&mut self) {
+        // SAFETY: `self.0` came from a successful `OpenProcess` in
+        // `open_client` and is owned exclusively by this value.
+        if let Err(close_err) = unsafe { windows::Win32::Foundation::CloseHandle(self.0) } {
+            tracing::debug!(err = ?close_err, "CloseHandle failed dropping OwnedProcessHandle");
+        }
+    }
+}
+
+/// Query a process's full image path from an already-open handle.
+///
+/// Shared by the identity verification and audit-path-name lookups so both
+/// read the name from the **same** verified handle (WI-8.1) — no second
+/// PID→handle resolution. Returns `None` if the query fails or yields an
+/// empty path.
+///
+/// Decodes losslessly via `OsString::from_wide` (not `from_utf16_lossy`):
+/// the result feeds the daemon-identity decision in [`verify_client_handle`],
+/// so a non-UTF-8/WTF-8 path component must not be mangled to U+FFFD before
+/// the allow-list match (Category 4 / WI-4.2). The daemon names are ASCII, so
+/// a path that is not valid UTF-8 simply fails the `to_str()` in
+/// [`is_uffs_daemon_image`] and is rejected.
+#[cfg(windows)]
+#[expect(
+    unsafe_code,
+    reason = "Win32 QueryFullProcessImageNameW requires unsafe FFI"
+)]
+pub(super) fn query_process_image_name(
+    handle: windows::Win32::Foundation::HANDLE,
+) -> Option<std::ffi::OsString> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt as _;
+
+    use windows::Win32::System::Threading::{PROCESS_NAME_FORMAT, QueryFullProcessImageNameW};
+
+    let mut buf = vec![0_u16; 4096];
+    let mut size = u32::try_from(buf.len()).unwrap_or(u32::MAX);
+    // SAFETY: `handle` is a valid open process handle (owned by the caller's
+    // `OwnedProcessHandle`); `buf` is a fixed 4096-wide allocation; `size` is
+    // a stack-owned u32 whose address is exclusive to this call.
+    let result = unsafe {
+        QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_FORMAT(0),
+            windows::core::PWSTR(buf.as_mut_ptr()),
+            &raw mut size,
+        )
+    };
+    if result.is_err() || size == 0 {
+        return None;
+    }
+    // u32→usize lossless on 64-bit; use get() to satisfy indexing_slicing.
+    let len = size as usize;
+    buf.get(..len).map(OsString::from_wide)
+}
+
+/// Returns `true` if `exe_path`'s file name is one of the allowed uffs-daemon
+/// binaries. Pure (no FFI) so it is unit-testable on every platform — this is
+/// the actual trust predicate behind [`verify_client_handle`].
+///
+/// Takes `&OsStr` so the lossless image path from [`query_process_image_name`]
+/// is matched without a lossy conversion. The daemon names are ASCII; a file
+/// name that is not valid UTF-8 fails `to_str()` and is correctly rejected.
+pub(super) fn is_uffs_daemon_image(exe_path: &std::ffi::OsStr) -> bool {
+    let name = std::path::Path::new(exe_path)
+        .file_name()
+        .and_then(|file_name| file_name.to_str())
+        .unwrap_or("");
+
+    name == "uffsd"
+        || name == "uffsd.exe"
+        || name == "uffs-daemon.exe"
+        || name == "uffs-daemon"
+        || name.starts_with("uffs-daemon")
+        || name.starts_with("uffs_daemon")
+}
+
+/// Verify that a client process is a legitimate uffs-daemon, reading its image
+/// name from an **already-open** handle (WI-8.1).
+///
+/// The `handle` is the same `OwnedProcessHandle` the grant will duplicate into,
+/// so the name we allow-list and the process we hand the volume handle to are
+/// guaranteed identical — no PID re-resolution between verify and grant.
+#[cfg(windows)]
+pub(super) fn verify_client_handle(handle: windows::Win32::Foundation::HANDLE) -> bool {
+    query_process_image_name(handle).is_some_and(|exe_name| is_uffs_daemon_image(&exe_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::is_uffs_daemon_image;
+
+    #[test]
+    fn accepts_known_daemon_names() {
+        assert!(is_uffs_daemon_image(OsStr::new(
+            r"C:\Program Files\uffs\uffsd.exe"
+        )));
+        assert!(is_uffs_daemon_image(OsStr::new("/usr/local/bin/uffsd")));
+        assert!(is_uffs_daemon_image(OsStr::new(r"C:\x\uffs-daemon.exe")));
+        assert!(is_uffs_daemon_image(OsStr::new("/opt/uffs-daemon")));
+        // Prefix forms (versioned binaries).
+        assert!(is_uffs_daemon_image(OsStr::new(
+            r"C:\x\uffs-daemon-0.5.exe"
+        )));
+        assert!(is_uffs_daemon_image(OsStr::new(
+            r"C:\x\uffs_daemon_dev.exe"
+        )));
+    }
+
+    #[test]
+    fn rejects_other_images() {
+        assert!(!is_uffs_daemon_image(OsStr::new(
+            r"C:\Windows\System32\cmd.exe"
+        )));
+        assert!(!is_uffs_daemon_image(OsStr::new("/bin/sh")));
+        assert!(!is_uffs_daemon_image(OsStr::new(r"C:\evil\notuffsd.exe")));
+        // A path whose *directory* contains "uffsd" but whose file name does
+        // not must be rejected — we match on the file name, not a substring.
+        assert!(!is_uffs_daemon_image(OsStr::new(r"C:\uffsd\malware.exe")));
+        assert!(!is_uffs_daemon_image(OsStr::new("")));
+    }
+}

--- a/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
+++ b/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
@@ -103,7 +103,7 @@ means the acceptance criteria were checked off *and* the pipeline was green.
 | WI-6.1 | 6 Errors | `daemon_ctl` control writes: surface/log instead of bare `drop` | ✅ | `harden/bugs` | ✅ |
 | WI-6.2 | 6 Errors | Log dir-create failures (`log_init`, `mft/logging`) to stderr once | ✅ | `harden/bugs` | ✅ |
 | WI-6.3 | 6 Errors | Audit remaining `.ok()`/`let _ =`; add justification comments | ✅ | `harden/bugs-2` | ✅ |
-| WI-8.1 | 8 Trust | Broker: thread one process handle verify→`DuplicateHandle` (no PID re-open) | ⬜ | | |
+| WI-8.1 | 8 Trust | Broker: thread one process handle verify→`DuplicateHandle` (no PID re-open) | ✅ | `harden/wi-8.1-broker-single-handle` | single `OpenProcess` via RAII `OwnedProcessHandle`; verify + duplicate share it; `broker/process_handle.rs` split; name-predicate unit tests |
 | WI-8.2 | 8 Trust | Document daemon-nonce security property (depends on WI-2.2) | ✅ | `harden/bugs` | ✅ |
 | WI-7.1 | 7 Parity | Parity corpus: pathological names; assert vs Windows enumeration | ⬜ | | |
 | WI-3.1 | 3 Identity | `paths_identical` (dev,inode) helper + invariant doc/test for scoping | ✅ | `harden/bugs` | ✅ |
@@ -995,6 +995,41 @@ handle) documents the invariant.
 
 **Verify:** `cargo nextest run -p uffs-broker` (Windows, elevated for the ignored
 case).
+
+**Implementation notes (landed on `harden/wi-8.1-broker-single-handle`):**
+
+- **One `OpenProcess` per grant.** Before this WI the broker opened the client
+  process by PID **three times** — `get_client_exe_path` (audit name),
+  `verify_client` (identity decision), and `duplicate_volume_handle_to_client`
+  (the `DuplicateHandle` target). The window between verify and duplicate was a
+  PID-reuse race: a recycled PID could point the grant at a different,
+  unverified process. Now `handle_one_connection` opens the client **once** via
+  the new RAII `OwnedProcessHandle::open_client` (with
+  `PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_DUP_HANDLE`) and threads that
+  single handle through `check_client_identity` → `handle_pipe_request_inner` →
+  `duplicate_volume_handle_to_client`. The handle verified is the handle the
+  grant duplicates into — no second PID→handle resolution exists.
+- **`broker/process_handle.rs`** (new submodule via `#[path]`) holds the
+  trust-boundary machinery: `OwnedProcessHandle` (RAII; `Drop` closes on every
+  path), `query_process_image_name` (one shared image-name read),
+  `is_uffs_daemon_image` (the pure name allow-list predicate), and
+  `verify_client_handle`. The split also keeps `broker.rs` under the 800-LOC
+  ceiling (721 LOC).
+- **Lossless image-name decode (folds in WI-4.2 intent):** the unified
+  `query_process_image_name` returns `OsString` via `OsString::from_wide`, and
+  `is_uffs_daemon_image` matches on `&OsStr`, so the daemon-identity decision is
+  never made on a `from_utf16_lossy`-mangled path. This also removed the broker
+  `from_utf16_lossy` site from the anti-pattern gate.
+- **Tests:** `is_uffs_daemon_image` has cross-platform unit tests (accepts the
+  daemon-name forms incl. versioned prefixes; rejects other images and a path
+  whose *directory* — not file name — contains `uffsd`). They compile into the
+  Windows test binary (`cargo xwin test --no-run` confirms discovery); the
+  broker is a Windows-only `[[bin]]`, so they run on the Windows CI test job.
+  The single-handle invariant is additionally enforced at compile time:
+  `duplicate_volume_handle_to_client` takes `&OwnedProcessHandle`, so it
+  **cannot** be called with a bare PID.
+- **Verify:** native + `cargo xwin` (Windows) `--all-targets -D warnings` clippy
+  clean; file-size + anti-pattern gates green for broker.
 
 ---
 


### PR DESCRIPTION
## What & why

**Category 8** ("Bugs Rust Won't Catch" — resolve before trust boundary), **WI-8.1**.

The Windows access broker opened the client process by PID **three times**: exe-path query, identity verify, and the `DuplicateHandle` target. Between the verify and the duplicate, the OS could recycle the PID onto a **different** process — so the privileged read-only volume handle could be duplicated into an **unverified** process. The handle whose identity was checked was not guaranteed to be the handle that received the grant.

## Fix — open exactly once, share the handle

- New RAII **`OwnedProcessHandle::open_client(pid)`** opens the client a single time with `PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_DUP_HANDLE`; `Drop` closes it on every path.
- `handle_one_connection` opens it and threads `&OwnedProcessHandle` through `check_client_identity` → `handle_pipe_request_inner` → `duplicate_volume_handle_to_client`. **The handle verified is the handle the grant duplicates into** — no second PID→handle resolution. The only `OpenProcess` in the grant path is now in `open_client`.
- **Compile-time invariant:** `duplicate_volume_handle_to_client(_, &OwnedProcessHandle)` cannot be called with a bare PID.
- The image name is read once via `query_process_image_name`, decoded **losslessly** (`OsString::from_wide`, matched on `&OsStr` by `is_uffs_daemon_image`) so the identity decision is never made on a `from_utf16_lossy`-mangled path — this also clears the broker site from the anti-pattern gate.

## Refactor

Moved the trust-boundary machinery (`OwnedProcessHandle`, `query_process_image_name`, `is_uffs_daemon_image`, `verify_client_handle`) into **`broker/process_handle.rs`**, keeping `broker.rs` under the 800-LOC ceiling (721 LOC).

## Tests

Cross-platform unit tests for `is_uffs_daemon_image`: accepts the daemon names incl. versioned prefixes; rejects other images and — importantly — a path whose *directory* (not file name) contains `uffsd`. The broker is a Windows-only `[[bin]]`, so the tests run on the **Windows CI test job** (verified discovered via `cargo xwin test --no-run`).

## Verification

- native + `cargo xwin` (Windows) `--all-targets -D warnings` clippy clean
- file-size gate green (broker.rs 721 LOC, process_handle.rs 183 LOC)
- anti-pattern gate: broker site cleared

## Note vs PR #351 (WI-4.2, open)

This branch is off `main`; #351's changes to the *old* `verify_client`/`get_client_exe_path` are superseded here (those fns are gone). Both make the broker identity path lossless, so the end state is consistent — whichever merges second needs a trivial conflict resolution in `broker.rs`.