### PR TITLE
fix(mft): rebuild no-journal cache past age ceiling (resilience)

### DIFF
--- a/crates/uffs-mft/src/lib.rs
+++ b/crates/uffs-mft/src/lib.rs
@@ -118,6 +118,7 @@
 //! | `RUST_LOG_FILE` | `path` | (none) | Optional log-file path override for the standalone `uffs_mft` binary.  INTERNAL semver class. |
 //! | `UFFS_LOG_DIR` | `path` | platform default | Log directory override for the standalone `uffs_mft` binary.  INTERNAL semver class. |
 //! | `UFFS_CACHE_PROFILE` | `bool` (`env::var_os(…).is_some()`) | `false` (unset) | Emits per-phase cache I/O timings to stderr (`[CACHE_PROFILE]` prefix) from `cache`, `index/storage/{deserialize,file_io}`, and `reader/persistence`.  Dev / benchmark only.  INTERNAL semver class. |
+//! | `UFFS_NO_JOURNAL_MAX_AGE_SECS` | `u64` (seconds) | `300` | Max age a cached index is served when the drive has **no active USN journal** (os error 1179); older caches trigger a full MFT rebuild instead of serving stale, in `reader::usn_apply`.  INTERNAL semver class. |
 //! | `UFFS_MFT_TEST_DIR` | `path` | (none) | Optional test-fixture directory for the parallel-reader chaos-order harness.  Test-only.  INTERNAL semver class. |
 //! | `UFFS_MFT_TEST_FILE` | `path` | (none) | Optional test-fixture file path for the parallel-reader chaos-order harness.  Test-only.  INTERNAL semver class. |
 //! | `UFFS_PARITY_DEBUG` | `bool` | `false` | Enables verbose chaos-order parity debugging in the LIVE parser (`io::readers::parallel::to_index`).  INTERNAL semver class (dev only). |

--- a/crates/uffs-mft/src/reader/index_cache.rs
+++ b/crates/uffs-mft/src/reader/index_cache.rs
@@ -79,7 +79,8 @@ impl MftReader {
                     records = index.len(),
                     "📦 Cache HIT - checking for USN updates"
                 );
-                self.apply_usn_updates_to_fresh_index(index, header).await
+                self.apply_usn_updates_to_fresh_index(index, header, age_seconds)
+                    .await
             }
             CacheStatus::Stale { age_seconds } => {
                 tracing::debug!(drive = %drive, "[TRIP] reader::read_index_cached -> CACHE_STALE path");
@@ -103,6 +104,12 @@ impl MftReader {
     /// [`Self::read_and_cache_index`] when the journal has been recreated or
     /// has wrapped past our checkpoint.
     ///
+    /// `age_seconds` is the cache file's age as reported by
+    /// [`crate::cache::check_cache_status`]; it drives the no-journal
+    /// resilience decision: when the drive's USN journal is unavailable a
+    /// cache older than [`crate::reader::usn_apply::no_journal_max_age_secs`]
+    /// is rebuilt rather than served stale.
+    ///
     /// Extracted from [`Self::read_index_cached`] so each function stays
     /// under the cyclomatic / line-count caps.
     #[cfg(windows)]
@@ -110,11 +117,12 @@ impl MftReader {
         &self,
         mut index: crate::index::MftIndex,
         header: crate::index::IndexHeader,
+        age_seconds: u64,
     ) -> Result<crate::index::MftIndex> {
         use tracing::warn;
 
         use crate::platform::VolumeHandle;
-        use crate::reader::usn_apply::{UsnDecision, classify_usn_state};
+        use crate::reader::usn_apply::{UsnDecision, classify_usn_state, classify_without_journal};
         use crate::usn::query_usn_journal;
 
         let drive = self.volume;
@@ -135,9 +143,12 @@ impl MftReader {
                 warn!(
                     drive = %drive,
                     error = %err,
-                    "⚠️ USN Journal unavailable - using cached index as-is"
+                    "⚠️ USN Journal unavailable - evaluating cache age"
                 );
-                return Ok(index);
+                return match classify_without_journal(drive, age_seconds) {
+                    UsnDecision::Rebuild => self.read_and_cache_index().await,
+                    UsnDecision::UseCached | UsnDecision::Apply { .. } => Ok(index),
+                };
             }
         };
 

--- a/crates/uffs-mft/src/reader/multi_drive/index.rs
+++ b/crates/uffs-mft/src/reader/multi_drive/index.rs
@@ -15,7 +15,7 @@ use crate::index::{IndexHeader, MftIndex};
 use crate::platform::VolumeHandle;
 use crate::reader::usn_apply::{
     UsnDecision, apply_targeted_usn_reads, classify_usn_state as classify_with_journal_info,
-    persist_usn_checkpoint, rebuild_derived_after_usn,
+    classify_without_journal, persist_usn_checkpoint, rebuild_derived_after_usn,
 };
 use crate::reader::{MftProgress, MftReader};
 use crate::usn::{aggregate_changes, query_usn_journal, read_usn_journal};
@@ -82,35 +82,7 @@ impl MultiDriveMftReader {
             if let Some(drive) = pending_drives.next() {
                 let ttl = ttl_seconds;
 
-                join_set.spawn(async move {
-                    match check_cache_status(drive, ttl) {
-                        CacheStatus::Fresh {
-                            index,
-                            header,
-                            age_seconds,
-                        } => {
-                            info!(
-                                drive = %drive,
-                                age_seconds,
-                                records = index.len(),
-                                "📦 Cache HIT - applying USN updates"
-                            );
-                            Self::apply_usn_updates_to_cached_index(drive, index, header).await
-                        }
-                        CacheStatus::Stale { age_seconds } => {
-                            info!(
-                                drive = %drive,
-                                age_seconds = ?age_seconds,
-                                "🔄 Cache STALE - rebuilding index"
-                            );
-                            Self::read_and_cache_single_drive(drive).await
-                        }
-                        CacheStatus::Missing => {
-                            info!(drive = %drive, "🆕 Cache MISS - building index");
-                            Self::read_and_cache_single_drive(drive).await
-                        }
-                    }
-                });
+                join_set.spawn(async move { Self::load_one_cached_drive(drive, ttl).await });
             }
         }
 
@@ -132,35 +104,7 @@ impl MultiDriveMftReader {
             if let Some(drive) = pending_drives.next() {
                 let ttl = ttl_seconds;
 
-                join_set.spawn(async move {
-                    match check_cache_status(drive, ttl) {
-                        CacheStatus::Fresh {
-                            index,
-                            header,
-                            age_seconds,
-                        } => {
-                            info!(
-                                drive = %drive,
-                                age_seconds,
-                                records = index.len(),
-                                "📦 Cache HIT - applying USN updates"
-                            );
-                            Self::apply_usn_updates_to_cached_index(drive, index, header).await
-                        }
-                        CacheStatus::Stale { age_seconds } => {
-                            info!(
-                                drive = %drive,
-                                age_seconds = ?age_seconds,
-                                "🔄 Cache STALE - rebuilding index"
-                            );
-                            Self::read_and_cache_single_drive(drive).await
-                        }
-                        CacheStatus::Missing => {
-                            info!(drive = %drive, "🆕 Cache MISS - building index");
-                            Self::read_and_cache_single_drive(drive).await
-                        }
-                    }
-                });
+                join_set.spawn(async move { Self::load_one_cached_drive(drive, ttl).await });
             }
         }
 
@@ -172,6 +116,56 @@ impl MultiDriveMftReader {
         }
 
         Ok(indices)
+    }
+
+    /// Load a single drive's index honouring the cache.
+    ///
+    /// Fresh caches are served after applying USN updates (which themselves
+    /// fall back to a rebuild when the journal is unavailable and the cache
+    /// has aged past the no-journal window); stale or missing caches trigger
+    /// a full rebuild.
+    async fn load_one_cached_drive(
+        drive: crate::platform::DriveLetter,
+        ttl_seconds: u64,
+    ) -> Result<MftIndex> {
+        match check_cache_status(drive, ttl_seconds) {
+            CacheStatus::Fresh {
+                index,
+                header,
+                age_seconds,
+            } => Self::serve_fresh_cache(drive, index, header, age_seconds).await,
+            CacheStatus::Stale { age_seconds } => {
+                info!(
+                    drive = %drive,
+                    age_seconds = ?age_seconds,
+                    "🔄 Cache STALE - rebuilding index"
+                );
+                Self::read_and_cache_single_drive(drive).await
+            }
+            CacheStatus::Missing => {
+                info!(drive = %drive, "🆕 Cache MISS - building index");
+                Self::read_and_cache_single_drive(drive).await
+            }
+        }
+    }
+
+    /// Serve a fresh cached `index` for `drive`, applying any pending USN
+    /// updates before returning it.  Split out of
+    /// [`Self::load_one_cached_drive`] to keep that dispatcher under the
+    /// cognitive-complexity bar.
+    async fn serve_fresh_cache(
+        drive: crate::platform::DriveLetter,
+        index: MftIndex,
+        header: IndexHeader,
+        age_seconds: u64,
+    ) -> Result<MftIndex> {
+        info!(
+            drive = %drive,
+            age_seconds,
+            records = index.len(),
+            "📦 Cache HIT - applying USN updates"
+        );
+        Self::apply_usn_updates_to_cached_index(drive, index, header, age_seconds).await
     }
 
     /// Internal implementation for concurrent lean index reading.
@@ -291,9 +285,10 @@ impl MultiDriveMftReader {
         drive: crate::platform::DriveLetter,
         index: MftIndex,
         header: IndexHeader,
+        age_seconds: u64,
     ) -> Result<MftIndex> {
         tokio::task::spawn_blocking(move || {
-            Self::apply_usn_updates_to_cached_index_sync(drive, index, &header)
+            Self::apply_usn_updates_to_cached_index_sync(drive, index, &header, age_seconds)
         })
         .await
         .map_err(|error| MftError::InvalidInput(format!("Task join error: {error}")))?
@@ -304,8 +299,9 @@ impl MultiDriveMftReader {
         drive: crate::platform::DriveLetter,
         index: MftIndex,
         header: &IndexHeader,
+        age_seconds: u64,
     ) -> Result<MftIndex> {
-        match Self::classify_usn_state(drive, header) {
+        match Self::classify_usn_state(drive, header, age_seconds) {
             UsnDecision::UseCached => Ok(index),
             UsnDecision::Rebuild => Self::read_and_cache_single_drive_sync(drive),
             UsnDecision::Apply {
@@ -322,11 +318,15 @@ impl MultiDriveMftReader {
     ///
     /// Thin adapter over [`crate::reader::usn_apply::classify_usn_state`]
     /// that handles the `query_usn_journal` failure path here: when the
-    /// journal is unavailable we fall back to [`UsnDecision::UseCached`]
-    /// so the cached index is still served instead of erroring out.
+    /// journal is unavailable the decision is delegated to
+    /// [`classify_without_journal`], which rebuilds a cache older than the
+    /// no-journal window (`age_seconds` vs
+    /// [`crate::reader::usn_apply::no_journal_max_age_secs`]) and otherwise
+    /// serves it as-is.
     fn classify_usn_state(
         drive: crate::platform::DriveLetter,
         header: &IndexHeader,
+        age_seconds: u64,
     ) -> UsnDecision {
         match query_usn_journal(drive) {
             Ok(info) => classify_with_journal_info(drive, header, &info),
@@ -334,9 +334,9 @@ impl MultiDriveMftReader {
                 warn!(
                     drive = %drive,
                     error = %error,
-                    "⚠️ USN Journal unavailable - using cached index as-is"
+                    "⚠️ USN Journal unavailable - evaluating cache age"
                 );
-                UsnDecision::UseCached
+                classify_without_journal(drive, age_seconds)
             }
         }
     }

--- a/crates/uffs-mft/src/reader/usn_apply.rs
+++ b/crates/uffs-mft/src/reader/usn_apply.rs
@@ -122,6 +122,82 @@ pub(super) fn classify_usn_state(
     }
 }
 
+/// Default ceiling, in seconds, for serving a freshly-loaded cache whose
+/// drive has **no active USN journal**.  Without a journal there is no
+/// incremental-update mechanism, so a cache older than this is rebuilt from
+/// a full MFT read rather than served stale.  Chosen to track the daemon's
+/// 300 s USN refresh cadence (`shards.usn_refresh_interval_secs`).
+#[cfg(any(windows, test))]
+const NO_JOURNAL_MAX_AGE_SECS_DEFAULT: u64 = 300;
+
+/// Parse a raw `UFFS_NO_JOURNAL_MAX_AGE_SECS` value into an effective ceiling,
+/// falling back to [`NO_JOURNAL_MAX_AGE_SECS_DEFAULT`] when the value is absent
+/// or not a valid `u64`.  Split from [`no_journal_max_age_secs`] so the
+/// override-parsing logic is host-testable without mutating process env.
+#[cfg(any(windows, test))]
+fn parse_no_journal_max_age(raw: Option<&str>) -> u64 {
+    raw.and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(NO_JOURNAL_MAX_AGE_SECS_DEFAULT)
+}
+
+/// Effective no-journal cache-age ceiling, honouring the
+/// `UFFS_NO_JOURNAL_MAX_AGE_SECS` environment override.  Falls back to
+/// [`NO_JOURNAL_MAX_AGE_SECS_DEFAULT`] when the variable is unset or
+/// unparseable.
+#[cfg(windows)]
+pub(super) fn no_journal_max_age_secs() -> u64 {
+    parse_no_journal_max_age(
+        std::env::var("UFFS_NO_JOURNAL_MAX_AGE_SECS")
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// Pure boundary predicate: a no-journal cache strictly older than
+/// `max_age_seconds` must be rebuilt; at or under the ceiling it is served
+/// as-is.  Extracted so the off-by-one boundary (`>`, not `>=`) is pinned by a
+/// host test independent of the Windows-only [`UsnDecision`] mapping.
+#[cfg(any(windows, test))]
+const fn no_journal_cache_is_stale(age_seconds: u64, max_age_seconds: u64) -> bool {
+    age_seconds > max_age_seconds
+}
+
+/// Decide what to do with a freshly-loaded cache when the drive's USN
+/// journal is **unavailable** (e.g. `query_usn_journal` returned
+/// os error 1179 — "the volume change journal is not active").
+///
+/// Without a journal there is no incremental refresh path, so the cache's
+/// own age is the only freshness evidence:
+/// - within [`no_journal_max_age_secs`] → [`UsnDecision::UseCached`] (serve
+///   as-is; a full rescan would dominate latency for a sub-window cache).
+/// - older than the ceiling → [`UsnDecision::Rebuild`] (full MFT read) so files
+///   created since the snapshot cannot stay invisible until the long safety-net
+///   TTL elapses.
+#[cfg(windows)]
+pub(super) fn classify_without_journal(
+    drive: crate::platform::DriveLetter,
+    age_seconds: u64,
+) -> UsnDecision {
+    let max_age = no_journal_max_age_secs();
+    if no_journal_cache_is_stale(age_seconds, max_age) {
+        warn!(
+            drive = %drive,
+            age_seconds,
+            max_age_seconds = max_age,
+            "🔄 USN Journal unavailable and cache past no-journal window - rebuilding index"
+        );
+        UsnDecision::Rebuild
+    } else {
+        warn!(
+            drive = %drive,
+            age_seconds,
+            max_age_seconds = max_age,
+            "⚠️ USN Journal unavailable - serving cache within no-journal window"
+        );
+        UsnDecision::UseCached
+    }
+}
+
 /// Issue targeted MFT reads for the FRSes the delete pass left behind so
 /// non-delete changes can be folded into `index`.  Failures are logged but
 /// do not abort the wider USN-update flow — the next refresh will pick up
@@ -211,5 +287,64 @@ pub(super) fn persist_usn_checkpoint(
             next_usn = %next_usn,
             "💾 Cache updated with new USN checkpoint"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        NO_JOURNAL_MAX_AGE_SECS_DEFAULT, no_journal_cache_is_stale, parse_no_journal_max_age,
+    };
+
+    #[test]
+    fn no_journal_cache_below_ceiling_is_served() {
+        assert!(!no_journal_cache_is_stale(
+            0,
+            NO_JOURNAL_MAX_AGE_SECS_DEFAULT
+        ));
+        assert!(!no_journal_cache_is_stale(
+            NO_JOURNAL_MAX_AGE_SECS_DEFAULT - 1,
+            NO_JOURNAL_MAX_AGE_SECS_DEFAULT,
+        ));
+    }
+
+    #[test]
+    fn no_journal_cache_at_ceiling_is_not_stale() {
+        // Boundary is strictly `>`, so age == ceiling is still fresh.
+        assert!(!no_journal_cache_is_stale(
+            NO_JOURNAL_MAX_AGE_SECS_DEFAULT,
+            NO_JOURNAL_MAX_AGE_SECS_DEFAULT,
+        ));
+    }
+
+    #[test]
+    fn no_journal_cache_above_ceiling_is_stale() {
+        // One second past the ceiling forces a rebuild.
+        assert!(no_journal_cache_is_stale(
+            NO_JOURNAL_MAX_AGE_SECS_DEFAULT + 1,
+            NO_JOURNAL_MAX_AGE_SECS_DEFAULT,
+        ));
+    }
+
+    #[test]
+    fn parse_no_journal_max_age_uses_default_when_absent() {
+        assert_eq!(
+            parse_no_journal_max_age(None),
+            NO_JOURNAL_MAX_AGE_SECS_DEFAULT
+        );
+    }
+
+    #[test]
+    fn parse_no_journal_max_age_uses_default_when_unparseable() {
+        assert_eq!(
+            parse_no_journal_max_age(Some("not-a-number")),
+            NO_JOURNAL_MAX_AGE_SECS_DEFAULT
+        );
+    }
+
+    #[test]
+    fn parse_no_journal_max_age_honours_override() {
+        assert_eq!(parse_no_journal_max_age(Some("600")), 600);
+        assert_eq!(parse_no_journal_max_age(Some("0")), 0);
     }
 }

--- a/scripts/windows/create-corrupted-name-tree.rs
+++ b/scripts/windows/create-corrupted-name-tree.rs
@@ -151,7 +151,11 @@ struct Cli {
 /// it is a directory. The name is `Vec<u16>` so it can carry lone surrogates
 /// that no `String`/`OsString`-from-`&str` could represent.
 struct PlannedEntry {
-    /// UTF-16 code units of the entry's leaf name (no path separators).
+    /// UTF-16 code units of the entry's name, RELATIVE to the root folder.
+    /// A flat entry is a single leaf with no separators; a NESTED entry encodes
+    /// its path components separated by a backslash (`0x005C`) — `materialize`
+    /// creates each ancestor directory before the leaf. Components may carry
+    /// lone surrogates, which no `String`/`OsString`-from-`&str` could hold.
     name_utf16: Vec<u16>,
     /// Human-readable description of WHY this name is hostile (for the report).
     why: &'static str,
@@ -211,7 +215,7 @@ fn run() -> Result<()> {
         print_header(&root, marker, plan.len());
 
         if cli.dry_run {
-            windows_impl::report_plan(&plan, /*created=*/ false);
+            windows_impl::report_plan(&plan, /*created=*/ None);
             println!(
                 "\n{} dry run — nothing written. Re-run without {} to create the tree.",
                 "note:".yellow().bold(),
@@ -220,8 +224,9 @@ fn run() -> Result<()> {
             return Ok(());
         }
 
-        let created = windows_impl::materialize(&root, &root_win, &plan)?;
-        windows_impl::report_plan(&plan, /*created=*/ true);
+        let created_mask = windows_impl::materialize(&root, &root_win, &plan)?;
+        windows_impl::report_plan(&plan, /*created=*/ Some(&created_mask));
+        let created = created_mask.iter().filter(|&&ok| ok).count();
         print_footer(&drive, marker, created, plan.len());
         Ok(())
     }
@@ -437,6 +442,51 @@ fn build_plan(marker: &str) -> Vec<PlannedEntry> {
         is_dir: true,
     });
 
+    // ── 6. NESTED structures — mid-path corruption (NOT flat) ───────────────
+    // Until now every entry was a direct child of the root, so the only crooked
+    // component was ever the LEAF. These plant crooked names at INTERIOR levels
+    // so the path resolver must walk THROUGH an ill-formed ancestor. `name_utf16`
+    // here is a RELATIVE PATH: components separated by `\` (0x005C); `materialize`
+    // creates each ancestor dir first. The intermediate GOOD dirs are auto-created
+    // (not separate plan rows) but appear on disk and are verified all the same.
+
+    // (a) WELL-FORMED leaf buried under a CROOKED interior dir — the headline
+    //     resolver torture: good/good/BAD/good/leaf. The leaf is fine, but an
+    //     ANCESTOR is crooked → a row with malformed:false yet malformed_path:true
+    //     whose displayed path silently drops the crooked middle component.
+    plan.push(PlannedEntry {
+        name_utf16: join(&[
+            &m, &ascii("_nestA1\\"),
+            &m, &ascii("_nestA2\\"),
+            &m, &ascii("_nestBad_"), &[0xD800], &ascii("\\"),
+            &m, &ascii("_nestA3\\"),
+            &m, &ascii("_nestLeaf.txt"),
+        ]),
+        why: "WELL-FORMED leaf under a CROOKED interior dir (good/good/BAD/good/leaf)",
+        is_dir: false,
+    });
+
+    // (b) WELL-FORMED file DIRECTLY inside a CROOKED parent dir: BAD/good.txt.
+    plan.push(PlannedEntry {
+        name_utf16: join(&[
+            &m, &ascii("_nestBadParent_"), &[0xDC00], &ascii("\\"),
+            &m, &ascii("_nestGoodChild.txt"),
+        ]),
+        why: "WELL-FORMED file directly inside a CROOKED parent dir (BAD/good)",
+        is_dir: false,
+    });
+
+    // (c) CROOKED leaf nested under a GOOD subdir: good/BAD-leaf.txt (a crooked
+    //     leaf below depth 1, so the parent chain is well-formed but the leaf is not).
+    plan.push(PlannedEntry {
+        name_utf16: join(&[
+            &m, &ascii("_nestGoodSub\\"),
+            &m, &ascii("_nestDeepBad_"), &[0xD800], &ascii(".txt"),
+        ]),
+        why: "CROOKED leaf nested under a GOOD subdir (good/BAD-leaf, below depth 1)",
+        is_dir: false,
+    });
+
     plan
 }
 
@@ -597,15 +647,60 @@ mod windows_impl {
         v
     }
 
+    /// Split a (possibly nested) relative name on the backslash separator
+    /// (`0x005C`) into its path components. A flat leaf yields one component; a
+    /// nested entry yields one per directory level plus the leaf. The backslash
+    /// is never a legal NTFS filename character, so the split is unambiguous.
+    fn split_components(name: &[u16]) -> Vec<&[u16]> {
+        name.split(|&u| u == 0x005C).collect()
+    }
+
+    /// Build a NUL-terminated `\\?\drive:\root\c0\c1\…` wide path by appending
+    /// each raw UTF-16 `component` (which may contain lone surrogates) under
+    /// `root_win`, backslash-separated. Used to create the ancestor directories
+    /// of a nested entry before its leaf.
+    fn wide_join_z(root_win: &str, components: &[&[u16]]) -> Vec<u16> {
+        let mut v: Vec<u16> = std::ffi::OsStr::new(root_win).encode_wide().collect();
+        for comp in components {
+            v.push(u16::from(b'\\'));
+            v.extend_from_slice(comp);
+        }
+        v.push(0);
+        v
+    }
+
     /// Create the root folder (normal path — its name is ASCII) and then every
-    /// planned child. Returns the count successfully created (or already
-    /// present). Names NTFS itself rejects are reported and skipped, not fatal.
-    pub fn materialize(root: &str, root_win: &str, plan: &[PlannedEntry]) -> Result<usize> {
+    /// planned child. Returns a per-entry success mask aligned 1:1 with `plan`
+    /// (`true` → that entry landed on disk, or was already present). Names NTFS
+    /// itself rejects are reported and left `false`, not fatal — so callers can
+    /// report and list only the entries that actually exist.
+    pub fn materialize(root: &str, root_win: &str, plan: &[PlannedEntry]) -> Result<Vec<bool>> {
         create_dir_str(root_win)
             .with_context(|| format!("creating root folder {root}"))?;
 
-        let mut created = 0_usize;
-        for entry in plan {
+        let mut created = vec![false; plan.len()];
+        for (idx, entry) in plan.iter().enumerate() {
+            // A nested entry's `name_utf16` is a RELATIVE PATH whose components
+            // are backslash-separated (0x005C); create each ancestor directory
+            // first (idempotently) so the leaf's parent chain exists. A flat
+            // entry has a single component and this loop body is a no-op.
+            let components = split_components(&entry.name_utf16);
+            let mut ancestor_failed = false;
+            for depth in 1..components.len() {
+                let dir_z = wide_join_z(root_win, &components[..depth]);
+                if let Err(code) = create_dir_wide(&dir_z) {
+                    eprintln!(
+                        "  {} NTFS rejected an ancestor dir (GetLastError={code}): {}",
+                        "skip:".yellow(),
+                        entry.why
+                    );
+                    ancestor_failed = true;
+                    break;
+                }
+            }
+            if ancestor_failed {
+                continue;
+            }
             let path_z = wide_child_z(root_win, &entry.name_utf16);
             let ok = if entry.is_dir {
                 create_dir_wide(&path_z)
@@ -613,7 +708,7 @@ mod windows_impl {
                 create_file_wide(&path_z)
             };
             match ok {
-                Ok(()) => created += 1,
+                Ok(()) => created[idx] = true,
                 Err(code) => {
                     eprintln!(
                         "  {} NTFS rejected an entry (GetLastError={code}): {}",
@@ -687,11 +782,22 @@ mod windows_impl {
 
     /// Print the plan as a numbered list with the WTF-8 byte preview for each
     /// name (so corrupted names are visible even though the terminal can't
-    /// render them).
-    pub fn report_plan(plan: &[PlannedEntry], created: bool) {
-        let verb = if created { "Created" } else { "Would create" };
-        println!("{verb} {} entries:", plan.len());
+    /// render them). `created` is the per-entry success mask from `materialize`
+    /// (aligned 1:1 with `plan`): when `Some`, only the entries that actually
+    /// landed are counted and listed (header verb "Created"); when `None`, the
+    /// full plan is shown as a preview (verb "Would create"), e.g. for dry runs.
+    pub fn report_plan(plan: &[PlannedEntry], created: Option<&[bool]>) {
+        let verb = if created.is_some() { "Created" } else { "Would create" };
+        let landed = |i: usize| created.is_none_or(|mask| mask.get(i).copied().unwrap_or(false));
+        let count = (0..plan.len()).filter(|&i| landed(i)).count();
+        println!("{verb} {count} entries:");
+        let mut shown = 0_usize;
         for (i, e) in plan.iter().enumerate() {
+            // Skip entries NTFS rejected so the listing matches the count above.
+            if !landed(i) {
+                continue;
+            }
+            shown += 1;
             let kind = if e.is_dir { "dir " } else { "file" };
             // Show the lossy display form + the raw UTF-16 units (hex) so the
             // exact bytes are auditable regardless of terminal capability.
@@ -700,7 +806,7 @@ mod windows_impl {
                 e.name_utf16.iter().map(|u| format!("{u:04X}")).collect();
             println!(
                 "  {:>2}. [{}] {}",
-                i + 1,
+                shown,
                 kind.magenta(),
                 e.why
             );
@@ -748,14 +854,28 @@ mod windows_impl {
         }
     }
 
-    /// Enumerate the real entries in `root_win` via `FindFirstFileW`/
-    /// `FindNextFileW`, skipping `.`/`..`. This reads the names the kernel
-    /// actually stored, so ill-formed (surrogate-bearing) names survive verbatim
-    /// — unlike Explorer, `dir`, or any `String`-based walk. Shared by `--list`
-    /// and `--verify`.
+    /// Enumerate the real entries under `root_win`, RECURSIVELY, via
+    /// `FindFirstFileW`/`FindNextFileW`, skipping `.`/`..`. Reads the names the
+    /// kernel actually stored, so ill-formed (surrogate-bearing) names — at any
+    /// depth — survive verbatim, unlike Explorer, `dir`, or any `String`-based
+    /// walk. Returns files AND directories at every level so nested torture
+    /// trees are covered. Shared by `--list` and `--verify`.
     pub fn enumerate_on_disk(root: &str, root_win: &str) -> Result<Vec<DiskEntry>> {
-        let pattern = format!(r"{root_win}\*");
-        let pattern_z = wide_z(&pattern);
+        let base: Vec<u16> = std::ffi::OsStr::new(root_win).encode_wide().collect();
+        let mut entries = Vec::new();
+        enumerate_dir(root, &base, &mut entries)?;
+        Ok(entries)
+    }
+
+    /// Enumerate a single directory (given as a raw wide path, so crooked-named
+    /// dirs stay traversable) and recurse depth-first into every subdirectory,
+    /// appending each non-`.`/`..` entry to `out`.
+    fn enumerate_dir(root: &str, dir_wide: &[u16], out: &mut Vec<DiskEntry>) -> Result<()> {
+        // Search pattern: `<dir_wide>\*` + NUL.
+        let mut pattern_z: Vec<u16> = dir_wide.to_vec();
+        pattern_z.push(u16::from(b'\\'));
+        pattern_z.push(u16::from(b'*'));
+        pattern_z.push(0);
 
         // SAFETY: `find_data` is zeroed and the kernel fully initialises it on a
         // successful call; `pattern_z` is a valid NUL-terminated wide string.
@@ -766,15 +886,14 @@ mod windows_impl {
             // SAFETY: immediately after a failed Win32 call.
             let err = unsafe { ffi::GetLastError() };
             if err == ffi::ERROR_NO_MORE_FILES {
-                return Ok(Vec::new());
+                return Ok(());
             }
             anyhow::bail!(
-                "FindFirstFileW on {root} failed (GetLastError={err}); does the folder exist? \
+                "FindFirstFileW under {root} failed (GetLastError={err}); does the folder exist? \
                  create it first (run without --list/--verify), or check the drive."
             );
         }
 
-        let mut entries = Vec::new();
         loop {
             // The kernel writes a NUL-terminated name into a fixed 260-unit
             // buffer; take everything up to the first NUL.
@@ -787,10 +906,18 @@ mod windows_impl {
             // Skip the `.` and `..` pseudo-entries.
             let is_dot = matches!(leaf.as_slice(), [0x002E] | [0x002E, 0x002E]);
             if !is_dot {
-                entries.push(DiskEntry {
-                    is_dir: find_data.dwFileAttributes & ffi::FILE_ATTRIBUTE_DIRECTORY != 0,
-                    name_utf16: leaf,
-                });
+                let is_dir = find_data.dwFileAttributes & ffi::FILE_ATTRIBUTE_DIRECTORY != 0;
+                if is_dir {
+                    // Build the child's raw wide path BEFORE moving `leaf`, then
+                    // recurse depth-first into it (its own FindFirst handle).
+                    let mut child = dir_wide.to_vec();
+                    child.push(u16::from(b'\\'));
+                    child.extend_from_slice(&leaf);
+                    out.push(DiskEntry { is_dir, name_utf16: leaf });
+                    enumerate_dir(root, &child, out)?;
+                } else {
+                    out.push(DiskEntry { is_dir, name_utf16: leaf });
+                }
             }
             // SAFETY: `handle` is valid; `find_data` is a live, owned struct.
             let more = unsafe { ffi::FindNextFileW(handle, &raw mut find_data) };
@@ -800,7 +927,7 @@ mod windows_impl {
         }
         // SAFETY: `handle` came from a successful FindFirstFileW.
         unsafe { ffi::FindClose(handle) };
-        Ok(entries)
+        Ok(())
     }
 
     /// Print each true on-disk name as display + raw UTF-16 hex, flagging


### PR DESCRIPTION
## Why

On drives with an **inactive USN journal** (os error 1179 — "the volume change
journal is not active"), the daemon served the cached index for the full
safety-net TTL with **no incremental-update path**. Files created after the
snapshot stayed invisible until the long TTL elapsed.

This surfaced while validating a nested malformed-name tree on G: — a
verify run kept missing freshly planted nested entries. TRACE logs proved the
corpus was never reloaded (cache HIT, journal unavailable, served as-is).

## What

Add a short **no-journal age ceiling**. When query_usn_journal fails, the cache
is served only while younger than UFFS_NO_JOURNAL_MAX_AGE_SECS (default 300s);
older caches trigger a full MFT rebuild so new files cannot stay hidden.

### Commit 1 — fix(mft)
- usn_apply.rs: shared classify_without_journal + no_journal_max_age_secs,
  factored into pure host-testable helpers (parse_no_journal_max_age,
  no_journal_cache_is_stale) gated cfg(any(windows, test)).
- index_cache.rs (single-drive) and multi_drive/index.rs (multi-drive): thread
  age_seconds through and delegate the journal-unavailable branch to the shared
  helper.
- multi_drive/index.rs: extract load_one_cached_drive + serve_fresh_cache,
  removing the two duplicated spawn blocks (clears too_many_lines and keeps the
  dispatcher under the cognitive-complexity bar).
- lib.rs: document UFFS_NO_JOURNAL_MAX_AGE_SECS in the env-var registry.

### Commit 2 — test(windows)
- create-corrupted-name-tree.rs: nested (mid-path) malformed entries in the
  verify harness — the corpus that exposed the staleness; per-leaf marker /
  name_hex proofs extend automatically.

## Regression tests

Six host unit tests in usn_apply.rs pin the strict-greater-than ceiling
boundary (below / at / above) and the env-override parse (default when absent,
default when unparseable, honours a valid override) — deterministic, no env
mutation.

## Verification

- cargo test -p uffs-mft (host) — all pass incl. 6 new tests.
- cargo xwin clippy --workspace --all-targets --all-features
  --target x86_64-pc-windows-msvc --no-deps -- -D warnings — clean.
- Full pre-push gate (lint-ci, lint-ci-windows, rustdoc, doc-tests, tests,
  smoke, file-size, typos, reuse) — green.
