### PR TITLE
chore(publish): apply per-crate readme override on all 6 publishable crates

### DIFF
--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -19,7 +19,16 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme.workspace = true
+# Per-crate README override.  Inheriting `readme.workspace = true`
+# resolves to the workspace-root README via `../../README.md`, which
+# cargo flags with the "readme appears to be a path outside of the
+# package" warning even though the archived crate already contains a
+# copy.  Pointing at this crate's own `README.md` (alongside this
+# manifest) ships the right doc on the crates.io detail page and
+# silences the warning.  Permitted by manifest-audit invariant 3.5 via
+# `KnownExceptions::readme_override_ok` (see
+# `scripts/ci/manifest-audit/src/audit.rs`).  Issue #240.
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/uffs-client/Cargo.toml
+++ b/crates/uffs-client/Cargo.toml
@@ -13,7 +13,15 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme.workspace = true
+# Per-crate README override.  Inheriting `readme.workspace = true`
+# resolves to the workspace-root app README (`../../README.md`), the
+# wrong artifact for this library crate's crates.io / docs.rs page and
+# the source of cargo's "readme appears to be a path outside of the
+# package" warning.  Pointing at the crate's own `README.md` (alongside
+# this manifest) ships the right doc and silences the warning.  Permitted
+# by manifest-audit invariant 3.5 via `KnownExceptions::readme_override_ok`
+# (see `scripts/ci/manifest-audit/src/audit.rs`).  Issue #240.
+readme = "README.md"
 # Per-crate keywords + categories override (Phase 1 §3.5 escape hatch
 # via `KnownExceptions::keywords_override_ok` / `categories_override_ok`
 # in `scripts/ci/manifest-audit/src/audit.rs`).  This is the thin

--- a/crates/uffs-mcp/Cargo.toml
+++ b/crates/uffs-mcp/Cargo.toml
@@ -14,7 +14,15 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme.workspace = true
+# Per-crate README override.  Inheriting `readme.workspace = true`
+# resolves to the workspace-root app README (`../../README.md`), the
+# wrong artifact for this library crate's crates.io / docs.rs page and
+# the source of cargo's "readme appears to be a path outside of the
+# package" warning.  Pointing at the crate's own `README.md` (alongside
+# this manifest) ships the right doc and silences the warning.  Permitted
+# by manifest-audit invariant 3.5 via `KnownExceptions::readme_override_ok`
+# (see `scripts/ci/manifest-audit/src/audit.rs`).  Issue #240.
+readme = "README.md"
 # Per-crate keywords + categories override (Phase 1 §3.5 escape hatch
 # via `KnownExceptions::keywords_override_ok` / `categories_override_ok`
 # in `scripts/ci/manifest-audit/src/audit.rs`).  This crate ships an

--- a/crates/uffs-mft/Cargo.toml
+++ b/crates/uffs-mft/Cargo.toml
@@ -19,7 +19,15 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme.workspace = true
+# Per-crate README override.  Inheriting `readme.workspace = true`
+# resolves to the workspace-root app README (`../../README.md`), the
+# wrong artifact for this library crate's crates.io / docs.rs page and
+# the source of cargo's "readme appears to be a path outside of the
+# package" warning.  Pointing at the crate's own `README.md` (alongside
+# this manifest) ships the right doc and silences the warning.  Permitted
+# by manifest-audit invariant 3.5 via `KnownExceptions::readme_override_ok`
+# (see `scripts/ci/manifest-audit/src/audit.rs`).  Issue #240.
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/uffs-text/Cargo.toml
+++ b/crates/uffs-text/Cargo.toml
@@ -15,7 +15,15 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme.workspace = true
+# Per-crate README override.  Inheriting `readme.workspace = true`
+# resolves to the workspace-root app README (`../../README.md`), the
+# wrong artifact for this library crate's crates.io / docs.rs page and
+# the source of cargo's "readme appears to be a path outside of the
+# package" warning.  Pointing at the crate's own `README.md` (alongside
+# this manifest) ships the right doc and silences the warning.  Permitted
+# by manifest-audit invariant 3.5 via `KnownExceptions::readme_override_ok`
+# (see `scripts/ci/manifest-audit/src/audit.rs`).  Issue #240.
+readme = "README.md"
 # Per-crate keywords + categories override (Phase 1 §3.5 escape hatch
 # via `KnownExceptions::keywords_override_ok` / `categories_override_ok`
 # in `scripts/ci/manifest-audit/src/audit.rs`).  This crate ships

--- a/crates/uffs-time/Cargo.toml
+++ b/crates/uffs-time/Cargo.toml
@@ -18,7 +18,15 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme.workspace = true
+# Per-crate README override.  Inheriting `readme.workspace = true`
+# resolves to the workspace-root app README (`../../README.md`), the
+# wrong artifact for this library crate's crates.io / docs.rs page and
+# the source of cargo's "readme appears to be a path outside of the
+# package" warning.  Pointing at the crate's own `README.md` (alongside
+# this manifest) ships the right doc and silences the warning.  Permitted
+# by manifest-audit invariant 3.5 via `KnownExceptions::readme_override_ok`
+# (see `scripts/ci/manifest-audit/src/audit.rs`).  Issue #240.
+readme = "README.md"
 # Per-crate keywords + categories override (Phase 1 §3.5 escape hatch
 # via `KnownExceptions::keywords_override_ok` / `categories_override_ok`
 # in `scripts/ci/manifest-audit/src/audit.rs`).  This is a library

--- a/scripts/ci/manifest-audit/src/audit.rs
+++ b/scripts/ci/manifest-audit/src/audit.rs
@@ -157,8 +157,21 @@ impl KnownExceptions {
         // Adding an entry here requires the crate to actually have a
         // `README.md` alongside its `Cargo.toml` — cargo will emit a
         // packaging error otherwise.
-        let readme_override_ok: BTreeSet<&'static str> =
-            ["uffs-text", "uffs-time"].into_iter().collect();
+        //
+        // All 6 crates of the publishable subset carry their own
+        // `README.md` (#237 + #239) and the explicit override silences
+        // the cosmetic `cargo package` warning about `../../README.md`
+        // being outside the package — see issue #240.
+        let readme_override_ok: BTreeSet<&'static str> = [
+            "uffs-cli",
+            "uffs-client",
+            "uffs-mcp",
+            "uffs-mft",
+            "uffs-text",
+            "uffs-time",
+        ]
+        .into_iter()
+        .collect();
 
         // Per-crate `keywords` + `categories` override allow-list.
         // The four library crates listed below ship a public surface
@@ -838,17 +851,30 @@ workspace = true
 
     #[test]
     fn readme_override_on_allowlisted_crate_is_suppressed() {
-        // `uffs-time` is on the allow-list and uses the conventional
-        // `readme = "README.md"` same-name pattern — must not fire.
+        // Every crate in the 6-member publishable subset is on the
+        // allow-list and uses the conventional `readme = "README.md"`
+        // same-name pattern — none must fire.  Iterating the whole set
+        // (not just `uffs-time`) guards against a future regression
+        // that silently drops one crate from `readme_override_ok`.
         let text = MEMBER_CLEAN.replace("readme.workspace = true", "readme = \"README.md\"");
         let m = parse_member(&text).unwrap();
-        let d = disc("crates/uffs-time/Cargo.toml", &m);
         let exc = KnownExceptions::new();
-        let findings = audit_metadata_fields(&d, "uffs-time", &exc);
-        assert!(
-            findings.is_empty(),
-            "allow-listed readme override should be suppressed; got: {findings:?}"
-        );
+        for id in [
+            "uffs-cli",
+            "uffs-client",
+            "uffs-mcp",
+            "uffs-mft",
+            "uffs-text",
+            "uffs-time",
+        ] {
+            let path = format!("crates/{id}/Cargo.toml");
+            let d = disc(&path, &m);
+            let findings = audit_metadata_fields(&d, id, &exc);
+            assert!(
+                !findings.iter().any(|f| f.detail.contains("`readme`")),
+                "allow-listed readme override should be suppressed for `{id}`; got: {findings:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #240.

## Problem
All 6 publishable crates ship their own `README.md` (#237 + #239) but still inherited `readme.workspace = true`, which resolves to the workspace-root app README via `../../README.md`. Every `cargo package` emitted:

```
warning: readme `../../README.md` appears to be a path outside of the package,
but there is already a file named `README.md` in the root of the package ...
```

## Fix
- Flip each of the 6 manifests (`uffs-time`, `uffs-text`, `uffs-mft`, `uffs-client`, `uffs-mcp`, `uffs-cli`) to `readme = "README.md"` with a rationale comment.
- Extend `KnownExceptions::readme_override_ok` from 2 to all 6 entries so manifest-audit invariant 3.5 permits the override.
- Strengthen the suppression test to iterate the whole 6-crate subset (catches a future regression that drops one).

## Verification
- `cargo test -p uffs-manifest-audit`: ✅ 24 passed
- `cargo run -p uffs-manifest-audit`: ✅ zero findings
- `cargo package -p <each of 6> --list`: ✅ no readme warning, `README.md` still archived
- lint-pre-push (all gates): ✅

## Note on #241
While investigating, confirmed #241's actionable parts are **already done**: keywords/categories overrides applied (uffs-time/text/client/mcp) and `doc_auto_cfg` present in all 5 lib.rs files. The remainder of #241 is deliberately publish-day-deferred.