### PR TITLE
chore: release v0.5.119 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -803,7 +803,7 @@ hunting for the wrong things.
 
 Plan §1 goal-4 ("no regression on CLI hot path vs the v0.5.35
 baseline") verified end-to-end on the Windows 7-drive reference
-box.  Current v0.5.118 (post-Phase-8 tiered architecture) is
+box.  Current v0.5.119 (post-Phase-8 tiered architecture) is
 **universally faster** than v0.5.35 across every benchmarked
 pattern, with the largest result set (`*.dll`, 44 529 rows)
 showing a **2.7× speedup**:
@@ -811,7 +811,7 @@ showing a **2.7× speedup**:
 ```
 Drive D, 7.07 M records, 30 rounds, HOT phase, p50 / p95 wall_ms:
 
-                              v0.5.35      v0.5.118       Δ p50
+                              v0.5.35      v0.5.119       Δ p50
     exact      (3 rows)       20 / 23   →  18 / 19      −10 %
     prefix     (8 732)        46 / 50   →  40 / 46      −13 %
     ext_rare   (11)           18 / 20   →  17 / 18       −6 %
@@ -987,7 +987,7 @@ log-message renames fail CI before reaching another 24-h soak.
   2026-05-13.  No new operator-surface features land on `main`
   until v0.6.0 ships.
 
-## [0.5.118] - 2026-05-08
+## [0.5.119] - 2026-05-08
 
 > **Note on the v0.5.91 gap.**  v0.5.91 was prepared and tagged but never
 > reached a published GitHub Release: the `release.yml` finalize step hit
@@ -996,7 +996,7 @@ log-message renames fail CI before reaching another 24-h soak.
 > partial release was deleted, the tag name became permanently locked by
 > GitHub's *immutable releases* feature (the pre-receive hook refuses any
 > future ref creation under that name even after a clean delete).  The
-> public release sequence therefore jumps `v0.5.90 → v0.5.118`; all
+> public release sequence therefore jumps `v0.5.90 → v0.5.119`; all
 > intended v0.5.91 changes are rolled forward into this release.
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,8 +37,8 @@ license-url: "https://github.com/skyllc-ai/UltraFastFileSearch/blob/main/LICENSE
 # Keep this in sync with [workspace.package].version in Cargo.toml.
 # The release pipeline (release-plz / just ship) should bump this automatically
 # once Pattern 5 in build/update_all_versions.rs is extended to cover CITATION.cff.
-version: "0.5.118"
-date-released: "2026-06-08"
+version: "0.5.119"
+date-released: "2026-06-09"
 
 # ── Classification ───────────────────────────────────────────────────────────
 type: software

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,7 +4325,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uffs-bench"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "chrono",
  "clap",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4351,14 +4351,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "clap",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "chrono",
  "itoa",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "clap",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "clap",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "clap",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "axum",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4586,14 +4586,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4608,14 +4608,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.118"
+version = "0.5.119"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.118"
+version = "0.5.119"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -119,21 +119,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.118" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.118" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.118" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.118" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.118" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.118" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.118" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.118" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.119" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.119" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.119" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.119" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.119" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.119" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.119" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.119" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.118" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.119" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.119** — the `[workspace.package].version` bump in `Cargo.toml`.  This PR routes that commit through branch-protection rules.  Once it merges to `main`, `auto-tag-release.yml` tags the commit and invokes `release.yml`, which builds the cross-platform binaries and publishes GitHub Release v0.5.119.

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

The auto-commit lived only on `release/v0.5.119`, so local `main` never drifted — sync it with a plain `git pull --ff-only origin main` (no `reset --hard` needed).