### PR TITLE
docs(cargo): correct stale publishable-set comment (2 crates, not 5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,12 +75,17 @@ keywords = ["mft", "ntfs", "file-search", "windows", "polars"]
 categories = ["filesystem", "command-line-utilities"]
 # Default publish policy: most workspace members are internal-only tooling
 # / facade / orchestration crates that must never accidentally hit crates.io.
-# Five crates intentionally override this with explicit `publish = true`
-# (`uffs-broker`, `uffs-broker-protocol`, `uffs-security`, `uffs-text`,
-# `uffs-time`) — see `release-automation-baseline.md` §10 row 5 for the
-# full publishable-set rationale.  Non-publishable members opt into this
-# default via `publish.workspace = true` (rather than declaring their own
-# `publish = false`) so the root manifest stays the single source of truth.
+# Exactly TWO crates intentionally override this with explicit `publish = true`
+# (`uffs-text`, `uffs-time`) — they are dependency-free leaf crates that are
+# the only members currently cleared for crates.io.  `uffs-broker`,
+# `uffs-broker-protocol`, and `uffs-security` were once earmarked publishable
+# but have since been flipped back to `publish = false` (name-squat
+# reservations / internal-only; see each crate's per-manifest rationale and
+# `docs/refactor/crates-io-publishability-deep-dive.md` §7.3–7.5).  Verify the
+# live set any time with `cargo metadata --no-deps` (publishable == `publish`
+# is null/ANY).  Non-publishable members opt into this default via
+# `publish.workspace = true` (rather than declaring their own `publish = false`)
+# so the root manifest stays the single source of truth.
 # Phase 1 closure gap A — see `docs/dev/baseline/2026-05-12/phase_1_findings.md`.
 publish = false
 

--- a/just/shared.just
+++ b/just/shared.just
@@ -442,6 +442,31 @@ toolchain-sync:
         # Clean up any BSD-sed backup artifact from older broken invocations.
         rm -f "${TOOLCHAIN_FILE}-e"
         rustup default "$CANDIDATE"
+
+        # ── Invalidate stale build caches after the bump ───────────
+        # The probe loop above used a per-candidate scratch CARGO_TARGET_DIR,
+        # so the MAIN `target/` and the sccache daemon are still holding the
+        # OLD nightly's artifacts.  Two distinct caches must be invalidated or
+        # the next build dies with E0514 "found crate X compiled by an
+        # incompatible version of rustc":
+        #   1. `cargo clean` — the main `target/` has rlibs/rmeta stamped with
+        #      the OLD rustc commit-hash; cargo's fingerprint does not always
+        #      force a rebuild across a nightly bump, so clear it outright.
+        #   2. `sccache --stop-server` — the long-lived sccache server caches
+        #      its compiler-version detection keyed by the `rustc` binary's
+        #      mtime/size.  Under rustup, `rustc` is a toolchain-agnostic proxy
+        #      (~/.cargo/bin/rustc -> rustup) whose bytes never change across a
+        #      bump, so the running daemon keeps serving/storing objects under
+        #      the OLD nightly's identity.  Stopping the server forces a fresh
+        #      `rustc -vV` probe on the next invocation, restoring correct
+        #      cache keying.  A full 30 GiB cache wipe is unnecessary — the
+        #      daemon restart is the targeted fix.
+        printf "\033[0;34m   Invalidating stale build caches (cargo clean + sccache restart)...\033[0m\n"
+        cargo clean 2>/dev/null || true
+        if command -v sccache >/dev/null 2>&1; then
+            sccache --stop-server >/dev/null 2>&1 || true
+        fi
+
         printf "\033[0;32m✅ Toolchain synced to %s\033[0m\n" "$CANDIDATE"
         rustc --version
         cargo --version


### PR DESCRIPTION
## What
The root `Cargo.toml` publish-policy comment claimed five crates were `publish = true` (`uffs-broker`, `uffs-broker-protocol`, `uffs-security`, `uffs-text`, `uffs-time`).

## Why it's wrong
`cargo metadata --no-deps` is authoritative and shows only **two** members resolve to `publish = ANY`:

| Crate | Resolved `publish` |
|---|---|
| `uffs-text` | ANY (publishable) |
| `uffs-time` | ANY (publishable) |
| *all 17 others* | `[]` (publish = false) |

`uffs-broker`, `uffs-broker-protocol`, and `uffs-security` were flipped back to `publish = false` (`publish.workspace = true`) with "Intentionally NOT published" rationale (name-squat reservations / internal-only — see each crate's per-manifest comment and `crates-io-publishability-deep-dive.md` §7.3–7.5). The root comment was never updated.

## Change
Comment-only correction in root `Cargo.toml`; points readers at `cargo metadata --no-deps` as the live source of truth. No manifest semantics change.

## Verification
Full pre-push gate green (cargo-check, lint-tests, tests, lint-ci-windows, deny, vet).