### PR TITLE
feat(bench): bench robustness — TTL fixes, interleaved HOT rounds, path-set parity checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,7 +209,7 @@ serde_json = "1.0.150"
 toml = "1.1.2"
 
 # ───── Data Structures ─────
-bitflags = "2.11.1"
+bitflags = "2.13.0"
 bytemuck = { version = "1.25.0", features = ["derive"] }
 smallvec = "1.15.1"
 zerocopy = { version = "0.8", features = ["derive"] }
@@ -257,7 +257,7 @@ aho-corasick = "1.1.4"
 globset = "0.4.18"
 
 # ───── Time ─────
-chrono = { version = "0.4.44", features = ["serde"] }
+chrono = { version = "0.4.45", features = ["serde"] }
 
 # ───── Directories / Path utilities ─────
 dirs-next = "2.0.0"

--- a/crates/uffs-bench/src/cards.rs
+++ b/crates/uffs-bench/src/cards.rs
@@ -146,7 +146,7 @@ fn unique_product_names(ids: &[&str]) -> Vec<String> {
 /// Always fires — even when all tools are present — so the operator can
 /// confirm (or in the future, deselect) which products will be benchmarked.
 /// When some tools are missing, the card notes them and points to the table.
-pub(crate) fn tool_selection_card(available: &[&str], missing: &[&str]) -> Card {
+pub(crate) fn tool_selection_card(available: &[&str], missing: &[&str], step_total: u32) -> Card {
     let avail_products = unique_product_names(available);
     let avail_names = avail_products.join(" and ");
     let avail_count = avail_products.len();
@@ -179,7 +179,7 @@ pub(crate) fn tool_selection_card(available: &[&str], missing: &[&str]) -> Card 
         id: "tool-selection".to_owned(),
         stage: "STAGE 0: PREFLIGHT".to_owned(),
         step_num: 1,
-        step_total: 1,
+        step_total,
         title,
         why,
         commands: Vec::new(),

--- a/crates/uffs-bench/src/cards.rs
+++ b/crates/uffs-bench/src/cards.rs
@@ -124,25 +124,31 @@ pub(crate) fn report_scope(cli: &Cli) -> String {
 ///
 /// The operator can press **proceed** to continue with the available tools or
 /// **abort** to quit and install the missing binaries first.
-pub(crate) fn missing_tools_card(missing: &[&str]) -> Card {
-    let list = missing.join(", ");
+pub(crate) fn missing_tools_card(missing: &[&str], available: &[&str]) -> Card {
+    let missing_list = missing.join(", ");
+    let avail_names = available.join(" and ");
+    let avail_count = available.len();
     Card {
         id: "missing-tools".to_owned(),
         stage: "STAGE 0: PREFLIGHT".to_owned(),
         step_num: 1,
         step_total: 1,
-        title: format!("Missing tool(s): {list}"),
-        why: "At least 2 tools are needed for a meaningful head-to-head benchmark.".to_owned(),
+        title: format!("Benchmarking {avail_names} — proceed or quit to install missing tools?"),
+        why: format!(
+            "Not found: {missing_list} (see install links in table above). \
+             Proceeding benchmarks only the {avail_count} available tool(s)."
+        ),
         commands: Vec::new(),
-        resources: Vec::new(),
+        resources: available.iter().map(|name| format!("✓  {name}")).collect(),
         backups: Vec::new(),
         est_time: "0 s".to_owned(),
-        recovery: "Read-only: aborting here changes nothing.".to_owned(),
-        long_why: "The table above shows install locations for each missing tool. \
-                   Install the binaries, then re-run for a full comparison. \
-                   Alternatively, proceed with only the available tools — results \
-                   will reflect a partial comparison."
-            .to_owned(),
+        recovery: "Read-only — aborting changes nothing.".to_owned(),
+        long_why: format!(
+            "Missing: {missing_list}.\n\
+             The table above shows install URLs for each missing tool.\n\
+             Install the binaries and re-run for a full comparison, or\n\
+             proceed now with: {avail_names}."
+        ),
     }
 }
 

--- a/crates/uffs-bench/src/cards.rs
+++ b/crates/uffs-bench/src/cards.rs
@@ -212,9 +212,9 @@ pub(crate) fn es_launch_card(capable_drives: &[char], admin: bool) -> Card {
     };
     let title = format!("Launch isolated Everything.exe instance for drives: {drive_list}");
     let why = format!(
-        "Everything is not running. The bench will start a private instance{admin_note} \
-         restricted to the RAM-budget-capable drives ({drive_list}) and shut it down \
-         when the run completes. Your permanent Everything.ini is not modified."
+        "The bench will stop any running Everything instance, then start a private \
+         instance{admin_note} restricted to the RAM-budget-capable drives ({drive_list}) \
+         and shut it down when the run completes. Your permanent Everything.ini is not modified."
     );
     let cmd = if admin {
         "Everything.exe -config <temp.ini> -instance uffs-bench -admin -startup".to_owned()
@@ -237,8 +237,9 @@ pub(crate) fn es_launch_card(capable_drives: &[char], admin: bool) -> Card {
         est_time: "~1-5 min (indexing)".to_owned(),
         recovery: "Aborting here skips ES cells entirely — UFFS-only run.".to_owned(),
         long_why: format!(
-            "{why}\n\nThe instance is named `uffs-bench` so it runs in parallel with \
-             any existing Everything session without interfering.\n\
+            "{why}\n\nAny running Everything instance (default or stale bench) is stopped \
+             first so the bench starts from a clean slate.  The instance is named `uffs-bench` \
+             to distinguish it from a regular session.\n\
              Pass `--es-admin` on the command line to spawn it elevated."
         ),
     }

--- a/crates/uffs-bench/src/cards.rs
+++ b/crates/uffs-bench/src/cards.rs
@@ -194,6 +194,56 @@ pub(crate) fn tool_selection_card(available: &[&str], missing: &[&str]) -> Card 
     }
 }
 
+/// Build the ES-instance launch confirmation [`Card`].
+///
+/// Shown after the negotiated matrix is displayed, before the bench tool
+/// actually spawns `Everything.exe`.  Gives the operator a chance to cancel
+/// if they don't want the bench to touch the Everything process.
+pub(crate) fn es_launch_card(capable_drives: &[char], admin: bool) -> Card {
+    let drive_list: String = capable_drives
+        .iter()
+        .map(char::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let admin_note = if admin {
+        " (as Administrator — `Everything.exe -admin`)"
+    } else {
+        ""
+    };
+    let title = format!("Launch isolated Everything.exe instance for drives: {drive_list}");
+    let why = format!(
+        "Everything is not running. The bench will start a private instance{admin_note} \
+         restricted to the RAM-budget-capable drives ({drive_list}) and shut it down \
+         when the run completes. Your permanent Everything.ini is not modified."
+    );
+    let cmd = if admin {
+        "Everything.exe -config <temp.ini> -instance uffs-bench -admin -startup".to_owned()
+    } else {
+        "Everything.exe -config <temp.ini> -instance uffs-bench -startup".to_owned()
+    };
+    Card {
+        id: "es-instance-launch".to_owned(),
+        stage: "STAGE 0: PREFLIGHT".to_owned(),
+        step_num: 2,
+        step_total: 2,
+        title,
+        why: why.clone(),
+        commands: vec![cmd],
+        resources: capable_drives
+            .iter()
+            .map(|ch| format!("{ch}: (Everything index)"))
+            .collect(),
+        backups: Vec::new(),
+        est_time: "~1-5 min (indexing)".to_owned(),
+        recovery: "Aborting here skips ES cells entirely — UFFS-only run.".to_owned(),
+        long_why: format!(
+            "{why}\n\nThe instance is named `uffs-bench` so it runs in parallel with \
+             any existing Everything session without interfering.\n\
+             Pass `--es-admin` on the command line to spawn it elevated."
+        ),
+    }
+}
+
 /// The [`StepResult`] used when a step is dry-run (rendered, not executed).
 pub(crate) fn dry_run_result() -> StepResult {
     StepResult {

--- a/crates/uffs-bench/src/cards.rs
+++ b/crates/uffs-bench/src/cards.rs
@@ -141,25 +141,47 @@ fn unique_product_names(ids: &[&str]) -> Vec<String> {
         .collect()
 }
 
-/// Build a gate [`Card`] presented when one or more tools are missing.
+/// Build the tool-selection gate [`Card`] shown after the env table.
 ///
-/// The operator can press **proceed** to continue with the available tools or
-/// **abort** to quit and install the missing binaries first.
-pub(crate) fn missing_tools_card(missing: &[&str], available: &[&str]) -> Card {
-    let missing_products = unique_product_names(missing).join(", ");
+/// Always fires — even when all tools are present — so the operator can
+/// confirm (or in the future, deselect) which products will be benchmarked.
+/// When some tools are missing, the card notes them and points to the table.
+pub(crate) fn tool_selection_card(available: &[&str], missing: &[&str]) -> Card {
     let avail_products = unique_product_names(available);
     let avail_names = avail_products.join(" and ");
     let avail_count = avail_products.len();
+    let (title, why, long_why) = if missing.is_empty() {
+        (
+            format!("Benchmark {avail_names} — confirm tool selection"),
+            format!("All {avail_count} product(s) found. Confirm to continue."),
+            format!(
+                "Proceeding will benchmark: {avail_names}.\n\
+                 Press [q] to abort and adjust the tool list."
+            ),
+        )
+    } else {
+        let missing_products = unique_product_names(missing).join(", ");
+        (
+            format!("Benchmark {avail_names} — proceed or quit to install missing tools first?"),
+            format!(
+                "Not found: {missing_products} (see install links in table above). \
+                 Proceeding benchmarks only the {avail_count} available product(s)."
+            ),
+            format!(
+                "Missing: {missing_products}.\n\
+                 The table above shows install URLs for each missing tool.\n\
+                 Install the binaries and re-run for a full comparison, or\n\
+                 proceed now with: {avail_names}."
+            ),
+        )
+    };
     Card {
-        id: "missing-tools".to_owned(),
+        id: "tool-selection".to_owned(),
         stage: "STAGE 0: PREFLIGHT".to_owned(),
         step_num: 1,
         step_total: 1,
-        title: format!("Benchmarking {avail_names} — proceed or quit to install missing tools?"),
-        why: format!(
-            "Not found: {missing_products} (see install links in table above). \
-             Proceeding benchmarks only the {avail_count} available product(s)."
-        ),
+        title,
+        why,
         commands: Vec::new(),
         resources: avail_products
             .iter()
@@ -168,12 +190,7 @@ pub(crate) fn missing_tools_card(missing: &[&str], available: &[&str]) -> Card {
         backups: Vec::new(),
         est_time: "0 s".to_owned(),
         recovery: "Read-only — aborting changes nothing.".to_owned(),
-        long_why: format!(
-            "Missing: {missing_products}.\n\
-             The table above shows install URLs for each missing tool.\n\
-             Install the binaries and re-run for a full comparison, or\n\
-             proceed now with: {avail_names}."
-        ),
+        long_why,
     }
 }
 

--- a/crates/uffs-bench/src/cards.rs
+++ b/crates/uffs-bench/src/cards.rs
@@ -120,14 +120,36 @@ pub(crate) fn report_scope(cli: &Cli) -> String {
     }
 }
 
+/// Map a probe id to a human-readable product name.
+///
+/// `everything` and `everything_gui` are two probes of the same product.
+fn tool_display_name(id: &str) -> &str {
+    match id {
+        "uffs" => "UFFS",
+        "uffs_cpp" => "UFFS (C++ ref)",
+        "everything" | "everything_gui" => "Everything",
+        _ => id,
+    }
+}
+
+/// Deduplicate a list of probe ids into unique, ordered product display names.
+fn unique_product_names(ids: &[&str]) -> Vec<String> {
+    let mut seen = alloc::collections::BTreeSet::new();
+    ids.iter()
+        .map(|id| tool_display_name(id).to_owned())
+        .filter(|name| seen.insert(name.clone()))
+        .collect()
+}
+
 /// Build a gate [`Card`] presented when one or more tools are missing.
 ///
 /// The operator can press **proceed** to continue with the available tools or
 /// **abort** to quit and install the missing binaries first.
 pub(crate) fn missing_tools_card(missing: &[&str], available: &[&str]) -> Card {
-    let missing_list = missing.join(", ");
-    let avail_names = available.join(" and ");
-    let avail_count = available.len();
+    let missing_products = unique_product_names(missing).join(", ");
+    let avail_products = unique_product_names(available);
+    let avail_names = avail_products.join(" and ");
+    let avail_count = avail_products.len();
     Card {
         id: "missing-tools".to_owned(),
         stage: "STAGE 0: PREFLIGHT".to_owned(),
@@ -135,16 +157,19 @@ pub(crate) fn missing_tools_card(missing: &[&str], available: &[&str]) -> Card {
         step_total: 1,
         title: format!("Benchmarking {avail_names} — proceed or quit to install missing tools?"),
         why: format!(
-            "Not found: {missing_list} (see install links in table above). \
-             Proceeding benchmarks only the {avail_count} available tool(s)."
+            "Not found: {missing_products} (see install links in table above). \
+             Proceeding benchmarks only the {avail_count} available product(s)."
         ),
         commands: Vec::new(),
-        resources: available.iter().map(|name| format!("✓  {name}")).collect(),
+        resources: avail_products
+            .iter()
+            .map(|name| format!("✓  {name}"))
+            .collect(),
         backups: Vec::new(),
         est_time: "0 s".to_owned(),
         recovery: "Read-only — aborting changes nothing.".to_owned(),
         long_why: format!(
-            "Missing: {missing_list}.\n\
+            "Missing: {missing_products}.\n\
              The table above shows install URLs for each missing tool.\n\
              Install the binaries and re-run for a full comparison, or\n\
              proceed now with: {avail_names}."

--- a/crates/uffs-bench/src/cards.rs
+++ b/crates/uffs-bench/src/cards.rs
@@ -138,7 +138,8 @@ pub(crate) fn missing_tools_card(missing: &[&str]) -> Card {
         backups: Vec::new(),
         est_time: "0 s".to_owned(),
         recovery: "Read-only: aborting here changes nothing.".to_owned(),
-        long_why: "Install the missing binaries (hints shown above), then re-run. \
+        long_why: "The table above shows install locations for each missing tool. \
+                   Install the binaries, then re-run for a full comparison. \
                    Alternatively, proceed with only the available tools — results \
                    will reflect a partial comparison."
             .to_owned(),

--- a/crates/uffs-bench/src/cards.rs
+++ b/crates/uffs-bench/src/cards.rs
@@ -120,6 +120,31 @@ pub(crate) fn report_scope(cli: &Cli) -> String {
     }
 }
 
+/// Build a gate [`Card`] presented when one or more tools are missing.
+///
+/// The operator can press **proceed** to continue with the available tools or
+/// **abort** to quit and install the missing binaries first.
+pub(crate) fn missing_tools_card(missing: &[&str]) -> Card {
+    let list = missing.join(", ");
+    Card {
+        id: "missing-tools".to_owned(),
+        stage: "STAGE 0: PREFLIGHT".to_owned(),
+        step_num: 1,
+        step_total: 1,
+        title: format!("Missing tool(s): {list}"),
+        why: "At least 2 tools are needed for a meaningful head-to-head benchmark.".to_owned(),
+        commands: Vec::new(),
+        resources: Vec::new(),
+        backups: Vec::new(),
+        est_time: "0 s".to_owned(),
+        recovery: "Read-only: aborting here changes nothing.".to_owned(),
+        long_why: "Install the missing binaries (hints shown above), then re-run. \
+                   Alternatively, proceed with only the available tools — results \
+                   will reflect a partial comparison."
+            .to_owned(),
+    }
+}
+
 /// The [`StepResult`] used when a step is dry-run (rendered, not executed).
 pub(crate) fn dry_run_result() -> StepResult {
     StepResult {

--- a/crates/uffs-bench/src/cards.rs
+++ b/crates/uffs-bench/src/cards.rs
@@ -194,12 +194,67 @@ pub(crate) fn tool_selection_card(available: &[&str], missing: &[&str], step_tot
     }
 }
 
+/// Build the UFFS daemon restart confirmation [`Card`].
+///
+/// Shown after the negotiated matrix when the daemon is currently loaded with
+/// more drives than the negotiated set.  The bench must kill the running daemon
+/// and restart it restricted to the capable drives so measurements are
+/// not polluted by index load on unused drives.
+pub(crate) fn uffs_restart_card(capable_drives: &[char], step_num: u32, step_total: u32) -> Card {
+    let drive_list: String = capable_drives
+        .iter()
+        .map(char::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let drive_args: String = capable_drives
+        .iter()
+        .map(|ch| format!("--drive {ch}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let title = format!("Restart UFFS daemon restricted to negotiated drives: {drive_list}");
+    let why = format!(
+        "The daemon is currently loaded with more drives than the negotiated set ({drive_list}). \
+         The bench will kill it and restart it with only those drives so index RAM, \
+         warmup time, and query routing are confined to the drives under test."
+    );
+    let cmd_kill = "uffs daemon kill".to_owned();
+    let cmd_start = format!("uffs daemon start {drive_args}");
+    Card {
+        id: "uffs-daemon-restart".to_owned(),
+        stage: "STAGE 0: PREFLIGHT".to_owned(),
+        step_num,
+        step_total,
+        title,
+        why: why.clone(),
+        commands: vec![cmd_kill, cmd_start],
+        resources: capable_drives
+            .iter()
+            .map(|ch| format!("{ch}: (UFFS index)"))
+            .collect(),
+        backups: vec!["uffs daemon run-state: restored to as-found state on teardown".to_owned()],
+        est_time: "~10-60 s (index load)".to_owned(),
+        recovery: "Aborting here keeps the daemon in its current state — all drives remain loaded."
+            .to_owned(),
+        long_why: format!(
+            "{why}\n\nThe daemon is stopped with `uffs daemon kill` (hard stop) rather than \
+             `restart` because `restart` reloads with the previous drive set. \
+             On teardown the bench will stop the restricted instance so your normal \
+             daemon session can reload with all drives on next use."
+        ),
+    }
+}
+
 /// Build the ES-instance launch confirmation [`Card`].
 ///
 /// Shown after the negotiated matrix is displayed, before the bench tool
 /// actually spawns `Everything.exe`.  Gives the operator a chance to cancel
 /// if they don't want the bench to touch the Everything process.
-pub(crate) fn es_launch_card(capable_drives: &[char], admin: bool) -> Card {
+pub(crate) fn es_launch_card(
+    capable_drives: &[char],
+    admin: bool,
+    step_num: u32,
+    step_total: u32,
+) -> Card {
     let drive_list: String = capable_drives
         .iter()
         .map(char::to_string)
@@ -224,8 +279,8 @@ pub(crate) fn es_launch_card(capable_drives: &[char], admin: bool) -> Card {
     Card {
         id: "es-instance-launch".to_owned(),
         stage: "STAGE 0: PREFLIGHT".to_owned(),
-        step_num: 2,
-        step_total: 2,
+        step_num,
+        step_total,
         title,
         why: why.clone(),
         commands: vec![cmd],

--- a/crates/uffs-bench/src/cli.rs
+++ b/crates/uffs-bench/src/cli.rs
@@ -88,6 +88,11 @@ pub struct Cli {
     /// Resume from this stage onward (1-based).
     #[arg(long = "from-stage")]
     pub from_stage: Option<u32>,
+    /// Skip these stages entirely (comma-separated, 1-based, e.g.
+    /// `--skip-stages 1,2`). Useful during development to bypass
+    /// long-running measurement stages.
+    #[arg(long = "skip-stages", value_delimiter = ',')]
+    pub skip_stages: Vec<u32>,
 
     /// Resume an existing bundle directory (loads its `state.json`).
     #[arg(long)]

--- a/crates/uffs-bench/src/cli.rs
+++ b/crates/uffs-bench/src/cli.rs
@@ -109,6 +109,11 @@ pub struct Cli {
     /// Keep any tools the suite acquired (default: remove at teardown).
     #[arg(long = "keep-tools")]
     pub keep_tools: bool,
+    /// Launch the bench-local Everything.exe instance as Administrator
+    /// (`Everything.exe -admin`).  Required on machines where NTFS volume
+    /// access is restricted to elevated processes.
+    #[arg(long = "es-admin")]
+    pub es_admin: bool,
 
     /// Optional subcommand (e.g. `fetch-competitors`); absent runs the suite.
     #[command(subcommand)]

--- a/crates/uffs-bench/src/cli.rs
+++ b/crates/uffs-bench/src/cli.rs
@@ -20,7 +20,7 @@ use clap::{Parser, Subcommand};
 use crate::gate::Mode;
 
 /// Default tool ids when `--tools` is omitted (the full head-to-head set).
-pub const DEFAULT_TOOLS: [&str; 3] = ["uffs", "uffs_cpp", "everything"];
+pub const DEFAULT_TOOLS: [&str; 4] = ["uffs", "uffs_cpp", "everything", "everything_gui"];
 
 /// Optional subcommands; an absent subcommand runs the full benchmark suite.
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
@@ -171,7 +171,8 @@ mod tests {
         assert_eq!(cli.tools_or_default(), vec![
             "uffs",
             "uffs_cpp",
-            "everything"
+            "everything",
+            "everything_gui"
         ]);
     }
 

--- a/crates/uffs-bench/src/env.rs
+++ b/crates/uffs-bench/src/env.rs
@@ -28,6 +28,11 @@ pub struct ToolProbe {
     pub exe: String,
     /// Arguments that make the tool print its version.
     pub args: Vec<String>,
+    /// When `Some`, select the first output line *containing* this substring
+    /// and trim up to and including the substring (plus surrounding whitespace)
+    /// rather than taking the first non-empty line. Useful for tools whose
+    /// first output line is a banner URL rather than a version number.
+    pub version_line_prefix: Option<String>,
 }
 
 /// A resolved tool name → version pair.
@@ -35,6 +40,8 @@ pub struct ToolProbe {
 pub struct ToolVersion {
     /// Display name of the tool.
     pub name: String,
+    /// Resolved executable path (or bare name when found via PATH).
+    pub exe: String,
     /// Reported version string (`"unknown"` if the probe produced nothing).
     pub version: String,
 }
@@ -195,13 +202,27 @@ fn probe_tool(host: &dyn Host, tool: &ToolProbe) -> ToolVersion {
     let version = host.run(&tool.exe, &arg_refs).ok().map_or_else(
         || "unknown".to_owned(),
         |out| {
-            first_nonempty(&out.stdout)
-                .or_else(|| first_nonempty(&out.stderr))
-                .unwrap_or_else(|| "unknown".to_owned())
+            let text = if out.stdout.is_empty() {
+                &out.stderr
+            } else {
+                &out.stdout
+            };
+            tool.version_line_prefix.as_ref().map_or_else(
+                || first_nonempty(text).unwrap_or_else(|| "unknown".to_owned()),
+                |prefix| {
+                    text.lines()
+                        .find(|line| line.contains(prefix.as_str()))
+                        .and_then(|line| line.split_once(prefix.as_str()))
+                        .map(|(_, after)| after.trim().to_owned())
+                        .filter(|ver| !ver.is_empty())
+                        .unwrap_or_else(|| "unknown".to_owned())
+                },
+            )
         },
     );
     ToolVersion {
         name: tool.name.clone(),
+        exe: tool.exe.clone(),
         version,
     }
 }
@@ -260,7 +281,7 @@ pub fn render_md(fp: &EnvFingerprint) -> String {
     } else {
         fp.tools
             .iter()
-            .map(|tool| format!("- **{}:** {}", tool.name, tool.version))
+            .map(|tool| format!("- **{}:** {} `{}`", tool.name, tool.version, tool.exe))
             .collect::<Vec<_>>()
             .join("\n")
     };
@@ -346,6 +367,28 @@ mod tests {
     }
 
     #[test]
+    fn probe_tool_version_line_prefix_extracts_correct_line() {
+        let banner = "Ultra Fast File Search   https://example.com\n\
+                      \n\
+                      based on SwiftSearch\n\
+                      \n\
+                      \tUFFS version:\t1.0.0\n\
+                      \tBuild for:\tx86_64\n";
+        let host = MockHost::new().with_run_result(ProcOutput {
+            code: Some(0_i32),
+            stdout: banner.to_owned(),
+            stderr: String::new(),
+        });
+        let tool = ToolProbe {
+            name: "uffs_cpp".to_owned(),
+            exe: "uffs.com".to_owned(),
+            args: vec!["--version".to_owned()],
+            version_line_prefix: Some("UFFS version:".to_owned()),
+        };
+        assert_eq!(probe_tool(&host, &tool).version, "1.0.0");
+    }
+
+    #[test]
     fn probe_tool_falls_back_to_stderr() {
         let host = MockHost::new().with_run_result(ProcOutput {
             code: Some(0_i32),
@@ -356,6 +399,7 @@ mod tests {
             name: "x".to_owned(),
             exe: "x".to_owned(),
             args: Vec::new(),
+            version_line_prefix: None,
         };
         assert_eq!(probe_tool(&host, &tool).version, "banner 9.9");
     }
@@ -375,6 +419,7 @@ mod tests {
                 name: "uffs".to_owned(),
                 exe: "uffs".to_owned(),
                 args: vec!["--version".to_owned()],
+                version_line_prefix: None,
             }],
         };
 
@@ -390,6 +435,7 @@ mod tests {
         assert_eq!(fp.arch, std::env::consts::ARCH);
         assert_eq!(fp.tools, vec![ToolVersion {
             name: "uffs".to_owned(),
+            exe: "uffs".to_owned(),
             version: "uffs 1.2.3".to_owned(),
         }]);
     }
@@ -407,6 +453,7 @@ mod tests {
             total_ram: "16.0 GiB".to_owned(),
             tools: vec![ToolVersion {
                 name: "uffs".to_owned(),
+                exe: "uffs.exe".to_owned(),
                 version: "1.2.3".to_owned(),
             }],
         }
@@ -422,7 +469,7 @@ mod tests {
 - **CPU:** Test CPU (8 logical)\n\
 - **RAM:** 16.0 GiB\n\
 \n### Tool versions\n\n\
-- **uffs:** 1.2.3\n";
+- **uffs:** 1.2.3 `uffs.exe`\n";
         assert_eq!(render_md(&sample_fp()), expected);
     }
 

--- a/crates/uffs-bench/src/env.rs
+++ b/crates/uffs-bench/src/env.rs
@@ -253,6 +253,13 @@ fn probe_state(host: &dyn Host, sp: &StateProbe) -> String {
 /// Probe one tool's version, preferring stdout then stderr (`"unknown"` on
 /// failure or empty output — many tools print their banner to stderr).
 fn probe_tool(host: &dyn Host, tool: &ToolProbe) -> ToolVersion {
+    // State is probed first so the daemon-error-marker path can reuse the
+    // result without issuing a second tasklist/pgrep call.
+    let state = tool
+        .state_probe
+        .as_ref()
+        .map_or_else(|| "n/a".to_owned(), |sp| probe_state(host, sp));
+
     let arg_refs: Vec<&str> = tool.args.iter().map(String::as_str).collect();
     let version = host.run(&tool.exe, &arg_refs).ok().map_or_else(
         || "unknown".to_owned(),
@@ -263,7 +270,17 @@ fn probe_tool(host: &dyn Host, tool: &ToolProbe) -> ToolVersion {
                 .iter()
                 .any(|marker| combined.contains(marker.as_str()))
             {
-                return "not running".to_owned();
+                // The IPC channel reported an error — es.exe cannot talk to
+                // the instance.  If the process is actually running (e.g. a
+                // private instance launched by the bench) report the version
+                // as "ipc unavailable" so the operator knows the binary
+                // exists but is not the default instance.  Only fall back to
+                // "not running" when the process is genuinely absent.
+                return if state == "running" {
+                    "ipc unavailable".to_owned()
+                } else {
+                    "not running".to_owned()
+                };
             }
             let text = if out.stdout.is_empty() {
                 &out.stderr
@@ -283,10 +300,6 @@ fn probe_tool(host: &dyn Host, tool: &ToolProbe) -> ToolVersion {
             )
         },
     );
-    let state = tool
-        .state_probe
-        .as_ref()
-        .map_or_else(|| "n/a".to_owned(), |sp| probe_state(host, sp));
     let exe = tool.display_exe.as_deref().unwrap_or(&tool.exe).to_owned();
     ToolVersion {
         name: tool.name.clone(),
@@ -491,8 +504,8 @@ mod tests {
     use chrono::{DateTime, Utc};
 
     use super::{
-        EnvFingerprint, EnvSpec, ToolProbe, ToolVersion, bytes_to_gib, capture, clean_value,
-        first_nonempty, probe_tool, render_md, write,
+        EnvFingerprint, EnvSpec, StateProbe, ToolProbe, ToolVersion, bytes_to_gib, capture,
+        clean_value, first_nonempty, probe_tool, render_md, write,
     };
     use crate::host::{Call, MockHost, ProcOutput};
 
@@ -677,6 +690,61 @@ mod tests {
         let mut fp = sample_fp();
         fp.tools.clear();
         assert!(render_md(&fp).contains("_None probed._"));
+    }
+
+    fn ipc_error_output() -> ProcOutput {
+        ProcOutput {
+            code: Some(1),
+            stdout: "Error 8: Everything IPC window not found.".to_owned(),
+            stderr: String::new(),
+        }
+    }
+
+    fn tasklist_found() -> ProcOutput {
+        stdout_of("\"Everything.exe\",\"1234\"")
+    }
+
+    fn tasklist_empty() -> ProcOutput {
+        stdout_of("")
+    }
+
+    fn gui_tool_probe() -> ToolProbe {
+        ToolProbe {
+            name: "everything_gui".to_owned(),
+            exe: "es.exe".to_owned(),
+            display_exe: Some("Everything.exe".to_owned()),
+            args: vec!["-get-everything-version".to_owned()],
+            version_line_prefix: None,
+            daemon_error_markers: vec!["Error 8".to_owned()],
+            state_probe: Some(StateProbe {
+                exe: "tasklist.exe".to_owned(),
+                args: vec!["/FI".to_owned(), "IMAGENAME eq Everything.exe".to_owned()],
+                running_marker: "Everything.exe".to_owned(),
+            }),
+        }
+    }
+
+    #[test]
+    fn ipc_error_with_process_running_reports_ipc_unavailable() {
+        let host = MockHost::new()
+            .with_run_result(tasklist_found())  // state probe: process running
+            .with_run_result(ipc_error_output()); // version probe: IPC error
+        let tv = probe_tool(&host, &gui_tool_probe());
+        assert_eq!(tv.state, "running");
+        assert_eq!(
+            tv.version, "ipc unavailable",
+            "process is up but es.exe cannot see the private instance"
+        );
+    }
+
+    #[test]
+    fn ipc_error_with_process_absent_reports_not_running() {
+        let host = MockHost::new()
+            .with_run_result(tasklist_empty())  // state probe: no process
+            .with_run_result(ipc_error_output()); // version probe: IPC error
+        let tv = probe_tool(&host, &gui_tool_probe());
+        assert_eq!(tv.state, "stopped");
+        assert_eq!(tv.version, "not running", "process is genuinely absent");
     }
 
     #[test]

--- a/crates/uffs-bench/src/env.rs
+++ b/crates/uffs-bench/src/env.rs
@@ -101,6 +101,8 @@ pub struct EnvFingerprint {
     pub logical_cpus: String,
     /// Total physical RAM (best-effort, human-readable).
     pub total_ram: String,
+    /// Total physical RAM in bytes (`0` when the probe fails).
+    pub ram_bytes: u64,
     /// Probed tool versions.
     pub tools: Vec<ToolVersion>,
 }
@@ -224,6 +226,14 @@ fn probe_value(host: &dyn Host, probe: &Probe) -> String {
     }
 }
 
+/// Run the RAM probe and return the raw byte count (`0` on failure).
+fn probe_ram_bytes(host: &dyn Host, probe: &Probe) -> u64 {
+    host.run(probe.exe, probe.args)
+        .ok()
+        .and_then(|out| clean_value(&out.stdout).parse::<u64>().ok())
+        .unwrap_or(0)
+}
+
 /// Run a [`StateProbe`] and return `"running"` or `"stopped"`.
 fn probe_state(host: &dyn Host, sp: &StateProbe) -> String {
     let arg_refs: Vec<&str> = sp.args.iter().map(String::as_str).collect();
@@ -308,7 +318,12 @@ pub fn capture(host: &dyn Host, spec: &EnvSpec) -> EnvFingerprint {
     let [model_probe, cores_probe, ram_probe] = sys_probes();
     let cpu = probe_value(host, &model_probe);
     let logical_cpus = probe_value(host, &cores_probe);
-    let total_ram = probe_value(host, &ram_probe);
+    let ram_bytes = probe_ram_bytes(host, &ram_probe);
+    let total_ram = if ram_bytes > 0 {
+        bytes_to_gib(ram_bytes)
+    } else {
+        probe_value(host, &ram_probe)
+    };
     let elevated = host.is_elevated();
     let tools = spec
         .tools
@@ -324,6 +339,7 @@ pub fn capture(host: &dyn Host, spec: &EnvSpec) -> EnvFingerprint {
         cpu,
         logical_cpus,
         total_ram,
+        ram_bytes,
         tools,
     }
 }
@@ -630,6 +646,7 @@ mod tests {
             cpu: "Test CPU".to_owned(),
             logical_cpus: "8".to_owned(),
             total_ram: "16.0 GiB".to_owned(),
+            ram_bytes: 17_179_869_184,
             tools: vec![ToolVersion {
                 name: "uffs".to_owned(),
                 exe: "uffs.exe".to_owned(),

--- a/crates/uffs-bench/src/env.rs
+++ b/crates/uffs-bench/src/env.rs
@@ -19,13 +19,31 @@ use serde::{Deserialize, Serialize};
 use crate::error::{BenchError, Result};
 use crate::host::Host;
 
+/// A lightweight probe that determines whether a tool's background
+/// process/daemon is currently running.
+#[derive(Debug, Clone)]
+pub struct StateProbe {
+    /// Executable to invoke.
+    pub exe: String,
+    /// Arguments to pass.
+    pub args: Vec<String>,
+    /// If this substring is present in combined stdout+stderr the state is
+    /// `"running"`, otherwise `"stopped"`.
+    pub running_marker: String,
+}
+
 /// A tool whose version string should be probed for the fingerprint.
 #[derive(Debug, Clone)]
 pub struct ToolProbe {
     /// Display name (for example `"uffs"`).
     pub name: String,
-    /// Executable to invoke.
+    /// Executable to invoke for version/state probes.
     pub exe: String,
+    /// Path shown in the report. Defaults to `exe` when `None`. Useful when
+    /// the version is queried via a helper binary (e.g. `es.exe` probing the
+    /// Everything daemon version) but the report should display the primary
+    /// binary path (e.g. `Everything.exe`).
+    pub display_exe: Option<String>,
     /// Arguments that make the tool print its version.
     pub args: Vec<String>,
     /// When `Some`, select the first output line *containing* this substring
@@ -38,9 +56,12 @@ pub struct ToolProbe {
     /// text. Useful for daemons (e.g. Everything) that exit 0 but print an IPC
     /// error when their background process is absent.
     pub daemon_error_markers: Vec<String>,
+    /// Optional probe to determine whether the tool's daemon/process is active.
+    /// `None` means the tool has no background process (renders as `"n/a"`).
+    pub state_probe: Option<StateProbe>,
 }
 
-/// A resolved tool name → version pair.
+/// A resolved tool name → version + state triple.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolVersion {
     /// Display name of the tool.
@@ -49,6 +70,9 @@ pub struct ToolVersion {
     pub exe: String,
     /// Reported version string (`"unknown"` if the probe produced nothing).
     pub version: String,
+    /// Daemon/process state: `"running"`, `"stopped"`, `"n/a"` (no daemon),
+    /// or `"unknown"` if the state probe failed unexpectedly.
+    pub state: String,
 }
 
 /// Inputs that scope an environment capture.
@@ -200,6 +224,22 @@ fn probe_value(host: &dyn Host, probe: &Probe) -> String {
     }
 }
 
+/// Run a [`StateProbe`] and return `"running"` or `"stopped"`.
+fn probe_state(host: &dyn Host, sp: &StateProbe) -> String {
+    let arg_refs: Vec<&str> = sp.args.iter().map(String::as_str).collect();
+    host.run(&sp.exe, &arg_refs).ok().map_or_else(
+        || "stopped".to_owned(),
+        |out| {
+            let combined = format!("{} {}", out.stdout, out.stderr);
+            if combined.contains(sp.running_marker.as_str()) {
+                "running".to_owned()
+            } else {
+                "stopped".to_owned()
+            }
+        },
+    )
+}
+
 /// Probe one tool's version, preferring stdout then stderr (`"unknown"` on
 /// failure or empty output — many tools print their banner to stderr).
 fn probe_tool(host: &dyn Host, tool: &ToolProbe) -> ToolVersion {
@@ -233,10 +273,16 @@ fn probe_tool(host: &dyn Host, tool: &ToolProbe) -> ToolVersion {
             )
         },
     );
+    let state = tool
+        .state_probe
+        .as_ref()
+        .map_or_else(|| "n/a".to_owned(), |sp| probe_state(host, sp));
+    let exe = tool.display_exe.as_deref().unwrap_or(&tool.exe).to_owned();
     ToolVersion {
         name: tool.name.clone(),
-        exe: tool.exe.clone(),
+        exe,
         version,
+        state,
     }
 }
 
@@ -294,7 +340,12 @@ pub fn render_md(fp: &EnvFingerprint) -> String {
     } else {
         fp.tools
             .iter()
-            .map(|tool| format!("- **{}:** {} `{}`", tool.name, tool.version, tool.exe))
+            .map(|tool| {
+                format!(
+                    "- **{}:** {} (state: {}) `{}`",
+                    tool.name, tool.version, tool.state, tool.exe
+                )
+            })
             .collect::<Vec<_>>()
             .join("\n")
     };
@@ -395,9 +446,11 @@ mod tests {
         let tool = ToolProbe {
             name: "uffs_cpp".to_owned(),
             exe: "uffs.com".to_owned(),
+            display_exe: None,
             args: vec!["--version".to_owned()],
             version_line_prefix: Some("UFFS version:".to_owned()),
             daemon_error_markers: vec![],
+            state_probe: None,
         };
         assert_eq!(probe_tool(&host, &tool).version, "1.0.0");
     }
@@ -414,9 +467,11 @@ mod tests {
         let tool = ToolProbe {
             name: "everything".to_owned(),
             exe: "es.exe".to_owned(),
+            display_exe: None,
             args: vec!["-get-everything-version".to_owned()],
             version_line_prefix: None,
             daemon_error_markers: vec!["Error 8".to_owned(), "IPC window not found".to_owned()],
+            state_probe: None,
         };
         assert_eq!(probe_tool(&host, &tool).version, "not running");
     }
@@ -431,9 +486,11 @@ mod tests {
         let tool = ToolProbe {
             name: "x".to_owned(),
             exe: "x".to_owned(),
+            display_exe: None,
             args: Vec::new(),
             version_line_prefix: None,
             daemon_error_markers: vec![],
+            state_probe: None,
         };
         assert_eq!(probe_tool(&host, &tool).version, "banner 9.9");
     }
@@ -452,9 +509,11 @@ mod tests {
             tools: vec![ToolProbe {
                 name: "uffs".to_owned(),
                 exe: "uffs".to_owned(),
+                display_exe: None,
                 args: vec!["--version".to_owned()],
                 version_line_prefix: None,
                 daemon_error_markers: vec![],
+                state_probe: None,
             }],
         };
 
@@ -472,6 +531,7 @@ mod tests {
             name: "uffs".to_owned(),
             exe: "uffs".to_owned(),
             version: "uffs 1.2.3".to_owned(),
+            state: "n/a".to_owned(),
         }]);
     }
 
@@ -490,6 +550,7 @@ mod tests {
                 name: "uffs".to_owned(),
                 exe: "uffs.exe".to_owned(),
                 version: "1.2.3".to_owned(),
+                state: "running".to_owned(),
             }],
         }
     }
@@ -504,7 +565,7 @@ mod tests {
 - **CPU:** Test CPU (8 logical)\n\
 - **RAM:** 16.0 GiB\n\
 \n### Tool versions\n\n\
-- **uffs:** 1.2.3 `uffs.exe`\n";
+- **uffs:** 1.2.3 (state: running) `uffs.exe`\n";
         assert_eq!(render_md(&sample_fp()), expected);
     }
 

--- a/crates/uffs-bench/src/env.rs
+++ b/crates/uffs-bench/src/env.rs
@@ -328,6 +328,86 @@ pub fn capture(host: &dyn Host, spec: &EnvSpec) -> EnvFingerprint {
     }
 }
 
+/// Render the tool-versions GFM table for `fp`.
+///
+/// Missing tools (version = `"unknown"`) appear with `⚠️ not found` in the
+/// Version cell and their install URL in the Path cell. Used both in the
+/// terminal (printed before the missing-tool gate) and embedded in
+/// [`render_md`] for the report file.
+#[must_use]
+pub(crate) fn render_tool_table(fp: &EnvFingerprint) -> String {
+    if fp.tools.is_empty() {
+        return "_None probed._".to_owned();
+    }
+    // Compute column widths for a padded GFM table (3 visible columns).
+    // `state` is retained on ToolVersion for downstream logic but is not
+    // shown in the report — the table is read by humans who care about
+    // which version is installed, not pre-run daemon status.
+    let w_name = fp
+        .tools
+        .iter()
+        .map(|tv| tv.name.len())
+        .max()
+        .unwrap_or(0)
+        .max("Tool".len());
+    let w_ver = fp
+        .tools
+        .iter()
+        .map(|tv| {
+            if tv.version == "unknown" {
+                "⚠️ not found".len()
+            } else {
+                tv.version.len()
+            }
+        })
+        .max()
+        .unwrap_or(0)
+        .max("Version".len());
+    let w_path = fp
+        .tools
+        .iter()
+        .map(|tv| {
+            if tv.version == "unknown" {
+                tool_install_hint(&tv.name).len()
+            } else {
+                // backtick-wrapped: exe + 2 chars
+                tv.exe.len() + 2
+            }
+        })
+        .max()
+        .unwrap_or(0)
+        .max("Path".len());
+    let sep = format!(
+        "|{}|{}|{}|",
+        "-".repeat(w_name + 2),
+        "-".repeat(w_ver + 2),
+        "-".repeat(w_path + 2),
+    );
+    let header = format!(
+        "| {:<w_name$} | {:<w_ver$} | {:<w_path$} |",
+        "Tool", "Version", "Path",
+    );
+    let rows: Vec<String> = fp
+        .tools
+        .iter()
+        .map(|tv| {
+            let (ver_cell, path_cell) = if tv.version == "unknown" {
+                (
+                    "\u{26a0}\u{fe0f} not found".to_owned(),
+                    tool_install_hint(&tv.name).to_owned(),
+                )
+            } else {
+                (tv.version.clone(), format!("`{}`", tv.exe))
+            };
+            format!(
+                "| {:<w_name$} | {:<w_ver$} | {:<w_path$} |",
+                tv.name, ver_cell, path_cell,
+            )
+        })
+        .collect();
+    format!("{header}\n{sep}\n{}", rows.join("\n"))
+}
+
 /// Render a captured fingerprint as the report's "Test environment" markdown.
 ///
 /// A pure function of its input (no host access), so it is covered by a golden
@@ -335,77 +415,7 @@ pub fn capture(host: &dyn Host, spec: &EnvSpec) -> EnvFingerprint {
 #[must_use]
 pub fn render_md(fp: &EnvFingerprint) -> String {
     let elevated = if fp.elevated { "yes" } else { "no" };
-    let tools = if fp.tools.is_empty() {
-        "_None probed._".to_owned()
-    } else {
-        // Compute column widths for a padded GFM table (3 visible columns).
-        // `state` is retained on ToolVersion for downstream logic but is not
-        // shown in the report — the table is read by humans who care about
-        // which version is installed, not pre-run daemon status.
-        let w_name = fp
-            .tools
-            .iter()
-            .map(|tv| tv.name.len())
-            .max()
-            .unwrap_or(0)
-            .max("Tool".len());
-        let w_ver = fp
-            .tools
-            .iter()
-            .map(|tv| {
-                if tv.version == "unknown" {
-                    "⚠️ not found".len()
-                } else {
-                    tv.version.len()
-                }
-            })
-            .max()
-            .unwrap_or(0)
-            .max("Version".len());
-        let w_path = fp
-            .tools
-            .iter()
-            .map(|tv| {
-                if tv.version == "unknown" {
-                    tool_install_hint(&tv.name).len()
-                } else {
-                    // backtick-wrapped: exe + 2 chars
-                    tv.exe.len() + 2
-                }
-            })
-            .max()
-            .unwrap_or(0)
-            .max("Path".len());
-        let sep = format!(
-            "|{}|{}|{}|",
-            "-".repeat(w_name + 2),
-            "-".repeat(w_ver + 2),
-            "-".repeat(w_path + 2),
-        );
-        let header = format!(
-            "| {:<w_name$} | {:<w_ver$} | {:<w_path$} |",
-            "Tool", "Version", "Path",
-        );
-        let rows: Vec<String> = fp
-            .tools
-            .iter()
-            .map(|tv| {
-                let (ver_cell, path_cell) = if tv.version == "unknown" {
-                    (
-                        "\u{26a0}\u{fe0f} not found".to_owned(),
-                        tool_install_hint(&tv.name).to_owned(),
-                    )
-                } else {
-                    (tv.version.clone(), format!("`{}`", tv.exe))
-                };
-                format!(
-                    "| {:<w_name$} | {:<w_ver$} | {:<w_path$} |",
-                    tv.name, ver_cell, path_cell,
-                )
-            })
-            .collect();
-        format!("{header}\n{sep}\n{}", rows.join("\n"))
-    };
+    let tools = render_tool_table(fp);
     format!(
         "## Test environment\n\n\
          - **Captured:** {}\n\

--- a/crates/uffs-bench/src/env.rs
+++ b/crates/uffs-bench/src/env.rs
@@ -352,15 +352,27 @@ pub fn render_md(fp: &EnvFingerprint) -> String {
         let w_ver = fp
             .tools
             .iter()
-            .map(|tv| tv.version.len())
+            .map(|tv| {
+                if tv.version == "unknown" {
+                    "⚠️ not found".len()
+                } else {
+                    tv.version.len()
+                }
+            })
             .max()
             .unwrap_or(0)
             .max("Version".len());
         let w_path = fp
             .tools
             .iter()
-            // backtick-wrapped in the cell: exe + 2 chars
-            .map(|tv| tv.exe.len() + 2)
+            .map(|tv| {
+                if tv.version == "unknown" {
+                    tool_install_hint(&tv.name).len()
+                } else {
+                    // backtick-wrapped: exe + 2 chars
+                    tv.exe.len() + 2
+                }
+            })
             .max()
             .unwrap_or(0)
             .max("Path".len());
@@ -378,10 +390,17 @@ pub fn render_md(fp: &EnvFingerprint) -> String {
             .tools
             .iter()
             .map(|tv| {
-                let path = format!("`{}`", tv.exe);
+                let (ver_cell, path_cell) = if tv.version == "unknown" {
+                    (
+                        "\u{26a0}\u{fe0f} not found".to_owned(),
+                        tool_install_hint(&tv.name).to_owned(),
+                    )
+                } else {
+                    (tv.version.clone(), format!("`{}`", tv.exe))
+                };
                 format!(
                     "| {:<w_name$} | {:<w_ver$} | {:<w_path$} |",
-                    tv.name, tv.version, path,
+                    tv.name, ver_cell, path_cell,
                 )
             })
             .collect();

--- a/crates/uffs-bench/src/env.rs
+++ b/crates/uffs-bench/src/env.rs
@@ -338,7 +338,10 @@ pub fn render_md(fp: &EnvFingerprint) -> String {
     let tools = if fp.tools.is_empty() {
         "_None probed._".to_owned()
     } else {
-        // Compute column widths for a padded GFM table.
+        // Compute column widths for a padded GFM table (3 visible columns).
+        // `state` is retained on ToolVersion for downstream logic but is not
+        // shown in the report — the table is read by humans who care about
+        // which version is installed, not pre-run daemon status.
         let w_name = fp
             .tools
             .iter()
@@ -353,13 +356,6 @@ pub fn render_md(fp: &EnvFingerprint) -> String {
             .max()
             .unwrap_or(0)
             .max("Version".len());
-        let w_state = fp
-            .tools
-            .iter()
-            .map(|tv| tv.state.len())
-            .max()
-            .unwrap_or(0)
-            .max("State".len());
         let w_path = fp
             .tools
             .iter()
@@ -369,15 +365,14 @@ pub fn render_md(fp: &EnvFingerprint) -> String {
             .unwrap_or(0)
             .max("Path".len());
         let sep = format!(
-            "|{}|{}|{}|{}|",
+            "|{}|{}|{}|",
             "-".repeat(w_name + 2),
             "-".repeat(w_ver + 2),
-            "-".repeat(w_state + 2),
             "-".repeat(w_path + 2),
         );
         let header = format!(
-            "| {:<w_name$} | {:<w_ver$} | {:<w_state$} | {:<w_path$} |",
-            "Tool", "Version", "State", "Path",
+            "| {:<w_name$} | {:<w_ver$} | {:<w_path$} |",
+            "Tool", "Version", "Path",
         );
         let rows: Vec<String> = fp
             .tools
@@ -385,8 +380,8 @@ pub fn render_md(fp: &EnvFingerprint) -> String {
             .map(|tv| {
                 let path = format!("`{}`", tv.exe);
                 format!(
-                    "| {:<w_name$} | {:<w_ver$} | {:<w_state$} | {:<w_path$} |",
-                    tv.name, tv.version, tv.state, path,
+                    "| {:<w_name$} | {:<w_ver$} | {:<w_path$} |",
+                    tv.name, tv.version, path,
                 )
             })
             .collect();
@@ -627,9 +622,9 @@ mod tests {
 - **CPU:** Test CPU (8 logical)\n\
 - **RAM:** 16.0 GiB\n\
 \n### Tool versions\n\n\
-| Tool | Version | State   | Path       |\n\
-|------|---------|---------|------------|\n\
-| uffs | 1.2.3   | running | `uffs.exe` |\n";
+| Tool | Version | Path       |\n\
+|------|---------|------------|\n\
+| uffs | 1.2.3   | `uffs.exe` |\n";
         assert_eq!(render_md(&sample_fp()), expected);
     }
 

--- a/crates/uffs-bench/src/env.rs
+++ b/crates/uffs-bench/src/env.rs
@@ -448,14 +448,12 @@ pub fn write(host: &dyn Host, fp: &EnvFingerprint, bundle_dir: &Path) -> Result<
 /// binary before they decide whether to proceed with the remaining tools.
 pub(crate) fn tool_install_hint(name: &str) -> &'static str {
     match name {
-        "uffs" => "Install UFFS: https://github.com/skyllc-ai/UltraFastFileSearch/releases",
+        "uffs" => "https://github.com/skyllc-ai/UltraFastFileSearch/releases",
         "uffs_cpp" => {
-            "Install UFFS C++ ref binary (uffs.com): run `just use` from the repo root \
-             or copy the release artefact to ~/bin/uffs.com"
+            "https://github.com/githubrobbi/Ultra-Fast-File-Search-legacy-cpp/releases/download/v1.0.0/uffs.com"
         }
-        "everything" | "everything_gui" => {
-            "Install Everything 1.4+ and its CLI (es.exe): https://www.voidtools.com/downloads/"
-        }
+        "everything" => "https://www.voidtools.com/downloads/#cli",
+        "everything_gui" => "https://www.voidtools.com/support/everything/installing_everything/",
         _ => "Ensure the binary is on PATH or in ~/bin and re-run",
     }
 }

--- a/crates/uffs-bench/src/env.rs
+++ b/crates/uffs-bench/src/env.rs
@@ -338,16 +338,59 @@ pub fn render_md(fp: &EnvFingerprint) -> String {
     let tools = if fp.tools.is_empty() {
         "_None probed._".to_owned()
     } else {
-        fp.tools
+        // Compute column widths for a padded GFM table.
+        let w_name = fp
+            .tools
             .iter()
-            .map(|tool| {
+            .map(|tv| tv.name.len())
+            .max()
+            .unwrap_or(0)
+            .max("Tool".len());
+        let w_ver = fp
+            .tools
+            .iter()
+            .map(|tv| tv.version.len())
+            .max()
+            .unwrap_or(0)
+            .max("Version".len());
+        let w_state = fp
+            .tools
+            .iter()
+            .map(|tv| tv.state.len())
+            .max()
+            .unwrap_or(0)
+            .max("State".len());
+        let w_path = fp
+            .tools
+            .iter()
+            // backtick-wrapped in the cell: exe + 2 chars
+            .map(|tv| tv.exe.len() + 2)
+            .max()
+            .unwrap_or(0)
+            .max("Path".len());
+        let sep = format!(
+            "|{}|{}|{}|{}|",
+            "-".repeat(w_name + 2),
+            "-".repeat(w_ver + 2),
+            "-".repeat(w_state + 2),
+            "-".repeat(w_path + 2),
+        );
+        let header = format!(
+            "| {:<w_name$} | {:<w_ver$} | {:<w_state$} | {:<w_path$} |",
+            "Tool", "Version", "State", "Path",
+        );
+        let rows: Vec<String> = fp
+            .tools
+            .iter()
+            .map(|tv| {
+                let path = format!("`{}`", tv.exe);
                 format!(
-                    "- **{}:** {} (state: {}) `{}`",
-                    tool.name, tool.version, tool.state, tool.exe
+                    "| {:<w_name$} | {:<w_ver$} | {:<w_state$} | {:<w_path$} |",
+                    tv.name, tv.version, tv.state, path,
                 )
             })
-            .collect::<Vec<_>>()
-            .join("\n")
+            .collect();
+        format!("{header}\n{sep}\n{}", rows.join("\n"))
     };
     format!(
         "## Test environment\n\n\
@@ -382,6 +425,25 @@ pub fn write(host: &dyn Host, fp: &EnvFingerprint, bundle_dir: &Path) -> Result<
     host.write_file(&md_path, render_md(fp).as_bytes())
         .map_err(|err| BenchError::io(&md_path, err))?;
     Ok(())
+}
+
+/// Return a human-readable install hint for a tool id, or a generic message
+/// if the tool is unknown.
+///
+/// Used by the missing-tool soft gate to tell the operator where to get the
+/// binary before they decide whether to proceed with the remaining tools.
+pub(crate) fn tool_install_hint(name: &str) -> &'static str {
+    match name {
+        "uffs" => "Install UFFS: https://github.com/skyllc-ai/UltraFastFileSearch/releases",
+        "uffs_cpp" => {
+            "Install UFFS C++ ref binary (uffs.com): run `just use` from the repo root \
+             or copy the release artefact to ~/bin/uffs.com"
+        }
+        "everything" | "everything_gui" => {
+            "Install Everything 1.4+ and its CLI (es.exe): https://www.voidtools.com/downloads/"
+        }
+        _ => "Ensure the binary is on PATH or in ~/bin and re-run",
+    }
 }
 
 #[cfg(test)]
@@ -565,7 +627,9 @@ mod tests {
 - **CPU:** Test CPU (8 logical)\n\
 - **RAM:** 16.0 GiB\n\
 \n### Tool versions\n\n\
-- **uffs:** 1.2.3 (state: running) `uffs.exe`\n";
+| Tool | Version | State   | Path       |\n\
+|------|---------|---------|------------|\n\
+| uffs | 1.2.3   | running | `uffs.exe` |\n";
         assert_eq!(render_md(&sample_fp()), expected);
     }
 

--- a/crates/uffs-bench/src/env.rs
+++ b/crates/uffs-bench/src/env.rs
@@ -33,6 +33,11 @@ pub struct ToolProbe {
     /// rather than taking the first non-empty line. Useful for tools whose
     /// first output line is a banner URL rather than a version number.
     pub version_line_prefix: Option<String>,
+    /// If any of these substrings appear in the combined stdout+stderr output,
+    /// the version is reported as `"not running"` instead of the raw error
+    /// text. Useful for daemons (e.g. Everything) that exit 0 but print an IPC
+    /// error when their background process is absent.
+    pub daemon_error_markers: Vec<String>,
 }
 
 /// A resolved tool name → version pair.
@@ -202,6 +207,14 @@ fn probe_tool(host: &dyn Host, tool: &ToolProbe) -> ToolVersion {
     let version = host.run(&tool.exe, &arg_refs).ok().map_or_else(
         || "unknown".to_owned(),
         |out| {
+            let combined = format!("{} {}", out.stdout, out.stderr);
+            if tool
+                .daemon_error_markers
+                .iter()
+                .any(|marker| combined.contains(marker.as_str()))
+            {
+                return "not running".to_owned();
+            }
             let text = if out.stdout.is_empty() {
                 &out.stderr
             } else {
@@ -384,8 +397,28 @@ mod tests {
             exe: "uffs.com".to_owned(),
             args: vec!["--version".to_owned()],
             version_line_prefix: Some("UFFS version:".to_owned()),
+            daemon_error_markers: vec![],
         };
         assert_eq!(probe_tool(&host, &tool).version, "1.0.0");
+    }
+
+    #[test]
+    fn probe_tool_daemon_error_markers_returns_not_running() {
+        let ipc_error =
+            "Error 8: Everything IPC window not found. Please make sure Everything is running.\n";
+        let host = MockHost::new().with_run_result(ProcOutput {
+            code: Some(0_i32),
+            stdout: ipc_error.to_owned(),
+            stderr: String::new(),
+        });
+        let tool = ToolProbe {
+            name: "everything".to_owned(),
+            exe: "es.exe".to_owned(),
+            args: vec!["-get-everything-version".to_owned()],
+            version_line_prefix: None,
+            daemon_error_markers: vec!["Error 8".to_owned(), "IPC window not found".to_owned()],
+        };
+        assert_eq!(probe_tool(&host, &tool).version, "not running");
     }
 
     #[test]
@@ -400,6 +433,7 @@ mod tests {
             exe: "x".to_owned(),
             args: Vec::new(),
             version_line_prefix: None,
+            daemon_error_markers: vec![],
         };
         assert_eq!(probe_tool(&host, &tool).version, "banner 9.9");
     }
@@ -420,6 +454,7 @@ mod tests {
                 exe: "uffs".to_owned(),
                 args: vec!["--version".to_owned()],
                 version_line_prefix: None,
+                daemon_error_markers: vec![],
             }],
         };
 

--- a/crates/uffs-bench/src/error.rs
+++ b/crates/uffs-bench/src/error.rs
@@ -65,6 +65,14 @@ pub enum BenchError {
     /// allowing callers to report every crumb before returning.
     #[error("{0} host difference(s) or restore failure(s) detected")]
     Crumbs(usize),
+
+    /// One or more required tools could not be invoked.
+    ///
+    /// Raised during Stage 0a when a version probe returns `"unknown"` for a
+    /// tool the operator requested, so the run aborts loudly before any
+    /// measurements start rather than silently producing incomplete results.
+    #[error("required tool(s) not found: {0}")]
+    MissingTools(String),
 }
 
 impl BenchError {

--- a/crates/uffs-bench/src/gate.rs
+++ b/crates/uffs-bench/src/gate.rs
@@ -145,7 +145,7 @@ fn show_full(host: &dyn Host, card: &Card) {
         "| est: {}   recovery: {}",
         card.est_time, card.recovery
     ));
-    host.out("|\n+- [y] proceed   [a] autopilot   [b] back   [q] quit   [e] explain   [?] help");
+    host.out("+- [Enter/y] proceed   [a] autopilot   [b] back   [q] quit   [e] explain   [?] help");
 }
 
 /// Render the DONE panel after a step has run.
@@ -208,6 +208,18 @@ fn prompt(host: &dyn Host, mode: &mut Mode, seen: &mut BTreeSet<String>, card: &
             return Decision::Abort;
         };
         if let Some(decision) = interpret_key(host, mode, card, key) {
+            let echo = match key {
+                '\n' | '\r' => "[Enter] → proceeding",
+                'y' | 'Y' => "[y] → proceeding",
+                'a' | 'A' => "[a] → autopilot",
+                's' | 'S' => "[s] → skipping",
+                'b' | 'B' => "[b] → going back",
+                'q' | 'Q' => "[q] → aborting",
+                _ => "",
+            };
+            if !echo.is_empty() {
+                host.out(&format!("   {echo}"));
+            }
             return decision;
         }
     }

--- a/crates/uffs-bench/src/gate.rs
+++ b/crates/uffs-bench/src/gate.rs
@@ -114,27 +114,38 @@ fn show_terse(host: &dyn Host, card: &Card) {
 
 /// Render the full teaching card.
 fn show_full(host: &dyn Host, card: &Card) {
+    host.out("");
     host.out(&format!(
-        "+- {} - step {}/{} ",
+        "+- {} - step {}/{}",
         card.stage, card.step_num, card.step_total
     ));
+    host.out("|");
     host.out(&format!("| {}", card.title));
-    host.out(&format!("| why: {}", card.why));
-    host.out("| commands (run verbatim):");
-    for cmd in &card.commands {
-        host.out(&format!("|   $ {cmd}"));
+    host.out("|");
+    host.out(&format!("| {}", card.why));
+    if !card.commands.is_empty() {
+        host.out("|");
+        host.out("| commands (run verbatim):");
+        for cmd in &card.commands {
+            host.out(&format!("|   $ {cmd}"));
+        }
     }
     if !card.resources.is_empty() {
-        host.out(&format!("| resources: {}", card.resources.join(", ")));
+        host.out("|");
+        for res in &card.resources {
+            host.out(&format!("| {res}"));
+        }
     }
     if !card.backups.is_empty() {
+        host.out("|");
         host.out(&format!("| backups: {}", card.backups.join(", ")));
     }
+    host.out("|");
     host.out(&format!(
         "| est: {}   recovery: {}",
         card.est_time, card.recovery
     ));
-    host.out("+- [y proceed - s skip - a autopilot - b back - q quit - e explain - ? help]");
+    host.out("|\n+- [y] proceed   [a] autopilot   [b] back   [q] quit   [e] explain   [?] help");
 }
 
 /// Render the DONE panel after a step has run.

--- a/crates/uffs-bench/src/gate.rs
+++ b/crates/uffs-bench/src/gate.rs
@@ -145,7 +145,7 @@ fn show_full(host: &dyn Host, card: &Card) {
         "| est: {}   recovery: {}",
         card.est_time, card.recovery
     ));
-    host.out("+- [Enter/y] proceed   [a] autopilot   [b] back   [q] quit   [e] explain   [?] help");
+    host.out("+- [Enter/y] proceed   [s] skip   [a] autopilot   [b] back   [q] quit   [e] explain   [?] help");
 }
 
 /// Render the DONE panel after a step has run.

--- a/crates/uffs-bench/src/host/mock.rs
+++ b/crates/uffs-bench/src/host/mock.rs
@@ -39,6 +39,8 @@ pub enum Call {
     CreateDirAll(PathBuf),
     /// [`super::Host::run`] with the executable and its arguments.
     Run(String, Vec<String>),
+    /// [`super::Host::run_streaming`] with the executable and its arguments.
+    RunStreaming(String, Vec<String>),
     /// [`super::Host::spawn`] with the executable and its arguments.
     Spawn(String, Vec<String>),
     /// [`super::Host::read_key`] consumed one scripted keypress.
@@ -253,6 +255,14 @@ impl super::Host for MockHost {
                 stdout: String::new(),
                 stderr: String::new(),
             }))
+    }
+
+    fn run_streaming(&self, exe: &str, args: &[&str]) -> io::Result<Option<i32>> {
+        self.record(Call::RunStreaming(
+            exe.to_owned(),
+            args.iter().map(|arg| (*arg).to_owned()).collect(),
+        ));
+        Ok(Some(0))
     }
 
     fn spawn(&self, exe: &str, args: &[&str]) -> io::Result<()> {

--- a/crates/uffs-bench/src/host/mock.rs
+++ b/crates/uffs-bench/src/host/mock.rs
@@ -39,6 +39,8 @@ pub enum Call {
     CreateDirAll(PathBuf),
     /// [`super::Host::run`] with the executable and its arguments.
     Run(String, Vec<String>),
+    /// [`super::Host::spawn`] with the executable and its arguments.
+    Spawn(String, Vec<String>),
     /// [`super::Host::read_key`] consumed one scripted keypress.
     ReadKey,
     /// [`super::Host::out`] emitted the given line.
@@ -251,6 +253,14 @@ impl super::Host for MockHost {
                 stdout: String::new(),
                 stderr: String::new(),
             }))
+    }
+
+    fn spawn(&self, exe: &str, args: &[&str]) -> io::Result<()> {
+        self.record(Call::Spawn(
+            exe.to_owned(),
+            args.iter().map(|arg| (*arg).to_owned()).collect(),
+        ));
+        Ok(())
     }
 
     fn env(&self, key: &str) -> Option<String> {

--- a/crates/uffs-bench/src/host/mod.rs
+++ b/crates/uffs-bench/src/host/mod.rs
@@ -96,6 +96,18 @@ pub trait Host {
     /// Returns an error if the process cannot be spawned.
     fn run(&self, exe: &str, args: &[&str]) -> io::Result<ProcOutput>;
 
+    /// Spawn `exe` with `args`, inheriting the parent's stdout and stderr so
+    /// the child's output streams live to the operator's terminal.
+    ///
+    /// Returns the process exit code (`None` if the OS did not provide one).
+    /// Use this for long-running harness scripts (Stage 1, Stage 2) where
+    /// buffering all output and returning it at the end would leave the
+    /// operator watching a blank screen for several minutes.
+    ///
+    /// # Errors
+    /// Returns an error if the process cannot be spawned.
+    fn run_streaming(&self, exe: &str, args: &[&str]) -> io::Result<Option<i32>>;
+
     /// Spawn `exe` with `args` as a detached background process.
     ///
     /// The child's stdout and stderr are discarded and the bench tool does not

--- a/crates/uffs-bench/src/host/mod.rs
+++ b/crates/uffs-bench/src/host/mod.rs
@@ -96,6 +96,17 @@ pub trait Host {
     /// Returns an error if the process cannot be spawned.
     fn run(&self, exe: &str, args: &[&str]) -> io::Result<ProcOutput>;
 
+    /// Spawn `exe` with `args` as a detached background process.
+    ///
+    /// The child's stdout and stderr are discarded and the bench tool does not
+    /// wait for it to exit.  Used for long-running GUI processes (e.g.
+    /// `Everything.exe`) that must run concurrently while the bench polls them
+    /// via the CLI.
+    ///
+    /// # Errors
+    /// Returns an error if the process cannot be spawned.
+    fn spawn(&self, exe: &str, args: &[&str]) -> io::Result<()>;
+
     /// Read an environment variable, if present and valid UTF-8.
     fn env(&self, key: &str) -> Option<String>;
 

--- a/crates/uffs-bench/src/host/system.rs
+++ b/crates/uffs-bench/src/host/system.rs
@@ -79,6 +79,13 @@ impl Host for SystemHost {
         })
     }
 
+    fn run_streaming(&self, exe: &str, args: &[&str]) -> io::Result<Option<i32>> {
+        Command::new(exe)
+            .args(args)
+            .status()
+            .map(|status| status.code())
+    }
+
     fn spawn(&self, exe: &str, args: &[&str]) -> io::Result<()> {
         use std::process::Stdio;
         Command::new(exe)

--- a/crates/uffs-bench/src/host/system.rs
+++ b/crates/uffs-bench/src/host/system.rs
@@ -79,6 +79,17 @@ impl Host for SystemHost {
         })
     }
 
+    fn spawn(&self, exe: &str, args: &[&str]) -> io::Result<()> {
+        use std::process::Stdio;
+        Command::new(exe)
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map(|_child| ())
+    }
+
     fn env(&self, key: &str) -> Option<String> {
         std::env::var(key).ok()
     }

--- a/crates/uffs-bench/src/lib.rs
+++ b/crates/uffs-bench/src/lib.rs
@@ -64,6 +64,7 @@ pub mod host;
 pub mod matrix;
 pub mod preflight;
 pub mod report;
+pub mod resolve;
 pub mod restore;
 pub mod run;
 pub mod stages;

--- a/crates/uffs-bench/src/matrix.rs
+++ b/crates/uffs-bench/src/matrix.rs
@@ -102,12 +102,28 @@ fn find_cell<'a>(
 /// RAM is within the budget.  When budget is 0 (unlimited), all candidate
 /// drives are included.
 fn ram_budget_capable_drives(spec: &MatrixSpec, preflight: &PreflightResult) -> Vec<char> {
+    // Only consider drives that made it through preflight (known to the UFFS
+    // daemon).  Drives absent from preflight.drives were dropped during capture
+    // and must not reappear here.
+    let known: alloc::collections::BTreeSet<char> = preflight
+        .drives
+        .iter()
+        .map(|preflight_dp| preflight_dp.drive)
+        .collect();
     if spec.es_ram_budget_bytes == 0 {
-        return spec.candidate_drives.clone();
+        return spec
+            .candidate_drives
+            .iter()
+            .copied()
+            .filter(|letter| known.contains(letter))
+            .collect();
     }
     let mut cumulative: u64 = 0;
     let mut result = Vec::new();
     for &drive in &spec.candidate_drives {
+        if !known.contains(&drive) {
+            continue;
+        }
         let count = find_drive(&preflight.drives, drive).map_or(0, |dp| dp.uffs_record_count);
         let est = count.saturating_mul(UFFS_BYTES_PER_RECORD);
         if cumulative.saturating_add(est) <= spec.es_ram_budget_bytes {
@@ -160,10 +176,10 @@ fn solo_reason(preflight: &PreflightResult, drive: char, pattern: &str) -> Strin
 
 /// Negotiate the cross-tool vs UFFS-only matrix (execution-plan §8.4).
 ///
-/// `capable_drives` is the candidate set intersected with every required tool's
-/// servable set (only Everything constrains it today). A cell is cross-tool
-/// when its drive is capable and Everything finds it feasible; otherwise it is
-/// UFFS-only with a per-cell reason.
+/// Only drives present in `preflight.drives` (confirmed by the UFFS daemon)
+/// participate.  `capable_drives` is the RAM-budget-filtered subset of those.
+/// A cell is cross-tool when its drive is capable and Everything finds it
+/// feasible; otherwise it is UFFS-only with a per-cell reason.
 #[must_use]
 pub fn compute_matrix(spec: &MatrixSpec, preflight: &PreflightResult) -> Matrix {
     let everything_required = spec
@@ -174,12 +190,27 @@ pub fn compute_matrix(spec: &MatrixSpec, preflight: &PreflightResult) -> Matrix 
     let capable_drives: Vec<char> = if everything_required {
         ram_budget_capable_drives(spec, preflight)
     } else {
-        spec.candidate_drives.clone()
+        // No budget constraint: all preflight-confirmed drives, in candidate order.
+        let known: alloc::collections::BTreeSet<char> = preflight
+            .drives
+            .iter()
+            .map(|preflight_dp| preflight_dp.drive)
+            .collect();
+        spec.candidate_drives
+            .iter()
+            .copied()
+            .filter(|letter| known.contains(letter))
+            .collect()
     };
 
     let mut cross_cells = Vec::new();
     let mut uffs_only = Vec::new();
-    for &drive in &spec.candidate_drives {
+    // Iterate only drives confirmed by preflight, preserving candidate order.
+    for &drive in spec
+        .candidate_drives
+        .iter()
+        .filter(|letter| preflight.drives.iter().any(|pdp| pdp.drive == **letter))
+    {
         let capable = capable_drives.contains(&drive);
         for pattern in &spec.patterns {
             let feasible = !everything_required
@@ -335,8 +366,10 @@ mod tests {
 
         let matrix = compute_matrix(&spec, &preflight);
 
-        // Budget=0 → all candidates are capable regardless of ES running state.
-        assert_eq!(matrix.capable_drives, vec!['C', 'D', 'E', 'F', 'M', 'S']);
+        // Budget=0 → all preflight-confirmed candidates are capable.
+        // F/M/S are in spec.candidate_drives but NOT in preflight.drives
+        // (dropped during capture as unknown to daemon) → excluded.
+        assert_eq!(matrix.capable_drives, vec!['C', 'D', 'E']);
         // Only C and D have feasibility cells → cross-tool.
         assert_eq!(
             matrix
@@ -346,9 +379,10 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!['C', 'D']
         );
-        // E/F/M/S: capable but no feasibility cell → UFFS-only.
+        // E: confirmed but no feasibility cell → UFFS-only.
+        // F/M/S: not in preflight → not emitted at all.
         let solo_drives: Vec<char> = matrix.uffs_only.iter().map(|cell| cell.drive).collect();
-        assert_eq!(solo_drives, vec!['E', 'F', 'M', 'S']);
+        assert_eq!(solo_drives, vec!['E']);
     }
 
     #[test]
@@ -414,7 +448,7 @@ mod tests {
     #[test]
     fn without_everything_every_cell_is_cross_tool() {
         let preflight = PreflightResult {
-            drives: Vec::new(),
+            drives: vec![hot_drive('C', 100), hot_drive('E', 200)],
             cells: Vec::new(),
         };
         let spec = MatrixSpec {

--- a/crates/uffs-bench/src/matrix.rs
+++ b/crates/uffs-bench/src/matrix.rs
@@ -103,9 +103,13 @@ fn solo_reason(preflight: &PreflightResult, drive: char, pattern: &str) -> Strin
              — download from https://www.voidtools.com/ and re-run"
         ),
         EsStatus::DaemonNotRunning => format!(
-            "{drive}: Everything daemon not running \
-             — start Everything.exe (system tray) then re-run; \
+            "{drive}: Everything not started \
+             — launch Everything.exe (system tray) then re-run; \
              to limit indexed drives open Options → Indexes → NTFS"
+        ),
+        EsStatus::DaemonStarting => format!(
+            "{drive}: Everything is starting (process running but IPC not ready) \
+             — wait a moment then re-run"
         ),
         EsStatus::NotConfigured => format!(
             "{drive}: drive not in Everything's index \

--- a/crates/uffs-bench/src/matrix.rs
+++ b/crates/uffs-bench/src/matrix.rs
@@ -23,8 +23,10 @@ use crate::error::{BenchError, Result};
 use crate::host::Host;
 use crate::preflight::{CellFeasibility, DrivePreflight, EsStatus, PreflightResult};
 
-/// Tool id of the competitor that constrains the cross-tool matrix.
+/// Tool id of the Everything CLI (es.exe) competitor.
 pub const EVERYTHING_TOOL: &str = "everything";
+/// Tool id of the Everything GUI (Everything.exe) daemon process.
+pub const EVERYTHING_GUI_TOOL: &str = "everything_gui";
 
 /// Inputs that scope a matrix negotiation.
 #[derive(Debug, Clone, Default)]

--- a/crates/uffs-bench/src/matrix.rs
+++ b/crates/uffs-bench/src/matrix.rs
@@ -285,6 +285,26 @@ pub fn render_md(matrix: &Matrix) -> String {
     )
 }
 
+/// Render only the capable-drives line of the negotiated matrix.
+///
+/// Used before the ES launch gate where the full matrix would show only
+/// misleading UFFS-only reasons ("ES not started").  The full matrix is
+/// rendered after the second-pass preflight once ES is loaded.
+#[must_use]
+pub fn render_capable_drives(matrix: &Matrix) -> String {
+    let capable = if matrix.capable_drives.is_empty() {
+        "_none_".to_owned()
+    } else {
+        matrix
+            .capable_drives
+            .iter()
+            .map(char::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    format!("## Negotiated matrix\n\n- **Capable drives (all tools):** {capable}\n")
+}
+
 /// Serialize `matrix` to `bundle_dir/matrix.json`.
 ///
 /// # Errors

--- a/crates/uffs-bench/src/matrix.rs
+++ b/crates/uffs-bench/src/matrix.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{BenchError, Result};
 use crate::host::Host;
-use crate::preflight::{CellFeasibility, DrivePreflight, PreflightResult};
+use crate::preflight::{CellFeasibility, DrivePreflight, EsStatus, PreflightResult};
 
 /// Tool id of the competitor that constrains the cross-tool matrix.
 pub const EVERYTHING_TOOL: &str = "everything";
@@ -91,22 +91,36 @@ fn everything_serves(preflight: &PreflightResult, drive: char) -> bool {
 
 /// Explain why competitors are excluded from a `(drive, pattern)` cell.
 ///
-/// Only reached when Everything is required and the cell is not cross-tool, so
-/// the cause is one of: drive not configured, configured-but-not-ready, or the
-/// row estimate exceeding the IPC ceiling.
+/// Only reached when Everything is required and the cell is not cross-tool.
+/// Uses the fine-grained [`EsStatus`] to surface actionable operator guidance
+/// rather than a generic "not loaded" message.
 fn solo_reason(preflight: &PreflightResult, drive: char, pattern: &str) -> String {
-    match find_drive(&preflight.drives, drive) {
-        None
-        | Some(DrivePreflight {
-            configured: false, ..
-        }) => format!("{drive}: es not loaded (not configured in Everything.ini)"),
-        Some(state) if !(state.loaded && state.hot) => {
-            format!("{drive}: es not loaded (configured but still indexing)")
+    let status = find_drive(&preflight.drives, drive)
+        .map_or(&EsStatus::NotConfigured, |drive_pf| &drive_pf.es_status);
+    match status {
+        EsStatus::NotInstalled => format!(
+            "{drive}: Everything not installed \
+             — download from https://www.voidtools.com/ and re-run"
+        ),
+        EsStatus::DaemonNotRunning => format!(
+            "{drive}: Everything daemon not running \
+             — start Everything.exe (system tray) then re-run; \
+             to limit indexed drives open Options → Indexes → NTFS"
+        ),
+        EsStatus::NotConfigured => format!(
+            "{drive}: drive not in Everything's index \
+             — open Everything Options → Indexes → NTFS and add {drive}:\\"
+        ),
+        EsStatus::StillIndexing => {
+            format!("{drive}: Everything is still indexing — re-run once the tray icon settles")
         }
-        Some(_) => {
+        EsStatus::Loaded => {
             let est = find_cell(&preflight.cells, drive, pattern).map_or(0, |cell| cell.est_rows);
             let ceiling = crate::preflight::ES_IPC_ROW_CEILING;
-            format!("{pattern}: es infeasible (est {est} rows > {ceiling} IPC ceiling)")
+            format!(
+                "{pattern}: es infeasible (est {est} rows > {ceiling} IPC ceiling) \
+                 — consider limiting indexed drives in Everything Options → Indexes → NTFS"
+            )
         }
     }
 }
@@ -226,7 +240,7 @@ mod tests {
 
     use super::{Matrix, MatrixSpec, compute_matrix, render_md, write};
     use crate::host::{Call, MockHost};
-    use crate::preflight::{CellFeasibility, DrivePreflight, PreflightResult};
+    use crate::preflight::{CellFeasibility, DrivePreflight, EsStatus, PreflightResult};
 
     /// A hot, loaded, configured drive record.
     fn hot_drive(drive: char, record_count: u64) -> DrivePreflight {
@@ -236,6 +250,7 @@ mod tests {
             loaded: true,
             hot: true,
             record_count,
+            es_status: EsStatus::Loaded,
         }
     }
 
@@ -268,6 +283,7 @@ mod tests {
                 loaded: false,
                 hot: false,
                 record_count: 0,
+                es_status: EsStatus::NotConfigured,
             }],
             cells: vec![
                 cell('C', "all_dlls", 500, true),
@@ -291,14 +307,16 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!['C', 'D']
         );
-        // E/F/M/S all land in UFFS-only with an "es not loaded" reason.
+        // E/F/M/S all land in UFFS-only; E is NotConfigured, F/M/S have no
+        // DrivePreflight record at all (also maps to NotConfigured).
         let solo_drives: Vec<char> = matrix.uffs_only.iter().map(|cell| cell.drive).collect();
         assert_eq!(solo_drives, vec!['E', 'F', 'M', 'S']);
         assert!(
             matrix
                 .uffs_only
                 .iter()
-                .all(|cell| cell.reason.contains("es not loaded"))
+                .all(|cell| cell.reason.contains("Everything Options")
+                    || cell.reason.contains("not in Everything"))
         );
     }
 
@@ -332,6 +350,7 @@ mod tests {
                 loaded: false,
                 hot: false,
                 record_count: 0,
+                es_status: EsStatus::StillIndexing,
             }],
             cells: Vec::new(),
         };

--- a/crates/uffs-bench/src/matrix.rs
+++ b/crates/uffs-bench/src/matrix.rs
@@ -21,7 +21,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{BenchError, Result};
 use crate::host::Host;
-use crate::preflight::{CellFeasibility, DrivePreflight, EsStatus, PreflightResult};
+use crate::preflight::{
+    CellFeasibility, DrivePreflight, EsStatus, PreflightResult, UFFS_BYTES_PER_RECORD,
+};
 
 /// Tool id of the Everything CLI (es.exe) competitor.
 pub const EVERYTHING_TOOL: &str = "everything";
@@ -37,6 +39,12 @@ pub struct MatrixSpec {
     pub candidate_drives: Vec<char>,
     /// Pattern names to negotiate, in display order.
     pub patterns: Vec<String>,
+    /// Maximum bytes Everything may use for its in-process index.
+    ///
+    /// Drives are added greedily (smallest UFFS record count first) until the
+    /// cumulative estimated RAM would exceed this budget; any remaining drive
+    /// is excluded from cross-tool cells.  `0` means no cap (unlimited).
+    pub es_ram_budget_bytes: u64,
 }
 
 /// An apples-to-apples cell timed for every required tool.
@@ -89,6 +97,46 @@ fn find_cell<'a>(
 /// Whether Everything can serve `drive` (index loaded *and* hot).
 fn everything_serves(preflight: &PreflightResult, drive: char) -> bool {
     find_drive(&preflight.drives, drive).is_some_and(|state| state.loaded && state.hot)
+}
+
+/// Greedy RAM-budget drive selector for Everything.
+///
+/// Sorts candidate drives by UFFS record count ascending (maximize drive count
+/// within budget), then accumulates until `es_ram_budget_bytes` would be
+/// exceeded. When budget is 0 (unlimited), falls back to the `loaded && hot`
+/// check only.
+fn ram_budget_capable_drives(spec: &MatrixSpec, preflight: &PreflightResult) -> Vec<char> {
+    if spec.es_ram_budget_bytes == 0 {
+        return spec
+            .candidate_drives
+            .iter()
+            .copied()
+            .filter(|&drive| everything_serves(preflight, drive))
+            .collect();
+    }
+    let mut candidates: Vec<(char, u64)> = spec
+        .candidate_drives
+        .iter()
+        .copied()
+        .filter(|&drive| everything_serves(preflight, drive))
+        .map(|drive| {
+            let uffs_count =
+                find_drive(&preflight.drives, drive).map_or(0, |dp| dp.uffs_record_count);
+            (drive, uffs_count)
+        })
+        .collect();
+    candidates.sort_by_key(|&(_, count)| count);
+    let mut cumulative: u64 = 0;
+    let mut result = Vec::new();
+    for (drive, count) in candidates {
+        let est = count.saturating_mul(UFFS_BYTES_PER_RECORD);
+        if cumulative.saturating_add(est) <= spec.es_ram_budget_bytes {
+            cumulative = cumulative.saturating_add(est);
+            result.push(drive);
+        }
+    }
+    result.sort_unstable();
+    result
 }
 
 /// Explain why competitors are excluded from a `(drive, pattern)` cell.
@@ -144,12 +192,11 @@ pub fn compute_matrix(spec: &MatrixSpec, preflight: &PreflightResult) -> Matrix 
         .iter()
         .any(|tool| tool == EVERYTHING_TOOL);
 
-    let capable_drives: Vec<char> = spec
-        .candidate_drives
-        .iter()
-        .copied()
-        .filter(|&drive| !everything_required || everything_serves(preflight, drive))
-        .collect();
+    let capable_drives: Vec<char> = if everything_required {
+        ram_budget_capable_drives(spec, preflight)
+    } else {
+        spec.candidate_drives.clone()
+    };
 
     let mut cross_cells = Vec::new();
     let mut uffs_only = Vec::new();
@@ -256,6 +303,7 @@ mod tests {
             loaded: true,
             hot: true,
             record_count,
+            uffs_record_count: record_count,
             es_status: EsStatus::Loaded,
         }
     }
@@ -289,6 +337,7 @@ mod tests {
                 loaded: false,
                 hot: false,
                 record_count: 0,
+                uffs_record_count: 0,
                 es_status: EsStatus::NotConfigured,
             }],
             cells: vec![
@@ -300,6 +349,7 @@ mod tests {
             required_tools: three_tools(),
             candidate_drives: vec!['C', 'D', 'E', 'F', 'M', 'S'],
             patterns: vec!["all_dlls".to_owned()],
+            es_ram_budget_bytes: 0,
         };
 
         let matrix = compute_matrix(&spec, &preflight);
@@ -336,6 +386,7 @@ mod tests {
             required_tools: three_tools(),
             candidate_drives: vec!['C'],
             patterns: vec!["full_scan".to_owned()],
+            es_ram_budget_bytes: 0,
         };
 
         let matrix = compute_matrix(&spec, &preflight);
@@ -356,6 +407,7 @@ mod tests {
                 loaded: false,
                 hot: false,
                 record_count: 0,
+                uffs_record_count: 0,
                 es_status: EsStatus::StillIndexing,
             }],
             cells: Vec::new(),
@@ -364,6 +416,7 @@ mod tests {
             required_tools: three_tools(),
             candidate_drives: vec!['C'],
             patterns: vec!["all_dlls".to_owned()],
+            es_ram_budget_bytes: 0,
         };
 
         let matrix = compute_matrix(&spec, &preflight);
@@ -389,6 +442,7 @@ mod tests {
             required_tools: vec!["uffs".to_owned(), "uffs_cpp".to_owned()],
             candidate_drives: vec!['C', 'E'],
             patterns: vec!["all_dlls".to_owned()],
+            es_ram_budget_bytes: 0,
         };
 
         let matrix = compute_matrix(&spec, &preflight);

--- a/crates/uffs-bench/src/matrix.rs
+++ b/crates/uffs-bench/src/matrix.rs
@@ -101,10 +101,9 @@ fn everything_serves(preflight: &PreflightResult, drive: char) -> bool {
 
 /// Greedy RAM-budget drive selector for Everything.
 ///
-/// Sorts candidate drives by UFFS record count ascending (maximize drive count
-/// within budget), then accumulates until `es_ram_budget_bytes` would be
-/// exceeded. When budget is 0 (unlimited), falls back to the `loaded && hot`
-/// check only.
+/// Accumulates candidate drives in the order the operator specified them
+/// until `es_ram_budget_bytes` would be exceeded. When budget is 0
+/// (unlimited), falls back to the `loaded && hot` check only.
 fn ram_budget_capable_drives(spec: &MatrixSpec, preflight: &PreflightResult) -> Vec<char> {
     if spec.es_ram_budget_bytes == 0 {
         return spec
@@ -114,28 +113,19 @@ fn ram_budget_capable_drives(spec: &MatrixSpec, preflight: &PreflightResult) -> 
             .filter(|&drive| everything_serves(preflight, drive))
             .collect();
     }
-    let mut candidates: Vec<(char, u64)> = spec
-        .candidate_drives
-        .iter()
-        .copied()
-        .filter(|&drive| everything_serves(preflight, drive))
-        .map(|drive| {
-            let uffs_count =
-                find_drive(&preflight.drives, drive).map_or(0, |dp| dp.uffs_record_count);
-            (drive, uffs_count)
-        })
-        .collect();
-    candidates.sort_by_key(|&(_, count)| count);
     let mut cumulative: u64 = 0;
     let mut result = Vec::new();
-    for (drive, count) in candidates {
+    for &drive in &spec.candidate_drives {
+        if !everything_serves(preflight, drive) {
+            continue;
+        }
+        let count = find_drive(&preflight.drives, drive).map_or(0, |dp| dp.uffs_record_count);
         let est = count.saturating_mul(UFFS_BYTES_PER_RECORD);
         if cumulative.saturating_add(est) <= spec.es_ram_budget_bytes {
             cumulative = cumulative.saturating_add(est);
             result.push(drive);
         }
     }
-    result.sort_unstable();
     result
 }
 

--- a/crates/uffs-bench/src/matrix.rs
+++ b/crates/uffs-bench/src/matrix.rs
@@ -94,31 +94,20 @@ fn find_cell<'a>(
         .find(|cell| cell.drive == drive && cell.pattern == pattern)
 }
 
-/// Whether Everything can serve `drive` (index loaded *and* hot).
-fn everything_serves(preflight: &PreflightResult, drive: char) -> bool {
-    find_drive(&preflight.drives, drive).is_some_and(|state| state.loaded && state.hot)
-}
-
 /// Greedy RAM-budget drive selector for Everything.
 ///
 /// Accumulates candidate drives in the order the operator specified them
-/// until `es_ram_budget_bytes` would be exceeded. When budget is 0
-/// (unlimited), falls back to the `loaded && hot` check only.
+/// until `es_ram_budget_bytes` would be exceeded.  Whether Everything is
+/// currently running does NOT gate inclusion — a drive fits if its estimated
+/// RAM is within the budget.  When budget is 0 (unlimited), all candidate
+/// drives are included.
 fn ram_budget_capable_drives(spec: &MatrixSpec, preflight: &PreflightResult) -> Vec<char> {
     if spec.es_ram_budget_bytes == 0 {
-        return spec
-            .candidate_drives
-            .iter()
-            .copied()
-            .filter(|&drive| everything_serves(preflight, drive))
-            .collect();
+        return spec.candidate_drives.clone();
     }
     let mut cumulative: u64 = 0;
     let mut result = Vec::new();
     for &drive in &spec.candidate_drives {
-        if !everything_serves(preflight, drive) {
-            continue;
-        }
         let count = find_drive(&preflight.drives, drive).map_or(0, |dp| dp.uffs_record_count);
         let est = count.saturating_mul(UFFS_BYTES_PER_RECORD);
         if cumulative.saturating_add(est) <= spec.es_ram_budget_bytes {
@@ -318,8 +307,10 @@ mod tests {
     }
 
     #[test]
-    fn everything_only_serves_loaded_hot_drives() {
-        // Everything holds only C and D; the operator asked for C,D,E,F,M,S.
+    fn ram_budget_gates_capable_drives_not_es_running_state() {
+        // RAM budget = 0 (unlimited) → all candidate drives are capable.
+        // ES running state only gates per-cell feasibility: C and D have
+        // feasibility cells and are cross-tool; E/F/M/S have no cell → solo.
         let preflight = PreflightResult {
             drives: vec![hot_drive('C', 1000), hot_drive('D', 2000), DrivePreflight {
                 drive: 'E',
@@ -344,7 +335,9 @@ mod tests {
 
         let matrix = compute_matrix(&spec, &preflight);
 
-        assert_eq!(matrix.capable_drives, vec!['C', 'D']);
+        // Budget=0 → all candidates are capable regardless of ES running state.
+        assert_eq!(matrix.capable_drives, vec!['C', 'D', 'E', 'F', 'M', 'S']);
+        // Only C and D have feasibility cells → cross-tool.
         assert_eq!(
             matrix
                 .cross_cells
@@ -353,17 +346,9 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!['C', 'D']
         );
-        // E/F/M/S all land in UFFS-only; E is NotConfigured, F/M/S have no
-        // DrivePreflight record at all (also maps to NotConfigured).
+        // E/F/M/S: capable but no feasibility cell → UFFS-only.
         let solo_drives: Vec<char> = matrix.uffs_only.iter().map(|cell| cell.drive).collect();
         assert_eq!(solo_drives, vec!['E', 'F', 'M', 'S']);
-        assert!(
-            matrix
-                .uffs_only
-                .iter()
-                .all(|cell| cell.reason.contains("Everything Options")
-                    || cell.reason.contains("not in Everything"))
-        );
     }
 
     #[test]
@@ -389,7 +374,9 @@ mod tests {
     }
 
     #[test]
-    fn configured_but_indexing_drive_is_uffs_only() {
+    fn indexing_drive_is_capable_but_cell_is_uffs_only() {
+        // C is budget-capable (within RAM limit) but ES is still indexing →
+        // no feasibility cell → solo.  capable_drives includes C.
         let preflight = PreflightResult {
             drives: vec![DrivePreflight {
                 drive: 'C',
@@ -411,7 +398,9 @@ mod tests {
 
         let matrix = compute_matrix(&spec, &preflight);
 
-        assert!(matrix.capable_drives.is_empty());
+        // Budget=0 → C is capable.
+        assert_eq!(matrix.capable_drives, vec!['C']);
+        // No feasibility cell → ES can't serve this cell → solo.
         assert!(
             matrix
                 .uffs_only

--- a/crates/uffs-bench/src/preflight.rs
+++ b/crates/uffs-bench/src/preflight.rs
@@ -242,20 +242,50 @@ fn poll_result_count(
     0
 }
 
-/// Observe one drive's competitor state. A configured drive reporting zero is
-/// re-polled (it may still be indexing); an unconfigured drive is probed once.
-/// Count all files+dirs on `drive` via UFFS `--count` (`0` on failure).
-fn uffs_drive_count(host: &dyn Host, uffs_exe: &str, drive: char) -> u64 {
-    let root = format!("{drive}:\\");
-    host.run(uffs_exe, &[root.as_str(), "*", "--count"])
-        .ok()
-        .and_then(|out| out.stdout.trim().parse::<u64>().ok())
-        .unwrap_or(0)
+/// Parse per-drive record counts from `uffs daemon status` stdout.
+///
+/// Each loaded drive appears as a line matching:
+/// ```text
+///   [Warm]   C: —  3,409,074 records (live) — …
+/// ```
+/// The drive letter is the first ASCII-alphabetic character after the tier
+/// tag, and the record count is the comma-separated integer before the word
+/// `records`. Returns a map of uppercase drive letter → record count.
+/// Drives not present in the output (e.g. still loading) are absent from
+/// the map; callers treat a missing entry as count = 0.
+#[must_use]
+pub(crate) fn parse_daemon_status_drives(status: &str) -> alloc::collections::BTreeMap<char, u64> {
+    let mut map = alloc::collections::BTreeMap::new();
+    for line in status.lines() {
+        let trimmed = line.trim_start();
+        // Lines look like:  [Warm]   C: —  3,409,074 records (live)
+        // Skip header lines and any line that doesn't contain "records".
+        if !trimmed.contains("records") {
+            continue;
+        }
+        // Find the first alpha char after the tier tag (e.g. 'C' in 'C:').
+        let drive = trimmed.split_whitespace().find_map(|token| {
+            let ch = token.trim_end_matches(':').chars().next()?;
+            ch.is_ascii_alphabetic().then(|| ch.to_ascii_uppercase())
+        });
+        // Find the comma-separated integer immediately before "records".
+        let count = trimmed
+            .split_whitespace()
+            .zip(trimmed.split_whitespace().skip(1))
+            .find_map(|(token, next)| {
+                (next == "records").then(|| token.replace(',', "").parse::<u64>().ok())?
+            });
+        if let (Some(letter), Some(records)) = (drive, count) {
+            map.insert(letter, records);
+        }
+    }
+    map
 }
 
-/// Probe one drive's ES and UFFS state.
+/// Probe one drive's ES state.
 ///
-/// Always runs a UFFS total-count to populate `uffs_record_count`.
+/// `uffs_record_count` is sourced from the already-parsed `uffs daemon status`
+/// output (passed in by the caller) — no additional UFFS IPC call is made.
 /// Returns early with zeroed ES fields if the daemon is unavailable.
 /// Otherwise polls `es.exe -get-result-count` (with backoff for configured
 /// drives, once for unconfigured drives).
@@ -265,8 +295,8 @@ fn probe_drive(
     drive: char,
     configured: bool,
     es_available: Option<&EsStatus>,
+    uffs_record_count: u64,
 ) -> DrivePreflight {
-    let uffs_record_count = uffs_drive_count(host, &spec.uffs_exe, drive);
     if let Some(status) = es_available {
         return DrivePreflight {
             drive,
@@ -342,8 +372,9 @@ fn feasibility_cells(
 
 /// Capture a [`PreflightResult`] for the given [`PreflightSpec`].
 ///
-/// Reads `Everything.ini` (never writes it), probes each candidate drive's live
-/// record count, then estimates per-pattern feasibility for the loaded drives.
+/// Reads `Everything.ini` (never writes it), fetches drive record counts from
+/// `uffs daemon status` in a single call, probes each candidate drive's ES
+/// state, then estimates per-pattern feasibility for the loaded drives.
 #[must_use]
 pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
     let ini = host
@@ -354,16 +385,21 @@ pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
 
     let es_available = check_es_available(host, &spec.es_exe);
 
+    let status = daemon_status_output(host, &spec.uffs_exe);
+    let uffs_counts = parse_daemon_status_drives(&status);
+
     let drives: Vec<DrivePreflight> = spec
         .candidate_drives
         .iter()
         .map(|&drive| {
+            let uffs_record_count = uffs_counts.get(&drive).copied().unwrap_or(0);
             probe_drive(
                 host,
                 spec,
                 drive,
                 configured_drives.contains(&drive),
                 es_available.as_ref(),
+                uffs_record_count,
             )
         })
         .collect();
@@ -372,9 +408,16 @@ pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
     PreflightResult { drives, cells }
 }
 
+/// Run `uffs daemon status` once and return the raw stdout (`""` on failure).
+fn daemon_status_output(host: &dyn Host, uffs_exe: &str) -> String {
+    host.run(uffs_exe, &["daemon", "status"])
+        .map(|out| out.stdout)
+        .unwrap_or_default()
+}
+
 /// Render a GFM drive-status table for display before the matrix.
 ///
-/// Columns: Drive | UFFS records | Est. RAM | ES status | ES capable
+/// Columns: Drive | UFFS records | Est. RAM | ES index  | ES capable
 /// "ES capable" uses the same RAM-budget logic as `matrix::compute_matrix` to
 /// show which drives would be included in cross-tool cells.
 #[must_use]
@@ -382,7 +425,7 @@ pub fn render_drive_table(result: &PreflightResult, es_ram_budget_bytes: u64) ->
     if result.drives.is_empty() {
         return String::new();
     }
-    let header = "| Drive | UFFS records | Est. RAM | ES status | ES capable |";
+    let header = "| Drive | UFFS records | Est. RAM | ES index  | ES capable |";
     let sep = "|-------|-------------|----------|-----------|------------|";
 
     let mut cumulative_bytes: u64 = 0;
@@ -476,7 +519,7 @@ mod tests {
 
     use super::{
         CellFeasibility, DrivePreflight, EsStatus, PatternProbe, PreflightResult, PreflightSpec,
-        capture, parse_drives_from_ini, write,
+        capture, parse_daemon_status_drives, parse_drives_from_ini, write,
     };
     use crate::host::{Call, MockHost, ProcOutput};
 
@@ -551,18 +594,39 @@ mod tests {
         assert_eq!(parse_drives_from_ini("a=1\nb=2\n"), Vec::<char>::new());
     }
 
+    /// Fake `uffs daemon status` output with C (3 M records) and D (7 M
+    /// records).
+    fn daemon_status_cd() -> &'static str {
+        "Version:       0.0.0\n\
+         Status:        Ready\n\
+         Drives:\n\
+           [Warm]   C: —  3,000,000 records (live) — 600 MB\n\
+           [Warm]   D: —  7,000,000 records (live) — 1400 MB\n"
+    }
+
+    #[test]
+    fn parse_daemon_status_drives_extracts_counts() {
+        let map = parse_daemon_status_drives(daemon_status_cd());
+        assert_eq!(map.get(&'C').copied(), Some(3_000_000));
+        assert_eq!(map.get(&'D').copied(), Some(7_000_000));
+        assert_eq!(map.get(&'E'), None);
+    }
+
     #[test]
     fn capture_is_read_only_and_records_state() {
-        // Call order: es availability (1), then per-drive: uffs count (1) +
-        // es result-count poll (1), then feasibility for loaded C (1).
+        // Call order:
+        //  1. check_es_available: es -get-everything-version (daemon running)
+        //  2. daemon_status_output: uffs daemon status (record counts)
+        //  3. C: es result-count poll → loaded
+        //  4. D: es result-count poll → not loaded
+        //  5. feasibility estimate for (C, all_dlls)
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\,D:\\".to_vec())
-            .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
-            .with_run_result(stdout_of("3000000")) // C: uffs count
-            .with_run_result(stdout_of("1000"))    // C: es result-count → loaded
-            .with_run_result(stdout_of("7000000")) // D: uffs count
-            .with_run_result(stdout_of("0"))       // D: es result-count → not loaded
-            .with_run_result(stdout_of("5000")); // uffs estimate for (C, all_dlls)
+            .with_run_result(stdout_of("1.4.1.1032"))       // 1: es availability
+            .with_run_result(stdout_of(daemon_status_cd())) // 2: uffs daemon status
+            .with_run_result(stdout_of("1000"))             // 3: C es result-count
+            .with_run_result(stdout_of("0"))                // 4: D es result-count
+            .with_run_result(stdout_of("5000")); // 5: uffs estimate C/all_dlls
         let spec = spec_for(&['C', 'D'], 1);
 
         let result = capture(&host, &spec);
@@ -604,11 +668,13 @@ mod tests {
     fn configured_zero_drive_is_polled_with_backoff() {
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
-            .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
-            .with_run_result(stdout_of("500000"))     // C: uffs count
-            .with_run_result(stdout_of("0"))          // C: es poll 1
-            .with_run_result(stdout_of("0"))          // C: es poll 2
-            .with_run_result(stdout_of("7")); // C: es poll 3 → loaded
+            .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
+            .with_run_result(stdout_of(                  // 2: uffs daemon status
+                "Status: Ready\n  [Warm]   C: —  500,000 records (live) — 50 MB\n"
+            ))
+            .with_run_result(stdout_of("0"))             // 3: C es poll 1
+            .with_run_result(stdout_of("0"))             // 4: C es poll 2
+            .with_run_result(stdout_of("7")); // 5: C es poll 3 → loaded
         let mut spec = spec_for(&['C'], 3);
         spec.patterns.clear();
 
@@ -630,9 +696,11 @@ mod tests {
     fn unconfigured_drive_probed_once_without_sleep() {
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
-            .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
-            .with_run_result(stdout_of("100000"))     // E: uffs count
-            .with_run_result(stdout_of("0")); // E: es result-count → not loaded
+            .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
+            .with_run_result(stdout_of(                  // 2: uffs daemon status (E absent)
+                "Status: Ready\n  [Warm]   C: —  100,000 records (live) — 10 MB\n"
+            ))
+            .with_run_result(stdout_of("0")); // 3: E es result-count → not loaded
         let mut spec = spec_for(&['E'], 5);
         spec.patterns.clear();
 
@@ -642,12 +710,17 @@ mod tests {
             result.drives.first().map(|drive| drive.configured),
             Some(false)
         );
+        // E is absent from daemon status → uffs_record_count = 0.
+        assert_eq!(
+            result.drives.first().map(|drive| drive.uffs_record_count),
+            Some(0)
+        );
         let runs = host
             .calls()
             .into_iter()
             .filter(|call| matches!(call, Call::Run(_, _)))
             .count();
-        assert_eq!(runs, 3); // 1 availability check + 1 uffs count + 1 es probe
+        assert_eq!(runs, 3); // 1 availability check + 1 daemon status + 1 es probe
         assert!(
             !host
                 .calls()
@@ -660,10 +733,12 @@ mod tests {
     fn cell_above_ipc_ceiling_is_infeasible() {
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
-            .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
-            .with_run_result(stdout_of("500000"))     // C: uffs count
-            .with_run_result(stdout_of("100"))        // C: es result-count → loaded
-            .with_run_result(stdout_of("200000")); // estimate over the 150k ceiling
+            .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
+            .with_run_result(stdout_of(                  // 2: uffs daemon status
+                "Status: Ready\n  [Warm]   C: —  500,000 records (live) — 50 MB\n"
+            ))
+            .with_run_result(stdout_of("100"))           // 3: C es result-count → loaded
+            .with_run_result(stdout_of("200000")); // 4: estimate over the 150k ceiling
         let spec = spec_for(&['C'], 1);
 
         let result = capture(&host, &spec);

--- a/crates/uffs-bench/src/preflight.rs
+++ b/crates/uffs-bench/src/preflight.rs
@@ -53,6 +53,12 @@ pub enum EsStatus {
 /// is flagged and run UFFS-only. Lifted from the capacity probe's findings.
 pub const ES_IPC_ROW_CEILING: u64 = 150_000;
 
+/// Approximate bytes Everything's in-process index consumes per indexed record.
+///
+/// Source: voidtools forum ("~100 MB per 1 M files").
+/// Used to estimate how much RAM Everything needs to index a drive.
+pub const UFFS_BYTES_PER_RECORD: u64 = 100;
+
 /// A pattern whose per-drive result size is estimated via UFFS.
 ///
 /// `args` are passed to the UFFS binary; the literal token `{DRIVE}` is
@@ -83,6 +89,13 @@ pub struct PreflightSpec {
     pub poll_attempts: u32,
     /// Delay between readiness-poll attempts, in milliseconds.
     pub poll_interval_ms: u64,
+    /// Maximum bytes Everything may use for its in-process index.
+    ///
+    /// Drives are added greedily (smallest first) until this budget is
+    /// exhausted; any drive that would overflow it is excluded from the
+    /// cross-tool capable set.  Defaults to 0 (no cap = any drive is capable
+    /// regardless of size) when not set by the caller.
+    pub es_ram_budget_bytes: u64,
 }
 
 /// Per-drive competitor state observed during preflight.
@@ -99,6 +112,11 @@ pub struct DrivePreflight {
     pub hot: bool,
     /// Live record count reported by `es.exe` (`0` when not loaded).
     pub record_count: u64,
+    /// Total file+dir count from UFFS (always populated, ES-independent).
+    ///
+    /// Used to estimate how much RAM Everything would need to index this drive
+    /// (`uffs_record_count × UFFS_BYTES_PER_RECORD`).  `0` when UFFS failed.
+    pub uffs_record_count: u64,
     /// Fine-grained reason why `es.exe` could not serve this drive (if any).
     pub es_status: EsStatus,
 }
@@ -226,6 +244,21 @@ fn poll_result_count(
 
 /// Observe one drive's competitor state. A configured drive reporting zero is
 /// re-polled (it may still be indexing); an unconfigured drive is probed once.
+/// Count all files+dirs on `drive` via UFFS `--count` (`0` on failure).
+fn uffs_drive_count(host: &dyn Host, uffs_exe: &str, drive: char) -> u64 {
+    let root = format!("{drive}:\\");
+    host.run(uffs_exe, &[root.as_str(), "*", "--count"])
+        .ok()
+        .and_then(|out| out.stdout.trim().parse::<u64>().ok())
+        .unwrap_or(0)
+}
+
+/// Probe one drive's ES and UFFS state.
+///
+/// Always runs a UFFS total-count to populate `uffs_record_count`.
+/// Returns early with zeroed ES fields if the daemon is unavailable.
+/// Otherwise polls `es.exe -get-result-count` (with backoff for configured
+/// drives, once for unconfigured drives).
 fn probe_drive(
     host: &dyn Host,
     spec: &PreflightSpec,
@@ -233,6 +266,7 @@ fn probe_drive(
     configured: bool,
     es_available: Option<&EsStatus>,
 ) -> DrivePreflight {
+    let uffs_record_count = uffs_drive_count(host, &spec.uffs_exe, drive);
     if let Some(status) = es_available {
         return DrivePreflight {
             drive,
@@ -240,6 +274,7 @@ fn probe_drive(
             loaded: false,
             hot: false,
             record_count: 0,
+            uffs_record_count,
             es_status: status.clone(),
         };
     }
@@ -264,6 +299,7 @@ fn probe_drive(
         loaded,
         hot: loaded,
         record_count,
+        uffs_record_count,
         es_status,
     }
 }
@@ -336,6 +372,92 @@ pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
     PreflightResult { drives, cells }
 }
 
+/// Render a GFM drive-status table for display before the matrix.
+///
+/// Columns: Drive | UFFS records | Est. RAM | ES status | ES capable
+/// "ES capable" uses the same RAM-budget logic as [`compute_matrix`] to show
+/// which drives would be included in cross-tool cells.
+#[must_use]
+pub fn render_drive_table(result: &PreflightResult, es_ram_budget_bytes: u64) -> String {
+    if result.drives.is_empty() {
+        return String::new();
+    }
+    let header = "| Drive | UFFS records | Est. RAM | ES status | ES capable |";
+    let sep = "|-------|-------------|----------|-----------|------------|";
+
+    let mut cumulative_bytes: u64 = 0;
+    let mut sorted_drives: Vec<&DrivePreflight> = result.drives.iter().collect();
+    sorted_drives.sort_by_key(|dp| dp.uffs_record_count);
+    let mut budget_capable: alloc::collections::BTreeSet<char> =
+        alloc::collections::BTreeSet::new();
+    for dp in &sorted_drives {
+        let est = dp.uffs_record_count.saturating_mul(UFFS_BYTES_PER_RECORD);
+        if es_ram_budget_bytes == 0 || cumulative_bytes.saturating_add(est) <= es_ram_budget_bytes {
+            cumulative_bytes = cumulative_bytes.saturating_add(est);
+            budget_capable.insert(dp.drive);
+        }
+    }
+
+    let rows: Vec<String> = result
+        .drives
+        .iter()
+        .map(|dp| {
+            let records = fmt_count(dp.uffs_record_count);
+            let est_ram = fmt_ram(dp.uffs_record_count.saturating_mul(UFFS_BYTES_PER_RECORD));
+            let es_status = match dp.es_status {
+                EsStatus::Loaded => "loaded",
+                EsStatus::NotInstalled => "not installed",
+                EsStatus::DaemonNotRunning => "not running",
+                EsStatus::DaemonStarting => "starting",
+                EsStatus::StillIndexing => "indexing",
+                EsStatus::NotConfigured => "not configured",
+            };
+            let capable = if budget_capable.contains(&dp.drive) {
+                "✓"
+            } else {
+                "✗ over budget"
+            };
+            format!(
+                "| {drive}     | {records:>12} | {est_ram:>8} | {es_status:<9} | {capable:<10} |",
+                drive = dp.drive
+            )
+        })
+        .collect();
+
+    format!(
+        "### Drive inventory\n\n{header}\n{sep}\n{}\n",
+        rows.join("\n")
+    )
+}
+
+/// Format a record count with thousands separators (e.g. `3,408,843`).
+fn fmt_count(n: u64) -> String {
+    let digits = n.to_string();
+    let mut out = String::new();
+    for (idx, ch) in digits.chars().rev().enumerate() {
+        if idx > 0 && idx % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out.chars().rev().collect()
+}
+
+/// Format bytes as `"<whole>.<tenth> GiB"` or `"<whole> MiB"` using integer
+/// math only — no floating-point arithmetic.
+fn fmt_ram(bytes: u64) -> String {
+    const MIB: u64 = 1024 * 1024;
+    const GIB: u64 = 1024 * MIB;
+    if bytes >= GIB {
+        let whole = bytes / GIB;
+        let tenth = (bytes % GIB) * 10 / GIB;
+        format!("{whole}.{tenth} GiB")
+    } else {
+        let mib = bytes / MIB;
+        format!("{mib} MiB")
+    }
+}
+
 /// Serialize `result` to `bundle_dir/competitor-preflight.json`.
 ///
 /// # Errors
@@ -384,6 +506,7 @@ mod tests {
             }],
             poll_attempts: attempts,
             poll_interval_ms: 500,
+            es_ram_budget_bytes: 0,
         }
     }
 
@@ -430,11 +553,15 @@ mod tests {
 
     #[test]
     fn capture_is_read_only_and_records_state() {
+        // Call order: es availability (1), then per-drive: uffs count (1) +
+        // es result-count poll (1), then feasibility for loaded C (1).
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\,D:\\".to_vec())
             .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
-            .with_run_result(stdout_of("1000")) // C: loaded
-            .with_run_result(stdout_of("0")) // D: configured but not loaded
+            .with_run_result(stdout_of("3000000")) // C: uffs count
+            .with_run_result(stdout_of("1000"))    // C: es result-count → loaded
+            .with_run_result(stdout_of("7000000")) // D: uffs count
+            .with_run_result(stdout_of("0"))       // D: es result-count → not loaded
             .with_run_result(stdout_of("5000")); // uffs estimate for (C, all_dlls)
         let spec = spec_for(&['C', 'D'], 1);
 
@@ -447,6 +574,7 @@ mod tests {
                 loaded: true,
                 hot: true,
                 record_count: 1000,
+                uffs_record_count: 3_000_000,
                 es_status: EsStatus::Loaded,
             },
             DrivePreflight {
@@ -455,6 +583,7 @@ mod tests {
                 loaded: false,
                 hot: false,
                 record_count: 0,
+                uffs_record_count: 7_000_000,
                 es_status: EsStatus::StillIndexing,
             },
         ]);
@@ -476,9 +605,10 @@ mod tests {
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
             .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
-            .with_run_result(stdout_of("0"))
-            .with_run_result(stdout_of("0"))
-            .with_run_result(stdout_of("7"));
+            .with_run_result(stdout_of("500000"))     // C: uffs count
+            .with_run_result(stdout_of("0"))          // C: es poll 1
+            .with_run_result(stdout_of("0"))          // C: es poll 2
+            .with_run_result(stdout_of("7")); // C: es poll 3 → loaded
         let mut spec = spec_for(&['C'], 3);
         spec.patterns.clear();
 
@@ -501,7 +631,8 @@ mod tests {
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
             .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
-            .with_run_result(stdout_of("0"));
+            .with_run_result(stdout_of("100000"))     // E: uffs count
+            .with_run_result(stdout_of("0")); // E: es result-count → not loaded
         let mut spec = spec_for(&['E'], 5);
         spec.patterns.clear();
 
@@ -516,7 +647,7 @@ mod tests {
             .into_iter()
             .filter(|call| matches!(call, Call::Run(_, _)))
             .count();
-        assert_eq!(runs, 2); // 1 availability check + 1 drive probe
+        assert_eq!(runs, 3); // 1 availability check + 1 uffs count + 1 es probe
         assert!(
             !host
                 .calls()
@@ -530,7 +661,8 @@ mod tests {
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
             .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
-            .with_run_result(stdout_of("100")) // C loaded
+            .with_run_result(stdout_of("500000"))     // C: uffs count
+            .with_run_result(stdout_of("100"))        // C: es result-count → loaded
             .with_run_result(stdout_of("200000")); // estimate over the 150k ceiling
         let spec = spec_for(&['C'], 1);
 
@@ -552,6 +684,7 @@ mod tests {
                 loaded: true,
                 hot: true,
                 record_count: 42,
+                uffs_record_count: 1_000_000,
                 es_status: EsStatus::Loaded,
             }],
             cells: Vec::new(),

--- a/crates/uffs-bench/src/preflight.rs
+++ b/crates/uffs-bench/src/preflight.rs
@@ -22,6 +22,27 @@ use serde::{Deserialize, Serialize};
 use crate::error::{BenchError, Result};
 use crate::host::Host;
 
+/// Why `es.exe` could not serve results for a drive.
+///
+/// Distinguishing these states lets the Stage 0 plan gate surface concrete
+/// operator instructions rather than a generic "not loaded" message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EsStatus {
+    /// `es.exe` binary not found: Everything (engine + CLI) is not installed.
+    NotInstalled,
+    /// `es.exe` found but reports IPC error 8 — the Everything daemon is
+    /// installed but not currently running.
+    DaemonNotRunning,
+    /// Everything is running and the drive is in `ntfs_volume_paths`, but the
+    /// index is still being built (result-count poll returned 0).
+    StillIndexing,
+    /// Everything is running and has a non-zero result count for this drive.
+    Loaded,
+    /// This drive is not in Everything's `ntfs_volume_paths` at all.
+    NotConfigured,
+}
+
 /// Everything's practical IPC row ceiling for a single cross-tool cell.
 ///
 /// Everything serves results over IPC (`-export-csv` tops out near ~2 GB);
@@ -75,6 +96,8 @@ pub struct DrivePreflight {
     pub hot: bool,
     /// Live record count reported by `es.exe` (`0` when not loaded).
     pub record_count: u64,
+    /// Fine-grained reason why `es.exe` could not serve this drive (if any).
+    pub es_status: EsStatus,
 }
 
 /// Per-(drive, pattern) feasibility against the IPC ceiling.
@@ -122,8 +145,27 @@ pub fn parse_drives_from_ini(ini: &str) -> Vec<char> {
     Vec::new()
 }
 
-/// Poll `es.exe "<drive>:\" -get-result-count`, returning the first non-zero
+/// Check whether `es.exe` is reachable and the Everything daemon is running.
+///
+/// Returns `None` when the binary executes but no IPC error is detected (daemon
+/// is running). Returns `Some(EsStatus)` when the binary is missing entirely or
+/// the daemon is not running (IPC error 8 in stderr).
+fn check_es_available(host: &dyn Host, es_exe: &str) -> Option<EsStatus> {
+    match host.run(es_exe, &["-get-everything-version"]) {
+        Err(_) => Some(EsStatus::NotInstalled),
+        Ok(out) => {
+            let combined = format!("{} {}", out.stdout, out.stderr);
+            (combined.contains("Error 8") || combined.contains("IPC window not found"))
+                .then_some(EsStatus::DaemonNotRunning)
+        }
+    }
+}
+
+/// Poll `es.exe <drive>: -get-result-count`, returning the first non-zero
 /// count within `attempts` (sleeping `interval_ms` between tries), else `0`.
+///
+/// Uses `"C:"` (no trailing backslash) as the drive scope, which matches
+/// `everything_capacity_probe.rs`'s L1+ convention.
 fn poll_result_count(
     host: &dyn Host,
     es_exe: &str,
@@ -131,7 +173,7 @@ fn poll_result_count(
     attempts: u32,
     interval_ms: u64,
 ) -> u64 {
-    let search = format!("{drive}:\\");
+    let search = format!("{drive}:");
     for attempt in 0..attempts {
         if attempt > 0 {
             host.sleep_ms(interval_ms);
@@ -155,7 +197,18 @@ fn probe_drive(
     spec: &PreflightSpec,
     drive: char,
     configured: bool,
+    es_available: Option<&EsStatus>,
 ) -> DrivePreflight {
+    if let Some(status) = es_available {
+        return DrivePreflight {
+            drive,
+            configured,
+            loaded: false,
+            hot: false,
+            record_count: 0,
+            es_status: status.clone(),
+        };
+    }
     let attempts = if configured {
         spec.poll_attempts.max(1)
     } else {
@@ -164,12 +217,20 @@ fn probe_drive(
     let record_count =
         poll_result_count(host, &spec.es_exe, drive, attempts, spec.poll_interval_ms);
     let loaded = record_count > 0;
+    let es_status = if loaded {
+        EsStatus::Loaded
+    } else if configured {
+        EsStatus::StillIndexing
+    } else {
+        EsStatus::NotConfigured
+    };
     DrivePreflight {
         drive,
         configured,
         loaded,
         hot: loaded,
         record_count,
+        es_status,
     }
 }
 
@@ -221,10 +282,20 @@ pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
         .unwrap_or_default();
     let configured_drives = parse_drives_from_ini(&ini);
 
+    let es_available = check_es_available(host, &spec.es_exe);
+
     let drives: Vec<DrivePreflight> = spec
         .candidate_drives
         .iter()
-        .map(|&drive| probe_drive(host, spec, drive, configured_drives.contains(&drive)))
+        .map(|&drive| {
+            probe_drive(
+                host,
+                spec,
+                drive,
+                configured_drives.contains(&drive),
+                es_available.as_ref(),
+            )
+        })
         .collect();
 
     let cells = feasibility_cells(host, spec, &drives);
@@ -248,8 +319,8 @@ mod tests {
     use std::path::PathBuf;
 
     use super::{
-        CellFeasibility, DrivePreflight, PatternProbe, PreflightResult, PreflightSpec, capture,
-        parse_drives_from_ini, write,
+        CellFeasibility, DrivePreflight, EsStatus, PatternProbe, PreflightResult, PreflightSpec,
+        capture, parse_drives_from_ini, write,
     };
     use crate::host::{Call, MockHost, ProcOutput};
 
@@ -297,6 +368,7 @@ mod tests {
     fn capture_is_read_only_and_records_state() {
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\,D:\\".to_vec())
+            .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
             .with_run_result(stdout_of("1000")) // C: loaded
             .with_run_result(stdout_of("0")) // D: configured but not loaded
             .with_run_result(stdout_of("5000")); // uffs estimate for (C, all_dlls)
@@ -311,6 +383,7 @@ mod tests {
                 loaded: true,
                 hot: true,
                 record_count: 1000,
+                es_status: EsStatus::Loaded,
             },
             DrivePreflight {
                 drive: 'D',
@@ -318,6 +391,7 @@ mod tests {
                 loaded: false,
                 hot: false,
                 record_count: 0,
+                es_status: EsStatus::StillIndexing,
             },
         ]);
         assert_eq!(result.cells, vec![CellFeasibility {
@@ -337,6 +411,7 @@ mod tests {
     fn configured_zero_drive_is_polled_with_backoff() {
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
+            .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
             .with_run_result(stdout_of("0"))
             .with_run_result(stdout_of("0"))
             .with_run_result(stdout_of("7"));
@@ -361,6 +436,7 @@ mod tests {
     fn unconfigured_drive_probed_once_without_sleep() {
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
+            .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
             .with_run_result(stdout_of("0"));
         let mut spec = spec_for(&['E'], 5);
         spec.patterns.clear();
@@ -376,7 +452,7 @@ mod tests {
             .into_iter()
             .filter(|call| matches!(call, Call::Run(_, _)))
             .count();
-        assert_eq!(runs, 1);
+        assert_eq!(runs, 2); // 1 availability check + 1 drive probe
         assert!(
             !host
                 .calls()
@@ -389,6 +465,7 @@ mod tests {
     fn cell_above_ipc_ceiling_is_infeasible() {
         let host = MockHost::new()
             .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
+            .with_run_result(stdout_of("1.4.1.1032")) // check_es_available: daemon running
             .with_run_result(stdout_of("100")) // C loaded
             .with_run_result(stdout_of("200000")); // estimate over the 150k ceiling
         let spec = spec_for(&['C'], 1);
@@ -411,6 +488,7 @@ mod tests {
                 loaded: true,
                 hot: true,
                 record_count: 42,
+                es_status: EsStatus::Loaded,
             }],
             cells: Vec::new(),
         };

--- a/crates/uffs-bench/src/preflight.rs
+++ b/crates/uffs-bench/src/preflight.rs
@@ -375,8 +375,8 @@ pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
 /// Render a GFM drive-status table for display before the matrix.
 ///
 /// Columns: Drive | UFFS records | Est. RAM | ES status | ES capable
-/// "ES capable" uses the same RAM-budget logic as [`compute_matrix`] to show
-/// which drives would be included in cross-tool cells.
+/// "ES capable" uses the same RAM-budget logic as `matrix::compute_matrix` to
+/// show which drives would be included in cross-tool cells.
 #[must_use]
 pub fn render_drive_table(result: &PreflightResult, es_ram_budget_bytes: u64) -> String {
     if result.drives.is_empty() {

--- a/crates/uffs-bench/src/preflight.rs
+++ b/crates/uffs-bench/src/preflight.rs
@@ -31,9 +31,12 @@ use crate::host::Host;
 pub enum EsStatus {
     /// `es.exe` binary not found: Everything (engine + CLI) is not installed.
     NotInstalled,
-    /// `es.exe` found but reports IPC error 8 — the Everything daemon is
-    /// installed but not currently running.
+    /// `es.exe` found but reports IPC error 8 and `Everything.exe` is not
+    /// in the process list — the daemon is installed but not started.
     DaemonNotRunning,
+    /// `es.exe` found, IPC error 8 detected, but `Everything.exe` is already
+    /// in the process list — started but IPC not yet ready (still loading).
+    DaemonStarting,
     /// Everything is running and the drive is in `ntfs_volume_paths`, but the
     /// index is still being built (result-count poll returned 0).
     StillIndexing,
@@ -148,16 +151,47 @@ pub fn parse_drives_from_ini(ini: &str) -> Vec<char> {
 /// Check whether `es.exe` is reachable and the Everything daemon is running.
 ///
 /// Returns `None` when the binary executes but no IPC error is detected (daemon
-/// is running). Returns `Some(EsStatus)` when the binary is missing entirely or
-/// the daemon is not running (IPC error 8 in stderr).
+/// is running). Returns `Some(EsStatus)` with a fine-grained status otherwise:
+/// - `NotInstalled` — binary could not be spawned at all.
+/// - `DaemonStarting` — IPC error but `Everything.exe` is in the process list
+///   (started but not yet ready).
+/// - `DaemonNotRunning` — IPC error and `Everything.exe` is not running at all.
 fn check_es_available(host: &dyn Host, es_exe: &str) -> Option<EsStatus> {
     match host.run(es_exe, &["-get-everything-version"]) {
         Err(_) => Some(EsStatus::NotInstalled),
         Ok(out) => {
             let combined = format!("{} {}", out.stdout, out.stderr);
-            (combined.contains("Error 8") || combined.contains("IPC window not found"))
-                .then_some(EsStatus::DaemonNotRunning)
+            (combined.contains("Error 8") || combined.contains("IPC window not found")).then(|| {
+                if is_everything_process_running(host) {
+                    EsStatus::DaemonStarting
+                } else {
+                    EsStatus::DaemonNotRunning
+                }
+            })
         }
+    }
+}
+
+/// Return `true` when `Everything.exe` appears in the running process list.
+///
+/// Uses `tasklist` on Windows (always available) and `pgrep` on Unix.
+/// Returns `false` on any execution failure — conservative default.
+fn is_everything_process_running(host: &dyn Host) -> bool {
+    #[cfg(windows)]
+    {
+        host.run("tasklist", &[
+            "/FI",
+            "IMAGENAME eq Everything.exe",
+            "/NH",
+            "/FO",
+            "CSV",
+        ])
+        .is_ok_and(|out| out.stdout.contains("Everything.exe"))
+    }
+    #[cfg(not(windows))]
+    {
+        host.run("pgrep", &["-x", "Everything"])
+            .is_ok_and(|out| !out.stdout.trim().is_empty())
     }
 }
 
@@ -351,6 +385,36 @@ mod tests {
             poll_attempts: attempts,
             poll_interval_ms: 500,
         }
+    }
+
+    /// Build an IPC-error output (what es.exe returns when Everything is not
+    /// running or not yet ready).
+    fn ipc_error_output() -> ProcOutput {
+        ProcOutput {
+            code: Some(1_i32),
+            stdout: "Error 8: Everything IPC window not found. \
+                     Please make sure Everything is running."
+                .to_owned(),
+            stderr: String::new(),
+        }
+    }
+
+    #[test]
+    fn check_es_daemon_not_running_when_process_absent() {
+        let host = MockHost::new()
+            .with_run_result(ipc_error_output()) // es.exe -get-everything-version
+            .with_run_result(stdout_of("")); // tasklist / pgrep: process NOT found
+        let status = super::check_es_available(&host, "es.exe");
+        assert_eq!(status, Some(EsStatus::DaemonNotRunning));
+    }
+
+    #[test]
+    fn check_es_daemon_starting_when_process_present() {
+        let host = MockHost::new()
+            .with_run_result(ipc_error_output()) // es.exe -get-everything-version
+            .with_run_result(stdout_of("\"Everything.exe\",\"1234\"")); // tasklist: found
+        let status = super::check_es_available(&host, "es.exe");
+        assert_eq!(status, Some(EsStatus::DaemonStarting));
     }
 
     #[test]

--- a/crates/uffs-bench/src/preflight/mod.rs
+++ b/crates/uffs-bench/src/preflight/mod.rs
@@ -59,6 +59,13 @@ pub const ES_IPC_ROW_CEILING: u64 = 150_000;
 /// Used to estimate how much RAM Everything needs to index a drive.
 pub const UFFS_BYTES_PER_RECORD: u64 = 100;
 
+/// Maximum RAM Everything can use for its in-process index before it OOMs.
+///
+/// Empirically determined: C (325 MiB) + D (673 MiB) = 998 MiB succeeds;
+/// adding E (279 MiB) → 1,277 MiB causes an out-of-memory crash.
+/// 1 GiB is used as a conservative safe ceiling.
+pub const ES_RAM_BUDGET_BYTES: u64 = 1_073_741_824; // 1 GiB
+
 /// A pattern whose per-drive result size is estimated via UFFS.
 ///
 /// `args` are passed to the UFFS binary; the literal token `{DRIVE}` is
@@ -456,29 +463,29 @@ fn warm_parked_drives(
     }
 }
 
-/// Render a GFM drive-status table for display before the matrix.
+/// Render a GFM ES RAM budget table for display before the matrix.
 ///
-/// Columns: Drive | UFFS records | Est. RAM | ES index  | ES capable
-/// "ES capable" uses the same RAM-budget logic as `matrix::compute_matrix` to
-/// show which drives would be included in cross-tool cells.
+/// Columns: Drive | UFFS records | Est. RAM | ES index | Fits budget
+/// Drives are greedily accepted smallest-first until `es_ram_budget_bytes`
+/// would be exceeded.  A footer shows the total RAM of fitting drives vs the
+/// budget cap.
 #[must_use]
 pub fn render_drive_table(result: &PreflightResult, es_ram_budget_bytes: u64) -> String {
     if result.drives.is_empty() {
         return String::new();
     }
-    let header = "| Drive | UFFS records | Est. RAM | ES index  | ES capable |";
-    let sep = "|-------|-------------|----------|-----------|------------|";
+    let header = "| Drive | UFFS records | Est. RAM | ES index  | Fits budget |";
+    let sep = "|-------|-------------|----------|-----------|-------------|";
 
     let mut cumulative_bytes: u64 = 0;
     let mut sorted_drives: Vec<&DrivePreflight> = result.drives.iter().collect();
     sorted_drives.sort_by_key(|dp| dp.uffs_record_count);
-    let mut budget_capable: alloc::collections::BTreeSet<char> =
-        alloc::collections::BTreeSet::new();
+    let mut budget_fits: alloc::collections::BTreeSet<char> = alloc::collections::BTreeSet::new();
     for dp in &sorted_drives {
         let est = dp.uffs_record_count.saturating_mul(UFFS_BYTES_PER_RECORD);
         if es_ram_budget_bytes == 0 || cumulative_bytes.saturating_add(est) <= es_ram_budget_bytes {
             cumulative_bytes = cumulative_bytes.saturating_add(est);
-            budget_capable.insert(dp.drive);
+            budget_fits.insert(dp.drive);
         }
     }
 
@@ -488,7 +495,7 @@ pub fn render_drive_table(result: &PreflightResult, es_ram_budget_bytes: u64) ->
         .map(|dp| {
             let records = fmt_count(dp.uffs_record_count);
             let est_ram = fmt_ram(dp.uffs_record_count.saturating_mul(UFFS_BYTES_PER_RECORD));
-            let es_status = match dp.es_status {
+            let es_index = match dp.es_status {
                 EsStatus::Loaded => "loaded",
                 EsStatus::NotInstalled => "not installed",
                 EsStatus::DaemonNotRunning => "not running",
@@ -496,20 +503,31 @@ pub fn render_drive_table(result: &PreflightResult, es_ram_budget_bytes: u64) ->
                 EsStatus::StillIndexing => "indexing",
                 EsStatus::NotConfigured => "not configured",
             };
-            let capable = if budget_capable.contains(&dp.drive) {
+            let fits = if budget_fits.contains(&dp.drive) {
                 "✓"
             } else {
                 "✗ over budget"
             };
             format!(
-                "| {drive}     | {records:>12} | {est_ram:>8} | {es_status:<9} | {capable:<10} |",
+                "| {drive}     | {records:>12} | {est_ram:>8} | {es_index:<9} | {fits:<11} |",
                 drive = dp.drive
             )
         })
         .collect();
 
+    let budget_summary = if es_ram_budget_bytes > 0 {
+        format!(
+            "\n> ES RAM budget: {} used of {} cap ({} drive(s) fit)",
+            fmt_ram(cumulative_bytes),
+            fmt_ram(es_ram_budget_bytes),
+            budget_fits.len()
+        )
+    } else {
+        String::new()
+    };
+
     format!(
-        "### Drive inventory\n\n{header}\n{sep}\n{}\n",
+        "### ES RAM budget\n\n{header}\n{sep}\n{}\n{budget_summary}\n",
         rows.join("\n")
     )
 }

--- a/crates/uffs-bench/src/preflight/mod.rs
+++ b/crates/uffs-bench/src/preflight/mod.rs
@@ -466,9 +466,9 @@ fn warm_parked_drives(
 /// Render a GFM ES RAM budget table for display before the matrix.
 ///
 /// Columns: Drive | UFFS records | Est. RAM | ES index | Fits budget
-/// Drives are greedily accepted smallest-first until `es_ram_budget_bytes`
-/// would be exceeded.  A footer shows the total RAM of fitting drives vs the
-/// budget cap.
+/// Drives are accepted in candidate order (as the operator specified them)
+/// until `es_ram_budget_bytes` would be exceeded.  A footer shows the total
+/// RAM of fitting drives vs the budget cap.
 #[must_use]
 pub fn render_drive_table(result: &PreflightResult, es_ram_budget_bytes: u64) -> String {
     if result.drives.is_empty() {
@@ -478,10 +478,8 @@ pub fn render_drive_table(result: &PreflightResult, es_ram_budget_bytes: u64) ->
     let sep = "|-------|-------------|----------|-----------|-------------|";
 
     let mut cumulative_bytes: u64 = 0;
-    let mut sorted_drives: Vec<&DrivePreflight> = result.drives.iter().collect();
-    sorted_drives.sort_by_key(|dp| dp.uffs_record_count);
     let mut budget_fits: alloc::collections::BTreeSet<char> = alloc::collections::BTreeSet::new();
-    for dp in &sorted_drives {
+    for dp in &result.drives {
         let est = dp.uffs_record_count.saturating_mul(UFFS_BYTES_PER_RECORD);
         if es_ram_budget_bytes == 0 || cumulative_bytes.saturating_add(est) <= es_ram_budget_bytes {
             cumulative_bytes = cumulative_bytes.saturating_add(est);

--- a/crates/uffs-bench/src/preflight/mod.rs
+++ b/crates/uffs-bench/src/preflight/mod.rs
@@ -266,6 +266,34 @@ fn poll_result_count(
     0
 }
 
+/// Parse the set of drive letters UFFS knows about from `uffs daemon status`
+/// stdout, regardless of tier or record count.
+///
+/// Parked drives appear without a record count (`[Parked]  C:`) so
+/// [`parse_daemon_status_drives`] does not capture them.  This function
+/// captures every drive letter that appears on a bracketed-tier line so
+/// callers can distinguish "UFFS knows this drive but it is parked" from
+/// "UFFS has never heard of this drive".
+#[must_use]
+pub(crate) fn parse_daemon_known_drives(status: &str) -> alloc::collections::BTreeSet<char> {
+    let mut set = alloc::collections::BTreeSet::new();
+    for line in status.lines() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with('[') {
+            continue;
+        }
+        // Lines look like:  [Warm]   C: — …  or  [Parked]  D:
+        // The drive letter is the first alphabetic token that ends with ':'.
+        if let Some(letter) = trimmed.split_whitespace().find_map(|token| {
+            let ch = token.trim_end_matches(':').chars().next()?;
+            (ch.is_ascii_alphabetic() && token.ends_with(':')).then(|| ch.to_ascii_uppercase())
+        }) {
+            set.insert(letter);
+        }
+    }
+    set
+}
+
 /// Parse per-drive record counts from `uffs daemon status` stdout.
 ///
 /// Each loaded drive appears as a line matching:
@@ -418,13 +446,23 @@ pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
     let status = daemon_status_output(host, &spec.uffs_exe);
     let mut uffs_counts = parse_daemon_status_drives(&status);
 
-    // Preload any candidate drives that are parked/cold (absent from warm map),
-    // then re-read status once so the record counts are available.
-    warm_parked_drives(host, &spec.uffs_exe, &spec.candidate_drives, &uffs_counts);
+    // Preload any candidate drives that UFFS knows about (present in the
+    // status output, even as [Parked]) but whose record count is not yet
+    // available.  Drives completely absent from the status (e.g. a drive
+    // letter the operator typed but UFFS has never indexed) are silently
+    // skipped — the filter below will warn and drop them.
+    let known_drives = parse_daemon_known_drives(&status);
+    warm_parked_drives(
+        host,
+        &spec.uffs_exe,
+        &spec.candidate_drives,
+        &uffs_counts,
+        &known_drives,
+    );
     if spec
         .candidate_drives
         .iter()
-        .any(|drive| !uffs_counts.contains_key(drive))
+        .any(|drive| known_drives.contains(drive) && !uffs_counts.contains_key(drive))
     {
         let status2 = daemon_status_output(host, &spec.uffs_exe);
         uffs_counts = parse_daemon_status_drives(&status2);
@@ -486,10 +524,14 @@ fn warm_parked_drives(
     uffs_exe: &str,
     candidates: &[char],
     warm_counts: &alloc::collections::BTreeMap<char, u64>,
+    known_drives: &alloc::collections::BTreeSet<char>,
 ) {
     for &drive in candidates {
         if warm_counts.contains_key(&drive) {
             continue; // already warm
+        }
+        if !known_drives.contains(&drive) {
+            continue; // UFFS has never heard of this drive — skip silently
         }
         host.out(&format!(
             "[preflight] Preloading parked drive {drive}: into Warm tier …"

--- a/crates/uffs-bench/src/preflight/mod.rs
+++ b/crates/uffs-bench/src/preflight/mod.rs
@@ -103,6 +103,12 @@ pub struct PreflightSpec {
     /// cross-tool capable set.  Defaults to 0 (no cap = any drive is capable
     /// regardless of size) when not set by the caller.
     pub es_ram_budget_bytes: u64,
+    /// When non-empty, all `es.exe` calls append `-instance <name>` so they
+    /// target an isolated Everything instance rather than the default one.
+    ///
+    /// Set after the bench suite launches its own Everything instance via
+    /// `Everything.exe -config <tempini> -instance <name> -startup`.
+    pub es_instance_name: String,
 }
 
 /// Per-drive competitor state observed during preflight.
@@ -181,8 +187,13 @@ pub fn parse_drives_from_ini(ini: &str) -> Vec<char> {
 /// - `DaemonStarting` — IPC error but `Everything.exe` is in the process list
 ///   (started but not yet ready).
 /// - `DaemonNotRunning` — IPC error and `Everything.exe` is not running at all.
-fn check_es_available(host: &dyn Host, es_exe: &str) -> Option<EsStatus> {
-    match host.run(es_exe, &["-get-everything-version"]) {
+fn check_es_available(host: &dyn Host, es_exe: &str, instance: &str) -> Option<EsStatus> {
+    let args: &[&str] = if instance.is_empty() {
+        &["-get-everything-version"]
+    } else {
+        &["-instance", instance, "-get-everything-version"]
+    };
+    match host.run(es_exe, args) {
         Err(_) => Some(EsStatus::NotInstalled),
         Ok(out) => {
             let combined = format!("{} {}", out.stdout, out.stderr);
@@ -228,6 +239,7 @@ fn is_everything_process_running(host: &dyn Host) -> bool {
 fn poll_result_count(
     host: &dyn Host,
     es_exe: &str,
+    instance: &str,
     drive: char,
     attempts: u32,
     interval_ms: u64,
@@ -237,8 +249,13 @@ fn poll_result_count(
         if attempt > 0 {
             host.sleep_ms(interval_ms);
         }
+        let args: &[&str] = if instance.is_empty() {
+            &[search.as_str(), "-get-result-count"]
+        } else {
+            &["-instance", instance, search.as_str(), "-get-result-count"]
+        };
         let count = host
-            .run(es_exe, &[search.as_str(), "-get-result-count"])
+            .run(es_exe, args)
             .ok()
             .and_then(|out| out.stdout.trim().parse::<u64>().ok())
             .unwrap_or(0);
@@ -320,8 +337,14 @@ fn probe_drive(
     } else {
         1
     };
-    let record_count =
-        poll_result_count(host, &spec.es_exe, drive, attempts, spec.poll_interval_ms);
+    let record_count = poll_result_count(
+        host,
+        &spec.es_exe,
+        &spec.es_instance_name,
+        drive,
+        attempts,
+        spec.poll_interval_ms,
+    );
     let loaded = record_count > 0;
     let es_status = if loaded {
         EsStatus::Loaded
@@ -390,7 +413,7 @@ pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
         .unwrap_or_default();
     let configured_drives = parse_drives_from_ini(&ini);
 
-    let es_available = check_es_available(host, &spec.es_exe);
+    let es_available = check_es_available(host, &spec.es_exe, &spec.es_instance_name);
 
     let status = daemon_status_output(host, &spec.uffs_exe);
     let mut uffs_counts = parse_daemon_status_drives(&status);

--- a/crates/uffs-bench/src/preflight/mod.rs
+++ b/crates/uffs-bench/src/preflight/mod.rs
@@ -410,15 +410,22 @@ pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
     let drives: Vec<DrivePreflight> = spec
         .candidate_drives
         .iter()
-        .filter(|&&drive| {
-            let known = uffs_counts.contains_key(&drive);
-            if !known {
+        .filter(|&&drive| match uffs_counts.get(&drive).copied() {
+            None => {
                 host.out(&format!(
                     "[preflight] WARNING: drive {drive}: not found in UFFS daemon \
-                     index — skipping"
+                         index — skipping"
                 ));
+                false
             }
-            known
+            Some(0) => {
+                host.out(&format!(
+                    "[preflight] WARNING: drive {drive}: 0 records in UFFS daemon \
+                         index — skipping"
+                ));
+                false
+            }
+            Some(_) => true,
         })
         .map(|&drive| {
             let uffs_record_count = uffs_counts.get(&drive).copied().unwrap_or(0);

--- a/crates/uffs-bench/src/preflight/mod.rs
+++ b/crates/uffs-bench/src/preflight/mod.rs
@@ -410,6 +410,16 @@ pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
     let drives: Vec<DrivePreflight> = spec
         .candidate_drives
         .iter()
+        .filter(|&&drive| {
+            let known = uffs_counts.contains_key(&drive);
+            if !known {
+                host.out(&format!(
+                    "[preflight] WARNING: drive {drive}: not found in UFFS daemon \
+                     index — skipping"
+                ));
+            }
+            known
+        })
         .map(|&drive| {
             let uffs_record_count = uffs_counts.get(&drive).copied().unwrap_or(0);
             probe_drive(

--- a/crates/uffs-bench/src/preflight/mod.rs
+++ b/crates/uffs-bench/src/preflight/mod.rs
@@ -386,7 +386,19 @@ pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
     let es_available = check_es_available(host, &spec.es_exe);
 
     let status = daemon_status_output(host, &spec.uffs_exe);
-    let uffs_counts = parse_daemon_status_drives(&status);
+    let mut uffs_counts = parse_daemon_status_drives(&status);
+
+    // Preload any candidate drives that are parked/cold (absent from warm map),
+    // then re-read status once so the record counts are available.
+    warm_parked_drives(host, &spec.uffs_exe, &spec.candidate_drives, &uffs_counts);
+    if spec
+        .candidate_drives
+        .iter()
+        .any(|drive| !uffs_counts.contains_key(drive))
+    {
+        let status2 = daemon_status_output(host, &spec.uffs_exe);
+        uffs_counts = parse_daemon_status_drives(&status2);
+    }
 
     let drives: Vec<DrivePreflight> = spec
         .candidate_drives
@@ -413,6 +425,35 @@ fn daemon_status_output(host: &dyn Host, uffs_exe: &str) -> String {
     host.run(uffs_exe, &["daemon", "status"])
         .map(|out| out.stdout)
         .unwrap_or_default()
+}
+
+/// Preload any candidate drive that is absent from `warm_counts` (i.e. parked
+/// or cold) so the follow-up `uffs daemon status` returns a `[Warm]` line with
+/// a live record count.
+///
+/// Fires `uffs daemon preload <DRIVE>` for each such drive and prints a status
+/// line so the operator knows the tool is promoting drives.  A preload failure
+/// is non-fatal — the drive will still appear with count = 0.
+fn warm_parked_drives(
+    host: &dyn Host,
+    uffs_exe: &str,
+    candidates: &[char],
+    warm_counts: &alloc::collections::BTreeMap<char, u64>,
+) {
+    for &drive in candidates {
+        if warm_counts.contains_key(&drive) {
+            continue; // already warm
+        }
+        host.out(&format!(
+            "[preflight] Preloading parked drive {drive}: into Warm tier …"
+        ));
+        let drive_s = drive.to_string();
+        if let Err(err) = host.run(uffs_exe, &["daemon", "preload", &drive_s]) {
+            host.out(&format!(
+                "[preflight] WARNING: could not preload drive {drive}: {err}"
+            ));
+        }
+    }
 }
 
 /// Render a GFM drive-status table for display before the matrix.
@@ -514,264 +555,4 @@ pub fn write(host: &dyn Host, result: &PreflightResult, bundle_dir: &Path) -> Re
 }
 
 #[cfg(test)]
-mod tests {
-    use std::path::PathBuf;
-
-    use super::{
-        CellFeasibility, DrivePreflight, EsStatus, PatternProbe, PreflightResult, PreflightSpec,
-        capture, parse_daemon_status_drives, parse_drives_from_ini, write,
-    };
-    use crate::host::{Call, MockHost, ProcOutput};
-
-    /// Build a scripted stdout-only process output.
-    fn stdout_of(stdout: &str) -> ProcOutput {
-        ProcOutput {
-            code: Some(0_i32),
-            stdout: stdout.to_owned(),
-            stderr: String::new(),
-        }
-    }
-
-    /// A spec over the given candidate drives with one all-DLL pattern.
-    fn spec_for(drives: &[char], attempts: u32) -> PreflightSpec {
-        PreflightSpec {
-            ini_path: PathBuf::from("/Everything.ini"),
-            candidate_drives: drives.to_vec(),
-            es_exe: "es".to_owned(),
-            uffs_exe: "uffs".to_owned(),
-            patterns: vec![PatternProbe {
-                name: "all_dlls".to_owned(),
-                args: vec![
-                    "{DRIVE}:\\".to_owned(),
-                    "*.dll".to_owned(),
-                    "--count".to_owned(),
-                ],
-            }],
-            poll_attempts: attempts,
-            poll_interval_ms: 500,
-            es_ram_budget_bytes: 0,
-        }
-    }
-
-    /// Build an IPC-error output (what es.exe returns when Everything is not
-    /// running or not yet ready).
-    fn ipc_error_output() -> ProcOutput {
-        ProcOutput {
-            code: Some(1_i32),
-            stdout: "Error 8: Everything IPC window not found. \
-                     Please make sure Everything is running."
-                .to_owned(),
-            stderr: String::new(),
-        }
-    }
-
-    #[test]
-    fn check_es_daemon_not_running_when_process_absent() {
-        let host = MockHost::new()
-            .with_run_result(ipc_error_output()) // es.exe -get-everything-version
-            .with_run_result(stdout_of("")); // tasklist / pgrep: process NOT found
-        let status = super::check_es_available(&host, "es.exe");
-        assert_eq!(status, Some(EsStatus::DaemonNotRunning));
-    }
-
-    #[test]
-    fn check_es_daemon_starting_when_process_present() {
-        let host = MockHost::new()
-            .with_run_result(ipc_error_output()) // es.exe -get-everything-version
-            .with_run_result(stdout_of("\"Everything.exe\",\"1234\"")); // tasklist: found
-        let status = super::check_es_available(&host, "es.exe");
-        assert_eq!(status, Some(EsStatus::DaemonStarting));
-    }
-
-    #[test]
-    fn parse_drives_reads_quoted_csv() {
-        let ini = "foo=1\nntfs_volume_paths=\"C:\\\",\"d:\\\"\nbar=2\n";
-        assert_eq!(parse_drives_from_ini(ini), vec!['C', 'D']);
-    }
-
-    #[test]
-    fn parse_drives_absent_key_is_empty() {
-        assert_eq!(parse_drives_from_ini("a=1\nb=2\n"), Vec::<char>::new());
-    }
-
-    /// Fake `uffs daemon status` output with C (3 M records) and D (7 M
-    /// records).
-    fn daemon_status_cd() -> &'static str {
-        "Version:       0.0.0\n\
-         Status:        Ready\n\
-         Drives:\n\
-           [Warm]   C: —  3,000,000 records (live) — 600 MB\n\
-           [Warm]   D: —  7,000,000 records (live) — 1400 MB\n"
-    }
-
-    #[test]
-    fn parse_daemon_status_drives_extracts_counts() {
-        let map = parse_daemon_status_drives(daemon_status_cd());
-        assert_eq!(map.get(&'C').copied(), Some(3_000_000));
-        assert_eq!(map.get(&'D').copied(), Some(7_000_000));
-        assert_eq!(map.get(&'E'), None);
-    }
-
-    #[test]
-    fn capture_is_read_only_and_records_state() {
-        // Call order:
-        //  1. check_es_available: es -get-everything-version (daemon running)
-        //  2. daemon_status_output: uffs daemon status (record counts)
-        //  3. C: es result-count poll → loaded
-        //  4. D: es result-count poll → not loaded
-        //  5. feasibility estimate for (C, all_dlls)
-        let host = MockHost::new()
-            .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\,D:\\".to_vec())
-            .with_run_result(stdout_of("1.4.1.1032"))       // 1: es availability
-            .with_run_result(stdout_of(daemon_status_cd())) // 2: uffs daemon status
-            .with_run_result(stdout_of("1000"))             // 3: C es result-count
-            .with_run_result(stdout_of("0"))                // 4: D es result-count
-            .with_run_result(stdout_of("5000")); // 5: uffs estimate C/all_dlls
-        let spec = spec_for(&['C', 'D'], 1);
-
-        let result = capture(&host, &spec);
-
-        assert_eq!(result.drives, vec![
-            DrivePreflight {
-                drive: 'C',
-                configured: true,
-                loaded: true,
-                hot: true,
-                record_count: 1000,
-                uffs_record_count: 3_000_000,
-                es_status: EsStatus::Loaded,
-            },
-            DrivePreflight {
-                drive: 'D',
-                configured: true,
-                loaded: false,
-                hot: false,
-                record_count: 0,
-                uffs_record_count: 7_000_000,
-                es_status: EsStatus::StillIndexing,
-            },
-        ]);
-        assert_eq!(result.cells, vec![CellFeasibility {
-            drive: 'C',
-            pattern: "all_dlls".to_owned(),
-            est_rows: 5000,
-            es_feasible: true,
-        }]);
-        // The whole stage must touch the ini read-only — never write or remove.
-        assert!(host.calls().iter().all(|call| !matches!(
-            call,
-            Call::WriteFile(_) | Call::RemoveFile(_) | Call::Rename(_, _)
-        )));
-    }
-
-    #[test]
-    fn configured_zero_drive_is_polled_with_backoff() {
-        let host = MockHost::new()
-            .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
-            .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
-            .with_run_result(stdout_of(                  // 2: uffs daemon status
-                "Status: Ready\n  [Warm]   C: —  500,000 records (live) — 50 MB\n"
-            ))
-            .with_run_result(stdout_of("0"))             // 3: C es poll 1
-            .with_run_result(stdout_of("0"))             // 4: C es poll 2
-            .with_run_result(stdout_of("7")); // 5: C es poll 3 → loaded
-        let mut spec = spec_for(&['C'], 3);
-        spec.patterns.clear();
-
-        let result = capture(&host, &spec);
-
-        assert_eq!(
-            result.drives.first().map(|drive| drive.record_count),
-            Some(7)
-        );
-        let sleeps = host
-            .calls()
-            .into_iter()
-            .filter(|call| matches!(call, Call::Sleep(_)))
-            .count();
-        assert_eq!(sleeps, 2);
-    }
-
-    #[test]
-    fn unconfigured_drive_probed_once_without_sleep() {
-        let host = MockHost::new()
-            .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
-            .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
-            .with_run_result(stdout_of(                  // 2: uffs daemon status (E absent)
-                "Status: Ready\n  [Warm]   C: —  100,000 records (live) — 10 MB\n"
-            ))
-            .with_run_result(stdout_of("0")); // 3: E es result-count → not loaded
-        let mut spec = spec_for(&['E'], 5);
-        spec.patterns.clear();
-
-        let result = capture(&host, &spec);
-
-        assert_eq!(
-            result.drives.first().map(|drive| drive.configured),
-            Some(false)
-        );
-        // E is absent from daemon status → uffs_record_count = 0.
-        assert_eq!(
-            result.drives.first().map(|drive| drive.uffs_record_count),
-            Some(0)
-        );
-        let runs = host
-            .calls()
-            .into_iter()
-            .filter(|call| matches!(call, Call::Run(_, _)))
-            .count();
-        assert_eq!(runs, 3); // 1 availability check + 1 daemon status + 1 es probe
-        assert!(
-            !host
-                .calls()
-                .iter()
-                .any(|call| matches!(call, Call::Sleep(_)))
-        );
-    }
-
-    #[test]
-    fn cell_above_ipc_ceiling_is_infeasible() {
-        let host = MockHost::new()
-            .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
-            .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
-            .with_run_result(stdout_of(                  // 2: uffs daemon status
-                "Status: Ready\n  [Warm]   C: —  500,000 records (live) — 50 MB\n"
-            ))
-            .with_run_result(stdout_of("100"))           // 3: C es result-count → loaded
-            .with_run_result(stdout_of("200000")); // 4: estimate over the 150k ceiling
-        let spec = spec_for(&['C'], 1);
-
-        let result = capture(&host, &spec);
-
-        assert_eq!(
-            result.cells.first().map(|cell| cell.es_feasible),
-            Some(false)
-        );
-    }
-
-    #[test]
-    fn write_emits_preflight_json_and_round_trips() {
-        let host = MockHost::new();
-        let result = PreflightResult {
-            drives: vec![DrivePreflight {
-                drive: 'C',
-                configured: true,
-                loaded: true,
-                hot: true,
-                record_count: 42,
-                uffs_record_count: 1_000_000,
-                es_status: EsStatus::Loaded,
-            }],
-            cells: Vec::new(),
-        };
-        let dir = PathBuf::from("/bundle");
-
-        write(&host, &result, &dir).expect("write preflight json");
-
-        let path = dir.join("competitor-preflight.json");
-        assert_eq!(host.calls(), vec![Call::WriteFile(path.clone())]);
-        let json = host.file(&path).expect("preflight json written");
-        let parsed: PreflightResult = serde_json::from_slice(&json).expect("valid json");
-        assert_eq!(parsed, result);
-    }
-}
+mod tests;

--- a/crates/uffs-bench/src/preflight/tests.rs
+++ b/crates/uffs-bench/src/preflight/tests.rs
@@ -200,43 +200,35 @@ fn configured_zero_drive_is_polled_with_backoff() {
 }
 
 #[test]
-fn unconfigured_drive_probed_once_without_sleep() {
-    // E is absent from the first daemon status → warm_parked_drives fires
-    // `preload E` then a second `daemon status`.  E stays absent after the
-    // second status too (simulate it not warming up), so uffs_record_count=0.
+fn drive_unknown_to_daemon_is_skipped() {
+    // E is absent from both daemon status reads (not a UFFS-indexed drive) →
+    // it must be filtered out entirely: no es-probe, drives list is empty.
     let host = MockHost::new()
         .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
         .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
         .with_run_result(stdout_of(                  // 2: uffs daemon status (E absent)
             "Status: Ready\n  [Warm]   C: \u{2014}  100,000 records (live) \u{2014} 10 MB\n"
         ))
-        .with_run_result(stdout_of("Promoted to Hot")) // 3: preload E
+        .with_run_result(stdout_of("Promoted to Hot")) // 3: preload E (attempt)
         .with_run_result(stdout_of(                  // 4: uffs daemon status re-check
             "Status: Ready\n  [Warm]   C: \u{2014}  100,000 records (live) \u{2014} 10 MB\n"
-        ))
-        .with_run_result(stdout_of("0")); // 5: E es result-count → not loaded
+        ));
+    // No es-probe call — E is dropped before probe_drive is reached.
     let mut spec = spec_for(&['E'], 5);
     spec.patterns.clear();
 
     let result = capture(&host, &spec);
 
-    assert_eq!(
-        result.drives.first().map(|drive| drive.configured),
-        Some(false)
-    );
-    // E absent from both status reads → uffs_record_count = 0.
-    assert_eq!(
-        result.drives.first().map(|drive| drive.uffs_record_count),
-        Some(0)
-    );
+    // E absent from both status reads → dropped entirely, not shown.
+    assert!(result.drives.is_empty(), "unknown drive must be skipped");
     let runs = host
         .calls()
         .into_iter()
         .filter(|call| matches!(call, Call::Run(_, _)))
         .count();
-    // 1 es availability + 1 daemon status + 1 preload + 1 daemon status + 1 es
-    // probe
-    assert_eq!(runs, 5);
+    // 1 es availability + 1 daemon status + 1 preload + 1 daemon status (no es
+    // probe)
+    assert_eq!(runs, 4);
     assert!(
         !host
             .calls()

--- a/crates/uffs-bench/src/preflight/tests.rs
+++ b/crates/uffs-bench/src/preflight/tests.rs
@@ -36,6 +36,7 @@ fn spec_for(drives: &[char], attempts: u32) -> PreflightSpec {
         poll_attempts: attempts,
         poll_interval_ms: 500,
         es_ram_budget_bytes: 0,
+        es_instance_name: String::new(),
     }
 }
 
@@ -56,7 +57,7 @@ fn check_es_daemon_not_running_when_process_absent() {
     let host = MockHost::new()
         .with_run_result(ipc_error_output()) // es.exe -get-everything-version
         .with_run_result(stdout_of("")); // tasklist / pgrep: process NOT found
-    let status = super::check_es_available(&host, "es.exe");
+    let status = super::check_es_available(&host, "es.exe", "");
     assert_eq!(status, Some(EsStatus::DaemonNotRunning));
 }
 
@@ -65,7 +66,7 @@ fn check_es_daemon_starting_when_process_present() {
     let host = MockHost::new()
         .with_run_result(ipc_error_output()) // es.exe -get-everything-version
         .with_run_result(stdout_of("\"Everything.exe\",\"1234\"")); // tasklist: found
-    let status = super::check_es_available(&host, "es.exe");
+    let status = super::check_es_available(&host, "es.exe", "");
     assert_eq!(status, Some(EsStatus::DaemonStarting));
 }
 

--- a/crates/uffs-bench/src/preflight/tests.rs
+++ b/crates/uffs-bench/src/preflight/tests.rs
@@ -28,8 +28,9 @@ fn spec_for(drives: &[char], attempts: u32) -> PreflightSpec {
         patterns: vec![PatternProbe {
             name: "all_dlls".to_owned(),
             args: vec![
-                "{DRIVE}:\\".to_owned(),
                 "*.dll".to_owned(),
+                "--drives".to_owned(),
+                "{DRIVE}".to_owned(),
                 "--count".to_owned(),
             ],
         }],

--- a/crates/uffs-bench/src/preflight/tests.rs
+++ b/crates/uffs-bench/src/preflight/tests.rs
@@ -209,27 +209,22 @@ fn drive_unknown_to_daemon_is_skipped() {
         .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
         .with_run_result(stdout_of(                  // 2: uffs daemon status (E absent)
             "Status: Ready\n  [Warm]   C: \u{2014}  100,000 records (live) \u{2014} 10 MB\n"
-        ))
-        .with_run_result(stdout_of("Promoted to Hot")) // 3: preload E (attempt)
-        .with_run_result(stdout_of(                  // 4: uffs daemon status re-check
-            "Status: Ready\n  [Warm]   C: \u{2014}  100,000 records (live) \u{2014} 10 MB\n"
         ));
-    // No es-probe call — E is dropped before probe_drive is reached.
+    // E is not in known_drives at all — no preload attempt, no re-check.
     let mut spec = spec_for(&['E'], 5);
     spec.patterns.clear();
 
     let result = capture(&host, &spec);
 
-    // E absent from both status reads → dropped entirely, not shown.
+    // E absent from status → dropped entirely, not shown.
     assert!(result.drives.is_empty(), "unknown drive must be skipped");
     let runs = host
         .calls()
         .into_iter()
         .filter(|call| matches!(call, Call::Run(_, _)))
         .count();
-    // 1 es availability + 1 daemon status + 1 preload + 1 daemon status (no es
-    // probe)
-    assert_eq!(runs, 4);
+    // 1 es availability + 1 daemon status only (no preload, no re-check)
+    assert_eq!(runs, 2);
     assert!(
         !host
             .calls()
@@ -245,7 +240,9 @@ fn parked_drive_is_preloaded_and_count_populated() {
     let host = MockHost::new()
         .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
         .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
-        .with_run_result(stdout_of("Status: Ready\nDrives:\n")) // 2: status (C absent)
+        .with_run_result(stdout_of(                  // 2: status (C parked — in known_drives)
+            "Status: Ready\n  [Parked]  C:\n"
+        ))
         .with_run_result(stdout_of("Promoted to Hot"))          // 3: preload C
         .with_run_result(stdout_of(                  // 4: status re-check (C now Warm)
             "Status: Ready\n  [Warm]   C: \u{2014}  500,000 records (live) \u{2014} 50 MB\n"

--- a/crates/uffs-bench/src/preflight/tests.rs
+++ b/crates/uffs-bench/src/preflight/tests.rs
@@ -98,6 +98,28 @@ fn parse_daemon_status_drives_extracts_counts() {
 }
 
 #[test]
+fn parse_daemon_status_drives_handles_hot_and_parked_tiers() {
+    // Real daemon output mix: [Parked] has no record count; [Hot] and [Warm]
+    // both have the "N records (live)" format.
+    let status = "Status:        Ready\n\
+        Drives:\n\
+          [Parked] G: \u{2014} bloom + trie kept resident; body released\n\
+          [Hot]    F: \u{2014}  2,221,339 records (live) \u{2014} 466 MB\n\
+          [Warm]   C: \u{2014}  3,409,074 records (live) \u{2014} 737 MB\n\
+          [Parked] S: \u{2014} bloom + trie kept resident; body released\n\
+          [Hot]    D: \u{2014}  7,066,034 records (live) \u{2014} 1337 MB\n";
+    let map = parse_daemon_status_drives(status);
+    // Parked drives are absent (no record count in their line).
+    assert_eq!(map.get(&'G'), None, "[Parked] G must be absent");
+    assert_eq!(map.get(&'S'), None, "[Parked] S must be absent");
+    // Hot drives are parsed identically to Warm.
+    assert_eq!(map.get(&'F').copied(), Some(2_221_339), "[Hot] F");
+    assert_eq!(map.get(&'D').copied(), Some(7_066_034), "[Hot] D");
+    // Warm drive is parsed correctly.
+    assert_eq!(map.get(&'C').copied(), Some(3_409_074), "[Warm] C");
+}
+
+#[test]
 fn capture_is_read_only_and_records_state() {
     // Call order:
     //  1. check_es_available: es -get-everything-version (daemon running)

--- a/crates/uffs-bench/src/preflight/tests.rs
+++ b/crates/uffs-bench/src/preflight/tests.rs
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+use std::path::PathBuf;
+
+use super::{
+    CellFeasibility, DrivePreflight, EsStatus, PatternProbe, PreflightResult, PreflightSpec,
+    capture, parse_daemon_status_drives, parse_drives_from_ini, write,
+};
+use crate::host::{Call, MockHost, ProcOutput};
+
+/// Build a scripted stdout-only process output.
+fn stdout_of(stdout: &str) -> ProcOutput {
+    ProcOutput {
+        code: Some(0_i32),
+        stdout: stdout.to_owned(),
+        stderr: String::new(),
+    }
+}
+
+/// A spec over the given candidate drives with one all-DLL pattern.
+fn spec_for(drives: &[char], attempts: u32) -> PreflightSpec {
+    PreflightSpec {
+        ini_path: PathBuf::from("/Everything.ini"),
+        candidate_drives: drives.to_vec(),
+        es_exe: "es".to_owned(),
+        uffs_exe: "uffs".to_owned(),
+        patterns: vec![PatternProbe {
+            name: "all_dlls".to_owned(),
+            args: vec![
+                "{DRIVE}:\\".to_owned(),
+                "*.dll".to_owned(),
+                "--count".to_owned(),
+            ],
+        }],
+        poll_attempts: attempts,
+        poll_interval_ms: 500,
+        es_ram_budget_bytes: 0,
+    }
+}
+
+/// Build an IPC-error output (what es.exe returns when Everything is not
+/// running or not yet ready).
+fn ipc_error_output() -> ProcOutput {
+    ProcOutput {
+        code: Some(1_i32),
+        stdout: "Error 8: Everything IPC window not found. \
+                 Please make sure Everything is running."
+            .to_owned(),
+        stderr: String::new(),
+    }
+}
+
+#[test]
+fn check_es_daemon_not_running_when_process_absent() {
+    let host = MockHost::new()
+        .with_run_result(ipc_error_output()) // es.exe -get-everything-version
+        .with_run_result(stdout_of("")); // tasklist / pgrep: process NOT found
+    let status = super::check_es_available(&host, "es.exe");
+    assert_eq!(status, Some(EsStatus::DaemonNotRunning));
+}
+
+#[test]
+fn check_es_daemon_starting_when_process_present() {
+    let host = MockHost::new()
+        .with_run_result(ipc_error_output()) // es.exe -get-everything-version
+        .with_run_result(stdout_of("\"Everything.exe\",\"1234\"")); // tasklist: found
+    let status = super::check_es_available(&host, "es.exe");
+    assert_eq!(status, Some(EsStatus::DaemonStarting));
+}
+
+#[test]
+fn parse_drives_reads_quoted_csv() {
+    let ini = "foo=1\nntfs_volume_paths=\"C:\\\",\"d:\\\"\nbar=2\n";
+    assert_eq!(parse_drives_from_ini(ini), vec!['C', 'D']);
+}
+
+#[test]
+fn parse_drives_absent_key_is_empty() {
+    assert_eq!(parse_drives_from_ini("a=1\nb=2\n"), Vec::<char>::new());
+}
+
+/// Fake `uffs daemon status` output with C (3 M records) and D (7 M records).
+fn daemon_status_cd() -> &'static str {
+    "Version:       0.0.0\n\
+     Status:        Ready\n\
+     Drives:\n\
+       [Warm]   C: \u{2014}  3,000,000 records (live) \u{2014} 600 MB\n\
+       [Warm]   D: \u{2014}  7,000,000 records (live) \u{2014} 1400 MB\n"
+}
+
+#[test]
+fn parse_daemon_status_drives_extracts_counts() {
+    let map = parse_daemon_status_drives(daemon_status_cd());
+    assert_eq!(map.get(&'C').copied(), Some(3_000_000));
+    assert_eq!(map.get(&'D').copied(), Some(7_000_000));
+    assert_eq!(map.get(&'E'), None);
+}
+
+#[test]
+fn capture_is_read_only_and_records_state() {
+    // Call order:
+    //  1. check_es_available: es -get-everything-version (daemon running)
+    //  2. daemon_status_output: uffs daemon status (record counts)
+    //  3. C: es result-count poll → loaded
+    //  4. D: es result-count poll → not loaded
+    //  5. feasibility estimate for (C, all_dlls)
+    let host = MockHost::new()
+        .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\,D:\\".to_vec())
+        .with_run_result(stdout_of("1.4.1.1032"))       // 1: es availability
+        .with_run_result(stdout_of(daemon_status_cd())) // 2: uffs daemon status
+        .with_run_result(stdout_of("1000"))             // 3: C es result-count
+        .with_run_result(stdout_of("0"))                // 4: D es result-count
+        .with_run_result(stdout_of("5000")); // 5: uffs estimate C/all_dlls
+    let spec = spec_for(&['C', 'D'], 1);
+
+    let result = capture(&host, &spec);
+
+    assert_eq!(result.drives, vec![
+        DrivePreflight {
+            drive: 'C',
+            configured: true,
+            loaded: true,
+            hot: true,
+            record_count: 1000,
+            uffs_record_count: 3_000_000,
+            es_status: EsStatus::Loaded,
+        },
+        DrivePreflight {
+            drive: 'D',
+            configured: true,
+            loaded: false,
+            hot: false,
+            record_count: 0,
+            uffs_record_count: 7_000_000,
+            es_status: EsStatus::StillIndexing,
+        },
+    ]);
+    assert_eq!(result.cells, vec![CellFeasibility {
+        drive: 'C',
+        pattern: "all_dlls".to_owned(),
+        est_rows: 5000,
+        es_feasible: true,
+    }]);
+    // The whole stage must touch the ini read-only — never write or remove.
+    assert!(host.calls().iter().all(|call| !matches!(
+        call,
+        Call::WriteFile(_) | Call::RemoveFile(_) | Call::Rename(_, _)
+    )));
+}
+
+#[test]
+fn configured_zero_drive_is_polled_with_backoff() {
+    let host = MockHost::new()
+        .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
+        .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
+        .with_run_result(stdout_of(                  // 2: uffs daemon status
+            "Status: Ready\n  [Warm]   C: \u{2014}  500,000 records (live) \u{2014} 50 MB\n"
+        ))
+        .with_run_result(stdout_of("0"))             // 3: C es poll 1
+        .with_run_result(stdout_of("0"))             // 4: C es poll 2
+        .with_run_result(stdout_of("7")); // 5: C es poll 3 → loaded
+    let mut spec = spec_for(&['C'], 3);
+    spec.patterns.clear();
+
+    let result = capture(&host, &spec);
+
+    assert_eq!(
+        result.drives.first().map(|drive| drive.record_count),
+        Some(7)
+    );
+    let sleeps = host
+        .calls()
+        .into_iter()
+        .filter(|call| matches!(call, Call::Sleep(_)))
+        .count();
+    assert_eq!(sleeps, 2);
+}
+
+#[test]
+fn unconfigured_drive_probed_once_without_sleep() {
+    // E is absent from the first daemon status → warm_parked_drives fires
+    // `preload E` then a second `daemon status`.  E stays absent after the
+    // second status too (simulate it not warming up), so uffs_record_count=0.
+    let host = MockHost::new()
+        .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
+        .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
+        .with_run_result(stdout_of(                  // 2: uffs daemon status (E absent)
+            "Status: Ready\n  [Warm]   C: \u{2014}  100,000 records (live) \u{2014} 10 MB\n"
+        ))
+        .with_run_result(stdout_of("Promoted to Hot")) // 3: preload E
+        .with_run_result(stdout_of(                  // 4: uffs daemon status re-check
+            "Status: Ready\n  [Warm]   C: \u{2014}  100,000 records (live) \u{2014} 10 MB\n"
+        ))
+        .with_run_result(stdout_of("0")); // 5: E es result-count → not loaded
+    let mut spec = spec_for(&['E'], 5);
+    spec.patterns.clear();
+
+    let result = capture(&host, &spec);
+
+    assert_eq!(
+        result.drives.first().map(|drive| drive.configured),
+        Some(false)
+    );
+    // E absent from both status reads → uffs_record_count = 0.
+    assert_eq!(
+        result.drives.first().map(|drive| drive.uffs_record_count),
+        Some(0)
+    );
+    let runs = host
+        .calls()
+        .into_iter()
+        .filter(|call| matches!(call, Call::Run(_, _)))
+        .count();
+    // 1 es availability + 1 daemon status + 1 preload + 1 daemon status + 1 es
+    // probe
+    assert_eq!(runs, 5);
+    assert!(
+        !host
+            .calls()
+            .iter()
+            .any(|call| matches!(call, Call::Sleep(_)))
+    );
+}
+
+#[test]
+fn parked_drive_is_preloaded_and_count_populated() {
+    // C is absent from the first status (parked) → preload fires, then
+    // second status returns C as Warm with 500,000 records.
+    let host = MockHost::new()
+        .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
+        .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
+        .with_run_result(stdout_of("Status: Ready\nDrives:\n")) // 2: status (C absent)
+        .with_run_result(stdout_of("Promoted to Hot"))          // 3: preload C
+        .with_run_result(stdout_of(                  // 4: status re-check (C now Warm)
+            "Status: Ready\n  [Warm]   C: \u{2014}  500,000 records (live) \u{2014} 50 MB\n"
+        ))
+        .with_run_result(stdout_of("100")); // 5: es result-count → loaded
+    let mut spec = spec_for(&['C'], 1);
+    spec.patterns.clear();
+
+    let result = capture(&host, &spec);
+
+    assert_eq!(
+        result.drives.first().map(|dp| dp.uffs_record_count),
+        Some(500_000),
+        "uffs_record_count must come from the post-preload status"
+    );
+    assert_eq!(result.drives.first().map(|dp| dp.loaded), Some(true));
+}
+
+#[test]
+fn cell_above_ipc_ceiling_is_infeasible() {
+    let host = MockHost::new()
+        .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
+        .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
+        .with_run_result(stdout_of(                  // 2: uffs daemon status
+            "Status: Ready\n  [Warm]   C: \u{2014}  500,000 records (live) \u{2014} 50 MB\n"
+        ))
+        .with_run_result(stdout_of("100"))           // 3: C es result-count → loaded
+        .with_run_result(stdout_of("200000")); // 4: estimate over the 150k ceiling
+    let spec = spec_for(&['C'], 1);
+
+    let result = capture(&host, &spec);
+
+    assert_eq!(
+        result.cells.first().map(|cell| cell.es_feasible),
+        Some(false)
+    );
+}
+
+#[test]
+fn write_emits_preflight_json_and_round_trips() {
+    let host = MockHost::new();
+    let result = PreflightResult {
+        drives: vec![DrivePreflight {
+            drive: 'C',
+            configured: true,
+            loaded: true,
+            hot: true,
+            record_count: 42,
+            uffs_record_count: 1_000_000,
+            es_status: EsStatus::Loaded,
+        }],
+        cells: Vec::new(),
+    };
+    let dir = PathBuf::from("/bundle");
+
+    write(&host, &result, &dir).expect("write preflight json");
+
+    let path = dir.join("competitor-preflight.json");
+    assert_eq!(host.calls(), vec![Call::WriteFile(path.clone())]);
+    let json = host.file(&path).expect("preflight json written");
+    let parsed: PreflightResult = serde_json::from_slice(&json).expect("valid json");
+    assert_eq!(parsed, result);
+}

--- a/crates/uffs-bench/src/resolve.rs
+++ b/crates/uffs-bench/src/resolve.rs
@@ -52,6 +52,45 @@ pub(crate) fn uffs_cpp_exe(host: &dyn Host) -> String {
     bin_name.to_owned()
 }
 
+/// Resolve the `Everything.exe` GUI binary to its absolute path.
+///
+/// Uses disk/PATH lookups only — no execution.
+///
+/// Search order:
+///   1. `where.exe Everything.exe` / `which Everything` — first PATH hit.
+///   2. `%ProgramFiles(x86)%\Everything\Everything.exe` — default installer.
+///   3. `%ProgramFiles%\Everything\Everything.exe` — 64-bit install.
+///   4. bare `Everything.exe` fallback.
+pub(crate) fn everything_exe(host: &dyn Host) -> String {
+    let bin_name = if cfg!(windows) {
+        "Everything.exe"
+    } else {
+        "Everything"
+    };
+
+    // 1. Ask the OS where the binary lives on PATH.
+    let where_cmd = if cfg!(windows) { "where.exe" } else { "which" };
+    if let Ok(out) = host.run(where_cmd, &[bin_name]) {
+        let first = out.stdout.lines().next().unwrap_or("").trim().to_owned();
+        if !first.is_empty() {
+            return first;
+        }
+    }
+
+    // 2-3. Known installer locations.
+    for env_var in &["ProgramFiles(x86)", "ProgramFiles"] {
+        if let Some(pf) = host.env(env_var) {
+            let candidate = PathBuf::from(&pf).join("Everything").join(bin_name);
+            if host.path_exists(&candidate) {
+                return candidate.to_string_lossy().into_owned();
+            }
+        }
+    }
+
+    // 4. Bare fallback.
+    bin_name.to_owned()
+}
+
 /// Resolve the `es.exe` binary (Everything CLI) to its absolute path.
 ///
 /// The binary exits 0 even when the Everything daemon is not running, so

--- a/crates/uffs-bench/src/resolve.rs
+++ b/crates/uffs-bench/src/resolve.rs
@@ -141,9 +141,11 @@ pub(crate) fn es_exe(host: &dyn Host) -> String {
 
 /// Default measurement patterns: display name + UFFS row-count argument
 /// template (`{DRIVE}` is substituted per drive during preflight).
+///
+/// Correct CLI form: `uffs.exe <pattern> --drives <DRIVE> --count`
 pub(crate) const DEFAULT_PATTERNS: [(&str, &[&str]); 2] = [
-    ("all_dlls", &["{DRIVE}:\\", "*.dll", "--count"]),
-    ("full_scan", &["{DRIVE}:\\", "*", "--count"]),
+    ("all_dlls", &["*.dll", "--drives", "{DRIVE}", "--count"]),
+    ("full_scan", &["*", "--drives", "{DRIVE}", "--count"]),
 ];
 
 /// Build the default measurement [`PatternProbe`] set (shared by preflight and

--- a/crates/uffs-bench/src/resolve.rs
+++ b/crates/uffs-bench/src/resolve.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Binary resolution cascades for the tools the bench suite invokes.
+//!
+//! Each function searches for its target executable in a fixed-priority order
+//! and returns the first one that exists (or a bare PATH-fallback name if
+//! none is found). All I/O flows through the [`Host`] seam so the logic is
+//! fully testable under `MockHost`.
+
+use std::path::PathBuf;
+
+use crate::host::Host;
+use crate::preflight::PatternProbe;
+
+/// Resolve the `uffs.exe` binary using the same cascade as the validation
+/// scripts: `$USERPROFILE\bin\uffs.exe` → `target\release\uffs.exe` → bare
+/// `uffs.exe` (PATH fallback).
+///
+/// The `target\release` step is intentionally **included** here because it is
+/// the Rust artefact; it is omitted for the C++ reference binary.
+pub(crate) fn uffs_exe(host: &dyn Host) -> String {
+    let home_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    let bin_name = if cfg!(windows) { "uffs.exe" } else { "uffs" };
+    let home = host.env(home_var).unwrap_or_default();
+    let candidates = [
+        PathBuf::from(&home).join("bin").join(bin_name),
+        PathBuf::from("target").join("release").join(bin_name),
+    ];
+    for candidate in &candidates {
+        if host.path_exists(candidate) {
+            return candidate.to_string_lossy().into_owned();
+        }
+    }
+    bin_name.to_owned()
+}
+
+/// Resolve the `uffs.com` (C++ reference) binary.
+///
+/// Same cascade as `uffs.exe` minus the `target/release` Rust step — the C++
+/// binary is never produced by `cargo build`:
+///   1. `$USERPROFILE\bin\uffs.com` — `just use` / manual install
+///   2. bare `uffs.com` (PATH fallback)
+pub(crate) fn uffs_cpp_exe(host: &dyn Host) -> String {
+    let home_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    let bin_name = "uffs.com";
+    let home = host.env(home_var).unwrap_or_default();
+    let candidate = PathBuf::from(&home).join("bin").join(bin_name);
+    if host.path_exists(&candidate) {
+        return candidate.to_string_lossy().into_owned();
+    }
+    bin_name.to_owned()
+}
+
+/// Resolve the `es.exe` binary (Everything CLI).
+///
+/// Search order:
+///   1. `es.exe` reachable via PATH (already-installed or bundle-staged)
+///   2. `%ProgramFiles%\Everything\es.exe` — default installer location
+///   3. `%ProgramFiles(x86)%\Everything\es.exe` — 32-bit installer on 64-bit
+///   4. bare `es.exe` (PATH fallback — lets the OS surface a clear error)
+pub(crate) fn es_exe(host: &dyn Host) -> String {
+    let bin_name = "es.exe";
+    if host.run(bin_name, &["-get-everything-version"]).is_ok() {
+        return bin_name.to_owned();
+    }
+    for env_var in &["ProgramFiles", "ProgramFiles(x86)"] {
+        if let Some(pf) = host.env(env_var) {
+            let candidate = PathBuf::from(&pf).join("Everything").join(bin_name);
+            if host.path_exists(&candidate) {
+                return candidate.to_string_lossy().into_owned();
+            }
+        }
+    }
+    bin_name.to_owned()
+}
+
+/// Default measurement patterns: display name + UFFS row-count argument
+/// template (`{DRIVE}` is substituted per drive during preflight).
+pub(crate) const DEFAULT_PATTERNS: [(&str, &[&str]); 2] = [
+    ("all_dlls", &["{DRIVE}:\\", "*.dll", "--count"]),
+    ("full_scan", &["{DRIVE}:\\", "*", "--count"]),
+];
+
+/// Build the default measurement [`PatternProbe`] set (shared by preflight and
+/// the native Stage 3 timing).
+pub(crate) fn default_pattern_probes() -> Vec<PatternProbe> {
+    DEFAULT_PATTERNS
+        .iter()
+        .map(|(name, args)| PatternProbe {
+            name: (*name).to_owned(),
+            args: args.iter().map(|arg| (*arg).to_owned()).collect(),
+        })
+        .collect()
+}

--- a/crates/uffs-bench/src/resolve.rs
+++ b/crates/uffs-bench/src/resolve.rs
@@ -52,18 +52,41 @@ pub(crate) fn uffs_cpp_exe(host: &dyn Host) -> String {
     bin_name.to_owned()
 }
 
-/// Resolve the `es.exe` binary (Everything CLI).
+/// Resolve the `es.exe` binary (Everything CLI) to its absolute path.
+///
+/// The binary exits 0 even when the Everything daemon is not running, so
+/// execution-based probes cannot distinguish "found" from "not found".
+/// This function uses disk/PATH lookups only — no execution.
 ///
 /// Search order:
-///   1. `es.exe` reachable via PATH (already-installed or bundle-staged)
-///   2. `%ProgramFiles%\Everything\es.exe` — default installer location
-///   3. `%ProgramFiles(x86)%\Everything\es.exe` — 32-bit installer on 64-bit
-///   4. bare `es.exe` (PATH fallback — lets the OS surface a clear error)
+///   1. `where.exe es.exe` (Windows) / `which es` (Unix) — first PATH hit,
+///      returns the full absolute path.
+///   2. `%USERPROFILE%\bin\es.exe` — `just use` / manual install location.
+///   3. `%ProgramFiles%\Everything\es.exe` — default installer location.
+///   4. `%ProgramFiles(x86)%\Everything\es.exe` — 32-bit installer on 64-bit.
+///   5. bare `es.exe` fallback (OS will error clearly if truly absent).
 pub(crate) fn es_exe(host: &dyn Host) -> String {
-    let bin_name = "es.exe";
-    if host.run(bin_name, &["-get-everything-version"]).is_ok() {
-        return bin_name.to_owned();
+    let bin_name = if cfg!(windows) { "es.exe" } else { "es" };
+
+    // 1. Ask the shell where the binary lives on PATH (gives full absolute path).
+    let where_cmd = if cfg!(windows) { "where.exe" } else { "which" };
+    if let Ok(out) = host.run(where_cmd, &[bin_name]) {
+        let first = out.stdout.lines().next().unwrap_or("").trim().to_owned();
+        if !first.is_empty() {
+            return first;
+        }
     }
+
+    // 2. ~/bin install location.
+    let home_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    if let Some(home) = host.env(home_var) {
+        let candidate = PathBuf::from(&home).join("bin").join(bin_name);
+        if host.path_exists(&candidate) {
+            return candidate.to_string_lossy().into_owned();
+        }
+    }
+
+    // 3-4. Known Windows installer locations.
     for env_var in &["ProgramFiles", "ProgramFiles(x86)"] {
         if let Some(pf) = host.env(env_var) {
             let candidate = PathBuf::from(&pf).join("Everything").join(bin_name);
@@ -72,6 +95,8 @@ pub(crate) fn es_exe(host: &dyn Host) -> String {
             }
         }
     }
+
+    // 5. Bare fallback — OS will surface a clear error if truly absent.
     bin_name.to_owned()
 }
 

--- a/crates/uffs-bench/src/run.rs
+++ b/crates/uffs-bench/src/run.rs
@@ -30,25 +30,18 @@ use crate::error::{CrumbError, Result};
 use crate::gate::{Decision, Mode, StepResult, confirm, done_panel};
 use crate::host::Host;
 use crate::matrix::{self, Matrix, MatrixSpec};
-use crate::preflight::{self, PatternProbe, PreflightResult, PreflightSpec};
+use crate::preflight::{self, PreflightResult, PreflightSpec};
 use crate::restore::RunGuard;
 use crate::stages::{self, StageCfg};
 use crate::state::{Decisions, State, Status, input_hash};
 use crate::tooling::Disposition;
-use crate::{competitors, report, teardown};
+use crate::{competitors, report, resolve, teardown};
 
 /// Suite version stamped into bundle names and `state.json`.
 const SUITE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Stable id of the Stage 0 plan step in the resume engine.
 pub(crate) const STAGE0_ID: &str = "stage0/plan";
-
-/// Default measurement patterns: display name + UFFS row-count argument
-/// template (`{DRIVE}` is substituted per drive during preflight).
-const DEFAULT_PATTERNS: [(&str, &[&str]); 2] = [
-    ("all_dlls", &["{DRIVE}:\\", "*.dll", "--count"]),
-    ("full_scan", &["{DRIVE}:\\", "*", "--count"]),
-];
 
 /// Default readiness-poll attempts for a configured-but-cold competitor drive.
 const PREFLIGHT_POLL_ATTEMPTS: u32 = 3;
@@ -83,10 +76,20 @@ const fn mode_name(mode: Mode) -> &'static str {
     }
 }
 
-/// Build a version-probe for one tool id (Everything uses `es` + its own flag).
-fn tool_probe(name: &str) -> ToolProbe {
+/// Build a version-probe for one tool id.
+///
+/// - `everything` → `es.exe -get-everything-version` (resolved via cascade)
+/// - `uffs_cpp`   → `uffs.com --version` (resolved via `~/bin` cascade)
+/// - anything else → `<exe> --version`
+fn tool_probe(host: &dyn Host, name: &str) -> ToolProbe {
     let (exe, args) = if name == matrix::EVERYTHING_TOOL {
-        ("es".to_owned(), vec!["-get-everything-version".to_owned()])
+        (resolve::es_exe(host), vec![
+            "-get-everything-version".to_owned(),
+        ])
+    } else if name == "uffs_cpp" {
+        (resolve::uffs_cpp_exe(host), vec!["--version".to_owned()])
+    } else if name == "uffs" {
+        (resolve::uffs_exe(host), vec!["--version".to_owned()])
     } else {
         (name.to_owned(), vec!["--version".to_owned()])
     };
@@ -160,12 +163,12 @@ fn plan_input_hash(decisions: &Decisions) -> String {
 }
 
 /// Build the Stage 0a [`EnvSpec`] (one version probe per requested tool).
-fn env_spec_from_cli(cli: &Cli) -> EnvSpec {
+fn env_spec_from_cli(host: &dyn Host, cli: &Cli) -> EnvSpec {
     EnvSpec {
         tools: cli
             .tools_or_default()
             .iter()
-            .map(|tool| tool_probe(tool))
+            .map(|tool| tool_probe(host, tool))
             .collect(),
     }
 }
@@ -175,9 +178,9 @@ fn preflight_spec_from_cli(host: &dyn Host, cli: &Cli) -> PreflightSpec {
     PreflightSpec {
         ini_path: everything_ini_path(host),
         candidate_drives: cli.drives_or_default(),
-        es_exe: "es".to_owned(),
-        uffs_exe: "uffs".to_owned(),
-        patterns: default_pattern_probes(),
+        es_exe: resolve::es_exe(host),
+        uffs_exe: resolve::uffs_exe(host),
+        patterns: resolve::default_pattern_probes(),
         poll_attempts: PREFLIGHT_POLL_ATTEMPTS,
         poll_interval_ms: PREFLIGHT_POLL_INTERVAL_MS,
     }
@@ -188,7 +191,7 @@ fn matrix_spec_from_cli(cli: &Cli) -> MatrixSpec {
     MatrixSpec {
         required_tools: cli.tools_or_default(),
         candidate_drives: cli.drives_or_default(),
-        patterns: DEFAULT_PATTERNS
+        patterns: resolve::DEFAULT_PATTERNS
             .iter()
             .map(|(name, _)| (*name).to_owned())
             .collect(),
@@ -269,18 +272,6 @@ struct Session {
     seen: BTreeSet<String>,
 }
 
-/// Build the default measurement [`PatternProbe`] set (shared by preflight and
-/// the native Stage 3 timing).
-fn default_pattern_probes() -> Vec<PatternProbe> {
-    DEFAULT_PATTERNS
-        .iter()
-        .map(|(name, args)| PatternProbe {
-            name: (*name).to_owned(),
-            args: args.iter().map(|arg| (*arg).to_owned()).collect(),
-        })
-        .collect()
-}
-
 /// Coordinates Stage 0 capture and the staged measurement loop over a [`Host`].
 struct Orchestrator<'a> {
     /// Host seam every side effect flows through.
@@ -311,7 +302,7 @@ impl Orchestrator<'_> {
     /// measurement stages (whose [`StageCfg`] draws its cross-tool-capable
     /// drive subset from the negotiated matrix), so no probe runs twice.
     fn capture(&self) -> Capture {
-        let fp = env::capture(self.host, &env_spec_from_cli(self.cli));
+        let fp = env::capture(self.host, &env_spec_from_cli(self.host, self.cli));
         let preflight =
             preflight::capture(self.host, &preflight_spec_from_cli(self.host, self.cli));
         let matrix = matrix::compute_matrix(&matrix_spec_from_cli(self.cli), &preflight);
@@ -332,8 +323,8 @@ impl Orchestrator<'_> {
             tools: self.cli.tools_or_default(),
             rounds: self.cli.rounds,
             drop_cache: self.cli.drop_os_cache,
-            patterns: default_pattern_probes(),
-            uffs_exe: "uffs".to_owned(),
+            patterns: resolve::default_pattern_probes(),
+            uffs_exe: resolve::uffs_exe(self.host),
         }
     }
 

--- a/crates/uffs-bench/src/run/bootstrap.rs
+++ b/crates/uffs-bench/src/run/bootstrap.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Bundle directory resolution and state bootstrapping helpers for the
+//! bench orchestrator's `run()` entry point.
+
+use std::path::{Path, PathBuf};
+
+use super::{SUITE_VERSION, decisions_from_cli};
+use crate::bundle::{bundle_path, new_bundle};
+use crate::cli::Cli;
+use crate::competitors;
+use crate::error::Result;
+use crate::gate::Mode;
+use crate::host::Host;
+use crate::state::{Decisions, State};
+use crate::tooling::Disposition;
+
+/// Resolve the output bundle directory.
+///
+/// Uses `--bundle <dir>` verbatim when provided; otherwise creates a new
+/// timestamped bundle under `--bundle-root` (or resumes the most-recent one
+/// in dry-run mode so no empty directories are created).
+pub(super) fn resolve_bundle_dir(host: &dyn Host, cli: &Cli, dry_run: bool) -> Result<PathBuf> {
+    if let Some(dir) = &cli.bundle {
+        return Ok(dir.clone());
+    }
+    if dry_run {
+        Ok(bundle_path(host, &cli.bundle_root, SUITE_VERSION))
+    } else {
+        new_bundle(host, &cli.bundle_root, SUITE_VERSION)
+    }
+}
+
+/// Disposition for tools the suite acquires (the `--keep-tools` toggle).
+pub(super) const fn tool_disposition(cli: &Cli) -> Disposition {
+    if cli.keep_tools {
+        Disposition::Keep
+    } else {
+        Disposition::Remove
+    }
+}
+
+/// Handle the `fetch-competitors` subcommand.
+///
+/// Resolves (or resumes) a bundle, fetches + SHA-256-verifies the pinned
+/// competitor from `competitors.toml` into `<bundle>/tools/`, and records the
+/// verified [`Acquisition`](crate::tooling::Acquisition) in `state.json`. A
+/// dry-run acquires nothing.
+///
+/// # Errors
+/// Returns an error if bundle/state I/O fails or provisioning fails (a
+/// malformed manifest, a failed download, or a SHA-256 mismatch — all fail
+/// closed).
+pub(super) fn run_fetch_competitors(host: &dyn Host, cli: &Cli) -> Result<()> {
+    if cli.mode() == Mode::DryRun {
+        host.out("dry-run: competitor fetch acquires nothing");
+        return Ok(());
+    }
+    let decisions = decisions_from_cli(cli);
+    let bundle_dir = resolve_bundle_dir(host, cli, false)?;
+    let state_path = bundle_dir.join("state.json");
+    let mut state = load_or_new_state(host, cli, &state_path, &decisions)?;
+
+    let manifest = competitors::load_manifest(host, Path::new(competitors::MANIFEST_PATH))?;
+    let acquisition = competitors::fetch(host, &manifest, &bundle_dir, tool_disposition(cli))?;
+    host.out(&format!(
+        "fetched {} (Everything v{}) -> {} [sha256 verified, {:?}]",
+        acquisition.name,
+        manifest.everything.version,
+        acquisition.path.display(),
+        acquisition.disposition
+    ));
+    state.acquisitions.push(acquisition);
+    state.save(host, &state_path)?;
+    Ok(())
+}
+
+/// Load `state.json` when resuming an existing bundle, else start fresh.
+pub(super) fn load_or_new_state(
+    host: &dyn Host,
+    cli: &Cli,
+    state_path: &Path,
+    decisions: &Decisions,
+) -> Result<State> {
+    if cli.bundle.is_some() && host.path_exists(state_path) {
+        State::load(host, state_path)
+    } else {
+        Ok(State::new(host, SUITE_VERSION, decisions.clone()))
+    }
+}

--- a/crates/uffs-bench/src/run/daemon.rs
+++ b/crates/uffs-bench/src/run/daemon.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! UFFS daemon readiness helpers for the bench orchestrator.
+//! UFFS daemon control helpers for the bench orchestrator.
 //!
-//! The bench tool kicks off the daemon as the very first action in Stage 0 so
-//! the index load runs in parallel with env capture and the tool-selection
-//! gate. Readiness is only polled once the drive-inventory table is needed,
-//! giving the daemon the maximum possible warm-up time before the hard wait.
+//! The daemon is always killed and restarted with only the negotiated capable
+//! drives before measurement begins, so index RAM and query routing are
+//! confined to the drives under test.
 
 use crate::error::{BenchError, Result};
 use crate::host::Host;
@@ -14,37 +13,54 @@ use crate::host::Host;
 /// Maximum poll attempts waiting for the UFFS daemon to reach `Status: Ready`.
 ///
 /// 90 attempts × 2 s = 3 minutes maximum — matches the user-facing timeout
-/// promise. The daemon is kicked off at the very start of `capture()`, so the
-/// index load runs in parallel with env capture and the tool-selection gate.
-/// Polling only starts once those steps are done and the drive table is needed.
+/// promise.
 pub(super) const DAEMON_READY_POLL_ATTEMPTS: u32 = 90;
 
 /// Milliseconds between UFFS daemon readiness polls.
 pub(super) const DAEMON_READY_POLL_INTERVAL_MS: u64 = 2_000;
 
-/// Check if the UFFS daemon is already running and ready.
+/// Kill the running UFFS daemon (hard stop) and start a fresh instance
+/// restricted to `capable_drives`.
 ///
-/// Returns `true` when `uffs daemon status` exits 0 and its output contains
-/// `Status:        Ready` (the literal string the daemon emits).
-fn daemon_is_ready(host: &dyn Host, uffs_exe: &str) -> bool {
-    host.run(uffs_exe, &["daemon", "status"])
-        .is_ok_and(|out| out.stdout.contains("Status:        Ready"))
-}
-
-/// Start the UFFS daemon if it is not already running or ready.
-///
-/// Fires `uffs daemon start` and returns immediately — the caller does not
-/// wait for the index to finish loading. Any start error is printed as a
-/// warning and swallowed; a subsequent [`ensure_daemon_ready`] call will
-/// catch the failure with a clear message.
-pub(super) fn daemon_start_if_needed(host: &dyn Host, uffs_exe: &str) {
-    if daemon_is_ready(host, uffs_exe) {
-        return; // already up
-    }
-    host.out("[preflight] UFFS daemon not ready — starting …");
-    if let Err(err) = host.run(uffs_exe, &["daemon", "start"]) {
+/// Fires `uffs daemon kill` first, waits briefly for the process to exit,
+/// then calls `uffs daemon start --drive X --drive Y …`.  Returns immediately
+/// after the start command — the caller must call [`ensure_daemon_ready`] to
+/// poll until the index is loaded.
+pub(super) fn kill_and_restart_with_drives(
+    host: &dyn Host,
+    uffs_exe: &str,
+    capable_drives: &[char],
+) {
+    host.out(&format!(
+        "[uffs-daemon] killing daemon to restart with drives: {} …",
+        capable_drives
+            .iter()
+            .map(char::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+    if let Err(err) = host.run(uffs_exe, &["daemon", "kill"]) {
         host.out(&format!(
-            "[preflight] WARNING: could not start UFFS daemon: {err}"
+            "[uffs-daemon] WARNING: kill returned error (may not have been running): {err}"
+        ));
+    }
+    // Brief pause to allow the OS to release sockets / named-pipe handles
+    // before we immediately re-launch.
+    host.sleep_ms(1_500);
+
+    let drive_strs: Vec<String> = capable_drives.iter().map(char::to_string).collect();
+    let mut args: Vec<&str> = vec!["daemon", "start"];
+    for drive_s in &drive_strs {
+        args.push("--drive");
+        args.push(drive_s.as_str());
+    }
+    host.out(&format!(
+        "[uffs-daemon] spawn: {uffs_exe} {}",
+        args.join(" ")
+    ));
+    if let Err(err) = host.run(uffs_exe, &args) {
+        host.out(&format!(
+            "[uffs-daemon] WARNING: could not restart UFFS daemon: {err}"
         ));
     }
 }

--- a/crates/uffs-bench/src/run/daemon.rs
+++ b/crates/uffs-bench/src/run/daemon.rs
@@ -20,6 +20,32 @@ pub(super) const DAEMON_READY_POLL_ATTEMPTS: u32 = 90;
 pub(super) const DAEMON_READY_POLL_INTERVAL_MS: u64 = 2_000;
 
 /// Kill the running UFFS daemon (hard stop) and start a fresh instance
+/// with **no `--drive` restrictions** so the daemon self-discovers every
+/// available drive.
+///
+/// Called at the start of preflight so the first drive-negotiation probe
+/// sees the full set of drives the host can index.  Returns immediately
+/// after the start command — the caller must call [`ensure_daemon_ready`]
+/// before issuing preflight queries.
+pub(super) fn kill_and_restart_all_drives(host: &dyn Host, uffs_exe: &str) {
+    host.out("[uffs-daemon] killing daemon to restart with all drives …");
+    if let Err(err) = host.run(uffs_exe, &["daemon", "kill"]) {
+        host.out(&format!(
+            "[uffs-daemon] WARNING: kill returned error (may not have been running): {err}"
+        ));
+    }
+    // Brief pause to allow the OS to release sockets / named-pipe handles
+    // before we immediately re-launch.
+    host.sleep_ms(1_500);
+    host.out(&format!("[uffs-daemon] spawn: {uffs_exe} daemon start"));
+    if let Err(err) = host.run(uffs_exe, &["daemon", "start"]) {
+        host.out(&format!(
+            "[uffs-daemon] WARNING: could not restart UFFS daemon: {err}"
+        ));
+    }
+}
+
+/// Kill the running UFFS daemon (hard stop) and start a fresh instance
 /// restricted to `capable_drives`.
 ///
 /// Fires `uffs daemon kill` first, waits briefly for the process to exit,

--- a/crates/uffs-bench/src/run/daemon.rs
+++ b/crates/uffs-bench/src/run/daemon.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! UFFS daemon readiness helpers for the bench orchestrator.
+//!
+//! The bench tool kicks off the daemon as the very first action in Stage 0 so
+//! the index load runs in parallel with env capture and the tool-selection
+//! gate. Readiness is only polled once the drive-inventory table is needed,
+//! giving the daemon the maximum possible warm-up time before the hard wait.
+
+use crate::error::{BenchError, Result};
+use crate::host::Host;
+
+/// Maximum poll attempts waiting for the UFFS daemon to reach `Status: Ready`.
+///
+/// 90 attempts × 2 s = 3 minutes maximum — matches the user-facing timeout
+/// promise. The daemon is kicked off at the very start of `capture()`, so the
+/// index load runs in parallel with env capture and the tool-selection gate.
+/// Polling only starts once those steps are done and the drive table is needed.
+pub(super) const DAEMON_READY_POLL_ATTEMPTS: u32 = 90;
+
+/// Milliseconds between UFFS daemon readiness polls.
+pub(super) const DAEMON_READY_POLL_INTERVAL_MS: u64 = 2_000;
+
+/// Check if the UFFS daemon is already running and ready.
+///
+/// Returns `true` when `uffs daemon status` exits 0 and its output contains
+/// `Status:        Ready` (the literal string the daemon emits).
+fn daemon_is_ready(host: &dyn Host, uffs_exe: &str) -> bool {
+    host.run(uffs_exe, &["daemon", "status"])
+        .is_ok_and(|out| out.stdout.contains("Status:        Ready"))
+}
+
+/// Start the UFFS daemon if it is not already running or ready.
+///
+/// Fires `uffs daemon start` and returns immediately — the caller does not
+/// wait for the index to finish loading. Any start error is printed as a
+/// warning and swallowed; a subsequent [`ensure_daemon_ready`] call will
+/// catch the failure with a clear message.
+pub(super) fn daemon_start_if_needed(host: &dyn Host, uffs_exe: &str) {
+    if daemon_is_ready(host, uffs_exe) {
+        return; // already up
+    }
+    host.out("[preflight] UFFS daemon not ready — starting …");
+    if let Err(err) = host.run(uffs_exe, &["daemon", "start"]) {
+        host.out(&format!(
+            "[preflight] WARNING: could not start UFFS daemon: {err}"
+        ));
+    }
+}
+
+/// Poll `uffs daemon status` until `Status:        Ready` appears, printing a
+/// progress line on each attempt so the operator knows the tool is waiting.
+///
+/// # Errors
+/// Returns [`BenchError::Command`] if the daemon does not become ready within
+/// [`DAEMON_READY_POLL_ATTEMPTS`] × [`DAEMON_READY_POLL_INTERVAL_MS`] ms
+/// (~3 minutes).
+pub(super) fn ensure_daemon_ready(host: &dyn Host, uffs_exe: &str) -> Result<()> {
+    for attempt in 1..=DAEMON_READY_POLL_ATTEMPTS {
+        match host.run(uffs_exe, &["daemon", "status"]) {
+            Ok(out) if out.stdout.contains("Status:        Ready") => {
+                host.out("[preflight] UFFS daemon is Ready — proceeding");
+                return Ok(());
+            }
+            Ok(out) => {
+                let status_line = out
+                    .stdout
+                    .lines()
+                    .find(|line| line.trim_start().starts_with("Status:"))
+                    .unwrap_or("Status: unknown")
+                    .trim()
+                    .to_owned();
+                host.out(&format!(
+                    "[preflight] Waiting for UFFS daemon … {status_line} \
+                     (attempt {attempt}/{DAEMON_READY_POLL_ATTEMPTS})"
+                ));
+            }
+            Err(err) => {
+                host.out(&format!(
+                    "[preflight] Waiting for UFFS daemon … not responding: {err} \
+                     (attempt {attempt}/{DAEMON_READY_POLL_ATTEMPTS})"
+                ));
+            }
+        }
+        host.sleep_ms(DAEMON_READY_POLL_INTERVAL_MS);
+    }
+    Err(BenchError::Command(
+        "UFFS daemon did not reach Ready within 3 minutes — \
+         check `uffs daemon status` and re-run"
+            .to_owned(),
+    ))
+}

--- a/crates/uffs-bench/src/run/es_instance.rs
+++ b/crates/uffs-bench/src/run/es_instance.rs
@@ -33,46 +33,183 @@ const LOAD_POLL_ATTEMPTS: u32 = 60;
 /// Milliseconds between bench-instance readiness polls.
 const LOAD_POLL_INTERVAL_MS: u64 = 5_000;
 
-/// Keys overridden in the temp ini to prevent ES from auto-discovering all
-/// fixed/removable volumes on the machine.
-const AUTO_INCLUDE_OVERRIDE: &str = "\
-auto_include_fixed_volumes=0\n\
-auto_include_removable_volumes=0\n\
-auto_include_fixed_refs_volumes=0\n\
-auto_include_removable_refs_volumes=0\n\
-auto_remove_offline_ntfs_volumes=0\n\
-auto_remove_moved_ntfs_volumes=0\n\
-auto_remove_offline_refs_volumes=0\n\
-auto_remove_moved_refs_volumes=0\n";
+/// Parse a `key=val1,val2,...` Everything.ini array value into tokens.
+///
+/// Handles the quoted-string format Everything uses: `"C:","D:"` for paths
+/// and bare integers `1,1,0` for flags.  Quoted tokens are kept whole.
+fn parse_ini_array(value: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut rest = value.trim();
+    while !rest.is_empty() {
+        if rest.starts_with('"') {
+            // find the closing quote (starts scanning after the opening quote)
+            let close = rest.char_indices().skip(1).find(|(_, ch)| *ch == '"');
+            let end = close.map_or(rest.len(), |(idx, _)| idx + 1);
+            let (tok, tail) = rest.split_at(end);
+            tokens.push(tok.to_owned());
+            rest = tail.trim_start_matches(',');
+        } else {
+            let end = rest.find(',').unwrap_or(rest.len());
+            let (tok, tail) = rest.split_at(end);
+            tokens.push(tok.to_owned());
+            rest = tail.trim_start_matches(',');
+        }
+    }
+    tokens
+}
 
 /// Write the bench `Everything.ini` into `path`.
 ///
-/// Copies the `ntfs_volume_*` lines **verbatim** from the permanent
-/// `Everything.ini` (so GUIDs, paths, includes, monitors all match exactly
-/// what the operator has configured), then prepends the `[Everything]` header
-/// with `auto_include_fixed_volumes=0` (and friends) so ES does not
-/// auto-discover drives outside the operator's configured set.
-///
-/// Falls back to an empty `ntfs_volume_*` block if the permanent ini cannot
-/// be read (non-Windows hosts, missing file, etc.).
-fn write_bench_ini(host: &dyn Host, path: &Path, _drives: &[char]) -> std::io::Result<()> {
+/// Reads the permanent `Everything.ini` and copies it line-for-line, replacing
+/// the `ntfs_volume_*` parallel arrays with versions filtered to only the
+/// `drives` the bench needs (alphabetically sorted, quoted format exactly as
+/// Everything writes them — `"C:","D:"`).
+fn write_bench_ini(host: &dyn Host, path: &Path, drives: &[char]) -> std::io::Result<()> {
     let permanent_ini = everything_ini_path(host);
-    let ntfs_lines = host
+    let text = host
         .read_file(&permanent_ini)
         .ok()
         .and_then(|bytes| String::from_utf8(bytes).ok())
-        .map(|text| {
-            text.lines()
-                .filter(|line| {
-                    let key = line.split('=').next().unwrap_or("").trim();
-                    key.starts_with("ntfs_volume_") || key.starts_with("refs_volume_")
-                })
-                .flat_map(|line| [line, "\n"])
-                .collect::<String>()
-        })
         .unwrap_or_default();
-    let ini = format!("[Everything]\n{AUTO_INCLUDE_OVERRIDE}{ntfs_lines}");
-    host.write_file(path, ini.as_bytes())
+
+    let mut bench_drives: Vec<char> = drives.to_vec();
+    bench_drives.sort_unstable_by_key(char::to_ascii_uppercase);
+    let bench_set: std::collections::HashSet<char> =
+        bench_drives.iter().map(char::to_ascii_uppercase).collect();
+
+    // Parse the seven parallel ntfs_volume_* arrays.
+    let mut guids = Vec::new();
+    let mut paths = Vec::new();
+    let mut roots = Vec::new();
+    let mut includes = Vec::new();
+    let mut load_recent = Vec::new();
+    let mut include_onlys = Vec::new();
+    let mut monitors = Vec::new();
+
+    for line in text.lines() {
+        let Some((key, val)) = line.split_once('=') else {
+            continue;
+        };
+        match key.trim() {
+            "ntfs_volume_guids" => guids = parse_ini_array(val),
+            "ntfs_volume_paths" => paths = parse_ini_array(val),
+            "ntfs_volume_roots" => roots = parse_ini_array(val),
+            "ntfs_volume_includes" => includes = parse_ini_array(val),
+            "ntfs_volume_load_recent_changes" => load_recent = parse_ini_array(val),
+            "ntfs_volume_include_onlys" => include_onlys = parse_ini_array(val),
+            "ntfs_volume_monitors" => monitors = parse_ini_array(val),
+            _ => {}
+        }
+    }
+
+    // Which indices correspond to bench drives?
+    let indices: Vec<usize> = paths
+        .iter()
+        .enumerate()
+        .filter(|(_, path_tok)| {
+            let letter = path_tok.trim_matches('"').chars().next().unwrap_or(' ');
+            bench_set.contains(&letter.to_ascii_uppercase())
+        })
+        .map(|(i, _)| i)
+        .collect();
+
+    let select = |arr: &[String], fallback: &str| -> String {
+        indices
+            .iter()
+            .map(|&i| arr.get(i).map_or(fallback, String::as_str))
+            .collect::<Vec<_>>()
+            .join(",")
+    };
+
+    let out_guids = select(&guids, "\"\"");
+    let out_paths = select(&paths, "\"\"");
+    let out_roots = select(&roots, "\"\"");
+    let out_includes = select(&includes, "1");
+    let out_load_recent = select(&load_recent, "1");
+    let out_include_onlys = select(&include_onlys, "\"\"");
+    let out_monitors = select(&monitors, "1");
+
+    let arrays = VolumeArrays {
+        guids: &out_guids,
+        paths: &out_paths,
+        roots: &out_roots,
+        includes: &out_includes,
+        load_recent: &out_load_recent,
+        include_onlys: &out_include_onlys,
+        monitors: &out_monitors,
+    };
+    let out = rebuild_ini(&text, &arrays);
+    host.write_file(path, out.as_bytes())
+}
+
+/// Filtered `ntfs_volume_*` array strings for the bench ini.
+struct VolumeArrays<'a> {
+    /// `ntfs_volume_guids` value.
+    guids: &'a str,
+    /// `ntfs_volume_paths` value.
+    paths: &'a str,
+    /// `ntfs_volume_roots` value.
+    roots: &'a str,
+    /// `ntfs_volume_includes` value.
+    includes: &'a str,
+    /// `ntfs_volume_load_recent_changes` value.
+    load_recent: &'a str,
+    /// `ntfs_volume_include_onlys` value.
+    include_onlys: &'a str,
+    /// `ntfs_volume_monitors` value.
+    monitors: &'a str,
+}
+
+/// Rebuild the ini text, replacing only the seven `ntfs_volume_*` array lines.
+fn rebuild_ini(text: &str, arrays: &VolumeArrays<'_>) -> String {
+    let mut out = String::with_capacity(text.len());
+    for line in text.lines() {
+        let key = line
+            .split_once('=')
+            .map_or("", |(key_part, _)| key_part.trim());
+        match key {
+            "ntfs_volume_guids" => {
+                out.push_str("ntfs_volume_guids=");
+                out.push_str(arrays.guids);
+                out.push('\n');
+            }
+            "ntfs_volume_paths" => {
+                out.push_str("ntfs_volume_paths=");
+                out.push_str(arrays.paths);
+                out.push('\n');
+            }
+            "ntfs_volume_roots" => {
+                out.push_str("ntfs_volume_roots=");
+                out.push_str(arrays.roots);
+                out.push('\n');
+            }
+            "ntfs_volume_includes" => {
+                out.push_str("ntfs_volume_includes=");
+                out.push_str(arrays.includes);
+                out.push('\n');
+            }
+            "ntfs_volume_load_recent_changes" => {
+                out.push_str("ntfs_volume_load_recent_changes=");
+                out.push_str(arrays.load_recent);
+                out.push('\n');
+            }
+            "ntfs_volume_include_onlys" => {
+                out.push_str("ntfs_volume_include_onlys=");
+                out.push_str(arrays.include_onlys);
+                out.push('\n');
+            }
+            "ntfs_volume_monitors" => {
+                out.push_str("ntfs_volume_monitors=");
+                out.push_str(arrays.monitors);
+                out.push('\n');
+            }
+            _ => {
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+    }
+    out
 }
 
 /// Derive a path for the temporary bench ini.

--- a/crates/uffs-bench/src/run/es_instance.rs
+++ b/crates/uffs-bench/src/run/es_instance.rs
@@ -33,6 +33,10 @@ const LOAD_POLL_ATTEMPTS: u32 = 60;
 /// Milliseconds between bench-instance readiness polls.
 const LOAD_POLL_INTERVAL_MS: u64 = 5_000;
 
+/// Milliseconds to wait after sending `-exit` to any existing Everything
+/// instances before spawning our own, giving the process time to flush its db.
+const ES_KILL_GRACE_MS: u64 = 2_000;
+
 /// Parse a `key=val1,val2,...` Everything.ini array value into tokens.
 ///
 /// Handles the quoted-string format Everything uses: `"C:","D:"` for paths
@@ -205,6 +209,11 @@ pub(super) fn launch(
         ));
         return None;
     }
+    // Terminate any existing Everything instances (default + stale bench) so
+    // we start from a clean slate with our own temp ini.  A short grace period
+    // lets the process finish writing its db before we spawn the new instance.
+    kill_existing_instances(host, everything_exe);
+    host.sleep_ms(ES_KILL_GRACE_MS);
     let admin_tag = if admin { " (admin)" } else { "" };
     host.out(&format!(
         "[es-instance] launching Everything{admin_tag} (drives: {}) …",
@@ -263,6 +272,17 @@ pub(super) fn wait_until_loaded(host: &dyn Host, es_exe: &str, drives: &[char]) 
          — ES cells will be measured with a partial index",
     );
     false
+}
+
+/// Ask any running Everything instances to exit before we launch our own.
+///
+/// Sends `-exit` to both the default (unnamed) instance and any stale
+/// `uffs-bench` instance left over from a previous interrupted run.
+/// Errors are non-fatal: if no instance is running the IPC call simply fails
+/// silently, which is the desired outcome.
+fn kill_existing_instances(host: &dyn Host, everything_exe: &str) {
+    drop(host.run(everything_exe, &["-exit"]));
+    drop(host.run(everything_exe, &["-instance", INSTANCE_NAME, "-exit"]));
 }
 
 /// Send `Everything.exe -instance uffs-bench -exit` and remove the temp ini.

--- a/crates/uffs-bench/src/run/es_instance.rs
+++ b/crates/uffs-bench/src/run/es_instance.rs
@@ -60,10 +60,15 @@ fn parse_ini_array(value: &str) -> Vec<String> {
 
 /// Write the bench `Everything.ini` into `path`.
 ///
-/// Reads the permanent `Everything.ini` and copies it line-for-line, replacing
-/// the `ntfs_volume_*` parallel arrays with versions filtered to only the
-/// `drives` the bench needs (alphabetically sorted, quoted format exactly as
-/// Everything writes them — `"C:","D:"`).
+/// Reads the permanent `Everything.ini` verbatim and produces the temp ini
+/// with two changes:
+///   1. `ntfs_volume_includes` and `ntfs_volume_monitors` are recomputed: `1`
+///      for each drive in `drives`, `0` for all other drives in the permanent
+///      ini.  All other volume arrays (guids/paths/roots/
+///      `load_recent_changes`/`include_onlys`) are kept as-is so the temp ini
+///      the same full set of drives as the permanent ini.
+///   2. `auto_include_fixed_volumes` (and siblings) are forced to `0` so ES
+///      does not auto-discover drives outside the configured set.
 fn write_bench_ini(host: &dyn Host, path: &Path, drives: &[char]) -> std::io::Result<()> {
     let permanent_ini = everything_ini_path(host);
     let text = host
@@ -72,95 +77,55 @@ fn write_bench_ini(host: &dyn Host, path: &Path, drives: &[char]) -> std::io::Re
         .and_then(|bytes| String::from_utf8(bytes).ok())
         .unwrap_or_default();
 
-    let mut bench_drives: Vec<char> = drives.to_vec();
-    bench_drives.sort_unstable_by_key(char::to_ascii_uppercase);
     let bench_set: std::collections::HashSet<char> =
-        bench_drives.iter().map(char::to_ascii_uppercase).collect();
+        drives.iter().map(char::to_ascii_uppercase).collect();
 
-    // Parse the seven parallel ntfs_volume_* arrays.
-    let mut guids = Vec::new();
-    let mut paths = Vec::new();
-    let mut roots = Vec::new();
-    let mut includes = Vec::new();
-    let mut load_recent = Vec::new();
-    let mut include_onlys = Vec::new();
-    let mut monitors = Vec::new();
-
+    // Parse ntfs_volume_paths to know which index maps to which drive letter.
+    let mut paths: Vec<String> = Vec::new();
     for line in text.lines() {
-        let Some((key, val)) = line.split_once('=') else {
-            continue;
-        };
-        match key.trim() {
-            "ntfs_volume_guids" => guids = parse_ini_array(val),
-            "ntfs_volume_paths" => paths = parse_ini_array(val),
-            "ntfs_volume_roots" => roots = parse_ini_array(val),
-            "ntfs_volume_includes" => includes = parse_ini_array(val),
-            "ntfs_volume_load_recent_changes" => load_recent = parse_ini_array(val),
-            "ntfs_volume_include_onlys" => include_onlys = parse_ini_array(val),
-            "ntfs_volume_monitors" => monitors = parse_ini_array(val),
-            _ => {}
+        if let Some((key, val)) = line.split_once('=')
+            && key.trim() == "ntfs_volume_paths"
+        {
+            paths = parse_ini_array(val);
+            break;
         }
     }
 
-    // Which indices correspond to bench drives?
-    let indices: Vec<usize> = paths
+    // Build includes/monitors: 1 for bench drives, 0 for all others,
+    // preserving the full positional array length from the permanent ini.
+    let includes: String = paths
         .iter()
-        .enumerate()
-        .filter(|(_, path_tok)| {
-            let letter = path_tok.trim_matches('"').chars().next().unwrap_or(' ');
-            bench_set.contains(&letter.to_ascii_uppercase())
+        .map(|tok| {
+            let letter = tok.trim_matches('"').chars().next().unwrap_or(' ');
+            if bench_set.contains(&letter.to_ascii_uppercase()) {
+                "1"
+            } else {
+                "0"
+            }
         })
-        .map(|(i, _)| i)
-        .collect();
-
-    let select = |arr: &[String], fallback: &str| -> String {
-        indices
-            .iter()
-            .map(|&i| arr.get(i).map_or(fallback, String::as_str))
-            .collect::<Vec<_>>()
-            .join(",")
-    };
-
-    let out_guids = select(&guids, "\"\"");
-    let out_paths = select(&paths, "\"\"");
-    let out_roots = select(&roots, "\"\"");
-    let out_includes = select(&includes, "1");
-    let out_load_recent = select(&load_recent, "1");
-    let out_include_onlys = select(&include_onlys, "\"\"");
-    let out_monitors = select(&monitors, "1");
+        .collect::<Vec<_>>()
+        .join(",");
+    let monitors = includes.clone();
 
     let arrays = VolumeArrays {
-        guids: &out_guids,
-        paths: &out_paths,
-        roots: &out_roots,
-        includes: &out_includes,
-        load_recent: &out_load_recent,
-        include_onlys: &out_include_onlys,
-        monitors: &out_monitors,
+        includes: &includes,
+        monitors: &monitors,
     };
     let out = rebuild_ini(&text, &arrays);
     host.write_file(path, out.as_bytes())
 }
 
-/// Filtered `ntfs_volume_*` array strings for the bench ini.
+/// Recomputed per-drive bit arrays for the bench ini.
 struct VolumeArrays<'a> {
-    /// `ntfs_volume_guids` value.
-    guids: &'a str,
-    /// `ntfs_volume_paths` value.
-    paths: &'a str,
-    /// `ntfs_volume_roots` value.
-    roots: &'a str,
-    /// `ntfs_volume_includes` value.
+    /// `ntfs_volume_includes` value — `1` for bench drives, `0` for others.
     includes: &'a str,
-    /// `ntfs_volume_load_recent_changes` value.
-    load_recent: &'a str,
-    /// `ntfs_volume_include_onlys` value.
-    include_onlys: &'a str,
-    /// `ntfs_volume_monitors` value.
+    /// `ntfs_volume_monitors` value — mirrors `includes`.
     monitors: &'a str,
 }
 
-/// Rebuild the ini text, replacing only the seven `ntfs_volume_*` array lines.
+/// Rebuild the ini text from `text`, replacing only `ntfs_volume_includes`,
+/// `ntfs_volume_monitors`, and the `auto_include_*`/`auto_remove_*` keys.
+/// All other lines are copied verbatim.
 fn rebuild_ini(text: &str, arrays: &VolumeArrays<'_>) -> String {
     let mut out = String::with_capacity(text.len());
     for line in text.lines() {
@@ -168,39 +133,29 @@ fn rebuild_ini(text: &str, arrays: &VolumeArrays<'_>) -> String {
             .split_once('=')
             .map_or("", |(key_part, _)| key_part.trim());
         match key {
-            "ntfs_volume_guids" => {
-                out.push_str("ntfs_volume_guids=");
-                out.push_str(arrays.guids);
-                out.push('\n');
-            }
-            "ntfs_volume_paths" => {
-                out.push_str("ntfs_volume_paths=");
-                out.push_str(arrays.paths);
-                out.push('\n');
-            }
-            "ntfs_volume_roots" => {
-                out.push_str("ntfs_volume_roots=");
-                out.push_str(arrays.roots);
-                out.push('\n');
-            }
             "ntfs_volume_includes" => {
                 out.push_str("ntfs_volume_includes=");
                 out.push_str(arrays.includes);
                 out.push('\n');
             }
-            "ntfs_volume_load_recent_changes" => {
-                out.push_str("ntfs_volume_load_recent_changes=");
-                out.push_str(arrays.load_recent);
-                out.push('\n');
-            }
-            "ntfs_volume_include_onlys" => {
-                out.push_str("ntfs_volume_include_onlys=");
-                out.push_str(arrays.include_onlys);
-                out.push('\n');
-            }
             "ntfs_volume_monitors" => {
                 out.push_str("ntfs_volume_monitors=");
                 out.push_str(arrays.monitors);
+                out.push('\n');
+            }
+            // Force to 0 — without this ES ignores ntfs_volume_paths and
+            // auto-discovers every fixed NTFS drive on the machine.
+            "auto_include_fixed_volumes"
+            | "auto_include_removable_volumes"
+            | "auto_include_fixed_refs_volumes"
+            | "auto_include_removable_refs_volumes"
+            | "auto_remove_offline_ntfs_volumes"
+            | "auto_remove_moved_ntfs_volumes"
+            | "auto_remove_offline_refs_volumes"
+            | "auto_remove_moved_refs_volumes" => {
+                out.push_str(key);
+                out.push('=');
+                out.push('0');
                 out.push('\n');
             }
             _ => {

--- a/crates/uffs-bench/src/run/es_instance.rs
+++ b/crates/uffs-bench/src/run/es_instance.rs
@@ -20,6 +20,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::host::Host;
+use crate::run::specs::everything_ini_path;
 
 /// Named instance used for the bench-local Everything process.
 pub(super) const INSTANCE_NAME: &str = "uffs-bench";
@@ -32,44 +33,45 @@ const LOAD_POLL_ATTEMPTS: u32 = 60;
 /// Milliseconds between bench-instance readiness polls.
 const LOAD_POLL_INTERVAL_MS: u64 = 5_000;
 
-/// Write a minimal `Everything.ini` restricted to `drives` into `path`.
+/// Keys overridden in the temp ini to prevent ES from auto-discovering all
+/// fixed/removable volumes on the machine.
+const AUTO_INCLUDE_OVERRIDE: &str = "\
+auto_include_fixed_volumes=0\n\
+auto_include_removable_volumes=0\n\
+auto_include_fixed_refs_volumes=0\n\
+auto_include_removable_refs_volumes=0\n\
+auto_remove_offline_ntfs_volumes=0\n\
+auto_remove_moved_ntfs_volumes=0\n\
+auto_remove_offline_refs_volumes=0\n\
+auto_remove_moved_refs_volumes=0\n";
+
+/// Write the bench `Everything.ini` into `path`.
 ///
-/// Must explicitly disable `auto_include_fixed_volumes` — without it
-/// Everything ignores `ntfs_volume_paths` and indexes every fixed NTFS volume
-/// on the machine automatically (confirmed via voidtools forum, author `void`).
+/// Copies the `ntfs_volume_*` lines **verbatim** from the permanent
+/// `Everything.ini` (so GUIDs, paths, includes, monitors all match exactly
+/// what the operator has configured), then prepends the `[Everything]` header
+/// with `auto_include_fixed_volumes=0` (and friends) so ES does not
+/// auto-discover drives outside the operator's configured set.
 ///
-/// The full set of keys required to pin indexing to exactly `drives`:
-/// - `auto_include_fixed_volumes=0` — don't auto-discover fixed drives
-/// - `auto_include_removable_volumes=0` — don't auto-discover removable drives
-/// - `auto_remove_offline_ntfs_volumes=0` — don't remove offline volumes
-/// - `ntfs_volume_paths=C:,D:,…` — exactly the bench drives to index
-/// - remaining `ntfs_volume_*` keys explicitly blank so ES doesn't inherit
-///   stale values from a partially-written config
-fn write_bench_ini(host: &dyn Host, path: &Path, drives: &[char]) -> std::io::Result<()> {
-    // Everything.ini uses a quoted comma-separated format for parallel arrays,
-    // e.g. ntfs_volume_paths="C:","D:","G:"
-    // ntfs_volume_includes / monitors / roots follow the same positional order.
-    let n = drives.len();
-    let volume_paths: String = drives
-        .iter()
-        .map(|letter| format!("\"{letter}:\""))
-        .collect::<Vec<_>>()
-        .join(",");
-    let ones = vec!["1"; n].join(",");
-    let empty_quoted = vec!["\"\""; n].join(",");
-    let ini = format!(
-        "[Everything]\n\
-         auto_include_fixed_volumes=0\n\
-         auto_include_removable_volumes=0\n\
-         auto_remove_offline_ntfs_volumes=0\n\
-         ntfs_volume_guids=\n\
-         ntfs_volume_paths={volume_paths}\n\
-         ntfs_volume_roots={empty_quoted}\n\
-         ntfs_volume_includes={ones}\n\
-         ntfs_volume_load_recent_changes={ones}\n\
-         ntfs_volume_include_onlys={empty_quoted}\n\
-         ntfs_volume_monitors={ones}\n"
-    );
+/// Falls back to an empty `ntfs_volume_*` block if the permanent ini cannot
+/// be read (non-Windows hosts, missing file, etc.).
+fn write_bench_ini(host: &dyn Host, path: &Path, _drives: &[char]) -> std::io::Result<()> {
+    let permanent_ini = everything_ini_path(host);
+    let ntfs_lines = host
+        .read_file(&permanent_ini)
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .map(|text| {
+            text.lines()
+                .filter(|line| {
+                    let key = line.split('=').next().unwrap_or("").trim();
+                    key.starts_with("ntfs_volume_") || key.starts_with("refs_volume_")
+                })
+                .flat_map(|line| [line, "\n"])
+                .collect::<String>()
+        })
+        .unwrap_or_default();
+    let ini = format!("[Everything]\n{AUTO_INCLUDE_OVERRIDE}{ntfs_lines}");
     host.write_file(path, ini.as_bytes())
 }
 

--- a/crates/uffs-bench/src/run/es_instance.rs
+++ b/crates/uffs-bench/src/run/es_instance.rs
@@ -301,20 +301,20 @@ pub(super) fn stop(host: &dyn Host, everything_exe: &str, ini_path: Option<&Path
     }
 }
 
-/// Whether the preflight result shows Everything is not running on any of the
-/// given drives (i.e. we need to launch our own instance).
+/// Whether the bench should launch its own isolated Everything instance.
+///
+/// Returns `true` for every ES status except `NotInstalled` (where
+/// `Everything.exe` is not present and cannot be launched).  This means the
+/// bench always replaces whatever instance the operator may have running — even
+/// a fully-loaded default instance — with a private one restricted to the
+/// RAM-budget-capable drives and a clean temp ini.
 pub(super) fn es_needs_launch(
     preflight: &crate::preflight::PreflightResult,
     drives: &[char],
 ) -> bool {
     drives.iter().any(|&letter| {
         preflight.drives.iter().any(|dp| {
-            dp.drive == letter
-                && matches!(
-                    dp.es_status,
-                    crate::preflight::EsStatus::DaemonNotRunning
-                        | crate::preflight::EsStatus::NotConfigured
-                )
+            dp.drive == letter && !matches!(dp.es_status, crate::preflight::EsStatus::NotInstalled)
         })
     })
 }

--- a/crates/uffs-bench/src/run/es_instance.rs
+++ b/crates/uffs-bench/src/run/es_instance.rs
@@ -34,14 +34,36 @@ const LOAD_POLL_INTERVAL_MS: u64 = 5_000;
 
 /// Write a minimal `Everything.ini` restricted to `drives` into `path`.
 ///
-/// Only `ntfs_volume_paths` is written; Everything fills in all other defaults.
+/// Must explicitly disable `auto_include_fixed_volumes` — without it
+/// Everything ignores `ntfs_volume_paths` and indexes every fixed NTFS volume
+/// on the machine automatically (confirmed via voidtools forum, author `void`).
+///
+/// The full set of keys required to pin indexing to exactly `drives`:
+/// - `auto_include_fixed_volumes=0` — don't auto-discover fixed drives
+/// - `auto_include_removable_volumes=0` — don't auto-discover removable drives
+/// - `auto_remove_offline_ntfs_volumes=0` — don't remove offline volumes
+/// - `ntfs_volume_paths=C:,D:,…` — exactly the bench drives to index
+/// - remaining `ntfs_volume_*` keys explicitly blank so ES doesn't inherit
+///   stale values from a partially-written config
 fn write_bench_ini(host: &dyn Host, path: &Path, drives: &[char]) -> std::io::Result<()> {
     let volume_paths: String = drives
         .iter()
-        .map(|letter| format!("{letter}:\\"))
+        .map(|letter| format!("{letter}:"))
         .collect::<Vec<_>>()
         .join(",");
-    let ini = format!("[Everything]\nntfs_volume_paths={volume_paths}\n");
+    let ini = format!(
+        "[Everything]\n\
+         auto_include_fixed_volumes=0\n\
+         auto_include_removable_volumes=0\n\
+         auto_remove_offline_ntfs_volumes=0\n\
+         ntfs_volume_paths={volume_paths}\n\
+         ntfs_volume_guids=\n\
+         ntfs_volume_roots=\n\
+         ntfs_volume_includes=\n\
+         ntfs_volume_load_recent_changes=\n\
+         ntfs_volume_include_onlys=\n\
+         ntfs_volume_monitors=\n"
+    );
     host.write_file(path, ini.as_bytes())
 }
 

--- a/crates/uffs-bench/src/run/es_instance.rs
+++ b/crates/uffs-bench/src/run/es_instance.rs
@@ -220,7 +220,7 @@ pub(super) fn launch(
         args.push("-admin");
     }
     args.push("-startup");
-    if let Err(err) = host.run(everything_exe, &args) {
+    if let Err(err) = host.spawn(everything_exe, &args) {
         host.out(&format!(
             "[es-instance] WARNING: could not launch Everything — {err}"
         ));

--- a/crates/uffs-bench/src/run/es_instance.rs
+++ b/crates/uffs-bench/src/run/es_instance.rs
@@ -46,23 +46,29 @@ const LOAD_POLL_INTERVAL_MS: u64 = 5_000;
 /// - remaining `ntfs_volume_*` keys explicitly blank so ES doesn't inherit
 ///   stale values from a partially-written config
 fn write_bench_ini(host: &dyn Host, path: &Path, drives: &[char]) -> std::io::Result<()> {
+    // Everything.ini uses a quoted comma-separated format for parallel arrays,
+    // e.g. ntfs_volume_paths="C:","D:","G:"
+    // ntfs_volume_includes / monitors / roots follow the same positional order.
+    let n = drives.len();
     let volume_paths: String = drives
         .iter()
-        .map(|letter| format!("{letter}:"))
+        .map(|letter| format!("\"{letter}:\""))
         .collect::<Vec<_>>()
         .join(",");
+    let ones = vec!["1"; n].join(",");
+    let empty_quoted = vec!["\"\""; n].join(",");
     let ini = format!(
         "[Everything]\n\
          auto_include_fixed_volumes=0\n\
          auto_include_removable_volumes=0\n\
          auto_remove_offline_ntfs_volumes=0\n\
-         ntfs_volume_paths={volume_paths}\n\
          ntfs_volume_guids=\n\
-         ntfs_volume_roots=\n\
-         ntfs_volume_includes=\n\
-         ntfs_volume_load_recent_changes=\n\
-         ntfs_volume_include_onlys=\n\
-         ntfs_volume_monitors=\n"
+         ntfs_volume_paths={volume_paths}\n\
+         ntfs_volume_roots={empty_quoted}\n\
+         ntfs_volume_includes={ones}\n\
+         ntfs_volume_load_recent_changes={ones}\n\
+         ntfs_volume_include_onlys={empty_quoted}\n\
+         ntfs_volume_monitors={ones}\n"
     );
     host.write_file(path, ini.as_bytes())
 }

--- a/crates/uffs-bench/src/run/es_instance.rs
+++ b/crates/uffs-bench/src/run/es_instance.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Isolated Everything.exe instance for the bench suite.
+//!
+//! When `es.exe` reports that Everything is not running, the bench tool cannot
+//! simply ask the operator to start it — that would index all drives on the
+//! machine. Instead it launches a **sandboxed instance** via
+//! `Everything.exe -config <tempini> -instance uffs-bench -startup`, where
+//! `<tempini>` contains only the RAM-budget-capable drives identified by the
+//! preflight. The permanent `Everything.ini` is never touched.
+//!
+//! Lifecycle:
+//! 1. [`launch`] — write the temp ini and start the instance.
+//! 2. [`wait_until_loaded`] — poll `es.exe -instance uffs-bench` until all
+//!    bench drives report a non-zero result count.
+//! 3. [`stop`] — send `Everything.exe -instance uffs-bench -exit` to shut it
+//!    down cleanly.
+
+use std::path::{Path, PathBuf};
+
+use crate::host::Host;
+
+/// Named instance used for the bench-local Everything process.
+pub(super) const INSTANCE_NAME: &str = "uffs-bench";
+
+/// Maximum poll attempts waiting for the bench ES instance to finish indexing.
+///
+/// 60 attempts × 5 s = 5 minutes maximum.
+const LOAD_POLL_ATTEMPTS: u32 = 60;
+
+/// Milliseconds between bench-instance readiness polls.
+const LOAD_POLL_INTERVAL_MS: u64 = 5_000;
+
+/// Write a minimal `Everything.ini` restricted to `drives` into `path`.
+///
+/// Only `ntfs_volume_paths` is written; Everything fills in all other defaults.
+fn write_bench_ini(host: &dyn Host, path: &Path, drives: &[char]) -> std::io::Result<()> {
+    let volume_paths: String = drives
+        .iter()
+        .map(|letter| format!("{letter}:\\"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let ini = format!("[Everything]\nntfs_volume_paths={volume_paths}\n");
+    host.write_file(path, ini.as_bytes())
+}
+
+/// Derive a path for the temporary bench ini.
+///
+/// Prefers `%TEMP%` on Windows; falls back to `bundle_dir` so it is always
+/// inside a location we already own.
+fn bench_ini_path(host: &dyn Host, bundle_dir: &Path) -> PathBuf {
+    host.env("TEMP").or_else(|| host.env("TMPDIR")).map_or_else(
+        || bundle_dir.join("uffs-bench-everything.ini"),
+        |tmp| PathBuf::from(tmp).join("uffs-bench-everything.ini"),
+    )
+}
+
+/// Launch an isolated Everything instance that indexes only `drives`.
+///
+/// Writes a temp ini and spawns `Everything.exe -config <ini>
+/// -instance uffs-bench -startup`.  Returns the ini path so the caller can
+/// remove it after [`stop`].
+///
+/// Does nothing and returns `None` when `everything_exe` resolves to the
+/// GUI-less `es.exe` stub (non-Windows hosts where Everything cannot run).
+pub(super) fn launch(
+    host: &dyn Host,
+    everything_exe: &str,
+    drives: &[char],
+    bundle_dir: &Path,
+) -> Option<PathBuf> {
+    if drives.is_empty() {
+        return None;
+    }
+    let ini_path = bench_ini_path(host, bundle_dir);
+    if let Err(err) = write_bench_ini(host, &ini_path, drives) {
+        host.out(&format!(
+            "[es-instance] WARNING: could not write temp ini — {err}"
+        ));
+        return None;
+    }
+    host.out(&format!(
+        "[es-instance] launching Everything (drives: {}) …",
+        drives
+            .iter()
+            .map(char::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+    let ini_str = ini_path.to_string_lossy();
+    if let Err(err) = host.run(everything_exe, &[
+        "-config",
+        ini_str.as_ref(),
+        "-instance",
+        INSTANCE_NAME,
+        "-startup",
+    ]) {
+        host.out(&format!(
+            "[es-instance] WARNING: could not launch Everything — {err}"
+        ));
+        return None;
+    }
+    Some(ini_path)
+}
+
+/// Poll `es.exe -instance uffs-bench` until every drive in `drives` reports a
+/// non-zero result count, or the poll budget is exhausted.
+///
+/// Returns `true` when all drives are loaded within the budget.
+pub(super) fn wait_until_loaded(host: &dyn Host, es_exe: &str, drives: &[char]) -> bool {
+    for attempt in 1..=LOAD_POLL_ATTEMPTS {
+        let all_loaded = drives.iter().all(|&letter| {
+            let search = format!("{letter}:");
+            host.run(es_exe, &[
+                "-instance",
+                INSTANCE_NAME,
+                search.as_str(),
+                "-get-result-count",
+            ])
+            .ok()
+            .and_then(|out| out.stdout.trim().parse::<u64>().ok())
+            .unwrap_or(0)
+                > 0
+        });
+        if all_loaded {
+            host.out("[es-instance] Everything index loaded — proceeding");
+            return true;
+        }
+        host.out(&format!(
+            "[es-instance] waiting for Everything to finish indexing … \
+             (attempt {attempt}/{LOAD_POLL_ATTEMPTS})"
+        ));
+        host.sleep_ms(LOAD_POLL_INTERVAL_MS);
+    }
+    host.out(
+        "[es-instance] WARNING: Everything did not finish indexing within 5 minutes \
+         — ES cells will be measured with a partial index",
+    );
+    false
+}
+
+/// Send `Everything.exe -instance uffs-bench -exit` and remove the temp ini.
+pub(super) fn stop(host: &dyn Host, everything_exe: &str, ini_path: Option<&Path>) {
+    if let Err(err) = host.run(everything_exe, &["-instance", INSTANCE_NAME, "-exit"]) {
+        host.out(&format!(
+            "[es-instance] WARNING: could not stop Everything instance — {err}"
+        ));
+    }
+    if let Some(path) = ini_path {
+        host.remove_file(path).unwrap_or_else(|err| {
+            host.out(&format!(
+                "[es-instance] WARNING: could not remove temp ini — {err}"
+            ));
+        });
+    }
+}
+
+/// Whether the preflight result shows Everything is not running on any of the
+/// given drives (i.e. we need to launch our own instance).
+pub(super) fn es_needs_launch(
+    preflight: &crate::preflight::PreflightResult,
+    drives: &[char],
+) -> bool {
+    drives.iter().any(|&letter| {
+        preflight.drives.iter().any(|dp| {
+            dp.drive == letter
+                && matches!(
+                    dp.es_status,
+                    crate::preflight::EsStatus::DaemonNotRunning
+                        | crate::preflight::EsStatus::NotConfigured
+                )
+        })
+    })
+}

--- a/crates/uffs-bench/src/run/es_instance.rs
+++ b/crates/uffs-bench/src/run/es_instance.rs
@@ -59,8 +59,10 @@ fn bench_ini_path(host: &dyn Host, bundle_dir: &Path) -> PathBuf {
 /// Launch an isolated Everything instance that indexes only `drives`.
 ///
 /// Writes a temp ini and spawns `Everything.exe -config <ini>
-/// -instance uffs-bench -startup`.  Returns the ini path so the caller can
-/// remove it after [`stop`].
+/// -instance uffs-bench [-admin] -startup`.  Returns the ini path so the
+/// caller can remove it after [`stop`].
+///
+/// Pass `admin = true` to add `-admin` (run Everything elevated).
 ///
 /// Does nothing and returns `None` when `everything_exe` resolves to the
 /// GUI-less `es.exe` stub (non-Windows hosts where Everything cannot run).
@@ -69,6 +71,7 @@ pub(super) fn launch(
     everything_exe: &str,
     drives: &[char],
     bundle_dir: &Path,
+    admin: bool,
 ) -> Option<PathBuf> {
     if drives.is_empty() {
         return None;
@@ -80,8 +83,9 @@ pub(super) fn launch(
         ));
         return None;
     }
+    let admin_tag = if admin { " (admin)" } else { "" };
     host.out(&format!(
-        "[es-instance] launching Everything (drives: {}) …",
+        "[es-instance] launching Everything{admin_tag} (drives: {}) …",
         drives
             .iter()
             .map(char::to_string)
@@ -89,13 +93,12 @@ pub(super) fn launch(
             .join(", ")
     ));
     let ini_str = ini_path.to_string_lossy();
-    if let Err(err) = host.run(everything_exe, &[
-        "-config",
-        ini_str.as_ref(),
-        "-instance",
-        INSTANCE_NAME,
-        "-startup",
-    ]) {
+    let mut args: Vec<&str> = vec!["-config", ini_str.as_ref(), "-instance", INSTANCE_NAME];
+    if admin {
+        args.push("-admin");
+    }
+    args.push("-startup");
+    if let Err(err) = host.run(everything_exe, &args) {
         host.out(&format!(
             "[es-instance] WARNING: could not launch Everything — {err}"
         ));

--- a/crates/uffs-bench/src/run/es_instance.rs
+++ b/crates/uffs-bench/src/run/es_instance.rs
@@ -35,7 +35,11 @@ const LOAD_POLL_INTERVAL_MS: u64 = 5_000;
 
 /// Milliseconds to wait after sending `-exit` to any existing Everything
 /// instances before spawning our own, giving the process time to flush its db.
-const ES_KILL_GRACE_MS: u64 = 2_000;
+const ES_KILL_GRACE_MS: u64 = 3_000;
+
+/// Milliseconds to wait after spawning Everything.exe before the first IPC
+/// poll — gives the process time to register its IPC window.
+const ES_STARTUP_GRACE_MS: u64 = 5_000;
 
 /// Parse a `key=val1,val2,...` Everything.ini array value into tokens.
 ///
@@ -229,6 +233,11 @@ pub(super) fn launch(
         args.push("-admin");
     }
     args.push("-startup");
+    host.out(&format!(
+        "[es-instance] spawn: {} {}",
+        everything_exe,
+        args.join(" ")
+    ));
     if let Err(err) = host.spawn(everything_exe, &args) {
         host.out(&format!(
             "[es-instance] WARNING: could not launch Everything — {err}"
@@ -243,27 +252,38 @@ pub(super) fn launch(
 ///
 /// Returns `true` when all drives are loaded within the budget.
 pub(super) fn wait_until_loaded(host: &dyn Host, es_exe: &str, drives: &[char]) -> bool {
+    host.sleep_ms(ES_STARTUP_GRACE_MS);
     for attempt in 1..=LOAD_POLL_ATTEMPTS {
-        let all_loaded = drives.iter().all(|&letter| {
-            let search = format!("{letter}:");
-            host.run(es_exe, &[
-                "-instance",
-                INSTANCE_NAME,
-                search.as_str(),
-                "-get-result-count",
-            ])
-            .ok()
-            .and_then(|out| out.stdout.trim().parse::<u64>().ok())
-            .unwrap_or(0)
-                > 0
-        });
+        let counts: Vec<(char, u64)> = drives
+            .iter()
+            .map(|&letter| {
+                let search = format!("{letter}:");
+                let count = host
+                    .run(es_exe, &[
+                        "-instance",
+                        INSTANCE_NAME,
+                        search.as_str(),
+                        "-get-result-count",
+                    ])
+                    .ok()
+                    .and_then(|out| out.stdout.trim().parse::<u64>().ok())
+                    .unwrap_or(0);
+                (letter, count)
+            })
+            .collect();
+        let all_loaded = counts.iter().all(|(_, n)| *n > 0);
         if all_loaded {
             host.out("[es-instance] Everything index loaded — proceeding");
             return true;
         }
+        let counts_str = counts
+            .iter()
+            .map(|(ch, n)| format!("{ch}:{n}"))
+            .collect::<Vec<_>>()
+            .join(" ");
         host.out(&format!(
             "[es-instance] waiting for Everything to finish indexing … \
-             (attempt {attempt}/{LOAD_POLL_ATTEMPTS})"
+             (attempt {attempt}/{LOAD_POLL_ATTEMPTS}) [{counts_str}]"
         ));
         host.sleep_ms(LOAD_POLL_INTERVAL_MS);
     }

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -387,43 +387,27 @@ impl Orchestrator<'_> {
         }
     }
 
-    /// Render the captured Stage 0 plan and gate it.
-    fn run_stage0(
-        &self,
-        state: &mut State,
-        session: &mut Session,
-        cap: &Capture,
-        hash: &str,
-    ) -> Result<Flow> {
+    /// Write the Stage 0 artifacts and mark the step done.
+    ///
+    /// No operator gate — by the time we reach here the operator has already
+    /// confirmed tool selection and (if needed) the ES launch.  Writing the
+    /// plan artifacts is a silent bookkeeping step.
+    fn run_stage0(&self, state: &mut State, cap: &Capture, hash: &str) -> Result<Flow> {
         let card = plan_card(&self.bundle_dir);
-        match act_of(confirm(
-            self.host,
-            &mut session.mode,
-            &mut session.seen,
-            &card,
-        )) {
-            Act::Run => {
-                self.write_stage0(&cap.fp, &cap.preflight, &cap.matrix)?;
-                state.set_step(
-                    self.host,
-                    STAGE0_ID,
-                    Status::Done,
-                    hash,
-                    stage0_outputs(&self.bundle_dir),
-                );
-                done_panel(self.host, &card, &stage0_result(&self.bundle_dir));
-                Ok(Flow::Continue)
-            }
-            Act::Noop => {
-                done_panel(self.host, &card, &dry_run_result());
-                Ok(Flow::Continue)
-            }
-            Act::Skip => {
-                state.set_step(self.host, STAGE0_ID, Status::Skipped, hash, Vec::new());
-                Ok(Flow::Continue)
-            }
-            Act::Stop => Ok(Flow::Stop),
+        if self.cli.mode() == Mode::DryRun {
+            done_panel(self.host, &card, &dry_run_result());
+            return Ok(Flow::Continue);
         }
+        self.write_stage0(&cap.fp, &cap.preflight, &cap.matrix)?;
+        state.set_step(
+            self.host,
+            STAGE0_ID,
+            Status::Done,
+            hash,
+            stage0_outputs(&self.bundle_dir),
+        );
+        done_panel(self.host, &card, &stage0_result(&self.bundle_dir));
+        Ok(Flow::Continue)
     }
 
     /// Plan, gate, and (on proceed) run one measurement stage through
@@ -549,7 +533,7 @@ impl Orchestrator<'_> {
                 self.host.out("-> STAGE 0: PLAN cached (resume) - skipping");
                 Flow::Continue
             } else if let Some(cap) = capture.as_ref() {
-                self.run_stage0(state, session, cap, hash)?
+                self.run_stage0(state, cap, hash)?
             } else {
                 Flow::Continue
             };

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -417,7 +417,7 @@ impl Orchestrator<'_> {
                 "operator chose to abort — install missing tools and re-run".to_owned(),
             ));
         }
-        let es_ram_budget = fp.ram_bytes / 2;
+        let es_ram_budget = preflight::ES_RAM_BUDGET_BYTES;
         daemon::ensure_daemon_ready(self.host, &resolve::uffs_exe(self.host))?;
         let preflight = preflight::capture(
             self.host,

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -291,7 +291,14 @@ impl Orchestrator<'_> {
         let everything_exe = resolve::everything_exe(self.host);
         let needs_launch =
             es_instance::es_needs_launch(&preflight_first, &matrix_first.capable_drives);
-        self.host.out(&matrix::render_md(&matrix_first));
+        // When ES needs launching, the UFFS-only reasons are all "ES not
+        // started/starting" — noisy and misleading before the launch gate.
+        // Only show capable drives; the full matrix is shown after launch.
+        if needs_launch {
+            self.host.out(&matrix::render_capable_drives(&matrix_first));
+        } else {
+            self.host.out(&matrix::render_md(&matrix_first));
+        }
         Ok(Capture {
             fp,
             preflight: preflight_first,
@@ -350,7 +357,10 @@ impl Orchestrator<'_> {
         }
         cap.es_ini_path = ini;
         // Second-pass preflight: re-probe ES now the instance is loaded.
+        // Restrict candidate_drives to drives that survived the first pass
+        // (UFFS-known) so H/I and other unknown drives are not re-warned.
         let mut spec2 = preflight_spec_from_cli(self.host, self.cli, es_ram_budget);
+        spec2.candidate_drives = cap.preflight.drives.iter().map(|dp| dp.drive).collect();
         if cap.es_ini_path.is_some() {
             spec2.es_instance_name = String::from(es_instance::INSTANCE_NAME);
         }

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -262,7 +262,12 @@ impl Orchestrator<'_> {
                 available.len()
             )));
         }
-        let card = tool_selection_card(&available, &missing);
+        let es_available = fp
+            .tools
+            .iter()
+            .any(|tv| tv.name == "everything" && tv.version != "unknown");
+        let preflight_steps = if es_available { 2 } else { 1 };
+        let card = tool_selection_card(&available, &missing, preflight_steps);
         if matches!(
             confirm(self.host, &mut session.mode, &mut session.seen, &card),
             Decision::Back | Decision::Abort

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -380,6 +380,7 @@ impl Orchestrator<'_> {
     /// after the operator's decision, or if the operator chooses to abort.
     fn capture(&self, session: &mut Session) -> Result<Capture> {
         let fp = env::capture(self.host, &env_spec_from_cli(self.host, self.cli));
+        self.host.out(&env::render_md(&fp));
         let missing: Vec<&str> = fp
             .tools
             .iter()
@@ -437,7 +438,6 @@ impl Orchestrator<'_> {
         cap: &Capture,
         hash: &str,
     ) -> Result<Flow> {
-        self.host.out(&env::render_md(&cap.fp));
         self.host.out(&matrix::render_md(&cap.matrix));
 
         let card = plan_card(&self.bundle_dir);

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -26,7 +26,7 @@ use crate::cards::{
 };
 use crate::cli::{Cli, Command};
 use crate::env::{self, EnvFingerprint, EnvSpec, ToolProbe};
-use crate::error::{CrumbError, Result};
+use crate::error::{BenchError, CrumbError, Result};
 use crate::gate::{Decision, Mode, StepResult, confirm, done_panel};
 use crate::host::Host;
 use crate::matrix::{self, Matrix, MatrixSpec};
@@ -82,21 +82,28 @@ const fn mode_name(mode: Mode) -> &'static str {
 /// - `uffs_cpp`   → `uffs.com --version` (resolved via `~/bin` cascade)
 /// - anything else → `<exe> --version`
 fn tool_probe(host: &dyn Host, name: &str) -> ToolProbe {
-    let (exe, args) = if name == matrix::EVERYTHING_TOOL {
-        (resolve::es_exe(host), vec![
-            "-get-everything-version".to_owned(),
-        ])
+    let (exe, args, version_line_prefix) = if name == matrix::EVERYTHING_TOOL {
+        (
+            resolve::es_exe(host),
+            vec!["-get-everything-version".to_owned()],
+            None,
+        )
     } else if name == "uffs_cpp" {
-        (resolve::uffs_cpp_exe(host), vec!["--version".to_owned()])
+        (
+            resolve::uffs_cpp_exe(host),
+            vec!["--version".to_owned()],
+            Some("UFFS version:".to_owned()),
+        )
     } else if name == "uffs" {
-        (resolve::uffs_exe(host), vec!["--version".to_owned()])
+        (resolve::uffs_exe(host), vec!["--version".to_owned()], None)
     } else {
-        (name.to_owned(), vec!["--version".to_owned()])
+        (name.to_owned(), vec!["--version".to_owned()], None)
     };
     ToolProbe {
         name: name.to_owned(),
         exe,
         args,
+        version_line_prefix,
     }
 }
 
@@ -301,16 +308,34 @@ impl Orchestrator<'_> {
     /// Computed at most once per run and shared by the plan gate and the
     /// measurement stages (whose [`StageCfg`] draws its cross-tool-capable
     /// drive subset from the negotiated matrix), so no probe runs twice.
-    fn capture(&self) -> Capture {
+    ///
+    /// # Errors
+    /// Returns [`BenchError::MissingTools`] if any requested tool could not be
+    /// invoked (version probe returned `"unknown"`). Fails fast and loud so the
+    /// operator knows exactly which binaries to install before any measurements
+    /// run.
+    fn capture(&self) -> Result<Capture> {
         let fp = env::capture(self.host, &env_spec_from_cli(self.host, self.cli));
+        let missing: Vec<&str> = fp
+            .tools
+            .iter()
+            .filter(|tv| tv.version == "unknown")
+            .map(|tv| tv.name.as_str())
+            .collect();
+        if !missing.is_empty() {
+            let list = missing.join(", ");
+            return Err(BenchError::MissingTools(format!(
+                "{list} — ensure the binaries are on PATH or in ~/bin and re-run"
+            )));
+        }
         let preflight =
             preflight::capture(self.host, &preflight_spec_from_cli(self.host, self.cli));
         let matrix = matrix::compute_matrix(&matrix_spec_from_cli(self.cli), &preflight);
-        Capture {
+        Ok(Capture {
             fp,
             preflight,
             matrix,
-        }
+        })
     }
 
     /// Build the [`StageCfg`] shared by every measurement stage from the CLI
@@ -478,7 +503,9 @@ impl Orchestrator<'_> {
         let measure_live = (1..=MEASUREMENT_STAGES).any(|stage| {
             stage_selected(self.cli, stage) && !state.should_skip(&stage_step_id(stage), hash)
         });
-        let capture = ((stage0_selected && !stage0_skip) || measure_live).then(|| self.capture());
+        let capture = ((stage0_selected && !stage0_skip) || measure_live)
+            .then(|| self.capture())
+            .transpose()?;
 
         if stage0_selected {
             let flow = if stage0_skip {
@@ -653,133 +680,4 @@ pub fn run(host: &dyn Host, cli: &Cli) -> Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use clap::Parser as _;
-
-    use super::{STAGE0_ID, decisions_from_cli, plan_input_hash, run, stage_selected};
-    use crate::cli::Cli;
-    use crate::host::{Call, MockHost};
-    use crate::state::{State, Status};
-
-    /// Whether any recorded call mutated the host filesystem.
-    fn is_mutation(call: &Call) -> bool {
-        matches!(
-            call,
-            Call::WriteFile(_) | Call::RemoveFile(_) | Call::Rename(_, _) | Call::CreateDirAll(_)
-        )
-    }
-
-    /// Paths written via `write_file` during the run, as display strings.
-    fn writes(host: &MockHost) -> Vec<String> {
-        host.calls()
-            .into_iter()
-            .filter_map(|call| {
-                if let Call::WriteFile(path) = call {
-                    Some(path.display().to_string())
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
-    #[test]
-    fn dry_run_mutates_nothing() {
-        let host = MockHost::new();
-        let cli = Cli::parse_from(["uffs-bench", "--dry-run", "--drives", "C"]);
-
-        run(&host, &cli).expect("dry run succeeds");
-
-        assert!(
-            host.calls().iter().all(|call| !is_mutation(call)),
-            "dry-run must perform zero filesystem mutations"
-        );
-    }
-
-    #[test]
-    fn autopilot_writes_stage0_artifacts_and_saves_state() {
-        let host = MockHost::new();
-        let cli = Cli::parse_from([
-            "uffs-bench",
-            "--auto",
-            "--drives",
-            "C",
-            "--bundle-root",
-            "/out",
-        ]);
-
-        run(&host, &cli).expect("autopilot run succeeds");
-
-        let calls = host.calls();
-        assert!(
-            calls
-                .iter()
-                .any(|call| matches!(call, Call::CreateDirAll(_))),
-            "a bundle directory should be created"
-        );
-        let written = writes(&host);
-        for artifact in ["env.json", "competitor-preflight.json", "matrix.json"] {
-            assert!(
-                written.iter().any(|path| path.ends_with(artifact)),
-                "expected {artifact} to be written, got {written:?}"
-            );
-        }
-        // `state.json` is saved atomically (temp write + rename).
-        assert!(calls.iter().any(|call| matches!(call, Call::Rename(_, _))));
-    }
-
-    #[test]
-    fn resume_skips_cached_stage0() {
-        let bundle = "/out/bench-fixed";
-        let cli = Cli::parse_from([
-            "uffs-bench",
-            "--auto",
-            "--only-stage",
-            "0",
-            "--drives",
-            "C",
-            "--bundle",
-            bundle,
-        ]);
-        // Seed a state where Stage 0 is already Done with the matching hash.
-        let seed = MockHost::new();
-        let hash = plan_input_hash(&decisions_from_cli(&cli));
-        let mut state = State::new(&seed, "test", decisions_from_cli(&cli));
-        state.set_step(&seed, STAGE0_ID, Status::Done, hash.as_str(), Vec::new());
-        let json = serde_json::to_vec(&state).expect("serialize seed state");
-        let host = MockHost::new().with_file(format!("{bundle}/state.json"), json);
-
-        run(&host, &cli).expect("resume run succeeds");
-
-        // Stage 0 was cached, so no matrix.json is (re)written.
-        assert!(
-            !writes(&host)
-                .iter()
-                .any(|path| path.ends_with("matrix.json")),
-            "cached Stage 0 must not rewrite its artifacts"
-        );
-        assert!(
-            host.output()
-                .iter()
-                .any(|line| line.contains("cached (resume)")),
-            "the cached-skip notice should be shown"
-        );
-    }
-
-    #[test]
-    fn stage_selection_honors_only_and_from() {
-        let only = Cli::parse_from(["uffs-bench", "--only-stage", "2"]);
-        assert!(stage_selected(&only, 2));
-        assert!(!stage_selected(&only, 1));
-        assert!(!stage_selected(&only, 0));
-
-        let from = Cli::parse_from(["uffs-bench", "--from-stage", "1"]);
-        assert!(!stage_selected(&from, 0));
-        assert!(stage_selected(&from, 1));
-        assert!(stage_selected(&from, 3));
-
-        let all = Cli::parse_from(["uffs-bench"]);
-        assert!(stage_selected(&all, 0));
-        assert!(stage_selected(&all, 3));
-    }
-}
+mod tests;

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -22,8 +22,8 @@ use std::path::{Path, PathBuf};
 
 use crate::bundle::{bundle_path, new_bundle};
 use crate::cards::{
-    assembly_card, dry_run_result, measurement_card, missing_tools_card, plan_card, report_scope,
-    stage0_result,
+    assembly_card, dry_run_result, measurement_card, plan_card, report_scope, stage0_result,
+    tool_selection_card,
 };
 use crate::cli::{Cli, Command};
 use crate::env::{self, EnvFingerprint, EnvSpec, StateProbe, ToolProbe};
@@ -387,29 +387,27 @@ impl Orchestrator<'_> {
             .filter(|tv| tv.version == "unknown")
             .map(|tv| tv.name.as_str())
             .collect();
-        if !missing.is_empty() {
-            let available: Vec<&str> = fp
-                .tools
-                .iter()
-                .filter(|tv| tv.version != "unknown")
-                .map(|tv| tv.name.as_str())
-                .collect();
-            if available.len() < 2 {
-                return Err(BenchError::MissingTools(format!(
-                    "only {} tool(s) available — need at least 2 to run a meaningful \
-                     benchmark. Install the missing tools and re-run.",
-                    available.len()
-                )));
-            }
-            let card = missing_tools_card(&missing, &available);
-            if matches!(
-                confirm(self.host, &mut session.mode, &mut session.seen, &card),
-                Decision::Back | Decision::Abort
-            ) {
-                return Err(BenchError::MissingTools(
-                    "operator chose to abort — install missing tools and re-run".to_owned(),
-                ));
-            }
+        let available: Vec<&str> = fp
+            .tools
+            .iter()
+            .filter(|tv| tv.version != "unknown")
+            .map(|tv| tv.name.as_str())
+            .collect();
+        if available.len() < 2 {
+            return Err(BenchError::MissingTools(format!(
+                "only {} tool(s) available — need at least 2 to run a meaningful \
+                 benchmark. Install the missing tools and re-run.",
+                available.len()
+            )));
+        }
+        let card = tool_selection_card(&available, &missing);
+        if matches!(
+            confirm(self.host, &mut session.mode, &mut session.seen, &card),
+            Decision::Back | Decision::Abort
+        ) {
+            return Err(BenchError::MissingTools(
+                "operator chose to abort — install missing tools and re-run".to_owned(),
+            ));
         }
         let preflight =
             preflight::capture(self.host, &preflight_spec_from_cli(self.host, self.cli));

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -248,6 +248,15 @@ impl Orchestrator<'_> {
     /// Returns [`BenchError::MissingTools`] if fewer than 2 tools are available
     /// after the operator's decision, or if the operator chooses to abort.
     fn capture(&self, session: &mut Session) -> Result<Capture> {
+        // Kill and restart the daemon with NO drive restrictions before any
+        // other probe so the first preflight sees the full set of NTFS drives
+        // the host can index.  Env probes + the operator gate run while the
+        // daemon is warming up; `ensure_daemon_ready` blocks just before the
+        // first preflight query.
+        let uffs_exe = resolve::uffs_exe(self.host);
+        if !self.cli.drives.is_empty() {
+            daemon::kill_and_restart_all_drives(self.host, &uffs_exe);
+        }
         let fp = env::capture(self.host, &env_spec_from_cli(self.host, self.cli));
         self.host.out(&env::render_md(&fp));
         let missing: Vec<&str> = fp
@@ -293,6 +302,15 @@ impl Orchestrator<'_> {
             ));
         }
         let es_ram_budget = preflight::ES_RAM_BUDGET_BYTES;
+        // Block here until the daemon is ready.  In most cases it will have
+        // finished loading during the env-probe + tool-selection gate above.
+        if !self.cli.drives.is_empty()
+            && let Err(err) = daemon::ensure_daemon_ready(self.host, &uffs_exe)
+        {
+            self.host.out(&format!(
+                "[uffs-daemon] WARNING: daemon did not become ready before preflight: {err}"
+            ));
+        }
         // Probe drives and display the drive table + negotiated matrix.
         // ES launch (if needed) is deferred to `launch_es_if_needed()` so the
         // operator can confirm before the bench touches the Everything process.

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -26,7 +26,7 @@ use crate::cards::{
     stage0_result,
 };
 use crate::cli::{Cli, Command};
-use crate::env::{self, EnvFingerprint, EnvSpec, StateProbe, ToolProbe, tool_install_hint};
+use crate::env::{self, EnvFingerprint, EnvSpec, StateProbe, ToolProbe};
 use crate::error::{BenchError, CrumbError, Result};
 use crate::gate::{Decision, Mode, StepResult, confirm, done_panel};
 use crate::host::Host;
@@ -387,13 +387,6 @@ impl Orchestrator<'_> {
             .map(|tv| tv.name.as_str())
             .collect();
         if !missing.is_empty() {
-            self.host.out("\n⚠️  Some tools could not be found:");
-            for name in &missing {
-                self.host.out(&format!(
-                    "  ✗  {name} — {hint}",
-                    hint = tool_install_hint(name)
-                ));
-            }
             let available = fp.tools.len() - missing.len();
             if available < 2 {
                 return Err(BenchError::MissingTools(format!(
@@ -401,9 +394,6 @@ impl Orchestrator<'_> {
                      benchmark. Install the missing tools and re-run."
                 )));
             }
-            self.host.out(&format!(
-                "\n{available} tool(s) available. Proceed with the tools we have?"
-            ));
             let card = missing_tools_card(&missing);
             if matches!(
                 confirm(self.host, &mut session.mode, &mut session.seen, &card),

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -25,11 +25,11 @@ use crate::cards::{
     assembly_card, dry_run_result, measurement_card, plan_card, report_scope, stage0_result,
 };
 use crate::cli::{Cli, Command};
-use crate::env::{self, EnvFingerprint, EnvSpec, ToolProbe};
+use crate::env::{self, EnvFingerprint, EnvSpec, StateProbe, ToolProbe};
 use crate::error::{BenchError, CrumbError, Result};
 use crate::gate::{Decision, Mode, StepResult, confirm, done_panel};
 use crate::host::Host;
-use crate::matrix::{self, Matrix, MatrixSpec};
+use crate::matrix::{self, EVERYTHING_GUI_TOOL, Matrix, MatrixSpec};
 use crate::preflight::{self, PreflightResult, PreflightSpec};
 use crate::restore::RunGuard;
 use crate::stages::{self, StageCfg};
@@ -76,46 +76,96 @@ const fn mode_name(mode: Mode) -> &'static str {
     }
 }
 
-/// Build a version-probe for one tool id.
+/// Build a version + state probe for one tool id.
 ///
-/// - `everything` → `es.exe -version` (ES CLI version, no daemon/IPC needed)
-/// - `uffs_cpp`   → `uffs.com --version` (resolved via `~/bin` cascade)
-/// - anything else → `<exe> --version`
+/// - `everything`     → `es.exe -version` (ES CLI version, no IPC), state via
+///   `tasklist`
+/// - `everything_gui` → `es.exe -get-everything-version` (daemon IPC version,
+///   `daemon_error_markers` turn IPC errors into `"not running"`), display exe
+///   = `Everything.exe`, state via `tasklist`
+/// - `uffs`           → `uffs --version`, state via `uffs daemon status`
+/// - `uffs_cpp`       → `uffs.com --version` (resolved via `~/bin` cascade), no
+///   daemon state
+/// - anything else    → `<exe> --version`, no daemon state
 fn tool_probe(host: &dyn Host, name: &str) -> ToolProbe {
-    let (exe, args, version_line_prefix, daemon_error_markers) = if name == matrix::EVERYTHING_TOOL
-    {
-        (
-            resolve::es_exe(host),
+    let tasklist_state = || StateProbe {
+        exe: "tasklist.exe".to_owned(),
+        args: vec![
+            "/FI".to_owned(),
+            "IMAGENAME eq Everything.exe".to_owned(),
+            "/NH".to_owned(),
+            "/FO".to_owned(),
+            "CSV".to_owned(),
+        ],
+        // tasklist CSV output contains the image name when the process is
+        // present; if the filter matches nothing it prints a "no tasks are
+        // running" message that does NOT contain this string.
+        running_marker: "Everything.exe".to_owned(),
+    };
+
+    if name == matrix::EVERYTHING_TOOL {
+        ToolProbe {
+            name: name.to_owned(),
+            exe: resolve::es_exe(host),
+            display_exe: None,
             // Use `-version` (ES CLI version, no IPC/daemon required) rather
             // than `-get-everything-version` which exits 0 but prints an IPC
             // error when the Everything daemon is not running.
-            vec!["-version".to_owned()],
-            None,
-            vec![],
-        )
+            args: vec!["-version".to_owned()],
+            version_line_prefix: None,
+            daemon_error_markers: vec![],
+            state_probe: Some(tasklist_state()),
+        }
+    } else if name == EVERYTHING_GUI_TOOL {
+        ToolProbe {
+            name: name.to_owned(),
+            // Version is queried via es.exe IPC; display path is Everything.exe.
+            exe: resolve::es_exe(host),
+            display_exe: Some(resolve::everything_exe(host)),
+            // `-get-everything-version` queries the running daemon via IPC and
+            // returns the GUI version. When the daemon is not running it exits
+            // 0 but prints an IPC error — daemon_error_markers turns this into
+            // "not running" in the version field.
+            args: vec!["-get-everything-version".to_owned()],
+            version_line_prefix: None,
+            daemon_error_markers: vec!["Error 8".to_owned(), "IPC window not found".to_owned()],
+            state_probe: Some(tasklist_state()),
+        }
     } else if name == "uffs_cpp" {
-        (
-            resolve::uffs_cpp_exe(host),
-            vec!["--version".to_owned()],
-            Some("UFFS version:".to_owned()),
-            vec![],
-        )
+        ToolProbe {
+            name: name.to_owned(),
+            exe: resolve::uffs_cpp_exe(host),
+            display_exe: None,
+            args: vec!["--version".to_owned()],
+            version_line_prefix: Some("UFFS version:".to_owned()),
+            daemon_error_markers: vec![],
+            state_probe: None,
+        }
     } else if name == "uffs" {
-        (
-            resolve::uffs_exe(host),
-            vec!["--version".to_owned()],
-            None,
-            vec![],
-        )
+        let uffs = resolve::uffs_exe(host);
+        ToolProbe {
+            name: name.to_owned(),
+            exe: uffs.clone(),
+            display_exe: None,
+            args: vec!["--version".to_owned()],
+            version_line_prefix: None,
+            daemon_error_markers: vec![],
+            state_probe: Some(StateProbe {
+                exe: uffs,
+                args: vec!["daemon".to_owned(), "status".to_owned()],
+                running_marker: "running".to_owned(),
+            }),
+        }
     } else {
-        (name.to_owned(), vec!["--version".to_owned()], None, vec![])
-    };
-    ToolProbe {
-        name: name.to_owned(),
-        exe,
-        args,
-        version_line_prefix,
-        daemon_error_markers,
+        ToolProbe {
+            name: name.to_owned(),
+            exe: name.to_owned(),
+            display_exe: None,
+            args: vec!["--version".to_owned()],
+            version_line_prefix: None,
+            daemon_error_markers: vec![],
+            state_probe: None,
+        }
     }
 }
 

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -241,8 +241,11 @@ fn env_spec_from_cli(host: &dyn Host, cli: &Cli) -> EnvSpec {
     }
 }
 
-/// Build the Stage 0c [`PreflightSpec`] from the CLI and host environment.
-fn preflight_spec_from_cli(host: &dyn Host, cli: &Cli) -> PreflightSpec {
+/// Build the Stage 0c [`PreflightSpec`] from the CLI and captured env.
+///
+/// `es_ram_budget_bytes` is set to 50 % of the system's physical RAM so that
+/// the greedy drive selector avoids OOM-ing Everything's in-process index.
+fn preflight_spec_from_cli(host: &dyn Host, cli: &Cli, es_ram_budget_bytes: u64) -> PreflightSpec {
     PreflightSpec {
         ini_path: everything_ini_path(host),
         candidate_drives: cli.drives_or_default(),
@@ -251,11 +254,12 @@ fn preflight_spec_from_cli(host: &dyn Host, cli: &Cli) -> PreflightSpec {
         patterns: resolve::default_pattern_probes(),
         poll_attempts: PREFLIGHT_POLL_ATTEMPTS,
         poll_interval_ms: PREFLIGHT_POLL_INTERVAL_MS,
+        es_ram_budget_bytes,
     }
 }
 
 /// Build the Stage 0d [`MatrixSpec`] from the CLI.
-fn matrix_spec_from_cli(cli: &Cli) -> MatrixSpec {
+fn matrix_spec_from_cli(cli: &Cli, es_ram_budget_bytes: u64) -> MatrixSpec {
     MatrixSpec {
         required_tools: cli.tools_or_default(),
         candidate_drives: cli.drives_or_default(),
@@ -263,6 +267,7 @@ fn matrix_spec_from_cli(cli: &Cli) -> MatrixSpec {
             .iter()
             .map(|(name, _)| (*name).to_owned())
             .collect(),
+        es_ram_budget_bytes,
     }
 }
 
@@ -409,9 +414,15 @@ impl Orchestrator<'_> {
                 "operator chose to abort — install missing tools and re-run".to_owned(),
             ));
         }
-        let preflight =
-            preflight::capture(self.host, &preflight_spec_from_cli(self.host, self.cli));
-        let matrix = matrix::compute_matrix(&matrix_spec_from_cli(self.cli), &preflight);
+        let es_ram_budget = fp.ram_bytes / 2;
+        let preflight = preflight::capture(
+            self.host,
+            &preflight_spec_from_cli(self.host, self.cli, es_ram_budget),
+        );
+        self.host
+            .out(&preflight::render_drive_table(&preflight, es_ram_budget));
+        let matrix =
+            matrix::compute_matrix(&matrix_spec_from_cli(self.cli, es_ram_budget), &preflight);
         self.host.out(&matrix::render_md(&matrix));
         Ok(Capture {
             fp,

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -291,12 +291,7 @@ impl Orchestrator<'_> {
         let everything_exe = resolve::everything_exe(self.host);
         let needs_launch =
             es_instance::es_needs_launch(&preflight_first, &matrix_first.capable_drives);
-        // Only render the first-pass matrix when ES is already running — if ES
-        // needs to be launched the matrix is stale (all UFFS-only) and the
-        // correct one will be rendered after the second-pass preflight.
-        if !needs_launch {
-            self.host.out(&matrix::render_md(&matrix_first));
-        }
+        self.host.out(&matrix::render_md(&matrix_first));
         Ok(Capture {
             fp,
             preflight: preflight_first,
@@ -365,7 +360,6 @@ impl Orchestrator<'_> {
             &cap.preflight,
         );
         cap.es_capable_drives = cap.matrix.capable_drives.clone();
-        self.host.out(&matrix::render_md(&cap.matrix));
     }
 
     /// Build the [`StageCfg`] shared by every measurement stage from the CLI

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -388,14 +388,20 @@ impl Orchestrator<'_> {
             .map(|tv| tv.name.as_str())
             .collect();
         if !missing.is_empty() {
-            let available = fp.tools.len() - missing.len();
-            if available < 2 {
+            let available: Vec<&str> = fp
+                .tools
+                .iter()
+                .filter(|tv| tv.version != "unknown")
+                .map(|tv| tv.name.as_str())
+                .collect();
+            if available.len() < 2 {
                 return Err(BenchError::MissingTools(format!(
-                    "only {available} tool(s) available — need at least 2 to run a meaningful \
-                     benchmark. Install the missing tools and re-run."
+                    "only {} tool(s) available — need at least 2 to run a meaningful \
+                     benchmark. Install the missing tools and re-run.",
+                    available.len()
                 )));
             }
-            let card = missing_tools_card(&missing);
+            let card = missing_tools_card(&missing, &available);
             if matches!(
                 confirm(self.host, &mut session.mode, &mut session.seen, &card),
                 Decision::Back | Decision::Abort

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -32,8 +32,8 @@ use specs::{
 
 use crate::bundle::{bundle_path, new_bundle};
 use crate::cards::{
-    assembly_card, dry_run_result, measurement_card, plan_card, report_scope, stage0_result,
-    tool_selection_card,
+    assembly_card, dry_run_result, es_launch_card, measurement_card, plan_card, report_scope,
+    stage0_result, tool_selection_card,
 };
 use crate::cli::{Cli, Command};
 use crate::env::{self, EnvFingerprint};
@@ -169,6 +169,11 @@ struct Capture {
     preflight: PreflightResult,
     /// Stage 0d negotiated matrix (its `capable_drives` feed Stage 1).
     matrix: Matrix,
+    /// Drives that need an ES instance launched (from first-pass matrix).
+    ///
+    /// Non-empty iff `es_needs_launch` was true after the first preflight pass.
+    /// Consumed by `launch_es_if_needed()` to decide whether to show the gate.
+    es_capable_drives: Vec<char>,
     /// Path to the temporary Everything ini written for the bench instance.
     ///
     /// `None` when Everything was already running or no instance was needed.
@@ -176,6 +181,12 @@ struct Capture {
     es_ini_path: Option<PathBuf>,
     /// Resolved path to `Everything.exe`, used for teardown.
     everything_exe: String,
+    /// Whether the first-pass preflight found ES not running on any capable
+    /// drive.
+    ///
+    /// When `true`, `launch_es_if_needed()` will show the confirmation gate and
+    /// (if the operator proceeds) launch the isolated Everything instance.
+    es_needs_launch: bool,
 }
 
 /// Mutable per-run gate state threaded through every staged confirm.
@@ -262,61 +273,98 @@ impl Orchestrator<'_> {
         }
         let es_ram_budget = preflight::ES_RAM_BUDGET_BYTES;
         daemon::ensure_daemon_ready(self.host, &resolve::uffs_exe(self.host))?;
-        // First pass: probe without an ES instance to discover which drives
-        // exist and what ES state they are in.
+        // Probe drives and display the drive table + negotiated matrix.
+        // ES launch (if needed) is deferred to `launch_es_if_needed()` so the
+        // operator can confirm before the bench touches the Everything process.
         let preflight_first = preflight::capture(
             self.host,
             &preflight_spec_from_cli(self.host, self.cli, es_ram_budget),
         );
+        self.host.out(&preflight::render_drive_table(
+            &preflight_first,
+            es_ram_budget,
+        ));
         let matrix_first = matrix::compute_matrix(
             &matrix_spec_from_cli(self.cli, es_ram_budget),
             &preflight_first,
         );
-        // If Everything is not running, launch an isolated instance restricted
-        // to the RAM-budget-capable drives, then re-run the ES probes only.
+        self.host.out(&matrix::render_md(&matrix_first));
         let everything_exe = resolve::everything_exe(self.host);
-        let es_ini_path =
-            if es_instance::es_needs_launch(&preflight_first, &matrix_first.capable_drives) {
-                let ini = es_instance::launch(
-                    self.host,
-                    &everything_exe,
-                    &matrix_first.capable_drives,
-                    &self.bundle_dir,
-                );
-                if ini.is_some() {
-                    es_instance::wait_until_loaded(
-                        self.host,
-                        &resolve::es_exe(self.host),
-                        &matrix_first.capable_drives,
-                    );
-                }
-                ini
-            } else {
-                None
-            };
-        // Second pass (or same result if no instance was launched): re-probe
-        // ES status now that the instance is (or was already) running.
-        let mut spec2 = preflight_spec_from_cli(self.host, self.cli, es_ram_budget);
-        if es_ini_path.is_some() {
-            spec2.es_instance_name = String::from(es_instance::INSTANCE_NAME);
-        }
-        let preflight = if es_ini_path.is_some() {
-            preflight::capture(self.host, &spec2)
-        } else {
-            preflight_first
-        };
-        self.host
-            .out(&preflight::render_drive_table(&preflight, es_ram_budget));
-        let matrix =
-            matrix::compute_matrix(&matrix_spec_from_cli(self.cli, es_ram_budget), &preflight);
-        self.host.out(&matrix::render_md(&matrix));
+        let needs_launch =
+            es_instance::es_needs_launch(&preflight_first, &matrix_first.capable_drives);
         Ok(Capture {
             fp,
-            preflight,
-            matrix,
-            es_ini_path,
+            preflight: preflight_first,
+            matrix: matrix_first,
+            es_capable_drives: Vec::new(), // populated by launch_es_if_needed()
+            es_ini_path: None,
             everything_exe,
+            es_needs_launch: needs_launch,
         })
+    }
+
+    /// Gate and (if confirmed) launch the bench-local Everything instance.
+    ///
+    /// Called from `execute()` after `capture()` has displayed the matrix.
+    /// When the operator confirms, writes a temp ini, spawns
+    /// `Everything.exe -instance uffs-bench [-admin]`, waits for the index to
+    /// load, then re-runs the ES preflight probes so `cap.preflight` and
+    /// `cap.matrix` reflect the loaded state.
+    ///
+    /// If the operator aborts the card, ES cells are silently skipped (the
+    /// matrix already shows them as UFFS-only).
+    fn launch_es_if_needed(&self, session: &mut Session, cap: &mut Capture) {
+        if !cap.es_needs_launch || cap.matrix.capable_drives.is_empty() {
+            return;
+        }
+        let card = es_launch_card(&cap.matrix.capable_drives, self.cli.es_admin);
+        match confirm(self.host, &mut session.mode, &mut session.seen, &card) {
+            Decision::Back | Decision::Abort => {
+                self.host.out(
+                    "[es-instance] operator skipped ES launch — \
+                     proceeding with UFFS-only cells",
+                );
+                return;
+            }
+            Decision::ProceedNoop => {
+                self.host
+                    .out("[es-instance] dry-run: skipping Everything.exe launch");
+                return;
+            }
+            Decision::Proceed | Decision::Autopilot | Decision::Skip => {}
+        }
+        let es_ram_budget = preflight::ES_RAM_BUDGET_BYTES;
+        let ini = es_instance::launch(
+            self.host,
+            &cap.everything_exe,
+            &cap.matrix.capable_drives,
+            &self.bundle_dir,
+            self.cli.es_admin,
+        );
+        if ini.is_some() {
+            es_instance::wait_until_loaded(
+                self.host,
+                &resolve::es_exe(self.host),
+                &cap.matrix.capable_drives,
+            );
+        }
+        cap.es_ini_path = ini;
+        // Second-pass preflight: re-probe ES now the instance is loaded.
+        let mut spec2 = preflight_spec_from_cli(self.host, self.cli, es_ram_budget);
+        if cap.es_ini_path.is_some() {
+            spec2.es_instance_name = String::from(es_instance::INSTANCE_NAME);
+        }
+        cap.preflight = preflight::capture(self.host, &spec2);
+        cap.matrix = matrix::compute_matrix(
+            &matrix_spec_from_cli(self.cli, es_ram_budget),
+            &cap.preflight,
+        );
+        cap.es_capable_drives = cap.matrix.capable_drives.clone();
+        self.host.out(&preflight::render_drive_table(
+            &cap.preflight,
+            es_ram_budget,
+        ));
+        self.host.out(&matrix::render_md(&cap.matrix));
     }
 
     /// Build the [`StageCfg`] shared by every measurement stage from the CLI
@@ -481,9 +529,15 @@ impl Orchestrator<'_> {
         let measure_live = (1..=MEASUREMENT_STAGES).any(|stage| {
             stage_selected(self.cli, stage) && !state.should_skip(&stage_step_id(stage), hash)
         });
-        let capture = ((stage0_selected && !stage0_skip) || measure_live)
+        let mut capture = ((stage0_selected && !stage0_skip) || measure_live)
             .then(|| self.capture(session))
             .transpose()?;
+        // Show the ES-instance confirm gate and launch if the operator agrees.
+        // This runs after the matrix is displayed and before the plan card, so
+        // the final (post-launch) matrix is what gets locked into stage0.
+        if let Some(cap) = capture.as_mut() {
+            self.launch_es_if_needed(session, cap);
+        }
 
         if stage0_selected {
             let flow = if stage0_skip {

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -20,6 +20,8 @@
 use alloc::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+mod daemon;
+
 use crate::bundle::{bundle_path, new_bundle};
 use crate::cards::{
     assembly_card, dry_run_result, measurement_card, plan_card, report_scope, stage0_result,
@@ -384,6 +386,7 @@ impl Orchestrator<'_> {
     /// Returns [`BenchError::MissingTools`] if fewer than 2 tools are available
     /// after the operator's decision, or if the operator chooses to abort.
     fn capture(&self, session: &mut Session) -> Result<Capture> {
+        daemon::daemon_start_if_needed(self.host, &resolve::uffs_exe(self.host));
         let fp = env::capture(self.host, &env_spec_from_cli(self.host, self.cli));
         self.host.out(&env::render_md(&fp));
         let missing: Vec<&str> = fp
@@ -415,6 +418,7 @@ impl Orchestrator<'_> {
             ));
         }
         let es_ram_budget = fp.ram_bytes / 2;
+        daemon::ensure_daemon_ready(self.host, &resolve::uffs_exe(self.host))?;
         let preflight = preflight::capture(
             self.host,
             &preflight_spec_from_cli(self.host, self.cli, es_ram_budget),

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -389,6 +389,10 @@ impl Orchestrator<'_> {
             drop_cache: self.cli.drop_os_cache,
             patterns: resolve::default_pattern_probes(),
             uffs_exe: resolve::uffs_exe(self.host),
+            es_instance_name: cap
+                .es_ini_path
+                .is_some()
+                .then(|| es_instance::INSTANCE_NAME.to_owned()),
         }
     }
 

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -273,11 +273,16 @@ impl Orchestrator<'_> {
             .tools
             .iter()
             .any(|tv| tv.name == "everything" && tv.version != "unknown");
-        // preflight_steps: tool-selection (step 1) is always present.
-        // ES launch adds a step when Everything is available.
-        // The UFFS restart step is checked post-matrix; we use a conservative
-        // upper bound here — the actual step numbers on each card are precise.
-        let preflight_steps = if es_available { 2 } else { 1 };
+        // Step numbering (all known here before any gate fires):
+        //   step 1: tool selection          — always
+        //   step 2: UFFS restart            — whenever drives are specified
+        //   step 2 or 3: ES launch          — whenever Everything is available
+        // The UFFS restart always fires when capable drives are non-empty;
+        // since the matrix hasn't run yet, use `!cli.drives.is_empty()` as the
+        // conservative proxy (if drives are empty, the matrix will be empty too
+        // and the restart gate is skipped anyway).
+        let uffs_restart_present = !self.cli.drives.is_empty();
+        let preflight_steps = 1 + u32::from(uffs_restart_present) + u32::from(es_available);
         let card = tool_selection_card(&available, &missing, preflight_steps);
         if matches!(
             confirm(self.host, &mut session.mode, &mut session.seen, &card),
@@ -342,12 +347,10 @@ impl Orchestrator<'_> {
         if cap.matrix.capable_drives.is_empty() {
             return;
         }
-        let es_step = if cap.es_needs_launch {
-            preflight_steps
-        } else {
-            0
-        };
-        let uffs_step_num = preflight_steps - es_step;
+        // UFFS restart is always step 2 (tool selection is step 1).
+        // total_steps is passed in from execute() where it is computed with
+        // full knowledge of which gates are active.
+        let uffs_step_num: u32 = 2;
         let card = uffs_restart_card(&cap.matrix.capable_drives, uffs_step_num, preflight_steps);
         match confirm(self.host, &mut session.mode, &mut session.seen, &card) {
             Decision::Back | Decision::Abort => {
@@ -607,12 +610,15 @@ impl Orchestrator<'_> {
         if let Some(cap) = capture.as_mut() {
             // Compute exact step numbers: UFFS restart (if needed) comes
             // before ES launch; ES launch is always last.
-            let uffs_restart_step = cap.uffs_needs_restart.then_some(2_u32);
-            let es_launch_step = cap
-                .es_needs_launch
-                .then(|| uffs_restart_step.map_or(2, |prev| prev + 1));
-            let total_steps = es_launch_step.or(uffs_restart_step).unwrap_or(1);
-            if uffs_restart_step.is_some() {
+            // Step 1: tool selection (shown in capture()).
+            // Step 2: UFFS restart (if capable drives exist).
+            // Step 2 or 3: ES launch (if Everything available, after UFFS).
+            let total_steps: u32 =
+                1 + u32::from(cap.uffs_needs_restart) + u32::from(cap.es_needs_launch);
+            let es_launch_step =
+                cap.es_needs_launch
+                    .then_some(if cap.uffs_needs_restart { 3_u32 } else { 2_u32 });
+            if cap.uffs_needs_restart {
                 self.restart_uffs_if_needed(session, cap, total_steps);
                 // After restart, re-run second-pass preflight to get fresh
                 // drive counts from the restricted daemon.

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -365,10 +365,6 @@ impl Orchestrator<'_> {
             &cap.preflight,
         );
         cap.es_capable_drives = cap.matrix.capable_drives.clone();
-        self.host.out(&preflight::render_drive_table(
-            &cap.preflight,
-            es_ram_budget,
-        ));
         self.host.out(&matrix::render_md(&cap.matrix));
     }
 

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -21,6 +21,14 @@ use alloc::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 mod daemon;
+mod es_instance;
+mod specs;
+
+pub(crate) use specs::everything_ini_path;
+use specs::{
+    decisions_from_cli, env_spec_from_cli, matrix_spec_from_cli, plan_input_hash,
+    preflight_spec_from_cli,
+};
 
 use crate::bundle::{bundle_path, new_bundle};
 use crate::cards::{
@@ -28,15 +36,15 @@ use crate::cards::{
     tool_selection_card,
 };
 use crate::cli::{Cli, Command};
-use crate::env::{self, EnvFingerprint, EnvSpec, StateProbe, ToolProbe};
+use crate::env::{self, EnvFingerprint};
 use crate::error::{BenchError, CrumbError, Result};
 use crate::gate::{Decision, Mode, StepResult, confirm, done_panel};
 use crate::host::Host;
-use crate::matrix::{self, EVERYTHING_GUI_TOOL, Matrix, MatrixSpec};
-use crate::preflight::{self, PreflightResult, PreflightSpec};
+use crate::matrix::{self, Matrix};
+use crate::preflight::{self, PreflightResult};
 use crate::restore::RunGuard;
 use crate::stages::{self, StageCfg};
-use crate::state::{Decisions, State, Status, input_hash};
+use crate::state::{Decisions, State, Status};
 use crate::tooling::Disposition;
 use crate::{competitors, report, resolve, teardown};
 
@@ -70,120 +78,13 @@ enum Flow {
 }
 
 /// The fixed name string for a launch [`Mode`] (feeds `state.json` + hashes).
-const fn mode_name(mode: Mode) -> &'static str {
+pub(super) const fn mode_name(mode: Mode) -> &'static str {
     match mode {
         Mode::Guided => "guided",
         Mode::Interactive => "interactive",
         Mode::AutoPilot => "auto",
         Mode::DryRun => "dry-run",
     }
-}
-
-/// Build a version + state probe for one tool id.
-///
-/// - `everything`     → `es.exe -version` (ES CLI version, no IPC), state via
-///   `tasklist`
-/// - `everything_gui` → `es.exe -get-everything-version` (daemon IPC version,
-///   `daemon_error_markers` turn IPC errors into `"not running"`), display exe
-///   = `Everything.exe`, state via `tasklist`
-/// - `uffs`           → `uffs --version`, state via `uffs daemon status`
-/// - `uffs_cpp`       → `uffs.com --version` (resolved via `~/bin` cascade), no
-///   daemon state
-/// - anything else    → `<exe> --version`, no daemon state
-fn tool_probe(host: &dyn Host, name: &str) -> ToolProbe {
-    let tasklist_state = || StateProbe {
-        exe: "tasklist.exe".to_owned(),
-        args: vec![
-            "/FI".to_owned(),
-            "IMAGENAME eq Everything.exe".to_owned(),
-            "/NH".to_owned(),
-            "/FO".to_owned(),
-            "CSV".to_owned(),
-        ],
-        // tasklist CSV output contains the image name when the process is
-        // present; if the filter matches nothing it prints a "no tasks are
-        // running" message that does NOT contain this string.
-        running_marker: "Everything.exe".to_owned(),
-    };
-
-    if name == matrix::EVERYTHING_TOOL {
-        ToolProbe {
-            name: name.to_owned(),
-            exe: resolve::es_exe(host),
-            display_exe: None,
-            // Use `-version` (ES CLI version, no IPC/daemon required) rather
-            // than `-get-everything-version` which exits 0 but prints an IPC
-            // error when the Everything daemon is not running.
-            args: vec!["-version".to_owned()],
-            version_line_prefix: None,
-            daemon_error_markers: vec![],
-            state_probe: Some(tasklist_state()),
-        }
-    } else if name == EVERYTHING_GUI_TOOL {
-        ToolProbe {
-            name: name.to_owned(),
-            // Version is queried via es.exe IPC; display path is Everything.exe.
-            exe: resolve::es_exe(host),
-            display_exe: Some(resolve::everything_exe(host)),
-            // `-get-everything-version` queries the running daemon via IPC and
-            // returns the GUI version. When the daemon is not running it exits
-            // 0 but prints an IPC error — daemon_error_markers turns this into
-            // "not running" in the version field.
-            args: vec!["-get-everything-version".to_owned()],
-            version_line_prefix: None,
-            daemon_error_markers: vec!["Error 8".to_owned(), "IPC window not found".to_owned()],
-            state_probe: Some(tasklist_state()),
-        }
-    } else if name == "uffs_cpp" {
-        ToolProbe {
-            name: name.to_owned(),
-            exe: resolve::uffs_cpp_exe(host),
-            display_exe: None,
-            args: vec!["--version".to_owned()],
-            version_line_prefix: Some("UFFS version:".to_owned()),
-            daemon_error_markers: vec![],
-            state_probe: None,
-        }
-    } else if name == "uffs" {
-        ToolProbe {
-            name: name.to_owned(),
-            exe: resolve::uffs_exe(host),
-            display_exe: None,
-            // `uffs --version` prints e.g. `uffs 0.5.117`; strip the prefix.
-            args: vec!["--version".to_owned()],
-            version_line_prefix: Some("uffs ".to_owned()),
-            daemon_error_markers: vec![],
-            // The daemon (uttfd) is started/restarted by the bench itself, so
-            // its pre-run state is irrelevant — report n/a.
-            state_probe: None,
-        }
-    } else {
-        ToolProbe {
-            name: name.to_owned(),
-            exe: name.to_owned(),
-            display_exe: None,
-            args: vec!["--version".to_owned()],
-            version_line_prefix: None,
-            daemon_error_markers: vec![],
-            state_probe: None,
-        }
-    }
-}
-
-/// Resolve the read-only `Everything.ini` path from the host environment.
-///
-/// Uses `%APPDATA%\Everything\Everything.ini` when `APPDATA` is set (the
-/// Windows install default), falling back to a bare relative name otherwise so
-/// the preflight simply observes an absent ini on other hosts.
-pub(crate) fn everything_ini_path(host: &dyn Host) -> PathBuf {
-    host.env("APPDATA").map_or_else(
-        || PathBuf::from("Everything.ini"),
-        |appdata| {
-            Path::new(&appdata)
-                .join("Everything")
-                .join("Everything.ini")
-        },
-    )
 }
 
 /// Normalized action a gate [`Decision`] maps to for one stage step.
@@ -205,71 +106,6 @@ const fn act_of(decision: Decision) -> Act {
         Decision::ProceedNoop => Act::Noop,
         Decision::Skip => Act::Skip,
         Decision::Back | Decision::Abort => Act::Stop,
-    }
-}
-
-/// Build the persisted [`Decisions`] record from the parsed CLI.
-fn decisions_from_cli(cli: &Cli) -> Decisions {
-    Decisions {
-        mode: mode_name(cli.mode()).to_owned(),
-        drives: cli
-            .drives_or_default()
-            .iter()
-            .map(char::to_string)
-            .collect(),
-        tools: cli.tools_or_default(),
-        rounds: cli.rounds,
-        drop_cache: cli.drop_os_cache,
-    }
-}
-
-/// Hash the plan-defining decisions into the Stage 0 resume `input_hash`.
-fn plan_input_hash(decisions: &Decisions) -> String {
-    let drives = decisions.drives.join(",");
-    let tools = decisions.tools.join(",");
-    let rounds = decisions.rounds.to_string();
-    let drop = if decisions.drop_cache { "drop" } else { "keep" };
-    input_hash(&[&decisions.mode, &drives, &tools, &rounds, drop])
-}
-
-/// Build the Stage 0a [`EnvSpec`] (one version probe per requested tool).
-fn env_spec_from_cli(host: &dyn Host, cli: &Cli) -> EnvSpec {
-    EnvSpec {
-        tools: cli
-            .tools_or_default()
-            .iter()
-            .map(|tool| tool_probe(host, tool))
-            .collect(),
-    }
-}
-
-/// Build the Stage 0c [`PreflightSpec`] from the CLI and captured env.
-///
-/// `es_ram_budget_bytes` is set to 50 % of the system's physical RAM so that
-/// the greedy drive selector avoids OOM-ing Everything's in-process index.
-fn preflight_spec_from_cli(host: &dyn Host, cli: &Cli, es_ram_budget_bytes: u64) -> PreflightSpec {
-    PreflightSpec {
-        ini_path: everything_ini_path(host),
-        candidate_drives: cli.drives_or_default(),
-        es_exe: resolve::es_exe(host),
-        uffs_exe: resolve::uffs_exe(host),
-        patterns: resolve::default_pattern_probes(),
-        poll_attempts: PREFLIGHT_POLL_ATTEMPTS,
-        poll_interval_ms: PREFLIGHT_POLL_INTERVAL_MS,
-        es_ram_budget_bytes,
-    }
-}
-
-/// Build the Stage 0d [`MatrixSpec`] from the CLI.
-fn matrix_spec_from_cli(cli: &Cli, es_ram_budget_bytes: u64) -> MatrixSpec {
-    MatrixSpec {
-        required_tools: cli.tools_or_default(),
-        candidate_drives: cli.drives_or_default(),
-        patterns: resolve::DEFAULT_PATTERNS
-            .iter()
-            .map(|(name, _)| (*name).to_owned())
-            .collect(),
-        es_ram_budget_bytes,
     }
 }
 
@@ -333,6 +169,13 @@ struct Capture {
     preflight: PreflightResult,
     /// Stage 0d negotiated matrix (its `capable_drives` feed Stage 1).
     matrix: Matrix,
+    /// Path to the temporary Everything ini written for the bench instance.
+    ///
+    /// `None` when Everything was already running or no instance was needed.
+    /// Dropped (file removed + instance exited) at the end of `execute()`.
+    es_ini_path: Option<PathBuf>,
+    /// Resolved path to `Everything.exe`, used for teardown.
+    everything_exe: String,
 }
 
 /// Mutable per-run gate state threaded through every staged confirm.
@@ -419,10 +262,49 @@ impl Orchestrator<'_> {
         }
         let es_ram_budget = preflight::ES_RAM_BUDGET_BYTES;
         daemon::ensure_daemon_ready(self.host, &resolve::uffs_exe(self.host))?;
-        let preflight = preflight::capture(
+        // First pass: probe without an ES instance to discover which drives
+        // exist and what ES state they are in.
+        let preflight_first = preflight::capture(
             self.host,
             &preflight_spec_from_cli(self.host, self.cli, es_ram_budget),
         );
+        let matrix_first = matrix::compute_matrix(
+            &matrix_spec_from_cli(self.cli, es_ram_budget),
+            &preflight_first,
+        );
+        // If Everything is not running, launch an isolated instance restricted
+        // to the RAM-budget-capable drives, then re-run the ES probes only.
+        let everything_exe = resolve::everything_exe(self.host);
+        let es_ini_path =
+            if es_instance::es_needs_launch(&preflight_first, &matrix_first.capable_drives) {
+                let ini = es_instance::launch(
+                    self.host,
+                    &everything_exe,
+                    &matrix_first.capable_drives,
+                    &self.bundle_dir,
+                );
+                if ini.is_some() {
+                    es_instance::wait_until_loaded(
+                        self.host,
+                        &resolve::es_exe(self.host),
+                        &matrix_first.capable_drives,
+                    );
+                }
+                ini
+            } else {
+                None
+            };
+        // Second pass (or same result if no instance was launched): re-probe
+        // ES status now that the instance is (or was already) running.
+        let mut spec2 = preflight_spec_from_cli(self.host, self.cli, es_ram_budget);
+        if es_ini_path.is_some() {
+            spec2.es_instance_name = String::from(es_instance::INSTANCE_NAME);
+        }
+        let preflight = if es_ini_path.is_some() {
+            preflight::capture(self.host, &spec2)
+        } else {
+            preflight_first
+        };
         self.host
             .out(&preflight::render_drive_table(&preflight, es_ram_budget));
         let matrix =
@@ -432,6 +314,8 @@ impl Orchestrator<'_> {
             fp,
             preflight,
             matrix,
+            es_ini_path,
+            everything_exe,
         })
     }
 
@@ -642,6 +526,10 @@ impl Orchestrator<'_> {
             } else if matches!(self.run_assembly(state, session, hash)?, Flow::Stop) {
                 return Ok(());
             }
+        }
+        // Tear down the bench-local Everything instance (if we launched one).
+        if let Some(cap) = capture.as_ref() {
+            es_instance::stop(self.host, &cap.everything_exe, cap.es_ini_path.as_deref());
         }
         Ok(())
     }

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -288,10 +288,15 @@ impl Orchestrator<'_> {
             &matrix_spec_from_cli(self.cli, es_ram_budget),
             &preflight_first,
         );
-        self.host.out(&matrix::render_md(&matrix_first));
         let everything_exe = resolve::everything_exe(self.host);
         let needs_launch =
             es_instance::es_needs_launch(&preflight_first, &matrix_first.capable_drives);
+        // Only render the first-pass matrix when ES is already running — if ES
+        // needs to be launched the matrix is stale (all UFFS-only) and the
+        // correct one will be rendered after the second-pass preflight.
+        if !needs_launch {
+            self.host.out(&matrix::render_md(&matrix_first));
+        }
         Ok(Capture {
             fp,
             preflight: preflight_first,

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -20,20 +20,21 @@
 use alloc::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+mod bootstrap;
 mod daemon;
 mod es_instance;
 mod specs;
 
+use bootstrap::{load_or_new_state, resolve_bundle_dir, run_fetch_competitors};
 pub(crate) use specs::everything_ini_path;
 use specs::{
     decisions_from_cli, env_spec_from_cli, matrix_spec_from_cli, plan_input_hash,
     preflight_spec_from_cli,
 };
 
-use crate::bundle::{bundle_path, new_bundle};
 use crate::cards::{
     assembly_card, dry_run_result, es_launch_card, measurement_card, plan_card, report_scope,
-    stage0_result, tool_selection_card,
+    stage0_result, tool_selection_card, uffs_restart_card,
 };
 use crate::cli::{Cli, Command};
 use crate::env::{self, EnvFingerprint};
@@ -44,9 +45,8 @@ use crate::matrix::{self, Matrix};
 use crate::preflight::{self, PreflightResult};
 use crate::restore::RunGuard;
 use crate::stages::{self, StageCfg};
-use crate::state::{Decisions, State, Status};
-use crate::tooling::Disposition;
-use crate::{competitors, report, resolve, teardown};
+use crate::state::{State, Status};
+use crate::{report, resolve, teardown};
 
 /// Suite version stamped into bundle names and `state.json`.
 const SUITE_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -191,6 +191,10 @@ struct Capture {
     /// When `true`, `launch_es_if_needed()` will show the confirmation gate and
     /// (if the operator proceeds) launch the isolated Everything instance.
     es_needs_launch: bool,
+    /// Whether the UFFS daemon should be killed and restarted with only the
+    /// negotiated capable drives before measurement begins.
+    /// Always `true` when capable drives are non-empty.
+    uffs_needs_restart: bool,
 }
 
 /// Mutable per-run gate state threaded through every staged confirm.
@@ -244,7 +248,6 @@ impl Orchestrator<'_> {
     /// Returns [`BenchError::MissingTools`] if fewer than 2 tools are available
     /// after the operator's decision, or if the operator chooses to abort.
     fn capture(&self, session: &mut Session) -> Result<Capture> {
-        daemon::daemon_start_if_needed(self.host, &resolve::uffs_exe(self.host));
         let fp = env::capture(self.host, &env_spec_from_cli(self.host, self.cli));
         self.host.out(&env::render_md(&fp));
         let missing: Vec<&str> = fp
@@ -270,6 +273,10 @@ impl Orchestrator<'_> {
             .tools
             .iter()
             .any(|tv| tv.name == "everything" && tv.version != "unknown");
+        // preflight_steps: tool-selection (step 1) is always present.
+        // ES launch adds a step when Everything is available.
+        // The UFFS restart step is checked post-matrix; we use a conservative
+        // upper bound here — the actual step numbers on each card are precise.
         let preflight_steps = if es_available { 2 } else { 1 };
         let card = tool_selection_card(&available, &missing, preflight_steps);
         if matches!(
@@ -281,7 +288,6 @@ impl Orchestrator<'_> {
             ));
         }
         let es_ram_budget = preflight::ES_RAM_BUDGET_BYTES;
-        daemon::ensure_daemon_ready(self.host, &resolve::uffs_exe(self.host))?;
         // Probe drives and display the drive table + negotiated matrix.
         // ES launch (if needed) is deferred to `launch_es_if_needed()` so the
         // operator can confirm before the bench touches the Everything process.
@@ -300,6 +306,7 @@ impl Orchestrator<'_> {
         let everything_exe = resolve::everything_exe(self.host);
         let needs_launch =
             es_instance::es_needs_launch(&preflight_first, &matrix_first.capable_drives);
+        let needs_uffs_restart = !matrix_first.capable_drives.is_empty();
         // When ES needs launching, the UFFS-only reasons are all "ES not
         // started/starting" — noisy and misleading before the launch gate.
         // Only show capable drives; the full matrix is shown after launch.
@@ -316,7 +323,56 @@ impl Orchestrator<'_> {
             es_ini_path: None,
             everything_exe,
             es_needs_launch: needs_launch,
+            uffs_needs_restart: needs_uffs_restart,
         })
+    }
+
+    /// Gate and (if confirmed) kill the running UFFS daemon and restart it
+    /// restricted to the negotiated capable drives.
+    ///
+    /// Always shown when capable drives are non-empty.  The daemon is always
+    /// killed and restarted (not conditionally) so measurements are confined
+    /// to the negotiated drive set regardless of what was loaded before.
+    fn restart_uffs_if_needed(
+        &self,
+        session: &mut Session,
+        cap: &mut Capture,
+        preflight_steps: u32,
+    ) {
+        if cap.matrix.capable_drives.is_empty() {
+            return;
+        }
+        let es_step = if cap.es_needs_launch {
+            preflight_steps
+        } else {
+            0
+        };
+        let uffs_step_num = preflight_steps - es_step;
+        let card = uffs_restart_card(&cap.matrix.capable_drives, uffs_step_num, preflight_steps);
+        match confirm(self.host, &mut session.mode, &mut session.seen, &card) {
+            Decision::Back | Decision::Abort => {
+                self.host.out(
+                    "[uffs-daemon] operator skipped UFFS restart — \
+                     daemon keeps all drives loaded",
+                );
+                cap.uffs_needs_restart = false;
+                return;
+            }
+            Decision::ProceedNoop => {
+                self.host
+                    .out("[uffs-daemon] dry-run: skipping daemon kill/restart");
+                cap.uffs_needs_restart = false;
+                return;
+            }
+            Decision::Proceed | Decision::Autopilot | Decision::Skip => {}
+        }
+        let uffs_exe = resolve::uffs_exe(self.host);
+        daemon::kill_and_restart_with_drives(self.host, &uffs_exe, &cap.matrix.capable_drives);
+        if let Err(err) = daemon::ensure_daemon_ready(self.host, &uffs_exe) {
+            self.host.out(&format!(
+                "[uffs-daemon] WARNING: daemon did not become ready: {err}"
+            ));
+        }
     }
 
     /// Gate and (if confirmed) launch the bench-local Everything instance.
@@ -329,11 +385,22 @@ impl Orchestrator<'_> {
     ///
     /// If the operator aborts the card, ES cells are silently skipped (the
     /// matrix already shows them as UFFS-only).
-    fn launch_es_if_needed(&self, session: &mut Session, cap: &mut Capture) {
+    fn launch_es_if_needed(
+        &self,
+        session: &mut Session,
+        cap: &mut Capture,
+        step_num: u32,
+        step_total: u32,
+    ) {
         if !cap.es_needs_launch || cap.matrix.capable_drives.is_empty() {
             return;
         }
-        let card = es_launch_card(&cap.matrix.capable_drives, self.cli.es_admin);
+        let card = es_launch_card(
+            &cap.matrix.capable_drives,
+            self.cli.es_admin,
+            step_num,
+            step_total,
+        );
         match confirm(self.host, &mut session.mode, &mut session.seen, &card) {
             Decision::Back | Decision::Abort => {
                 self.host.out(
@@ -534,11 +601,32 @@ impl Orchestrator<'_> {
         let mut capture = ((stage0_selected && !stage0_skip) || measure_live)
             .then(|| self.capture(session))
             .transpose()?;
-        // Show the ES-instance confirm gate and launch if the operator agrees.
-        // This runs after the matrix is displayed and before the plan card, so
-        // the final (post-launch) matrix is what gets locked into stage0.
+        // Show UFFS restart gate (kill + start with only capable drives), then
+        // ES-instance gate, in that order — both before the plan card so the
+        // final matrix is what gets locked into stage0.
         if let Some(cap) = capture.as_mut() {
-            self.launch_es_if_needed(session, cap);
+            // Compute exact step numbers: UFFS restart (if needed) comes
+            // before ES launch; ES launch is always last.
+            let uffs_restart_step = cap.uffs_needs_restart.then_some(2_u32);
+            let es_launch_step = cap
+                .es_needs_launch
+                .then(|| uffs_restart_step.map_or(2, |prev| prev + 1));
+            let total_steps = es_launch_step.or(uffs_restart_step).unwrap_or(1);
+            if uffs_restart_step.is_some() {
+                self.restart_uffs_if_needed(session, cap, total_steps);
+                // After restart, re-run second-pass preflight to get fresh
+                // drive counts from the restricted daemon.
+                let es_ram_budget = preflight::ES_RAM_BUDGET_BYTES;
+                let mut spec2 = preflight_spec_from_cli(self.host, self.cli, es_ram_budget);
+                spec2.candidate_drives = cap.preflight.drives.iter().map(|dp| dp.drive).collect();
+                if cap.es_ini_path.is_some() {
+                    spec2.es_instance_name = String::from(es_instance::INSTANCE_NAME);
+                }
+                cap.preflight = preflight::capture(self.host, &spec2);
+            }
+            if let Some(step) = es_launch_step {
+                self.launch_es_if_needed(session, cap, step, total_steps);
+            }
         }
 
         if stage0_selected {
@@ -594,77 +682,6 @@ impl Orchestrator<'_> {
             es_instance::stop(self.host, &cap.everything_exe, cap.es_ini_path.as_deref());
         }
         Ok(())
-    }
-}
-
-/// Resolve the bundle directory: resume an explicit `--bundle`, else mint a new
-/// timestamped one (a dry-run computes the path without creating it).
-fn resolve_bundle_dir(host: &dyn Host, cli: &Cli, dry_run: bool) -> Result<PathBuf> {
-    if let Some(dir) = &cli.bundle {
-        return Ok(dir.clone());
-    }
-    if dry_run {
-        Ok(bundle_path(host, &cli.bundle_root, SUITE_VERSION))
-    } else {
-        new_bundle(host, &cli.bundle_root, SUITE_VERSION)
-    }
-}
-
-/// Disposition for tools the suite acquires (the `--keep-tools` toggle).
-const fn tool_disposition(cli: &Cli) -> Disposition {
-    if cli.keep_tools {
-        Disposition::Keep
-    } else {
-        Disposition::Remove
-    }
-}
-
-/// Handle the `fetch-competitors` subcommand.
-///
-/// Resolves (or resumes) a bundle, fetches + SHA-256-verifies the pinned
-/// competitor from `competitors.toml` into `<bundle>/tools/`, and records the
-/// verified [`Acquisition`](crate::tooling::Acquisition) in `state.json`. A
-/// dry-run acquires nothing.
-///
-/// # Errors
-/// Returns an error if bundle/state I/O fails or provisioning fails (a
-/// malformed manifest, a failed download, or a SHA-256 mismatch — all fail
-/// closed).
-fn run_fetch_competitors(host: &dyn Host, cli: &Cli) -> Result<()> {
-    if cli.mode() == Mode::DryRun {
-        host.out("dry-run: competitor fetch acquires nothing");
-        return Ok(());
-    }
-    let decisions = decisions_from_cli(cli);
-    let bundle_dir = resolve_bundle_dir(host, cli, false)?;
-    let state_path = bundle_dir.join("state.json");
-    let mut state = load_or_new_state(host, cli, &state_path, &decisions)?;
-
-    let manifest = competitors::load_manifest(host, Path::new(competitors::MANIFEST_PATH))?;
-    let acquisition = competitors::fetch(host, &manifest, &bundle_dir, tool_disposition(cli))?;
-    host.out(&format!(
-        "fetched {} (Everything v{}) -> {} [sha256 verified, {:?}]",
-        acquisition.name,
-        manifest.everything.version,
-        acquisition.path.display(),
-        acquisition.disposition
-    ));
-    state.acquisitions.push(acquisition);
-    state.save(host, &state_path)?;
-    Ok(())
-}
-
-/// Load `state.json` when resuming an existing bundle, else start fresh.
-fn load_or_new_state(
-    host: &dyn Host,
-    cli: &Cli,
-    state_path: &Path,
-    decisions: &Decisions,
-) -> Result<State> {
-    if cli.bundle.is_some() && host.path_exists(state_path) {
-        State::load(host, state_path)
-    } else {
-        Ok(State::new(host, SUITE_VERSION, decisions.clone()))
     }
 }
 

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -22,10 +22,11 @@ use std::path::{Path, PathBuf};
 
 use crate::bundle::{bundle_path, new_bundle};
 use crate::cards::{
-    assembly_card, dry_run_result, measurement_card, plan_card, report_scope, stage0_result,
+    assembly_card, dry_run_result, measurement_card, missing_tools_card, plan_card, report_scope,
+    stage0_result,
 };
 use crate::cli::{Cli, Command};
-use crate::env::{self, EnvFingerprint, EnvSpec, StateProbe, ToolProbe};
+use crate::env::{self, EnvFingerprint, EnvSpec, StateProbe, ToolProbe, tool_install_hint};
 use crate::error::{BenchError, CrumbError, Result};
 use crate::gate::{Decision, Mode, StepResult, confirm, done_panel};
 use crate::host::Host;
@@ -142,19 +143,17 @@ fn tool_probe(host: &dyn Host, name: &str) -> ToolProbe {
             state_probe: None,
         }
     } else if name == "uffs" {
-        let uffs = resolve::uffs_exe(host);
         ToolProbe {
             name: name.to_owned(),
-            exe: uffs.clone(),
+            exe: resolve::uffs_exe(host),
             display_exe: None,
+            // `uffs --version` prints e.g. `uffs 0.5.117`; strip the prefix.
             args: vec!["--version".to_owned()],
-            version_line_prefix: None,
+            version_line_prefix: Some("uffs ".to_owned()),
             daemon_error_markers: vec![],
-            state_probe: Some(StateProbe {
-                exe: uffs,
-                args: vec!["daemon".to_owned(), "status".to_owned()],
-                running_marker: "running".to_owned(),
-            }),
+            // The daemon (uttfd) is started/restarted by the bench itself, so
+            // its pre-run state is irrelevant — report n/a.
+            state_probe: None,
         }
     } else {
         ToolProbe {
@@ -371,12 +370,15 @@ impl Orchestrator<'_> {
     /// measurement stages (whose [`StageCfg`] draws its cross-tool-capable
     /// drive subset from the negotiated matrix), so no probe runs twice.
     ///
+    /// When one or more tools cannot be found (version = `"unknown"`), the
+    /// operator is shown an install hint per missing tool and asked whether to
+    /// proceed with the remaining tools or quit. If fewer than two tools are
+    /// available after the gate, the run is aborted.
+    ///
     /// # Errors
-    /// Returns [`BenchError::MissingTools`] if any requested tool could not be
-    /// invoked (version probe returned `"unknown"`). Fails fast and loud so the
-    /// operator knows exactly which binaries to install before any measurements
-    /// run.
-    fn capture(&self) -> Result<Capture> {
+    /// Returns [`BenchError::MissingTools`] if fewer than 2 tools are available
+    /// after the operator's decision, or if the operator chooses to abort.
+    fn capture(&self, session: &mut Session) -> Result<Capture> {
         let fp = env::capture(self.host, &env_spec_from_cli(self.host, self.cli));
         let missing: Vec<&str> = fp
             .tools
@@ -385,10 +387,32 @@ impl Orchestrator<'_> {
             .map(|tv| tv.name.as_str())
             .collect();
         if !missing.is_empty() {
-            let list = missing.join(", ");
-            return Err(BenchError::MissingTools(format!(
-                "{list} — ensure the binaries are on PATH or in ~/bin and re-run"
-            )));
+            self.host.out("\n⚠️  Some tools could not be found:");
+            for name in &missing {
+                self.host.out(&format!(
+                    "  ✗  {name} — {hint}",
+                    hint = tool_install_hint(name)
+                ));
+            }
+            let available = fp.tools.len() - missing.len();
+            if available < 2 {
+                return Err(BenchError::MissingTools(format!(
+                    "only {available} tool(s) available — need at least 2 to run a meaningful \
+                     benchmark. Install the missing tools and re-run."
+                )));
+            }
+            self.host.out(&format!(
+                "\n{available} tool(s) available. Proceed with the tools we have?"
+            ));
+            let card = missing_tools_card(&missing);
+            if matches!(
+                confirm(self.host, &mut session.mode, &mut session.seen, &card),
+                Decision::Back | Decision::Abort
+            ) {
+                return Err(BenchError::MissingTools(
+                    "operator chose to abort — install missing tools and re-run".to_owned(),
+                ));
+            }
         }
         let preflight =
             preflight::capture(self.host, &preflight_spec_from_cli(self.host, self.cli));
@@ -566,7 +590,7 @@ impl Orchestrator<'_> {
             stage_selected(self.cli, stage) && !state.should_skip(&stage_step_id(stage), hash)
         });
         let capture = ((stage0_selected && !stage0_skip) || measure_live)
-            .then(|| self.capture())
+            .then(|| self.capture(session))
             .transpose()?;
 
         if stage0_selected {

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -109,8 +109,12 @@ const fn act_of(decision: Decision) -> Act {
     }
 }
 
-/// Whether `stage` is selected by the `--only-stage` / `--from-stage` filters.
-const fn stage_selected(cli: &Cli, stage: u32) -> bool {
+/// Whether `stage` is selected by the `--only-stage` / `--from-stage` /
+/// `--skip-stages` filters.
+fn stage_selected(cli: &Cli, stage: u32) -> bool {
+    if cli.skip_stages.contains(&stage) {
+        return false;
+    }
     match (cli.only_stage, cli.from_stage) {
         (Some(only), _) => stage == only,
         (None, Some(from)) => stage >= from,
@@ -552,6 +556,12 @@ impl Orchestrator<'_> {
         }
         for stage in 1..=MEASUREMENT_STAGES {
             if !stage_selected(self.cli, stage) {
+                if self.cli.skip_stages.contains(&stage) {
+                    self.host.out(&format!(
+                        "-> {} skipped (--skip-stages)",
+                        stage_banner(stage)
+                    ));
+                }
                 continue;
             }
             if state.should_skip(&stage_step_id(stage), hash) {

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -414,6 +414,7 @@ impl Orchestrator<'_> {
         let preflight =
             preflight::capture(self.host, &preflight_spec_from_cli(self.host, self.cli));
         let matrix = matrix::compute_matrix(&matrix_spec_from_cli(self.cli), &preflight);
+        self.host.out(&matrix::render_md(&matrix));
         Ok(Capture {
             fp,
             preflight,
@@ -444,8 +445,6 @@ impl Orchestrator<'_> {
         cap: &Capture,
         hash: &str,
     ) -> Result<Flow> {
-        self.host.out(&matrix::render_md(&cap.matrix));
-
         let card = plan_card(&self.bundle_dir);
         match act_of(confirm(
             self.host,

--- a/crates/uffs-bench/src/run/mod.rs
+++ b/crates/uffs-bench/src/run/mod.rs
@@ -78,32 +78,44 @@ const fn mode_name(mode: Mode) -> &'static str {
 
 /// Build a version-probe for one tool id.
 ///
-/// - `everything` → `es.exe -get-everything-version` (resolved via cascade)
+/// - `everything` → `es.exe -version` (ES CLI version, no daemon/IPC needed)
 /// - `uffs_cpp`   → `uffs.com --version` (resolved via `~/bin` cascade)
 /// - anything else → `<exe> --version`
 fn tool_probe(host: &dyn Host, name: &str) -> ToolProbe {
-    let (exe, args, version_line_prefix) = if name == matrix::EVERYTHING_TOOL {
+    let (exe, args, version_line_prefix, daemon_error_markers) = if name == matrix::EVERYTHING_TOOL
+    {
         (
             resolve::es_exe(host),
-            vec!["-get-everything-version".to_owned()],
+            // Use `-version` (ES CLI version, no IPC/daemon required) rather
+            // than `-get-everything-version` which exits 0 but prints an IPC
+            // error when the Everything daemon is not running.
+            vec!["-version".to_owned()],
             None,
+            vec![],
         )
     } else if name == "uffs_cpp" {
         (
             resolve::uffs_cpp_exe(host),
             vec!["--version".to_owned()],
             Some("UFFS version:".to_owned()),
+            vec![],
         )
     } else if name == "uffs" {
-        (resolve::uffs_exe(host), vec!["--version".to_owned()], None)
+        (
+            resolve::uffs_exe(host),
+            vec!["--version".to_owned()],
+            None,
+            vec![],
+        )
     } else {
-        (name.to_owned(), vec!["--version".to_owned()], None)
+        (name.to_owned(), vec!["--version".to_owned()], None, vec![])
     };
     ToolProbe {
         name: name.to_owned(),
         exe,
         args,
         version_line_prefix,
+        daemon_error_markers,
     }
 }
 

--- a/crates/uffs-bench/src/run/specs.rs
+++ b/crates/uffs-bench/src/run/specs.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Spec-builder helpers: construct [`EnvSpec`], [`PreflightSpec`], and
+//! [`MatrixSpec`] from the parsed CLI.  Extracted from `run/mod.rs` to keep
+//! that file within the workspace file-size policy (≤ 800 LOC).
+
+use std::path::{Path, PathBuf};
+
+use super::{PREFLIGHT_POLL_ATTEMPTS, PREFLIGHT_POLL_INTERVAL_MS, mode_name};
+use crate::cli::Cli;
+use crate::env::{EnvSpec, StateProbe, ToolProbe};
+use crate::host::Host;
+use crate::matrix::{self, EVERYTHING_GUI_TOOL, MatrixSpec};
+use crate::preflight::PreflightSpec;
+use crate::resolve;
+use crate::state::{Decisions, input_hash};
+
+/// Build a version + state probe for one tool id.
+pub(super) fn tool_probe(host: &dyn Host, name: &str) -> ToolProbe {
+    let tasklist_state = || StateProbe {
+        exe: "tasklist.exe".to_owned(),
+        args: vec![
+            "/FI".to_owned(),
+            "IMAGENAME eq Everything.exe".to_owned(),
+            "/NH".to_owned(),
+            "/FO".to_owned(),
+            "CSV".to_owned(),
+        ],
+        running_marker: "Everything.exe".to_owned(),
+    };
+
+    if name == matrix::EVERYTHING_TOOL {
+        ToolProbe {
+            name: name.to_owned(),
+            exe: resolve::es_exe(host),
+            display_exe: None,
+            args: vec!["-version".to_owned()],
+            version_line_prefix: None,
+            daemon_error_markers: vec![],
+            state_probe: Some(tasklist_state()),
+        }
+    } else if name == EVERYTHING_GUI_TOOL {
+        ToolProbe {
+            name: name.to_owned(),
+            exe: resolve::es_exe(host),
+            display_exe: Some(resolve::everything_exe(host)),
+            args: vec!["-get-everything-version".to_owned()],
+            version_line_prefix: None,
+            daemon_error_markers: vec!["Error 8".to_owned(), "IPC window not found".to_owned()],
+            state_probe: Some(tasklist_state()),
+        }
+    } else if name == "uffs_cpp" {
+        ToolProbe {
+            name: name.to_owned(),
+            exe: resolve::uffs_cpp_exe(host),
+            display_exe: None,
+            args: vec!["--version".to_owned()],
+            version_line_prefix: Some("UFFS version:".to_owned()),
+            daemon_error_markers: vec![],
+            state_probe: None,
+        }
+    } else if name == "uffs" {
+        ToolProbe {
+            name: name.to_owned(),
+            exe: resolve::uffs_exe(host),
+            display_exe: None,
+            args: vec!["--version".to_owned()],
+            version_line_prefix: Some("uffs ".to_owned()),
+            daemon_error_markers: vec![],
+            state_probe: None,
+        }
+    } else {
+        ToolProbe {
+            name: name.to_owned(),
+            exe: name.to_owned(),
+            display_exe: None,
+            args: vec!["--version".to_owned()],
+            version_line_prefix: None,
+            daemon_error_markers: vec![],
+            state_probe: None,
+        }
+    }
+}
+
+/// Resolve the read-only `Everything.ini` path from the host environment.
+///
+/// Uses `%APPDATA%\Everything\Everything.ini` when `APPDATA` is set (the
+/// Windows install default), falling back to a bare relative name otherwise so
+/// the preflight simply observes an absent ini on other hosts.
+pub(crate) fn everything_ini_path(host: &dyn Host) -> PathBuf {
+    host.env("APPDATA").map_or_else(
+        || PathBuf::from("Everything.ini"),
+        |appdata| {
+            Path::new(&appdata)
+                .join("Everything")
+                .join("Everything.ini")
+        },
+    )
+}
+
+/// Build the persisted [`Decisions`] record from the parsed CLI.
+pub(super) fn decisions_from_cli(cli: &Cli) -> Decisions {
+    Decisions {
+        mode: mode_name(cli.mode()).to_owned(),
+        drives: cli
+            .drives_or_default()
+            .iter()
+            .map(char::to_string)
+            .collect(),
+        tools: cli.tools_or_default(),
+        rounds: cli.rounds,
+        drop_cache: cli.drop_os_cache,
+    }
+}
+
+/// Hash the plan-defining decisions into the Stage 0 resume `input_hash`.
+pub(super) fn plan_input_hash(decisions: &Decisions) -> String {
+    let drives = decisions.drives.join(",");
+    let tools = decisions.tools.join(",");
+    let rounds = decisions.rounds.to_string();
+    let drop = if decisions.drop_cache { "drop" } else { "keep" };
+    input_hash(&[&decisions.mode, &drives, &tools, &rounds, drop])
+}
+
+/// Build the Stage 0a [`EnvSpec`] (one version probe per requested tool).
+pub(super) fn env_spec_from_cli(host: &dyn Host, cli: &Cli) -> EnvSpec {
+    EnvSpec {
+        tools: cli
+            .tools_or_default()
+            .iter()
+            .map(|tool| tool_probe(host, tool))
+            .collect(),
+    }
+}
+
+/// Build the Stage 0c [`PreflightSpec`] from the CLI and captured env.
+pub(super) fn preflight_spec_from_cli(
+    host: &dyn Host,
+    cli: &Cli,
+    es_ram_budget_bytes: u64,
+) -> PreflightSpec {
+    PreflightSpec {
+        ini_path: everything_ini_path(host),
+        candidate_drives: cli.drives_or_default(),
+        es_exe: resolve::es_exe(host),
+        uffs_exe: resolve::uffs_exe(host),
+        patterns: resolve::default_pattern_probes(),
+        poll_attempts: PREFLIGHT_POLL_ATTEMPTS,
+        poll_interval_ms: PREFLIGHT_POLL_INTERVAL_MS,
+        es_ram_budget_bytes,
+        es_instance_name: String::new(),
+    }
+}
+
+/// Build the Stage 0d [`MatrixSpec`] from the CLI.
+pub(super) fn matrix_spec_from_cli(cli: &Cli, es_ram_budget_bytes: u64) -> MatrixSpec {
+    MatrixSpec {
+        required_tools: cli.tools_or_default(),
+        candidate_drives: cli.drives_or_default(),
+        patterns: resolve::DEFAULT_PATTERNS
+            .iter()
+            .map(|(name, _)| (*name).to_owned())
+            .collect(),
+        es_ram_budget_bytes,
+    }
+}

--- a/crates/uffs-bench/src/run/tests.rs
+++ b/crates/uffs-bench/src/run/tests.rs
@@ -17,9 +17,15 @@ fn stdout_of(text: &str) -> ProcOutput {
     }
 }
 
-/// The `Status:        Ready` line the daemon emits when fully loaded.
-const DAEMON_READY_STATUS: &str =
-    "Version:       0.0.0\nDaemon PID:    1\nStatus:        Ready\nDrives:\n";
+/// The `Status:        Ready` output the daemon emits when fully loaded.
+///
+/// Includes a `[Warm]` line for `C:` so the preflight `warm_parked_drives`
+/// step skips the preload call for the `--drives C` test spec.
+const DAEMON_READY_STATUS: &str = "Version:       0.0.0\n\
+    Daemon PID:    1\n\
+    Status:        Ready\n\
+    Drives:\n\
+      [Warm]   C: \u{2014}  3,000,000 records (live) \u{2014} 300 MB\n";
 
 /// Queue the run results needed for the `--dry-run` code path.
 ///

--- a/crates/uffs-bench/src/run/tests.rs
+++ b/crates/uffs-bench/src/run/tests.rs
@@ -44,10 +44,10 @@ const DAEMON_READY_STATUS: &str = "Version:       0.0.0\n\
 ///  7. `env::capture` `total_ram`
 ///  8. `env::capture` uffs --version
 ///  9. `env::capture` `uffs_cpp` --version
-/// 10. `env::capture` es -version
-/// 11. tasklist (everything state probe — stopped)
-/// 12. `env::capture` es -get-everything-version
-/// 13. tasklist (`everything_gui` state probe — stopped)
+/// 10. tasklist (`everything` state probe — stopped)   ← state before version
+/// 11. `env::capture` es -version
+/// 12. tasklist (`everything_gui` state probe — stopped)
+/// 13. `env::capture` es -get-everything-version
 /// 14. `preflight`  — `es -get-everything-version` (availability)
 /// 15. `preflight`  — `uffs daemon status` (record counts for C)
 /// 16. `preflight`  — `es -get-result-count C:` → loaded
@@ -63,10 +63,10 @@ fn dry_run_host() -> MockHost {
         .with_run_result(stdout_of("8589934592"))             //  7: total_ram
         .with_run_result(stdout_of("uffs 0.0.0"))             //  8: uffs --version
         .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) //  9: uffs_cpp --version
-        .with_run_result(stdout_of("1.1.0.30"))               // 10: es -version
-        .with_run_result(stdout_of(""))                       // 11: tasklist (stopped)
-        .with_run_result(stdout_of("1.4.1.1032"))             // 12: es -get-everything-version
-        .with_run_result(stdout_of(""))                       // 13: tasklist (stopped)
+        .with_run_result(stdout_of(""))                       // 10: tasklist (everything stopped)
+        .with_run_result(stdout_of("1.1.0.30"))               // 11: es -version
+        .with_run_result(stdout_of(""))                       // 12: tasklist (everything_gui stopped)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 13: es -get-everything-version
         .with_run_result(stdout_of("1.4.1.1032"))             // 14: preflight es availability
         .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 15: preflight daemon status
         .with_run_result(stdout_of("1000")) // 16: es result-count C
@@ -88,10 +88,10 @@ fn dry_run_host() -> MockHost {
 ///  8. `env::capture` `total_ram`
 ///  9. `env::capture` uffs --version
 /// 10. `env::capture` `uffs_cpp` --version
-/// 11. `env::capture` es -version
-/// 12. tasklist (everything state probe — stopped)
-/// 13. `env::capture` es -get-everything-version
-/// 14. tasklist (`everything_gui` state probe — stopped)
+/// 11. tasklist (`everything` state probe — stopped)   ← state before version
+/// 12. `env::capture` es -version
+/// 13. tasklist (`everything_gui` state probe — stopped)
+/// 14. `env::capture` es -get-everything-version
 /// 15. `preflight`  — `es -get-everything-version` (availability)
 /// 16. `preflight`  — `uffs daemon status` (record counts for C)
 /// 17. `preflight`  — `es -get-result-count C:` → loaded
@@ -114,10 +114,10 @@ fn autopilot_host() -> MockHost {
         .with_run_result(stdout_of("8589934592"))             //  8: total_ram
         .with_run_result(stdout_of("uffs 0.0.0"))             //  9: uffs --version
         .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 10: uffs_cpp --version
-        .with_run_result(stdout_of("1.1.0.30"))               // 11: es -version
-        .with_run_result(stdout_of(""))                       // 12: tasklist (stopped)
-        .with_run_result(stdout_of("1.4.1.1032"))             // 13: es -get-everything-version
-        .with_run_result(stdout_of(""))                       // 14: tasklist (stopped)
+        .with_run_result(stdout_of(""))                       // 11: tasklist (everything stopped)
+        .with_run_result(stdout_of("1.1.0.30"))               // 12: es -version
+        .with_run_result(stdout_of(""))                       // 13: tasklist (everything_gui stopped)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 14: es -get-everything-version
         .with_run_result(stdout_of("1.4.1.1032"))             // 15: preflight es availability
         .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 16: preflight daemon status
         .with_run_result(stdout_of("1000"))                   // 17: es result-count C

--- a/crates/uffs-bench/src/run/tests.rs
+++ b/crates/uffs-bench/src/run/tests.rs
@@ -17,52 +17,78 @@ fn stdout_of(text: &str) -> ProcOutput {
     }
 }
 
-/// Queue the 8 run results needed for the `--dry-run` code path.
+/// Queue the run results needed for the `--dry-run` code path.
 ///
-/// `--dry-run` skips `teardown::baseline`, so the call order is:
-///  1. `resolve::es_exe` — `where.exe es.exe` (returns full path)
-///  2. `env::capture` hostname
-///  3. `env::capture` cpu
-///  4. `env::capture` `logical_cpus`
-///  5. `env::capture` `total_ram`
-///  6. `env::capture` uffs --version
-///  7. `env::capture` `uffs_cpp` --version (needs "UFFS version:" line)
-///  8. `env::capture` es -version
+/// `--dry-run` skips `teardown::baseline`, call order is:
+///  1. `resolve::es_exe`         — `where.exe es.exe` (for `everything`)
+///  2. `resolve::es_exe`         — `where.exe es.exe` (for `everything_gui`)
+///  3. `resolve::everything_exe` — `where.exe Everything.exe`
+///  4. `env::capture` hostname
+///  5. `env::capture` cpu
+///  6. `env::capture` `logical_cpus`
+///  7. `env::capture` `total_ram`
+///  8. `env::capture` uffs --version
+///  9. uffs daemon status (state probe)
+///  10. `env::capture` `uffs_cpp` --version
+///  11. `env::capture` es -version
+///  12. tasklist (everything state probe — stopped)
+///  13. `env::capture` es -get-everything-version
+///  14. tasklist (`everything_gui` state probe — stopped)
 fn dry_run_host() -> MockHost {
+    let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
     MockHost::new()
-        .with_run_result(stdout_of("C:\\bin\\es.exe"))         // 1: where.exe es.exe
-        .with_run_result(stdout_of("myhost"))                 // 2: hostname
-        .with_run_result(stdout_of("Name=Test CPU"))          // 3: cpu
-        .with_run_result(stdout_of("8"))                      // 4: logical_cpus
-        .with_run_result(stdout_of("8589934592"))             // 5: total_ram
-        .with_run_result(stdout_of("uffs 0.0.0"))             // 6: uffs --version
-        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 7: uffs_cpp --version
-        .with_run_result(stdout_of("1.1.0.30")) // 8: es -version
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  1: where.exe es.exe
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  2: where.exe es.exe
+        .with_run_result(stdout_of(evr))                      //  3: where.exe Everything.exe
+        .with_run_result(stdout_of("myhost"))                 //  4: hostname
+        .with_run_result(stdout_of("Name=Test CPU"))          //  5: cpu
+        .with_run_result(stdout_of("8"))                      //  6: logical_cpus
+        .with_run_result(stdout_of("8589934592"))             //  7: total_ram
+        .with_run_result(stdout_of("uffs 0.0.0"))             //  8: uffs --version
+        .with_run_result(stdout_of("running"))                //  9: uffs daemon status
+        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 10: uffs_cpp --version
+        .with_run_result(stdout_of("1.1.0.30"))               // 11: es -version
+        .with_run_result(stdout_of(""))                       // 12: tasklist (stopped)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 13: es -get-everything-version
+        .with_run_result(stdout_of("")) // 14: tasklist (stopped)
 }
 
-/// Queue the 9 run results needed for the autopilot (non-dry-run) path.
+/// Queue the run results needed for the autopilot (non-dry-run) path.
 ///
 /// `teardown::baseline` fires `uffs daemon status` before the env probes:
-///  1. `teardown::baseline` — `uffs daemon status`
-///  2. `resolve::es_exe` — `where.exe es.exe` (returns full path)
-///  3. `env::capture` hostname
-///  4. `env::capture` cpu
-///  5. `env::capture` `logical_cpus`
-///  6. `env::capture` `total_ram`
-///  7. `env::capture` uffs --version
-///  8. `env::capture` `uffs_cpp` --version (needs "UFFS version:" line)
-///  9. `env::capture` es -version
+///  1. `teardown::baseline`      — `uffs daemon status`
+///  2. `resolve::es_exe`         — `where.exe es.exe` (for `everything`)
+///  3. `resolve::es_exe`         — `where.exe es.exe` (for `everything_gui`)
+///  4. `resolve::everything_exe` — `where.exe Everything.exe`
+///  5. `env::capture` hostname
+///  6. `env::capture` cpu
+///  7. `env::capture` `logical_cpus`
+///  8. `env::capture` `total_ram`
+///  9. `env::capture` uffs --version
+///  10. uffs daemon status (state probe)
+///  11. `env::capture` `uffs_cpp` --version
+///  12. `env::capture` es -version
+///  13. tasklist (everything state probe — stopped)
+///  14. `env::capture` es -get-everything-version
+///  15. tasklist (`everything_gui` state probe — stopped)
 fn autopilot_host() -> MockHost {
+    let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
     MockHost::new()
-        .with_run_result(stdout_of("running"))                 // 1: uffs daemon status
-        .with_run_result(stdout_of("C:\\bin\\es.exe"))         // 2: where.exe es.exe
-        .with_run_result(stdout_of("myhost"))                 // 3: hostname
-        .with_run_result(stdout_of("Name=Test CPU"))          // 4: cpu
-        .with_run_result(stdout_of("8"))                      // 5: logical_cpus
-        .with_run_result(stdout_of("8589934592"))             // 6: total_ram
-        .with_run_result(stdout_of("uffs 0.0.0"))             // 7: uffs --version
-        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 8: uffs_cpp --version
-        .with_run_result(stdout_of("1.1.0.30")) // 9: es -version
+        .with_run_result(stdout_of("running"))                 //  1: uffs daemon status
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  2: where.exe es.exe
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  3: where.exe es.exe
+        .with_run_result(stdout_of(evr))                      //  4: where.exe Everything.exe
+        .with_run_result(stdout_of("myhost"))                 //  5: hostname
+        .with_run_result(stdout_of("Name=Test CPU"))          //  6: cpu
+        .with_run_result(stdout_of("8"))                      //  7: logical_cpus
+        .with_run_result(stdout_of("8589934592"))             //  8: total_ram
+        .with_run_result(stdout_of("uffs 0.0.0"))             //  9: uffs --version
+        .with_run_result(stdout_of("running"))                // 10: uffs daemon status
+        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 11: uffs_cpp --version
+        .with_run_result(stdout_of("1.1.0.30"))               // 12: es -version
+        .with_run_result(stdout_of(""))                       // 13: tasklist (stopped)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 14: es -get-everything-version
+        .with_run_result(stdout_of("")) // 15: tasklist (stopped)
 }
 
 /// Whether any recorded call mutated the host filesystem.

--- a/crates/uffs-bench/src/run/tests.rs
+++ b/crates/uffs-bench/src/run/tests.rs
@@ -27,13 +27,13 @@ fn stdout_of(text: &str) -> ProcOutput {
 ///  5. `env::capture` cpu
 ///  6. `env::capture` `logical_cpus`
 ///  7. `env::capture` `total_ram`
-///  8. `env::capture` uffs --version
-///  9. uffs daemon status (state probe)
-///  10. `env::capture` `uffs_cpp` --version
-///  11. `env::capture` es -version
-///  12. tasklist (everything state probe — stopped)
-///  13. `env::capture` es -get-everything-version
-///  14. tasklist (`everything_gui` state probe — stopped)
+///  8. `env::capture` uffs --version (prefix stripped: `"uffs 0.0.0"` →
+///     `"0.0.0"`)
+///  9. `env::capture` `uffs_cpp` --version
+///  10. `env::capture` es -version
+///  11. tasklist (everything state probe — stopped)
+///  12. `env::capture` es -get-everything-version
+///  13. tasklist (`everything_gui` state probe — stopped)
 fn dry_run_host() -> MockHost {
     let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
     MockHost::new()
@@ -45,12 +45,11 @@ fn dry_run_host() -> MockHost {
         .with_run_result(stdout_of("8"))                      //  6: logical_cpus
         .with_run_result(stdout_of("8589934592"))             //  7: total_ram
         .with_run_result(stdout_of("uffs 0.0.0"))             //  8: uffs --version
-        .with_run_result(stdout_of("running"))                //  9: uffs daemon status
-        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 10: uffs_cpp --version
-        .with_run_result(stdout_of("1.1.0.30"))               // 11: es -version
-        .with_run_result(stdout_of(""))                       // 12: tasklist (stopped)
-        .with_run_result(stdout_of("1.4.1.1032"))             // 13: es -get-everything-version
-        .with_run_result(stdout_of("")) // 14: tasklist (stopped)
+        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) //  9: uffs_cpp --version
+        .with_run_result(stdout_of("1.1.0.30"))               // 10: es -version
+        .with_run_result(stdout_of(""))                       // 11: tasklist (stopped)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 12: es -get-everything-version
+        .with_run_result(stdout_of("")) // 13: tasklist (stopped)
 }
 
 /// Queue the run results needed for the autopilot (non-dry-run) path.
@@ -64,13 +63,13 @@ fn dry_run_host() -> MockHost {
 ///  6. `env::capture` cpu
 ///  7. `env::capture` `logical_cpus`
 ///  8. `env::capture` `total_ram`
-///  9. `env::capture` uffs --version
-///  10. uffs daemon status (state probe)
-///  11. `env::capture` `uffs_cpp` --version
-///  12. `env::capture` es -version
-///  13. tasklist (everything state probe — stopped)
-///  14. `env::capture` es -get-everything-version
-///  15. tasklist (`everything_gui` state probe — stopped)
+///  9. `env::capture` uffs --version (prefix stripped: `"uffs 0.0.0"` →
+///     `"0.0.0"`)
+///  10. `env::capture` `uffs_cpp` --version
+///  11. `env::capture` es -version
+///  12. tasklist (everything state probe — stopped)
+///  13. `env::capture` es -get-everything-version
+///  14. tasklist (`everything_gui` state probe — stopped)
 fn autopilot_host() -> MockHost {
     let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
     MockHost::new()
@@ -83,12 +82,11 @@ fn autopilot_host() -> MockHost {
         .with_run_result(stdout_of("8"))                      //  7: logical_cpus
         .with_run_result(stdout_of("8589934592"))             //  8: total_ram
         .with_run_result(stdout_of("uffs 0.0.0"))             //  9: uffs --version
-        .with_run_result(stdout_of("running"))                // 10: uffs daemon status
-        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 11: uffs_cpp --version
-        .with_run_result(stdout_of("1.1.0.30"))               // 12: es -version
-        .with_run_result(stdout_of(""))                       // 13: tasklist (stopped)
-        .with_run_result(stdout_of("1.4.1.1032"))             // 14: es -get-everything-version
-        .with_run_result(stdout_of("")) // 15: tasklist (stopped)
+        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 10: uffs_cpp --version
+        .with_run_result(stdout_of("1.1.0.30"))               // 11: es -version
+        .with_run_result(stdout_of(""))                       // 12: tasklist (stopped)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 13: es -get-everything-version
+        .with_run_result(stdout_of("")) // 14: tasklist (stopped)
 }
 
 /// Whether any recorded call mutated the host filesystem.

--- a/crates/uffs-bench/src/run/tests.rs
+++ b/crates/uffs-bench/src/run/tests.rs
@@ -29,104 +29,118 @@ const DAEMON_READY_STATUS: &str = "Version:       0.0.0\n\
 
 /// Queue the run results needed for the `--dry-run` code path.
 ///
-/// `--dry-run` skips `teardown::baseline`.  Early `daemon_start_if_needed`
-/// and `ensure_daemon_ready` are removed — the daemon is always killed and
-/// restarted after the matrix is negotiated.  In dry-run mode the
-/// restart gate fires as `ProceedNoop` so the kill/start are skipped;
-/// no second-pass preflight is run.
+/// `capture()` first kills and restarts the daemon with no drive restrictions
+/// so it self-discovers all drives, then env-probes, then `ensure_daemon_ready`
+/// before first preflight.  In dry-run mode the gated restart fires as
+/// `ProceedNoop` so the kill/start `--drive C` are skipped; no second-pass
+/// preflight is run.
 ///
-///  1. `resolve::es_exe`         — `where.exe es.exe` (for `everything`)
-///  2. `resolve::es_exe`         — `where.exe es.exe` (for `everything_gui`)
-///  3. `resolve::everything_exe` — `where.exe Everything.exe`
-///  4. `env::capture` hostname
-///  5. `env::capture` cpu
-///  6. `env::capture` `logical_cpus`
-///  7. `env::capture` `total_ram`
-///  8. `env::capture` uffs --version
-///  9. `env::capture` `uffs_cpp` --version
-/// 10. tasklist (`everything` state probe — stopped)   ← state before version
-/// 11. `env::capture` es -version
-/// 12. tasklist (`everything_gui` state probe — stopped)
-/// 13. `env::capture` es -get-everything-version
-/// 14. `preflight`  — `es -get-everything-version` (availability)
-/// 15. `preflight`  — `uffs daemon status` (record counts for C)
-/// 16. `preflight`  — `es -get-result-count C:` → loaded
+///  1. `capture()` initial kill  -- `uffs daemon kill`
+///  2. `capture()` initial start -- `uffs daemon start` (no drives)
+///  3. `resolve::es_exe`         -- `where.exe es.exe` (for `everything`)
+///  4. `resolve::es_exe`         -- `where.exe es.exe` (for `everything_gui`)
+///  5. `resolve::everything_exe` -- `where.exe Everything.exe`
+///  6. `env::capture` hostname
+///  7. `env::capture` cpu
+///  8. `env::capture` `logical_cpus`
+///  9. `env::capture` `total_ram`
+/// 10. `env::capture` uffs --version
+/// 11. `env::capture` `uffs_cpp` --version
+/// 12. tasklist (`everything` state probe -- stopped)
+/// 13. `env::capture` es -version
+/// 14. tasklist (`everything_gui` state probe -- stopped)
+/// 15. `env::capture` es -get-everything-version
+/// 16. `ensure_daemon_ready`     -- `uffs daemon status` -> Ready
+/// 17. `preflight`  -- `es -get-everything-version` (availability)
+/// 18. `preflight`  -- `uffs daemon status` (record counts for C)
+/// 19. `preflight`  -- `es -get-result-count C:` -> loaded
 fn dry_run_host() -> MockHost {
     let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
     MockHost::new()
-        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  1: where.exe es.exe
-        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  2: where.exe es.exe
-        .with_run_result(stdout_of(evr))                      //  3: where.exe Everything.exe
-        .with_run_result(stdout_of("myhost"))                 //  4: hostname
-        .with_run_result(stdout_of("Name=Test CPU"))          //  5: cpu
-        .with_run_result(stdout_of("8"))                      //  6: logical_cpus
-        .with_run_result(stdout_of("8589934592"))             //  7: total_ram
-        .with_run_result(stdout_of("uffs 0.0.0"))             //  8: uffs --version
-        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) //  9: uffs_cpp --version
-        .with_run_result(stdout_of(""))                       // 10: tasklist (everything stopped)
-        .with_run_result(stdout_of("1.1.0.30"))               // 11: es -version
-        .with_run_result(stdout_of(""))                       // 12: tasklist (everything_gui stopped)
-        .with_run_result(stdout_of("1.4.1.1032"))             // 13: es -get-everything-version
-        .with_run_result(stdout_of("1.4.1.1032"))             // 14: preflight es availability
-        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 15: preflight daemon status
-        .with_run_result(stdout_of("1000")) // 16: es result-count C
+        .with_run_result(stdout_of(""))                       //  1: initial daemon kill
+        .with_run_result(stdout_of(""))                       //  2: initial daemon start (all drives)
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  3: where.exe es.exe
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  4: where.exe es.exe
+        .with_run_result(stdout_of(evr))                      //  5: where.exe Everything.exe
+        .with_run_result(stdout_of("myhost"))                 //  6: hostname
+        .with_run_result(stdout_of("Name=Test CPU"))          //  7: cpu
+        .with_run_result(stdout_of("8"))                      //  8: logical_cpus
+        .with_run_result(stdout_of("8589934592"))             //  9: total_ram
+        .with_run_result(stdout_of("uffs 0.0.0"))             // 10: uffs --version
+        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 11: uffs_cpp --version
+        .with_run_result(stdout_of(""))                       // 12: tasklist (everything stopped)
+        .with_run_result(stdout_of("1.1.0.30"))               // 13: es -version
+        .with_run_result(stdout_of(""))                       // 14: tasklist (everything_gui stopped)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 15: es -get-everything-version
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 16: ensure_daemon_ready (all-drives)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 17: preflight es availability
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 18: preflight daemon status
+        .with_run_result(stdout_of("1000")) // 19: es result-count C
 }
 
 /// Queue the run results needed for the autopilot (non-dry-run) path.
 ///
-/// `teardown::baseline` fires `uffs daemon status` before the env probes.
-/// After the matrix is computed the UFFS daemon is always killed and
-/// restarted with `--drive C`; a second-pass preflight follows.
+/// `teardown::baseline` fires `uffs daemon status` first.  Then `capture()`
+/// kills+restarts with no drives (self-discover all), env-probes,
+/// `ensure_daemon_ready`, first preflight.  After the matrix the gated
+/// UFFS restart kills+starts with `--drive C`; a second-pass preflight
+/// follows.
 ///
-///  1. `teardown::baseline`      — `uffs daemon status`
-///  2. `resolve::es_exe`         — `where.exe es.exe` (for `everything`)
-///  3. `resolve::es_exe`         — `where.exe es.exe` (for `everything_gui`)
-///  4. `resolve::everything_exe` — `where.exe Everything.exe`
-///  5. `env::capture` hostname
-///  6. `env::capture` cpu
-///  7. `env::capture` `logical_cpus`
-///  8. `env::capture` `total_ram`
-///  9. `env::capture` uffs --version
-/// 10. `env::capture` `uffs_cpp` --version
-/// 11. tasklist (`everything` state probe — stopped)   ← state before version
-/// 12. `env::capture` es -version
-/// 13. tasklist (`everything_gui` state probe — stopped)
-/// 14. `env::capture` es -get-everything-version
-/// 15. `preflight`  — `es -get-everything-version` (availability)
-/// 16. `preflight`  — `uffs daemon status` (record counts for C)
-/// 17. `preflight`  — `es -get-result-count C:` → loaded
-/// 18. `uffs daemon kill`   (restart gate: autopilot → proceed)
-/// 19. `uffs daemon start --drive C`
-/// 20. `ensure_daemon_ready` poll — `uffs daemon status` → Ready
-/// 21. second-pass preflight  — `es -get-everything-version`
-/// 22. second-pass preflight  — `uffs daemon status`
-/// 23. second-pass preflight  — `es -get-result-count C:`
+///  1. `teardown::baseline`      -- `uffs daemon status`
+///  2. `capture()` initial kill  -- `uffs daemon kill`
+///  3. `capture()` initial start -- `uffs daemon start` (no drives)
+///  4. `resolve::es_exe`         -- `where.exe es.exe` (for `everything`)
+///  5. `resolve::es_exe`         -- `where.exe es.exe` (for `everything_gui`)
+///  6. `resolve::everything_exe` -- `where.exe Everything.exe`
+///  7. `env::capture` hostname
+///  8. `env::capture` cpu
+///  9. `env::capture` `logical_cpus`
+/// 10. `env::capture` `total_ram`
+/// 11. `env::capture` uffs --version
+/// 12. `env::capture` `uffs_cpp` --version
+/// 13. tasklist (`everything` state probe -- stopped)
+/// 14. `env::capture` es -version
+/// 15. tasklist (`everything_gui` state probe -- stopped)
+/// 16. `env::capture` es -get-everything-version
+/// 17. `ensure_daemon_ready`     -- `uffs daemon status` -> Ready
+/// 18. `preflight`  -- `es -get-everything-version` (availability)
+/// 19. `preflight`  -- `uffs daemon status` (record counts for C)
+/// 20. `preflight`  -- `es -get-result-count C:` -> loaded
+/// 21. `uffs daemon kill`   (gated restart: autopilot -> proceed)
+/// 22. `uffs daemon start --drive C`
+/// 23. `ensure_daemon_ready` poll -- `uffs daemon status` -> Ready
+/// 24. second-pass preflight  -- `es -get-everything-version`
+/// 25. second-pass preflight  -- `uffs daemon status`
+/// 26. second-pass preflight  -- `es -get-result-count C:`
 fn autopilot_host() -> MockHost {
     let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
     MockHost::new()
         .with_run_result(stdout_of("running"))                 //  1: teardown daemon status
-        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  2: where.exe es.exe
-        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  3: where.exe es.exe
-        .with_run_result(stdout_of(evr))                      //  4: where.exe Everything.exe
-        .with_run_result(stdout_of("myhost"))                 //  5: hostname
-        .with_run_result(stdout_of("Name=Test CPU"))          //  6: cpu
-        .with_run_result(stdout_of("8"))                      //  7: logical_cpus
-        .with_run_result(stdout_of("8589934592"))             //  8: total_ram
-        .with_run_result(stdout_of("uffs 0.0.0"))             //  9: uffs --version
-        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 10: uffs_cpp --version
-        .with_run_result(stdout_of(""))                       // 11: tasklist (everything stopped)
-        .with_run_result(stdout_of("1.1.0.30"))               // 12: es -version
-        .with_run_result(stdout_of(""))                       // 13: tasklist (everything_gui stopped)
-        .with_run_result(stdout_of("1.4.1.1032"))             // 14: es -get-everything-version
-        .with_run_result(stdout_of("1.4.1.1032"))             // 15: preflight es availability
-        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 16: preflight daemon status
-        .with_run_result(stdout_of("1000"))                   // 17: es result-count C
-        .with_run_result(stdout_of(""))                       // 18: daemon kill
-        .with_run_result(stdout_of(""))                       // 19: daemon start --drive C
-        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 20: ensure_daemon_ready poll
-        .with_run_result(stdout_of("1.4.1.1032"))             // 21: 2nd-pass preflight es avail
-        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 22: 2nd-pass preflight status
-        .with_run_result(stdout_of("1000")) // 23: 2nd-pass es result-count C
+        .with_run_result(stdout_of(""))                       //  2: initial daemon kill
+        .with_run_result(stdout_of(""))                       //  3: initial daemon start (all drives)
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  4: where.exe es.exe
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  5: where.exe es.exe
+        .with_run_result(stdout_of(evr))                      //  6: where.exe Everything.exe
+        .with_run_result(stdout_of("myhost"))                 //  7: hostname
+        .with_run_result(stdout_of("Name=Test CPU"))          //  8: cpu
+        .with_run_result(stdout_of("8"))                      //  9: logical_cpus
+        .with_run_result(stdout_of("8589934592"))             // 10: total_ram
+        .with_run_result(stdout_of("uffs 0.0.0"))             // 11: uffs --version
+        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 12: uffs_cpp --version
+        .with_run_result(stdout_of(""))                       // 13: tasklist (everything stopped)
+        .with_run_result(stdout_of("1.1.0.30"))               // 14: es -version
+        .with_run_result(stdout_of(""))                       // 15: tasklist (everything_gui stopped)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 16: es -get-everything-version
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 17: ensure_daemon_ready (all-drives)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 18: preflight es availability
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 19: preflight daemon status
+        .with_run_result(stdout_of("1000"))                   // 20: es result-count C
+        .with_run_result(stdout_of(""))                       // 21: daemon kill (gated restart)
+        .with_run_result(stdout_of(""))                       // 22: daemon start --drive C
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 23: ensure_daemon_ready poll
+        .with_run_result(stdout_of("1.4.1.1032"))             // 24: 2nd-pass preflight es avail
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 25: 2nd-pass preflight status
+        .with_run_result(stdout_of("1000")) // 26: 2nd-pass es result-count C
 }
 
 /// Whether any recorded call mutated the host filesystem.

--- a/crates/uffs-bench/src/run/tests.rs
+++ b/crates/uffs-bench/src/run/tests.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+use clap::Parser as _;
+
+use super::{STAGE0_ID, decisions_from_cli, plan_input_hash, run, stage_selected};
+use crate::cli::Cli;
+use crate::host::{Call, MockHost, ProcOutput};
+use crate::state::{State, Status};
+
+/// Build an output with the given stdout (empty stderr, exit 0).
+fn stdout_of(text: &str) -> ProcOutput {
+    ProcOutput {
+        code: Some(0),
+        stdout: text.to_owned(),
+        stderr: String::new(),
+    }
+}
+
+/// Queue the 8 run results needed for the `--dry-run` code path.
+///
+/// `--dry-run` skips `teardown::baseline`, so the call order is:
+///  1. `resolve::es_exe` PATH probe
+///  2. `env::capture` hostname
+///  3. `env::capture` cpu
+///  4. `env::capture` `logical_cpus`
+///  5. `env::capture` `total_ram`
+///  6. `env::capture` uffs --version
+///  7. `env::capture` `uffs_cpp` --version (needs "UFFS version:" line)
+///  8. `env::capture` es -get-everything-version
+fn dry_run_host() -> MockHost {
+    MockHost::new()
+        .with_run_result(stdout_of("1.4.1.1032"))             // 1: es_exe PATH probe
+        .with_run_result(stdout_of("myhost"))                 // 2: hostname
+        .with_run_result(stdout_of("Name=Test CPU"))          // 3: cpu
+        .with_run_result(stdout_of("8"))                      // 4: logical_cpus
+        .with_run_result(stdout_of("8589934592"))             // 5: total_ram
+        .with_run_result(stdout_of("uffs 0.0.0"))             // 6: uffs --version
+        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 7: uffs_cpp --version
+        .with_run_result(stdout_of("1.4.1.1032")) // 8: es -get-everything-version
+}
+
+/// Queue the 9 run results needed for the autopilot (non-dry-run) path.
+///
+/// `teardown::baseline` fires `uffs daemon status` before the env probes:
+///  1. `teardown::baseline` — `uffs daemon status`
+///  2. `resolve::es_exe` PATH probe
+///  3. `env::capture` hostname
+///  4. `env::capture` cpu
+///  5. `env::capture` `logical_cpus`
+///  6. `env::capture` `total_ram`
+///  7. `env::capture` uffs --version
+///  8. `env::capture` `uffs_cpp` --version (needs "UFFS version:" line)
+///  9. `env::capture` es -get-everything-version
+fn autopilot_host() -> MockHost {
+    MockHost::new()
+        .with_run_result(stdout_of("running"))                 // 1: uffs daemon status
+        .with_run_result(stdout_of("1.4.1.1032"))             // 2: es_exe PATH probe
+        .with_run_result(stdout_of("myhost"))                 // 3: hostname
+        .with_run_result(stdout_of("Name=Test CPU"))          // 4: cpu
+        .with_run_result(stdout_of("8"))                      // 5: logical_cpus
+        .with_run_result(stdout_of("8589934592"))             // 6: total_ram
+        .with_run_result(stdout_of("uffs 0.0.0"))             // 7: uffs --version
+        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 8: uffs_cpp --version
+        .with_run_result(stdout_of("1.4.1.1032")) // 9: es -get-everything-version
+}
+
+/// Whether any recorded call mutated the host filesystem.
+fn is_mutation(call: &Call) -> bool {
+    matches!(
+        call,
+        Call::WriteFile(_) | Call::RemoveFile(_) | Call::Rename(_, _) | Call::CreateDirAll(_)
+    )
+}
+
+/// Paths written via `write_file` during the run, as display strings.
+fn writes(host: &MockHost) -> Vec<String> {
+    host.calls()
+        .into_iter()
+        .filter_map(|call| {
+            if let Call::WriteFile(path) = call {
+                Some(path.display().to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn dry_run_mutates_nothing() {
+    let host = dry_run_host();
+    let cli = Cli::parse_from(["uffs-bench", "--dry-run", "--drives", "C"]);
+
+    run(&host, &cli).expect("dry run succeeds");
+
+    assert!(
+        host.calls().iter().all(|call| !is_mutation(call)),
+        "dry-run must perform zero filesystem mutations"
+    );
+}
+
+#[test]
+fn autopilot_writes_stage0_artifacts_and_saves_state() {
+    let host = autopilot_host();
+    let cli = Cli::parse_from([
+        "uffs-bench",
+        "--auto",
+        "--drives",
+        "C",
+        "--bundle-root",
+        "/out",
+    ]);
+
+    run(&host, &cli).expect("autopilot run succeeds");
+
+    let calls = host.calls();
+    assert!(
+        calls
+            .iter()
+            .any(|call| matches!(call, Call::CreateDirAll(_))),
+        "a bundle directory should be created"
+    );
+    let written = writes(&host);
+    for artifact in ["env.json", "competitor-preflight.json", "matrix.json"] {
+        assert!(
+            written.iter().any(|path| path.ends_with(artifact)),
+            "expected {artifact} to be written, got {written:?}"
+        );
+    }
+    // `state.json` is saved atomically (temp write + rename).
+    assert!(calls.iter().any(|call| matches!(call, Call::Rename(_, _))));
+}
+
+#[test]
+fn resume_skips_cached_stage0() {
+    let bundle = "/out/bench-fixed";
+    let cli = Cli::parse_from([
+        "uffs-bench",
+        "--auto",
+        "--only-stage",
+        "0",
+        "--drives",
+        "C",
+        "--bundle",
+        bundle,
+    ]);
+    // Seed a state where Stage 0 is already Done with the matching hash.
+    let seed = MockHost::new();
+    let hash = plan_input_hash(&decisions_from_cli(&cli));
+    let mut state = State::new(&seed, "test", decisions_from_cli(&cli));
+    state.set_step(&seed, STAGE0_ID, Status::Done, hash.as_str(), Vec::new());
+    let json = serde_json::to_vec(&state).expect("serialize seed state");
+    let host = MockHost::new().with_file(format!("{bundle}/state.json"), json);
+
+    run(&host, &cli).expect("resume run succeeds");
+
+    // Stage 0 was cached, so no matrix.json is (re)written.
+    assert!(
+        !writes(&host)
+            .iter()
+            .any(|path| path.ends_with("matrix.json")),
+        "cached Stage 0 must not rewrite its artifacts"
+    );
+    assert!(
+        host.output()
+            .iter()
+            .any(|line| line.contains("cached (resume)")),
+        "the cached-skip notice should be shown"
+    );
+}
+
+#[test]
+fn stage_selection_honors_only_and_from() {
+    let only = Cli::parse_from(["uffs-bench", "--only-stage", "2"]);
+    assert!(stage_selected(&only, 2));
+    assert!(!stage_selected(&only, 1));
+    assert!(!stage_selected(&only, 0));
+
+    let from = Cli::parse_from(["uffs-bench", "--from-stage", "1"]);
+    assert!(!stage_selected(&from, 0));
+    assert!(stage_selected(&from, 1));
+    assert!(stage_selected(&from, 3));
+
+    let all = Cli::parse_from(["uffs-bench"]);
+    assert!(stage_selected(&all, 0));
+    assert!(stage_selected(&all, 3));
+}

--- a/crates/uffs-bench/src/run/tests.rs
+++ b/crates/uffs-bench/src/run/tests.rs
@@ -40,10 +40,10 @@ const DAEMON_READY_STATUS: &str =
 ///  12. tasklist (everything state probe — stopped)
 ///  13. `env::capture` es -get-everything-version
 ///  14. tasklist (`everything_gui` state probe — stopped)
-///  15. `ensure_daemon_ready` — `uffs daemon status` → Ready on first poll
-///  16. `preflight` — `es -get-everything-version` (availability check)
-///  17. `preflight` — `uffs C:\ * --count` (UFFS record count for C)
-///  18. `preflight` — `es -get-result-count C:\` (ES count for C → loaded)
+///  15. `ensure_daemon_ready`  — `uffs daemon status` → Ready on first poll
+///  16. `preflight`             — `es -get-everything-version` (availability)
+///  17. `preflight`             — `uffs daemon status` (record counts for C)
+///  18. `preflight`             — `es -get-result-count C:` → loaded
 fn dry_run_host() -> MockHost {
     let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
     MockHost::new()
@@ -63,8 +63,8 @@ fn dry_run_host() -> MockHost {
         .with_run_result(stdout_of(""))                       // 14: tasklist (stopped)
         .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 15: ensure_daemon_ready poll
         .with_run_result(stdout_of("1.4.1.1032"))             // 16: preflight es availability
-        .with_run_result(stdout_of("3000000"))                // 17: uffs C:\ count
-        .with_run_result(stdout_of("1000")) // 18: es result-count C → loaded
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 17: preflight daemon status
+        .with_run_result(stdout_of("1000")) // 18: es result-count C
 }
 
 /// Queue the run results needed for the autopilot (non-dry-run) path.
@@ -89,8 +89,8 @@ fn dry_run_host() -> MockHost {
 ///  15. tasklist (`everything_gui` state probe — stopped)
 ///  16. `ensure_daemon_ready`    — `uffs daemon status` → Ready on first poll
 ///  17. `preflight`              — `es -get-everything-version` (availability)
-///  18. `preflight`              — `uffs C:\ * --count`
-///  19. `preflight`              — `es -get-result-count C:\` → loaded
+///  18. `preflight`              — `uffs daemon status` (record counts for C)
+///  19. `preflight`              — `es -get-result-count C:` → loaded
 fn autopilot_host() -> MockHost {
     let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
     MockHost::new()
@@ -111,8 +111,8 @@ fn autopilot_host() -> MockHost {
         .with_run_result(stdout_of(""))                       // 15: tasklist (stopped)
         .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 16: ensure_daemon_ready poll
         .with_run_result(stdout_of("1.4.1.1032"))             // 17: preflight es availability
-        .with_run_result(stdout_of("3000000"))                // 18: uffs C:\ count
-        .with_run_result(stdout_of("1000")) // 19: es result-count C → loaded
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 18: preflight daemon status
+        .with_run_result(stdout_of("1000")) // 19: es result-count C
 }
 
 /// Whether any recorded call mutated the host filesystem.

--- a/crates/uffs-bench/src/run/tests.rs
+++ b/crates/uffs-bench/src/run/tests.rs
@@ -17,45 +17,15 @@ fn stdout_of(text: &str) -> ProcOutput {
     }
 }
 
+/// The `Status:        Ready` line the daemon emits when fully loaded.
+const DAEMON_READY_STATUS: &str =
+    "Version:       0.0.0\nDaemon PID:    1\nStatus:        Ready\nDrives:\n";
+
 /// Queue the run results needed for the `--dry-run` code path.
 ///
 /// `--dry-run` skips `teardown::baseline`, call order is:
-///  1. `resolve::es_exe`         — `where.exe es.exe` (for `everything`)
-///  2. `resolve::es_exe`         — `where.exe es.exe` (for `everything_gui`)
-///  3. `resolve::everything_exe` — `where.exe Everything.exe`
-///  4. `env::capture` hostname
-///  5. `env::capture` cpu
-///  6. `env::capture` `logical_cpus`
-///  7. `env::capture` `total_ram`
-///  8. `env::capture` uffs --version (prefix stripped: `"uffs 0.0.0"` →
-///     `"0.0.0"`)
-///  9. `env::capture` `uffs_cpp` --version
-///  10. `env::capture` es -version
-///  11. tasklist (everything state probe — stopped)
-///  12. `env::capture` es -get-everything-version
-///  13. tasklist (`everything_gui` state probe — stopped)
-fn dry_run_host() -> MockHost {
-    let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
-    MockHost::new()
-        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  1: where.exe es.exe
-        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  2: where.exe es.exe
-        .with_run_result(stdout_of(evr))                      //  3: where.exe Everything.exe
-        .with_run_result(stdout_of("myhost"))                 //  4: hostname
-        .with_run_result(stdout_of("Name=Test CPU"))          //  5: cpu
-        .with_run_result(stdout_of("8"))                      //  6: logical_cpus
-        .with_run_result(stdout_of("8589934592"))             //  7: total_ram
-        .with_run_result(stdout_of("uffs 0.0.0"))             //  8: uffs --version
-        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) //  9: uffs_cpp --version
-        .with_run_result(stdout_of("1.1.0.30"))               // 10: es -version
-        .with_run_result(stdout_of(""))                       // 11: tasklist (stopped)
-        .with_run_result(stdout_of("1.4.1.1032"))             // 12: es -get-everything-version
-        .with_run_result(stdout_of("")) // 13: tasklist (stopped)
-}
-
-/// Queue the run results needed for the autopilot (non-dry-run) path.
-///
-/// `teardown::baseline` fires `uffs daemon status` before the env probes:
-///  1. `teardown::baseline`      — `uffs daemon status`
+///  1. `daemon_start_if_needed` — `uffs daemon status` (already Ready → skip
+///     start)
 ///  2. `resolve::es_exe`         — `where.exe es.exe` (for `everything`)
 ///  3. `resolve::es_exe`         — `where.exe es.exe` (for `everything_gui`)
 ///  4. `resolve::everything_exe` — `where.exe Everything.exe`
@@ -70,10 +40,14 @@ fn dry_run_host() -> MockHost {
 ///  12. tasklist (everything state probe — stopped)
 ///  13. `env::capture` es -get-everything-version
 ///  14. tasklist (`everything_gui` state probe — stopped)
-fn autopilot_host() -> MockHost {
+///  15. `ensure_daemon_ready` — `uffs daemon status` → Ready on first poll
+///  16. `preflight` — `es -get-everything-version` (availability check)
+///  17. `preflight` — `uffs C:\ * --count` (UFFS record count for C)
+///  18. `preflight` — `es -get-result-count C:\` (ES count for C → loaded)
+fn dry_run_host() -> MockHost {
     let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
     MockHost::new()
-        .with_run_result(stdout_of("running"))                 //  1: uffs daemon status
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      //  1: daemon status (Ready)
         .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  2: where.exe es.exe
         .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  3: where.exe es.exe
         .with_run_result(stdout_of(evr))                      //  4: where.exe Everything.exe
@@ -86,7 +60,59 @@ fn autopilot_host() -> MockHost {
         .with_run_result(stdout_of("1.1.0.30"))               // 11: es -version
         .with_run_result(stdout_of(""))                       // 12: tasklist (stopped)
         .with_run_result(stdout_of("1.4.1.1032"))             // 13: es -get-everything-version
-        .with_run_result(stdout_of("")) // 14: tasklist (stopped)
+        .with_run_result(stdout_of(""))                       // 14: tasklist (stopped)
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 15: ensure_daemon_ready poll
+        .with_run_result(stdout_of("1.4.1.1032"))             // 16: preflight es availability
+        .with_run_result(stdout_of("3000000"))                // 17: uffs C:\ count
+        .with_run_result(stdout_of("1000")) // 18: es result-count C → loaded
+}
+
+/// Queue the run results needed for the autopilot (non-dry-run) path.
+///
+/// `teardown::baseline` fires `uffs daemon status` before the env probes:
+///  1. `teardown::baseline`      — `uffs daemon status`
+///  2. `daemon_start_if_needed`  — `uffs daemon status` (already Ready → skip
+///     start)
+///  3. `resolve::es_exe`         — `where.exe es.exe` (for `everything`)
+///  4. `resolve::es_exe`         — `where.exe es.exe` (for `everything_gui`)
+///  5. `resolve::everything_exe` — `where.exe Everything.exe`
+///  6. `env::capture` hostname
+///  7. `env::capture` cpu
+///  8. `env::capture` `logical_cpus`
+///  9. `env::capture` `total_ram`
+///  10. `env::capture` uffs --version (prefix stripped: `"uffs 0.0.0"` →
+///      `"0.0.0"`)
+///  11. `env::capture` `uffs_cpp` --version
+///  12. `env::capture` es -version
+///  13. tasklist (everything state probe — stopped)
+///  14. `env::capture` es -get-everything-version
+///  15. tasklist (`everything_gui` state probe — stopped)
+///  16. `ensure_daemon_ready`    — `uffs daemon status` → Ready on first poll
+///  17. `preflight`              — `es -get-everything-version` (availability)
+///  18. `preflight`              — `uffs C:\ * --count`
+///  19. `preflight`              — `es -get-result-count C:\` → loaded
+fn autopilot_host() -> MockHost {
+    let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
+    MockHost::new()
+        .with_run_result(stdout_of("running"))                 //  1: teardown daemon status
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      //  2: daemon_start_if_needed
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  3: where.exe es.exe
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  4: where.exe es.exe
+        .with_run_result(stdout_of(evr))                      //  5: where.exe Everything.exe
+        .with_run_result(stdout_of("myhost"))                 //  6: hostname
+        .with_run_result(stdout_of("Name=Test CPU"))          //  7: cpu
+        .with_run_result(stdout_of("8"))                      //  8: logical_cpus
+        .with_run_result(stdout_of("8589934592"))             //  9: total_ram
+        .with_run_result(stdout_of("uffs 0.0.0"))             // 10: uffs --version
+        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 11: uffs_cpp --version
+        .with_run_result(stdout_of("1.1.0.30"))               // 12: es -version
+        .with_run_result(stdout_of(""))                       // 13: tasklist (stopped)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 14: es -get-everything-version
+        .with_run_result(stdout_of(""))                       // 15: tasklist (stopped)
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 16: ensure_daemon_ready poll
+        .with_run_result(stdout_of("1.4.1.1032"))             // 17: preflight es availability
+        .with_run_result(stdout_of("3000000"))                // 18: uffs C:\ count
+        .with_run_result(stdout_of("1000")) // 19: es result-count C → loaded
 }
 
 /// Whether any recorded call mutated the host filesystem.

--- a/crates/uffs-bench/src/run/tests.rs
+++ b/crates/uffs-bench/src/run/tests.rs
@@ -20,49 +20,49 @@ fn stdout_of(text: &str) -> ProcOutput {
 /// Queue the 8 run results needed for the `--dry-run` code path.
 ///
 /// `--dry-run` skips `teardown::baseline`, so the call order is:
-///  1. `resolve::es_exe` PATH probe
+///  1. `resolve::es_exe` — `where.exe es.exe` (returns full path)
 ///  2. `env::capture` hostname
 ///  3. `env::capture` cpu
 ///  4. `env::capture` `logical_cpus`
 ///  5. `env::capture` `total_ram`
 ///  6. `env::capture` uffs --version
 ///  7. `env::capture` `uffs_cpp` --version (needs "UFFS version:" line)
-///  8. `env::capture` es -get-everything-version
+///  8. `env::capture` es -version
 fn dry_run_host() -> MockHost {
     MockHost::new()
-        .with_run_result(stdout_of("1.4.1.1032"))             // 1: es_exe PATH probe
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         // 1: where.exe es.exe
         .with_run_result(stdout_of("myhost"))                 // 2: hostname
         .with_run_result(stdout_of("Name=Test CPU"))          // 3: cpu
         .with_run_result(stdout_of("8"))                      // 4: logical_cpus
         .with_run_result(stdout_of("8589934592"))             // 5: total_ram
         .with_run_result(stdout_of("uffs 0.0.0"))             // 6: uffs --version
         .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 7: uffs_cpp --version
-        .with_run_result(stdout_of("1.4.1.1032")) // 8: es -get-everything-version
+        .with_run_result(stdout_of("1.1.0.30")) // 8: es -version
 }
 
 /// Queue the 9 run results needed for the autopilot (non-dry-run) path.
 ///
 /// `teardown::baseline` fires `uffs daemon status` before the env probes:
 ///  1. `teardown::baseline` — `uffs daemon status`
-///  2. `resolve::es_exe` PATH probe
+///  2. `resolve::es_exe` — `where.exe es.exe` (returns full path)
 ///  3. `env::capture` hostname
 ///  4. `env::capture` cpu
 ///  5. `env::capture` `logical_cpus`
 ///  6. `env::capture` `total_ram`
 ///  7. `env::capture` uffs --version
 ///  8. `env::capture` `uffs_cpp` --version (needs "UFFS version:" line)
-///  9. `env::capture` es -get-everything-version
+///  9. `env::capture` es -version
 fn autopilot_host() -> MockHost {
     MockHost::new()
         .with_run_result(stdout_of("running"))                 // 1: uffs daemon status
-        .with_run_result(stdout_of("1.4.1.1032"))             // 2: es_exe PATH probe
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         // 2: where.exe es.exe
         .with_run_result(stdout_of("myhost"))                 // 3: hostname
         .with_run_result(stdout_of("Name=Test CPU"))          // 4: cpu
         .with_run_result(stdout_of("8"))                      // 5: logical_cpus
         .with_run_result(stdout_of("8589934592"))             // 6: total_ram
         .with_run_result(stdout_of("uffs 0.0.0"))             // 7: uffs --version
         .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 8: uffs_cpp --version
-        .with_run_result(stdout_of("1.4.1.1032")) // 9: es -get-everything-version
+        .with_run_result(stdout_of("1.1.0.30")) // 9: es -version
 }
 
 /// Whether any recorded call mutated the host filesystem.

--- a/crates/uffs-bench/src/run/tests.rs
+++ b/crates/uffs-bench/src/run/tests.rs
@@ -29,9 +29,56 @@ const DAEMON_READY_STATUS: &str = "Version:       0.0.0\n\
 
 /// Queue the run results needed for the `--dry-run` code path.
 ///
-/// `--dry-run` skips `teardown::baseline`, call order is:
-///  1. `daemon_start_if_needed` — `uffs daemon status` (already Ready → skip
-///     start)
+/// `--dry-run` skips `teardown::baseline`.  Early `daemon_start_if_needed`
+/// and `ensure_daemon_ready` are removed — the daemon is always killed and
+/// restarted after the matrix is negotiated.  In dry-run mode the
+/// restart gate fires as `ProceedNoop` so the kill/start are skipped;
+/// no second-pass preflight is run.
+///
+///  1. `resolve::es_exe`         — `where.exe es.exe` (for `everything`)
+///  2. `resolve::es_exe`         — `where.exe es.exe` (for `everything_gui`)
+///  3. `resolve::everything_exe` — `where.exe Everything.exe`
+///  4. `env::capture` hostname
+///  5. `env::capture` cpu
+///  6. `env::capture` `logical_cpus`
+///  7. `env::capture` `total_ram`
+///  8. `env::capture` uffs --version
+///  9. `env::capture` `uffs_cpp` --version
+/// 10. `env::capture` es -version
+/// 11. tasklist (everything state probe — stopped)
+/// 12. `env::capture` es -get-everything-version
+/// 13. tasklist (`everything_gui` state probe — stopped)
+/// 14. `preflight`  — `es -get-everything-version` (availability)
+/// 15. `preflight`  — `uffs daemon status` (record counts for C)
+/// 16. `preflight`  — `es -get-result-count C:` → loaded
+fn dry_run_host() -> MockHost {
+    let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
+    MockHost::new()
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  1: where.exe es.exe
+        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  2: where.exe es.exe
+        .with_run_result(stdout_of(evr))                      //  3: where.exe Everything.exe
+        .with_run_result(stdout_of("myhost"))                 //  4: hostname
+        .with_run_result(stdout_of("Name=Test CPU"))          //  5: cpu
+        .with_run_result(stdout_of("8"))                      //  6: logical_cpus
+        .with_run_result(stdout_of("8589934592"))             //  7: total_ram
+        .with_run_result(stdout_of("uffs 0.0.0"))             //  8: uffs --version
+        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) //  9: uffs_cpp --version
+        .with_run_result(stdout_of("1.1.0.30"))               // 10: es -version
+        .with_run_result(stdout_of(""))                       // 11: tasklist (stopped)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 12: es -get-everything-version
+        .with_run_result(stdout_of(""))                       // 13: tasklist (stopped)
+        .with_run_result(stdout_of("1.4.1.1032"))             // 14: preflight es availability
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 15: preflight daemon status
+        .with_run_result(stdout_of("1000")) // 16: es result-count C
+}
+
+/// Queue the run results needed for the autopilot (non-dry-run) path.
+///
+/// `teardown::baseline` fires `uffs daemon status` before the env probes.
+/// After the matrix is computed the UFFS daemon is always killed and
+/// restarted with `--drive C`; a second-pass preflight follows.
+///
+///  1. `teardown::baseline`      — `uffs daemon status`
 ///  2. `resolve::es_exe`         — `where.exe es.exe` (for `everything`)
 ///  3. `resolve::es_exe`         — `where.exe es.exe` (for `everything_gui`)
 ///  4. `resolve::everything_exe` — `where.exe Everything.exe`
@@ -39,21 +86,25 @@ const DAEMON_READY_STATUS: &str = "Version:       0.0.0\n\
 ///  6. `env::capture` cpu
 ///  7. `env::capture` `logical_cpus`
 ///  8. `env::capture` `total_ram`
-///  9. `env::capture` uffs --version (prefix stripped: `"uffs 0.0.0"` →
-///     `"0.0.0"`)
-///  10. `env::capture` `uffs_cpp` --version
-///  11. `env::capture` es -version
-///  12. tasklist (everything state probe — stopped)
-///  13. `env::capture` es -get-everything-version
-///  14. tasklist (`everything_gui` state probe — stopped)
-///  15. `ensure_daemon_ready`  — `uffs daemon status` → Ready on first poll
-///  16. `preflight`             — `es -get-everything-version` (availability)
-///  17. `preflight`             — `uffs daemon status` (record counts for C)
-///  18. `preflight`             — `es -get-result-count C:` → loaded
-fn dry_run_host() -> MockHost {
+///  9. `env::capture` uffs --version
+/// 10. `env::capture` `uffs_cpp` --version
+/// 11. `env::capture` es -version
+/// 12. tasklist (everything state probe — stopped)
+/// 13. `env::capture` es -get-everything-version
+/// 14. tasklist (`everything_gui` state probe — stopped)
+/// 15. `preflight`  — `es -get-everything-version` (availability)
+/// 16. `preflight`  — `uffs daemon status` (record counts for C)
+/// 17. `preflight`  — `es -get-result-count C:` → loaded
+/// 18. `uffs daemon kill`   (restart gate: autopilot → proceed)
+/// 19. `uffs daemon start --drive C`
+/// 20. `ensure_daemon_ready` poll — `uffs daemon status` → Ready
+/// 21. second-pass preflight  — `es -get-everything-version`
+/// 22. second-pass preflight  — `uffs daemon status`
+/// 23. second-pass preflight  — `es -get-result-count C:`
+fn autopilot_host() -> MockHost {
     let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
     MockHost::new()
-        .with_run_result(stdout_of(DAEMON_READY_STATUS))      //  1: daemon status (Ready)
+        .with_run_result(stdout_of("running"))                 //  1: teardown daemon status
         .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  2: where.exe es.exe
         .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  3: where.exe es.exe
         .with_run_result(stdout_of(evr))                      //  4: where.exe Everything.exe
@@ -67,58 +118,15 @@ fn dry_run_host() -> MockHost {
         .with_run_result(stdout_of(""))                       // 12: tasklist (stopped)
         .with_run_result(stdout_of("1.4.1.1032"))             // 13: es -get-everything-version
         .with_run_result(stdout_of(""))                       // 14: tasklist (stopped)
-        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 15: ensure_daemon_ready poll
-        .with_run_result(stdout_of("1.4.1.1032"))             // 16: preflight es availability
-        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 17: preflight daemon status
-        .with_run_result(stdout_of("1000")) // 18: es result-count C
-}
-
-/// Queue the run results needed for the autopilot (non-dry-run) path.
-///
-/// `teardown::baseline` fires `uffs daemon status` before the env probes:
-///  1. `teardown::baseline`      — `uffs daemon status`
-///  2. `daemon_start_if_needed`  — `uffs daemon status` (already Ready → skip
-///     start)
-///  3. `resolve::es_exe`         — `where.exe es.exe` (for `everything`)
-///  4. `resolve::es_exe`         — `where.exe es.exe` (for `everything_gui`)
-///  5. `resolve::everything_exe` — `where.exe Everything.exe`
-///  6. `env::capture` hostname
-///  7. `env::capture` cpu
-///  8. `env::capture` `logical_cpus`
-///  9. `env::capture` `total_ram`
-///  10. `env::capture` uffs --version (prefix stripped: `"uffs 0.0.0"` →
-///      `"0.0.0"`)
-///  11. `env::capture` `uffs_cpp` --version
-///  12. `env::capture` es -version
-///  13. tasklist (everything state probe — stopped)
-///  14. `env::capture` es -get-everything-version
-///  15. tasklist (`everything_gui` state probe — stopped)
-///  16. `ensure_daemon_ready`    — `uffs daemon status` → Ready on first poll
-///  17. `preflight`              — `es -get-everything-version` (availability)
-///  18. `preflight`              — `uffs daemon status` (record counts for C)
-///  19. `preflight`              — `es -get-result-count C:` → loaded
-fn autopilot_host() -> MockHost {
-    let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
-    MockHost::new()
-        .with_run_result(stdout_of("running"))                 //  1: teardown daemon status
-        .with_run_result(stdout_of(DAEMON_READY_STATUS))      //  2: daemon_start_if_needed
-        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  3: where.exe es.exe
-        .with_run_result(stdout_of("C:\\bin\\es.exe"))         //  4: where.exe es.exe
-        .with_run_result(stdout_of(evr))                      //  5: where.exe Everything.exe
-        .with_run_result(stdout_of("myhost"))                 //  6: hostname
-        .with_run_result(stdout_of("Name=Test CPU"))          //  7: cpu
-        .with_run_result(stdout_of("8"))                      //  8: logical_cpus
-        .with_run_result(stdout_of("8589934592"))             //  9: total_ram
-        .with_run_result(stdout_of("uffs 0.0.0"))             // 10: uffs --version
-        .with_run_result(stdout_of("\tUFFS version:\t1.0.0")) // 11: uffs_cpp --version
-        .with_run_result(stdout_of("1.1.0.30"))               // 12: es -version
-        .with_run_result(stdout_of(""))                       // 13: tasklist (stopped)
-        .with_run_result(stdout_of("1.4.1.1032"))             // 14: es -get-everything-version
-        .with_run_result(stdout_of(""))                       // 15: tasklist (stopped)
-        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 16: ensure_daemon_ready poll
-        .with_run_result(stdout_of("1.4.1.1032"))             // 17: preflight es availability
-        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 18: preflight daemon status
-        .with_run_result(stdout_of("1000")) // 19: es result-count C
+        .with_run_result(stdout_of("1.4.1.1032"))             // 15: preflight es availability
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 16: preflight daemon status
+        .with_run_result(stdout_of("1000"))                   // 17: es result-count C
+        .with_run_result(stdout_of(""))                       // 18: daemon kill
+        .with_run_result(stdout_of(""))                       // 19: daemon start --drive C
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 20: ensure_daemon_ready poll
+        .with_run_result(stdout_of("1.4.1.1032"))             // 21: 2nd-pass preflight es avail
+        .with_run_result(stdout_of(DAEMON_READY_STATUS))      // 22: 2nd-pass preflight status
+        .with_run_result(stdout_of("1000")) // 23: 2nd-pass es result-count C
 }
 
 /// Whether any recorded call mutated the host filesystem.

--- a/crates/uffs-bench/src/stages.rs
+++ b/crates/uffs-bench/src/stages.rs
@@ -138,10 +138,23 @@ impl Invocation {
         }
     }
 
-    /// Spawn the command through the [`Host`] seam.
+    /// Spawn the command through the [`Host`] seam, capturing all output.
     fn run(&self, host: &dyn Host) -> io::Result<ProcOutput> {
         let refs: Vec<&str> = self.args.iter().map(String::as_str).collect();
         host.run(&self.exe, &refs)
+    }
+
+    /// Spawn the command, inheriting the parent's stdout/stderr so output
+    /// flows live to the operator's terminal.  Returns a synthetic
+    /// [`ProcOutput`] with the exit code and empty captured streams.
+    fn run_streaming(&self, host: &dyn Host) -> io::Result<ProcOutput> {
+        let refs: Vec<&str> = self.args.iter().map(String::as_str).collect();
+        let code = host.run_streaming(&self.exe, &refs)?;
+        Ok(ProcOutput {
+            code,
+            stdout: String::new(),
+            stderr: String::new(),
+        })
     }
 }
 
@@ -553,7 +566,7 @@ fn step_from_output(out: &ProcOutput, output_path: &Path, label: &str) -> StepRe
 fn run_cross_tool(host: &dyn Host, guard: &mut RunGuard<'_>, cfg: &StageCfg) -> Result<StepResult> {
     snapshot_daemon(host, guard);
     let out = cross_tool_invocation(cfg)
-        .run(host)
+        .run_streaming(host)
         .map_err(|err| BenchError::Command(format!("cross-tool harness: {err}")))?;
     let out_path = cfg.bundle_dir.join(CROSS_TOOL_OUT);
     Ok(step_from_output(&out, &out_path, "cross-tool"))
@@ -566,7 +579,7 @@ fn run_parity(host: &dyn Host, guard: &mut RunGuard<'_>, cfg: &StageCfg) -> Resu
         snapshot_cache(host, guard, cfg)?;
     }
     let out = parity_invocation(cfg)
-        .run(host)
+        .run_streaming(host)
         .map_err(|err| BenchError::Command(format!("parity harness: {err}")))?;
     let out_path = cfg.bundle_dir.join(PARITY_OUT);
     Ok(step_from_output(&out, &out_path, "parity"))

--- a/crates/uffs-bench/src/stages.rs
+++ b/crates/uffs-bench/src/stages.rs
@@ -220,13 +220,17 @@ fn join_drives(drives: &[char]) -> String {
         .join(",")
 }
 
-/// Map a bench tool id to the cross-tool harness's accepted spelling.
+/// Map a bench CLI tool name to the token the cross-tool harness accepts,
+/// or `None` if the harness does not support that tool.
 ///
-/// The harness accepts `uffs`, `uffs-cpp`/`cpp`, and `everything`/`es`; the
-/// bench CLI uses underscored ids (`uffs_cpp`), so a single `_`→`-` rewrite
-/// (`uffs_cpp`→`uffs-cpp`) lands on an alias the harness understands.
-fn harness_tool(name: &str) -> String {
-    name.replace('_', "-")
+/// `everything_gui` (`Everything.exe`) has no CLI benchmarking interface
+/// the harness can drive; it is benchmarked indirectly via `es.exe` (the
+/// `everything` token).  All other names are passed through with `_` → `-`.
+fn harness_tool(name: &str) -> Option<String> {
+    match name {
+        "everything_gui" | "everything-gui" => None,
+        other => Some(other.replace('_', "-")),
+    }
 }
 
 /// Card note describing the daemon restore taken before mutating.
@@ -302,7 +306,7 @@ fn cross_tool_invocation(cfg: &StageCfg) -> Invocation {
     args.push(
         cfg.tools
             .iter()
-            .map(|tool| harness_tool(tool))
+            .filter_map(|tool| harness_tool(tool))
             .collect::<Vec<_>>()
             .join(","),
     );

--- a/crates/uffs-bench/src/stages.rs
+++ b/crates/uffs-bench/src/stages.rs
@@ -343,9 +343,9 @@ fn parity_invocation(cfg: &StageCfg) -> Invocation {
         "-File".to_owned(),
         PARITY_SCRIPT.to_owned(),
     ];
-    if !cfg.drives.is_empty() {
+    if !cfg.capable_drives.is_empty() {
         args.push("-Drives".to_owned());
-        args.push(join_drives(&cfg.drives));
+        args.push(join_drives(&cfg.capable_drives));
     }
     args.push("-Rounds".to_owned());
     args.push(cfg.rounds.to_string());
@@ -646,8 +646,8 @@ pub fn plan(stage: u32, cfg: &StageCfg) -> StagePlan {
             let mut resources = vec![DAEMON_RESOURCE.to_owned()];
             let mut backups = vec![daemon_backup_note()];
             if cfg.drop_cache {
-                resources.push(format!("uffs cache: {}", join_drives(&cfg.drives)));
-                backups.push(cache_backup_note(&cfg.drives));
+                resources.push(format!("uffs cache: {}", join_drives(&cfg.capable_drives)));
+                backups.push(cache_backup_note(&cfg.capable_drives));
             }
             StagePlan {
                 commands: vec![parity_invocation(cfg).display()],

--- a/crates/uffs-bench/src/stages.rs
+++ b/crates/uffs-bench/src/stages.rs
@@ -10,8 +10,9 @@
 //!
 //! - **Stage 1 (cross-tool)** shells out to `cross-tool-benchmark.rs` with
 //!   `--skip-cold`; the harness writes `bundle/cross-tool-summary.csv` itself.
-//! - **Stage 2 (parity)** shells out to `cold-parity-per-drive.ps1`; the script
-//!   transcribes to `bundle/parity.txt` (purging cache first when requested).
+//! - **Stage 2 (parity)** shells out to `cold-parity-per-drive.rs` via
+//!   `rust-script`; the harness writes `bundle/parity.txt` (purging cache first
+//!   when `--purge-cache` is set).
 //! - **Stage 3 (full suite)** times native UFFS queries directly (N rounds per
 //!   drive × pattern), reduces each cell with the unit-tested [`percentiles`]
 //!   helper, and emits `bundle/full-suite.csv` + `bundle/full-suite.txt`.
@@ -34,7 +35,7 @@ use crate::restore::RunGuard;
 /// Repo-relative path to the cross-tool harness shelled out to by Stage 1.
 pub const CROSS_TOOL_SCRIPT: &str = "scripts/windows/cross-tool-benchmark.rs";
 /// Repo-relative path to the parity harness shelled out to by Stage 2.
-pub const PARITY_SCRIPT: &str = "scripts/windows/cold-parity-per-drive.ps1";
+pub const PARITY_SCRIPT: &str = "scripts/windows/cold-parity-per-drive.rs";
 
 /// Bundle-relative name of the cross-tool summary CSV (written by the harness).
 const CROSS_TOOL_OUT: &str = "cross-tool-summary.csv";
@@ -158,10 +159,8 @@ impl Invocation {
     }
 }
 
-/// The `rust-script` launcher used to run the cross-tool harness (Stage 1).
+/// The `rust-script` launcher used to run the Stage 1 and Stage 2 harnesses.
 const RUST_SCRIPT_EXE: &str = "rust-script";
-/// The PowerShell launcher used to run the parity harness (Stage 2).
-const POWERSHELL_EXE: &str = "powershell";
 
 /// Card-facing label for the daemon run-state resource (R1).
 const DAEMON_RESOURCE: &str = "uffs daemon (run-state)";
@@ -336,27 +335,21 @@ fn cross_tool_invocation(cfg: &StageCfg) -> Invocation {
 /// Build the Stage 2 parity harness invocation.
 fn parity_invocation(cfg: &StageCfg) -> Invocation {
     let out_path = cfg.bundle_dir.join(PARITY_OUT);
-    let mut args = vec![
-        "-NoProfile".to_owned(),
-        "-ExecutionPolicy".to_owned(),
-        "Bypass".to_owned(),
-        "-File".to_owned(),
-        PARITY_SCRIPT.to_owned(),
-    ];
+    let mut args = vec![PARITY_SCRIPT.to_owned()];
     if !cfg.capable_drives.is_empty() {
-        args.push("-Drives".to_owned());
+        args.push("--drives".to_owned());
         args.push(join_drives(&cfg.capable_drives));
     }
-    args.push("-Rounds".to_owned());
+    args.push("--rounds".to_owned());
     args.push(cfg.rounds.to_string());
-    args.push("-OutputFile".to_owned());
+    args.push("--output-file".to_owned());
     args.push(out_path.display().to_string());
-    // The parity script purges every drive cache before the cold warm-up.
+    // The parity harness purges every drive cache before the cold warm-up.
     if cfg.drop_cache {
-        args.push("-PurgeCacheFirst".to_owned());
+        args.push("--purge-cache".to_owned());
     }
     Invocation {
-        exe: POWERSHELL_EXE.to_owned(),
+        exe: RUST_SCRIPT_EXE.to_owned(),
         args,
     }
 }

--- a/crates/uffs-bench/src/stages.rs
+++ b/crates/uffs-bench/src/stages.rs
@@ -404,7 +404,7 @@ fn snapshot_cache(host: &dyn Host, guard: &mut RunGuard<'_>, cfg: &StageCfg) -> 
     let backup_dir = cfg.bundle_dir.join("backup");
     host.create_dir_all(&backup_dir)
         .map_err(|err| BenchError::io(&backup_dir, err))?;
-    for &drive in &cfg.drives {
+    for &drive in &cfg.capable_drives {
         for suffix in CACHE_SUFFIXES {
             let src = dir.join(format!("{drive}{suffix}"));
             if !host.path_exists(&src) {
@@ -598,7 +598,7 @@ fn run_native(host: &dyn Host, guard: &mut RunGuard<'_>, cfg: &StageCfg) -> Resu
     let version = probe_version(host, &cfg.uffs_exe);
     let mut cells = Vec::new();
     let mut all_ok = true;
-    for &drive in &cfg.drives {
+    for &drive in &cfg.capable_drives {
         for probe in &cfg.patterns {
             let cell = measure_cell(host, cfg, drive, probe);
             all_ok = all_ok && cell.ok;
@@ -651,7 +651,7 @@ pub fn plan(stage: u32, cfg: &StageCfg) -> StagePlan {
         }
         _ => {
             let commands = cfg
-                .drives
+                .capable_drives
                 .iter()
                 .flat_map(|&drive| {
                     cfg.patterns

--- a/crates/uffs-bench/src/stages.rs
+++ b/crates/uffs-bench/src/stages.rs
@@ -192,6 +192,11 @@ pub struct StageCfg {
     pub patterns: Vec<PatternProbe>,
     /// The UFFS executable invoked for Stage 3 native timing.
     pub uffs_exe: String,
+    /// Named Everything instance to connect to via `es.exe -instance <name>`.
+    /// `None` means the default IPC window (system-wide Everything instance).
+    /// Set to `Some(INSTANCE_NAME)` when the bench tool launched a private
+    /// `Everything.exe -instance uffs-bench` so the harness can find it.
+    pub es_instance_name: Option<String>,
 }
 
 /// The card-facing plan for one measurement stage.
@@ -310,6 +315,10 @@ fn cross_tool_invocation(cfg: &StageCfg) -> Invocation {
             .collect::<Vec<_>>()
             .join(","),
     );
+    if let Some(inst) = &cfg.es_instance_name {
+        args.push("--es-instance".to_owned());
+        args.push(inst.clone());
+    }
     args.push("--rounds".to_owned());
     args.push(cfg.rounds.to_string());
     args.push("--out".to_owned());

--- a/crates/uffs-daemon/src/cache/policy.rs
+++ b/crates/uffs-daemon/src/cache/policy.rs
@@ -82,15 +82,16 @@ use super::shard::ShardState;
 /// drives don't re-warm just because their bloom got faulted in by
 /// a wildcard scan.
 ///
-/// 60 s default makes the Hot → Warm transition observable in
-/// normal dev iteration; the runtime-mmap rebuild on the next
-/// query is sub-millisecond so the demotion is essentially free.
+/// 10 min (600 s) default — enough time to cover typical interactive
+/// usage bursts without demoting mid-session.  The runtime-mmap
+/// rebuild on the next query is sub-millisecond so the demotion cost
+/// is negligible when it does fire.
 ///
 /// Consumed by [`crate::index::IndexManager::demote_idle_shards`]
 /// (Phase 3 Commit D) via [`next_state_for_idle_with_thresholds`]
 /// — Phase 6 Commit C feeds it adaptive thresholds derived from
 /// this constant via `crate::config::TiersConfig::default()`.
-pub(crate) const HOT_TO_WARM_IDLE_SECS: u64 = 60;
+pub(crate) const HOT_TO_WARM_IDLE_SECS: u64 = 600;
 
 /// Default for the `Warm` → `Parked` idle threshold.
 ///
@@ -98,14 +99,13 @@ pub(crate) const HOT_TO_WARM_IDLE_SECS: u64 = 60;
 /// `Parked` drops the runtime mmap (the records / names columns
 /// are released; bloom + trie persist for Phase 4+ search-skip).
 ///
-/// 5 min default lets dev iteration exercise the Phase 4
-/// re-promote path (which #93 parallelised) without waiting the
-/// 30 min the original prototype used.  The bloom + trie pre-check
-/// from Commit F means a Parked re-promote only re-decrypts the
-/// compact body when the query actually hits the drive, so the
-/// extra demote/promote churn at this cadence is bounded by query
-/// pattern, not by the timer alone.
-pub(crate) const WARM_TO_PARKED_IDLE_SECS: u64 = 300;
+/// 30 min (1 800 s) default — keeps the body resident across typical
+/// human-scale gaps in usage (lunch break, context switch) while
+/// still freeing memory on genuinely idle drives.  The bloom + trie
+/// pre-check from Commit F means a Parked re-promote only
+/// re-decrypts the compact body when the query actually hits the
+/// drive, so the cost of a miss is bounded by query pattern.
+pub(crate) const WARM_TO_PARKED_IDLE_SECS: u64 = 1_800;
 
 /// Default for the `Parked` → `Cold` idle threshold.
 ///
@@ -124,11 +124,10 @@ pub(crate) const PARKED_TO_COLD_IDLE_SECS: u64 = 86_400;
 /// idle-tier transition.
 ///
 /// 5 min is a deliberate trade-off: short enough that `Warm` shards
-/// don't drift more than `WARM_TO_PARKED_IDLE_SECS / 6` between
-/// refreshes (so nothing demotes mid-refresh), long enough that the
-/// USN journal accumulates a meaningful batch (per-drive replay
-/// dominated by fixed setup, not by record count).  Override at
-/// daemon startup via [`USN_REFRESH_INTERVAL_ENV`].
+/// accumulate at most ~5 min of filesystem churn before a refresh,
+/// long enough that the USN journal builds a meaningful batch
+/// (per-drive replay is dominated by fixed setup cost, not record
+/// count).  Override at daemon startup via [`USN_REFRESH_INTERVAL_ENV`].
 pub(crate) const USN_REFRESH_INTERVAL_SECS: u64 = 300;
 
 /// Env var that overrides [`HOT_TO_WARM_IDLE_SECS`].

--- a/crates/uffs-daemon/src/config.rs
+++ b/crates/uffs-daemon/src/config.rs
@@ -496,8 +496,8 @@ mod tests {
         // fire — the const block is build-time, so its position is
         // purely stylistic relative to the runtime asserts below.
         const _: () = {
-            assert!(crate::cache::policy::HOT_TO_WARM_IDLE_SECS == 60);
-            assert!(crate::cache::policy::WARM_TO_PARKED_IDLE_SECS == 300);
+            assert!(crate::cache::policy::HOT_TO_WARM_IDLE_SECS == 600);
+            assert!(crate::cache::policy::WARM_TO_PARKED_IDLE_SECS == 1_800);
             assert!(crate::cache::policy::PARKED_TO_COLD_IDLE_SECS == 86_400);
             assert!(crate::cache::policy::USN_REFRESH_INTERVAL_SECS == 300);
         };

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -27,8 +27,8 @@
 //! | `CARGO_PKG_VERSION` | `string` | (set by Cargo) | Read via `env!()` for status payload + log preludes.  CARGO semver class. |
 //! | `RUST_LOG` | `string` | `info` | `tracing-subscriber` filter directive; consulted in `main` when `UFFS_LOG` is unset.  STANDARD semver class (tracing convention). |
 //! | `UFFS_LOG` | `string` | `info` | UFFS-specific log level override for the daemon binary.  INTERNAL semver class. |
-//! | `UFFS_HOT_TO_WARM_IDLE_SECS` | `int` (seconds) | `60` | Cache tier `Hot → Warm` transition timer override (via `HOT_TO_WARM_IDLE_ENV` const indirection).  INTERNAL semver class. |
-//! | `UFFS_WARM_TO_PARKED_IDLE_SECS` | `int` (seconds) | `300` (5 min) | Cache tier `Warm → Parked` transition timer override (via `WARM_TO_PARKED_IDLE_ENV` const indirection).  INTERNAL semver class. |
+//! | `UFFS_HOT_TO_WARM_IDLE_SECS` | `int` (seconds) | `600` (10 min) | Cache tier `Hot → Warm` transition timer override (via `HOT_TO_WARM_IDLE_ENV` const indirection).  INTERNAL semver class. |
+//! | `UFFS_WARM_TO_PARKED_IDLE_SECS` | `int` (seconds) | `1_800` (30 min) | Cache tier `Warm → Parked` transition timer override (via `WARM_TO_PARKED_IDLE_ENV` const indirection).  INTERNAL semver class. |
 //! | `UFFS_PARKED_TO_COLD_IDLE_SECS` | `int` (seconds) | `86_400` (24 h) | Cache tier `Parked → Cold` transition timer override (via `PARKED_TO_COLD_IDLE_ENV` const indirection).  INTERNAL semver class. |
 //! | `UFFS_USN_REFRESH_INTERVAL_SECS` | `int` (seconds) | `300` (5 min) | USN journal refresh interval override (via `USN_REFRESH_INTERVAL_ENV` const indirection).  INTERNAL semver class. |
 //! | `UFFS_SEARCH_MAX_CONCURRENCY` | `int` (search permits) | auto: `max(2, cpus × 26 / (drives × 10))` | Overrides the auto-tuned search-permit target for `(cpus, drives)` topology (via `index::DriveIndex::SEARCH_CONCURRENCY_ENV` const indirection).  INTERNAL semver class. |

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -31,7 +31,11 @@ The report publishes **everything these numbers don't cover too** — a row-coun
 
 ## How UFFS benchmarks
 
-Four principles, documented in full in [`methodology.md`](methodology.md) (the single-link reply to *"this comparison is rigged because..."*):
+**Ready to run a benchmark cycle?** See the **[operator runbook →](runbook.md)** for prerequisites,
+step-by-step commands, crash recovery, and how to promote results to a canonical report.
+
+Four fairness principles, documented in full in [`methodology.md`](methodology.md) (the single-link
+reply to *"this comparison is rigged because..."*):
 
 - **Separate cold / warm / hot.** Cold build + warm restart + hot query are three different workloads. We measure and publish them separately instead of averaging them into one "startup time" lie.
 - **Separate interactive from bulk.** Targeted-query latency (`notepad.exe`, `*.dll`) and full-scan export (`*` → CSV for 23 M rows) are different workload classes. Different tools win each. We test both.

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -119,7 +119,7 @@ Every canonical report documents:
 - **RAM** (e.g. 64 GB)
 - **OS and build** (e.g. Windows 11 Pro 24H2)
 - **Drive topology** (e.g. 7 NTFS volumes, 3 NVMe + 3 SATA HDD + 1 USB stick, specific record counts per drive)
-- **Binary versions** (e.g. UFFS Rust v0.5.66 `2ff76fb45`, UFFS C++ reference commit, Everything 1.1.0.30 — the single pinned competitor version lives in [`scripts/windows/competitors.toml`](../../scripts/windows/competitors.toml))
+- **Binary versions** (e.g. UFFS Rust v0.5.66 `2ff76fb45`, UFFS C++ reference commit, Everything GUI engine 1.4.1.1032 + ES CLI 1.1.0.30 — the pinned versions live in [`scripts/windows/competitors.toml`](../../scripts/windows/competitors.toml). Note: `es.exe` is a thin IPC wrapper; the GUI daemon version determines search behaviour and must be documented alongside the CLI version.)
 - **Elevation state** (both tools run elevated — UFFS needs it for raw MFT read; Everything recommends it for volume enumeration)
 
 This isn't optional boilerplate. When a reader sees a surprising number, the first debugging step is "did they run on the same-ish hardware I have?". Disclosure is what makes that reasoning possible.

--- a/docs/benchmarks/runbook.md
+++ b/docs/benchmarks/runbook.md
@@ -39,9 +39,12 @@ winget install Casey.Just
 # 3. rust-script (required for Stage 1 cross-tool harness)
 cargo install rust-script
 
-# 4. Everything 1.1.0.30 (the pinned competitor — fetched automatically by the
-#    orchestrator, but es.exe must be reachable for Stage 1/2 to run)
-#    OR let the orchestrator fetch it:
+# 4. Everything GUI engine 1.4.1.1032 (the daemon es.exe talks to over IPC).
+#    es.exe is a thin wrapper — the engine version determines search behaviour
+#    and performance. Install the GUI first:
+#    https://www.voidtools.com/Everything-1.4.1.1032.x64-Setup.exe
+#
+#    Then fetch + SHA-256-verify the pinned ES CLI (1.1.0.30) automatically:
 just bench-fetch-competitors --keep-tools
 ```
 

--- a/docs/benchmarks/runbook.md
+++ b/docs/benchmarks/runbook.md
@@ -1,0 +1,299 @@
+# UFFS benchmark suite — operator runbook
+
+**Audience:** the person sitting at the Windows benchmark machine, about to run or publish a
+benchmark. Not the person designing the methodology (see [`methodology.md`](methodology.md)) or
+building the orchestrator (see [`robust-benchmark-flow-implementation-guide.md`](robust-benchmark-flow-implementation-guide.md)).
+
+**TL;DR for an experienced operator:**
+
+```powershell
+# one-time setup already done? skip to "Run a benchmark cycle" below.
+just bench-suite --drives C,D,E,F,M,S --keep-tools
+```
+
+---
+
+## Prerequisites
+
+### Machine requirements
+
+| Requirement | Detail |
+|-------------|--------|
+| **OS** | Windows 10/11 (NTFS volumes required; MFT read needs elevation) |
+| **Elevation** | Run PowerShell / Windows Terminal **as Administrator** |
+| **Drives** | At least one populated NTFS volume; multi-drive gives more data points |
+| **RAM** | ≥ 16 GB recommended (UFFS daemon caches ~181 MB per million records) |
+| **Disk** | ≥ 2 GB free on the system drive for bundle artifacts and tool backups |
+
+### Software prerequisites
+
+```powershell
+# 1. Rust toolchain (stable, MSVC target)
+winget install Rustlang.Rustup
+rustup update stable
+rustup target add x86_64-pc-windows-msvc
+
+# 2. just (task runner)
+winget install Casey.Just
+
+# 3. rust-script (required for Stage 1 cross-tool harness)
+cargo install rust-script
+
+# 4. Everything 1.1.0.30 (the pinned competitor — fetched automatically by the
+#    orchestrator, but es.exe must be reachable for Stage 1/2 to run)
+#    OR let the orchestrator fetch it:
+just bench-fetch-competitors --keep-tools
+```
+
+### Build UFFS from source
+
+```powershell
+# from repo root (elevated PowerShell)
+cargo build --release -p uffs -p uffsd
+```
+
+The orchestrator resolves `uffs.exe` from the release target directory; no
+manual install step is needed.
+
+---
+
+## Run a benchmark cycle
+
+### Option A — guided (recommended for first run or after a gap)
+
+```powershell
+just bench-suite --drives C,D,E,F,M,S
+```
+
+The orchestrator walks you through each stage with a gate card showing the exact
+commands it will run, the resources it will touch, and the estimated time. Press
+**`y`** to proceed, **`s`** to skip a stage, **`b`** to back up, **`q`** to abort cleanly.
+
+On first run you will also be asked about `--keep-tools` (whether to retain the
+downloaded `es.exe` after the run).
+
+### Option B — autopilot (CI / unattended)
+
+```powershell
+just bench-suite-auto --drives C,D,E,F,M,S --keep-tools
+```
+
+No prompts. All stages run sequentially. Snapshot/restore and fingerprint
+verification still run — the hygiene is never skipped.
+
+### Option C — dry run (see what would happen, mutate nothing)
+
+```powershell
+just bench-suite-dry --drives C,D
+```
+
+Renders every gate card and the negotiated matrix. Nothing is written, no
+daemon is touched, no tools are downloaded.
+
+### Option D — preflight only (plan + sanity check, no measurement)
+
+```powershell
+just bench-preflight --drives C,D,E,F,M,S
+```
+
+Runs Stage 0 only: environment fingerprint, competitor preflight (is `es.exe`
+reachable? does it respond to `--version`?), and matrix negotiation (which
+drives support cross-tool comparison vs UFFS-only). No measurement stages run.
+Use this to validate the machine state before committing to a full run.
+
+---
+
+## What the orchestrator does (stage map)
+
+| Stage | Name | What it does | Mutates host? |
+|-------|------|--------------|---------------|
+| 0a | Env fingerprint | Captures OS, CPU, RAM, hostname, tool versions | No |
+| 0b | Competitor preflight | Probes `es.exe` version + drive indexing state | No |
+| 0c | Matrix negotiation | Decides cross-tool vs UFFS-only per drive | No |
+| 0d | Gate card | Shows the full plan; waits for operator approval | No |
+| 1 | Cross-tool | Shells to `cross-tool-benchmark.rs` (UFFS vs Everything, n rounds) | Yes (daemon restart) |
+| 2 | Parity | Shells to `cold-parity-per-drive.ps1` (cold Rust vs warm C++) | Yes (daemon + cache) |
+| 3 | Native full-suite | Times UFFS natively, emits CSV + TXT | Yes (daemon) |
+| 4 | Assembly | Assembles `REPORT-DRAFT.md` from bundle artifacts | No |
+| 5 | Teardown | Drains restore stack, diffs fingerprints, resets manifest, saves state | Restores host |
+
+Every mutation in stages 1–3 is preceded by a snapshot registered on the
+restore stack. On teardown (stage 5) every snapshot is replayed in reverse
+(LIFO) order — daemon state, cache files, tool downloads. The host is always
+returned to its as-found state.
+
+---
+
+## Bundle directory layout
+
+The orchestrator writes everything to a timestamped bundle directory under
+`LOG/bench/<timestamp>/` (override with `--bundle <path>`):
+
+```
+LOG/bench/20260607T140000Z/
+├── state.json                  # resume/audit record (do not edit)
+├── fingerprint-before.json     # pre-run host state snapshot
+├── fingerprint-after.json      # post-run host state snapshot (written at teardown)
+├── restore-manifest.json       # crash-recovery serialized undo list
+├── env.json / env.md           # Stage 0a environment capture
+├── preflight.json              # Stage 0b competitor probe results
+├── matrix.json                 # Stage 0c negotiated drive × tool matrix
+├── cross-tool-summary.csv      # Stage 1 output
+├── parity.txt                  # Stage 2 output
+├── full-suite.csv              # Stage 3 output
+├── full-suite.txt              # Stage 3 human summary
+├── REPORT-DRAFT.md             # Stage 4 assembled draft
+├── backup/                     # R2 UFFS cache file backups (restored at teardown)
+└── tools/                      # Downloaded competitor binaries (if --keep-tools)
+```
+
+---
+
+## Resuming an interrupted run
+
+If a run is interrupted mid-way (Ctrl-C, reboot, stage failure), resume from
+where it left off:
+
+```powershell
+just bench-resume LOG\bench\20260607T140000Z
+```
+
+The orchestrator loads `state.json`, skips all steps marked `Done`, and
+continues from the first `Pending` step. Pass the same flags as the original
+run (`--drives`, `--rounds`, etc.) to avoid a plan-hash mismatch.
+
+---
+
+## Crash recovery (hard kill / power loss)
+
+If the process was killed while a mutation was in progress (before teardown
+ran), the host may be in a partially mutated state. Use the `restore`
+subcommand to replay the persisted undo list:
+
+```powershell
+just bench-restore LOG\bench\20260607T140000Z
+```
+
+This replays every entry in `restore-manifest.json` in LIFO order. On success
+the manifest is reset to a no-op sentinel. Exits non-zero if any undo fails —
+inspect the output, fix manually, then re-run to confirm.
+
+After restoring, verify the host is clean:
+
+```powershell
+just bench-suite-verify LOG\bench\20260607T140000Z
+```
+
+Diffs the current host state against `fingerprint-before.json`. Exits non-zero
+if any difference remains; writes `fingerprint-after.json` for forensics.
+
+---
+
+## Selecting stages and drives
+
+```powershell
+# Run only Stage 3 (native full-suite) on drives C and D
+just bench-suite --only-stage 3 --drives C,D
+
+# Start from Stage 2 onwards (skip Stage 0 and 1)
+just bench-suite --from-stage 2 --drives C,D,E
+
+# Re-run Stage 0 even if already Done in state.json
+just bench-suite --redo
+
+# Re-run all stages from scratch (ignore cached Done state)
+just bench-suite --force
+```
+
+---
+
+## Publishing results
+
+After a successful run, `LOG/bench/<timestamp>/REPORT-DRAFT.md` contains a
+pre-filled report scaffold. To promote it to a canonical benchmark report:
+
+1. **Review the draft** — fill in the `<!-- TODO -->` placeholders, add the
+   §Known regressions section, and verify every table number against
+   `full-suite.csv` and `cross-tool-summary.csv`.
+
+2. **Copy raw artifacts** into the tree:
+   ```powershell
+   copy LOG\bench\<timestamp>\full-suite.csv         docs\benchmarks\raw\<date>-vX.Y.Z_full-suite.csv
+   copy LOG\bench\<timestamp>\cross-tool-summary.csv docs\benchmarks\raw\<date>-vX.Y.Z_cross-tool.csv
+   copy LOG\bench\<timestamp>\parity.txt             docs\benchmarks\raw\<date>-vX.Y.Z_parity.txt
+   ```
+
+3. **Generate charts** from the CSV (see existing chart scripts in
+   `scripts/windows/`) and commit them under
+   `docs/benchmarks/charts/<date>-vX.Y.Z/`.
+
+4. **Move the current canonical report** to `docs/benchmarks/archive/`
+   (verbatim — no edits).
+
+5. **Commit the new report** as `docs/benchmarks/<date>-vX.Y.Z-<scope>.md`
+   and update `docs/benchmarks/README.md` to point at it.
+
+6. **Update `competitors.toml`** if the competitor version changed:
+   `scripts/windows/competitors.toml`.
+
+---
+
+## Flags reference
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--drives <C,D,…>` | `C` | Comma-separated NTFS drive letters to benchmark |
+| `--tools <uffs,es,…>` | `uffs,everything` | Tool IDs for cross-tool stage |
+| `--rounds <n>` | `10` | Measurement rounds per cell (30+ for publishable results) |
+| `--only-stage <n>` | — | Run exactly stage N (0–4) and stop |
+| `--from-stage <n>` | — | Skip stages before N |
+| `--bundle <dir>` | auto-timestamped | Override bundle directory |
+| `--redo` | false | Re-run Stage 0 even if already Done |
+| `--force` | false | Invalidate all Done steps and re-run everything |
+| `--keep-tools` | false | Retain downloaded competitor binaries after teardown |
+| `--drop-os-cache` | false | Purge UFFS cache files before Stage 2 (cold parity) |
+| `--auto` | false | Autopilot — no interactive prompts |
+| `--dry-run` | false | Render plan only, mutate nothing |
+| `--guided` | true (default) | Full gate cards on first visit, terse thereafter |
+
+---
+
+## Troubleshooting
+
+**`es.exe` not found / preflight fails**
+Run `just bench-fetch-competitors --keep-tools` to download and SHA-256-verify
+the pinned competitor binary into the bundle.
+
+**`uffs daemon` won't start (elevation error)**
+The orchestrator requires an elevated shell. Re-run from an elevated PowerShell
+or Windows Terminal.
+
+**Stage 1 fails with `rust-script not found`**
+Install it: `cargo install rust-script`.
+
+**Fingerprint diff after teardown shows daemon still running**
+The daemon restore undo (Stage 5) logs a crumb warning. Run
+`uffs daemon stop` manually, then `just bench-suite-verify <bundle>` to
+confirm the host is clean.
+
+**`restore-manifest.json` replay fails for a cache file**
+The cache backup in `<bundle>/backup/` may have been corrupted or the
+destination path changed. Copy the backup file back manually:
+```powershell
+copy <bundle>\backup\C_index.uffs $env:LOCALAPPDATA\uffs\cache\C_index.uffs
+```
+
+**Run completed but `REPORT-DRAFT.md` is missing**
+Stage 4 (assembly) was skipped or failed. Resume with:
+```powershell
+just bench-resume <bundle> --only-stage 4
+```
+
+---
+
+## See also
+
+- [`methodology.md`](methodology.md) — the fairness doctrine every published number must satisfy
+- [`README.md`](README.md) — benchmark hub and current canonical report
+- [`robust-benchmark-flow-execution-plan.md`](robust-benchmark-flow-execution-plan.md) — orchestrator design doc
+- `just bench-help` — quick recipe reference in the terminal

--- a/docs/benchmarks/runbook.md
+++ b/docs/benchmarks/runbook.md
@@ -45,15 +45,26 @@ cargo install rust-script
 just bench-fetch-competitors --keep-tools
 ```
 
-### Build UFFS from source
+### UFFS binary — resolution cascade
+
+The orchestrator resolves `uffs.exe` automatically using the same cascade as
+all UFFS validation scripts. It does **not** auto-build; you control which
+artifact is exercised:
+
+| Priority | Location | How to get there |
+|----------|----------|------------------|
+| 1st | `%USERPROFILE%\bin\uffs.exe` | `just use` — installs the latest release or a dist build |
+| 2nd | `target\release\uffs.exe` | `cargo build --release -p uffs -p uffsd` |
+| 3rd | `uffs.exe` on PATH | any other install method |
+
+If none of the above exist, the orchestrator surfaces the OS "executable not
+found" error with the search path — clearer than a silent failure.
+
+To pin a specific binary for a run:
 
 ```powershell
-# from repo root (elevated PowerShell)
-cargo build --release -p uffs -p uffsd
+just bench-suite --bin C:\path\to\my\uffs.exe --drives C,D
 ```
-
-The orchestrator resolves `uffs.exe` from the release target directory; no
-manual install step is needed.
 
 ---
 
@@ -242,6 +253,7 @@ pre-filled report scaffold. To promote it to a canonical benchmark report:
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--bin <path>` | auto-cascade | Override the `uffs.exe` path (skips cascade) |
 | `--drives <C,D,…>` | `C` | Comma-separated NTFS drive letters to benchmark |
 | `--tools <uffs,es,…>` | `uffs,everything` | Tool IDs for cross-tool stage |
 | `--rounds <n>` | `10` | Measurement rounds per cell (30+ for publishable results) |

--- a/just/bench_uffs.just
+++ b/just/bench_uffs.just
@@ -423,23 +423,23 @@ bench-help:
 # Full benchmark suite (Stage 0→5); guided on first run, terse after.
 # Pass extra flags through, e.g. `just bench-suite --drives C,D --only-stage 1`.
 bench-suite *args:
-    cargo run -p uffs-bench -- {{args}}
+    cargo run --release -p uffs-bench -- {{args}}
 
 # Full suite with no prompts (snapshot/restore/verify still run).
 bench-suite-auto *args:
-    cargo run -p uffs-bench -- --auto {{args}}
+    cargo run --release -p uffs-bench -- --auto {{args}}
 
 # Render every card and the negotiated matrix, mutating nothing.
 bench-suite-dry *args:
-    cargo run -p uffs-bench -- --dry-run {{args}}
+    cargo run --release -p uffs-bench -- --dry-run {{args}}
 
 # Stage 0 only: env fingerprint + competitor preflight + matrix (no measurement).
 bench-preflight *args:
-    cargo run -p uffs-bench -- --only-stage 0 {{args}}
+    cargo run --release -p uffs-bench -- --only-stage 0 {{args}}
 
 # Resume an existing bundle: load its state.json, skip Done steps, continue.
 bench-resume bundle *args:
-    cargo run -p uffs-bench -- --bundle {{bundle}} {{args}}
+    cargo run --release -p uffs-bench -- --bundle {{bundle}} {{args}}
 
 # Download + SHA-256-verify the pinned competitor (`es.exe`) into the bundle.
 # Reads scripts/windows/competitors.toml (the single pinned version), fetches
@@ -447,7 +447,7 @@ bench-resume bundle *args:
 # to retain the binary; otherwise it is removed at teardown. Forward flags like
 # `--bundle <dir>`, e.g. `just bench-fetch-competitors --bundle out/bench`.
 bench-fetch-competitors *args:
-    cargo run -p uffs-bench -- {{args}} fetch-competitors
+    cargo run --release -p uffs-bench -- {{args}} fetch-competitors
 
 # Replay a bundle's restore-manifest.json after a hard kill (crash recovery).
 # Re-applies every serialized undo in LIFO order to return the host to its
@@ -455,7 +455,7 @@ bench-fetch-competitors *args:
 # On success the manifest is reset to a no-op sentinel. Requires --bundle <dir>.
 # Example: just bench-restore --bundle LOG/bench/20260601T120000Z
 bench-restore bundle:
-    cargo run -p uffs-bench -- --bundle {{bundle}} restore
+    cargo run --release -p uffs-bench -- --bundle {{bundle}} restore
 
 # Re-capture the host fingerprint and diff it against a bundle's baseline.
 # Compares the current host state against fingerprint-before.json from a
@@ -463,5 +463,5 @@ bench-restore bundle:
 # writes fingerprint-after.json for forensics. Requires --bundle <dir>.
 # Example: just bench-suite-verify --bundle LOG/bench/20260601T120000Z
 bench-suite-verify bundle:
-    cargo run -p uffs-bench -- --bundle {{bundle}} verify
+    cargo run --release -p uffs-bench -- --bundle {{bundle}} verify
 

--- a/scripts/windows/cold-parity-per-drive.rs
+++ b/scripts/windows/cold-parity-per-drive.rs
@@ -429,41 +429,54 @@ fn daemon_total_records(uffs_bin: &str) -> Option<u64> {
     None
 }
 
+/// Result of the three-pass daemon warm-up sequence.
+struct WarmupResult {
+    /// Wall-clock for each of the three passes (seconds).
+    pass_wall_sec: [f64; 3],
+    /// `Await ready` from pass-1 stderr (ms): daemon spawn + MFT load + index build.
+    await_ready_ms: Option<u64>,
+    /// `daemon:` search time from each pass's stderr (ms).
+    pass_daemon_ms: [Option<u64>; 3],
+    /// Total records indexed, read after all passes settle.
+    total_records: Option<u64>,
+}
+
 /// Prime the daemon with three `uffs * --limit 1 --profile` queries.
 ///
-/// The first call triggers the initial load + JIT index warm-up (the slow
-/// path).  Calls 2 and 3 exercise the HOT path and get the daemon into its
-/// fully-primed query state.  We report the wall-clock of the **first** call
-/// as the load time and `await_ready` from its stderr; the final record count
-/// is read once after all three queries settle.
+/// Pass 1 — COLD load path: daemon reads MFT (or compact cache) and builds
+///          the in-memory index; `await_ready` measures this.
+/// Pass 2 — first HOT query: JIT query structures are built for the first time.
+/// Pass 3 — fully primed HOT query: steady-state latency.
 ///
-/// Returns `(load_wall_sec, await_ready_ms, total_records)`.
-fn warmup_daemon_primed(uffs_bin: &str, dump_raw: bool) -> (f64, Option<u64>, Option<u64>) {
-    let mut load_wall = 0.0f64;
-    let mut ready_ms = None;
-    for pass in 1u8..=3 {
+/// All three wall times are returned so the caller can display the full
+/// COLD → WARM → HOT trajectory.
+fn warmup_daemon_primed(uffs_bin: &str, dump_raw: bool) -> WarmupResult {
+    let mut pass_wall_sec = [0.0f64; 3];
+    let mut pass_daemon_ms = [None::<u64>; 3];
+    let mut await_ready_ms = None;
+    for pass in 0usize..3 {
         let t = Instant::now();
         let result = Command::new(uffs_bin)
             .args(["*", "--limit", "1", "--profile"])
             .output();
-        let elapsed = t.elapsed().as_secs_f64();
+        pass_wall_sec[pass] = t.elapsed().as_secs_f64();
         let stderr = match result {
             Ok(ref o) => String::from_utf8_lossy(&o.stderr).into_owned(),
             Err(ref e) => {
-                eprintln!("    WARNING: warm-up pass {pass} failed: {e}");
+                eprintln!("    WARNING: warm-up pass {} failed: {e}", pass + 1);
                 continue;
             }
         };
         if dump_raw {
-            eprintln!("    [warm-up pass {pass}] {stderr}");
+            eprintln!("    [warm-up pass {}]\n{stderr}", pass + 1);
         }
-        if pass == 1 {
-            load_wall = elapsed;
-            ready_ms = parse_tagged_ms(&stderr, "Await ready:");
+        pass_daemon_ms[pass] = parse_tagged_ms(&stderr, "daemon:");
+        if pass == 0 {
+            await_ready_ms = parse_tagged_ms(&stderr, "Await ready:");
         }
     }
-    let records = daemon_total_records(uffs_bin);
-    (load_wall, ready_ms, records)
+    let total_records = daemon_total_records(uffs_bin);
+    WarmupResult { pass_wall_sec, await_ready_ms, pass_daemon_ms, total_records }
 }
 
 fn parse_tagged_ms(text: &str, marker: &str) -> Option<u64> {
@@ -742,15 +755,25 @@ fn main() {
 
     // ── Phase 0b: daemon warm-up (3 priming passes) ────────────────────────
     out.divider("Phase 0b: daemon warm-up — 3 priming passes");
-    out.line("  Pass 1: load path + await_ready (COLD).  Passes 2-3: prime HOT query state.");
+    out.line("  Pass 1 = COLD load (MFT read / cache hit + await_ready)");
+    out.line("  Pass 2 = WARM (first HOT query, JIT structures built)");
+    out.line("  Pass 3 = HOT  (fully primed, steady-state latency)");
     out.line("  Running `uffs '*' --limit 1 --profile`  ×3 …");
-    let (warmup_wall, warmup_ready_ms, warmup_records) =
-        warmup_daemon_primed(&uffs_bin, args.dump_raw);
+    let wu = warmup_daemon_primed(&uffs_bin, args.dump_raw);
+    let pass_labels = ["COLD", "WARM", "HOT "];
+    for i in 0..3 {
+        out.line(&format!(
+            "    [pass {} — {}]  wall = {:.2} s   daemon = {}",
+            i + 1,
+            pass_labels[i],
+            wu.pass_wall_sec[i],
+            opt_ms(wu.pass_daemon_ms[i]),
+        ));
+    }
     out.line(&format!(
-        "    -> pass-1 wall = {:.2} s   await_ready = {}   total_records = {}",
-        warmup_wall,
-        opt_ms(warmup_ready_ms),
-        opt_count(warmup_records),
+        "  await_ready (pass 1) = {}   total_records = {}",
+        opt_ms(wu.await_ready_ms),
+        opt_count(wu.total_records),
     ));
     out.line(&format!(
         "  Mode: {}",
@@ -965,13 +988,27 @@ fn main() {
 
     // ── Warm-up recap ──────────────────────────────────────────────────────
     out.divider("Summary — daemon warm-up (Phase 0b)");
-    out.line(&format!("  Pass-1 wall   : {:.2} s  (daemon load + await_ready)", warmup_wall));
-    if let Some(rm) = warmup_ready_ms {
-        out.line(&format!("  Await ready   : {rm} ms  (MFT read + index build)"));
+    let pass_labels = ["COLD", "WARM", "HOT "];
+    let pass_notes  = [
+        "daemon load + MFT read / cache hit",
+        "first HOT query — JIT structures built",
+        "fully primed — steady-state latency",
+    ];
+    for i in 0..3 {
+        out.line(&format!(
+            "  Pass {} [{} ]  wall = {:.2} s   daemon = {}   ({})",
+            i + 1,
+            pass_labels[i],
+            wu.pass_wall_sec[i],
+            opt_ms(wu.pass_daemon_ms[i]),
+            pass_notes[i],
+        ));
     }
-    if let Some(rec) = warmup_records {
-        out.line(&format!("  Total records : {}", fmt_count(rec)));
-    }
+    out.line(&format!(
+        "  Await ready   : {}   total_records = {}",
+        opt_ms(wu.await_ready_ms),
+        opt_count(wu.total_records),
+    ));
     out.line(&format!(
         "  Mode          : {}",
         if args.purge_cache {

--- a/scripts/windows/cold-parity-per-drive.rs
+++ b/scripts/windows/cold-parity-per-drive.rs
@@ -26,9 +26,18 @@
 //!      every drive; records wall-clock warm-up time.
 //!   3. Per-drive loop (`--rounds` iterations each):
 //!        UFFS Rust HOT:  `uffs.exe '*' --drive X --out <tmp> --columns Path
-//!                         --hide-system --hide-ads --profile`
+//!                         --profile`
 //!        C++ MFT-reread: `uffs.com '*' --drives=X --columns=path --out=<tmp>`
-//!      Report p50 wall-clock (+ daemon-ms from `--profile` stderr) per drive.
+//!      Report p50 wall-clock + daemon-ms (from `--profile`) per drive.
+//!      `--hide-system` / `--hide-ads` are intentionally **omitted**: those
+//!      flags exist only to align row counts with Everything (which skips
+//!      system files and ADS).  This benchmark is uffs.exe vs uffs.com only
+//!      — the full unfiltered MFT corpus is the correct baseline.
+//!      `--profile` is kept: it prints `daemon: N ms` on stderr so Table 2
+//!      can break the wall-clock into daemon-search vs CLI overhead, giving
+//!      insight into the daemon IPC cost.  It is a non-default code path but
+//!      the extra `SearchProfile` payload is small and does not materially
+//!      change wall-clock at the >100 ms scale of these queries.
 //!   4. Two markdown summary tables.
 //!
 //! # Binary resolution (same cascade as the bench suite)
@@ -193,14 +202,14 @@ fn resolve_uffs(explicit: Option<&str>) -> (String, String) {
     if let Ok(home) = env::var(home_var) {
         let p = PathBuf::from(&home).join("bin").join(bin);
         if p.exists() {
-            return (p.to_string_lossy().into_owned(), format!("%USERPROFILE%\\bin ({p:?})"));
+            return (p.to_string_lossy().into_owned(), format!("%USERPROFILE%\\bin ({})", p.display()));
         }
     }
     let tgt = PathBuf::from("target").join("release").join(bin);
     if tgt.exists() {
         return (
             tgt.to_string_lossy().into_owned(),
-            format!("target\\release ({tgt:?})"),
+            format!("target\\release ({})", tgt.display()),
         );
     }
     (
@@ -219,13 +228,31 @@ fn resolve_cpp(explicit: Option<&str>) -> (String, String) {
     if let Ok(home) = env::var(home_var) {
         let p = PathBuf::from(&home).join("bin").join(bin);
         if p.exists() {
-            return (p.to_string_lossy().into_owned(), format!("%USERPROFILE%\\bin ({p:?})"));
+            return (p.to_string_lossy().into_owned(), format!("%USERPROFILE%\\bin ({})", p.display()));
         }
     }
     (
         bin.to_owned(),
         format!("unresolved (tried: explicit, %USERPROFILE%\\bin\\{bin}, PATH)"),
     )
+}
+
+/// Extract the version string from uffs.com `--version` output.
+/// The C++ binary prints several lines; the one starting with
+/// `\tUFFS version:` (after trimming) holds the actual version number.
+fn extract_cpp_version(raw: &str) -> String {
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("UFFS version:") {
+            return format!("uffs.com {}", rest.trim());
+        }
+    }
+    // Fallback: first non-empty line.
+    raw.lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("uffs.com (version unknown)")
+        .to_owned()
 }
 
 fn binary_available(bin: &str) -> bool {
@@ -454,8 +481,6 @@ fn run_uffs_hot(uffs_bin: &str, drive: &str, dump_raw: bool) -> Round {
             out_path.to_str().unwrap_or("out.csv"),
             "--columns",
             "Path",
-            "--hide-system",
-            "--hide-ads",
             "--profile",
         ])
         .output();
@@ -543,6 +568,20 @@ fn opt_ms(n: Option<u64>) -> String {
     n.map(|v| format!("{v} ms")).unwrap_or_else(|| "n/a".to_owned())
 }
 
+/// Format a millisecond value as `"N ms"` with thousands-separated N.
+fn ms_str(ms: u64) -> String {
+    format!("{} ms", fmt_count(ms))
+}
+
+/// Format a speedup ratio as `"N.Nx"`, or `"n/a"` / `"(skipped)"`.
+fn speedup_str(cpp_ms: Option<u64>, rust_ms: u64) -> String {
+    match cpp_ms {
+        Some(c) if rust_ms > 0 => format!("{:.1}x", c as f64 / rust_ms as f64),
+        Some(_) => "n/a".to_owned(),
+        None => "(skipped)".to_owned(),
+    }
+}
+
 fn now_str() -> String {
     // No chrono dep: use the OS time via a simple epoch calculation.
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -617,7 +656,9 @@ fn main() {
         std::process::exit(1);
     }
     if let Ok(o) = Command::new(&uffs_bin).arg("--version").output() {
-        out.line(&format!("  {}", String::from_utf8_lossy(&o.stdout).trim()));
+        let ver = String::from_utf8_lossy(&o.stdout);
+        let ver = ver.lines().map(str::trim).find(|l| !l.is_empty()).unwrap_or("");
+        out.line(&format!("  {ver}"));
     }
 
     // Verify uffs.com (optional).
@@ -626,7 +667,8 @@ fn main() {
         if !avail {
             print_missing_cpp_warning(&cpp_bin, &cpp_src);
         } else if let Ok(o) = Command::new(&cpp_bin).arg("--version").output() {
-            out.line(&format!("  {}", String::from_utf8_lossy(&o.stdout).trim()));
+            let raw = String::from_utf8_lossy(&o.stdout);
+            out.line(&format!("  {}", extract_cpp_version(&raw)));
         }
         avail
     };
@@ -692,7 +734,7 @@ fn main() {
         for r in 1..=args.rounds {
             out.line(&format!(
                 "  [Rust HOT {r}/{}]  uffs.exe '*' --drive {drive} \
-                 --out <tmp> --columns Path --hide-system --hide-ads --profile",
+                 --out <tmp> --columns Path --profile",
                 args.rounds
             ));
             let res = run_uffs_hot(&uffs_bin, drive, args.dump_raw);
@@ -760,13 +802,26 @@ fn main() {
         });
     }
 
+    // ── Pre-compute column widths from data for aligned tables ────────────
+    let w_drive   = table.iter().map(|r| r.drive.len() + 1).max().unwrap_or(5).max(5); // "Drive"
+    let w_cpp     = table.iter().map(|r| r.cpp_p50.map(|v| ms_str(v).len()).unwrap_or(9)).max().unwrap_or(9).max(17); // "C++ (MFT re-read)"
+    let w_rust    = table.iter().map(|r| ms_str(r.rust_p50).len()).max().unwrap_or(9).max(17); // "Rust (daemon HOT)"
+    let w_speedup = table.iter().map(|r| speedup_str(r.cpp_p50, r.rust_p50).len()).max().unwrap_or(7).max(7); // "Speedup"
+    let w_rrows   = table.iter().map(|r| opt_count(r.rust_rows).len()).max().unwrap_or(9).max(9); // "Rust rows"
+    let w_crows   = table.iter().map(|r| opt_count(r.cpp_rows).len()).max().unwrap_or(8).max(8);  // "C++ rows"
+
     // ── Summary table 1: parity ────────────────────────────────────────────
     out.divider(&format!(
         "Summary — table 1: per-drive parity (wall-clock p50 over {} round(s))",
         args.rounds
     ));
-    out.line("| Drive | C++ (MFT re-read) | Rust (daemon HOT) | Speedup | Rust rows | C++ rows |");
-    out.line("|-------|------------------:|------------------:|--------:|----------:|---------:|");
+
+    let h1 = format!("| {:<w_drive$} | {:>w_cpp$} | {:>w_rust$} | {:>w_speedup$} | {:>w_rrows$} | {:>w_crows$} |",
+        "Drive", "C++ (MFT re-read)", "Rust (daemon HOT)", "Speedup", "Rust rows", "C++ rows");
+    let sep1 = format!("| {:-<w_drive$} | {:->w_cpp$}: | {:->w_rust$}: | {:->w_speedup$}: | {:->w_rrows$}: | {:->w_crows$}: |",
+        "", "", "", "", "", "");
+    out.line(&h1);
+    out.line(&sep1);
 
     let mut total_rust_ms: u64 = 0;
     let mut total_cpp_ms: u64 = 0;
@@ -774,23 +829,21 @@ fn main() {
 
     for row in &table {
         total_rust_ms += row.rust_p50;
-        let speedup = match row.cpp_p50 {
-            Some(c) if row.rust_p50 > 0 => format!("{:.1}x", c as f64 / row.rust_p50 as f64),
-            Some(_) => "n/a".to_owned(),
-            None => "(skipped)".to_owned(),
-        };
+        let speedup = speedup_str(row.cpp_p50, row.rust_p50);
         let cpp_cell = row
             .cpp_p50
             .map(|c| {
                 total_cpp_ms += c;
                 any_cpp = true;
-                format!("{c:>7} ms")
+                ms_str(c)
             })
             .unwrap_or_else(|| "(skipped)".to_owned());
         out.line(&format!(
-            "| {}: | {cpp_cell} | {:>7} ms | {speedup:>8} | {:>9} | {:>8} |",
-            row.drive,
-            row.rust_p50,
+            "| {:<w_drive$} | {:>w_cpp$} | {:>w_rust$} | {:>w_speedup$} | {:>w_rrows$} | {:>w_crows$} |",
+            format!("{}:", row.drive),
+            cpp_cell,
+            ms_str(row.rust_p50),
+            speedup,
             opt_count(row.rust_rows),
             opt_count(row.cpp_rows),
         ));
@@ -798,42 +851,62 @@ fn main() {
 
     if any_cpp && total_rust_ms > 0 {
         let total_speedup = total_cpp_ms as f64 / total_rust_ms as f64;
+        let speedup_label = format!("{total_speedup:.1}x");
         out.line(&format!(
-            "| **TOTAL** | **{total_cpp_ms:>7} ms** | **{total_rust_ms:>7} ms** \
-             | **{total_speedup:.1}x** | — | — |"
+            "| {:<w_drive$} | {:>w_cpp$} | {:>w_rust$} | {:>w_speedup$} | {:>w_rrows$} | {:>w_crows$} |",
+            "TOTAL",
+            ms_str(total_cpp_ms),
+            ms_str(total_rust_ms),
+            speedup_label,
+            "—",
+            "—",
         ));
     } else {
         out.line(&format!(
-            "| **TOTAL (Rust sum)** | — | **{total_rust_ms:>7} ms** | — | — | — |"
+            "| {:<w_drive$} | {:>w_cpp$} | {:>w_rust$} | {:>w_speedup$} | {:>w_rrows$} | {:>w_crows$} |",
+            "TOTAL",
+            "—",
+            ms_str(total_rust_ms),
+            "—",
+            "—",
+            "—",
         ));
     }
 
     // ── Summary table 2: Rust daemon breakdown ─────────────────────────────
+    let w2_rows  = table.iter().map(|r| opt_count(r.rust_rows).len()).max().unwrap_or(9).max(9);
+    let w2_wall  = table.iter().map(|r| ms_str(r.rust_p50).len()).max().unwrap_or(13).max(13);
+    let w2_dmn   = table.iter().map(|r| r.rust_daemon_p50.map(|v| ms_str(v).len()).unwrap_or(3)).max().unwrap_or(15).max(15);
+    let w2_over  = table.iter().map(|r| r.rust_daemon_p50.map(|dm| ms_str(r.rust_p50.saturating_sub(dm)).len()).unwrap_or(3)).max().unwrap_or(12).max(12);
+
     out.divider("Summary — table 2: Rust wall vs daemon breakdown");
-    out.line("| Drive | Rust rows | Rust wall p50 | Rust daemon p50 | CLI overhead |");
-    out.line("|-------|----------:|--------------:|----------------:|-------------:|");
+    let h2 = format!("| {:<w_drive$} | {:>w2_rows$} | {:>w2_wall$} | {:>w2_dmn$} | {:>w2_over$} |",
+        "Drive", "Rust rows", "Rust wall p50", "Rust daemon p50", "CLI overhead");
+    let sep2 = format!("| {:-<w_drive$} | {:->w2_rows$}: | {:->w2_wall$}: | {:->w2_dmn$}: | {:->w2_over$}: |",
+        "", "", "", "", "");
+    out.line(&h2);
+    out.line(&sep2);
     for row in &table {
-        let overhead = row.rust_daemon_p50.map(|dm| {
-            let ov = row.rust_p50.saturating_sub(dm);
-            format!("{ov:>5} ms")
-        });
+        let daemon_cell = row.rust_daemon_p50.map(ms_str).unwrap_or_else(|| "n/a".to_owned());
+        let overhead_cell = row.rust_daemon_p50
+            .map(|dm| ms_str(row.rust_p50.saturating_sub(dm)))
+            .unwrap_or_else(|| "n/a".to_owned());
         out.line(&format!(
-            "| {}: | {:>9} | {:>9} ms | {:>11} | {:>12} |",
-            row.drive,
+            "| {:<w_drive$} | {:>w2_rows$} | {:>w2_wall$} | {:>w2_dmn$} | {:>w2_over$} |",
+            format!("{}:", row.drive),
             opt_count(row.rust_rows),
-            row.rust_p50,
-            row.rust_daemon_p50
-                .map(|d| format!("{d:>5} ms"))
-                .unwrap_or_else(|| "    n/a".to_owned()),
-            overhead.unwrap_or_else(|| "    n/a".to_owned()),
+            ms_str(row.rust_p50),
+            daemon_cell,
+            overhead_cell,
         ));
     }
     out.line("");
     out.line("  Legend:");
     out.line("    Rust wall p50    = process wall-clock from spawn to exit (Rust Instant).");
-    out.line("    Rust daemon p50  = daemon-reported search duration (--profile 'daemon: N ms').");
-    out.line("    CLI overhead     = wall − daemon  (process start + IPC + file write).");
+    out.line("    Rust daemon p50  = daemon-reported search duration (--profile stderr: 'daemon: N ms').");
+    out.line("    CLI overhead     = wall − daemon  (process spawn + IPC round-trip + file write).");
     out.line("    C++ has no daemon — its wall-clock IS its total cost (full MFT re-read every run).");
+    out.line("    Row counts differ: Rust returns all MFT records; C++ may apply implicit filters.");
 
     // ── Warm-up recap ──────────────────────────────────────────────────────
     out.divider("Summary — daemon warm-up (Phase 0b)");

--- a/scripts/windows/cold-parity-per-drive.rs
+++ b/scripts/windows/cold-parity-per-drive.rs
@@ -1,0 +1,858 @@
+#!/usr/bin/env rust-script
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+//! Per-drive parity benchmark: UFFS (Rust daemon HOT) vs UFFS (C++ MFT re-read)
+//!
+//! # Methodology
+//!
+//!   Both tools answer the same `*` (all-files, path-only) query per drive:
+//!
+//!   - **UFFS Rust** (`uffs.exe`): daemon model.  The daemon loads all drives
+//!     once and serves each per-drive `*` query from the in-memory index.
+//!     Each round is HOT (daemon already warm for every drive before the loop).
+//!
+//!   - **UFFS C++** (`uffs.com`): no daemon.  Re-reads the MFT on every
+//!     invocation regardless of `--drives=X`.  The `--drives` flag is an
+//!     *output filter*, not a load-time filter — each round is effectively COLD.
+//!
+//!   The per-drive table therefore measures the real-world workflow difference:
+//!   how fast can each tool answer an interactive `*` query on a single drive?
+//!
+//! # Sequence
+//!
+//!   1. (`--purge-cache`) Stop daemon, remove drive cache files — re-measures
+//!      the one-time cold daemon warm-up path.
+//!   2. Warm-up: `uffs * --limit 1 --profile` auto-spawns the daemon and loads
+//!      every drive; records wall-clock warm-up time.
+//!   3. Per-drive loop (`--rounds` iterations each):
+//!        UFFS Rust HOT:  `uffs.exe '*' --drive X --out <tmp> --columns Path
+//!                         --hide-system --hide-ads --profile`
+//!        C++ MFT-reread: `uffs.com '*' --drives=X --columns=path --out=<tmp>`
+//!      Report p50 wall-clock (+ daemon-ms from `--profile` stderr) per drive.
+//!   4. Two markdown summary tables.
+//!
+//! # Binary resolution (same cascade as the bench suite)
+//!
+//!   1. Explicit `--uffs-bin` / `--cpp-bin`
+//!   2. `%USERPROFILE%\bin\uffs.exe` / `%USERPROFILE%\bin\uffs.com`
+//!   3. `target\release\uffs.exe`  (Rust only)
+//!   4. bare name on PATH (OS errors clearly if absent)
+//!
+//!   If a required binary is not found an actionable error with the download
+//!   URL is printed and the script exits non-zero.
+//!
+//! # Usage
+//!
+//! ```powershell
+//! rust-script scripts\windows\cold-parity-per-drive.rs --drives C,D,G
+//! rust-script scripts\windows\cold-parity-per-drive.rs --drives C,D --rounds 3
+//! rust-script scripts\windows\cold-parity-per-drive.rs --purge-cache
+//! rust-script scripts\windows\cold-parity-per-drive.rs --skip-cpp
+//! rust-script scripts\windows\cold-parity-per-drive.rs --dump-raw
+//! rust-script scripts\windows\cold-parity-per-drive.rs --uffs-bin C:\tools\uffs.exe
+//! ```
+//!
+//! ```cargo
+//! [dependencies]
+//! ```
+
+use std::env;
+use std::fs;
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const UFFS_DOWNLOAD_URL: &str =
+    "https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest";
+const CPP_DOWNLOAD_URL: &str =
+    "https://github.com/githubrobbi/Ultra-Fast-File-Search/releases/latest";
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+struct Args {
+    drives: Vec<String>,
+    uffs_bin: Option<String>,
+    cpp_bin: Option<String>,
+    rounds: usize,
+    sleep_ms: u64,
+    purge_cache: bool,
+    skip_cpp: bool,
+    dump_raw: bool,
+    output_file: Option<String>,
+}
+
+impl Args {
+    fn parse() -> Self {
+        let raw: Vec<String> = env::args().skip(1).collect();
+        let mut a = Args {
+            drives: vec!["C".into(), "D".into()],
+            uffs_bin: None,
+            cpp_bin: None,
+            rounds: 1,
+            sleep_ms: 1_000,
+            purge_cache: false,
+            skip_cpp: false,
+            dump_raw: false,
+            output_file: None,
+        };
+        let mut i = 0usize;
+        while i < raw.len() {
+            match raw[i].as_str() {
+                "--drives" => {
+                    i += 1;
+                    if i < raw.len() {
+                        a.drives = raw[i]
+                            .split(',')
+                            .map(|d| d.trim().to_uppercase())
+                            .filter(|d| !d.is_empty())
+                            .collect();
+                    }
+                }
+                "--uffs-bin" => {
+                    i += 1;
+                    if i < raw.len() {
+                        a.uffs_bin = Some(raw[i].clone());
+                    }
+                }
+                "--cpp-bin" => {
+                    i += 1;
+                    if i < raw.len() {
+                        a.cpp_bin = Some(raw[i].clone());
+                    }
+                }
+                "--rounds" => {
+                    i += 1;
+                    if i < raw.len() {
+                        a.rounds = raw[i].parse().unwrap_or(1).max(1);
+                    }
+                }
+                "--sleep-ms" => {
+                    i += 1;
+                    if i < raw.len() {
+                        a.sleep_ms = raw[i].parse().unwrap_or(1_000);
+                    }
+                }
+                "--output-file" => {
+                    i += 1;
+                    if i < raw.len() {
+                        a.output_file = Some(raw[i].clone());
+                    }
+                }
+                "--purge-cache" => a.purge_cache = true,
+                "--skip-cpp" => a.skip_cpp = true,
+                "--dump-raw" => a.dump_raw = true,
+                "--help" | "-h" => {
+                    print_help();
+                    std::process::exit(0);
+                }
+                other => {
+                    eprintln!("Unknown argument: {other}  (use --help)");
+                    std::process::exit(1);
+                }
+            }
+            i += 1;
+        }
+        a
+    }
+}
+
+fn print_help() {
+    println!(
+        "cold-parity-per-drive — UFFS Rust (daemon HOT) vs UFFS C++ (MFT re-read)\n\
+         \n\
+         Usage:  rust-script cold-parity-per-drive.rs [OPTIONS]\n\
+         \n\
+         Options:\n\
+           --drives C,D,G       Comma-separated drives to test (default: C,D)\n\
+           --rounds N           Rounds per drive per tool (default: 1)\n\
+           --uffs-bin <path>    Explicit path to uffs.exe\n\
+           --cpp-bin  <path>    Explicit path to uffs.com\n\
+           --purge-cache        Stop daemon + purge all cache files before warm-up\n\
+           --skip-cpp           Skip the C++ reference column entirely\n\
+           --dump-raw           Print raw stderr for each invocation\n\
+           --sleep-ms N         Sleep between rounds in ms (default: 1000)\n\
+           --output-file <path> Tee all output to a file\n\
+           --help               Show this help\n\
+         \n\
+         Requires admin elevation for MFT reads (C++ column)."
+    );
+}
+
+// ── Binary resolution ─────────────────────────────────────────────────────────
+
+/// Returns `(resolved_path, source_description)`.
+fn resolve_uffs(explicit: Option<&str>) -> (String, String) {
+    if let Some(e) = explicit {
+        return (e.to_owned(), format!("explicit --uffs-bin ({e})"));
+    }
+    let bin = "uffs.exe";
+    let home_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    if let Ok(home) = env::var(home_var) {
+        let p = PathBuf::from(&home).join("bin").join(bin);
+        if p.exists() {
+            return (p.to_string_lossy().into_owned(), format!("%USERPROFILE%\\bin ({p:?})"));
+        }
+    }
+    let tgt = PathBuf::from("target").join("release").join(bin);
+    if tgt.exists() {
+        return (
+            tgt.to_string_lossy().into_owned(),
+            format!("target\\release ({tgt:?})"),
+        );
+    }
+    (
+        bin.to_owned(),
+        format!("unresolved (tried: explicit, %USERPROFILE%\\bin\\{bin}, target\\release, PATH)"),
+    )
+}
+
+/// Returns `(resolved_path, source_description)`.
+fn resolve_cpp(explicit: Option<&str>) -> (String, String) {
+    if let Some(e) = explicit {
+        return (e.to_owned(), format!("explicit --cpp-bin ({e})"));
+    }
+    let bin = "uffs.com";
+    let home_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    if let Ok(home) = env::var(home_var) {
+        let p = PathBuf::from(&home).join("bin").join(bin);
+        if p.exists() {
+            return (p.to_string_lossy().into_owned(), format!("%USERPROFILE%\\bin ({p:?})"));
+        }
+    }
+    (
+        bin.to_owned(),
+        format!("unresolved (tried: explicit, %USERPROFILE%\\bin\\{bin}, PATH)"),
+    )
+}
+
+fn binary_available(bin: &str) -> bool {
+    if PathBuf::from(bin).exists() {
+        return true;
+    }
+    Command::new(bin)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
+}
+
+fn print_missing_uffs_error(path: &str, source: &str) {
+    eprintln!();
+    eprintln!("ERROR: uffs.exe not found.");
+    eprintln!("       Resolved  : {path}");
+    eprintln!("       Source    : {source}");
+    eprintln!();
+    eprintln!("       Looked in order:");
+    eprintln!("         1. --uffs-bin <path> (not provided)");
+    eprintln!("         2. %USERPROFILE%\\bin\\uffs.exe");
+    eprintln!("         3. target\\release\\uffs.exe  (cargo build --release)");
+    eprintln!("         4. PATH");
+    eprintln!();
+    eprintln!("       Download: {UFFS_DOWNLOAD_URL}");
+    eprintln!();
+}
+
+fn print_missing_cpp_warning(path: &str, source: &str) {
+    eprintln!();
+    eprintln!("WARNING: uffs.com (C++ reference) not found — C++ column will be skipped.");
+    eprintln!("         Resolved  : {path}");
+    eprintln!("         Source    : {source}");
+    eprintln!("         Looked in order:");
+    eprintln!("           1. --cpp-bin <path> (not provided)");
+    eprintln!("           2. %USERPROFILE%\\bin\\uffs.com");
+    eprintln!("           3. PATH");
+    eprintln!("         Download: {CPP_DOWNLOAD_URL}");
+    eprintln!();
+}
+
+// ── Output sink (console + optional file tee) ─────────────────────────────────
+
+struct Out {
+    file: Option<fs::File>,
+}
+
+impl Out {
+    fn open(path: Option<&str>) -> Self {
+        let file = path.and_then(|p| {
+            if let Some(parent) = PathBuf::from(p).parent() {
+                if !parent.as_os_str().is_empty() {
+                    let _ = fs::create_dir_all(parent);
+                }
+            }
+            fs::File::create(p)
+                .map_err(|e| eprintln!("WARNING: cannot open output file {p}: {e}"))
+                .ok()
+        });
+        Self { file }
+    }
+
+    fn line(&mut self, s: &str) {
+        println!("{s}");
+        if let Some(f) = &mut self.file {
+            let _ = writeln!(f, "{s}");
+        }
+    }
+
+    fn divider(&mut self, title: &str) {
+        let bar = "=".repeat(110);
+        self.line("");
+        self.line(&bar);
+        if !title.is_empty() {
+            self.line(&format!("  {title}"));
+        }
+        self.line(&bar);
+        self.line("");
+    }
+}
+
+// ── Round result ──────────────────────────────────────────────────────────────
+
+struct Round {
+    wall_ms: u64,
+    daemon_ms: Option<u64>,
+    rows: Option<u64>,
+}
+
+// ── Cache helpers ─────────────────────────────────────────────────────────────
+
+fn uffs_cache_dir() -> PathBuf {
+    env::var("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .or_else(|_| {
+            env::var("USERPROFILE").map(|h| {
+                PathBuf::from(h)
+                    .join("AppData")
+                    .join("Local")
+            })
+        })
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join("uffs")
+        .join("cache")
+}
+
+fn purge_drive_cache(cache_dir: &PathBuf, drive: &str, dump_raw: bool) {
+    for suffix in &[
+        "_compact.uffs",
+        "_index.uffs",
+        "_index.uffs.tmp",
+        "_index.lock",
+        "_compact.uffs.tmp",
+    ] {
+        let p = cache_dir.join(format!("{drive}{suffix}"));
+        if p.exists() {
+            match fs::remove_file(&p) {
+                Ok(()) => {
+                    if dump_raw {
+                        eprintln!("    - removed {}", p.display());
+                    }
+                }
+                Err(e) => eprintln!("    WARNING: could not remove {}: {e}", p.display()),
+            }
+        }
+    }
+}
+
+// ── Daemon helpers ────────────────────────────────────────────────────────────
+
+fn stop_daemon(uffs_bin: &str) {
+    let _ = Command::new(uffs_bin)
+        .args(["daemon", "kill"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    std::thread::sleep(std::time::Duration::from_millis(800));
+}
+
+fn daemon_total_records(uffs_bin: &str) -> Option<u64> {
+    let out = Command::new(uffs_bin)
+        .args(["daemon", "stats"])
+        .output()
+        .ok()?;
+    let text = String::from_utf8_lossy(&out.stdout);
+    for line in text.lines() {
+        if line.contains("Total records:") {
+            let digits: String = line.chars().filter(|c| c.is_ascii_digit()).collect();
+            return digits.parse().ok();
+        }
+    }
+    None
+}
+
+/// Auto-spawn daemon via `uffs * --limit 1 --profile` and wait for completion.
+/// Returns `(wall_sec, await_ready_ms, total_records)`.
+fn warmup_daemon(uffs_bin: &str, dump_raw: bool) -> (f64, Option<u64>, Option<u64>) {
+    let t = Instant::now();
+    let result = Command::new(uffs_bin)
+        .args(["*", "--limit", "1", "--profile"])
+        .output();
+    let wall_sec = t.elapsed().as_secs_f64();
+    let stderr = match result {
+        Ok(ref o) => String::from_utf8_lossy(&o.stderr).into_owned(),
+        Err(ref e) => {
+            eprintln!("    WARNING: warm-up failed: {e}");
+            return (wall_sec, None, None);
+        }
+    };
+    if dump_raw {
+        eprintln!("{stderr}");
+    }
+    let ready_ms = parse_tagged_ms(&stderr, "Await ready:");
+    let records = daemon_total_records(uffs_bin);
+    (wall_sec, ready_ms, records)
+}
+
+fn parse_tagged_ms(text: &str, marker: &str) -> Option<u64> {
+    for line in text.lines() {
+        if let Some(after) = line.split_once(marker).map(|(_, r)| r) {
+            let digits: String = after
+                .chars()
+                .skip_while(|c| !c.is_ascii_digit())
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
+            if !digits.is_empty() {
+                return digits.parse().ok();
+            }
+        }
+    }
+    None
+}
+
+// ── File line counter ─────────────────────────────────────────────────────────
+
+fn count_lines(path: &PathBuf) -> Option<u64> {
+    let bytes = fs::read(path).ok()?;
+    Some(bytes.iter().filter(|&&b| b == b'\n').count() as u64)
+}
+
+// ── Unique temp path ──────────────────────────────────────────────────────────
+
+fn tmp_path(prefix: &str, drive: &str) -> PathBuf {
+    env::temp_dir().join(format!(
+        "uffs_{prefix}_{drive}_{}.csv",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0)
+    ))
+}
+
+// ── Round runners ─────────────────────────────────────────────────────────────
+
+fn run_uffs_hot(uffs_bin: &str, drive: &str, dump_raw: bool) -> Round {
+    let out_path = tmp_path("hot", drive);
+    let t = Instant::now();
+    let result = Command::new(uffs_bin)
+        .args([
+            "*",
+            "--drive",
+            drive,
+            "--out",
+            out_path.to_str().unwrap_or("out.csv"),
+            "--columns",
+            "Path",
+            "--hide-system",
+            "--hide-ads",
+            "--profile",
+        ])
+        .output();
+    let wall_ms = t.elapsed().as_millis() as u64;
+    let (daemon_ms, stderr) = match result {
+        Ok(ref o) => {
+            let s = String::from_utf8_lossy(&o.stderr).into_owned();
+            (parse_tagged_ms(&s, "daemon:"), s)
+        }
+        Err(ref e) => {
+            eprintln!("    WARNING: uffs.exe failed: {e}");
+            (None, String::new())
+        }
+    };
+    if dump_raw && !stderr.is_empty() {
+        eprintln!("{stderr}");
+    }
+    let rows = count_lines(&out_path);
+    let _ = fs::remove_file(&out_path);
+    Round { wall_ms, daemon_ms, rows }
+}
+
+fn run_cpp(cpp_bin: &str, drive: &str, dump_raw: bool) -> Round {
+    let out_path = tmp_path("cpp", drive);
+    // C++ binary uses freopen() internally — must NOT capture stdout/stderr via
+    // pipe; inherit both so the internal redirect onto --out= works correctly.
+    let t = Instant::now();
+    let status = Command::new(cpp_bin)
+        .args([
+            "*",
+            &format!("--drives={drive}"),
+            "--columns=path",
+            &format!("--out={}", out_path.display()),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status();
+    let wall_ms = t.elapsed().as_millis() as u64;
+    if dump_raw {
+        let code = status.map(|s| s.code().unwrap_or(-1)).unwrap_or(-1);
+        eprintln!("    [cpp exit: {code}]");
+    }
+    let rows = count_lines(&out_path);
+    let _ = fs::remove_file(&out_path);
+    Round { wall_ms, daemon_ms: None, rows }
+}
+
+// ── Statistics ────────────────────────────────────────────────────────────────
+
+fn p50(values: &[u64]) -> u64 {
+    if values.is_empty() {
+        return 0;
+    }
+    let mut s = values.to_vec();
+    s.sort_unstable();
+    let mid = s.len() / 2;
+    if s.len() % 2 == 1 {
+        s[mid]
+    } else {
+        (s[mid - 1] + s[mid]) / 2
+    }
+}
+
+// ── Formatting ────────────────────────────────────────────────────────────────
+
+fn fmt_count(n: u64) -> String {
+    // Insert thousands separators.
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out.chars().rev().collect()
+}
+
+fn opt_count(n: Option<u64>) -> String {
+    n.map(fmt_count).unwrap_or_else(|| "n/a".to_owned())
+}
+
+fn opt_ms(n: Option<u64>) -> String {
+    n.map(|v| format!("{v} ms")).unwrap_or_else(|| "n/a".to_owned())
+}
+
+fn now_str() -> String {
+    // No chrono dep: use the OS time via a simple epoch calculation.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let (s, m, h, d, mo, y) = epoch_to_ymd_hms(secs);
+    format!("{y}-{mo:02}-{d:02} {h:02}:{m:02}:{s:02} UTC")
+}
+
+fn epoch_to_ymd_hms(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    let days = secs / 86_400;
+    // Tomohiko Sakamoto's algorithm (Jan 1 1970 = day 0).
+    let mut y = 1970u64;
+    let mut remaining = days;
+    loop {
+        let leap = (y % 4 == 0 && y % 100 != 0) || y % 400 == 0;
+        let days_in_year = if leap { 366 } else { 365 };
+        if remaining < days_in_year {
+            break;
+        }
+        remaining -= days_in_year;
+        y += 1;
+    }
+    let leap = (y % 4 == 0 && y % 100 != 0) || y % 400 == 0;
+    let month_days: [u64; 12] = [31, if leap { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut mo = 1u64;
+    for days_in_month in month_days {
+        if remaining < days_in_month {
+            break;
+        }
+        remaining -= days_in_month;
+        mo += 1;
+    }
+    (s, m, h, remaining + 1, mo, y)
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+fn main() {
+    let args = Args::parse();
+
+    // Binary resolution.
+    let (uffs_bin, uffs_src) = resolve_uffs(args.uffs_bin.as_deref());
+    let (cpp_bin, cpp_src) = resolve_cpp(args.cpp_bin.as_deref());
+
+    let mut out = Out::open(args.output_file.as_deref());
+
+    // ── Preflight header ───────────────────────────────────────────────────
+    out.divider(&format!("UFFS per-drive parity benchmark  —  {}", now_str()));
+    out.line(&format!("  uffs.exe     : {uffs_bin}"));
+    out.line(&format!("  uffs.exe src : {uffs_src}"));
+    if args.skip_cpp {
+        out.line("  uffs.com     : (--skip-cpp)");
+    } else {
+        out.line(&format!("  uffs.com     : {cpp_bin}"));
+        out.line(&format!("  uffs.com src : {cpp_src}"));
+    }
+    out.line(&format!("  drives       : {}", args.drives.join(", ")));
+    out.line(&format!("  rounds/drive : {}", args.rounds));
+    out.line(&format!("  purge-cache  : {}", args.purge_cache));
+    out.line(&format!("  cache dir    : {}", uffs_cache_dir().display()));
+    out.line("");
+
+    // Verify uffs.exe (required).
+    if !binary_available(&uffs_bin) {
+        print_missing_uffs_error(&uffs_bin, &uffs_src);
+        std::process::exit(1);
+    }
+    if let Ok(o) = Command::new(&uffs_bin).arg("--version").output() {
+        out.line(&format!("  {}", String::from_utf8_lossy(&o.stdout).trim()));
+    }
+
+    // Verify uffs.com (optional).
+    let cpp_available = !args.skip_cpp && {
+        let avail = binary_available(&cpp_bin);
+        if !avail {
+            print_missing_cpp_warning(&cpp_bin, &cpp_src);
+        } else if let Ok(o) = Command::new(&cpp_bin).arg("--version").output() {
+            out.line(&format!("  {}", String::from_utf8_lossy(&o.stdout).trim()));
+        }
+        avail
+    };
+
+    // ── Phase 0a: optional cache purge ─────────────────────────────────────
+    if args.purge_cache {
+        out.divider("Phase 0a: stop daemon + purge all drive caches (true COLD)");
+        out.line("  Stopping daemon …");
+        stop_daemon(&uffs_bin);
+        let cdir = uffs_cache_dir();
+        for drive in &args.drives {
+            out.line(&format!("  Purging cache for {drive}: …"));
+            purge_drive_cache(&cdir, drive, args.dump_raw);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(args.sleep_ms));
+    }
+
+    // ── Phase 0b: daemon warm-up ───────────────────────────────────────────
+    out.divider("Phase 0b: daemon warm-up — load all drives");
+    out.line("  Spawning daemon via `uffs * --limit 1 --profile` …");
+    let (warmup_wall, warmup_ready_ms, warmup_records) =
+        warmup_daemon(&uffs_bin, args.dump_raw);
+    out.line(&format!(
+        "    -> wall = {:.2} s   await_ready = {}   total_records = {}",
+        warmup_wall,
+        opt_ms(warmup_ready_ms),
+        opt_count(warmup_records),
+    ));
+    out.line(&format!(
+        "  Mode: {}",
+        if args.purge_cache {
+            "COLD — cache purged before warm-up"
+        } else {
+            "WARM — pre-existing cache reused (use --purge-cache for COLD)"
+        }
+    ));
+    std::thread::sleep(std::time::Duration::from_millis(args.sleep_ms));
+
+    // ── Phase 1: per-drive loop ────────────────────────────────────────────
+
+    struct DriveRow {
+        drive: String,
+        rust_p50: u64,
+        rust_daemon_p50: Option<u64>,
+        rust_rows: Option<u64>,
+        cpp_p50: Option<u64>,
+        cpp_rows: Option<u64>,
+    }
+
+    let mut table: Vec<DriveRow> = Vec::new();
+
+    for drive in &args.drives {
+        out.divider(&format!(
+            "Drive {drive}:  — {} round(s) per tool",
+            args.rounds
+        ));
+
+        // Rust HOT rounds.
+        let mut rust_walls: Vec<u64> = Vec::new();
+        let mut rust_daemons: Vec<u64> = Vec::new();
+        let mut rust_rows_r1: Option<u64> = None;
+
+        for r in 1..=args.rounds {
+            out.line(&format!(
+                "  [Rust HOT {r}/{}]  uffs.exe '*' --drive {drive} \
+                 --out <tmp> --columns Path --hide-system --hide-ads --profile",
+                args.rounds
+            ));
+            let res = run_uffs_hot(&uffs_bin, drive, args.dump_raw);
+            out.line(&format!(
+                "    -> wall = {} ms   daemon = {}   rows = {}",
+                res.wall_ms,
+                opt_ms(res.daemon_ms),
+                opt_count(res.rows),
+            ));
+            if r == 1 {
+                rust_rows_r1 = res.rows;
+            }
+            rust_walls.push(res.wall_ms);
+            if let Some(dm) = res.daemon_ms {
+                rust_daemons.push(dm);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(args.sleep_ms));
+        }
+
+        let rust_p50 = p50(&rust_walls);
+        let rust_daemon_p50 = if rust_daemons.is_empty() {
+            None
+        } else {
+            Some(p50(&rust_daemons))
+        };
+
+        // C++ MFT-reread rounds.
+        let mut cpp_walls: Vec<u64> = Vec::new();
+        let mut cpp_rows_r1: Option<u64> = None;
+
+        if cpp_available {
+            for r in 1..=args.rounds {
+                out.line(&format!(
+                    "  [C++ MFT-reread {r}/{}]  uffs.com '*' --drives={drive} \
+                     --columns=path --out=<tmp>",
+                    args.rounds
+                ));
+                let res = run_cpp(&cpp_bin, drive, args.dump_raw);
+                out.line(&format!(
+                    "    -> wall = {} ms   rows = {}",
+                    res.wall_ms,
+                    opt_count(res.rows),
+                ));
+                if r == 1 {
+                    cpp_rows_r1 = res.rows;
+                }
+                cpp_walls.push(res.wall_ms);
+                std::thread::sleep(std::time::Duration::from_millis(args.sleep_ms));
+            }
+        }
+
+        let cpp_p50 = if cpp_walls.is_empty() {
+            None
+        } else {
+            Some(p50(&cpp_walls))
+        };
+
+        table.push(DriveRow {
+            drive: drive.clone(),
+            rust_p50,
+            rust_daemon_p50,
+            rust_rows: rust_rows_r1,
+            cpp_p50,
+            cpp_rows: cpp_rows_r1,
+        });
+    }
+
+    // ── Summary table 1: parity ────────────────────────────────────────────
+    out.divider(&format!(
+        "Summary — table 1: per-drive parity (wall-clock p50 over {} round(s))",
+        args.rounds
+    ));
+    out.line("| Drive | C++ (MFT re-read) | Rust (daemon HOT) | Speedup | Rust rows | C++ rows |");
+    out.line("|-------|------------------:|------------------:|--------:|----------:|---------:|");
+
+    let mut total_rust_ms: u64 = 0;
+    let mut total_cpp_ms: u64 = 0;
+    let mut any_cpp = false;
+
+    for row in &table {
+        total_rust_ms += row.rust_p50;
+        let speedup = match row.cpp_p50 {
+            Some(c) if row.rust_p50 > 0 => format!("{:.1}x", c as f64 / row.rust_p50 as f64),
+            Some(_) => "n/a".to_owned(),
+            None => "(skipped)".to_owned(),
+        };
+        let cpp_cell = row
+            .cpp_p50
+            .map(|c| {
+                total_cpp_ms += c;
+                any_cpp = true;
+                format!("{c:>7} ms")
+            })
+            .unwrap_or_else(|| "(skipped)".to_owned());
+        out.line(&format!(
+            "| {}: | {cpp_cell} | {:>7} ms | {speedup:>8} | {:>9} | {:>8} |",
+            row.drive,
+            row.rust_p50,
+            opt_count(row.rust_rows),
+            opt_count(row.cpp_rows),
+        ));
+    }
+
+    if any_cpp && total_rust_ms > 0 {
+        let total_speedup = total_cpp_ms as f64 / total_rust_ms as f64;
+        out.line(&format!(
+            "| **TOTAL** | **{total_cpp_ms:>7} ms** | **{total_rust_ms:>7} ms** \
+             | **{total_speedup:.1}x** | — | — |"
+        ));
+    } else {
+        out.line(&format!(
+            "| **TOTAL (Rust sum)** | — | **{total_rust_ms:>7} ms** | — | — | — |"
+        ));
+    }
+
+    // ── Summary table 2: Rust daemon breakdown ─────────────────────────────
+    out.divider("Summary — table 2: Rust wall vs daemon breakdown");
+    out.line("| Drive | Rust rows | Rust wall p50 | Rust daemon p50 | CLI overhead |");
+    out.line("|-------|----------:|--------------:|----------------:|-------------:|");
+    for row in &table {
+        let overhead = row.rust_daemon_p50.map(|dm| {
+            let ov = row.rust_p50.saturating_sub(dm);
+            format!("{ov:>5} ms")
+        });
+        out.line(&format!(
+            "| {}: | {:>9} | {:>9} ms | {:>11} | {:>12} |",
+            row.drive,
+            opt_count(row.rust_rows),
+            row.rust_p50,
+            row.rust_daemon_p50
+                .map(|d| format!("{d:>5} ms"))
+                .unwrap_or_else(|| "    n/a".to_owned()),
+            overhead.unwrap_or_else(|| "    n/a".to_owned()),
+        ));
+    }
+    out.line("");
+    out.line("  Legend:");
+    out.line("    Rust wall p50    = process wall-clock from spawn to exit (Rust Instant).");
+    out.line("    Rust daemon p50  = daemon-reported search duration (--profile 'daemon: N ms').");
+    out.line("    CLI overhead     = wall − daemon  (process start + IPC + file write).");
+    out.line("    C++ has no daemon — its wall-clock IS its total cost (full MFT re-read every run).");
+
+    // ── Warm-up recap ──────────────────────────────────────────────────────
+    out.divider("Summary — daemon warm-up (Phase 0b)");
+    out.line(&format!("  Wall-clock    : {:.2} s", warmup_wall));
+    if let Some(rm) = warmup_ready_ms {
+        out.line(&format!(
+            "  Await ready   : {rm} ms  (daemon spawn + MFT load + index build)"
+        ));
+    }
+    if let Some(rec) = warmup_records {
+        out.line(&format!("  Total records : {}", fmt_count(rec)));
+    }
+    out.line(&format!(
+        "  Mode          : {}",
+        if args.purge_cache { "COLD" } else { "WARM" }
+    ));
+
+    out.divider("Done");
+    if let Some(path) = &args.output_file {
+        println!("Full log written to: {path}");
+    }
+}

--- a/scripts/windows/cold-parity-per-drive.rs
+++ b/scripts/windows/cold-parity-per-drive.rs
@@ -20,10 +20,14 @@
 //!
 //! # Sequence
 //!
-//!   1. (`--purge-cache`) Stop daemon, remove drive cache files — re-measures
-//!      the one-time cold daemon warm-up path.
-//!   2. Warm-up: `uffs * --limit 1 --profile` auto-spawns the daemon and loads
-//!      every drive; records wall-clock warm-up time.
+//!   1. Kill the running daemon and restart it with the requested `--drives`
+//!      (or with no filter so it auto-discovers all system drives when none
+//!      are given).  This ensures every run starts from a known COLD state.
+//!      If `--purge-cache` is also set the on-disk cache files are deleted
+//!      before the restart, forcing a true MFT re-read on first load.
+//!   2. Warm-up: issue `uffs * --limit 1 --profile` **three times** so the
+//!      daemon moves through its load path (pass 1) then fully primes its
+//!      JIT query state (passes 2-3).  Pass-1 wall + `await_ready` reported.
 //!   3. Per-drive loop (`--rounds` iterations each):
 //!        UFFS Rust HOT:  `uffs.exe '*' --drive X --out <tmp> --columns Path
 //!                         --profile`
@@ -385,13 +389,29 @@ fn purge_drive_cache(cache_dir: &PathBuf, drive: &str, dump_raw: bool) {
 
 // ── Daemon helpers ────────────────────────────────────────────────────────────
 
-fn stop_daemon(uffs_bin: &str) {
+/// Kill any running daemon and start a fresh one with the given drives.
+/// If `drives` is empty the daemon auto-discovers all system drives.
+/// Sleeps briefly after kill to let the OS release socket / named-pipe handles.
+fn kill_and_restart_daemon(uffs_bin: &str, drives: &[String]) {
     let _ = Command::new(uffs_bin)
         .args(["daemon", "kill"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
-    std::thread::sleep(std::time::Duration::from_millis(800));
+    std::thread::sleep(std::time::Duration::from_millis(1_200));
+    let mut start_args: Vec<&str> = vec!["daemon", "start"];
+    let drive_flags: Vec<String> = drives
+        .iter()
+        .flat_map(|d| ["--drive".to_owned(), d.clone()])
+        .collect();
+    for s in &drive_flags {
+        start_args.push(s.as_str());
+    }
+    let _ = Command::new(uffs_bin)
+        .args(&start_args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
 }
 
 fn daemon_total_records(uffs_bin: &str) -> Option<u64> {
@@ -409,27 +429,41 @@ fn daemon_total_records(uffs_bin: &str) -> Option<u64> {
     None
 }
 
-/// Auto-spawn daemon via `uffs * --limit 1 --profile` and wait for completion.
-/// Returns `(wall_sec, await_ready_ms, total_records)`.
-fn warmup_daemon(uffs_bin: &str, dump_raw: bool) -> (f64, Option<u64>, Option<u64>) {
-    let t = Instant::now();
-    let result = Command::new(uffs_bin)
-        .args(["*", "--limit", "1", "--profile"])
-        .output();
-    let wall_sec = t.elapsed().as_secs_f64();
-    let stderr = match result {
-        Ok(ref o) => String::from_utf8_lossy(&o.stderr).into_owned(),
-        Err(ref e) => {
-            eprintln!("    WARNING: warm-up failed: {e}");
-            return (wall_sec, None, None);
+/// Prime the daemon with three `uffs * --limit 1 --profile` queries.
+///
+/// The first call triggers the initial load + JIT index warm-up (the slow
+/// path).  Calls 2 and 3 exercise the HOT path and get the daemon into its
+/// fully-primed query state.  We report the wall-clock of the **first** call
+/// as the load time and `await_ready` from its stderr; the final record count
+/// is read once after all three queries settle.
+///
+/// Returns `(load_wall_sec, await_ready_ms, total_records)`.
+fn warmup_daemon_primed(uffs_bin: &str, dump_raw: bool) -> (f64, Option<u64>, Option<u64>) {
+    let mut load_wall = 0.0f64;
+    let mut ready_ms = None;
+    for pass in 1u8..=3 {
+        let t = Instant::now();
+        let result = Command::new(uffs_bin)
+            .args(["*", "--limit", "1", "--profile"])
+            .output();
+        let elapsed = t.elapsed().as_secs_f64();
+        let stderr = match result {
+            Ok(ref o) => String::from_utf8_lossy(&o.stderr).into_owned(),
+            Err(ref e) => {
+                eprintln!("    WARNING: warm-up pass {pass} failed: {e}");
+                continue;
+            }
+        };
+        if dump_raw {
+            eprintln!("    [warm-up pass {pass}] {stderr}");
         }
-    };
-    if dump_raw {
-        eprintln!("{stderr}");
+        if pass == 1 {
+            load_wall = elapsed;
+            ready_ms = parse_tagged_ms(&stderr, "Await ready:");
+        }
     }
-    let ready_ms = parse_tagged_ms(&stderr, "Await ready:");
     let records = daemon_total_records(uffs_bin);
-    (wall_sec, ready_ms, records)
+    (load_wall, ready_ms, records)
 }
 
 fn parse_tagged_ms(text: &str, marker: &str) -> Option<u64> {
@@ -673,26 +707,47 @@ fn main() {
         avail
     };
 
-    // ── Phase 0a: optional cache purge ─────────────────────────────────────
-    if args.purge_cache {
-        out.divider("Phase 0a: stop daemon + purge all drive caches (true COLD)");
-        out.line("  Stopping daemon …");
-        stop_daemon(&uffs_bin);
-        let cdir = uffs_cache_dir();
-        for drive in &args.drives {
-            out.line(&format!("  Purging cache for {drive}: …"));
-            purge_drive_cache(&cdir, drive, args.dump_raw);
+    // ── Phase 0a: kill + (optional cache purge) + restart daemon ──────────
+    {
+        let drives_label = if args.drives.is_empty() {
+            "(auto-discover all)".to_owned()
+        } else {
+            args.drives.join(", ")
+        };
+        let phase_title = if args.purge_cache {
+            format!("Phase 0a: kill + purge caches + restart  [{drives_label}]  (true COLD)")
+        } else {
+            format!("Phase 0a: kill + restart daemon  [{drives_label}]")
+        };
+        out.divider(&phase_title);
+        if args.purge_cache {
+            out.line("  Killing daemon …");
+            let cdir = uffs_cache_dir();
+            for drive in &args.drives {
+                out.line(&format!("  Purging cache for {drive}: …"));
+                purge_drive_cache(&cdir, drive, args.dump_raw);
+            }
+        } else {
+            out.line("  Killing daemon …");
         }
+        kill_and_restart_daemon(&uffs_bin, &args.drives);
+        let drives_hint = if args.drives.is_empty() {
+            "all drives (auto-discovered)"
+        } else {
+            "requested drives"
+        };
+        out.line(&format!("  Daemon restarted with {drives_hint}."));
         std::thread::sleep(std::time::Duration::from_millis(args.sleep_ms));
     }
 
-    // ── Phase 0b: daemon warm-up ───────────────────────────────────────────
-    out.divider("Phase 0b: daemon warm-up — load all drives");
-    out.line("  Spawning daemon via `uffs * --limit 1 --profile` …");
+    // ── Phase 0b: daemon warm-up (3 priming passes) ────────────────────────
+    out.divider("Phase 0b: daemon warm-up — 3 priming passes");
+    out.line("  Pass 1: load path + await_ready (COLD).  Passes 2-3: prime HOT query state.");
+    out.line("  Running `uffs '*' --limit 1 --profile`  ×3 …");
     let (warmup_wall, warmup_ready_ms, warmup_records) =
-        warmup_daemon(&uffs_bin, args.dump_raw);
+        warmup_daemon_primed(&uffs_bin, args.dump_raw);
     out.line(&format!(
-        "    -> wall = {:.2} s   await_ready = {}   total_records = {}",
+        "    -> pass-1 wall = {:.2} s   await_ready = {}   total_records = {}",
         warmup_wall,
         opt_ms(warmup_ready_ms),
         opt_count(warmup_records),
@@ -700,9 +755,9 @@ fn main() {
     out.line(&format!(
         "  Mode: {}",
         if args.purge_cache {
-            "COLD — cache purged before warm-up"
+            "COLD — daemon restarted from scratch, cache files purged"
         } else {
-            "WARM — pre-existing cache reused (use --purge-cache for COLD)"
+            "COLD — daemon restarted (on-disk cache retained for faster load)"
         }
     ));
     std::thread::sleep(std::time::Duration::from_millis(args.sleep_ms));
@@ -910,18 +965,20 @@ fn main() {
 
     // ── Warm-up recap ──────────────────────────────────────────────────────
     out.divider("Summary — daemon warm-up (Phase 0b)");
-    out.line(&format!("  Wall-clock    : {:.2} s", warmup_wall));
+    out.line(&format!("  Pass-1 wall   : {:.2} s  (daemon load + await_ready)", warmup_wall));
     if let Some(rm) = warmup_ready_ms {
-        out.line(&format!(
-            "  Await ready   : {rm} ms  (daemon spawn + MFT load + index build)"
-        ));
+        out.line(&format!("  Await ready   : {rm} ms  (MFT read + index build)"));
     }
     if let Some(rec) = warmup_records {
         out.line(&format!("  Total records : {}", fmt_count(rec)));
     }
     out.line(&format!(
         "  Mode          : {}",
-        if args.purge_cache { "COLD" } else { "WARM" }
+        if args.purge_cache {
+            "COLD (daemon restarted, cache purged — true MFT re-read)"
+        } else {
+            "COLD (daemon restarted, on-disk cache retained for faster load)"
+        }
     ));
 
     out.divider("Done");

--- a/scripts/windows/cold-parity-per-drive.rs
+++ b/scripts/windows/cold-parity-per-drive.rs
@@ -392,6 +392,11 @@ fn purge_drive_cache(cache_dir: &PathBuf, drive: &str, dump_raw: bool) {
 /// Kill any running daemon and start a fresh one with the given drives.
 /// If `drives` is empty the daemon auto-discovers all system drives.
 /// Sleeps briefly after kill to let the OS release socket / named-pipe handles.
+///
+/// The daemon is started with extended idle-demote TTLs so it stays HOT
+/// for the entire bench run without spurious Hot→Warm or Warm→Parked demotes:
+///   `UFFS_HOT_TO_WARM_IDLE_SECS=3600`   (1 hr — default 10 min)
+///   `UFFS_WARM_TO_PARKED_IDLE_SECS=7200` (2 hr — default 30 min)
 fn kill_and_restart_daemon(uffs_bin: &str, drives: &[String]) {
     let _ = Command::new(uffs_bin)
         .args(["daemon", "kill"])
@@ -409,6 +414,8 @@ fn kill_and_restart_daemon(uffs_bin: &str, drives: &[String]) {
     }
     let _ = Command::new(uffs_bin)
         .args(&start_args)
+        .env("UFFS_HOT_TO_WARM_IDLE_SECS", "3600")
+        .env("UFFS_WARM_TO_PARKED_IDLE_SECS", "7200")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();

--- a/scripts/windows/competitors.toml
+++ b/scripts/windows/competitors.toml
@@ -20,7 +20,17 @@
 [everything]
 # The canonical Everything CLI version cited by the README and the published
 # head-to-head reports (docs/benchmarks/). This is the one pinned number.
+#
+# NOTE: es.exe is a thin IPC wrapper around the Everything GUI daemon. The
+# daemon version determines search behaviour and performance. Always run
+# benchmarks with the engine version documented here installed and running.
+# Latest GUI stable as of 2026-06-07: 1.4.1.1032
+# (https://www.voidtools.com/Everything-1.4.1.1032.x64-Setup.exe)
 version = "1.1.0.30"
+# Everything GUI daemon version used in published benchmark results.
+# es.exe queries this daemon over IPC; the engine version is part of the
+# benchmark environment and must be documented alongside the CLI version.
+engine_version = "1.4.1.1032"
 # Upstream download (command-line `es.exe` distribution). Link only.
 es_url = "https://www.voidtools.com/ES-1.1.0.30.x64.zip"
 # Hex SHA-256 of the downloaded artifact. Operator pastes the upstream hash;

--- a/scripts/windows/cross-tool-benchmark.rs
+++ b/scripts/windows/cross-tool-benchmark.rs
@@ -238,6 +238,24 @@ fn p50(s: &[u64]) -> u64 { if s.is_empty() { 0 } else { s[s.len()/2] } }
 fn p95(s: &[u64]) -> u64 { if s.is_empty() { 0 } else { s[(s.len() as f64 * 0.95) as usize % s.len()] } }
 fn sw(runs: &[Timing]) -> Vec<u64> { let mut v: Vec<u64> = runs.iter().filter(|r| r.ok).map(|r| r.wall_ms).collect(); v.sort(); v }
 
+/// Shuffle three indices [0,1,2] using a minimal LCG seeded from a nanosecond
+/// timestamp.  No external deps — works inside `rust-script` with zero cargo
+/// overhead.  The LCG constants are the same ones used by glibc's `rand()`.
+fn lcg_shuffle3(seed: u64) -> [usize; 3] {
+    let mut s = seed ^ (seed >> 33);
+    let mut next = || -> u64 {
+        s = s.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1_442_695_040_888_963_407);
+        s
+    };
+    let mut idx = [0usize, 1, 2];
+    // Fisher-Yates on 3 elements
+    let j = (next() % 3) as usize;
+    idx.swap(0, j);
+    let j = 1 + (next() % 2) as usize;
+    idx.swap(1, j);
+    idx
+}
+
 // ── Discovery ────────────────────────────────────────────────────────────────
 fn find_in(cs: &[PathBuf]) -> Option<PathBuf> { cs.iter().find(|p| p.exists()).cloned() }
 fn where_exe(name: &str) -> Option<PathBuf> {
@@ -880,111 +898,173 @@ fn main() {
             eprintln!(" ready.");
         }
 
-        // ── Per-sink HOT rotation (UFFS HOT + UFFS C++ + Everything) ──────
+        // ── Per-sink HOT rotation (interleaved rounds, randomised tool order) ─
+        //
+        // For each (sink, pattern) the tools run in a freshly shuffled order
+        // every round so no tool consistently benefits from OS file-system
+        // caching warmed up by a prior tool.  After every round the superset
+        // constraint is checked immediately:
+        //
+        //   uffs.exe rows  ≥  uffs.com rows  ≥  es.exe rows
+        //
+        // This reflects the fact that UFFS (Rust) covers all files including
+        // system files / ADS when --hide-system / --hide-ads are NOT passed
+        // (here they ARE, so the counts should be close), and that Everything
+        // does not index NTFS metadata files that uffs.com does include.
+        // A violation is printed as a warning per round — it does not abort —
+        // so timing data is preserved even when parity is off.
         for sink in cfg.sinks.iter().copied() {
             if cfg.sinks.len() > 1 {
                 println!("  ── sink={}  ──────────────────────────────────────────────", sink.label());
             }
 
-            // ── UFFS HOT ────────────────────────────────────────────────
-            if cfg.tools.contains(&Tool::Uffs) {
-                eprintln!("  UFFS HOT [sink={}]:  {} rounds", sink.label(), cfg.rounds);
-                for &(label, pat, _, _, _, validate) in PATTERNS {
-                    if cfg.skip_pattern(label) { continue; }
-                    eprint!("    {label:<12} ");  flush();
-                    let mut runs = Vec::new();
-                    for _ in 0..cfg.rounds {
-                        runs.push(check_dnf(run_uffs(&cfg.uffs, drive, pat, validate, sink)));
-                    }
-                    let s = sw(&runs);
-                    let mut dm: Vec<u64> = runs.iter().filter(|r| r.ok && r.daemon_ms > 0).map(|r| r.daemon_ms).collect();
-                    dm.sort();
-                    let any_bad = runs.iter().any(|r| r.bad_rows > 0);
-                    let verdict = if runs.iter().any(|r| r.dnf) { "DNF" } else if any_bad { "WRONG" } else { "PASS" };
-                    let daemon_str = if dm.is_empty() { String::new() } else { format!("  daemon_p50={}", fms(p50(&dm))) };
-                    let first_ok = runs.iter().find(|r| r.ok);
-                    let bad_str = first_ok.filter(|r| r.bad_rows > 0).map_or(String::new(), |r| format!("  bad={}", r.bad_rows));
-                    eprintln!("p50={:>6}  p95={:>6}{}  rows={}{}  {}", fms(p50(&s)), fms(p95(&s)), daemon_str, first_ok.map_or(0, |r| r.rows), bad_str, verdict);
-                    all_rows.push(Row { tool: Tool::Uffs, phase: Phase::Hot, sink,
-                        drive: drive.clone(), pat: label.into(), runs });
-                }
-            }
+            for &(label, pat, es_pat, cpp_pat, cpp_ext, validate) in PATTERNS {
+                if cfg.skip_pattern(label) { continue; }
 
-            // ── UFFS C++ (uffs.com) ─────────────────────────────────────
-            if cfg.tools.contains(&Tool::UffsCpp) {
-                if let Some(ref cpp) = cfg.uffs_cpp {
-                    eprintln!("  UFFS C++ (MFT re-read, no --limit) [sink={}]:  {} rounds",
-                        sink.label(), cfg.rounds);
-                    for &(label, _, _, cpp_pat, cpp_ext, validate) in PATTERNS {
-                        if cfg.skip_pattern(label) { continue; }
-                        if cpp_pat.is_empty() {
-                            eprintln!("    {label:<12} SKIP (C++ does not support this pattern)");
-                            continue;
-                        }
-                        eprint!("    {label:<12} ");  flush();
-                        let mut runs = Vec::new();
-                        for _ in 0..cfg.rounds {
-                            runs.push(check_dnf(run_uffs_cpp(cpp, drive, cpp_pat, cpp_ext, validate, sink)));
-                        }
-                        let s = sw(&runs);
-                        let first_ok = runs.iter().find(|r| r.ok);
-                        let any_bad = runs.iter().any(|r| r.bad_rows > 0);
-                        let verdict = if runs.iter().any(|r| r.dnf) { "DNF" } else if any_bad { "WRONG" } else if runs.iter().all(|r| r.ok) { "PASS" } else { "ERROR" };
-                        let bad_str = first_ok.filter(|r| r.bad_rows > 0).map_or(String::new(), |r| format!("  bad={}", r.bad_rows));
-                        eprintln!("p50={:>6}  p95={:>6}  rows={}{}  {}", fms(p50(&s)), fms(p95(&s)), first_ok.map_or(0, |r| r.rows), bad_str, verdict);
-                        all_rows.push(Row { tool: Tool::UffsCpp, phase: Phase::Hot, sink,
-                            drive: drive.clone(), pat: label.into(), runs });
-                    }
-                }
-            }
+                // Skip full_scan for Everything (2GB IPC ceiling).
+                let es_skip = label == "full_scan";
+                // Skip patterns C++ does not support.
+                let cpp_skip = cpp_pat.is_empty();
 
-            // ── Everything ──────────────────────────────────────────────
-            if cfg.tools.contains(&Tool::Everything) {
-                if let Some(ref es) = cfg.es {
-                    eprintln!("  Everything HOT [sink={}]:  {} rounds (always-hot, daemon model)",
-                        sink.label(), cfg.rounds);
-                    for &(label, _, es_pat, _, _, validate) in PATTERNS {
-                        if cfg.skip_pattern(label) { continue; }
-                        // Skip full_scan for Everything — es.exe has a 2GB IPC
-                        // memory limit that crashes on drives with >2M entries.
-                        // See verify_parity.rs and Everything 1.4 known limitation.
-                        if label == "full_scan" {
-                            eprintln!("    {label:<12} SKIP (es.exe 2GB IPC limit)");
-                            continue;
-                        }
-                        eprint!("    {label:<12} ");  flush();
-                        let mut runs = Vec::new();
-                        let mut aborted_early = false;
-                        for round in 0..cfg.rounds {
-                            let t = check_dnf(run_es(es, drive, es_pat, validate, sink, cfg.es_instance.as_deref()));
-                            // If round 0 is a fast deterministic failure (e.g.
-                            // es.exe -export-csv IPC buffer overflow on result
-                            // sets past the ~150 K-row ceiling), the next 29
-                            // rounds will repeat the same exit code in the same
-                            // ~50 ms.  Short-circuit and mark the verdict as
-                            // ERROR; the summary table will still show the
-                            // observed (failing) run with rows=0.
-                            let abort = round == 0 && is_fast_deterministic_fail(&t);
-                            runs.push(t);
-                            if abort {
-                                aborted_early = true;
-                                break;
+                let run_uffs_tool  = cfg.tools.contains(&Tool::Uffs);
+                let run_cpp_tool   = cfg.tools.contains(&Tool::UffsCpp) && cfg.uffs_cpp.is_some() && !cpp_skip;
+                let run_es_tool    = cfg.tools.contains(&Tool::Everything) && cfg.es.is_some() && !es_skip;
+
+                if !run_uffs_tool && !run_cpp_tool && !run_es_tool { continue; }
+
+                eprintln!("  HOT [{sink}] {label:<12}  {} rounds  (tools shuffled each round)",
+                    cfg.rounds, sink = sink.label());
+
+                let mut uffs_runs: Vec<Timing> = Vec::new();
+                let mut cpp_runs:  Vec<Timing> = Vec::new();
+                let mut es_runs:   Vec<Timing> = Vec::new();
+                let mut es_aborted = false;
+
+                for round in 0..cfg.rounds {
+                    // Fresh random tool order every round — seeded from wall clock
+                    // nanoseconds so consecutive rounds get different seeds.
+                    let seed = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.subsec_nanos() as u64 + round as u64 * 1_000_000_007)
+                        .unwrap_or(round as u64 + 1);
+                    let order = lcg_shuffle3(seed);
+
+                    // Collect (tool_id, timing) for this round so we can do the
+                    // superset check right after all three fire.
+                    let mut round_rows: [Option<u64>; 3] = [None; 3]; // [uffs, cpp, es]
+
+                    for &slot in &order {
+                        match slot {
+                            0 if run_uffs_tool => {
+                                let t = check_dnf(run_uffs(&cfg.uffs, drive, pat, validate, sink));
+                                round_rows[0] = t.ok.then_some(t.rows);
+                                uffs_runs.push(t);
                             }
+                            1 if run_cpp_tool => {
+                                let cpp = cfg.uffs_cpp.as_ref().unwrap();
+                                let t = check_dnf(run_uffs_cpp(cpp, drive, cpp_pat, cpp_ext, validate, sink));
+                                round_rows[1] = t.ok.then_some(t.rows);
+                                cpp_runs.push(t);
+                            }
+                            2 if run_es_tool && !es_aborted => {
+                                let es = cfg.es.as_ref().unwrap();
+                                let t = check_dnf(run_es(es, drive, es_pat, validate, sink, cfg.es_instance.as_deref()));
+                                // Fast deterministic failure on round 0 → abort es for this pattern.
+                                if round == 0 && is_fast_deterministic_fail(&t) {
+                                    eprintln!("    [round {round}] es.exe fast-fail (exit={:?}); skipping remaining es rounds", t.err);
+                                    es_aborted = true;
+                                }
+                                round_rows[2] = t.ok.then_some(t.rows);
+                                es_runs.push(t);
+                            }
+                            _ => {}
                         }
-                        let s = sw(&runs);
-                        let first_ok = runs.iter().find(|r| r.ok);
-                        let any_bad = runs.iter().any(|r| r.bad_rows > 0);
-                        let verdict = if runs.iter().any(|r| r.dnf) { "DNF" } else if any_bad { "WRONG" } else if runs.iter().all(|r| r.ok) { "PASS" } else { "ERROR" };
-                        let bad_str = first_ok.filter(|r| r.bad_rows > 0).map_or(String::new(), |r| format!("  bad={}", r.bad_rows));
-                        let abort_str = if aborted_early {
-                            format!("  (fast-fail, skipped {} rounds)", cfg.rounds - 1)
-                        } else { String::new() };
-                        eprintln!("p50={:>6}  p95={:>6}  rows={}{}  {}{}",
-                            fms(p50(&s)), fms(p95(&s)), first_ok.map_or(0, |r| r.rows),
-                            bad_str, verdict, abort_str);
-                        all_rows.push(Row { tool: Tool::Everything, phase: Phase::Hot, sink,
-                            drive: drive.clone(), pat: label.into(), runs });
                     }
+
+                    // ── Superset check after every round ──────────────────
+                    // uffs.exe ≥ uffs.com  (both index same MFT, uffs.exe has parity filters)
+                    // uffs.exe ≥ es.exe    (Everything skips system/ADS files)
+                    // uffs.com ≥ es.exe    (C++ also includes system files)
+                    let mut violations: Vec<String> = Vec::new();
+                    if let (Some(u), Some(c)) = (round_rows[0], round_rows[1]) {
+                        if u < c {
+                            violations.push(format!("uffs({u}) < cpp({c})"));
+                        }
+                    }
+                    if let (Some(u), Some(e)) = (round_rows[0], round_rows[2]) {
+                        if u < e {
+                            violations.push(format!("uffs({u}) < es({e})"));
+                        }
+                    }
+                    if let (Some(c), Some(e)) = (round_rows[1], round_rows[2]) {
+                        if c < e {
+                            violations.push(format!("cpp({c}) < es({e})"));
+                        }
+                    }
+                    let round_order_labels: Vec<&str> = order.iter().map(|&s| match s {
+                        0 => "uffs", 1 => "cpp", 2 => "es", _ => "?"
+                    }).collect();
+                    if violations.is_empty() {
+                        eprintln!("    [round {:>2}] order=[{}]  rows: uffs={} cpp={} es={}  ✓ superset ok",
+                            round + 1,
+                            round_order_labels.join(","),
+                            round_rows[0].map_or("-".into(), |n| n.to_string()),
+                            round_rows[1].map_or("-".into(), |n| n.to_string()),
+                            round_rows[2].map_or("-".into(), |n| n.to_string()),
+                        );
+                    } else {
+                        eprintln!("    [round {:>2}] order=[{}]  rows: uffs={} cpp={} es={}  ⚠ SUPERSET VIOLATION: {}",
+                            round + 1,
+                            round_order_labels.join(","),
+                            round_rows[0].map_or("-".into(), |n| n.to_string()),
+                            round_rows[1].map_or("-".into(), |n| n.to_string()),
+                            round_rows[2].map_or("-".into(), |n| n.to_string()),
+                            violations.join(", "),
+                        );
+                    }
+                }
+
+                // ── Per-tool summary lines ────────────────────────────────
+                if run_uffs_tool && !uffs_runs.is_empty() {
+                    let s = sw(&uffs_runs);
+                    let mut dm: Vec<u64> = uffs_runs.iter().filter(|r| r.ok && r.daemon_ms > 0).map(|r| r.daemon_ms).collect();
+                    dm.sort();
+                    let daemon_str = if dm.is_empty() { String::new() } else { format!("  daemon_p50={}", fms(p50(&dm))) };
+                    let any_bad = uffs_runs.iter().any(|r| r.bad_rows > 0);
+                    let verdict = if uffs_runs.iter().any(|r| r.dnf) { "DNF" } else if any_bad { "WRONG" } else { "PASS" };
+                    let first_ok = uffs_runs.iter().find(|r| r.ok);
+                    eprintln!("    UFFS     p50={:>6}  p95={:>6}{}  rows={}  {}",
+                        fms(p50(&s)), fms(p95(&s)), daemon_str,
+                        first_ok.map_or(0, |r| r.rows), verdict);
+                    all_rows.push(Row { tool: Tool::Uffs, phase: Phase::Hot, sink,
+                        drive: drive.clone(), pat: label.into(), runs: uffs_runs });
+                }
+                if run_cpp_tool && !cpp_runs.is_empty() {
+                    let s = sw(&cpp_runs);
+                    let any_bad = cpp_runs.iter().any(|r| r.bad_rows > 0);
+                    let verdict = if cpp_runs.iter().any(|r| r.dnf) { "DNF" } else if any_bad { "WRONG" } else if cpp_runs.iter().all(|r| r.ok) { "PASS" } else { "ERROR" };
+                    let first_ok = cpp_runs.iter().find(|r| r.ok);
+                    eprintln!("    UFFS-C++ p50={:>6}  p95={:>6}  rows={}  {}",
+                        fms(p50(&s)), fms(p95(&s)), first_ok.map_or(0, |r| r.rows), verdict);
+                    all_rows.push(Row { tool: Tool::UffsCpp, phase: Phase::Hot, sink,
+                        drive: drive.clone(), pat: label.into(), runs: cpp_runs });
+                }
+                if run_es_tool && !es_runs.is_empty() {
+                    let s = sw(&es_runs);
+                    let any_bad = es_runs.iter().any(|r| r.bad_rows > 0);
+                    let abort_str = if es_aborted { format!("  (fast-fail, {} rounds)", es_runs.len()) } else { String::new() };
+                    let verdict = if es_runs.iter().any(|r| r.dnf) { "DNF" } else if any_bad { "WRONG" } else if es_runs.iter().all(|r| r.ok) { "PASS" } else { "ERROR" };
+                    let first_ok = es_runs.iter().find(|r| r.ok);
+                    eprintln!("    ES       p50={:>6}  p95={:>6}  rows={}  {}{}",
+                        fms(p50(&s)), fms(p95(&s)), first_ok.map_or(0, |r| r.rows), verdict, abort_str);
+                    all_rows.push(Row { tool: Tool::Everything, phase: Phase::Hot, sink,
+                        drive: drive.clone(), pat: label.into(), runs: es_runs });
+                }
+                if run_es_tool && es_skip {
+                    eprintln!("    {label:<12} ES SKIP (es.exe 2GB IPC limit)");
+                }
+                if run_cpp_tool && cpp_skip {
+                    eprintln!("    {label:<12} C++ SKIP (pattern not supported)");
                 }
             }
         }

--- a/scripts/windows/cross-tool-benchmark.rs
+++ b/scripts/windows/cross-tool-benchmark.rs
@@ -205,6 +205,11 @@ struct Cfg { uffs: PathBuf, uffs_cpp: Option<PathBuf>, es: Option<PathBuf>,
              drives: Vec<String>, rounds: usize,
              tools: Vec<Tool>, sinks: Vec<OutputSink>, skip_cold: bool,
              patterns: Option<Vec<String>>,
+             /// Named Everything instance to connect to via `-instance <name>`.
+             /// When the bench tool launches a private Everything.exe with
+             /// `-instance uffs-bench`, the default IPC window is absent and
+             /// es.exe must be told which instance to query.
+             es_instance: Option<String>,
              /// Optional summary CSV output path.  When `Some`, the post-run
              /// summary (one row per Tool × Phase × Sink × Drive × Pattern
              /// combination, with p50/p95/rows/bad/verdict) is written to
@@ -529,14 +534,22 @@ fn parse_daemon_ms(s: &str) -> u64 {
 /// File sink: `-export-csv <file>`; Stdout sink: default CSV to stdout; Null
 /// sink: default to stdout then redirect via cmd.  No -n limit — all results
 /// are returned.
-fn run_es(bin: &Path, drive: &str, pattern: &str, validate: &str, sink: OutputSink) -> Timing {
+fn run_es(bin: &Path, drive: &str, pattern: &str, validate: &str, sink: OutputSink, es_instance: Option<&str>) -> Timing {
     cleanup_bench_file();
     let bpath = bench_out_path();
     // es.exe expects path filter and search term as SEPARATE arguments:
     //   es.exe "C:\" ext:dll -export-csv file.csv
     // NOT as one combined string.
+    // When a named instance is in use (private bench instance launched with
+    // -instance <name>), prepend -instance <name> so es.exe connects to the
+    // correct IPC window instead of the default one.
     let drive_path = format!("{drive}:\\");
-    let mut args: Vec<String> = vec![drive_path];
+    let mut args: Vec<String> = Vec::new();
+    if let Some(inst) = es_instance {
+        args.push("-instance".into());
+        args.push(inst.into());
+    }
+    args.push(drive_path);
     if pattern != "*" { args.push(pattern.into()); }
     if matches!(sink, OutputSink::File) {
         args.push("-export-csv".into());
@@ -663,6 +676,7 @@ fn parse_args() -> Cfg {
     let mut uffs_bin: Option<PathBuf> = None;
     let mut patterns_filter: Option<Vec<String>> = None;
     let mut out: Option<PathBuf> = None;
+    let mut es_instance: Option<String> = None;
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
@@ -674,6 +688,7 @@ fn parse_args() -> Cfg {
             "--skip-cold" => { skip_cold = true; }
             "--uffs-bin" => { i += 1; uffs_bin = Some(PathBuf::from(&args[i])); }
             "--out" => { i += 1; out = Some(PathBuf::from(&args[i])); }
+            "--es-instance" => { i += 1; es_instance = Some(args[i].clone()); }
             "--help" | "-h" => { print_help(); std::process::exit(0); }
             other => {
                 if other.starts_with('-') {
@@ -707,7 +722,7 @@ fn parse_args() -> Cfg {
         .map(OutputSink::parse_list)
         .filter(|v| !v.is_empty())
         .unwrap_or_else(|| vec![OutputSink::File]);
-    Cfg { uffs, uffs_cpp, es, drives, rounds, tools, sinks, skip_cold, patterns: patterns_filter, out }
+    Cfg { uffs, uffs_cpp, es, drives, rounds, tools, sinks, skip_cold, patterns: patterns_filter, es_instance, out }
 }
 
 fn print_help() {
@@ -727,6 +742,10 @@ fn print_help() {
     eprintln!("                        ext_rare, ext_dll, ext_regex_alt, substring");
     eprintln!("  --skip-cold           Skip UFFS COLD and WARM phases");
     eprintln!("  --uffs-bin <path>     Path to uffs.exe (Rust)");
+    eprintln!("  --es-instance <name>  Connect es.exe to a named Everything instance");
+    eprintln!("                        (passes -instance <name> to every es.exe call).");
+    eprintln!("                        Required when Everything.exe was launched with");
+    eprintln!("                        -instance <name> (e.g. uffs-bench private instance).");
     eprintln!("  --out <path>          Write the post-run summary table to CSV at <path>.");
     eprintln!("                        Columns: tool,phase,sink,drive,pattern,p50_ms,");
     eprintln!("                        p95_ms,rows,bad,verdict,rounds_ok,rounds_total.");
@@ -913,7 +932,7 @@ fn main() {
                         let mut runs = Vec::new();
                         let mut aborted_early = false;
                         for round in 0..cfg.rounds {
-                            let t = check_dnf(run_es(es, drive, es_pat, validate, sink));
+                            let t = check_dnf(run_es(es, drive, es_pat, validate, sink, cfg.es_instance.as_deref()));
                             // If round 0 is a fast deterministic failure (e.g.
                             // es.exe -export-csv IPC buffer overflow on result
                             // sets past the ~150 K-row ceiling), the next 29

--- a/scripts/windows/cross-tool-benchmark.rs
+++ b/scripts/windows/cross-tool-benchmark.rs
@@ -390,6 +390,53 @@ fn count_and_validate(path: &str, needle: &str) -> (u64, u64) {
     (total, bad_lines.len() as u64)
 }
 fn cleanup_bench_file() { let p = bench_out_path(); let _ = std::fs::remove_file(&p); }
+fn cleanup_file(p: &str) { let _ = std::fs::remove_file(p); }
+
+/// Extract the path column from a tool's output file or byte buffer into a
+/// normalised (lowercase, trimmed) set of strings.  Headers, footers, and
+/// empty lines are stripped by `is_header_or_footer` so the set only
+/// contains actual filesystem paths.  Used for path-set superset checks.
+fn extract_paths_from_file(path: &str) -> std::collections::HashSet<String> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => match std::fs::read(path) {
+            Ok(bytes) if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE => {
+                let u16s: Vec<u16> = bytes[2..].chunks_exact(2)
+                    .map(|c| u16::from_le_bytes([c[0], c[1]])).collect();
+                String::from_utf16_lossy(&u16s)
+            }
+            Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+            Err(_) => return std::collections::HashSet::new(),
+        },
+    };
+    content.lines()
+        .filter(|l| !is_header_or_footer(l))
+        .map(|l| {
+            // The Path column may be quoted CSV: strip surrounding quotes and
+            // take only the first comma-delimited field (path is always first).
+            let trimmed = l.trim().trim_matches('"');
+            trimmed.split(',').next().unwrap_or(trimmed).trim().to_lowercase()
+        })
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+
+/// Check that `subset` is a subset of `superset`; return a short summary
+/// string.  Reports the first few missing paths on a violation.
+fn check_subset(
+    subset_label: &str,
+    subset: &std::collections::HashSet<String>,
+    superset_label: &str,
+    superset: &std::collections::HashSet<String>,
+) -> Option<String> {
+    if subset.is_empty() || superset.is_empty() { return None; }
+    let missing: Vec<&String> = subset.iter().filter(|p| !superset.contains(*p)).collect();
+    if missing.is_empty() { return None; }
+    let preview: Vec<&str> = missing.iter().take(3).map(|s| s.as_str()).collect();
+    Some(format!("{subset_label}⊄{superset_label}: {} paths missing (e.g. {})",
+        missing.len(), preview.join(", ")))
+}
 
 /// Count data lines in a captured stdout byte buffer, filtering the same
 /// headers/footers as `count_and_validate` so the two validators stay aligned.
@@ -492,8 +539,11 @@ fn validate_output(sink: OutputSink, path: &str, stdout: &[u8], needle: &str) ->
 /// every UFFS invocation — useful for one-off profile captures without
 /// having to patch this script.
 fn run_uffs(bin: &Path, drive: &str, pattern: &str, validate: &str, sink: OutputSink) -> Timing {
-    cleanup_bench_file();
-    let bpath = bench_out_path();
+    run_uffs_to(bin, drive, pattern, validate, sink, &bench_out_path())
+}
+fn run_uffs_to(bin: &Path, drive: &str, pattern: &str, validate: &str, sink: OutputSink, bpath: &str) -> Timing {
+    cleanup_file(bpath);
+    let bpath = bpath.to_owned();
     // Path-only output for fair comparison with es.exe (which only outputs Filename).
     // --hide-system + --hide-ads bring UFFS result semantics in line with
     // Everything (which does not index NTFS system files or Alternate Data
@@ -568,9 +618,9 @@ fn parse_daemon_ms(s: &str) -> u64 {
 /// File sink: `-export-csv <file>`; Stdout sink: default CSV to stdout; Null
 /// sink: default to stdout then redirect via cmd.  No -n limit — all results
 /// are returned.
-fn run_es(bin: &Path, drive: &str, pattern: &str, validate: &str, sink: OutputSink, es_instance: Option<&str>) -> Timing {
-    cleanup_bench_file();
-    let bpath = bench_out_path();
+fn run_es_to(bin: &Path, drive: &str, pattern: &str, validate: &str, sink: OutputSink, es_instance: Option<&str>, bpath: &str) -> Timing {
+    cleanup_file(bpath);
+    let bpath = bpath.to_owned();
     // es.exe expects path filter and search term as SEPARATE arguments:
     //   es.exe "C:\" ext:dll -export-csv file.csv
     // NOT as one combined string.
@@ -621,9 +671,9 @@ fn run_es(bin: &Path, drive: &str, pattern: &str, validate: &str, sink: OutputSi
 /// - `Stdout` / `Null`: drop `--out=` entirely.  With no `--out=` the freopen
 ///   path never fires, so piped-capture (Stdout) and `cmd /C "... > NUL"`
 ///   (Null) behave normally.
-fn run_uffs_cpp(bin: &Path, drive: &str, pattern: &str, cpp_ext: &str, validate: &str, sink: OutputSink) -> Timing {
-    cleanup_bench_file();
-    let bpath = bench_out_path();
+fn run_uffs_cpp_to(bin: &Path, drive: &str, pattern: &str, cpp_ext: &str, validate: &str, sink: OutputSink, bpath: &str) -> Timing {
+    cleanup_file(bpath);
+    let bpath = bpath.to_owned();
     let mut args: Vec<String> = Vec::new();
     if !cpp_ext.is_empty() {
         args.push("*".into());
@@ -940,6 +990,13 @@ fn main() {
                 let mut es_runs:   Vec<Timing> = Vec::new();
                 let mut es_aborted = false;
 
+                // Per-tool output files for this pattern — kept alive for the
+                // duration of a round so path sets can be compared, then deleted.
+                // C++ cannot write to absolute paths, so all three use relative names.
+                let f_uffs = format!("bench_uffs_{label}.csv");
+                let f_cpp  = format!("bench_cpp_{label}.csv");
+                let f_es   = format!("bench_es_{label}.csv");
+
                 for round in 0..cfg.rounds {
                     // Fresh random tool order every round — seeded from wall clock
                     // nanoseconds so consecutive rounds get different seeds.
@@ -949,29 +1006,26 @@ fn main() {
                         .unwrap_or(round as u64 + 1);
                     let order = lcg_shuffle3(seed);
 
-                    // Collect (tool_id, timing) for this round so we can do the
-                    // superset check right after all three fire.
                     let mut round_rows: [Option<u64>; 3] = [None; 3]; // [uffs, cpp, es]
 
                     for &slot in &order {
                         match slot {
                             0 if run_uffs_tool => {
-                                let t = check_dnf(run_uffs(&cfg.uffs, drive, pat, validate, sink));
+                                let t = check_dnf(run_uffs_to(&cfg.uffs, drive, pat, validate, sink, &f_uffs));
                                 round_rows[0] = t.ok.then_some(t.rows);
                                 uffs_runs.push(t);
                             }
                             1 if run_cpp_tool => {
                                 let cpp = cfg.uffs_cpp.as_ref().unwrap();
-                                let t = check_dnf(run_uffs_cpp(cpp, drive, cpp_pat, cpp_ext, validate, sink));
+                                let t = check_dnf(run_uffs_cpp_to(cpp, drive, cpp_pat, cpp_ext, validate, sink, &f_cpp));
                                 round_rows[1] = t.ok.then_some(t.rows);
                                 cpp_runs.push(t);
                             }
                             2 if run_es_tool && !es_aborted => {
                                 let es = cfg.es.as_ref().unwrap();
-                                let t = check_dnf(run_es(es, drive, es_pat, validate, sink, cfg.es_instance.as_deref()));
-                                // Fast deterministic failure on round 0 → abort es for this pattern.
+                                let t = check_dnf(run_es_to(es, drive, es_pat, validate, sink, cfg.es_instance.as_deref(), &f_es));
                                 if round == 0 && is_fast_deterministic_fail(&t) {
-                                    eprintln!("    [round {round}] es.exe fast-fail (exit={:?}); skipping remaining es rounds", t.err);
+                                    eprintln!("    [round {round}] es.exe fast-fail (exit={}); skipping remaining es rounds", t.err);
                                     es_aborted = true;
                                 }
                                 round_rows[2] = t.ok.then_some(t.rows);
@@ -981,31 +1035,48 @@ fn main() {
                         }
                     }
 
-                    // ── Superset check after every round ──────────────────
-                    // uffs.exe ≥ uffs.com  (both index same MFT, uffs.exe has parity filters)
-                    // uffs.exe ≥ es.exe    (Everything skips system/ADS files)
-                    // uffs.com ≥ es.exe    (C++ also includes system files)
-                    let mut violations: Vec<String> = Vec::new();
-                    if let (Some(u), Some(c)) = (round_rows[0], round_rows[1]) {
-                        if u < c {
-                            violations.push(format!("uffs({u}) < cpp({c})"));
-                        }
-                    }
-                    if let (Some(u), Some(e)) = (round_rows[0], round_rows[2]) {
-                        if u < e {
-                            violations.push(format!("uffs({u}) < es({e})"));
-                        }
-                    }
-                    if let (Some(c), Some(e)) = (round_rows[1], round_rows[2]) {
-                        if c < e {
-                            violations.push(format!("cpp({c}) < es({e})"));
-                        }
-                    }
+                    // ── Path-set superset check after every round (File sink only) ──
+                    // Superset contract:
+                    //   es.exe paths  ⊆  uffs.com paths  ⊆  uffs.exe paths
+                    // Stdout/Null sinks don't retain output files so we skip
+                    // the set check there; row counts are still shown.
                     let round_order_labels: Vec<&str> = order.iter().map(|&s| match s {
                         0 => "uffs", 1 => "cpp", 2 => "es", _ => "?"
                     }).collect();
+
+                    let mut violations: Vec<String> = Vec::new();
+                    if matches!(sink, OutputSink::File) {
+                        let uffs_paths = extract_paths_from_file(&f_uffs);
+                        let cpp_paths  = extract_paths_from_file(&f_cpp);
+                        let es_paths   = extract_paths_from_file(&f_es);
+
+                        if run_es_tool && !es_aborted && run_uffs_tool
+                            && !uffs_paths.is_empty() && !es_paths.is_empty() {
+                            if let Some(v) = check_subset("es", &es_paths, "uffs", &uffs_paths) {
+                                violations.push(v);
+                            }
+                        }
+                        if run_es_tool && !es_aborted && run_cpp_tool
+                            && !cpp_paths.is_empty() && !es_paths.is_empty() {
+                            if let Some(v) = check_subset("es", &es_paths, "cpp", &cpp_paths) {
+                                violations.push(v);
+                            }
+                        }
+                        if run_cpp_tool && run_uffs_tool
+                            && !uffs_paths.is_empty() && !cpp_paths.is_empty() {
+                            if let Some(v) = check_subset("cpp", &cpp_paths, "uffs", &uffs_paths) {
+                                violations.push(v);
+                            }
+                        }
+                    }
+
+                    // Clean up per-tool files for this round.
+                    cleanup_file(&f_uffs);
+                    cleanup_file(&f_cpp);
+                    cleanup_file(&f_es);
+
                     if violations.is_empty() {
-                        eprintln!("    [round {:>2}] order=[{}]  rows: uffs={} cpp={} es={}  ✓ superset ok",
+                        eprintln!("    [round {:>2}] order=[{}]  rows: uffs={} cpp={} es={}  ✓ paths ok",
                             round + 1,
                             round_order_labels.join(","),
                             round_rows[0].map_or("-".into(), |n| n.to_string()),
@@ -1013,13 +1084,13 @@ fn main() {
                             round_rows[2].map_or("-".into(), |n| n.to_string()),
                         );
                     } else {
-                        eprintln!("    [round {:>2}] order=[{}]  rows: uffs={} cpp={} es={}  ⚠ SUPERSET VIOLATION: {}",
+                        eprintln!("    [round {:>2}] order=[{}]  rows: uffs={} cpp={} es={}  ⚠ PATH SUPERSET VIOLATION: {}",
                             round + 1,
                             round_order_labels.join(","),
                             round_rows[0].map_or("-".into(), |n| n.to_string()),
                             round_rows[1].map_or("-".into(), |n| n.to_string()),
                             round_rows[2].map_or("-".into(), |n| n.to_string()),
-                            violations.join(", "),
+                            violations.join(" | "),
                         );
                     }
                 }

--- a/scripts/windows/cross-tool-benchmark.rs
+++ b/scripts/windows/cross-tool-benchmark.rs
@@ -118,6 +118,7 @@ fn bench_out_path() -> String {
 /// cpp_ext: if non-empty, C++ UFFS uses `* --ext=<val>` instead of glob
 /// validate: case-insensitive substring that every result line must contain
 ///           (empty = skip validation, e.g. full_scan)
+/// cpp_pattern: empty string means C++ does not support this pattern — skip.
 ///
 /// `ext_regex_alt` exercises the v0.5.66 regex-alternation → ExtensionIndex
 /// promotion (`extract_extensions_from_regex`).  UFFS takes the regex form
@@ -152,7 +153,9 @@ fn bench_out_path() -> String {
 const PATTERNS: &[(&str, &str, &str, &str, &str, &str)] = &[
     ("full_scan",     "*",                         "*",                    "*",           "",              ""),
     ("exact",         "notepad.exe",               "notepad.exe",          "notepad.exe", "",              "notepad"),
-    ("prefix",        "win*",                      "win*",                 "win*",        "",              "win"),
+    ("prefix",        "win*",                      "win*",                 "",            "",              "win"),
+    // ^^ cpp_pattern="" — uffs.com does not support trailing-wildcard prefix
+    //    glob (win* returns nothing/errors).  UFFS Rust vs Everything only.
     ("ext_rare",      "*.dbt",                     "ext:dbt",              "*.dbt",       "dbt",           ".dbt"),
     ("ext_dll",       "*.dll",                     "ext:dll",              "*.dll",       "dll",           ".dll"),
     ("ext_regex_alt", ">.*\\.(wav|idrc|cmake)$",   "*.wav|*.idrc|*.cmake", "*",           "wav,idrc,cmake", ""),
@@ -895,12 +898,16 @@ fn main() {
                 if let Some(ref cpp) = cfg.uffs_cpp {
                     eprintln!("  UFFS C++ (MFT re-read, no --limit) [sink={}]:  {} rounds",
                         sink.label(), cfg.rounds);
-                    for &(label, pat, _, _, cpp_ext, validate) in PATTERNS {
+                    for &(label, _, _, cpp_pat, cpp_ext, validate) in PATTERNS {
                         if cfg.skip_pattern(label) { continue; }
+                        if cpp_pat.is_empty() {
+                            eprintln!("    {label:<12} SKIP (C++ does not support this pattern)");
+                            continue;
+                        }
                         eprint!("    {label:<12} ");  flush();
                         let mut runs = Vec::new();
                         for _ in 0..cfg.rounds {
-                            runs.push(check_dnf(run_uffs_cpp(cpp, drive, pat, cpp_ext, validate, sink)));
+                            runs.push(check_dnf(run_uffs_cpp(cpp, drive, cpp_pat, cpp_ext, validate, sink)));
                         }
                         let s = sw(&runs);
                         let first_ok = runs.iter().find(|r| r.ok);

--- a/scripts/windows/cross-tool-benchmark.rs
+++ b/scripts/windows/cross-tool-benchmark.rs
@@ -285,6 +285,19 @@ fn uffs_stop(bin: &Path) {
     let _ = Command::new(bin).args(["daemon","kill"]).stdout(Stdio::null()).stderr(Stdio::null()).status();
     std::thread::sleep(Duration::from_secs(2));
 }
+/// Start the daemon with bench-safe idle-demote TTLs so it never demotes
+/// Hot→Warm or Warm→Parked mid-run.  These env vars are scoped to the
+/// daemon child process only — the bench script's own env is unchanged,
+/// and teardown's next `uffs daemon start` gets production defaults.
+fn uffs_start(bin: &Path) {
+    let _ = Command::new(bin)
+        .args(["daemon", "start"])
+        .env("UFFS_HOT_TO_WARM_IDLE_SECS",   "3600")
+        .env("UFFS_WARM_TO_PARKED_IDLE_SECS", "7200")
+        .stdout(Stdio::null()).stderr(Stdio::null())
+        .status();
+    std::thread::sleep(Duration::from_millis(500));
+}
 fn uffs_purge_cache() {
     // Remove both cache locations:
     //   %LOCALAPPDATA%\uffs\cache\  (primary)
@@ -794,9 +807,11 @@ fn main() {
 
     // ── Daemon warmup (once for all drives) ─────────────────────────────
     if cfg.tools.contains(&Tool::Uffs) && cfg.skip_cold {
-        // When skipping COLD/WARM, ensure the daemon is running before HOT.
-        // The daemon loads ALL drives on startup, so one probe is enough.
+        // When skipping COLD/WARM, kill+restart with bench-safe TTLs then
+        // issue one probe so the daemon is fully loaded before HOT starts.
         eprint!("  Warming up UFFS daemon (all drives)...");  flush();
+        uffs_stop(&cfg.uffs);
+        uffs_start(&cfg.uffs);
         let _ = Command::new(&cfg.uffs)
             .args(["__uffs_warmup_probe__", "--limit", "1"])
             .stdout(Stdio::null()).stderr(Stdio::null())
@@ -840,6 +855,7 @@ fn main() {
                 if cfg.skip_pattern(label) { continue; }
                 eprint!("    {label:<12} ");  flush();
                 uffs_stop(&cfg.uffs);
+                uffs_start(&cfg.uffs);
                 let t = check_dnf(run_uffs(&cfg.uffs, drive, pat, validate, OutputSink::File));
                 let verdict = if t.dnf { "DNF" } else if t.bad_rows > 0 { "WRONG" } else if t.ok { "PASS" } else { "ERROR" };
                 let bad_str = if t.bad_rows > 0 { format!("  bad={}", t.bad_rows) } else { String::new() };
@@ -856,6 +872,7 @@ fn main() {
             // minimise I/O.  Done once per drive — the daemon stays warm
             // across every sink iteration below.
             eprint!("  UFFS HOT:  warming up daemon...");  flush();
+            uffs_start(&cfg.uffs);
             let _ = Command::new(&cfg.uffs)
                 .args(["__uffs_warmup_probe__", "--drive", drive, "--limit", "1"])
                 .stdout(Stdio::null()).stderr(Stdio::null())


### PR DESCRIPTION
## Summary

Batch of bench-harness improvements accumulated on `feat/bench-preflight-robustness`.

### Daemon TTL defaults (`fix(bench)`)
- `HOT_TO_WARM_IDLE_SECS`: 60 s → 600 s (10 min)
- `WARM_TO_PARKED_IDLE_SECS`: 300 s → 1 800 s (30 min)
- Previous 1 min / 5 min defaults caused spurious mid-bench demotions.
- Both bench scripts (`cold-parity-per-drive.rs`, `cross-tool-benchmark.rs`) now start the daemon with bench-safe overrides scoped to the daemon child process:
  - `UFFS_HOT_TO_WARM_IDLE_SECS=3600`
  - `UFFS_WARM_TO_PARKED_IDLE_SECS=7200`
- `config.rs` const-pin and `lib.rs` env-var doc table updated.

### Interleaved HOT rounds with random tool order (`feat(bench)`)
- Previously all N rounds of UFFS ran first, then C++, then Everything — later tools benefited from OS FS cache warmed by earlier tools.
- New structure: for each `(sink, pattern)`, every round shuffles `[uffs, cpp, es]` with a fresh LCG seed, runs them in that order, then reports.
- Zero new dependencies — LCG Fisher-Yates on 3 elements using glibc constants.

### Path-set superset check per round (`fix(bench)`)
- Row counts can match by coincidence.
- Each tool now writes to a separate per-pattern output file (`bench_uffs_<pat>.csv` etc.) so all three coexist within a round.
- After every round (File sink): extract normalised path sets, verify:
  ```
  es.exe paths ⊆ uffs.com paths ⊆ uffs.exe paths
  ```
- Violations printed immediately with first 3 missing paths as examples.
- Files cleaned up after each round check.

### Stage 3 / preflight CLI arg order fix (`fix(bench)`)
- `DEFAULT_PATTERNS` and preflight test fixture corrected to match actual `uffs.exe` CLI: pattern first, then `--drives DRIVE`, then `--count`.

### Cold-parity and warm-up polish
- `cold-parity-per-drive.rs` always restarts daemon with 3-pass warm-up.
- Full COLD→WARM→HOT trajectory shown in warm-up output.

## Testing
All CI gates pass: fmt, typos, reuse, lint-ci, lint-prod, lint-tests, rustdoc, doc-tests, tests, smoke, lint-ci-windows.