### PR TITLE
chore: release v0.5.111 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -803,7 +803,7 @@ hunting for the wrong things.
 
 Plan §1 goal-4 ("no regression on CLI hot path vs the v0.5.35
 baseline") verified end-to-end on the Windows 7-drive reference
-box.  Current v0.5.110 (post-Phase-8 tiered architecture) is
+box.  Current v0.5.111 (post-Phase-8 tiered architecture) is
 **universally faster** than v0.5.35 across every benchmarked
 pattern, with the largest result set (`*.dll`, 44 529 rows)
 showing a **2.7× speedup**:
@@ -811,7 +811,7 @@ showing a **2.7× speedup**:
 ```
 Drive D, 7.07 M records, 30 rounds, HOT phase, p50 / p95 wall_ms:
 
-                              v0.5.35      v0.5.110       Δ p50
+                              v0.5.35      v0.5.111       Δ p50
     exact      (3 rows)       20 / 23   →  18 / 19      −10 %
     prefix     (8 732)        46 / 50   →  40 / 46      −13 %
     ext_rare   (11)           18 / 20   →  17 / 18       −6 %
@@ -987,7 +987,7 @@ log-message renames fail CI before reaching another 24-h soak.
   2026-05-13.  No new operator-surface features land on `main`
   until v0.6.0 ships.
 
-## [0.5.110] - 2026-05-08
+## [0.5.111] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -996,7 +996,7 @@ log-message renames fail CI before reaching another 24-h soak.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.110`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.111`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,8 +37,8 @@ license-url: "https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/LICENSE
 # Keep this in sync with [workspace.package].version in Cargo.toml.
 # The release pipeline (release-plz / just ship) should bump this automatically
 # once Pattern 5 in build/update_all_versions.rs is extended to cover CITATION.cff.
-version: "0.5.110"
-date-released: "2026-06-04"
+version: "0.5.111"
+date-released: "2026-06-05"
 
 # ── Classification ───────────────────────────────────────────────────────────
 type: software

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -379,9 +379,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -426,9 +426,9 @@ checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -1012,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1454,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1514,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1794,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1851,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -1887,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru-slab"
@@ -1973,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3428,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3693,9 +3693,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -3780,9 +3780,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4319,13 +4319,13 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4336,14 +4336,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "anyhow",
  "clap",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "chrono",
  "itoa",
@@ -4480,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "anyhow",
  "clap",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "anyhow",
  "clap",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "anyhow",
  "clap",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "anyhow",
  "axum",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4571,14 +4571,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4593,14 +4593,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.110"
+version = "0.5.111"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.110"
+version = "0.5.111"
 
 [[package]]
 name = "unarray"
@@ -4640,9 +4640,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -4804,9 +4804,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4817,9 +4817,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4827,9 +4827,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4837,9 +4837,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4850,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4906,9 +4906,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5452,9 +5452,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5475,18 +5475,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.110"
+version = "0.5.111"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -118,21 +118,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.110" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.110" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.110" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.110" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.110" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.110" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.110" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.110" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.111" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.111" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.111" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.111" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.111" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.111" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.111" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.111" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.110" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.111" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
+++ b/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
@@ -110,21 +110,24 @@ means the acceptance criteria were checked off *and* the pipeline was green.
 
 ### 1.2 Category coverage rollup (fill as phases close)
 
-> **Status (partial landing — 13 WIs of 20):** this branch closes Phase A
-> entirely plus the surgical subset of B/C/E. The remaining WIs (4.1, 4.2, 5.2,
-> 5.3, 6.3, 7.1, 8.1) are larger / cross-cutting / Windows-only and are tracked
-> as follow-ups below — see §1.1 statuses and the per-WI deviation notes. The
-> plan's §2 "Definition of done" is therefore **not yet met**; this is
-> incremental, reviewable progress, not the finished effort.
+> **Status (effort complete):** all 20 work items are ✅, landed across
+> PRs #345–#354 (Phase-A foundation `harden/bugs*` plus WI-4.2 #351, WI-5.2
+> #349, WI-5.3 #350, WI-8.1 #352, WI-7.1 #353, and the WI-G.1 pipeline wiring
+> #354). The lone exception is **WI-4.4**, which is 🟨 by design: its RFC
+> (`refactor/lossless-name-column-rfc.md`) is landed and the *elimination*
+> implementation is a tracked, maintainer-gated follow-up — WI-4.1 already
+> ships the required mitigation (loss is non-silent, measured, and tested).
+> The §2 "Definition of done" is therefore **met** (per its own clause 1,
+> which permits WI-4.4 to remain 🟨 behind an approved RFC).
 
 | # | Category | Mitigation definition (acceptance) | WIs | Coverage |
 |---|----------|------------------------------------|-----|:--------:|
 | 1 | TOCTOU | No check→use on re-resolved paths; no predictable temp + `File::create` | 1.1, 1.2, 2.4 | **100%** |
 | 2 | Perms-after-create | Every secret/dir **born** with final perms; zero chmod-after on secrets | 2.1–2.4 | **100%** |
 | 3 | Path string identity | No safety decision on path strings; identity helper exists + tested | 3.1 | **100%** |
-| 4 | UTF-8 byte boundary | Zero **silent** lossy conversions; argv/IPC use `OsString`; lossless storage RFC landed | 4.1–4.4 | ~40% (4.3 ✅ + 4.4 RFC ✅; 4.1 decoder + 4.2 argv pending — gate still red on 36 byte sites) |
+| 4 | UTF-8 byte boundary | Zero **silent** lossy conversions; argv/IPC use `OsString`; lossless storage RFC landed | 4.1–4.4 | **100%** for "non-silent + measured + argv/IPC correct" (4.1 instrumented decoder ✅, 4.2 `OsString` argv ✅, 4.3 strict-parse ✅, 4.4 RFC ✅; anti-pattern gate green). 4.4 *elimination* tracked separately as a 🟨 follow-up per §2 DoD. |
 | 5 | Panic = DoS | Missing lints on; parsers `.get()` + `checked_*`; fuzz tests green | 5.1–5.3 | ✅ 100% (5.1 ✅; 5.2 ✅ all 5 parsers hardened + module-scoped `arithmetic_side_effects`; 5.3 ✅ parser malformed-record test + deserializer truncation/boundary/seeded-fuzz corpus) |
-| 6 | Discarded errors | No bare `drop(write/flush)`; every intentional discard commented | 6.1–6.3 | ~66% (6.1, 6.2 ✅; 6.3 workspace audit pending) |
+| 6 | Discarded errors | No bare `drop(write/flush)`; every intentional discard commented | 6.1–6.3 | **100%** (6.1 control writes surfaced ✅, 6.2 dir-create failures logged ✅, 6.3 `.ok()`/`let _` audit + justification comments ✅) |
 | 7 | Bug-for-bug parity | Parity test covers pathological names; runs in CI | 7.1 | **100%** (7.1 ✅: Tier-1 decoder pins in CI + Tier-2 offline-capture-vs-golden, validated on real capture) |
 | 8 | Resolve before trust boundary | One process handle threads verify→grant; nonce property documented | 8.1, 8.2 | **100%** (8.1 ✅ single `OpenProcess` RAII handle threaded verify→duplicate; 8.2 ✅) |
 | G | Regression guard | Grep-gate in CI blocks reintroduction of all anti-patterns | G.1 | **100%** (gate fully green + **wired into the pipeline**: runs as "Anti-pattern gate" in `phase1_fanout_validation`, enforced by `just go` / ship) |

--- a/just/workflow.just
+++ b/just/workflow.just
@@ -45,7 +45,7 @@ phase2-ship:
     @printf "\033[0;34m🚀 PHASE 2: Explicit Ship Lane\033[0m\n"
     @printf "\033[1;33mThis lane performs version bump, deploy, commit, and push behavior.\033[0m\n"
     @echo "========================================================"
-    cargo run -q --release -p uffs-ci-pipeline -- phase2
+    cargo run -q --release --target-dir target/ci-bootstrap -p uffs-ci-pipeline -- phase2
 
 # Backward compatibility alias for phase2-ship.
 phase2-commit: phase2-ship
@@ -57,7 +57,7 @@ go:
     @printf "\033[1;33mNo version bump, deploy, commit, or push in this default lane.\033[0m\n"
     @printf "\033[0;36m📝 Lints macOS code paths — Linux cfg() paths validated by CI on push.\033[0m\n"
     @echo "========================================================"
-    cargo run -q --release -p uffs-ci-pipeline -- go
+    cargo run -q --release --target-dir target/ci-bootstrap -p uffs-ci-pipeline -- go
 
 # Full ship pipeline: Phase 1 validation + Phase 2 deploy (resumable).
 # Re-runs automatically skip already-completed steps.
@@ -68,7 +68,7 @@ ship *ARGS:
     @printf "\033[1;33mValidates and ships. Re-runs skip completed steps.\033[0m\n"
     @printf "\033[0;36m📝 Lints macOS code paths — Linux cfg() paths validated by CI on push.\033[0m\n"
     @echo "========================================================"
-    cargo run -q --release -p uffs-ci-pipeline -- ship {{ ARGS }}
+    cargo run -q --release --target-dir target/ci-bootstrap -p uffs-ci-pipeline -- ship {{ ARGS }}
 
 # Full ship pipeline from scratch (ignores previous progress).
 # Pass flags like: just ship-fresh -v
@@ -76,7 +76,7 @@ ship-fresh *ARGS:
     @printf "\033[0;34m🚢 Full Ship Pipeline (Fresh Start)\033[0m\n"
     @printf "\033[1;33mIgnoring previous progress, starting from scratch.\033[0m\n"
     @echo "========================================================"
-    cargo run -q --release -p uffs-ci-pipeline -- ship --fresh {{ ARGS }}
+    cargo run -q --release --target-dir target/ci-bootstrap -p uffs-ci-pipeline -- ship --fresh {{ ARGS }}
 
 # Safe-by-default validation workflow (justfile fallback).
 go-justfile:
@@ -105,14 +105,14 @@ check-all:
     @printf "\033[0;34m📋 Comprehensive Validation (RUST OPTIMIZED)\033[0m\n"
     @printf "\033[1;33mUsing high-performance Rust script with parallel execution...\033[0m\n"
     @echo "========================================================"
-    cargo run -q --release -p uffs-ci-pipeline -- check-all
+    cargo run -q --release --target-dir target/ci-bootstrap -p uffs-ci-pipeline -- check-all
 
 # Generate coverage report (Rust optimized).
 coverage-report:
     @printf "\033[0;34m📊 Coverage Report Generation (RUST OPTIMIZED)\033[0m\n"
     @printf "\033[1;33mSmart detection: generates from existing data or runs tests if needed...\033[0m\n"
     @echo "========================================================"
-    cargo run -q --release -p uffs-ci-pipeline -- coverage-report
+    cargo run -q --release --target-dir target/ci-bootstrap -p uffs-ci-pipeline -- coverage-report
 
 # Watch the latest release workflow run.
 release-watch:
@@ -127,15 +127,15 @@ release-status:
 # Check current workflow status.
 workflow-status:
     @printf "\033[0;34m📊 Checking workflow status...\033[0m\n"
-    @cargo run -q --release -p uffs-ci-pipeline -- workflow-status
+    @cargo run -q --release --target-dir target/ci-bootstrap -p uffs-ci-pipeline -- workflow-status
 
 # Reset workflow state.
 workflow-reset:
     @printf "\033[0;33m⚠️  Resetting workflow state...\033[0m\n"
-    @cargo run -q --release -p uffs-ci-pipeline -- workflow-reset
+    @cargo run -q --release --target-dir target/ci-bootstrap -p uffs-ci-pipeline -- workflow-reset
 
 # Resume incomplete workflow.
 workflow-resume:
     @printf "\033[0;34m🔄 Resuming workflow...\033[0m\n"
-    @cargo run -q --release -p uffs-ci-pipeline -- workflow-resume
+    @cargo run -q --release --target-dir target/ci-bootstrap -p uffs-ci-pipeline -- workflow-resume
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -7,11 +7,41 @@ criteria = "safe-to-run"
 delta = "2.2.1 -> 2.2.2"
 notes = "Delta audit reviewed via cargo vet diff. Replaces the silent exemption bump from PR #166 (which was a supply-chain #[allow] — see docs/architecture/security/supply-chain-posture.md). Changes: (1) #[track_caller] attributes on assert/failure/success paths + replacement of `.unwrap_or_else(AssertError::panic)` chains with explicit `match` blocks so caller location is preserved through panic; (2) edition-2024 idiom updates (Self::Variant / Self {..}); (3) include-list path normalization in Cargo.toml (/build.rs etc.); (4) internal lints.clippy config tightening. No semantic changes to assertion logic, no new unsafe, no new network/FS access paths. assert_cmd is test-only (safe-to-run)."
 
+[[audits.autocfg]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.5.0 -> 1.5.1"
+notes = "Delta audit (cargo vet diff 1.5.0 -> 1.5.1). TEST-ONLY change: ZERO src/ library changes. README adds the 1.5.1 changelog line ('Refactor the test_wrappers test without any shell script'). Cargo.toml(.orig) declares explicit [[test]] targets and sets harness=false for the wrappers test. The bash helper tests/wrap_ignored is deleted and replaced by a Rust main() in tests/wrappers.rs that acts as the rustc-wrapper stand-in. No change to autocfg's build-probe library logic, no new unsafe, no new runtime deps; the changed code runs only under `cargo test`. autocfg is a build-dependency (via num-traits). Publisher cuviper (Josh Stone), already trusted by isrg/mozilla/bytecode-alliance."
+
+[[audits.brotli]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "8.0.2 -> 8.0.3"
+notes = "Delta audit (cargo vet diff 8.0.2 -> 8.0.3). Bulk of the diff is tests (src/enc/threading/test.rs +309, src/bin/test_broccoli.rs +292, test_custom_dict.rs) and the CLI binary src/bin/brotli.rs (the TMPDIR/TEMP std::env::var + std::fs::File::create probe flagged by scanning lives in the bin/test harness, NOT the library — bins are not linked when brotli is consumed as a dependency). Library changes: src/concat/mod.rs adds a fallible BroCatli::try_new_with_window_size(u8) -> Result<BroCatli, BroCatliResult> constructor (returns InvalidWindowSize for ws not in 10..=24-style range) and reduces the legacy panicking new_with_window_size to a thin .expect() wrapper over it; src/ffi/broccoli.rs mirrors the window-size handling at the C-ABI boundary. src/enc/{threading,encode,backward_references/{mod,hash_to_binary_tree,hq}}.rs is internal compression-encoder refactoring that threads a `ringbuffer_break` parameter through the H10 hasher path (initialize_h10 / StitchToPreviousBlockH10). Pure-Rust codec; no NEW unsafe, extern, network, or process capability added to the library path. Publisher danielrh (Dropbox, brotli-rust maintainer)."
+
+[[audits.brotli-decompressor]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "5.0.0 -> 5.0.1"
+notes = 'Delta audit (cargo vet diff 5.0.0 -> 5.0.1, small). src/decode.rs + src/writer.rs: adds a few #[cfg(feature="std")] gates and a buffer-size fallback (`if buffer_size == 0 { 4096 } else { buffer_size }`) so a zero requested buffer size no longer yields a zero-length allocation, plus a loop `break;` fix. src/bin/error_handling_tests.rs + src/test.rs are test/bin only. No new unsafe, no new deps, no new I/O/FFI/process/network capability — defensive bugfix release of the pure-Rust brotli decoder. Publisher danielrh (Dropbox, brotli-rust maintainer).'
+
+[[audits.chrono]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.44 -> 0.4.45"
+notes = 'Delta audit (cargo vet diff 0.4.44 -> 0.4.45). Cargo.toml(.orig)/CITATION.cff: version bump + dev-dep similar-asserts 1.6.1 -> 2.0.0 (test-only). src/offset/local/tz_data.rs: Android-only (#[cfg(target_os="android")]) — adds an ANDROID_TZDATA_ROOT (/etc/tz) probe ahead of the existing ANDROID_DATA/ANDROID_ROOT env lookups, reusing the same std::env::var + File::open pattern (no new capability class). src/offset/local/tz_info/rule.rs: bugfix tightening the POSIX TZ transition-rule offset-hour bound from 0..=24 to 0..=23 (a 24h offset cannot fit in a FixedOffset, which is ±23:59:59), with a new test_invalid_offset_hour unit test covering FOO24/+24/-24 rejection and 23:59:59 acceptance. No new unsafe, no FFI/network/process; Android is not a shipping UFFS target. Publisher djc (chrono maintainer).'
+
 [[audits.colored]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 version = "3.1.1"
 notes = "Reviewed v3.1.1 source. Scope: ANSI terminal coloring. One unsafe block in control.rs (Windows Console FFI via windows-sys: GetStdHandle / GetConsoleMode / SetConsoleMode) — standard Win32 terminal setup, properly cfg(windows)-gated. No network I/O, no filesystem writes, no process spawning. Only std types plus windows-sys on Windows. Dev-deps (rspec, insta, ansiterm) are standard testing crates. MPL-2.0 licensed, same as our workspace."
+
+[[audits.compact_str]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.0 -> 0.9.1"
+notes = """Delta audit (cargo vet diff 0.9.0 -> 0.9.1, 3 src files). src/lib.rs: CompactString::repeat now computes capacity with self.len().checked_mul(n).expect("capacity overflow") instead of an unchecked multiply — an overflow-safety hardening. src/repr/heap.rs: realloc uses Capacity::new(new_capacity) and adds a regression test (test_realloc_shrink_to_min_heap_gap) covering the shrink-to-MIN_HEAP_SIZE boundary. src/tests.rs additions are test-only. No NEW unsafe blocks (the crate's existing inline-repr unsafe is unchanged), no new deps, no new ambient capability. Publisher ParkMyCar (compact_str maintainer)."""
 
 [[audits.crypto-common]]
 who = "Robert Nio <robert_nio@intuit.com>"
@@ -49,6 +79,12 @@ criteria = "safe-to-deploy"
 delta = "0.1.48 -> 0.1.49"
 notes = "Delta audit (cargo vet diff 0.1.48 -> 0.1.49). ZERO vendored-C files changed (no v2/v3 tree edits this release). build.rs unchanged. src/extended.rs adds exactly one new FFI binding: 'pub fn mi_stats_get_json(buf_size: usize, buf: *mut c_char) -> *mut c_char' (#[cfg(not(feature=v2))], v3-only) backing mimalloc's stats-to-JSON feature, plus a test 'use super::super::mi_malloc'. The C implementation already existed upstream; this is just the Rust extern declaration. No new ambient capability / I/O / process / network / env access."
 
+[[audits.libredox]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.16 -> 0.1.17"
+notes = """Delta audit (cargo vet diff 0.1.16 -> 0.1.17). Cargo.toml(.orig): version bump + redox_syscall dep 0.7 -> 0.8. src/lib.rs: (a) cosmetic reorder of a libc MSG_* re-export list (no semantic change); (b) adds one Redox kernel FFI binding redox_relpathat_v0(dirfd, fd, dst_base, dst_len) -> RawResult plus the safe wrappers Fd::relpathat / call::relpathat, mirroring the existing redox_fpath_v1 binding exactly (Error::demux over an unsafe extern call using the caller-provided &mut [u8] buffer's ptr+len). The single new unsafe block is a like-for-like copy of the adjacent fpath binding. libredox is the Redox stable-ABI shim, reachable only via redox_users on target_os="redox"; the extern symbols are never linked on UFFS shipping targets (Windows/macOS). No network/FS-path/process/env additions. Publisher 4lDO2 (Redox maintainer)."""
+
 [[audits.mimalloc]]
 who = "Robert Nio <robert_nio@intuit.com>"
 criteria = "safe-to-deploy"
@@ -60,6 +96,12 @@ who = "Robert Nio <robert_nio@intuit.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.51 -> 0.1.52"
 notes = "Delta audit (cargo vet diff 0.1.51 -> 0.1.52). Cargo.toml(.orig): version bump + libmimalloc-sys dep 0.1.48->0.1.49. src/lib.rs + src/extended.rs add a v3-only (#[cfg(not(feature=v2))]) 'stats_json() -> Result<StatsJson, &str>' wrapper plus a StatsJson newtype with Deref/Drop. The unsafe blocks are allocator FFI into mimalloc's own functions (the new mi_stats_get_json getter and mi_free for the returned buffer) — standard mimalloc-sys FFI, no new ambient capability / I/O / network."
+
+[[audits.mio]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.2.1"
+notes = """Delta audit (cargo vet diff 1.2.0 -> 1.2.1). Portability + correctness patch: adds target_os="horizon" (Nintendo 3DS) cfg gating and a WASI p1/p2 waker path split across src/sys/* and src/poll.rs; src/sys/unix/selector/poll.rs introduces a per-platform PollFlagInt type alias (c_short vs c_int) with 0-valued fallbacks for POLLRDHUP/POLLPRI/POLLRDBAND/POLLWRBAND on platforms lacking them; and a poll-timeout rounding fix that rounds sub-millisecond Durations up via checked_add(Duration::from_nanos(999_999)) before as_millis(), clamped to libc::c_int::MAX. All changes are libc-constant/cfg plumbing over the existing epoll/poll/IOCP backends; no NEW unsafe logic, no new deps, no new process/network capability beyond mio's existing readiness-I/O purpose. Publisher Thomasdezeeuw (mio/tokio maintainer)."""
 
 [[audits.num-conv]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -121,11 +163,23 @@ Delta audit (Apr 2026, v0.5.71):
   No runtime behavior change.
 - No unsafe additions, no API changes, no new ambient capabilities."""
 
+[[audits.rustls-native-certs]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.3 -> 0.8.4"
+notes = "Delta audit (cargo vet diff 0.8.3 -> 0.8.4). Most of the diff is CI/workflow/example/test files (.github/*, examples/*, tests/*, integration-tests/*). The only library change in src/lib.rs: a rustls_native_certs_docsrs doc_cfg feature attribute, and a refinement of the SSL_CERT_DIR-style directory handling to use env::split_paths(&dirs).filter(|p| !p.as_os_str().is_empty()) so multiple (OS-separator-delimited) cert directories are parsed and empty entries skipped. Reading SSL_CERT_FILE/SSL_CERT_DIR env + OS trust stores is rustls-native-certs's existing and sole purpose — no NEW capability class is introduced. No new unsafe, no new deps. Publisher (rustls project, ctz/djc)."
+
 [[audits.siphasher]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.2 -> 1.0.3"
 notes = "Delta audit (cargo vet diff 1.0.2 -> 1.0.3, 5 files +105/-36). .gitignore: adds .swival editor tmpdir (no runtime effect). Cargo.toml/Cargo.toml.orig: version bump only. src/sip.rs + src/sip128.rs: single-shot fast-path optimization for the existing SipHasher{,13,24}::hash() and ::hash() (Hash128) public APIs. The old impls cloned the Hasher state, called .write(bytes), then .finish() — going through the buffered short_write codepath byte-by-byte even though the full message was available up-front. The new impls add private Hasher<S>::hash(msg) / hash128(msg) fast paths that, when ntail==0 (no buffered tail bytes from a prior write), XOR-fold msg's 8-byte chunks directly into the SipHash state in a tight loop, then finalize with the standard tail handling. When ntail!=0 the impl falls back to the original clone-write-finish path so correctness is preserved for partially-streamed hashers. The fast path's two unsafe blocks (load_int_le! and u8to64_le) were already present in the pre-existing .write() path and are reused unchanged: the 'while i < len - left' loop with 'left = len & 0x7' guarantees i + 8 <= len, so load_int_le! is in bounds; u8to64_le's 3rd arg 'left' is bounded to 0..8 by construction. Also adds Hasher::write_u16 (was missing — previously fell through to the default Hasher trait impl, which is byte-by-byte). write_u16 mirrors the existing write_u32/_u64/_usize pattern: short_write(i, i.to_le() as u64). finish()/finish128() are refactored to delegate to static finish{,128}_with_state(state,length,tail) helpers — pure structural extraction, output bytes unchanged for any given (state,length,tail). Net result: speed-up for single-shot byte-array hashing; no public-API additions beyond write_u16 (which is part of the std::hash::Hasher trait, not a new surface); no new unsafe operations beyond what already existed; no FFI / FS / network / process — pure crypto primitive, used here only via phf_shared for compile-time string hashing in transitive deps. Author jedisct1 (Frank Denis) is a well-known cryptography maintainer."
+
+[[audits.socket2]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.3 -> 0.6.4"
+notes = """Delta audit (cargo vet diff 0.6.3 -> 0.6.4). The overwhelming majority of changes add target_os="horizon" (Nintendo 3DS) to existing cfg exclusion lists and refine QNX gating to all(target_os="nto", any(target_env="nto70","nto71")). Two genuinely new items: `unsafe impl Send for MsgHdr<'_,'_,'_>` and `unsafe impl Send for MsgHdrMut<'_,'_,'_>` — these wrapper types hold a platform msghdr plus PhantomData lifetime markers over caller-borrowed buffers; Send is sound because the struct is plain data referencing borrow-checked buffers (no interior !Send handles), matching the established pattern for the sibling SockAddr/iovec wrappers. Also type-correctness fixes: getsockopt::<Bool> (was c_int) for IPV6_V6ONLY, and `!= 0` instead of `!= false as Bool`. No new extern symbols, no new process/network capability beyond socket2's existing socket-syscall purpose. Publisher Thomasdezeeuw (socket2/tokio maintainer)."""
 
 [[audits.tokio]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -133,11 +187,35 @@ criteria = "safe-to-deploy"
 delta = "1.52.2 -> 1.52.3"
 notes = "Delta audit reviewed via cargo vet diff. Replaces the silent exemption bump from PR #166 (which was a supply-chain #[allow]). Changes scoped to src/sync/mpsc/* and src/sync/rwlock.rs, implementing four documented upstream bug-fix PRs per tokio 1.52.3 release notes (May 2026): tokio#8062 fix mpsc len() underflow; tokio#8074 return TryRecvError::Empty from try_recv() when mpsc closed with outstanding permits; tokio#8075 notify receivers in mpsc OwnedPermit::release() by reusing non-owned Permit Drop impl; tokio#8076 reject RwLock::new max_readers==0 (prevents div-by-zero in semaphore fast path). Companion tests in tests/sync_mpsc.rs + tests/sync_rwlock.rs. No feature additions, no new unsafe, no public API signature changes."
 
+[[audits.typenum]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.20.0 -> 1.20.1"
+notes = "Delta audit (cargo vet diff 1.20.0 -> 1.20.1). Cargo.toml(.orig)/README: version bump + key reordering and URL/formatting touch-ups (no runtime effect). src/lib.rs: html_root_url 1.20.0 -> 1.20.1 doc attribute only. src/array.rs: macro-hygiene bugfix — the recursive arms of the tarr! macro now invoke $crate::tarr![...] instead of bare tarr![...], so the macro resolves correctly in downstream crates that have not imported tarr into scope (the 'Fixed tarr import resolution' changelog entry). Pure compile-time type-level macro change; no unsafe, no deps, no I/O/FFI/process/network. Publisher paholg (typenum maintainer)."
+
 [[audits.uuid]]
 who = "Robert Nio <robert_nio@intuit.com>"
 criteria = "safe-to-deploy"
 delta = "1.23.1 -> 1.23.2"
 notes = "Delta audit (cargo vet diff 1.23.1 -> 1.23.2). Files: Cargo.toml(.orig) version bump, README, src/{error,fmt,parser,lib,external/serde_support}.rs. Patch release by KodrAus (uuid maintainer): formatting/parser refinements + serde tweak. The single unsafe is std::str::from_utf8_unchecked(self.0) on the crate's own fixed-size format buffer, which uuid populates exclusively with ASCII hex digits + hyphens before formatting — sound zero-copy formatting (same pattern as the vetted 1.23.1). No new I/O / FFI / process / network / ambient capability."
+
+[[audits.yoke]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.2 -> 0.8.3"
+notes = "Delta audit (cargo vet diff 0.8.2 -> 0.8.3). Cargo.toml(.orig): version bump, edition.workspace -> edition=2021, and a 'bool-assert-comparison = allow' clippy lint relaxation (dev-time only). src/cartable_ptr.rs: SOUNDNESS FIX — the unsafe Send/Sync impls for CartableOptionPointer<C> had swapped bounds (previously 'Send where C: Sync' and 'Sync where C: Send'); they are corrected to 'Send where C: Send' and 'Sync where C: Sync', matching the documented 'logically an Option<C>' invariant. This tightens (not loosens) the conditions under which the type crosses threads. A new Miri test (test_send_drops_on_another_thread) constructs a Send + !Sync cart and drops it on another thread, which compiles under the corrected bounds and would fail under the old swapped bounds. No new unsafe blocks introduced (the two impls already existed), no FFI/FS/network/process. Publisher Manishearth (ICU4X)."
+
+[[audits.zerocopy]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.48 -> 0.8.50"
+notes = "Delta audit (cargo vet diff 0.8.48 -> 0.8.50). The bulk of the diff is committed codegen-snapshot fixtures under benches/*.x86-64 and *.mca (machine-code-analyzer output) reflecting a multiply-overflow-check optimization — test fixtures, not shipped code. Library changes (src/): (1) centralizes the scattered `isize::MAX as usize` allocation bound into a new pub(crate) const DstLayout::MAX_SIZE and a new is_valid_metadata/maximum_trailing_slice_len helper, used in layout.rs/util/mod.rs and Kani proof harnesses; (2) replaces a checked Layout::from_size_align + manual saturating max_alloc check with `unsafe { Layout::from_size_align_unchecked(size, align) }` guarded by an explicit `if !T::is_valid_metadata(meta) { return Err(AllocError) }` precondition — the new SAFETY comment correctly establishes align is a non-zero power of two (KnownLayout invariant) and size <= isize::MAX (the is_valid_metadata gate); (3) widens many pointer-internal items from pub(crate) to pub behind #[cfg_attr(not(zerocopy_unstable_ptr), doc(hidden))] / allow(unreachable_pub) — the affected `unsafe fn`s (with_meta, split_at_unchecked, slice_unchecked) and `unsafe trait TryWithError` already existed with identical bodies; this is visibility-only, no new unsafe LOGIC; (4) adds PointerMetadata: + Ord, a slice Ptr is_empty()/len(), iter() now takes self by value with strengthened disjoint-aliasing safety comments and a new test (test_iter_exclusive_yields_disjoint_ptrs). No new extern/process/network/fs capability. Publisher joshlf (Google, zerocopy maintainer; crate is Kani-proof-backed)."
+
+[[audits.zerocopy-derive]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.48 -> 0.8.50"
+notes = "Delta audit (cargo vet diff 0.8.48 -> 0.8.50). The diff is limited to Cargo.toml and Cargo.toml.orig version-string bumps 0.8.48 -> 0.8.50 — ZERO source (src/) changes across both patch releases. No proc-macro logic change, no new deps, no new unsafe, no new ambient capability. Publisher joshlf (zerocopy maintainer, Google)."
 
 [[audits.zerofrom]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -31,6 +31,9 @@ audit-as-crates-io = true
 [policy.polars-compute]
 audit-as-crates-io = true
 
+[policy.polars-config]
+audit-as-crates-io = true
+
 [policy.polars-core]
 audit-as-crates-io = true
 
@@ -53,6 +56,9 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.polars-mem-engine]
+audit-as-crates-io = true
+
+[policy.polars-ooc]
 audit-as-crates-io = true
 
 [policy.polars-ops]
@@ -186,6 +192,10 @@ criteria = "safe-to-deploy"
 version = "2.0.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.bitflags]]
+version = "2.12.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.blake3]]
 version = "1.8.5"
 criteria = "safe-to-deploy"
@@ -199,11 +209,11 @@ version = "0.2.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.brotli]]
-version = "8.0.2"
+version = "8.0.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.brotli-decompressor]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.bstr]]
@@ -263,7 +273,7 @@ version = "7.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.compact_str]]
-version = "0.9.0"
+version = "0.9.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.concurrent-queue]]
@@ -364,6 +374,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.dirs-sys-next]]
 version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.displaydoc]]
+version = "0.2.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.dyn-clone]]
@@ -610,6 +624,10 @@ criteria = "safe-to-deploy"
 version = "0.4.14"
 criteria = "safe-to-deploy"
 
+[[exemptions.log]]
+version = "0.4.32"
+criteria = "safe-to-deploy"
+
 [[exemptions.lru-slab]]
 version = "0.1.2"
 criteria = "safe-to-deploy"
@@ -635,7 +653,7 @@ version = "0.1.50"
 criteria = "safe-to-deploy"
 
 [[exemptions.mio]]
-version = "1.2.0"
+version = "1.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.now]]
@@ -730,6 +748,10 @@ criteria = "safe-to-deploy"
 version = "0.53.0@git:1e9a63b95923291cd8849d70d96b8cec4e96da6a"
 criteria = "safe-to-deploy"
 
+[[exemptions.polars-config]]
+version = "0.53.0@git:1e9a63b95923291cd8849d70d96b8cec4e96da6a"
+criteria = "safe-to-deploy"
+
 [[exemptions.polars-core]]
 version = "0.53.0@git:1e9a63b95923291cd8849d70d96b8cec4e96da6a"
 criteria = "safe-to-deploy"
@@ -759,6 +781,10 @@ version = "0.53.0@git:1e9a63b95923291cd8849d70d96b8cec4e96da6a"
 criteria = "safe-to-deploy"
 
 [[exemptions.polars-mem-engine]]
+version = "0.53.0@git:1e9a63b95923291cd8849d70d96b8cec4e96da6a"
+criteria = "safe-to-deploy"
+
+[[exemptions.polars-ooc]]
 version = "0.53.0@git:1e9a63b95923291cd8849d70d96b8cec4e96da6a"
 criteria = "safe-to-deploy"
 
@@ -935,7 +961,7 @@ version = "0.23.40"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-native-certs]]
-version = "0.8.3"
+version = "0.8.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-pki-types]]
@@ -1010,6 +1036,10 @@ criteria = "safe-to-deploy"
 version = "0.11.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.shlex]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.signal-hook]]
 version = "0.4.4"
 criteria = "safe-to-deploy"
@@ -1047,7 +1077,7 @@ version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.socket2]]
-version = "0.6.3"
+version = "0.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.sqlparser]]
@@ -1463,7 +1493,7 @@ version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]
-version = "0.8.48"
+version = "0.8.50"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy-derive]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2,15 +2,15 @@
 # cargo-vet imports lock
 
 [[publisher.bumpalo]]
-version = "3.20.2"
-when = "2026-02-19"
+version = "3.20.3"
+when = "2026-05-22"
 user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.cc]]
-version = "1.2.62"
-when = "2026-05-08"
+version = "1.2.63"
+when = "2026-05-29"
 trusted-publisher = "github:rust-lang/cc-rs"
 
 [[publisher.digest]]
@@ -26,8 +26,8 @@ user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.http]]
-version = "1.4.0"
-when = "2025-11-24"
+version = "1.4.1"
+when = "2026-05-25"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -52,8 +52,8 @@ when = "2026-05-09"
 trusted-publisher = "github:RustCrypto/hybrid-array"
 
 [[publisher.hyper]]
-version = "1.9.0"
-when = "2026-03-31"
+version = "1.10.1"
+when = "2026-05-29"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -66,8 +66,8 @@ user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.js-sys]]
-version = "0.3.98"
-when = "2026-05-07"
+version = "0.3.99"
+when = "2026-05-22"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.memchr]]
@@ -127,8 +127,8 @@ user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
 [[publisher.unicode-segmentation]]
-version = "1.13.2"
-when = "2026-03-26"
+version = "1.13.3"
+when = "2026-06-01"
 user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
@@ -169,28 +169,28 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-bindgen]]
-version = "0.2.121"
-when = "2026-05-07"
+version = "0.2.122"
+when = "2026-05-22"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-futures]]
-version = "0.4.71"
-when = "2026-05-07"
+version = "0.4.72"
+when = "2026-05-22"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-macro]]
-version = "0.2.121"
-when = "2026-05-07"
+version = "0.2.122"
+when = "2026-05-22"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-macro-support]]
-version = "0.2.121"
-when = "2026-05-07"
+version = "0.2.122"
+when = "2026-05-22"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-shared]]
-version = "0.2.121"
-when = "2026-05-07"
+version = "0.2.122"
+when = "2026-05-22"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-encoder]]
@@ -210,8 +210,8 @@ when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.web-sys]]
-version = "0.3.98"
-when = "2026-05-07"
+version = "0.3.99"
+when = "2026-05-22"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.winnow]]
@@ -395,46 +395,6 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 version = "1.1.2"
 notes = "Contains `unsafe` code but it's well-documented and scoped to what it's intended to be doing. Otherwise a well-focused and straightforward crate."
-
-[[audits.bytecode-alliance.audits.bitflags]]
-who = "Jamey Sharp <jsharp@fastly.com>"
-criteria = "safe-to-deploy"
-delta = "2.1.0 -> 2.2.1"
-notes = """
-This version adds unsafe impls of traits from the bytemuck crate when built
-with that library enabled, but I believe the impls satisfy the documented
-safety requirements for bytemuck. The other changes are minor.
-"""
-
-[[audits.bytecode-alliance.audits.bitflags]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "2.3.2 -> 2.3.3"
-notes = """
-Nothing outside the realm of what one would expect from a bitflags generator,
-all as expected.
-"""
-
-[[audits.bytecode-alliance.audits.bitflags]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "2.4.1 -> 2.6.0"
-notes = """
-Changes in how macros are invoked and various bits and pieces of macro-fu.
-Otherwise no major changes and nothing dealing with `unsafe`.
-"""
-
-[[audits.bytecode-alliance.audits.bitflags]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "2.7.0 -> 2.9.4"
-notes = "Tweaks to the macro, nothing out of order."
-
-[[audits.bytecode-alliance.audits.bitflags]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "2.10.0 -> 2.11.1"
-notes = "Minor updates, nothing awry here."
 
 [[audits.bytecode-alliance.audits.block-buffer]]
 who = "Benjamin Bouvier <public@benj.me>"
@@ -644,12 +604,6 @@ criteria = "safe-to-deploy"
 version = "0.1.4"
 notes = "I always really enjoy reading eliza's code, she left perfect comments at every use of unsafe."
 
-[[audits.bytecode-alliance.audits.shlex]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-version = "1.1.0"
-notes = "Only minor `unsafe` code blocks which look valid and otherwise does what it says on the tin."
-
 [[audits.bytecode-alliance.audits.thread_local]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -785,22 +739,6 @@ criteria = "safe-to-deploy"
 version = "0.22.1"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.bitflags]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-version = "1.3.2"
-notes = """
-Security review of earlier versions of the crate can be found at
-(Google-internal, sorry): go/image-crate-chromium-security-review
-
-The crate exposes a function marked as `unsafe`, but doesn't use any
-`unsafe` blocks (except for tests of the single `unsafe` function).  I
-think this justifies marking this crate as `ub-risk-1`.
-
-Additional review comments can be found at https://crrev.com/c/4723145/31
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.cast]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
@@ -843,13 +781,6 @@ who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 version = "2.0.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.displaydoc]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "0.2.5"
-notes = "No unsafe code"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.either]]
 who = "Manish Goregaokar <manishearth@google.com>"
@@ -975,32 +906,6 @@ who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.4.0 -> 1.5.0"
 notes = "Unsafe review notes: https://crrev.com/c/5650836"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.log]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-version = "0.4.22"
-notes = """
-Unsafe review in https://docs.google.com/document/d/1IXQbD1GhTRqNHIGxq6yy7qHqxeO4CwN5noMFXnqyDIM/edit?usp=sharing
-
-Unsafety is generally very well-documented, with one exception, which we
-describe in the review doc.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.log]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.22 -> 0.4.25"
-notes = "No impact on `unsafe` usage in `lib.rs`."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.log]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.25 -> 0.4.26"
-notes = "Only trivial code and documentation changes."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.num-traits]]
@@ -1981,53 +1886,6 @@ criteria = "safe-to-deploy"
 delta = "0.7.0 -> 0.8.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.bitflags]]
-who = "Alex Franchuk <afranchuk@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.3.2 -> 2.0.2"
-notes = "Removal of some unsafe code/methods. No changes to externals, just some refactoring (mostly internal)."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = "Nicolas Silva <nical@fastmail.com>"
-criteria = "safe-to-deploy"
-delta = "2.0.2 -> 2.1.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "2.2.1 -> 2.3.2"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "2.3.3 -> 2.4.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "2.4.0 -> 2.4.1"
-notes = "Only allowing new clippy lints"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = [
-    "Teodor Tanasoaia <ttanasoaia@mozilla.com>",
-    "Erich Gubler <erichdongubler@gmail.com>",
-]
-criteria = "safe-to-deploy"
-delta = "2.6.0 -> 2.7.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.bitflags]]
-who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "2.9.4 -> 2.10.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.block-buffer]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -2153,12 +2011,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Simon Friedberger <simon@mozilla.com>"
 criteria = "safe-to-deploy"
 version = "0.4.3"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.log]]
-who = "Erich Gubler <erichdongubler@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.4.26 -> 0.4.29"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-conv]]
@@ -2394,12 +2246,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mark Hammond <mhammond@skippinet.com.au>"
 criteria = "safe-to-deploy"
 delta = "0.1.4 -> 0.1.7"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.shlex]]
-who = "Max Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "1.1.0 -> 1.3.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.smallvec]]


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.111** — the `[workspace.package].version` bump in `Cargo.toml`.  This PR routes that commit through branch-protection rules.  Once it merges to `main`, `auto-tag-release.yml` tags the commit and invokes `release.yml`, which builds the cross-platform binaries and publishes GitHub Release v0.5.111.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

The auto-commit lived only on `release/v0.5.111`, so local `main` never drifted — sync it with a plain `git pull --ff-only origin main` (no `reset --hard` needed).