### PR TITLE
fix(winget): seeder strips the unsupported portable Scope field

### DIFF
--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -31,6 +31,12 @@ reads it and **idempotently** inserts any entry missing from a manifest. Adding
 a future binary (e.g. `uffs-gui`) is a one-line edit to that yaml, never a code
 change, and never a new script.
 
+The seeder also strips the no-op top-level `Scope:` field (carried over from the
+founding template) — a zip/portable installer has no install scope, so winget's
+validator warns "Scope is not supported for InstallerType portable" on every
+version. Removing it clears the warning; komac preserves the absence going
+forward.
+
 ## Hard precondition
 
 Only seed an alias whose binary is **actually in** `uffs-windows-x64.zip` for the

--- a/scripts/dev/winget_seed_aliases.sh
+++ b/scripts/dev/winget_seed_aliases.sh
@@ -115,8 +115,23 @@ while IFS= read -r line; do
   esac
 done < "$ALIASES_FILE"
 
+# Strip the no-op top-level `Scope:` field. It carried over from the
+# founding manifest template, but a zip/portable installer has no
+# per-user/per-machine scope — winget's validator emits "Scope is not
+# supported for InstallerType portable" on every version. Removing it
+# clears the warning, and komac preserves the absence on the next
+# version bump. Idempotent: a no-op once it's gone.
+scope_removed=0
+if grep -qE '^Scope:' "$MANIFEST"; then
+  tmp="$(mktemp)"
+  grep -vE '^Scope:' "$MANIFEST" > "$tmp"
+  mv "$tmp" "$MANIFEST"
+  echo "➖ Removed unsupported 'Scope' field (portable installer)"
+  scope_removed=1
+fi
+
 echo
-echo "Done: ${added} added, ${skipped} already present in $MANIFEST"
-if (( added > 0 )); then
+echo "Done: ${added} added, ${skipped} already present, ${scope_removed} scope removed in $MANIFEST"
+if (( added > 0 || scope_removed > 0 )); then
   echo "Review the diff, commit, and push to the winget-pkgs PR branch."
 fi


### PR DESCRIPTION
The winget validator warns *"Scope is not supported for InstallerType portable"* on every `SkyLLC.UFFS` version. The `Scope: user` line carried over from the founding manifest template, but a zip/portable installer has no per-user/per-machine scope.

`winget_seed_aliases.sh` now removes it when it runs — CRLF-safe and idempotent (a no-op once gone). komac preserves the absence on the next version bump, so the warning clears for good after the next seeded release.

Tested against a synthetic CRLF manifest: adds the broker alias, skips already-present tui, strips Scope, and run 2 is fully idempotent.

The in-flight 0.5.123 winget PR is left untouched on purpose — re-pushing would restart its ~40-min validation for a cosmetic warning; this self-heals on the next release's seed.

Docs-adjacent (shell + markdown only); no code or release impact.