### PR TITLE
fix(release): restore the version bump inside just ship Phase 2

### DIFF
--- a/just/build.just
+++ b/just/build.just
@@ -6,59 +6,30 @@ version:
     @printf "\033[0;34m📋 Current version:\033[0m\n"
     @cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "uffs-cli") | .version'
 
-# ── Manual on-demand binary release (Path B) ────────────────────────
+# ── Binary release (Path B) — `just ship` cuts it ───────────────────
 #
 # UFFS ships its BINARY on your command, not automatically.  release-plz
 # only versions the 2 publishable leaf libs (uffs-time / uffs-text) — it
-# physically cannot see changes to uffs-cli/core/daemon/… (their
-# `cargo package` can't resolve unpublished internal deps), so it never
-# drives binary releases.  To cut a binary release that captures ANY
-# change anywhere in the workspace:
+# physically cannot see changes to uffs-cli/core/daemon/…, so it never
+# drives binary releases.  The release lives in your normal flow:
 #
-#   1.  just release-pr [patch|minor|major]   # opens the version-bump PR
-#   2.  (review + squash-merge that PR on GitHub)
-#   3.  just release-tag                       # tags main → builds binaries
+#   1.  just ship            # validate (Phase 1) → bump → commit →
+#                            #   open auto-merging release/vX.Y.Z PR (Phase 2)
+#   2.  (PR auto-merges once its CI is green)
+#   3.  just release-tag     # tag main → release.yml builds the binaries
 #
-# Step 1 bumps the lockstep `[workspace.package].version`, refreshes the
-# lockfile, and opens a `release/vX.Y.Z` PR (main requires PRs).  Step 3
-# creates the signed `vX.Y.Z` tag on main, which fires release.yml's
-# 15-platform binary build.  Nothing happens on a normal merge — that is
-# the manual-on-demand design, not a bug.
-#
-# (`ship` / `phase2-ship` are the DEV validate+push lanes — unrelated to
-# cutting a release.)
+# `just ship` Phase 2 bumps the lockstep `[workspace.package].version`
+# (patch) ONLY after Phase 1 validation passes — code is verified clean
+# before the version moves.  `release-tag` then cuts the signed `vX.Y.Z`
+# tag, which fires release.yml's 15-platform build.  A normal merge to
+# `main` triggers no release — that is the manual-on-demand design.
 
-# Retained alias — the retired R5 stub now points at the real flow.
+# Retired R5 stub — version bumps now happen inside `just ship` Phase 2.
 version-bump:
-    @printf "\033[0;36m💡 'version-bump' is now 'just release-pr [patch|minor|major]'.\033[0m\n"
-    @printf "\033[0;36m   Then merge the PR and run 'just release-tag'.\033[0m\n"
+    @printf "\033[0;36m💡 Version bumps are part of 'just ship' now (Phase 2, patch).\033[0m\n"
+    @printf "\033[0;36m   After the release PR merges, run 'just release-tag' to build binaries.\033[0m\n"
 
-# Open a version-bump release PR (default bump: patch).
-release-pr level="patch":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    printf "\033[0;34m🚢 Cutting release PR (%s bump)…\033[0m\n" "{{ level }}"
-    # ── Preflight: clean tree on an up-to-date main ──
-    branch=$(git branch --show-current)
-    [ "$branch" = "main" ] || { printf "\033[0;31m❌ run from main (you are on %s)\033[0m\n" "$branch"; exit 1; }
-    [ -z "$(git status --porcelain)" ] || { printf "\033[0;31m❌ working tree not clean\033[0m\n"; exit 1; }
-    git fetch origin main --quiet
-    [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] || { printf "\033[0;31m❌ local main is behind origin/main — pull first\033[0m\n"; exit 1; }
-    # ── Bump the lockstep workspace version + refresh the lockfile ──
-    cargo set-version --bump "{{ level }}"
-    new=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name=="uffs-cli") | .version')
-    cargo update --workspace --quiet
-    # ── Commit on a release branch + open the PR (main requires PRs) ──
-    rel="release/v${new}"
-    git switch -c "$rel"
-    git commit -aqm "chore(release): v${new}"
-    git push -u origin "$rel" --quiet
-    body="Cut binary release v${new} (Path B manual trigger). Bumps the lockstep workspace version; after squash-merge run 'just release-tag' to tag main and build the 15-platform binaries. No crate code changed — release-cut commit only."
-    gh pr create --base main --head "$rel" --title "chore(release): v${new}" --body "$body"
-    printf "\n\033[0;32m✅ Release PR opened for v%s.\033[0m\n" "$new"
-    printf "\033[0;36m   Next: review + squash-merge, then run: just release-tag\033[0m\n"
-
-# After the release PR is merged: tag main → build binaries.
+# After the `just ship` release PR is merged: tag main → build binaries.
 release-tag:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/scripts/ci-pipeline/src/git_ops.rs
+++ b/scripts/ci-pipeline/src/git_ops.rs
@@ -264,10 +264,11 @@ async fn open_release_pr(
          `just ship` Phase 2 auto-commit for **v{version}** — the \
          `[workspace.package].version` bump in `Cargo.toml`.  This PR \
          routes that commit through branch-protection rules.  Once it \
-         merges to `{base_branch}`, `auto-tag-release.yml` tags the \
-         commit and invokes `release.yml`, which builds the \
-         cross-platform binaries and publishes GitHub Release \
-         v{version}.\n\n\
+         merges to `{base_branch}`, run `just release-tag` to cut the \
+         signed `v{version}` tag, which fires `release.yml` and builds \
+         the cross-platform binaries + GitHub Release v{version}.  \
+         (No auto-tag on merge — the tag step is manual on-demand, \
+         Path B.)\n\n\
          ## Auto-merge\n\n\
          `--auto --squash` is queued — GitHub will merge as soon as the \
          required status checks pass.  Squash is required because \

--- a/scripts/ci-pipeline/src/ship.rs
+++ b/scripts/ci-pipeline/src/ship.rs
@@ -39,7 +39,7 @@ use crate::exec::{
     execute_step_with_tracking,
 };
 use crate::git_ops::{count_unpushed_commits, git_commit, git_push};
-use crate::version::get_current_version;
+use crate::version::{bump_workspace_version, get_current_version};
 use crate::workflow::{
     ALL_STEPS, STEP_CLEAN_ARTIFACTS, STEP_COVERAGE_TESTS, STEP_FORMAT_CHECK, STEP_FORMAT_CODE,
     STEP_GIT_COMMIT, STEP_GIT_PUSH, STEP_PARALLEL_VALIDATION, STEP_TOOLCHAIN_SYNC, WorkflowPhase,
@@ -458,17 +458,21 @@ pub(crate) async fn run_enhanced_phase2(
 ) -> Result<()> {
     println!(
         "{}",
-        "📦 PHASE 2: Release PR (version bump handled by release-plz)"
+        "📦 PHASE 2: version bump → commit → release PR"
             .blue()
             .bold()
     );
 
-    // Note: Version increment (step 07) was retired in Phase R5.
-    // release-plz now handles version bumps automatically on `main`.
-
+    // Version increment (Path B, 2026-06-10): restored after R5 retired it.
+    // release-plz only versions the 2 publishable leaf libs — it cannot drive
+    // binary releases — so the lockstep workspace bump happens HERE, at the end
+    // of `just ship`, gated behind the resumable `version_incremented` flag so a
+    // re-run after a mid-ship failure never double-bumps.  Default level: patch.
     if !state.version_incremented {
+        bump_workspace_version("patch").context("Failed to bump workspace version")?;
         state.version_incremented = true;
-        let new_version = get_current_version().context("Failed to get updated version")?;
+        let new_version = get_current_version().context("Failed to read bumped version")?;
+        println!("🔖 Bumped workspace version → v{new_version}");
         state.current_version = new_version;
         state.save()?;
     }
@@ -540,10 +544,22 @@ fn load_or_reset_ship_state(ctx: &PipelineContext) -> Result<WorkflowState> {
             .context("Failed to save fresh workflow state")?;
         Ok(new_state)
     } else {
-        Ok(WorkflowState::load().unwrap_or_else(|_| {
-            let current_version = get_current_version().unwrap_or_else(|_| "unknown".to_owned());
-            WorkflowState::new_workflow(current_version)
-        }))
+        let loaded = WorkflowState::load().ok();
+        // A COMPLETED cycle must not be "resumed": its steps are all marked
+        // done and `version_incremented` is set, so resuming would skip both
+        // Phase 1 validation AND the Phase 2 version bump — the next release
+        // would commit nothing.  `is_resumable()` already excludes Completed,
+        // so a finished state starts a fresh cycle.  (`--fresh` is still the
+        // explicit reset; this just stops a stale terminal state from wedging
+        // the next `just ship`.)
+        match loaded {
+            Some(state) if state.phase != WorkflowPhase::Completed => Ok(state),
+            _ => {
+                let current_version =
+                    get_current_version().unwrap_or_else(|_| "unknown".to_owned());
+                Ok(WorkflowState::new_workflow(current_version))
+            }
+        }
     }
 }
 

--- a/scripts/ci-pipeline/src/ship.rs
+++ b/scripts/ci-pipeline/src/ship.rs
@@ -407,6 +407,33 @@ pub(crate) async fn run_enhanced_phase1(
         "🚀 Using safe parallel optimization: format → compile → parallel(doc tests + linting)"
     );
 
+    // ── Tree-hash invalidation ──
+    // A resumed `just ship` skips a validation step only when the code it
+    // validated is byte-identical.  If the working tree changed since Phase 1
+    // last passed (you edited a tracked file or committed between runs), the
+    // cached "completed" flags for the code-dependent steps are invalidated so
+    // they re-run on the new code.  An unchanged tree (e.g. resuming after a
+    // Phase-2 push failure) keeps the fast skip.  The authoritative gate is
+    // still the uncacheable PR CI; this closes the local "passed step skipped
+    // after a code edit" gap.
+    let fingerprint = working_tree_fingerprint();
+    if state.validated_fingerprint != fingerprint {
+        if !state.validated_fingerprint.is_empty() {
+            println!(
+                "{}",
+                "↻ Working tree changed since last validation — re-running Phase 1 checks".yellow()
+            );
+        }
+        for step in [
+            STEP_FORMAT_CODE,
+            STEP_COVERAGE_TESTS,
+            STEP_PARALLEL_VALIDATION,
+            STEP_FORMAT_CHECK,
+        ] {
+            state.invalidate_step(step)?;
+        }
+    }
+
     tracked_toolchain_step(state, ctx).await?;
 
     println!("{}", "📋 Stage 1: Sequential Prerequisites".yellow().bold());
@@ -432,6 +459,13 @@ pub(crate) async fn run_enhanced_phase1(
     tracked_parallel_validation_step(state, ctx).await?;
     tracked_format_check_step(state, ctx).await?;
 
+    // Record the (post-`cargo fmt`) tree this Phase-1 run validated, so a
+    // resume on an unchanged tree skips the checks and any later edit re-runs
+    // them.  Recomputed here (not reused from the top) because `03-format-code`
+    // may have rewritten files.
+    state.validated_fingerprint = working_tree_fingerprint();
+    state.save()?;
+
     println!(
         "{}",
         "✅ PHASE 1 COMPLETE - All testing and validation passed!"
@@ -439,6 +473,32 @@ pub(crate) async fn run_enhanced_phase1(
             .bold()
     );
     Ok(())
+}
+
+/// Fingerprint of the working tree that validation actually sees: the `HEAD`
+/// commit plus the full diff of tracked changes against it.  A new commit or
+/// any edit to a tracked file changes the hash; a brand-new *untracked* file
+/// is the one gap, and the uncacheable PR CI still covers it.
+///
+/// Uses `DefaultHasher` (fixed-key `SipHash` — deterministic across processes,
+/// unlike `HashMap`'s randomized state); non-cryptographic but ample for
+/// change detection.  On any `git` error the components default to empty, which
+/// simply makes the fingerprint conservative (more likely to differ → re-run).
+fn working_tree_fingerprint() -> String {
+    use core::hash::{Hash as _, Hasher as _};
+
+    fn git(args: &[&str]) -> Vec<u8> {
+        std::process::Command::new("git")
+            .args(args)
+            .output()
+            .map(|out| out.stdout)
+            .unwrap_or_default()
+    }
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    git(&["rev-parse", "HEAD"]).hash(&mut hasher);
+    git(&["diff", "HEAD"]).hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
 }
 
 /// Phase 2 of the ship pipeline: version bump + commit + push + open
@@ -715,7 +775,22 @@ pub(crate) async fn run_ship_pipeline(ctx: &PipelineContext) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CleanDecision, CleanMode, decide_clean};
+    use super::{CleanDecision, CleanMode, decide_clean, working_tree_fingerprint};
+
+    #[test]
+    fn tree_fingerprint_is_deterministic_and_nonempty() {
+        // Two back-to-back calls observe the same working tree, so they MUST
+        // agree — if the fingerprint were unstable, every `just ship` would
+        // needlessly re-run all of Phase 1.  16 hex chars (u64) is the shape.
+        let first = working_tree_fingerprint();
+        let second = working_tree_fingerprint();
+        assert_eq!(
+            first, second,
+            "fingerprint must be stable for an unchanged tree"
+        );
+        assert_eq!(first.len(), 16, "fingerprint is the 16-hex-char u64 hash");
+        assert!(first.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
 
     #[test]
     fn force_mode_always_cleans() {

--- a/scripts/ci-pipeline/src/version.rs
+++ b/scripts/ci-pipeline/src/version.rs
@@ -30,6 +30,46 @@ pub(crate) fn get_current_version() -> Result<String> {
     bail!("Could not find version in Cargo.toml")
 }
 
+/// Bump the lockstep `[workspace.package].version` (plus the internal
+/// `[workspace.dependencies]` version requirements and the lockfile) by
+/// `level` — `"patch"`, `"minor"`, or `"major"` — via `cargo set-version`.
+///
+/// This restores the Phase-2 version-increment step retired in R5.  It shells
+/// out to `cargo-edit`'s `set-version` rather than re-implementing semver math
+/// (the ~1430 LOC R5 deleted): `set-version` already handles workspace
+/// inheritance and the internal dep-requirement updates correctly.  `just ship`
+/// is a maintainer-only release command, so requiring `cargo-edit` on the
+/// release machine is acceptable.
+///
+/// # Errors
+///
+/// Returns an error if `cargo set-version` is not installed or the bump fails.
+pub(crate) fn bump_workspace_version(level: &str) -> Result<()> {
+    let available = std::process::Command::new("cargo")
+        .args(["set-version", "--help"])
+        .output()
+        .is_ok_and(|out| out.status.success());
+    if !available {
+        bail!(
+            "`cargo set-version` not found — install it with `cargo install cargo-edit` \
+             (required by `just ship` to bump the release version)."
+        );
+    }
+    let status = std::process::Command::new("cargo")
+        .args(["set-version", "--bump", level])
+        .status()
+        .context("running `cargo set-version`")?;
+    if !status.success() {
+        bail!("`cargo set-version --bump {level}` failed");
+    }
+    // Refresh the lockfile so the release commit is byte-reproducible.
+    std::process::Command::new("cargo")
+        .args(["update", "--workspace", "--quiet"])
+        .status()
+        .context("refreshing Cargo.lock after version bump")?;
+    Ok(())
+}
+
 /// Parse `content` (the text of a workspace root `Cargo.toml`) and
 /// extract the `version = "..."` entry from the `[workspace.package]`
 /// table specifically — ignores any unrelated `version = ...` lines in

--- a/scripts/ci-pipeline/src/workflow.rs
+++ b/scripts/ci-pipeline/src/workflow.rs
@@ -151,6 +151,14 @@ pub(crate) struct WorkflowState {
     /// previous run.
     pub version_incremented: bool,
 
+    /// Working-tree fingerprint that Phase 1 last validated against (HEAD +
+    /// tracked diff, see `ship::working_tree_fingerprint`).  Empty until the
+    /// first validation passes.  On a re-run, if the current fingerprint
+    /// differs, the code-dependent validation steps are invalidated so they
+    /// re-run on the changed code; an unchanged tree keeps the resume speedup.
+    #[serde(default)]
+    pub validated_fingerprint: String,
+
     /// Per-step duration metrics (seconds), keyed by the step id (e.g.
     /// `03-coverage-tests`). Stored in the workflow-state file so you
     /// can compare runs over time.
@@ -256,6 +264,7 @@ impl WorkflowState {
             last_error: None,
             step_tracker: StepTracker::default(),
             version_incremented: false,
+            validated_fingerprint: String::new(),
             step_durations_secs: BTreeMap::new(),
         }
     }
@@ -378,6 +387,7 @@ impl Default for WorkflowState {
             last_error: None,
             step_tracker: StepTracker::default(),
             version_incremented: false,
+            validated_fingerprint: String::new(),
             step_durations_secs: BTreeMap::new(),
         }
     }


### PR DESCRIPTION
## Restore the version bump inside `just ship` Phase 2

**Bug:** R5 deleted the Phase-2 version-increment step but left the rest of the ship machinery intact (commit → open `release/vX.Y.Z` PR with auto-merge). With no version change to commit, `just ship` / `ship-fresh` fails at `git-commit` with *"nothing to commit, working tree clean."*

**Fix — put the bump back where it always lived** (not the parallel `release-pr`/`just go` flow I wrongly added first):

- `version.rs` — `bump_workspace_version(level)` shells out to `cargo set-version` (handles workspace inheritance + internal dep requirements + lockfile). No re-implementation of the ~1430 LOC R5 deleted.
- `ship.rs` Phase 2 — the bump (default **patch**) runs **after Phase 1 validation passes**, so code is verified clean before the version moves. Gated by the existing resumable `version_incremented` flag (no double-bump on a mid-ship re-run). Also resets a **Completed** workflow state on non-fresh load, so a second `just ship` starts a fresh release cycle instead of resuming a terminal state (which would skip validation *and* the bump).
- `git_ops.rs` — the release-PR body now points at `just release-tag` (the deleted `auto-tag-release.yml` reference was stale).
- `just/build.just` — drop the redundant `release-pr` recipe; keep `release-tag` (post-merge tag → binaries).

### The flow
```
just ship          # validate → bump → commit → auto-merging release/vX.Y.Z PR
# (PR auto-merges when its CI is green)
just release-tag   # tag main → release.yml builds the 15-platform binaries
```

`uffs-ci-pipeline`: clippy clean, 7 tests pass.