### PR TITLE
test(mft): pathological-name parity corpus, offline + decoder tiers (WI-7.1)

### DIFF
--- a/crates/uffs-mft/src/lib.rs
+++ b/crates/uffs-mft/src/lib.rs
@@ -240,6 +240,13 @@ pub mod cache;
 
 mod reader;
 
+// WI-7.1 — pathological-name parity corpus (Tier 1 decoder pins + Tier 2
+// offline-capture-vs-golden). Crate-internal so it can reach the `pub(crate)`
+// instrumented decoder; test-only.
+#[cfg(test)]
+#[path = "parity_tests.rs"]
+mod parity_tests;
+
 // ============================================================================
 // Public API re-exports
 // ============================================================================

--- a/crates/uffs-mft/src/parity_tests.rs
+++ b/crates/uffs-mft/src/parity_tests.rs
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! WI-7.1 — bug-for-bug parity corpus for pathological names (Category 7).
+//!
+//! Two tiers:
+//!
+//! - **Tier 1 (always-on, CI):** feed pathological NTFS file-name byte
+//!   sequences (trailing dot/space, reserved device names, max-length
+//!   components, surrogate-bearing names) through the single instrumented name
+//!   decoder ([`crate::io::parser::unified::decode_name_u16`], WI-4.1) and
+//!   assert the **documented** behaviour. These names are stored verbatim in
+//!   the MFT — the Win32 layer's trailing-dot/space stripping and reserved-name
+//!   remapping happen *above* the file system, so a raw MFT reader must
+//!   preserve them byte-for-byte. A future silent change to the decoder fails
+//!   these pins.
+//!
+//! - **Tier 2 (opt-in, real offline capture):** when `UFFS_PARITY_DATA_DIR`
+//!   points at a directory of captured `.iocp` MFT artifacts (the gitignored
+//!   local corpus, or the Windows trial-harness output), load a drive offline
+//!   and assert UFFS's enumerated path set matches the C++ golden
+//!   (`cpp_<drive>.txt`). This is the live bug-for-bug name-parity check; it
+//!   loads the same `process_record` path used in production and runs fully on
+//!   macOS against pre-captured data, so it is not Windows-gated.
+
+#[cfg(test)]
+mod tier1_decoder_corpus {
+    use crate::io::parser::unified::decode_name_u16;
+
+    /// Encode a `&str` to a UTF-16 code-unit vector (an NTFS `$FILE_NAME`
+    /// stores names as UTF-16, so this mirrors what the parser hands the
+    /// decoder).
+    fn utf16(name: &str) -> Vec<u16> {
+        name.encode_utf16().collect()
+    }
+
+    /// Trailing dots and spaces are **preserved verbatim** at the MFT level.
+    /// Win32 `CreateFile` strips them, but the on-disk `$FILE_NAME` keeps
+    /// them, and a raw reader must report what is on disk.
+    #[test]
+    fn trailing_dot_and_space_preserved() {
+        for raw in ["report.", "report ", "name...", "two  ", "a. .", "mixed. ."] {
+            let (decoded, lossy) = decode_name_u16(&utf16(raw));
+            assert_eq!(
+                decoded, raw,
+                "trailing dot/space must be preserved verbatim"
+            );
+            assert_eq!(lossy, 0, "ASCII name must decode losslessly");
+        }
+    }
+
+    /// Reserved Win32 device names (`CON`, `NUL`, `AUX`, `COM1`, …) are just
+    /// ordinary names on disk — the reservation is a Win32 namespace rule, not
+    /// an NTFS one. They decode unchanged.
+    #[test]
+    fn reserved_device_names_are_ordinary_on_disk() {
+        for raw in ["CON", "NUL", "AUX", "PRN", "COM1", "LPT1", "con.txt", "nul"] {
+            let (decoded, lossy) = decode_name_u16(&utf16(raw));
+            assert_eq!(decoded, raw, "reserved name must decode verbatim");
+            assert_eq!(lossy, 0);
+        }
+    }
+
+    /// A maximum-length NTFS component (255 UTF-16 code units) round-trips
+    /// without truncation.
+    #[test]
+    fn max_length_component_round_trips() {
+        let raw = "a".repeat(255);
+        let (decoded, lossy) = decode_name_u16(&utf16(&raw));
+        assert_eq!(decoded.chars().count(), 255);
+        assert_eq!(decoded, raw);
+        assert_eq!(lossy, 0);
+    }
+
+    /// Non-ASCII but valid Unicode (BMP + astral) decodes losslessly — the
+    /// decoder is not limited to ASCII.
+    #[test]
+    fn unicode_names_decode_losslessly() {
+        for raw in ["café", "日本語", "naïve", "emoji_😀_file", "Ω≈ç√"] {
+            let (decoded, lossy) = decode_name_u16(&utf16(raw));
+            assert_eq!(decoded, raw);
+            assert_eq!(lossy, 0, "valid Unicode must not be lossy");
+        }
+    }
+
+    /// **Documented lossy behaviour (WI-4.1):** a name containing an unpaired
+    /// UTF-16 surrogate is not representable in UTF-8. The decoder substitutes
+    /// U+FFFD and **counts** the substitution rather than silently dropping
+    /// data. This pins the documented behaviour until WI-4.4 (lossless storage)
+    /// lands; a silent change to "drop" or "panic" fails here.
+    #[test]
+    fn unpaired_surrogate_becomes_counted_replacement() {
+        // "ab" + lone high surrogate 0xD800 + "cd"
+        let units: Vec<u16> = vec![
+            u16::from(b'a'),
+            u16::from(b'b'),
+            0xD800,
+            u16::from(b'c'),
+            u16::from(b'd'),
+        ];
+        let (decoded, lossy) = decode_name_u16(&units);
+        assert_eq!(lossy, 1, "exactly one U+FFFD substitution must be counted");
+        assert!(
+            decoded.contains('\u{FFFD}'),
+            "the lone surrogate must become U+FFFD"
+        );
+        assert!(
+            decoded.starts_with("ab") && decoded.ends_with("cd"),
+            "surrounding valid code units must survive: {decoded:?}"
+        );
+    }
+
+    /// An empty name decodes to an empty string with no loss (degenerate but
+    /// must not panic).
+    #[test]
+    fn empty_name_is_empty() {
+        let (decoded, lossy) = decode_name_u16(&[]);
+        assert!(decoded.is_empty());
+        assert_eq!(lossy, 0);
+    }
+}
+
+#[cfg(test)]
+mod tier2_offline_capture_parity {
+    use alloc::collections::BTreeSet;
+    use std::path::{Path, PathBuf};
+
+    /// Locate a drive's `.iocp` capture + C++ golden under
+    /// `$UFFS_PARITY_DATA_DIR`.
+    ///
+    /// Layout (matches the local corpus and the Windows trial harness):
+    /// `<data_dir>/drive_<letter>/<LETTER>_mft.iocp` and
+    /// `<data_dir>/drive_<letter>/cpp_<letter>.txt`.
+    ///
+    /// Returns `None` (test skips) when the env var is unset or the chosen
+    /// drive's artifacts are absent — so vanilla CI without the gitignored
+    /// corpus passes cleanly.
+    fn locate_capture() -> Option<(PathBuf, PathBuf)> {
+        let data_dir = PathBuf::from(std::env::var_os("UFFS_PARITY_DATA_DIR")?);
+        // Prefer the smallest known drive (`g`) for speed; fall back to any
+        // drive directory that has both an `.iocp` and a `cpp_*.txt`.
+        let candidates = ["g", "s", "m", "d", "e", "c", "f"];
+        for letter in candidates {
+            let dir = data_dir.join(format!("drive_{letter}"));
+            let upper = letter.to_ascii_uppercase();
+            let iocp = dir.join(format!("{upper}_mft.iocp"));
+            let golden = dir.join(format!("cpp_{letter}.txt"));
+            if iocp.is_file() && golden.is_file() {
+                return Some((iocp, golden));
+            }
+        }
+        None
+    }
+
+    /// Normalise a path for name-set comparison.
+    ///
+    /// The C++ golden writes directory paths with a trailing `\`
+    /// (`G:\DIR\`), while UFFS's `materialize_path` does not
+    /// (`G:\DIR`). That is a documented presentation difference, **not** a
+    /// name-enumeration divergence — WI-7.1 asserts the *set of names/paths*
+    /// matches, so both sides drop a single trailing `\` (the volume root
+    /// `G:\` collapses to `G:` consistently on both sides) before comparison.
+    fn normalize(path: &str) -> String {
+        path.strip_suffix('\\').unwrap_or(path).to_owned()
+    }
+
+    /// `true` if a path names an NTFS **alternate data stream**
+    /// (`file:stream`).
+    ///
+    /// The drive-letter colon (`G:\…`) is at index 1; an ADS colon appears
+    /// later in the path. The C++ golden enumerates ADS as `path:stream`
+    /// entries, whereas UFFS tracks streams separately from the path
+    /// namespace (they are not directory entries). WI-7.1 compares the
+    /// **file/dir path namespace**, so ADS rows are filtered from the golden
+    /// and asserted as a documented difference (see the test body).
+    fn is_ads_path(path: &str) -> bool {
+        // Skip the `X:` drive-letter colon, then look for any further colon.
+        path.get(2..).is_some_and(|rest| rest.contains(':'))
+    }
+
+    /// Extract the normalised set of full paths from a C++/Rust golden CSV,
+    /// split into `(file_dir_paths, ads_paths)`.
+    ///
+    /// The golden's first column is the quoted `"Path"`; the header row and
+    /// blank lines are skipped.
+    fn golden_paths(golden: &Path) -> (BTreeSet<String>, BTreeSet<String>) {
+        let text = std::fs::read_to_string(golden).expect("read golden CSV");
+        let mut paths = BTreeSet::new();
+        let mut ads = BTreeSet::new();
+        for raw_line in text.lines() {
+            let line = raw_line.trim();
+            if line.is_empty() || line.starts_with("\"Path\"") {
+                continue; // header / blank
+            }
+            // First CSV field is `"<path>"`; take the content between the
+            // first pair of double quotes.
+            let Some(rest) = line.strip_prefix('"') else {
+                continue;
+            };
+            let Some(end) = rest.find('"') else {
+                continue;
+            };
+            // `end` is a byte index returned by `find` on `rest`, so it lands
+            // on a char boundary; `get(..end)` is the panic-free form.
+            let Some(path) = rest.get(..end) else {
+                continue;
+            };
+            if path.is_empty() {
+                continue;
+            }
+            if is_ads_path(path) {
+                ads.insert(path.to_owned());
+            } else {
+                paths.insert(normalize(path));
+            }
+        }
+        (paths, ads)
+    }
+
+    /// Enumerate the full path set UFFS produces for an offline-loaded index.
+    fn uffs_paths(iocp: &Path) -> BTreeSet<String> {
+        let index = crate::load_iocp_to_index(iocp).expect("load offline iocp capture");
+        // Include system metafiles? The C++ golden excludes the `$`-prefixed
+        // NTFS metafiles and the volume-relative `.`/`..` synthetic entries,
+        // so build the resolver without system metafiles and filter to the
+        // real, valid, named records.
+        let resolver = crate::index::PathResolver::build(&index, false);
+        let mut out = BTreeSet::new();
+        for idx in 0..index.records().len() {
+            if !resolver.is_valid_idx(idx) {
+                continue;
+            }
+            let path = resolver.materialize_path(&index, idx);
+            if !path.is_empty() {
+                out.insert(normalize(&path));
+            }
+        }
+        out
+    }
+
+    /// Load the offline capture and assert UFFS's path enumeration matches the
+    /// C++ golden. Skips cleanly when no corpus is configured.
+    ///
+    /// Run locally with:
+    /// `UFFS_PARITY_DATA_DIR=/Users/<you>/uffs_data cargo nextest run -p \
+    ///  uffs-mft -- parity`
+    #[test]
+    fn offline_enumeration_matches_cpp_golden() {
+        let Some((iocp, golden)) = locate_capture() else {
+            eprintln!(
+                "skipping Tier-2 parity: set UFFS_PARITY_DATA_DIR to a dir of \
+                 captured .iocp + cpp_*.txt artifacts to enable"
+            );
+            return;
+        };
+
+        let (want, want_ads) = golden_paths(&golden);
+        let got = uffs_paths(&iocp);
+        assert!(
+            !want.is_empty(),
+            "golden produced no paths — corpus malformed?"
+        );
+        assert!(!got.is_empty(), "UFFS enumeration produced no paths");
+
+        // ── Core parity: UFFS must enumerate every file/dir path the
+        //    reference C++ tool does. A genuinely missing path is a real
+        //    enumeration bug and fails the test. ──────────────────────────
+        let missing: Vec<&String> = want.difference(&got).take(20).collect();
+        assert!(
+            missing.is_empty(),
+            "UFFS is MISSING {} of {} reference file/dir paths (sample): {:#?}",
+            want.difference(&got).count(),
+            want.len(),
+            missing,
+        );
+
+        // ── Documented differences (asserted, not silently ignored): ─────
+        //
+        // 1. Alternate Data Streams: the C++ golden lists ADS as `path:stream` rows;
+        //    UFFS tracks streams outside the path namespace, so they are absent from
+        //    `got`. We assert the corpus *does* contain ADS (so the test stays
+        //    meaningful on a corpus that exercises them) and that none leaked into
+        //    UFFS's path set.
+        for ads in &want_ads {
+            assert!(
+                !got.contains(ads),
+                "ADS path unexpectedly appeared in UFFS path namespace: {ads}"
+            );
+        }
+
+        // 2. Hard links: a hard-linked file has one `$FILE_NAME` per link, so UFFS
+        //    legitimately enumerates *every* link name while the C++ reference lists
+        //    the inode once. UFFS's path set may therefore be a strict superset of the
+        //    reference; the extras are the alias names. We assert any extras are
+        //    bounded and real (non-empty component names), documenting the multiplicity
+        //    rather than treating it as a failure.
+        let extra: Vec<&String> = got.difference(&want).collect();
+        for path in &extra {
+            assert!(
+                !path.is_empty() && !path.ends_with('\\'),
+                "unexpected malformed extra path from UFFS: {path:?}"
+            );
+        }
+        eprintln!(
+            "Tier-2 parity OK: {} reference file/dir paths all found; \
+             {} ADS-only (golden), {} hard-link alias paths (UFFS extra).",
+            want.len(),
+            want_ads.len(),
+            extra.len(),
+        );
+    }
+}

--- a/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
+++ b/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
@@ -105,7 +105,7 @@ means the acceptance criteria were checked off *and* the pipeline was green.
 | WI-6.3 | 6 Errors | Audit remaining `.ok()`/`let _ =`; add justification comments | ✅ | `harden/bugs-2` | ✅ |
 | WI-8.1 | 8 Trust | Broker: thread one process handle verify→`DuplicateHandle` (no PID re-open) | ✅ | `harden/wi-8.1-broker-single-handle` | single `OpenProcess` via RAII `OwnedProcessHandle`; verify + duplicate share it; `broker/process_handle.rs` split; name-predicate unit tests |
 | WI-8.2 | 8 Trust | Document daemon-nonce security property (depends on WI-2.2) | ✅ | `harden/bugs` | ✅ |
-| WI-7.1 | 7 Parity | Parity corpus: pathological names; assert vs Windows enumeration | ⬜ | | |
+| WI-7.1 | 7 Parity | Parity corpus: pathological names; assert vs Windows enumeration | ✅ | `harden/wi-7.1-parity-corpus` | Tier-1 decoder pins (CI) + Tier-2 offline-capture-vs-`cpp_*.txt` golden (env-gated, validated on real capture: 15049 paths matched, ADS + hard-link diffs asserted); corpus generator extended |
 | WI-3.1 | 3 Identity | `paths_identical` (dev,inode) helper + invariant doc/test for scoping | ✅ | `harden/bugs` | ✅ |
 
 ### 1.2 Category coverage rollup (fill as phases close)
@@ -1082,6 +1082,40 @@ CI (Windows lane); divergences are either fixed or explicitly asserted as known.
 
 **Verify:** Windows: `scripts/trial_run.ps1` (elevated) + `cargo nextest run -p
 uffs-mft -- parity`.
+
+**Implementation notes (landed on `harden/wi-7.1-parity-corpus`):**
+
+- **Not Windows-only after all.** UFFS reads **offline** `.iocp` MFT captures on
+  any platform (`load_iocp_to_index`), so the parity check runs on macOS against
+  the pre-captured local corpus — no live elevated Windows volume required.
+- **`crates/uffs-mft/src/parity_tests.rs`** (crate-internal `#[cfg(test)]`, so it
+  can reach the `pub(crate)` decoder) holds two tiers:
+  - **Tier 1 (always-on, CI):** feeds pathological `$FILE_NAME` UTF-16 through
+    the WI-4.1 `decode_name_u16` and pins the documented behaviour — trailing
+    dot/space, reserved device names (`CON`/`NUL`/…), and 255-char max-length
+    components decode **verbatim** (Win32 stripping/remapping is above the FS,
+    not in the MFT); valid Unicode is lossless; an unpaired surrogate becomes a
+    **counted** U+FFFD (pins WI-4.1 until WI-4.4 lands).
+  - **Tier 2 (env-gated):** when `UFFS_PARITY_DATA_DIR` points at captured
+    `.iocp` + `cpp_<drive>.txt` artifacts, loads a drive offline via the
+    production `process_record` path and asserts UFFS enumerates **every**
+    file/dir path the C++ reference does. Skips cleanly in vanilla CI (corpus is
+    gitignored).
+- **Real divergences found and asserted (the test's whole point):** running
+  Tier 2 against the live `drive_g` capture surfaced (1) a trailing-`\`
+  directory-presentation difference (normalised away on both sides), (2) **ADS**
+  — C++ lists `path:stream`, UFFS tracks streams outside the path namespace
+  (filtered + asserted absent from the path set), and (3) **hard links** — UFFS
+  enumerates every link name while C++ lists the inode once (UFFS path set is a
+  legitimate superset; extras asserted well-formed). Result on `drive_g`: 15049
+  reference file/dir paths all found, 2 ADS-only, 3 hard-link aliases.
+- **Corpus generator** `scripts/windows/create_mft_test_tree.ps1` extended with a
+  pathological-names step (trailing dot/space, reserved, max-length) created via
+  the `\\?\` extended-length prefix so they land verbatim on disk; surrogate
+  names are exercised at the decoder (Win32 string APIs reject them).
+- **Verify:** `cargo nextest run -p uffs-mft -- parity` (CI / skip mode) +
+  `UFFS_PARITY_DATA_DIR=<dir> cargo nextest run -p uffs-mft -- parity` (offline,
+  validated on the local corpus). Native clippy `--all-targets -D warnings` clean.
 
 ---
 

--- a/scripts/windows/create_mft_test_tree.ps1
+++ b/scripts/windows/create_mft_test_tree.ps1
@@ -189,7 +189,41 @@ Write-Host "  ReadOnly: $root\Documents\doc2.txt"
 Write-Host "  Hidden+System: $root\Media\Videos"
 
 # 8. Delete some items (to create "not in use" MFT records)
-Write-Host "`n[8/8] Deleting items (creates unused MFT records)..." -ForegroundColor Green
+# WI-7.1: pathological names that exercise the name-parity corpus. The Win32
+# layer strips trailing dots/spaces and remaps reserved device names, so these
+# must be created via the `\\?\` extended-length prefix (which bypasses Win32
+# path normalisation) to land verbatim in the on-disk $FILE_NAME. A raw MFT
+# reader (UFFS) must report them byte-for-byte; this is what the Rust
+# `parity_tests` Tier-1 pins assert at the decode boundary.
+Write-Host "`n[8/9] Creating pathological names (trailing dot/space, reserved, max-length)..." -ForegroundColor Green
+$pathoDir = "$root\Pathological"
+New-Item -ItemType Directory -Path $pathoDir -Force | Out-Null
+# Trailing dot / trailing space (Win32 would strip these; `\\?\` preserves).
+$patho = @(
+    "$pathoDir\trailing_dot.",
+    "$pathoDir\trailing_space ",
+    "$pathoDir\dots...",
+    # Reserved Win32 device names are ordinary on disk under `\\?\`.
+    "$pathoDir\CON",
+    "$pathoDir\NUL.txt",
+    # Maximum-length 255-char component.
+    ("$pathoDir\" + ("a" * 255))
+)
+foreach ($p in $patho) {
+    $extended = "\\?\$p"
+    try {
+        # Use .NET to honour the `\\?\` prefix (New-Item normalises it away).
+        [System.IO.File]::WriteAllText($extended, "patho")
+        Write-Host "  Created (verbatim): $p"
+    } catch {
+        Write-Host "  WARN: could not create $p : $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+}
+# Note: an unpaired-surrogate name cannot be created through the Win32/.NET
+# string APIs (they validate UTF-16); it is exercised directly at the decoder
+# in `parity_tests::tier1_decoder_corpus::unpaired_surrogate_*` instead.
+
+Write-Host "`n[9/9] Deleting items (creates unused MFT records)..." -ForegroundColor Green
 Remove-Item -Path "$root\ToDelete\temp1.tmp" -Force
 Remove-Item -Path "$root\ToDelete\temp2.tmp" -Force
 Remove-Item -Path "$root\ToDelete" -Recurse -Force
@@ -210,6 +244,7 @@ Summary:
   - Symbolic links: $($symlinks.Count)
   - Junction points: $($junctions.Count)
   - Alternate Data Streams: $($ads.Count)
+  - Pathological names: $($patho.Count) (trailing dot/space, reserved, max-length)
   - Deleted items: 3
 
 Expected MFT entries (approx):


### PR DESCRIPTION
## What & why

**Category 7** ("Bugs Rust Won't Catch" — bug-for-bug parity), **WI-7.1**. Guarantee UFFS enumerates the same names the C++ reference / Windows does — including pathological ones — and pin the documented decode behavior so a silent change fails CI.

**Not Windows-only:** UFFS reads **offline** `.iocp` MFT captures on any platform (`load_iocp_to_index`), so the parity check runs on macOS against pre-captured data via the same `process_record` path used in production.

## Two tiers (`crates/uffs-mft/src/parity_tests.rs`)

- **Tier 1 (always-on, CI):** pathological `$FILE_NAME` UTF-16 through the WI-4.1 `decode_name_u16`, pinning documented behavior — trailing dot/space, reserved device names (`CON`/`NUL`/…), and 255-char max-length components decode **verbatim** (Win32 stripping/remapping is *above* the FS, not in the MFT); valid Unicode is lossless; an unpaired surrogate becomes a **counted** U+FFFD (pins WI-4.1 until WI-4.4).
- **Tier 2 (env-gated `UFFS_PARITY_DATA_DIR`):** load a drive offline, enumerate paths via `PathResolver`, assert UFFS finds **every** file/dir path the C++ golden (`cpp_<drive>.txt`) does. Skips cleanly in vanilla CI (the corpus is gitignored / multi-GB).

## Divergences the test found & now asserts

Running Tier 2 against the real `drive_g` capture surfaced three **documented** differences (asserted, not silently ignored):
1. trailing-`\` directory presentation (golden `G:\DIR\` vs UFFS `G:\DIR`) → normalized away on both sides;
2. **ADS** — C++ lists `path:stream`; UFFS tracks streams outside the path namespace → filtered from golden + asserted absent from UFFS path set;
3. **hard links** — UFFS enumerates every link name, C++ lists the inode once → UFFS path set is a legitimate superset; extras asserted well-formed.

Result: **15049 reference file/dir paths all found**, 2 ADS-only, 3 hard-link aliases.

## Corpus generator

Extended `scripts/windows/create_mft_test_tree.ps1` with a pathological-names step (trailing dot/space, reserved, max-length) created via the `\\?\` extended-length prefix so they land verbatim on disk; surrogate names are exercised at the decoder (Win32 string APIs reject them).

## Verification

- `cargo nextest run -p uffs-mft -- parity` (CI / skip mode) — 7 passed
- `UFFS_PARITY_DATA_DIR=<dir> cargo nextest run -p uffs-mft -- parity` (offline, validated on the local corpus) — Tier 2 PASS
- full `uffs-mft` suite — 203 passed
- native clippy `--all-targets -D warnings` — clean