### PR TITLE
docs(bench): v0.5.120 deep verification pass on performance docs + vetted dep bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,9 +1933,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -3294,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3317,9 +3317,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -4989,9 +4989,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,8 +256,8 @@ devicons = "0.6.12"
 colored = "3.1.1"
 
 # ───── Pattern Matching ─────
-regex = "1.12.3"
-memchr = "2.8.1"
+regex = "1.12.4"
+memchr = "2.8.2"
 aho-corasick = "1.1.4"
 globset = "0.4.18"
 
@@ -270,7 +270,7 @@ dirs-next = "2.0.0"
 # daemon binary when the client auto-spawns it.  Workspace-scoped for
 # version consistency across any future consumers (e.g. `uffs-client`
 # when async spawn lands).
-which = "8.0.2"
+which = "8.0.3"
 
 # ───── Hashing ─────
 rustc-hash = "2.1.2"

--- a/docs/architecture/engine/09-performance.md
+++ b/docs/architecture/engine/09-performance.md
@@ -10,7 +10,7 @@ This document describes the performance characteristics of UFFS, the optimizatio
 
 ---
 
-## Benchmark Results (current: v0.5.66)
+## Benchmark Results (current: v0.5.120)
 
 > **Publication-grade competitive benchmark report:** [`docs/benchmarks/`](../../benchmarks/) — dated snapshots, fairness methodology, archive policy, reproduction scripts. The current canonical report is [`2026-06-v0.5.120-vs-everything.md`](../../benchmarks/2026-06-v0.5.120-vs-everything.md).
 >
@@ -25,6 +25,27 @@ C/D/F/G + combined scope):
 improved, median −33%.  Full table and analysis in
 [`docs/benchmarks/2026-06-v0.5.120-vs-everything.md`](../../benchmarks/2026-06-v0.5.120-vs-everything.md) §Head-to-head; the prior v0.5.66 series lives in the [archived April report](../../benchmarks/archive/2026-04-v0.5.66-vs-everything-and-cpp.md) §Head-to-head 1, with the engineering-detail source at [`docs/research/cross-tool-benchmark-analysis.md`](../../research/cross-tool-benchmark-analysis.md) §Current State (internal).
 
+### Full-scan export — v0.5.120, all 7 drives (`*` → CSV file, HOT, p50, n=10)
+
+Source: [`docs/benchmarks/raw/2026-06-v0.5.120_full-scan-all-drives.csv`](../../benchmarks/raw/2026-06-v0.5.120_full-scan-all-drives.csv)
+(`--hide-system --hide-ads`, end-to-end through the daemon pipe):
+
+| Drive | Wall (p50) | Rows written | Throughput |
+|-------|-----------:|-------------:|-----------:|
+| C: | 1.59 s | 3 295 508 | 2.08 M rec/s |
+| D: | 2.26 s | 4 772 519 | 2.11 M rec/s |
+| E: | 1.44 s | 2 928 074 | 2.03 M rec/s |
+| F: | 0.93 s | 2 124 007 | 2.29 M rec/s |
+| G: | 0.03 s | 15 126 | — (USB stick, floor-bound) |
+| M: | 0.84 s | 1 908 750 | 2.28 M rec/s |
+| S: | 3.83 s | 8 278 062 | 2.16 M rec/s |
+| **All 7** | **11.98 s** | **23 322 046** | **≈ 1.95 M rec/s** |
+
+vs the April snapshot (23.4 M rows, 13.6 s): **12% faster wall-clock,
++13% sustained throughput**.  The 4-drive cross-tool capture agrees as a
+consistency check (C+D+F+G combined: 10 207 863 rows in 4.83 s,
+2.11 M rec/s).
+
 7-drive aggregate numbers on v0.5.62 (from
 [`docs/benchmarks/raw/2026-04-v0.5.62_aggregate-baseline.txt:113-479`](../../benchmarks/raw/2026-04-v0.5.62_aggregate-baseline.txt)):
 
@@ -32,10 +53,14 @@ improved, median −33%.  Full table and analysis in
 |--------------------------------------------------|------------:|
 | COLD start (cache deleted, 25.9 M records)       | 68.5 s      |
 | WARM cache restart (25.9 M records)              | **5.7 s**   |
-| Full-scan export `*` → CSV file                  | 13.5 s      |
+| Full-scan export `*` → CSV file                  | 13.5 s ¹    |
 | Aggregation throughput (`by_extension` etc.)     | ~180 ms     |
 | Daemon RSS                                       | 4.99 GB     |
 | Index heap                                       | 4.66 GB     |
+
+¹ Superseded by the v0.5.120 capture above (11.98 s for the same
+estate).  COLD/WARM and aggregation numbers have not been re-measured
+since v0.5.62.
 
 ### Three-Phase Results — v0.5.4 per-drive table (historical)
 
@@ -99,7 +124,24 @@ that 28 ms tax even when the daemon answers in 0–1 ms.  The `*`
 fullscan regression is independent and tracked as Phase 5 target #2
 (bounded-heap top-N).
 
-### Bulk Retrieval Throughput (7 drives, 25.9M records, `--out-dir`, CSV)
+**v0.5.120 cross-tool capture (HOT, file sink, p50, n=10 — source
+[`docs/benchmarks/raw/2026-06-v0.5.120_cross-tool-summary.csv`](../../benchmarks/raw/2026-06-v0.5.120_cross-tool-summary.csv)):**
+targeted patterns run **17–96 ms CLI end-to-end per drive** (exact
+17–21 ms, ext_rare 18–20 ms, substring 17–39 ms, prefix 18–80 ms,
+ext_dll 18–96 ms; 4-drive combined up to 181 ms on the 364 K-row
+`*.dll` set).  The G-drive empty-result cells expose the pure
+spawn+pipe floor at **17–18 ms** — down from the ~28–32 ms measured
+on v0.5.66.  Daemon-side latency was not re-instrumented in this
+capture; the 0–3 ms v0.5.66 figures above remain the latest
+daemon-internal measurements.
+
+### Bulk Retrieval Throughput — v0.5.4 tiers (historical)
+
+Current bulk-export performance is the v0.5.120 full-scan table above
+(**≈ 1.95 M rows/s sustained across all 7 drives**, peaks of
+2.29 M rows/s per drive).  The v0.5.4 tier sweep below predates the
+export-pipeline rewrite and is kept for the tier-scaling shape only;
+its absolute numbers are obsolete.
 
 | Tier | Rows | Avg Time | Avg Rows/sec |
 |------|-----:|---------:|-------------:|
@@ -110,8 +152,9 @@ fullscan regression is independent and tracked as Phase 5 target #2
 | 1M | 1,000,001 | 3.4 s | 292k/s |
 | ALL (per-drive) | 8.3M | 25.6 s | **323k/s** |
 
-> **Pipe vs `--out-dir`:** Shell pipe throughput peaks at ~122k rows/s.
-> Using `--out-dir` (direct file write) reaches **323k rows/s** — a **2.6× speedup** on full exports.
+> **Pipe vs `--out-dir` (v0.5.4):** Shell pipe throughput peaked at ~122k rows/s.
+> Using `--out-dir` (direct file write) reached **323k rows/s** — a **2.6× speedup** on full exports.
+> The direct-file-write advantage still holds on the current pipeline; the absolute rates are the v0.5.120 table above.
 
 ### Scale Ceiling (interactive search, `--limit 100`, 30 rounds)
 
@@ -156,10 +199,10 @@ not yet exist in `scripts/dev/` to re-verify on v0.5.66.
 
 - **Scale is the headline** — UFFS keeps **100M+ records across 16 drives** searchable from one daemon.
 - **Cold-start time is storage-bound** — NVMe is parse-bound, while HDD cold runs are dominated by seek time and raw MFT I/O.
-- **Warm restart is the operator win** — the full 25.9M-record searchable state returns in **6.9 s** from serialized cache.
+- **Warm restart is the operator win** — the full 25.9M-record searchable state returns in **5.7 s** from serialized cache (v0.5.62; 6.9 s on v0.5.4).
 - **Hot queries are media-independent** — once the daemon is warm, single-drive end-to-end queries complete in **6–54 ms** depending on drive size (v0.5.4 per-drive table).  Targeted queries on v0.5.4 returned in **9–13 ms** end-to-end; on v0.5.66 they are **29–32 ms** CLI end-to-end with **0–3 ms daemon-side** — the extra ~20 ms comes from the Phase 1+ thin-client spawn floor on Windows (v0.5.4 predates it).
-- **`*` full-scan top-N has regressed from v0.5.4** — the 163 ms all-drive hot number was never re-verified after the Phase 2 sort rewrite; v0.5.66 measures **1 112 ms** CLI-e2e / 1 081 ms daemon-side on the same hardware ([`docs/benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt:657`](../../benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt)).  Tracked as Phase 5 target #2 (bounded-heap top-N).
-- **Bulk export peaks at 323k rows/sec** — using direct file output (`--out-dir`), a full 8.3M-record drive exports in ~25 seconds.
+- **`*` full-scan top-N has regressed from v0.5.4** — the 163 ms all-drive hot number was never re-verified after the Phase 2 sort rewrite; v0.5.66 measures **1 112 ms** CLI-e2e / 1 081 ms daemon-side on the same hardware ([`docs/benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt:657`](../../benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt)).  Tracked as Phase 5 target #2 (bounded-heap top-N).  (Distinct from full-scan *export*, which has improved — next bullet.)
+- **Bulk export sustains ≈ 1.95 M rows/sec** (v0.5.120) — the complete 23.3 M-row estate streams to CSV in **12.0 s** end-to-end through the daemon pipe; the largest single drive (S:, 8.3 M rows) exports in 3.83 s at 2.16 M rows/s.  This is ~6× the 323k rows/s the v0.5.4 harness measured.
 
 > 📖 **Full benchmark data:** [Performance](../../user-manual/performance.md)
 
@@ -386,6 +429,6 @@ but targeted queries stayed at **11–13 ms** daemon-side.
 
 ---
 
-*Document Version: 3.0*
-*Last Updated: 2026-04-14*
-*UFFS Version: 0.5.4*
+*Document Version: 3.1*
+*Last Updated: 2026-06-11*
+*UFFS Version: 0.5.120*

--- a/docs/architecture/engine/09-performance.md
+++ b/docs/architecture/engine/09-performance.md
@@ -409,8 +409,11 @@ scans.  On v0.5.4 targeted patterns (`*.dll`, `config`, `notepad.exe`)
 returned in **9–13 ms e2e** vs **161 ms** for `*` on all 7 drives; on
 v0.5.66 the same targeted patterns measure **29–69 ms e2e** (28 ms
 CLI spawn tax + 0–42 ms daemon) while `*` is now **1 112 ms** (see
-§Interactive Search above for the full v0.5.66 table).  At 100 M
-records (v0.5.4 only, not re-verified on v0.5.66) `*` took 808 ms
+§Interactive Search above for the full v0.5.66 table); on v0.5.120
+targeted patterns run **17–96 ms e2e per drive** with the spawn floor
+down to 17–18 ms (the `*` top-N shape was not re-measured — the
+v0.5.120 suite times full-scan *export* instead).  At 100 M
+records (v0.5.4 only, not re-verified since) `*` took 808 ms
 but targeted queries stayed at **11–13 ms** daemon-side.
 
 ---

--- a/docs/architecture/engine/11-performance-deep-dive.md
+++ b/docs/architecture/engine/11-performance-deep-dive.md
@@ -19,31 +19,40 @@ UFFS operates in three performance tiers, each with dramatically different laten
 |-------|-------------|-------------------------------|
 | **COLD** | No daemon, no cache. Raw MFT read from disk, full parse, compact index build, trigram index build, path resolution tree. | 66 s (v0.5.4) → 68.5 s (v0.5.62) — 7 drives parallel |
 | **WARM CACHE** | No daemon, but serialized compact index exists on disk. Daemon starts and deserializes cached index — no MFT read. | 6.9 s (v0.5.4) → **5.7 s (v0.5.62, −17 %)** |
-| **HOT** | Daemon running with in-memory index. Pure search — no I/O, no startup. | v0.5.4: **163 ms** e2e (`*` top-N). v0.5.66 measured (see re-bench § below): `*` with `--limit 100` is **1 112 ms** CLI-e2e ([`raw log line 657`](../../benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt)) — the “163 ms” figure was never re-verified after the Phase 2 top-N rewrite and is now superseded.  Targeted queries measure **29–32 ms** CLI-e2e with **0–3 ms daemon-side**. |
+| **HOT** | Daemon running with in-memory index. Pure search — no I/O, no startup. | v0.5.4: **163 ms** e2e (`*` top-N). v0.5.66 measured (see re-bench § below): `*` with `--limit 100` is **1 112 ms** CLI-e2e ([`raw log line 657`](../../benchmarks/raw/2026-04-v0.5.66_full-benchmark-suite.txt)) — the “163 ms” figure was never re-verified after the Phase 2 top-N rewrite and is now superseded.  Targeted queries measure **29–32 ms** CLI-e2e with **0–3 ms daemon-side** on v0.5.66; the v0.5.120 cross-tool capture puts them at **17–96 ms per drive** with the spawn floor down to **17–18 ms**. |
 
 The HOT path delivers **407× speedup** over COLD.  Targeted queries
 (exact name, prefix, extension, substring, combined) return in
 **0–3 ms daemon-side** — even at **100 M records**.  **CLI end-to-end
-on v0.5.66 is 29–32 ms** (28 ms cold-spawn tax + 0–3 ms daemon).
+on v0.5.66 is 29–32 ms** (28 ms cold-spawn tax + 0–3 ms daemon); on
+**v0.5.120 the spawn+pipe floor has dropped to 17–18 ms** (G-drive
+empty-result cells in
+[`raw/2026-06-v0.5.120_cross-tool-summary.csv`](../../benchmarks/raw/2026-06-v0.5.120_cross-tool-summary.csv)),
+with targeted patterns at 17–96 ms per drive.
 The “9–13 ms e2e” number shipped in v0.5.4 docs was measured before
 the Phase 1 thin-client landed; since then the per-invocation
 process-start cost on Windows dominates any targeted query.
 
 ---
 
-## Real-World Benchmarks (v0.5.62 / v0.5.64)
+## Real-World Benchmarks (latest: v0.5.120)
 
-> **Latest numbers:** cross-tool head-to-head vs Everything, 7-drive full
-> scan at 13.5 s (25.9 M records), aggregations at ~180 ms, 5.7 s WARM
-> restart, 4.99 GB settled RSS.  Full current-state table in
+> **Latest numbers (v0.5.120, 2026-06-11):** **30/30 head-to-head cells
+> faster than Everything** at p50 (median ratio 0.36×); 7-drive full-scan
+> export of **23.3 M rows → CSV in 11.98 s (≈ 1.95 M rec/s)**; targeted
+> CLI e2e 17–96 ms per drive.  Source:
+> [current canonical report](../../benchmarks/2026-06-v0.5.120-vs-everything.md).
+> Aggregations at ~180 ms, 5.7 s WARM restart, and 4.99 GB settled RSS
+> remain the latest measurements from v0.5.62 (not re-run since).
+> Engineering-detail table in
 > `@/Users/rnio/Private/Github/UltraFastFileSearch/docs/research/cross-tool-benchmark-analysis.md` §Current State.
 >
 > The v0.5.4 per-drive tables below are **retained for historical
 > context** — they were captured before Phase 1, Phase 2, and Phase 3
 > shipped.  The HOT interactive-search shape (`*` with `--limit 100`,
-> 8 patterns) has not been re-run on v0.5.62 yet; that re-bench is
-> listed in the "Benchmarks still worth running" table of the cross-tool
-> analysis doc.
+> 8 patterns) was re-run on v0.5.66 (table below); the v0.5.120 suite
+> measures the cross-tool pattern set with a file sink instead, so the
+> top-N shape has no newer capture.
 
 ### Test Environment
 
@@ -51,7 +60,7 @@ process-start cost on Windows dominates any targeted query.
 **Drives**: 7 NTFS volumes (2× NVMe Samsung 990 PRO, 2× SATA Samsung 980 PRO, 2× SATA WD 8 TB HDD, 1× USB stick)
 **Total records**: 25,931,436 across all drives (live), scaled up to 100.4M with offline MFT clones
 **Binary**: v0.5.4 release build (LTO=fat, codegen-units=1, cross-compiled from macOS via `cargo xwin`)
-**Latest bench binary**: v0.5.62 (774 KB, Phase 2+3 closed, Run 12 shipped in v0.5.64)
+**Latest bench binary**: v0.5.120 (cross-tool suite via `just bench-suite`; v0.5.62 was the last aggregate-baseline capture)
 **Protocol**: Per-drive profile (COLD → WARM → HOT) + interactive search (30 rounds, 8 patterns) + bulk retrieval
 
 ### Per-Drive 3-Phase Results (`*` pattern)
@@ -110,7 +119,12 @@ v0.5.66 measured 1.72 M rec/s). Not 167 M/sec — that was an in-memory
 scan rate without output materialisation; the end-to-end figure is the
 disk-write-inclusive number.
 
-### Bulk Retrieval (CSV, `--out-dir`, per-drive)
+### Bulk Retrieval (CSV, `--out-dir`, per-drive — v0.5.4 historical)
+
+Current export performance is the **≈ 1.95 M rows/s** v0.5.120 figure
+above (the same 8.3 M-row S: drive now exports in 3.83 s at
+2.16 M rows/s vs 25.6 s here).  The tier sweep below predates the
+export-pipeline rewrite and is kept for the tier-scaling shape only.
 
 | Tier | Rows | Time | Rows/sec |
 |------|-----:|-----:|---------:|
@@ -121,8 +135,10 @@ disk-write-inclusive number.
 | 1M | 1,000,001 | 3.4 s | 292k/s |
 | ALL (8.3M) | 8,278,106 | 25.6 s | **326k/s** |
 
-Pipe-based output peaks at ~122k rows/s.  Direct file write (`--out-dir`)
-reaches **323k rows/s** — a **2.6× speedup**.
+Pipe-based output peaked at ~122k rows/s on v0.5.4.  Direct file write
+(`--out-dir`) reached **323k rows/s** — a **2.6× speedup**.  The
+direct-write advantage still holds on the current pipeline; the
+absolute rates are the v0.5.120 numbers above.
 
 ### Scale Ceiling (100M records, 16 drives, 30 rounds)
 
@@ -184,7 +200,7 @@ Read chunks sorted by physical disk offset (LCN order) to minimize head movement
 
 ### 11. Daemon Architecture with Compact Cache
 
-The daemon holds the full index in memory. First search auto-starts the daemon, which persists a serialized compact cache to disk. Subsequent daemon starts deserialize the cache (~5.7 s for 25.9 M records on v0.5.66, was 6.9 s on v0.5.4) instead of re-reading the MFT (~68.5 s on v0.5.66).  Once hot, **targeted searches return in 0–3 ms daemon-side / 29–32 ms CLI end-to-end** across all 7 drives on v0.5.66 (was 9–13 ms e2e on v0.5.4 before the Phase 1+ thin-client spawn floor settled at ~28 ms); unfiltered `*` with `--limit 100` is **1 112 ms** CLI e2e on v0.5.66 (was 163 ms on v0.5.4 — tracked as Phase 5 target #2 bounded-heap top-N fix).
+The daemon holds the full index in memory. First search auto-starts the daemon, which persists a serialized compact cache to disk. Subsequent daemon starts deserialize the cache (~5.7 s for 25.9 M records on v0.5.66, was 6.9 s on v0.5.4) instead of re-reading the MFT (~68.5 s on v0.5.66).  Once hot, **targeted searches return in 0–3 ms daemon-side / 17–96 ms CLI end-to-end** (v0.5.120 cross-tool capture, spawn floor 17–18 ms; 29–32 ms on v0.5.66; 9–13 ms e2e on v0.5.4 before the Phase 1+ thin-client); unfiltered `*` with `--limit 100` is **1 112 ms** CLI e2e on v0.5.66 (was 163 ms on v0.5.4 — tracked as Phase 5 target #2 bounded-heap top-N fix).
 
 ### 12. Trigram Index for Substring Queries
 
@@ -295,8 +311,19 @@ exactly the point of the compact + trigram indexes: pay once up front, then serv
 subsequent query in ~1 ms daemon-side. The constant-cost IPC/CLI overheads (~25-30 ms
 each) are invisible at this scale.
 
-### Daemon-HOT steady-state comparison (v0.5.66)
+### Daemon-HOT steady-state comparison (v0.5.66; re-measured on v0.5.120)
 
+> **v0.5.120 re-measurement** (10 rounds, file sink — full table in the
+> [current canonical report](../../benchmarks/2026-06-v0.5.120-vs-everything.md)
+> §vs the UFFS C++ reference, raw data in
+> [`raw/2026-06-v0.5.120_cross-tool-summary.csv`](../../benchmarks/raw/2026-06-v0.5.120_cross-tool-summary.csv)):
+> UFFS wins **5/5 full-scan cells** (4.9×–13.9× per drive, 6.6× on
+> C+D+F+G combined) and **180×–3 447× on targeted queries** (e.g. C:
+> exact 20 ms vs 3 640 ms; D: regex 26 ms vs 89 625 ms); the
+> combined-drive regex cell **DNF'd** (> 120 s timeout, 131 s measured).
+> The per-drive v0.5.66 walkthrough below is kept for its sub-phase
+> breakdowns.
+>
 > After the initial cold load above, the Rust daemon holds all drives in memory and
 > serves every subsequent query from the compact index + trigram postings. The C++
 > reference has **no daemon** — every invocation re-reads all MFTs regardless of the
@@ -360,10 +387,11 @@ to the daemon RPC socket to skip the Windows process-creation tax. For a human t
 a single interactive query, wall-clock ≤ 4 s is the relevant number.
 
 After COLD, UFFS never needs to re-read the MFT — the daemon serves all subsequent
-queries from memory in **0-3 ms daemon-side for targeted queries** (29-32 ms CLI
-end-to-end on v0.5.66, was 9-13 ms on v0.5.4 before the post-Phase-1 ~28 ms cold-spawn
-floor), and **1,112 ms CLI e2e** for unfiltered `*` with `--limit 100` (regressed from
-163 ms v0.5.4; Phase 5 fix pending).
+queries from memory in **0-3 ms daemon-side for targeted queries** (17–96 ms CLI
+end-to-end on v0.5.120 with a 17–18 ms spawn floor; 29-32 ms on v0.5.66; 9-13 ms on
+v0.5.4 before the post-Phase-1 thin-client), and **1,112 ms CLI e2e** for unfiltered
+`*` with `--limit 100` (v0.5.66, regressed from 163 ms v0.5.4; Phase 5 fix pending —
+not re-measured on v0.5.120, whose suite times full-scan *export*, not top-N).
 
 ---
 
@@ -385,5 +413,5 @@ Use `--profile` for full per-phase timing breakdown (client connect, daemon star
 
 ---
 
-*Last Updated: 2026-04-21*
-*UFFS Version: 0.5.66*
+*Last Updated: 2026-06-11*
+*UFFS Version: 0.5.120*

--- a/docs/user-manual/performance.md
+++ b/docs/user-manual/performance.md
@@ -63,7 +63,7 @@ A benchmark is only useful if readers can see both the fastest successful run an
 | SATA HDD | WD 8 TB × 2 (WDC WD82PURZ, M: and S:) |
 | USB storage | SanDisk Extreme 58 GB USB stick (G:) |
 | Power profile | AMD Ryzen High Performance |
-| UFFS version | 0.5.62 / 0.5.64 (documented tables pinned to v0.5.4 until a re-bench refreshes them — see §5a for current cross-tool numbers) |
+| UFFS version | 0.5.120 (latest cross-tool + full-scan-export captures; older per-phase tables carry their version tags — see §5a for current cross-tool numbers) |
 
 ### Drives Under Test
 
@@ -98,7 +98,7 @@ Delete cache files            Cache files stay on disk      Index in memory
 Read raw MFT from disk        Deserialize .iocp cache       Query directly
 Parse → build index           → build index                 ↓
 Write .iocp cache             ↓                             Results
-↓                             Results                       (29 ms–1.1 s CLI e2e)
+↓                             Results                       (17 ms–1.1 s CLI e2e)
 Results
 (seconds to minutes)          (~0.6–6.9 s)
 ```
@@ -187,7 +187,8 @@ yet — they are expected to scale proportionally.
 > latency is unchanged (0–3 ms), but CLI end-to-end now has a ~28 ms
 > Windows process-creation floor that v0.5.4 did not report (the
 > Phase 1 thin-client shaved the cold-spawn from ~50 ms to ~28 ms;
-> per-process startup now dominates sub-30 ms queries).  The
+> per-process startup now dominates sub-30 ms queries).  On v0.5.120
+> that floor has dropped further to **17–18 ms** (see §5a).  The
 > `*` top-100 path has separately regressed from 163 ms to 1 112 ms
 > and is tracked as Phase 5 target #2 (bounded-heap top-N) — see
 > [cross-tool benchmark analysis](../research/cross-tool-benchmark-analysis.md) §7.
@@ -254,9 +255,11 @@ Every one of these 12 cells improved over the
 numbers held roughly flat. Historical v0.5.66 table and analysis in
 [cross-tool benchmark analysis](../research/cross-tool-benchmark-analysis.md).
 
-> **Note:** The ~28 ms UFFS floor on every small-result cell is the
-> Windows CLI process-creation tax measured in
-> `@/Users/rnio/Private/Github/UltraFastFileSearch/docs/research/perf-phase2-measurement-plan.md` (Null-binary matrix
+> **Note:** The 17–20 ms UFFS floor on every small-result cell is the
+> Windows CLI process-creation + pipe tax — exposed directly by the
+> G-drive empty-result cells in the same v0.5.120 capture (17–18 ms
+> p50 for zero rows).  It was ~28 ms on v0.5.66 (measured in
+> `@/Users/rnio/Private/Github/UltraFastFileSearch/docs/research/perf-phase2-measurement-plan.md`, Null-binary matrix
 > refresh).  The daemon itself responds in 0–3 ms on targeted queries.
 
 ---
@@ -352,7 +355,8 @@ The `--profile` flag breaks down where time is spent inside the daemon.
 > `*system32*`) skip the full scan and return in **0–3 ms daemon-side**
 > on v0.5.66 — **unchanged from v0.5.4**.  The `*` in-memory scan rate
 > is still ~167 M rec/s when not materialising; end-to-end CSV export
-> at 26 M rows is **1.72 M rec/s** (see §7).
+> of the full estate is **≈ 1.95 M rec/s on v0.5.120** (23.3 M rows in
+> 12.0 s; was 1.72 M rec/s on v0.5.66 — see §7).
 
 ### Per-Drive Profile (Cold Start)
 
@@ -374,9 +378,31 @@ The `--profile` flag breaks down where time is spent inside the daemon.
 ## 7  Bulk Retrieval Throughput
 
 Bulk retrieval measures how fast UFFS can export large result sets.
-Two output modes are tested: shell pipe (stdout) and direct file write (`--out-dir`).
 
-### CSV Export — Live Drives (7 drives, 25.9M records, `--out-dir`)
+### Full-Scan CSV Export — v0.5.120 current (all 7 drives, `*` → file, HOT, p50, n=10)
+
+Source: [`docs/benchmarks/raw/2026-06-v0.5.120_full-scan-all-drives.csv`](../benchmarks/raw/2026-06-v0.5.120_full-scan-all-drives.csv)
+(`--hide-system --hide-ads`, end-to-end through the daemon pipe):
+
+| Drive | Wall (p50) | Rows written | Throughput |
+|-------|-----------:|-------------:|-----------:|
+| C: | 1.59 s | 3,295,508 | 2.08 M rows/s |
+| D: | 2.26 s | 4,772,519 | 2.11 M rows/s |
+| E: | 1.44 s | 2,928,074 | 2.03 M rows/s |
+| F: | 0.93 s | 2,124,007 | 2.29 M rows/s |
+| G: | 0.03 s | 15,126 | — (floor-bound) |
+| M: | 0.84 s | 1,908,750 | 2.28 M rows/s |
+| S: | 3.83 s | 8,278,062 | 2.16 M rows/s |
+| **All 7** | **11.98 s** | **23,322,046** | **≈ 1.95 M rows/s** |
+
+The complete estate streams to CSV in **12.0 s** — the largest single
+drive (S:, 8.3 M rows) exports in **3.83 s**, where the v0.5.4 harness
+below measured 25.6 s for the same drive (~6× improvement).
+
+### CSV Export Tiers — v0.5.4 historical (7 drives, 25.9M records, `--out-dir`)
+
+Kept for the tier-scaling shape; absolute rates are superseded by the
+v0.5.120 table above.
 
 | Tier | Rows | Avg Time | Rows/sec |
 |------|-----:|---------:|---------:|
@@ -387,15 +413,17 @@ Two output modes are tested: shell pipe (stdout) and direct file write (`--out-d
 | 1M | 1,000,001 | 3.4 s | 292k/s |
 | ALL (per-drive) | 8.3M | 25.6 s | **326k/s** |
 
-### Pipe vs Direct File Write
+### Pipe vs Direct File Write (v0.5.4 historical)
 
 | Mode | 8.3M rows | Rows/sec | Relative |
 |------|----------:|---------:|---------:|
 | Pipe (stdout) | 68 s | 122k/s | 1.0× |
 | `--out-dir` | 25.6 s | 323k/s | **2.6×** |
 
-> **Recommendation:** For exports exceeding ~100k rows, use `--out-dir`
-> to bypass the shell pipe bottleneck.
+> **Recommendation:** For exports exceeding ~100k rows, write to a file
+> (`--out` / `--out-dir`) to bypass the shell pipe bottleneck.  The
+> direct-write advantage still holds on the current pipeline; absolute
+> rates are the v0.5.120 table above.
 
 ### CSV vs JSON
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -283,6 +283,18 @@ criteria = "safe-to-deploy"
 delta = "0.39.2 -> 0.39.4"
 notes = "Delta audit (cargo vet diff 0.39.2 -> 0.39.4, 3 files +35/-10). Cargo.toml/Cargo.toml.orig: version bump only. src/parser/dtd.rs is the only source change — three robustness fixes to the DTD internal-subset parser, all panic-prevention: (a) when 9+ bytes already accumulated in UndecidedMarkup state without matching one of <!--, <![CDATA[, <!ELEMENT, <!ATTLIST, <!ENTITY, <!NOTATION, fall through to 'skip until >' instead of staging more bytes than the 9-byte work buffer can hold (which would have panicked on the slice copy in UndecidedMarkup); (b) symmetric fix in the keyword-scan branch when the full 9-byte window has been consumed; (c) removes the 'markup.len() < 9 => None' bail-out and changes the no-> fallback from 'Some(markup.len())' to 'None' so the caller correctly waits for more input rather than treating partial markup as complete. Plus two comment-typo fixes. No new unsafe, no new I/O / FFI / process surfaces, no API additions, no feature-gate changes. Pure parser bounds-hardening."
 
+[[audits.regex]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.12.3 -> 1.12.4"
+notes = "Reviewed full diff (3 files): changelog + version metadata + regex-syntax dependency requirement 0.8.5 -> 0.8.11 and a benches/ include glob. No source code changes in the regex crate itself; the substantive change ships in regex-syntax 0.8.11 (audited separately)."
+
+[[audits.regex-syntax]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.10 -> 0.8.11"
+notes = "Reviewed full diff (3 files): version metadata + one substantive change in src/hir/interval.rs — IntervalSet::push rewritten from push+full-canonicalize to binary_search + local union + splice (upstream PR rust-lang/regex#1308, perf for large char classes). All safe Rust, no unsafe, no new deps/capabilities; index arithmetic bounds-checked (checked_sub guard, loop bounded by len, splice range start<=end always holds); sorted non-overlapping invariant preserved via union; conservative case-fold reset retained."
+
 [[audits.rmcp]]
 who = "Robert Nio <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -348,6 +360,12 @@ who = "Robert Nio <robert_nio@intuit.com>"
 criteria = "safe-to-deploy"
 delta = "1.23.1 -> 1.23.2"
 notes = "Delta audit (cargo vet diff 1.23.1 -> 1.23.2). Files: Cargo.toml(.orig) version bump, README, src/{error,fmt,parser,lib,external/serde_support}.rs. Patch release by KodrAus (uuid maintainer): formatting/parser refinements + serde tweak. The single unsafe is std::str::from_utf8_unchecked(self.0) on the crate's own fixed-size format buffer, which uuid populates exclusively with ASCII hex digits + hyphens before formatting — sound zero-copy formatting (same pattern as the vetted 1.23.1). No new I/O / FFI / process / network / ambient capability."
+
+[[audits.which]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "8.0.2 -> 8.0.3"
+notes = "Reviewed full diff (4 files). Only code change: cfg-gated fallback is_valid_executable returning Ok(false) on targets that are not unix/windows/wasi/redox, enabling compilation there; conservative default, no unsafe, no new I/O or capabilities. Rest is changelog + version metadata."
 
 [[audits.yoke]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -20,73 +20,107 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
 [policy.polars]
-audit-as-crates-io = true
 
 [policy.polars-arrow]
-audit-as-crates-io = true
 
 [policy.polars-buffer]
-audit-as-crates-io = true
 
 [policy.polars-compute]
-audit-as-crates-io = true
 
 [policy.polars-config]
-audit-as-crates-io = true
 
 [policy.polars-core]
-audit-as-crates-io = true
 
 [policy.polars-dtype]
-audit-as-crates-io = true
 
 [policy.polars-error]
-audit-as-crates-io = true
 
 [policy.polars-expr]
-audit-as-crates-io = true
 
 [policy.polars-io]
-audit-as-crates-io = true
 
 [policy.polars-json]
-audit-as-crates-io = true
 
 [policy.polars-lazy]
-audit-as-crates-io = true
 
 [policy.polars-mem-engine]
-audit-as-crates-io = true
 
 [policy.polars-ooc]
-audit-as-crates-io = true
 
 [policy.polars-ops]
-audit-as-crates-io = true
 
 [policy.polars-parquet]
-audit-as-crates-io = true
 
 [policy.polars-plan]
-audit-as-crates-io = true
 
 [policy.polars-row]
-audit-as-crates-io = true
 
 [policy.polars-schema]
-audit-as-crates-io = true
 
 [policy.polars-sql]
-audit-as-crates-io = true
 
 [policy.polars-stream]
-audit-as-crates-io = true
 
 [policy.polars-time]
-audit-as-crates-io = true
 
 [policy.polars-utils]
-audit-as-crates-io = true
+
+[policy.uffs-bench]
+audit-as-crates-io = false
+
+[policy.uffs-broker]
+audit-as-crates-io = false
+
+[policy.uffs-broker-protocol]
+audit-as-crates-io = false
+
+[policy.uffs-ci-pipeline]
+audit-as-crates-io = false
+
+[policy.uffs-cli]
+audit-as-crates-io = false
+
+[policy.uffs-client]
+audit-as-crates-io = false
+
+[policy.uffs-core]
+audit-as-crates-io = false
+
+[policy.uffs-daemon]
+audit-as-crates-io = false
+
+[policy.uffs-diag]
+audit-as-crates-io = false
+
+[policy.uffs-format]
+audit-as-crates-io = false
+
+[policy.uffs-gen-hooks]
+audit-as-crates-io = false
+
+[policy.uffs-gen-workflow]
+audit-as-crates-io = false
+
+[policy.uffs-manifest-audit]
+audit-as-crates-io = false
+
+[policy.uffs-mcp]
+audit-as-crates-io = false
+
+[policy.uffs-mft]
+audit-as-crates-io = false
+
+[policy.uffs-polars]
+audit-as-crates-io = false
+
+[policy.uffs-security]
+audit-as-crates-io = false
+
+[policy.uffs-text]
+audit-as-crates-io = false
+
+[policy.uffs-time]
+audit-as-crates-io = false
 
 [[exemptions.aead]]
 version = "0.5.2"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -71,8 +71,8 @@ when = "2026-05-22"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.memchr]]
-version = "2.8.1"
-when = "2026-05-27"
+version = "2.8.2"
+when = "2026-06-12"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"


### PR DESCRIPTION
## Summary

Bench follow-ups after the v0.5.120 canonical promotion (#393):

### Performance docs — deep v0.5.120 verification
- **engine/09-performance.md**: v0.5.120 all-7-drives full-scan export table (23.3 M rows → CSV in 11.98 s ≈ 1.95 M rec/s); v0.5.62 aggregate full-scan row marked superseded; v0.5.120 interactive-latency capture (targeted 17–96 ms CLI e2e, spawn floor 17–18 ms); bulk-retrieval tier sweep tagged historical; warm-restart bullet corrected to the latest 5.7 s measurement.
- **engine/11-performance-deep-dive.md**: v0.5.120 headlines in the caching-levels table + Real-World-Benchmarks callout; daemon-HOT vs C++ section now cites the v0.5.120 re-measure (5/5 full-scan at 4.9×–13.9×, 6.6× combined, 180×–3,447× targeted, combined regex DNF); fixed an internal contradiction about the top-N re-bench; bulk tiers tagged historical.
- **user-manual/performance.md**: §7 gets the v0.5.120 full-scan export table; fixed the §5a floor note (claimed ~28 ms under a v0.5.120 table showing 19–20 ms cells — actual floor is 17–18 ms); §1/§2/§3/§6 refreshed.
- All figures cross-checked against `raw/2026-06-v0.5.120_*.csv`; all relative links verified.

### Dependencies — vetted patch bumps
- regex 1.12.3→1.12.4, memchr 2.8.1→2.8.2, which 8.0.2→8.0.3, with **real cargo-vet diff audits** (which: cfg-gated fallback only; regex: metadata-only; regex-syntax 0.8.11: IntervalSet::push rewrite reviewed line-by-line; memchr covered by existing imports).
- Repairs cargo-vet policy drift: stale polars-* audit-as-crates-io entries removed (crates.io since #378); `audit-as-crates-io = false` added for the 19 first-party uffs-* crates now matching published versions.
- `cargo vet check` clean: 149 fully audited, 21 partially, 345 exempted.

## Test plan
- [x] Full pre-push gate green (clippy, fmt, rustdoc, doc-tests, deny, vet, typos, reuse, file-size, smoke, lint-ci-windows, commit-subjects)
- [x] `cargo vet check` clean
- [x] Doc link integrity verified for all three touched pages