### PR TITLE
fix: --malformed filter bypass (is_empty gate, DisplayRow predicate, limit leak)

### DIFF
--- a/crates/uffs-core/src/search/filters/apply.rs
+++ b/crates/uffs-core/src/search/filters/apply.rs
@@ -43,6 +43,15 @@ pub(crate) fn row_passes_filters(
     if filters.hide_ads && row.name().contains(':') {
         return false;
     }
+    // WI-4.4: malformed-name toggle for the DisplayRow paths (Path/PathOnly
+    // tree-walk and the regex/trigram post-filter pass). The `malformed` bit
+    // is precomputed against the lossless name bytes in `make_display_row`, so
+    // we read the carrier here rather than re-deriving from the lossy `path`.
+    if let Some(want) = filters.malformed
+        && row.malformed != want
+    {
+        return false;
+    }
     if let Some(min) = filters.min_size
         && row.size < min
     {

--- a/crates/uffs-core/src/search/filters/mod.rs
+++ b/crates/uffs-core/src/search/filters/mod.rs
@@ -775,6 +775,11 @@ impl SearchFilters {
             && self.min_tree_allocated.is_none()
             && self.max_tree_allocated.is_none()
             && self.allowed_months.is_empty()
+            // WI-4.4: a malformed-name toggle (`--malformed` / `--well-formed`)
+            // is a real filter — omitting it here makes the numeric match-all
+            // gate (`has_filters = !is_empty()`) skip `matches_record`, so the
+            // filter silently no-ops on `uffs "*" --malformed`.
+            && self.malformed.is_none()
     }
 }
 

--- a/crates/uffs-core/src/search/filters/tests_ext.rs
+++ b/crates/uffs-core/src/search/filters/tests_ext.rs
@@ -551,6 +551,77 @@ fn apply_type_filter_rejects_wrong_extension() {
     assert_eq!(rows.first().expect("rows non-empty").name(), "main.rs");
 }
 
+/// WI-4.4 regression: the `DisplayRow` filter path (Path/PathOnly tree-walk and
+/// the regex/trigram post-filter pass) must honor `--malformed` /
+/// `--well-formed`. Before the fix `is_empty()` ignored `malformed`, so
+/// `apply_search_filters` early-returned, and `row_passes_filters` had no
+/// malformed arm — the toggle silently no-opped.
+#[test]
+fn apply_malformed_filter_keeps_only_ill_formed_rows() {
+    let bad = DisplayRow::new(
+        0,
+        uffs_mft::platform::DriveLetter::C,
+        "C:\\dir\\\u{fffd}.txt".to_owned(),
+        100,
+        false,
+        0,
+        0,
+        0,
+        0x20,
+        4096,
+        0,
+        0,
+        0,
+    )
+    .with_forensics(true, true, None);
+    let good = DisplayRow::new(
+        0,
+        uffs_mft::platform::DriveLetter::C,
+        "C:\\dir\\readme.txt".to_owned(),
+        100,
+        false,
+        0,
+        0,
+        0,
+        0x20,
+        4096,
+        0,
+        0,
+        0,
+    )
+    .with_forensics(false, false, None);
+
+    let mut keep_malformed = vec![bad.clone(), good.clone()];
+    apply_search_filters(&mut keep_malformed, &SearchFilters {
+        malformed: Some(true),
+        ..Default::default()
+    });
+    assert_eq!(
+        keep_malformed.len(),
+        1,
+        "only the ill-formed row should remain"
+    );
+    assert!(
+        keep_malformed.first().expect("row kept").malformed,
+        "kept row must be the malformed one"
+    );
+
+    let mut keep_well_formed = vec![bad, good];
+    apply_search_filters(&mut keep_well_formed, &SearchFilters {
+        malformed: Some(false),
+        ..Default::default()
+    });
+    assert_eq!(
+        keep_well_formed.len(),
+        1,
+        "only the well-formed row should remain"
+    );
+    assert!(
+        !keep_well_formed.first().expect("row kept").malformed,
+        "kept row must be the well-formed one"
+    );
+}
+
 /// Regression T88h/T95: --in-path filter must match resolved path substring.
 #[test]
 fn apply_path_contains_filters_by_substring() {

--- a/crates/uffs-core/src/search/filters/tests_malformed.rs
+++ b/crates/uffs-core/src/search/filters/tests_malformed.rs
@@ -120,3 +120,31 @@ fn malformed_filter_uses_lossless_bytes_not_lossy_view() {
     };
     assert!(filters.matches_record(&bad, &names, &mut Vec::new(), CaseFold::default_table()));
 }
+
+#[test]
+fn malformed_makes_is_empty_false() {
+    // Regression: a malformed-only query must NOT count as "no filters".
+    // The numeric match-all gate is `has_filters = !is_empty()`, so if
+    // `is_empty()` ignored `malformed`, `matches_record` would be skipped and
+    // `uffs "*" --malformed` would return every (well-formed) record.
+    assert!(
+        SearchFilters::default().is_empty(),
+        "default has no filters"
+    );
+    assert!(
+        !SearchFilters {
+            malformed: Some(true),
+            ..Default::default()
+        }
+        .is_empty(),
+        "--malformed must register as an active filter"
+    );
+    assert!(
+        !SearchFilters {
+            malformed: Some(false),
+            ..Default::default()
+        }
+        .is_empty(),
+        "--well-formed must register as an active filter"
+    );
+}

--- a/crates/uffs-daemon/src/index/search.rs
+++ b/crates/uffs-daemon/src/index/search.rs
@@ -752,11 +752,11 @@ impl IndexManager {
 /// (path-contains / type) both already do this.
 ///
 /// `malformed_positive` (`--malformed`, near-zero hit rate) joins them:
-/// the lift is safe even for match-all because `collect_global_top_n`
-/// filters *during* the heap scan, keeping it tiny.  The inverse
-/// `--well-formed` is deliberately NOT lifted — it matches ~every file,
-/// so an unbounded match-all scan would admit the whole index into the
-/// heap (OOM-class blowup), and it never under-returns anyway.
+/// the lift is safe for match-all because `collect_global_top_n_numeric`
+/// filters *before* its bounded top-N heap.  `--well-formed` is NOT
+/// lifted — the lift's `usize::MAX` flips that scan's `use_heap =
+/// limit < 1M` to `false`, so its fallback `Vec` collects every survivor
+/// (~the whole index here → OOM-class); it never under-returns anyway.
 const fn resolve_search_limit(
     requires_post_filter: bool,
     needs_display_row_filter: bool,

--- a/crates/uffs-daemon/src/index/search.rs
+++ b/crates/uffs-daemon/src/index/search.rs
@@ -211,11 +211,12 @@ impl IndexManager {
             max_size: filters.max_size,
         };
 
-        let search_limit = if requires_post_filter || filters.needs_display_row_filter() {
-            None
-        } else {
-            effective_params.limit
-        };
+        let search_limit = resolve_search_limit(
+            requires_post_filter,
+            filters.needs_display_row_filter(),
+            filters.malformed == Some(true),
+            effective_params.limit,
+        );
 
         // ── Execute search on a blocking thread with timeout ────────
         // `search_index` uses rayon `par_iter`, which blocks the current
@@ -737,6 +738,35 @@ impl IndexManager {
         std::fs::rename(&tmp_path, target)?;
 
         Ok(rows.len())
+    }
+}
+
+/// Decide the backend scan limit (the cap applied *before* the daemon's
+/// final truncate-to-`user_limit`).
+///
+/// Filters evaluated *after* the per-drive scan must lift the cap
+/// (`None` = unbounded) on name/regex/tree patterns — those branches cap
+/// at `limit` *pattern* matches first, then filter, so a low-hit-rate
+/// filter would under-return.  `requires_post_filter` (wire predicate
+/// matched on the resolved `DisplayRow`) and `needs_display_row_filter`
+/// (path-contains / type) both already do this.
+///
+/// `malformed_positive` (`--malformed`, near-zero hit rate) joins them:
+/// the lift is safe even for match-all because `collect_global_top_n`
+/// filters *during* the heap scan, keeping it tiny.  The inverse
+/// `--well-formed` is deliberately NOT lifted — it matches ~every file,
+/// so an unbounded match-all scan would admit the whole index into the
+/// heap (OOM-class blowup), and it never under-returns anyway.
+const fn resolve_search_limit(
+    requires_post_filter: bool,
+    needs_display_row_filter: bool,
+    malformed_positive: bool,
+    user_limit: Option<u32>,
+) -> Option<u32> {
+    if requires_post_filter || needs_display_row_filter || malformed_positive {
+        None
+    } else {
+        user_limit
     }
 }
 

--- a/crates/uffs-daemon/src/index/search_tests.rs
+++ b/crates/uffs-daemon/src/index/search_tests.rs
@@ -165,3 +165,44 @@ fn write_rows_to_file_ignores_pre_planted_predictable_tmp() {
     #[cfg(unix)]
     assert_eq!(std::fs::read(&sentinel).unwrap(), b"DO NOT TOUCH");
 }
+
+// ── resolve_search_limit ───────────────────────────────────────────
+
+/// With no post-scan filter, the user's limit flows straight through so
+/// the backend can stop early (the common, cheap path).
+#[test]
+fn resolve_search_limit_passes_user_limit_when_no_post_filter() {
+    assert_eq!(
+        resolve_search_limit(false, false, false, Some(10)),
+        Some(10)
+    );
+    assert_eq!(resolve_search_limit(false, false, false, None), None);
+}
+
+/// A wire post-filter or a display-row filter lifts the cap so the
+/// post-scan pass can still satisfy the user's limit.
+#[test]
+fn resolve_search_limit_lifts_cap_for_post_and_display_filters() {
+    assert_eq!(resolve_search_limit(true, false, false, Some(10)), None);
+    assert_eq!(resolve_search_limit(false, true, false, Some(10)), None);
+}
+
+/// `--malformed` (near-zero hit rate) lifts the cap so name/regex/tree
+/// scans don't under-return.  Safe for match-all because
+/// `collect_global_top_n` filters during the heap scan.
+#[test]
+fn resolve_search_limit_lifts_cap_for_malformed_positive() {
+    assert_eq!(resolve_search_limit(false, false, true, Some(10)), None);
+}
+
+/// `--well-formed` (~100% hit rate) must NOT lift the cap: an unbounded
+/// match-all scan would admit the whole index into the heap.  The caller
+/// passes `malformed_positive = false` for `Some(false)`, so the user
+/// limit is preserved.
+#[test]
+fn resolve_search_limit_keeps_cap_for_well_formed() {
+    assert_eq!(
+        resolve_search_limit(false, false, false, Some(10)),
+        Some(10)
+    );
+}

--- a/just/build.just
+++ b/just/build.just
@@ -146,9 +146,29 @@ use-local:
 # are bit-identical to what your end users download.  For local dev builds
 # from source, use `just use-local` instead.
 #
+# Smart status: before installing, the recipe gathers four facts (all
+# read-only, all degrade gracefully) and prints a status report:
+#   • origin/main wants  — version on `origin/main` Cargo.toml (offline target)
+#   • latest published   — newest FINISHED GitHub release (the install target)
+#   • in flight (CI)     — version of any queued/in_progress release.yml run
+#   • installed (~/bin)  — what `uffs --version` currently reports
+# Decisions:
+#   • Already on the target with all binaries present → no-op (exit 0).
+#   • A strictly-newer release is mid-build → warn it's "not settled yet",
+#     install the current published version, and tell the user to re-run later.
+#
+# Target version: the binaries are downloaded from GitHub Releases, so the
+# local branch / working tree is irrelevant to *what* gets installed — only
+# the version number matters.  The target is the latest *published* release
+# when `gh` is online; offline we fall back to the `origin/main` Cargo.toml
+# version (via `git fetch` + `git show FETCH_HEAD:Cargo.toml`), which works
+# from ANY branch and never switches branches or modifies the working tree.
+# This avoids the stale-local-`main` trap (a release PR merged on GitHub but
+# never pulled).
+#
 # Resilience strategy (each tier falls through to the next on miss):
-#   A. Exact cache hit on `dist/vX.Y.Z` matching workspace `Cargo.toml`.
-#   B. `gh release download vX.Y.Z` for the workspace version.
+#   A. Exact cache hit on `dist/vX.Y.Z` matching the resolved version.
+#   B. `gh release download vX.Y.Z` for the resolved version.
 #   C. `gh release download <latest-published-tag>` — graceful older-version
 #      install when the workspace version's release PR is still in CI
 #      (the exact failure mode that motivated this recipe: `just ship`
@@ -166,8 +186,98 @@ use:
     set -euo pipefail
     printf "\033[0;34m📦 Installing UFFS binaries from dist/ cache...\033[0m\n"
 
-    # Read workspace version from Cargo.toml
-    CARGO_VER=$(awk '/^\[workspace\.package\]/{flag=1; next} flag && /^version/{print "v"$3; exit}' Cargo.toml | tr -d '"')
+    # ── Gather release facts (all read-only, all degrade gracefully) ──
+    # `just use` installs binaries from GitHub Releases, so the local
+    # branch / working tree is irrelevant to *what gets installed* — only
+    # version numbers matter.  We collect four facts, report them, and make
+    # a smart decision (no-op when current, warn when a newer release is
+    # mid-build).  Every git/gh step is read-only: NEVER switches branches,
+    # touches the index, or modifies the working tree, so any WIP /
+    # detached-HEAD / mid-rebase state is safe.  GIT_TERMINAL_PROMPT=0 makes
+    # a credential-less fetch fail fast instead of hanging on an auth prompt.
+    read_ws_ver() { awk '/^\[workspace\.package\]/{f=1; next} f && /^version/{print "v"$3; exit}' | tr -d '"'; }
+    extract_ver() { grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true; }
+
+    BIN_DIR="$HOME/bin"
+    declare -A BINARIES=(
+        ["uffs-macos-arm64"]="uffs"
+        ["uffsd-macos-arm64"]="uffsd"
+        ["uffsmcp-macos-arm64"]="uffsmcp"
+        ["uffs-mft-macos-arm64"]="uffs-mft"
+    )
+
+    # 1. What origin/main wants (informational + offline-fallback target).
+    MAIN_VER=""
+    if git rev-parse --is-inside-work-tree &>/dev/null \
+        && git remote get-url origin &>/dev/null \
+        && GIT_TERMINAL_PROMPT=0 git fetch --quiet origin main 2>/dev/null; then
+        MAIN_CARGO=$(git show FETCH_HEAD:Cargo.toml 2>/dev/null || true)
+        [[ -n "$MAIN_CARGO" ]] && MAIN_VER=$(printf '%s\n' "$MAIN_CARGO" | read_ws_ver)
+    fi
+    [[ -z "$MAIN_VER" ]] && MAIN_VER=$(read_ws_ver < Cargo.toml)
+
+    # 2. Latest FINISHED published release (the primary install target).
+    PUBLISHED_VER=""
+    GH_OK=0
+    if command -v gh &>/dev/null; then
+        PUBLISHED_VER=$(gh release view --json tagName -q .tagName 2>/dev/null | extract_ver)
+        [[ -n "$PUBLISHED_VER" ]] && GH_OK=1
+    fi
+
+    # 3. In-flight release (queued / in_progress release.yml run); the run
+    #    title embeds the version, e.g. "🚀 UFFS Release v0.5.114".
+    INFLIGHT_VER=""
+    if command -v gh &>/dev/null; then
+        INFLIGHT_VER=$(gh run list --workflow=release.yml --limit 10 \
+            --json status,displayTitle \
+            -q '.[] | select(.status=="in_progress" or .status=="queued") | .displayTitle' 2>/dev/null \
+            | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1 || true)
+    fi
+
+    # 4. What's currently installed in ~/bin.
+    INSTALLED_VER=""
+    if [[ -x "$BIN_DIR/uffs" ]]; then
+        INSTALLED_VER=$("$BIN_DIR/uffs" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+        [[ -n "$INSTALLED_VER" ]] && INSTALLED_VER="v$INSTALLED_VER"
+    fi
+
+    # ── Target: latest published when online, else origin/main offline ──
+    if [[ "$GH_OK" -eq 1 ]]; then
+        CARGO_VER="$PUBLISHED_VER"
+    else
+        CARGO_VER="$MAIN_VER"
+    fi
+
+    # ── Status report ────────────────────────────────────────────────
+    printf "\033[0;34m  ── Release status ──────────────────────────\033[0m\n"
+    printf "    origin/main wants : %s\n" "${MAIN_VER:-unknown}"
+    printf "    latest published  : %s\n" "${PUBLISHED_VER:-unknown (gh offline)}"
+    printf "    in flight (CI)    : %s\n" "${INFLIGHT_VER:-none}"
+    printf "    installed (~/bin) : %s\n" "${INSTALLED_VER:-none}"
+    printf "\033[0;34m  ────────────────────────────────────────────\033[0m\n"
+
+    # ── In-flight notice: a strictly-newer release is mid-build ──────
+    # Compare via `sort -V`; only flag when in-flight > published.
+    if [[ -n "$INFLIGHT_VER" ]]; then
+        NEWER=$(printf '%s\n%s\n' "$INFLIGHT_VER" "$PUBLISHED_VER" | sort -V | tail -1)
+        if [[ "$INFLIGHT_VER" != "$PUBLISHED_VER" ]] && [[ "$NEWER" == "$INFLIGHT_VER" ]]; then
+            printf "\033[1;33m  ⏳ Release %s is in flight — not published yet.\033[0m\n" "$INFLIGHT_VER"
+            printf "\033[1;33m     Installing current published %s now; re-run 'just use' once %s lands.\033[0m\n" "${PUBLISHED_VER:-latest}" "$INFLIGHT_VER"
+        fi
+    fi
+
+    # ── No-op: already on target with a complete install ─────────────
+    if [[ -n "$INSTALLED_VER" ]] && [[ -n "$CARGO_VER" ]] && [[ "$INSTALLED_VER" == "$CARGO_VER" ]]; then
+        ALL_PRESENT=1
+        for DEST_NAME in "${BINARIES[@]}"; do
+            [[ -x "$BIN_DIR/$DEST_NAME" ]] || { ALL_PRESENT=0; break; }
+        done
+        if [[ "$ALL_PRESENT" -eq 1 ]]; then
+            printf "\033[0;32m  ✅ Already up to date: %s installed in ~/bin — nothing to do.\033[0m\n" "$INSTALLED_VER"
+            exit 0
+        fi
+        printf "\033[1;33m  ⚠️  %s installed but some binaries are missing — reinstalling.\033[0m\n" "$INSTALLED_VER"
+    fi
 
     DIST_DIR=""
     STALE_NOTE=""
@@ -254,16 +364,8 @@ use:
         printf "\033[0;34m  → Source: %s\033[0m\n" "$DIST_DIR"
     fi
 
-    BIN_DIR="$HOME/bin"
+    # BIN_DIR and BINARIES were defined up top (gather block).
     mkdir -p "$BIN_DIR"
-
-    # Map release asset names → install names
-    declare -A BINARIES=(
-        ["uffs-macos-arm64"]="uffs"
-        ["uffsd-macos-arm64"]="uffsd"
-        ["uffsmcp-macos-arm64"]="uffsmcp"
-        ["uffs-mft-macos-arm64"]="uffs-mft"
-    )
     INSTALLED=0
     SKIPPED=0
 
@@ -312,29 +414,129 @@ use:
 # Resilience strategy (mirrors the unix recipe — see its docstring for
 # the motivating failure mode and the design rationale).  Each tier
 # falls through to the next on miss:
-#   A. Exact cache hit on `dist/vX.Y.Z` matching workspace `Cargo.toml`.
-#   B. `gh release download vX.Y.Z` for the workspace version.
+#   A. Exact cache hit on `dist/vX.Y.Z` matching the resolved version.
+#   B. `gh release download vX.Y.Z` for the resolved version.
 #   C. `gh release download <latest-published-tag>` (older fallback).
 #   D. Latest populated `dist/v*` cache (offline / gh missing).
 #
+# Target version is resolved from `origin/main` (branch-agnostic, never
+# touches the working tree); see the unix recipe docstring.
 # Prerequisite for B/C: `gh` CLI (winget install GitHub.cli).
 [windows]
 use:
     #!powershell
     Write-Host "[use] Installing UFFS binaries from dist/ cache..." -ForegroundColor Blue
 
-    # Read workspace version from Cargo.toml
-    $cargoVer = $null
-    $inPkg = $false
-    foreach ($line in Get-Content "Cargo.toml") {
-        if ($line -match '^\[workspace\.package\]') { $inPkg = $true; continue }
-        if ($inPkg -and $line -match '^version\s*=\s*"([^"]+)"') { $cargoVer = "v$($Matches[1])"; break }
-        if ($line -match '^\[' -and $inPkg) { break }
+    # Gather release facts (all read-only, all degrade gracefully) — see
+    # unix recipe.  Deliberately read-only: NEVER switches branches, touches
+    # the index, or modifies the working tree, so WIP / detached-HEAD state
+    # is safe.  Only side effect is `git fetch` updating remote-tracking refs
+    # under .git.  GIT_TERMINAL_PROMPT=0 makes a credential-less fetch fail
+    # fast instead of hanging on an auth prompt.
+    function Get-WorkspaceVersion($lines) {
+        $inPkg = $false
+        foreach ($line in $lines) {
+            if ($line -match '^\[workspace\.package\]') { $inPkg = $true; continue }
+            if ($inPkg -and $line -match '^version\s*=\s*"([^"]+)"') { return "v$($Matches[1])" }
+            if ($line -match '^\[' -and $inPkg) { break }
+        }
+        return $null
+    }
+    function Get-SemVer($text) {
+        if ($text -and ($text -match 'v?\d+\.\d+\.\d+')) { return "v$($Matches[0] -replace '^v','')" }
+        return $null
+    }
+
+    $ghAvailable = [bool](Get-Command gh -ErrorAction SilentlyContinue)
+    $binDir = Join-Path $env:USERPROFILE 'bin'
+    $binaries = @{
+        'uffs-windows-x64.exe' = 'uffs.exe'
+        'uffsd-windows-x64.exe' = 'uffsd.exe'
+        'uffsmcp-windows-x64.exe' = 'uffsmcp.exe'
+        'uffs-mft-windows-x64.exe' = 'uffs-mft.exe'
+    }
+
+    # 1. What origin/main wants (informational + offline-fallback target).
+    $mainCargo = $null
+    git rev-parse --is-inside-work-tree 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        git remote get-url origin 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            $env:GIT_TERMINAL_PROMPT = "0"
+            git fetch --quiet origin main 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) { $mainCargo = (git show FETCH_HEAD:Cargo.toml 2>$null) }
+        }
+    }
+    if ($mainCargo) {
+        $mainVer = Get-WorkspaceVersion $mainCargo
+    } else {
+        $mainVer = Get-WorkspaceVersion (Get-Content "Cargo.toml")
+    }
+
+    # 2. Latest FINISHED published release (the primary install target).
+    $publishedVer = $null
+    $ghOk = $false
+    if ($ghAvailable) {
+        $publishedVer = Get-SemVer (gh release view --json tagName -q ".tagName" 2>$null)
+        if ($publishedVer) { $ghOk = $true }
+    }
+
+    # 3. In-flight release (queued / in_progress release.yml run); the run
+    #    title embeds the version, e.g. "UFFS Release v0.5.114".
+    $inflightVer = $null
+    if ($ghAvailable) {
+        $titles = gh run list --workflow=release.yml --limit 10 `
+            --json status,displayTitle `
+            -q ".[] | select(.status==`"in_progress`" or .status==`"queued`") | .displayTitle" 2>$null
+        $cands = @()
+        foreach ($t in @($titles)) { $sv = Get-SemVer $t; if ($sv) { $cands += $sv } }
+        if ($cands.Count -gt 0) {
+            $inflightVer = ($cands | Sort-Object { [version]($_ -replace '^v','') })[-1]
+        }
+    }
+
+    # 4. What's currently installed in ~/bin.
+    $installedVer = $null
+    $uffsExe = Join-Path $binDir 'uffs.exe'
+    if (Test-Path $uffsExe) { $installedVer = Get-SemVer (& $uffsExe --version 2>$null) }
+
+    # Target: latest published when online, else origin/main offline.
+    if ($ghOk) { $cargoVer = $publishedVer } else { $cargoVer = $mainVer }
+
+    # ── Status report ────────────────────────────────────────────────
+    Write-Host "  -- Release status --------------------------" -ForegroundColor Blue
+    Write-Host "    origin/main wants : $(if ($mainVer) {$mainVer} else {'unknown'})"
+    Write-Host "    latest published  : $(if ($publishedVer) {$publishedVer} else {'unknown (gh offline)'})"
+    Write-Host "    in flight (CI)    : $(if ($inflightVer) {$inflightVer} else {'none'})"
+    Write-Host "    installed (~/bin) : $(if ($installedVer) {$installedVer} else {'none'})"
+    Write-Host "  --------------------------------------------" -ForegroundColor Blue
+
+    # ── In-flight notice: a strictly-newer release is mid-build ──────
+    if ($inflightVer -and ($inflightVer -ne $publishedVer)) {
+        $infV = [version]($inflightVer -replace '^v','')
+        $pubV = if ($publishedVer) { [version]($publishedVer -replace '^v','') } else { [version]'0.0.0' }
+        if ($infV -gt $pubV) {
+            Write-Host "  IN FLIGHT: Release $inflightVer is building - not published yet." -ForegroundColor Yellow
+            $pubDisplay = if ($publishedVer) { $publishedVer } else { 'latest' }
+            Write-Host "    Installing current published $pubDisplay now; re-run 'just use' once $inflightVer lands." -ForegroundColor Yellow
+        }
+    }
+
+    # ── No-op: already on target with a complete install ─────────────
+    if ($installedVer -and $cargoVer -and ($installedVer -eq $cargoVer)) {
+        $allPresent = $true
+        foreach ($d in $binaries.Values) {
+            if (-not (Test-Path (Join-Path $binDir $d))) { $allPresent = $false; break }
+        }
+        if ($allPresent) {
+            Write-Host "  OK: Already up to date: $installedVer installed in ~/bin - nothing to do." -ForegroundColor Green
+            exit 0
+        }
+        Write-Host "  WARNING: $installedVer installed but some binaries are missing - reinstalling." -ForegroundColor Yellow
     }
 
     $distDir = $null
     $staleNote = ""
-    $ghAvailable = [bool](Get-Command gh -ErrorAction SilentlyContinue)
 
     # Helper: does `dir` exist AND contain at least one entry?
     function Test-Populated($path) {
@@ -429,7 +631,7 @@ use:
     } else {
         Write-Host "  Source: $distDir" -ForegroundColor Cyan
     }
-    $binDir = Join-Path $env:USERPROFILE 'bin'
+    # $binDir and $binaries were defined up top (gather block).
     if (-not (Test-Path $binDir)) { New-Item -ItemType Directory -Path $binDir -Force | Out-Null }
 
     # Kill running UFFS processes before copying to avoid file locks.
@@ -442,12 +644,6 @@ use:
         }
     }
 
-    $binaries = @{
-        'uffs-windows-x64.exe' = 'uffs.exe'
-        'uffsd-windows-x64.exe' = 'uffsd.exe'
-        'uffsmcp-windows-x64.exe' = 'uffsmcp.exe'
-        'uffs-mft-windows-x64.exe' = 'uffs-mft.exe'
-    }
     $installed = 0; $skipped = 0
     foreach ($src in $binaries.Keys) {
         $srcPath = Join-Path $distDir $src


### PR DESCRIPTION
## Summary

Fixes `uffs "*" --malformed` returning well-formed names on `main` (post #359). Three real bugs plus a doc clarification, split into atomic commits.

## Bugs fixed

**Bug 3 — `is_empty()` gate dropped the malformed filter (the reported one).**
`SearchFilters::is_empty()` omitted the `malformed` field, so a query carrying *only* `--malformed` was treated as "no filters" and the numeric match-all hot path skipped `matches_record` entirely → every (well-formed) record passed. Fixed by including `self.malformed.is_none()` in the gate.

**Bug 4 — `row_passes_filters` ignored `malformed`.**
The `DisplayRow` predicate (Path/PathOnly tree-walk + regex/trigram post-filter) never checked `row.malformed`, dropping the filter even when the gate was correct. Now reads the precomputed `row.malformed` carrier (set from lossless bytes in `make_display_row`).

**Bug 5 — named/regex patterns under-returned (`--limit` leak).**
Non-match-all branches cap at `limit` *pattern* matches **before** `apply_search_filters` runs, then truncate. With `--malformed` (near-zero hit rate) the cap fills with well-formed candidates and the result shrinks to ~0. Fixed in the daemon: `resolve_search_limit(...)` lifts the scan cap (`None` = unbounded) when `malformed == Some(true)`.

### Deliberate asymmetry (`Some(true)`, not `is_some()`)

`--well-formed` (`Some(false)`, ~100% hit rate) is **not** lifted. The lift sets `limit = usize::MAX`, which flips `collect_global_top_n_numeric`'s `use_heap = limit < 1M` to `false`, so its fallback `Vec` would collect every survivor (~the whole index) before sort+truncate — an OOM-class path. The match-all numeric path scans fully and filters *before* the bounded top-N heap, so it never under-returns and needs no lift.

## Commits

| Commit | Scope |
|---|---|
| `fix(core)` | `is_empty()` gate + `DisplayRow` predicate (+ regression tests) |
| `fix(daemon)` | `resolve_search_limit()` cap lift + 4 unit tests |
| `chore(just)` | smart release-status detection (pre-existing, unrelated) |
| `docs(daemon)` | pin the asymmetry rationale to the `use_heap` mechanism |

## Validation

- Full pre-push gate green (clippy ultra-strict, fmt, rustdoc, doc-tests, tests, smoke, windows lint, file-size, typos, reuse).
- `uffs-core`: filter regression tests pass; `uffs-daemon`: 4 new `resolve_search_limit` tests pass.
- `search.rs` at 798 LOC (under the 800 ceiling).

## Open item

Live-Windows acceptance (`scripts/windows/create-corrupted-name-tree.rs --verify`) on a real NTFS volume — runnable once this lands.
