### PR TITLE
fix(toolchain): invalidate target/ + sccache after a nightly bump

### DIFF
--- a/just/shared.just
+++ b/just/shared.just
@@ -442,6 +442,31 @@ toolchain-sync:
         # Clean up any BSD-sed backup artifact from older broken invocations.
         rm -f "${TOOLCHAIN_FILE}-e"
         rustup default "$CANDIDATE"
+
+        # ── Invalidate stale build caches after the bump ───────────
+        # The probe loop above used a per-candidate scratch CARGO_TARGET_DIR,
+        # so the MAIN `target/` and the sccache daemon are still holding the
+        # OLD nightly's artifacts.  Two distinct caches must be invalidated or
+        # the next build dies with E0514 "found crate X compiled by an
+        # incompatible version of rustc":
+        #   1. `cargo clean` — the main `target/` has rlibs/rmeta stamped with
+        #      the OLD rustc commit-hash; cargo's fingerprint does not always
+        #      force a rebuild across a nightly bump, so clear it outright.
+        #   2. `sccache --stop-server` — the long-lived sccache server caches
+        #      its compiler-version detection keyed by the `rustc` binary's
+        #      mtime/size.  Under rustup, `rustc` is a toolchain-agnostic proxy
+        #      (~/.cargo/bin/rustc -> rustup) whose bytes never change across a
+        #      bump, so the running daemon keeps serving/storing objects under
+        #      the OLD nightly's identity.  Stopping the server forces a fresh
+        #      `rustc -vV` probe on the next invocation, restoring correct
+        #      cache keying.  A full 30 GiB cache wipe is unnecessary — the
+        #      daemon restart is the targeted fix.
+        printf "\033[0;34m   Invalidating stale build caches (cargo clean + sccache restart)...\033[0m\n"
+        cargo clean 2>/dev/null || true
+        if command -v sccache >/dev/null 2>&1; then
+            sccache --stop-server >/dev/null 2>&1 || true
+        fi
+
         printf "\033[0;32m✅ Toolchain synced to %s\033[0m\n" "$CANDIDATE"
         rustc --version
         cargo --version


### PR DESCRIPTION
## Problem
After `just toolchain-sync` bumps the `rust-toolchain.toml` nightly pin, the next local build dies with:

```
error[E0514]: found crate `assert_cmd` compiled by an incompatible version of rustc
  = note: ... compiled by rustc 1.98.0-nightly (6bdf43094 2026-06-01)
  = help: please recompile that crate (consider running `cargo clean` first)
```

(also hit `winnow`, `tempfile`, `toml_parser`). This blocked pre-push gates this session.

## Root cause — two stale caches, not one
`toolchain-sync` probes candidate nightlies in a **per-candidate scratch `CARGO_TARGET_DIR`** (it already knows sharing the main `target/` across toolchains throws E0514), then commits the bump and **exits without touching the main caches**:

1. **`target/`** — rlibs/rmeta carry the old rustc commit-hash; cargo fingerprints don't reliably force a full rebuild across a nightly bump.
2. **the sccache daemon** — the non-obvious one. The long-lived sccache *server* caches its compiler-version detection keyed by the `rustc` binary's mtime/size. Under rustup, `~/.cargo/bin/rustc` is a **toolchain-agnostic proxy** (symlink → `rustup`) whose bytes never change across a bump, so the daemon keeps serving the OLD nightly's objects and **re-poisons `target/` right after a `cargo clean`**. This is why `cargo clean` alone didn't fix it.

## Fix
After `toolchain-sync` commits a bump (only in the "found newer nightly" branch, not "no bump available"), run:
- `cargo clean` — clear the old-nightly `target/`.
- `sccache --stop-server` — force the daemon to re-probe `rustc -vV` on next invocation, restoring correct cache keying. A full 30 GiB cache wipe is unnecessary; the daemon restart is the targeted fix.

## Verification
- Reproduced E0514 locally; fixed with `cargo clean` + `sccache --stop-server`; full `cargo build --workspace --all-targets` clean afterward.
- **This PR's own pre-push gate passed all Rust compilation gates** (`cargo-check`, `lint-tests`, `tests`, `lint-ci-windows`) — the exact gates that were failing with E0514 before the cache fix.