### PR TITLE
fix(ci): release-plz packages never-publish crates — add release=false

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -343,23 +343,36 @@ pr_branch_prefix = "release-plz-"
 #         because release-plz's hardcoded `cargo package -p` baseline
 #         step trips on the polars chrono mismatch unless every chain
 #         member is excluded from iteration (R6→R8 deviation, 2026-05-08).
-#     (b) Explicit-`publish = false` crates (`uffs-security`, `uffs-broker`,
-#         `uffs-broker-protocol`, `uffs-diag`) — auto-skipped by release-
-#         plz following cargo's convention.  No `[[package]]` block needed.
-#         Rationale per crate:
+#     (b) Other never-publish crates (`uffs-security`, `uffs-broker`,
+#         `uffs-broker-protocol`, `uffs-diag`, `uffs-bench`) — these ALSO
+#         need an explicit `release = false` block below.  CORRECTION
+#         (2026-06-09, release-plz active run #79): the earlier assumption
+#         that a `publish = false` crate is "auto-skipped by release-plz
+#         following cargo's convention" is WRONG.  `publish = false` only
+#         blocks the crates.io UPLOAD step; release-plz still iterates the
+#         crate for version-bump + changelog + tag, and its baseline
+#         `cargo package` step runs on it.  That step fails for any crate
+#         with a versioned path-dep on an unpublished workspace member
+#         (`uffs-broker` → `uffs-broker-protocol`; `uffs-diag` → `uffs-mft`
+#         + `uffs-polars`) with "no matching package ... found, location
+#         searched: crates.io index".  Only `release = false` removes a
+#         crate from release-plz's iteration.  Rationale per crate:
 #           uffs-security     UFFS-internals dressed as a generic crate
 #                              — see crate manifest comment
 #           uffs-broker       Windows `[[bin]]` only; standalone install
 #                              is meaningless without the daemon pairing
 #           uffs-broker-protocol  1-RTT wire protocol nobody else speaks
 #           uffs-diag         developer diagnostic tooling
+#           uffs-bench        benchmark-suite orchestrator (internal only)
 #
-#   Internal CI tools (3) — `release = false` below as the surgical
+#   Internal CI tools (4) — `release = false` below as the surgical
 #   release-plz-specific exclusion (their `publish = false` is the
-#   actual `cargo publish` block):
+#   actual `cargo publish` block, but see the (b) correction above —
+#   it does NOT exclude them from release-plz iteration on its own):
 #     scripts/ci-pipeline      (uffs-ci-pipeline)
 #     scripts/ci/gen-hooks     (uffs-gen-hooks)
 #     scripts/ci/gen-workflow  (uffs-gen-workflow)
+#     scripts/ci/manifest-audit (uffs-manifest-audit)
 #
 #   Out of band (1) — separate cargo workspace, release-plz never
 #   sees it; listed here for completeness:
@@ -400,6 +413,10 @@ release = false
 name = "uffs-gen-workflow"
 release = false
 
+[[package]]
+name = "uffs-manifest-audit"
+release = false
+
 # ─── Publishable crates (R4) ─ share the workspace-root CHANGELOG.md ─
 #
 # Order matches the workspace dep graph (leaves → roots) so the file
@@ -426,12 +443,13 @@ release = false
 #       • Reserve-name-only crates (`uffs-core`, `uffs-daemon` —
 #         deferred publish decision per the 2026-05-14 scrub).
 #
-# Crates with `publish = false` in their own Cargo.toml (`uffs-polars`,
-# `uffs-format`, `uffs-security`, `uffs-broker`, `uffs-broker-protocol`,
-# `uffs-diag`) are auto-skipped by release-plz following cargo's
-# convention — no `[[package]]` block needed for them.  Only crates
-# that EITHER are publish-ready OR need the explicit `release = false`
-# release-plz-specific knob appear below.
+# Every other workspace member needs an explicit `release = false`
+# block — `publish = false` alone does NOT remove a crate from
+# release-plz's iteration (it only blocks the crates.io upload).  See
+# the (b) correction note above (release-plz active run #79, 2026-06-09).
+# Without these blocks release-plz runs `cargo package` on the crate and
+# fails whenever it carries a versioned path-dep on an unpublished
+# workspace member.
 
 [[package]]
 name = "uffs-time"
@@ -477,4 +495,37 @@ release = false
 
 [[package]]
 name = "uffs-cli"
+release = false
+
+# ─── Never-publish internal crates (run #79 fix, 2026-06-09) ────────
+#
+# These were previously assumed to be "auto-skipped because
+# `publish = false`" (see the corrected (b) note above), but release-plz
+# active run #79 proved otherwise: it packaged `uffs-broker` and failed
+# with "no matching package named `uffs-broker-protocol` found, location
+# searched: crates.io index" because `uffs-broker`'s versioned path-dep
+# on the unpublished `uffs-broker-protocol` forces a registry lookup
+# during `cargo package`.  `uffs-diag` hits the same wall via its
+# `uffs-mft` + `uffs-polars` deps.  Excluding all five from release-plz
+# iteration leaves exactly the two publish-ready crates (`uffs-time`,
+# `uffs-text`) in scope — matching the 2026-05-14 scrub's "ready today"
+# set.
+[[package]]
+name = "uffs-broker"
+release = false
+
+[[package]]
+name = "uffs-broker-protocol"
+release = false
+
+[[package]]
+name = "uffs-security"
+release = false
+
+[[package]]
+name = "uffs-diag"
+release = false
+
+[[package]]
+name = "uffs-bench"
 release = false


### PR DESCRIPTION
## Problem
release-plz active run #79 (the merge of #380) failed:

```
cargo package failed: no matching package named `uffs-broker-protocol` found,
location searched: crates.io index, required by package `uffs-broker v0.5.120`
```

## Root cause
The `release-plz.toml` comments claimed `publish = false` crates are *auto-skipped* by release-plz. **That is wrong.** `publish = false` only blocks the crates.io **upload**; release-plz still iterates the crate for version-bump/changelog/tag and runs its baseline `cargo package` step on it. That step fails for any crate carrying a **versioned path-dep on an unpublished workspace member**:
- `uffs-broker` → `uffs-broker-protocol`
- `uffs-diag` → `uffs-mft` + `uffs-polars`

## Fix
Add explicit `release = false` blocks for the never-publish crates release-plz was iterating (`uffs-broker`, `uffs-broker-protocol`, `uffs-security`, `uffs-diag`, `uffs-bench`) plus the previously-**missed** CI tool `uffs-manifest-audit`. This leaves exactly the two publish-ready crates (`uffs-time`, `uffs-text` — both dependency-free, package cleanly) in release-plz's scope, matching the 2026-05-14 publishability scrub.

Also corrected the two stale comment blocks that asserted the wrong auto-skip behavior (per rule: CI proved the contract wrong → update docs).

## Verification
- Confirmed locally: `cargo package -p uffs-broker --allow-dirty --no-verify` reproduces the exact failure (even with `--no-verify` — the error is at metadata-prep, not the verify build).
- `uffs-text` / `uffs-time` have no internal `uffs-*` deps → package cleanly.
- All 19 workspace members now accounted for (2 in-scope + 17 `release = false`).
- lint-pre-push: ✅

Follow-up to #380.