### PR TITLE
chore: release v0.5.122 — ship pipeline auto-commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4372,7 +4372,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uffs-bench"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "chrono",
  "clap",
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4398,14 +4398,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4437,7 +4437,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "anyhow",
  "clap",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "chrono",
  "itoa",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "anyhow",
  "clap",
@@ -4552,7 +4552,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "anyhow",
  "clap",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "anyhow",
  "clap",
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "anyhow",
  "axum",
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4634,14 +4634,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4656,14 +4656,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.5.121"
+version = "0.5.122"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.5.121"
+version = "0.5.122"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.5.121"
+version = "0.5.122"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -124,21 +124,21 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.5.121" }
-uffs-security = { path = "crates/uffs-security", version = "0.5.121" }
-uffs-text = { path = "crates/uffs-text", version = "0.5.121" }
-uffs-time = { path = "crates/uffs-time", version = "0.5.121" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.5.121" }
-uffs-format = { path = "crates/uffs-format", version = "0.5.121" }
-uffs-core = { path = "crates/uffs-core", version = "0.5.121" }
-uffs-client = { path = "crates/uffs-client", version = "0.5.121" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.5.122" }
+uffs-security = { path = "crates/uffs-security", version = "0.5.122" }
+uffs-text = { path = "crates/uffs-text", version = "0.5.122" }
+uffs-time = { path = "crates/uffs-time", version = "0.5.122" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.5.122" }
+uffs-format = { path = "crates/uffs-format", version = "0.5.122" }
+uffs-core = { path = "crates/uffs-core", version = "0.5.122" }
+uffs-client = { path = "crates/uffs-client", version = "0.5.122" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.121" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.5.122" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/main.rs"
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-client = { path = "../uffs-client", version = "0.5.121", default-features = false }
+uffs-client = { path = "../uffs-client", version = "0.5.122", default-features = false }
 
 # Canonical CSV / parity / legacy-footer writer.  Direct dep (not a
 # re-export chain through `uffs-client`) so the CLI and the daemon
@@ -77,7 +77,7 @@ uffs-client = { path = "../uffs-client", version = "0.5.121", default-features =
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-format = { path = "../uffs-format", version = "0.5.121" }
+uffs-format = { path = "../uffs-format", version = "0.5.122" }
 
 # Typed drive-letter newtype.  Direct dep so the CLI command signatures
 # (`daemon_load`, `daemon_tiering`, etc.) name `DriveLetter` natively


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.5.122** — the `[workspace.package].version` bump in `Cargo.toml`.  This PR routes that commit through branch-protection rules.  Once it merges to `main`, run `just release-tag` to cut the signed `v0.5.122` tag, which fires `release.yml` and builds the cross-platform binaries + GitHub Release v0.5.122.  (No auto-tag on merge — the tag step is manual on-demand, Path B.)

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

The auto-commit lived only on `release/v0.5.122`, so local `main` never drifted — sync it with a plain `git pull --ff-only origin main` (no `reset --hard` needed).