### PR TITLE
fix(broker): make the Access Broker work end-to-end + production follow-up playbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4448,6 +4448,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uffs-broker-protocol",
  "uffs-format",
  "uffs-mft",
  "uffs-security",

--- a/crates/uffs-broker/Cargo.toml
+++ b/crates/uffs-broker/Cargo.toml
@@ -41,21 +41,20 @@ default-target = "x86_64-pc-windows-msvc"
 name = "uffs-broker"
 path = "src/main.rs"
 
-[dependencies]
-# `tracing` macros are used cross-platform: the bin's non-Windows path
-# in `main.rs` emits `tracing::error!` before exiting.  The Windows-only
-# broker logic uses `tracing` heavily in `broker.rs`.
-tracing.workspace = true
-
 # Windows-only deps: the elevated handle-broker logic in `broker.rs` is
 # fully `#[cfg(windows)]`, so its supporting crates compile only on the
 # Windows target.  Scoped to `[target.'cfg(windows)'.dependencies]` so
 # the bin's non-Windows compilation (a tiny error-message stub in
-# `main.rs`) doesn't pull in `anyhow`, `tracing-subscriber`, `windows`,
-# or the broker protocol — each would otherwise be visible-but-unused
-# on Linux/macOS and need a `use X as _;` marker.  F5 / issue #205.
+# `main.rs` that uses only `eprintln!`) doesn't pull in `anyhow`,
+# `tracing`, `tracing-subscriber`, `windows`, or the broker protocol —
+# each would otherwise be visible-but-unused on Linux/macOS and need a
+# `use X as _;` marker.  F5 / issue #205.
 [target.'cfg(windows)'.dependencies]
 anyhow.workspace = true
+# `tracing` macros are used heavily in the Windows-only `broker.rs`; the
+# non-Windows `main.rs` stub uses `eprintln!`, so tracing is not needed
+# off Windows.
+tracing.workspace = true
 tracing-subscriber.workspace = true
 windows.workspace = true
 # Wire-protocol types shared with `uffs-daemon::broker_client`.  Lives

--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -336,6 +336,7 @@ fn audit_log(action: &str, pid: u32, exe: Option<&str>, drive: Option<char>, det
 fn create_broker_pipe() -> anyhow::Result<windows::Win32::Foundation::HANDLE> {
     use std::os::windows::ffi::OsStrExt as _;
 
+    use windows::Win32::Security::SECURITY_ATTRIBUTES;
     use windows::Win32::Storage::FileSystem::{FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_ACCESS_DUPLEX};
     use windows::Win32::System::Pipes::{
         CreateNamedPipeW, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_WAIT,
@@ -347,8 +348,23 @@ fn create_broker_pipe() -> anyhow::Result<windows::Win32::Foundation::HANDLE> {
         .chain(Some(0))
         .collect();
 
-    // SAFETY: `pipe_name` is a NUL-terminated UTF-16 buffer owned for the
-    // duration of this call; all other arguments are plain integers or None.
+    // The whole point of the broker is to serve a NON-elevated daemon.  With
+    // `None` security, an elevated/SYSTEM creator gets an owner-only DACL AND
+    // a high mandatory-integrity label, so the medium-integrity daemon can't
+    // even open the pipe.  Build an explicit descriptor that lets the daemon
+    // connect; the broker still verifies the client is uffsd + Authenticode
+    // before granting any handle (`check_client_identity`), so a permissive
+    // *connect* ACL is not a privilege leak.
+    let security = PipeSecurity::build()?;
+    let sa = SECURITY_ATTRIBUTES {
+        nLength: u32::try_from(size_of::<SECURITY_ATTRIBUTES>()).unwrap_or(0),
+        lpSecurityDescriptor: security.descriptor_ptr(),
+        bInheritHandle: false.into(),
+    };
+
+    // SAFETY: `pipe_name` is a NUL-terminated UTF-16 buffer and `sa` (with its
+    // security descriptor) both live until after this call returns; the pipe
+    // copies the descriptor, so `security` may be dropped afterwards.
     let handle = unsafe {
         CreateNamedPipeW(
             PCWSTR(pipe_name.as_ptr()),
@@ -358,9 +374,10 @@ fn create_broker_pipe() -> anyhow::Result<windows::Win32::Foundation::HANDLE> {
             1024, // out buffer
             1024, // in buffer
             0,    // default timeout
-            None, // default security (owner-only for elevated process)
+            Some(&raw const sa),
         )
     };
+    drop(security);
 
     if handle.is_invalid() {
         anyhow::bail!(
@@ -370,6 +387,81 @@ fn create_broker_pipe() -> anyhow::Result<windows::Win32::Foundation::HANDLE> {
     }
 
     Ok(handle)
+}
+
+/// Owns a self-relative security descriptor built from SDDL, for the broker
+/// pipe.  Frees the descriptor (`LocalFree`) on drop.
+///
+/// SDDL: `D:(A;;GRGW;;;AU)S:(ML;;NW;;;LW)`
+/// - DACL grants Authenticated Users generic read+write (enough to open and
+///   talk to the pipe — identity is checked at the app layer per request).
+/// - SACL sets a **low** mandatory-integrity label so the medium-integrity
+///   (non-elevated) daemon is not blocked by the high label an elevated/SYSTEM
+///   creator would otherwise stamp on the object.
+#[cfg(windows)]
+struct PipeSecurity {
+    /// `LocalAlloc`-ed self-relative security descriptor; freed on drop.
+    descriptor: windows::Win32::Security::PSECURITY_DESCRIPTOR,
+}
+
+#[cfg(windows)]
+impl PipeSecurity {
+    /// Build the broker-pipe security descriptor from SDDL (see the type docs).
+    #[expect(
+        unsafe_code,
+        reason = "FFI: ConvertStringSecurityDescriptorToSecurityDescriptorW"
+    )]
+    fn build() -> anyhow::Result<Self> {
+        use windows::Win32::Security::Authorization::{
+            ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+        };
+        use windows::Win32::Security::PSECURITY_DESCRIPTOR;
+        use windows::core::PCWSTR;
+
+        let sddl: Vec<u16> = "D:(A;;GRGW;;;AU)S:(ML;;NW;;;LW)"
+            .encode_utf16()
+            .chain(Some(0))
+            .collect();
+        let mut descriptor = PSECURITY_DESCRIPTOR::default();
+        // SAFETY: `sddl` is a NUL-terminated UTF-16 string valid for the call;
+        // `descriptor` is a valid out-pointer that receives a `LocalAlloc`-ed
+        // descriptor we free in `Drop`.
+        unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                PCWSTR(sddl.as_ptr()),
+                SDDL_REVISION_1,
+                &raw mut descriptor,
+                None,
+            )
+        }
+        .map_err(|err| anyhow::anyhow!("failed to build pipe security descriptor: {err}"))?;
+        Ok(Self { descriptor })
+    }
+
+    /// Raw pointer to the descriptor, for `SECURITY_ATTRIBUTES`.
+    const fn descriptor_ptr(&self) -> *mut core::ffi::c_void {
+        self.descriptor.0
+    }
+}
+
+#[cfg(windows)]
+impl Drop for PipeSecurity {
+    #[expect(
+        unsafe_code,
+        reason = "FFI: LocalFree of the SDDL-allocated descriptor"
+    )]
+    fn drop(&mut self) {
+        if !self.descriptor.0.is_null() {
+            // SAFETY: `descriptor.0` was allocated by
+            // `ConvertStringSecurityDescriptorToSecurityDescriptorW` via
+            // `LocalAlloc`; freeing it once on drop is the documented contract.
+            _ = unsafe {
+                windows::Win32::Foundation::LocalFree(Some(windows::Win32::Foundation::HLOCAL(
+                    self.descriptor.0,
+                )))
+            };
+        }
+    }
 }
 
 /// Wait for a client to connect to the pipe.

--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -438,8 +438,8 @@ fn get_pipe_client_pid(pipe: windows::Win32::Foundation::HANDLE) -> Option<u32> 
 #[expect(unsafe_code, reason = "CreateFileW is an FFI call")]
 fn open_volume_read_only(drive_letter: char) -> anyhow::Result<windows::Win32::Foundation::HANDLE> {
     use windows::Win32::Storage::FileSystem::{
-        CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_GENERIC_READ, FILE_SHARE_READ,
-        FILE_SHARE_WRITE, OPEN_EXISTING,
+        CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OVERLAPPED, FILE_FLAG_SEQUENTIAL_SCAN,
+        FILE_GENERIC_READ, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
     };
 
     let volume_path = format!("\\\\.\\{drive_letter}:");
@@ -447,6 +447,12 @@ fn open_volume_read_only(drive_letter: char) -> anyhow::Result<windows::Win32::F
 
     // SAFETY: `wide_path` is a NUL-terminated UTF-16 buffer owned for the
     // duration of this call; all other arguments are plain integers or None.
+    //
+    // The handle is duplicated into the (non-elevated) daemon, which reads
+    // the MFT through it via overlapped/IOCP I/O — so it must be opened
+    // `FILE_FLAG_OVERLAPPED` (and `SEQUENTIAL_SCAN`, matching the reader's
+    // direct-open flags in `uffs-mft::VolumeHandle`).  Without OVERLAPPED the
+    // daemon's IOCP reads on the vended handle fail.
     let create_file_result = unsafe {
         CreateFileW(
             windows::core::PCWSTR(wide_path.as_ptr()),
@@ -454,7 +460,7 @@ fn open_volume_read_only(drive_letter: char) -> anyhow::Result<windows::Win32::F
             FILE_SHARE_READ | FILE_SHARE_WRITE,
             None,
             OPEN_EXISTING,
-            FILE_FLAG_BACKUP_SEMANTICS,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED | FILE_FLAG_SEQUENTIAL_SCAN,
             None,
         )
     };

--- a/crates/uffs-broker/src/broker/service.rs
+++ b/crates/uffs-broker/src/broker/service.rs
@@ -9,33 +9,75 @@
 //! pipe-serving or client-verification logic. Both are admin-only CLI commands
 //! invoked from `broker::run`.
 
-/// Register the broker as a Windows Service via `sc create`.
+/// Register the broker as an auto-start Windows Service and start it.
+///
+/// # Why the argv is split the way it is
+///
+/// `sc create` parses `option= value` where `option=` and the value are
+/// **separate command-line tokens** (the space after `=` is the
+/// delimiter).  The prior code passed `binPath= "<path>"` as a *single*
+/// argument, so the registered `ImagePath` ended up as ` "<path>"` —
+/// with a leading space and literal quotes — and the service failed to
+/// start with `StartService` error 87 (`ERROR_INVALID_PARAMETER`).  Here
+/// `binPath=` and the raw path are distinct argv elements; `std`'s
+/// Windows argument quoting wraps the path in quotes only if it contains
+/// spaces, producing a valid `ImagePath` in both cases.
 #[cfg(windows)]
 #[expect(
     clippy::print_stdout,
     reason = "CLI admin command — stdout is the user-visible result channel"
 )]
 pub(super) fn install_service() -> anyhow::Result<()> {
+    if !super::is_elevated() {
+        anyhow::bail!(
+            "installing the broker service requires Administrator.\n\
+             Open an elevated terminal (right-click PowerShell or cmd → \
+             \"Run as administrator\") and re-run:\n    uffs-broker --install"
+        );
+    }
+
     let exe = std::env::current_exe()?;
-    let output = std::process::Command::new("sc")
+    let create = std::process::Command::new("sc.exe")
         .args([
             "create",
             "UffsAccessBroker",
-            &format!("binPath= \"{}\"", exe.display()),
+            "binPath=",
+            &exe.display().to_string(),
             "start=",
-            "demand",
+            "auto",
             "DisplayName=",
             "UFFS Access Broker",
         ])
         .output()?;
 
-    if output.status.success() {
-        println!("Service installed. Start with: sc start UffsAccessBroker");
+    if !create.status.success() {
+        // AUDIT-OK(bytes): `sc` stderr surfaced verbatim to the operator —
+        // display only, no decision.
+        let stderr = String::from_utf8_lossy(&create.stderr);
+        anyhow::bail!("Install failed (sc create): {stderr}");
+    }
+
+    // Start it now so the broker is usable immediately — the whole point
+    // is "no future UAC", which only holds once the service is running.
+    // `start= auto` also brings it back on every boot.
+    let start = std::process::Command::new("sc.exe")
+        .args(["start", "UffsAccessBroker"])
+        .output()?;
+
+    if start.status.success() {
+        println!(
+            "UFFS Access Broker installed and started (auto-start on boot).\n\
+             Non-elevated `uffs` searches will now use the broker for volume \
+             access — no more UAC prompts."
+        );
     } else {
-        // AUDIT-OK(bytes): `sc` command stderr surfaced verbatim in an
-        // error message for the operator — display only, no decision.
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Install failed: {stderr}");
+        // AUDIT-OK(bytes): `sc` stderr surfaced verbatim to the operator.
+        let stderr = String::from_utf8_lossy(&start.stderr);
+        println!(
+            "Service installed (auto-start on boot), but starting it failed: \
+             {stderr}\nStart it manually from an elevated shell with:\n    \
+             sc.exe start UffsAccessBroker"
+        );
     }
     Ok(())
 }
@@ -49,7 +91,13 @@ pub(super) fn install_service() -> anyhow::Result<()> {
     reason = "CLI admin command — stdout is the user-visible result channel"
 )]
 pub(super) fn uninstall_service() -> anyhow::Result<()> {
-    let output = std::process::Command::new("sc")
+    if !super::is_elevated() {
+        anyhow::bail!(
+            "removing the broker service requires Administrator.\n\
+             Open an elevated terminal and re-run:\n    uffs-broker --uninstall"
+        );
+    }
+    let output = std::process::Command::new("sc.exe")
         .args(["delete", "UffsAccessBroker"])
         .output()?;
 

--- a/crates/uffs-broker/src/main.rs
+++ b/crates/uffs-broker/src/main.rs
@@ -29,18 +29,26 @@
 #[cfg(windows)]
 mod broker;
 
+#[expect(
+    clippy::print_stderr,
+    reason = "the --install/--uninstall paths run before any tracing subscriber \
+              exists, so tracing::error! is silently dropped (a non-elevated \
+              `--install` failed with NO output). stderr always reaches the operator."
+)]
 fn main() {
     #[cfg(windows)]
     {
         if let Err(run_err) = broker::run() {
-            tracing::error!(%run_err, "uffs-broker fatal error");
+            // `{:#}` prints the full anyhow cause chain (e.g. the `sc`
+            // stderr or the elevation-required message).
+            eprintln!("uffs-broker: {run_err:#}");
             std::process::exit(1);
         }
     }
 
     #[cfg(not(windows))]
     {
-        tracing::error!("uffs-broker is a Windows-only component");
+        eprintln!("uffs-broker is a Windows-only component.");
         std::process::exit(1);
     }
 }

--- a/crates/uffs-client/Cargo.toml
+++ b/crates/uffs-client/Cargo.toml
@@ -114,6 +114,9 @@ libc.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
+# Broker pipe-name constant + protocol, so daemon-spawn can detect a
+# running Access Broker and skip the elevation gate when one is present.
+uffs-broker-protocol.workspace = true
 
 [dev-dependencies]
 # Temporary PID-file fixtures for verify_strict / deep_health_check tests.

--- a/crates/uffs-client/src/broker_probe.rs
+++ b/crates/uffs-client/src/broker_probe.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Detect a running UFFS Access Broker.
+//!
+//! The broker is an elevated Windows service that vends read-only NTFS
+//! volume handles to a non-elevated daemon.  [`broker_pipe_present`] lets
+//! the client's daemon-spawn logic ([`crate::daemon_spawn`]) decide
+//! whether a non-elevated `uffs` can start the daemon anyway (the daemon
+//! then obtains handles from the broker) instead of returning
+//! [`crate::error::ClientError::DaemonNeedsElevation`].
+//!
+//! This whole module is `#[cfg(windows)]` (declared so in `lib.rs`), so
+//! it carries no per-item cfg gates.
+
+/// Return `true` when the UFFS Access Broker named pipe exists — i.e. the
+/// broker Windows service is installed and running.
+///
+/// Mirrors `uffs-daemon::broker_client::broker_available` (the daemon
+/// can't be a dependency of the client), using a single
+/// `GetFileAttributesW` probe on [`uffs_broker_protocol::PIPE_NAME`] —
+/// cheap, opens no handle, no side effects.
+pub(crate) fn broker_pipe_present() -> bool {
+    use std::os::windows::ffi::OsStrExt as _;
+
+    use uffs_broker_protocol::PIPE_NAME;
+    use windows::Win32::Storage::FileSystem::GetFileAttributesW;
+    use windows::core::PCWSTR;
+
+    let wide: Vec<u16> = std::ffi::OsStr::new(PIPE_NAME)
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+
+    #[expect(unsafe_code, reason = "GetFileAttributesW probe for pipe existence")]
+    // SAFETY: `wide` is a null-terminated UTF-16 buffer that outlives the
+    // call; `GetFileAttributesW` only reads through the pointer.
+    let attrs = unsafe { GetFileAttributesW(PCWSTR(wide.as_ptr())) };
+
+    // INVALID_FILE_ATTRIBUTES (u32::MAX) means the pipe does not exist.
+    attrs != u32::MAX
+}

--- a/crates/uffs-client/src/daemon_spawn.rs
+++ b/crates/uffs-client/src/daemon_spawn.rs
@@ -204,13 +204,40 @@ fn spawn_daemon_windows(
 
     match policy {
         ElevationPolicy::AllowUacPrompt => spawn_via_uac_prompt(exe, args),
-        ElevationPolicy::RequireExistingElevation => {
-            tracing::info!("Not elevated and policy forbids UAC — returning DaemonNeedsElevation");
-            Err(crate::error::ClientError::DaemonNeedsElevation {
-                daemon_path: exe.display().to_string(),
-            })
-        }
+        ElevationPolicy::RequireExistingElevation => spawn_unelevated_or_refuse(exe, args),
     }
+}
+
+/// `RequireExistingElevation` arm of [`spawn_daemon_windows`]: the shell
+/// is not elevated and UAC is forbidden.
+///
+/// Before refusing, check for a running Access Broker: if its named pipe
+/// is present the daemon can start as the current (non-elevated) user and
+/// obtain volume handles from the broker instead of needing admin itself
+/// (the whole point of `uffs-broker --install`; the daemon-side consumer
+/// is `uffs-daemon::broker_client`).  With no broker, return
+/// [`DaemonNeedsElevation`](crate::error::ClientError::DaemonNeedsElevation)
+/// so the CLI renders its recovery help.
+#[cfg(windows)]
+#[expect(
+    clippy::single_call_fn,
+    reason = "extracted from spawn_daemon_windows to stay under the cognitive-complexity ceiling"
+)]
+fn spawn_unelevated_or_refuse(
+    exe: &std::path::Path,
+    args: &[std::ffi::OsString],
+) -> Result<DaemonChildHandle, crate::error::ClientError> {
+    if crate::broker_probe::broker_pipe_present() {
+        tracing::info!(
+            "Not elevated, but the Access Broker pipe is present — spawning the \
+             daemon non-elevated; it will obtain volume handles via the broker."
+        );
+        return spawn_detached_no_inherit(exe, args);
+    }
+    tracing::info!("Not elevated and policy forbids UAC — returning DaemonNeedsElevation");
+    Err(crate::error::ClientError::DaemonNeedsElevation {
+        daemon_path: exe.display().to_string(),
+    })
 }
 
 /// UAC-prompt arm of [`spawn_daemon_windows`].

--- a/crates/uffs-client/src/lib.rs
+++ b/crates/uffs-client/src/lib.rs
@@ -185,4 +185,9 @@ pub(crate) mod verify;
 #[cfg(windows)]
 pub(crate) mod windows_deadline;
 
+/// Access Broker detection (Windows-only): probe the broker named pipe so
+/// daemon-spawn can skip the elevation gate when a broker is running.
+#[cfg(windows)]
+pub(crate) mod broker_probe;
+
 pub mod schema;

--- a/crates/uffs-daemon/src/broker_client.rs
+++ b/crates/uffs-daemon/src/broker_client.rs
@@ -26,29 +26,11 @@
 //! an extern crate at all on non-Windows targets — no `use … as _;`
 //! marker is needed.
 
-/// Check if the Access Broker is available (pipe exists).
-#[cfg(windows)]
-pub(crate) fn broker_available() -> bool {
-    use std::os::windows::ffi::OsStrExt as _;
-
-    use uffs_broker_protocol::PIPE_NAME;
-    use windows::Win32::Storage::FileSystem::GetFileAttributesW;
-    use windows::core::PCWSTR;
-
-    let wide: Vec<u16> = std::ffi::OsStr::new(PIPE_NAME)
-        .encode_wide()
-        .chain(Some(0))
-        .collect();
-
-    #[expect(unsafe_code, reason = "GetFileAttributesW to check pipe existence")]
-    // SAFETY: `wide` is a null-terminated UTF-16 buffer that lives for
-    // the duration of the call; `GetFileAttributesW` only reads from
-    // the pointer.
-    let attrs = unsafe { GetFileAttributesW(PCWSTR(wide.as_ptr())) };
-
-    // If not INVALID_FILE_ATTRIBUTES, the pipe exists
-    attrs != u32::MAX
-}
+// NOTE: there is intentionally no `broker_available()` probe.  A
+// `GetFileAttributesW` existence check on the pipe *connects to* the broker's
+// single instance and leaves it busy, starving the real handle request with
+// ERROR_PIPE_BUSY (2026-06-13 VM finding).  Broker presence is established
+// solely by `request_volume_handle` attempting the connection.
 
 /// Request a volume handle from the broker for a drive letter.
 ///
@@ -123,13 +105,4 @@ fn interpret_handle_response(
             anyhow::bail!("Broker returned Status::Error for drive {drive_letter}")
         }
     }
-}
-
-/// Non-Windows: broker is never available.
-///
-/// `request_volume_handle` has no non-Windows stub: its only caller,
-/// `warm_up_broker_handles`, is itself `#[cfg(windows)]`.
-#[cfg(not(windows))]
-pub(crate) const fn broker_available() -> bool {
-    false
 }

--- a/crates/uffs-daemon/src/broker_client.rs
+++ b/crates/uffs-daemon/src/broker_client.rs
@@ -58,23 +58,31 @@ pub(crate) fn broker_available() -> bool {
 pub(crate) fn request_volume_handle(
     drive_letter: uffs_mft::platform::DriveLetter,
 ) -> anyhow::Result<u64> {
+    let response = broker_pipe_round_trip(drive_letter)?;
+    interpret_handle_response(drive_letter, response)
+}
+
+/// Open the broker pipe, send the 1-byte drive request, and read the raw
+/// 9-byte response.  Split from [`request_volume_handle`] to keep both under
+/// the cognitive-complexity ceiling and to isolate the I/O failure points
+/// (the diagnostic `tracing` calls pinpoint where a non-elevated daemon's
+/// access to the broker pipe breaks).
+#[cfg(windows)]
+fn broker_pipe_round_trip(
+    drive_letter: uffs_mft::platform::DriveLetter,
+) -> anyhow::Result<[u8; uffs_broker_protocol::RESPONSE_WIRE_LEN]> {
     use std::io::{Read as _, Write as _};
 
-    use uffs_broker_protocol::{
-        HandleRequest, HandleResponse, PIPE_NAME, RESPONSE_WIRE_LEN, Status,
-    };
+    use uffs_broker_protocol::{HandleRequest, PIPE_NAME, RESPONSE_WIRE_LEN};
 
-    // Connect to broker pipe
-    let pipe_path = std::path::Path::new(PIPE_NAME);
+    tracing::debug!(drive = %drive_letter, pipe = PIPE_NAME, "Opening broker pipe");
     let mut pipe = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
-        .open(pipe_path)
-        .map_err(|err| anyhow::anyhow!("Failed to connect to broker: {err}"))?;
+        .open(std::path::Path::new(PIPE_NAME))
+        .map_err(|err| anyhow::anyhow!("opening broker pipe: {err}"))?;
+    tracing::debug!(drive = %drive_letter, "Broker pipe opened; sending request");
 
-    // Encode the 1-byte request via the shared protocol module.
-    // `uffs-broker-protocol` is a leaf crate with no `uffs-mft` dep,
-    // so we convert at the boundary.
     let request_bytes = HandleRequest {
         drive: drive_letter.as_char(),
     }
@@ -82,13 +90,26 @@ pub(crate) fn request_volume_handle(
     pipe.write_all(&request_bytes)?;
     pipe.flush()?;
 
-    // Read and parse the 9-byte response via the shared protocol module.
     let mut response = [0_u8; RESPONSE_WIRE_LEN];
     pipe.read_exact(&mut response)?;
+    tracing::debug!(drive = %drive_letter, "Broker response received");
+    Ok(response)
+}
+
+/// Parse and interpret the broker's 9-byte response into a handle value.
+///
+/// Split out of [`request_volume_handle`] to keep that function under the
+/// cognitive-complexity ceiling.
+#[cfg(windows)]
+fn interpret_handle_response(
+    drive_letter: uffs_mft::platform::DriveLetter,
+    response: [u8; uffs_broker_protocol::RESPONSE_WIRE_LEN],
+) -> anyhow::Result<u64> {
+    use uffs_broker_protocol::{HandleResponse, Status};
+
     let parsed = HandleResponse::parse(response).map_err(|parse_err| {
         anyhow::anyhow!("malformed broker response for drive {drive_letter}: {parse_err}")
     })?;
-
     match parsed.status {
         Status::Ok => {
             tracing::info!(

--- a/crates/uffs-daemon/src/broker_client.rs
+++ b/crates/uffs-daemon/src/broker_client.rs
@@ -126,19 +126,10 @@ fn interpret_handle_response(
 }
 
 /// Non-Windows: broker is never available.
+///
+/// `request_volume_handle` has no non-Windows stub: its only caller,
+/// `warm_up_broker_handles`, is itself `#[cfg(windows)]`.
 #[cfg(not(windows))]
 pub(crate) const fn broker_available() -> bool {
     false
-}
-
-/// Non-Windows: broker request always fails.
-#[cfg(not(windows))]
-#[expect(
-    clippy::single_call_fn,
-    reason = "platform stub — mirrors Windows variant"
-)]
-pub(crate) fn request_volume_handle(
-    _drive_letter: uffs_mft::platform::DriveLetter,
-) -> anyhow::Result<u64> {
-    anyhow::bail!("Access Broker is a Windows-only feature")
 }

--- a/crates/uffs-daemon/src/index/loading.rs
+++ b/crates/uffs-daemon/src/index/loading.rs
@@ -393,7 +393,12 @@ impl IndexManager {
             Ok((letter, Err(err))) => {
                 *loaded += 1;
                 eprintln!("[diag] load_live_drives: FAILED drive={letter}  error={err:#}");
-                tracing::error!(drive = %letter, error = %err, "Failed to load live drive");
+                // Log the FULL anyhow cause chain to the file sink (the
+                // detached daemon's stderr above is discarded).  `%err`
+                // alone shows only the outer context, hiding the real
+                // failure deep in the broker-handle read path.
+                let err_chain = format!("{err:#}");
+                tracing::error!(drive = %letter, error = %err_chain, "Failed to load live drive");
             }
             Err(err) => {
                 *loaded += 1;

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -324,6 +324,10 @@ async fn load_live_drives_if_windows(
 /// ignored — the direct-open path takes over transparently.
 #[cfg(windows)]
 fn warm_up_broker_handles(drives: &[uffs_mft::platform::DriveLetter]) {
+    tracing::info!(
+        drives = ?drives,
+        "warm_up_broker_handles: requesting volume handles from the Access Broker"
+    );
     for &drive_letter in drives {
         match broker_client::request_volume_handle(drive_letter) {
             Ok(handle) => {
@@ -338,10 +342,10 @@ fn warm_up_broker_handles(drives: &[uffs_mft::platform::DriveLetter]) {
                 tracing::info!(drive = %drive_letter, handle, "Registered broker volume handle");
             }
             Err(broker_err) => {
-                tracing::debug!(
+                tracing::warn!(
                     drive = %drive_letter,
                     error = %broker_err,
-                    "Broker unavailable, using direct access"
+                    "Access Broker handle request FAILED — falling back to direct (elevated) open"
                 );
             }
         }

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -327,7 +327,15 @@ fn warm_up_broker_handles(drives: &[uffs_mft::platform::DriveLetter]) {
     for &drive_letter in drives {
         match broker_client::request_volume_handle(drive_letter) {
             Ok(handle) => {
-                tracing::info!(drive = %drive_letter, handle, "Got broker handle");
+                // Deposit the broker's (elevated, overlapped) volume handle in
+                // the uffs-mft registry; the subsequent `VolumeHandle::open`
+                // for this drive adopts it instead of calling `CreateFileW`
+                // (which a non-elevated daemon can't do).  This is what makes
+                // the broker path actually load the MFT — previously the
+                // handle was fetched and dropped, so the reader fell back to a
+                // direct open and failed with access-denied.
+                uffs_mft::register_broker_handle(drive_letter, handle);
+                tracing::info!(drive = %drive_letter, handle, "Registered broker volume handle");
             }
             Err(broker_err) => {
                 tracing::debug!(

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -247,7 +247,6 @@ fn spawn_load_task(
     no_cache: bool,
     load_lifecycle: lifecycle::LifecycleHandle,
 ) -> tokio::task::JoinHandle<()> {
-    let broker_is_available = broker_client::broker_available();
     tokio::spawn(async move {
         tracing::info!(mft_files = mft_files.len(), drives = ?drives, "Load task starting");
         if !mft_files.is_empty() {
@@ -258,18 +257,7 @@ fn spawn_load_task(
         // Live-MFT scanning is Windows-only; on every other platform the
         // load task is fully covered by `load_from_data_dir` above.
         #[cfg(windows)]
-        load_live_drives_if_windows(
-            &load_index,
-            &drives,
-            no_cache,
-            &load_lifecycle,
-            broker_is_available,
-        )
-        .await;
-        if broker_is_available {
-            let _handle_result =
-                broker_client::request_volume_handle(uffs_mft::platform::DriveLetter::C);
-        }
+        load_live_drives_if_windows(&load_index, &drives, no_cache, &load_lifecycle).await;
         tracing::info!("Load task completed");
 
         // Latch the load phase as complete: from this point on, a daemon
@@ -303,14 +291,22 @@ async fn load_live_drives_if_windows(
     drives: &[uffs_mft::platform::DriveLetter],
     no_cache: bool,
     load_lifecycle: &lifecycle::LifecycleHandle,
-    broker_is_available: bool,
 ) {
     if drives.is_empty() {
         return;
     }
-    if broker_is_available {
-        warm_up_broker_handles(drives);
-    }
+    // Always attempt the broker warm-up.  Gating on a separate
+    // `broker_available()` check is unreliable: that probe connects to and
+    // consumes the broker's single pipe instance, so a second probe races to
+    // `false` and the warm-up is wrongly skipped (2026-06-13 VM finding).  The
+    // handle request below is the only authoritative test — it succeeds when a
+    // broker is serving and fails fast (WARN + direct-open fallback) when not.
+    tracing::info!(
+        pid = std::process::id(),
+        drive_count = drives.len(),
+        "load_live_drives_if_windows: attempting broker warm-up unconditionally"
+    );
+    warm_up_broker_handles(drives);
     tracing::info!(drives = ?drives, "Loading live drives...");
     load_index
         .load_live_drives(drives, no_cache, load_lifecycle)
@@ -325,6 +321,7 @@ async fn load_live_drives_if_windows(
 #[cfg(windows)]
 fn warm_up_broker_handles(drives: &[uffs_mft::platform::DriveLetter]) {
     tracing::info!(
+        daemon_pid = std::process::id(),
         drives = ?drives,
         "warm_up_broker_handles: requesting volume handles from the Access Broker"
     );

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -14,7 +14,7 @@
 use alloc::sync::Arc;
 use std::path::PathBuf;
 
-use crate::{DaemonConfig, broker_client, config, events, lifecycle};
+use crate::{DaemonConfig, config, events, lifecycle};
 
 /// Bail if the daemon has nothing to serve.
 pub(crate) fn validate_data_sources(
@@ -54,10 +54,15 @@ pub(crate) fn validate_data_sources(
 /// the operator might want to grep for.  Extracted so the orchestrator
 /// stays under clippy's `cognitive_complexity` budget.
 pub(crate) fn log_daemon_starting(config: &DaemonConfig) {
+    // NOTE: do NOT probe the Access Broker here.  The previous
+    // `broker_available()` call used `GetFileAttributesW`, which *connects to*
+    // the broker's single pipe instance and leaves it busy — so the real
+    // `warm_up_broker_handles` request milliseconds later failed with
+    // ERROR_PIPE_BUSY (2026-06-13 VM finding).  Broker presence is now
+    // established only by attempting the handle request itself.
     tracing::info!(
         pid = std::process::id(),
         version = env!("CARGO_PKG_VERSION"),
-        broker_available = broker_client::broker_available(),
         mft_files = ?config.mft_files,
         drives = ?config.drives,
         data_dir = ?config.data_dir,

--- a/crates/uffs-mft/src/lib.rs
+++ b/crates/uffs-mft/src/lib.rs
@@ -315,7 +315,7 @@ pub use platform::{DriveType, MftBitmap, MftExtent, SystemMemory, query_system_m
 // is_volume_read_only) are pub(crate) and consumed only via
 // `crate::platform::*` paths, so no crate-root re-export is needed.
 #[cfg(windows)]
-pub use platform::{VolumeHandle, detect_ntfs_drives};
+pub use platform::{VolumeHandle, detect_ntfs_drives, register_broker_handle};
 pub use raw::{
     LoadRawOptions, RawMftData, RawMftHeader, SaveRawOptions, load_raw_mft, load_raw_mft_header,
     save_raw_mft,

--- a/crates/uffs-mft/src/platform.rs
+++ b/crates/uffs-mft/src/platform.rs
@@ -76,7 +76,7 @@ pub(crate) use volume::{
 // `VolumeHandle::volume_data()` returns `&NtfsVolumeData` so the latter
 // must be at least as public as the former.
 #[cfg(windows)]
-pub use volume::{NtfsVolumeData, VolumeHandle};
+pub use volume::{NtfsVolumeData, VolumeHandle, register_broker_handle};
 
 #[cfg(test)]
 #[cfg(windows)]

--- a/crates/uffs-mft/src/platform/volume.rs
+++ b/crates/uffs-mft/src/platform/volume.rs
@@ -42,6 +42,48 @@ pub(crate) const WAIT_TIMEOUT_ERROR_CODE: u32 = 258;
 /// Win32 error code reported when an overlapped operation is aborted.
 const ERROR_OPERATION_ABORTED_CODE: u32 = 995;
 
+// ── Access Broker handle registry ──────────────────────────────────────────
+//
+// On Windows, opening `\\.\X:` for raw MFT reads needs Administrator.  When a
+// non-elevated daemon runs with the UFFS Access Broker service available, the
+// broker (elevated) opens the volume and hands the daemon a duplicated handle
+// over a named pipe.  The daemon deposits that handle here keyed by drive
+// letter; `VolumeHandle::open` checks the registry FIRST and adopts the
+// pre-opened handle instead of calling `CreateFileW` (which would fail with
+// access-denied).  This keeps the broker plumbing out of the deep
+// load-live-drives call chain — one deposit, one lookup.
+//
+// Handles are stored as the raw `u64` value the broker sends over the wire
+// (`HANDLE` itself is not `Send`/`Sync`); the value is a process-local
+// capability already duplicated into this process by the broker.
+
+/// Process-wide map of drive letter → broker-supplied raw volume handle.
+#[cfg(windows)]
+static BROKER_HANDLES: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<char, u64>>> =
+    std::sync::OnceLock::new();
+
+/// Deposit a broker-supplied volume handle for `drive`.
+///
+/// `raw_handle` is the duplicated `HANDLE` value `uffs-broker` returned over
+/// its pipe.  The next [`VolumeHandle::open`] for this drive adopts it (and
+/// removes it from the registry, so each handle is consumed once).
+#[cfg(windows)]
+pub fn register_broker_handle(drive: super::DriveLetter, raw_handle: u64) {
+    let map =
+        BROKER_HANDLES.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    if let Ok(mut guard) = map.lock() {
+        guard.insert(drive.as_char(), raw_handle);
+    }
+}
+
+/// Remove and return a previously-registered broker handle for `drive`, if any.
+#[cfg(windows)]
+fn take_broker_handle(drive: super::DriveLetter) -> Option<u64> {
+    let map = BROKER_HANDLES.get()?;
+    let mut guard = map.lock().ok()?;
+    guard.remove(&drive.as_char())
+}
+
 /// Convert a `windows::core::Error` into the equivalent `std::io::Error`,
 /// **unwrapping** the `HRESULT_FROM_WIN32` envelope so std's
 /// `decode_error_kind` table (keyed on bare Win32 codes like
@@ -140,6 +182,11 @@ pub struct VolumeHandle {
     volume: super::DriveLetter,
     /// NTFS volume data from `FSCTL_GET_NTFS_VOLUME_DATA`.
     volume_data: NtfsVolumeData,
+    /// `true` when `handle` was supplied by the Access Broker rather than
+    /// opened here via `CreateFileW`.  A broker handle is already an
+    /// elevated, overlapped volume handle, so [`Self::open_overlapped_handle`]
+    /// duplicates it instead of re-opening `\\.\X:` (which would need admin).
+    broker_backed: bool,
 }
 
 #[expect(
@@ -226,6 +273,14 @@ impl VolumeHandle {
     /// descriptor for the opened handle.
     #[expect(unsafe_code, reason = "FFI: windows API (CreateFileW)")]
     pub fn open(volume: super::DriveLetter) -> Result<Self> {
+        // Access Broker fast-path: if the (elevated) broker has deposited a
+        // pre-opened, duplicated volume handle for this drive, adopt it
+        // instead of calling `CreateFileW` — which would fail with
+        // access-denied in a non-elevated daemon.  See the registry above.
+        if let Some(raw_handle) = take_broker_handle(volume) {
+            return Self::from_broker_handle(volume, raw_handle);
+        }
+
         // `DriveLetter` is already validated (`A..=Z`), so no fallible
         // pre-check is needed here.  The wire path uses the
         // canonical uppercase ASCII byte directly.
@@ -273,6 +328,37 @@ impl VolumeHandle {
             handle,
             volume,
             volume_data,
+            broker_backed: false,
+        })
+    }
+
+    /// Adopt a pre-opened, duplicated volume handle supplied by the Access
+    /// Broker (Windows-only, see the broker handle registry above).
+    ///
+    /// `raw_handle` is the raw `HANDLE` value the broker duplicated into this
+    /// process; ownership transfers to the returned `VolumeHandle` (its `Drop`
+    /// closes it).  The broker opens the volume with
+    /// `FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED |
+    /// FILE_FLAG_SEQUENTIAL_SCAN`, matching the direct-open flags, so the
+    /// handle is usable for both the volume-data query here and the
+    /// overlapped MFT read via [`Self::open_overlapped_handle`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MftError`] if the volume descriptor cannot be read from the
+    /// adopted handle.
+    #[cfg(windows)]
+    pub fn from_broker_handle(volume: super::DriveLetter, raw_handle: u64) -> Result<Self> {
+        let handle = HANDLE(core::ptr::with_exposed_provenance_mut::<core::ffi::c_void>(
+            usize::try_from(raw_handle).unwrap_or(0),
+        ));
+        let volume_data = Self::get_ntfs_volume_data(handle, volume)?;
+        tracing::info!(drive = %volume, "Adopted Access Broker volume handle for MFT read");
+        Ok(Self {
+            handle,
+            volume,
+            volume_data,
+            broker_backed: true,
         })
     }
 
@@ -367,6 +453,14 @@ impl VolumeHandle {
     #[expect(unsafe_code, reason = "FFI: windows API (CreateFileW)")]
     pub fn open_overlapped_handle(&self) -> Result<HANDLE> {
         let volume = self.volume;
+
+        // Broker-backed: `\\.\X:` can't be re-opened here (non-elevated →
+        // access-denied).  The broker handle is already overlapped, so hand
+        // back an independent duplicate the caller can close on its own.
+        if self.broker_backed {
+            return self.duplicate_broker_handle();
+        }
+
         let volume_path: Vec<u16> = format!("\\\\.\\{volume}:")
             .encode_utf16()
             .chain(core::iter::once(0))
@@ -391,6 +485,45 @@ impl VolumeHandle {
             volume,
             source: hresult_to_io_error(&err),
         })
+    }
+
+    /// Duplicate the adopted broker handle into a fresh, independently-owned
+    /// overlapped handle for the bulk MFT read path.
+    ///
+    /// Same-process `DuplicateHandle` with `DUPLICATE_SAME_ACCESS` clones the
+    /// access rights and the `FILE_FLAG_OVERLAPPED` mode of the broker handle;
+    /// the caller closes the returned handle, leaving `self.handle` intact for
+    /// the volume-data queries and for `Drop`.
+    #[cfg(windows)]
+    #[expect(unsafe_code, reason = "FFI: DuplicateHandle / GetCurrentProcess")]
+    fn duplicate_broker_handle(&self) -> Result<HANDLE> {
+        use windows::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle};
+        use windows::Win32::System::Threading::GetCurrentProcess;
+
+        let mut duplicated = HANDLE::default();
+        // SAFETY: `GetCurrentProcess` takes no arguments and returns the
+        // current-process pseudo-handle; there are no preconditions.
+        let process = unsafe { GetCurrentProcess() };
+        // SAFETY: `process` is a valid (pseudo) process handle; `self.handle`
+        // is a valid open volume handle owned by this `VolumeHandle`;
+        // `&raw mut duplicated` is a valid out-pointer.  On success ownership
+        // of `duplicated` transfers to the caller.
+        let result = unsafe {
+            DuplicateHandle(
+                process,
+                self.handle,
+                process,
+                &raw mut duplicated,
+                0,
+                false,
+                DUPLICATE_SAME_ACCESS,
+            )
+        };
+        result.map_err(|err| MftError::VolumeOpen {
+            volume: self.volume,
+            source: hresult_to_io_error(&err),
+        })?;
+        Ok(duplicated)
     }
 
     /// Opens a read handle to `X:\$MFT` for direct file-based MFT reading.

--- a/crates/uffs-mft/src/platform/volume.rs
+++ b/crates/uffs-mft/src/platform/volume.rs
@@ -65,8 +65,11 @@ static BROKER_HANDLES: std::sync::OnceLock<std::sync::Mutex<std::collections::Ha
 /// Deposit a broker-supplied volume handle for `drive`.
 ///
 /// `raw_handle` is the duplicated `HANDLE` value `uffs-broker` returned over
-/// its pipe.  The next [`VolumeHandle::open`] for this drive adopts it (and
-/// removes it from the registry, so each handle is consumed once).
+/// its pipe.  Every [`VolumeHandle::open`] for this drive **duplicates** it
+/// (the registry copy stays in place) — the live MFT read opens the volume
+/// more than once (read pass + cache-write pass), so a take-once handle would
+/// leave the second open to fall back to `CreateFileW` and fail with
+/// access-denied.  The registry entry is freed by [`release_broker_handle`].
 #[cfg(windows)]
 pub fn register_broker_handle(drive: super::DriveLetter, raw_handle: u64) {
     let map =
@@ -76,12 +79,18 @@ pub fn register_broker_handle(drive: super::DriveLetter, raw_handle: u64) {
     }
 }
 
-/// Remove and return a previously-registered broker handle for `drive`, if any.
+/// Read (without removing) the registered broker handle for `drive`, if any.
+///
+/// The entry is intentionally retained for the daemon's lifetime: every
+/// `VolumeHandle::open` duplicates it (so multiple opens in one load, and
+/// later re-reads, all succeed), and the OS closes the original on process
+/// exit.  Keeping it also means re-reads keep working even if the broker
+/// service later stops — the daemon holds its own independent handle.
 #[cfg(windows)]
-fn take_broker_handle(drive: super::DriveLetter) -> Option<u64> {
+fn peek_broker_handle(drive: super::DriveLetter) -> Option<u64> {
     let map = BROKER_HANDLES.get()?;
-    let mut guard = map.lock().ok()?;
-    guard.remove(&drive.as_char())
+    let guard = map.lock().ok()?;
+    guard.get(&drive.as_char()).copied()
 }
 
 /// Convert a `windows::core::Error` into the equivalent `std::io::Error`,
@@ -274,10 +283,11 @@ impl VolumeHandle {
     #[expect(unsafe_code, reason = "FFI: windows API (CreateFileW)")]
     pub fn open(volume: super::DriveLetter) -> Result<Self> {
         // Access Broker fast-path: if the (elevated) broker has deposited a
-        // pre-opened, duplicated volume handle for this drive, adopt it
-        // instead of calling `CreateFileW` — which would fail with
-        // access-denied in a non-elevated daemon.  See the registry above.
-        if let Some(raw_handle) = take_broker_handle(volume) {
+        // pre-opened, duplicated volume handle for this drive, adopt a
+        // duplicate of it instead of calling `CreateFileW` — which would fail
+        // with access-denied in a non-elevated daemon.  See the registry
+        // above; the entry stays so later opens in the same load succeed.
+        if let Some(raw_handle) = peek_broker_handle(volume) {
             return Self::from_broker_handle(volume, raw_handle);
         }
 
@@ -332,26 +342,54 @@ impl VolumeHandle {
         })
     }
 
-    /// Adopt a pre-opened, duplicated volume handle supplied by the Access
-    /// Broker (Windows-only, see the broker handle registry above).
+    /// Adopt a **duplicate** of the broker-supplied volume handle for `volume`.
     ///
-    /// `raw_handle` is the raw `HANDLE` value the broker duplicated into this
-    /// process; ownership transfers to the returned `VolumeHandle` (its `Drop`
-    /// closes it).  The broker opens the volume with
+    /// `raw_handle` is the registry's broker handle (the one `uffs-broker`
+    /// duplicated into this process).  This function `DuplicateHandle`s it so
+    /// the returned `VolumeHandle` owns an independent copy — its `Drop` closes
+    /// only the duplicate, leaving the registry entry valid for the next open
+    /// in the same load (the original is freed via `release_broker_handle`).
+    /// The broker opens the volume with
     /// `FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED |
-    /// FILE_FLAG_SEQUENTIAL_SCAN`, matching the direct-open flags, so the
-    /// handle is usable for both the volume-data query here and the
-    /// overlapped MFT read via [`Self::open_overlapped_handle`].
+    /// FILE_FLAG_SEQUENTIAL_SCAN`, so the duplicate is usable for both the
+    /// volume-data query here and the overlapped MFT read via
+    /// [`Self::open_overlapped_handle`].
     ///
     /// # Errors
     ///
-    /// Returns [`MftError`] if the volume descriptor cannot be read from the
-    /// adopted handle.
+    /// Returns [`MftError`] if the handle cannot be duplicated or the volume
+    /// descriptor cannot be read from it.
     #[cfg(windows)]
+    #[expect(unsafe_code, reason = "FFI: DuplicateHandle / GetCurrentProcess")]
     pub fn from_broker_handle(volume: super::DriveLetter, raw_handle: u64) -> Result<Self> {
-        let handle = HANDLE(core::ptr::with_exposed_provenance_mut::<core::ffi::c_void>(
+        use windows::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle};
+        use windows::Win32::System::Threading::GetCurrentProcess;
+
+        let registered = HANDLE(core::ptr::with_exposed_provenance_mut::<core::ffi::c_void>(
             usize::try_from(raw_handle).unwrap_or(0),
         ));
+        let mut handle = HANDLE::default();
+        // SAFETY: returns the current-process pseudo-handle; no preconditions.
+        let process = unsafe { GetCurrentProcess() };
+        // SAFETY: `process` is valid; `registered` is the broker handle owned
+        // by this process; `&raw mut handle` is a valid out-pointer.  On
+        // success the duplicate is owned by the returned `VolumeHandle`.
+        let dup = unsafe {
+            DuplicateHandle(
+                process,
+                registered,
+                process,
+                &raw mut handle,
+                0,
+                false,
+                DUPLICATE_SAME_ACCESS,
+            )
+        };
+        dup.map_err(|err| MftError::VolumeOpen {
+            volume,
+            source: hresult_to_io_error(&err),
+        })?;
+
         let volume_data = Self::get_ntfs_volume_data(handle, volume)?;
         tracing::info!(drive = %volume, "Adopted Access Broker volume handle for MFT read");
         Ok(Self {

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -2,332 +2,570 @@
 SPDX-FileCopyrightText: 2025-2026 SKY, LLC.
 SPDX-License-Identifier: MPL-2.0
 -->
-# UFFS Access Broker — follow-up work
+# UFFS Access Broker — Follow-up Implementation Playbook
+
+**Audience:** an engineer (junior welcome) picking up the broker hardening work
+with no prior context. Everything you need to implement each item is here:
+where the code lives, what to change, the gotchas, how to know you're done, and
+how to test it. Read [§0 Orientation](#0-orientation) first.
 
 **Status:** the broker's core path works end to end as of branch
-`fix/broker-service-and-elevation` (2026-06-14). This document captures the
-deliberate follow-ups that remain before the broker is production-grade for
-**multi-drive, resident, at-scale** use. None of them block the basic
-single-drive read; each is a scoped, root-cause piece of work.
-
-> **Design reference:** `docs/dev/architecture/DAEMON_SERVICE_ARCHITECTURE.md`
-> (intent: an elevated `LocalSystem` service vends duplicated NTFS volume
-> handles to a non-elevated daemon, so the daemon reads the MFT with zero UAC)
-> and `docs/dev/architecture/SECURITY_IMPLEMENTATION_PLAN.md` §S5 (broker
-> hardening). Both live under gitignored `docs/dev/`.
+`fix/broker-service-and-elevation` (verified on a Windows 11 VM, 2026-06-14): a
+non-elevated `uffs "<query>"` spawns a non-elevated daemon, which obtains an
+elevated volume handle from the broker, reads the MFT through it (zero UAC), and
+serves queries. None of the follow-ups below block that path; each is a scoped,
+root-cause improvement toward production-grade **multi-drive, resident, at-scale**
+operation.
 
 ---
 
-## What works today (baseline)
+## Table of contents
 
-The elevation model and handle plumbing are functional:
+- [0. Orientation](#0-orientation)
+- [1. Tracking board](#1-tracking-board)
+- [2. How to work an item](#2-how-to-work-an-item)
+- [3. Shared building blocks](#3-shared-building-blocks)
+- [4. The follow-ups](#4-the-follow-ups)
+  - [FU-9 — Gate broker warm-up on `!is_elevated()`](#fu-9--gate-broker-warm-up-on-is_elevated)
+  - [FU-2 — USN journal through the broker (+ stop the retry storm)](#fu-2--usn-journal-through-the-broker--stop-the-retry-storm)
+  - [FU-3 — `get_mft_extents` through the broker (fragmented MFTs)](#fu-3--get_mft_extents-through-the-broker-fragmented-mfts)
+  - [FU-8 — `$UpCase` read on the overlapped handle](#fu-8--upcase-read-on-the-overlapped-handle)
+  - [FU-1 — Windows Service dispatcher](#fu-1--windows-service-dispatcher)
+  - [FU-4 — `WinVerifyTrust` + Authenticode caching](#fu-4--winverifytrust--authenticode-caching)
+  - [FU-5 — Async multi-instance broker + `OwnedHandle`](#fu-5--async-multi-instance-broker--ownedhandle)
+  - [FU-6 — Non-connecting client pipe probe](#fu-6--non-connecting-client-pipe-probe)
+  - [FU-7 — Volume-data FSCTL on the overlapped handle](#fu-7--volume-data-fsctl-on-the-overlapped-handle)
+- [5. Testing strategy](#5-testing-strategy)
+- [6. Suggested sequencing](#6-suggested-sequencing)
+- [7. Glossary](#7-glossary)
 
-- The broker registers and starts as a service (`uffs-broker --install`) and
-  runs in foreground for debugging (`uffs-broker --run`).
-- Pipe security lets a **non-elevated** daemon connect (explicit SDDL:
+---
+
+## 0. Orientation
+
+### What the broker is
+
+A tiny, elevated Windows service (`uffs-broker`, runs as `LocalSystem`) whose
+only job is to hand a non-elevated process an **already-duplicated, elevated NTFS
+volume handle** over a named pipe. With that handle, the non-elevated `uffsd`
+daemon can read the raw MFT — something that normally needs Administrator. This
+is the standard "privilege-separation broker" pattern: keep the big, long-lived,
+index-holding daemon **un**elevated, and isolate the elevation into a process
+small enough to audit.
+
+### The flow, end to end
+
+```
+uffs.exe (non-elevated CLI)
+  └─ broker_pipe_present()? ── spawns ──▶ uffsd.exe (non-elevated daemon)
+                                              │
+        load_live_drives_if_windows() ───────┤
+        warm_up_broker_handles(drives)        │  one request per drive
+              │ request_volume_handle(drive)  │
+              ▼                                │
+  \\.\pipe\uffs-broker  ◀──────────────────────┘
+   (uffs-broker.exe, LocalSystem)
+     • get_pipe_client_pid → open client process ONCE
+     • verify it's uffsd (name allowlist) + Authenticode
+     • open_volume_read_only(drive)  → elevated overlapped volume HANDLE
+     • DuplicateHandle into the daemon's process
+     • write 9-byte response { status, handle }
+              │
+              ▼
+  register_broker_handle(drive, handle)   [in uffs-mft registry]
+              │
+   VolumeHandle::open(drive)  ── peek_broker_handle → DuplicateHandle ─▶ MFT read
+```
+
+### The crates you'll touch
+
+| Crate | Role | Key files for this work |
+|---|---|---|
+| `uffs-broker` | elevated handle vendor (the service) | `src/broker.rs`, `src/broker/service.rs`, `src/main.rs` |
+| `uffs-broker-protocol` | the 1-byte request / 9-byte response wire format | `src/lib.rs` |
+| `uffs-mft` | MFT reader; holds the broker-handle registry | `src/platform/volume.rs`, `src/usn/windows.rs`, `src/platform/upcase.rs`, `src/lib.rs` |
+| `uffs-daemon` | resident index server; client of the broker | `src/lib.rs`, `src/broker_client.rs`, `src/cache/journal_loop.rs` |
+| `uffs-client` | non-elevated launcher | `src/broker_probe.rs`, `src/daemon_spawn.rs` |
+
+> **Design references** (gitignored, under `docs/dev/`):
+> `docs/dev/architecture/DAEMON_SERVICE_ARCHITECTURE.md` (intent) and
+> `docs/dev/architecture/SECURITY_IMPLEMENTATION_PLAN.md` §S5 (broker hardening,
+> the `S5.x` / `WI-x` tags you'll see in code comments).
+
+### What works today (baseline — do not regress)
+
+- Broker installs/starts as a service (`uffs-broker --install`) and runs in
+  foreground for debugging (`uffs-broker --run`).
+- Pipe security lets a **non-elevated** daemon connect (SDDL
   `D:(A;;GRGW;;;AU)S:(ML;;NW;;;LW)` — Authenticated-Users connect + low
-  mandatory-integrity label), while the broker still verifies the client is
-  `uffsd` + Authenticode before granting a handle.
+  mandatory-integrity label), while the broker still verifies client identity
+  before granting.
 - The daemon requests **one handle per drive** at load
-  (`warm_up_broker_handles`), the broker `DuplicateHandle`s an elevated,
-  overlapped volume handle into the daemon, and the daemon registers it.
-- `uffs_mft::VolumeHandle::open` adopts a **duplicate** of the registered
-  handle on every open (peek + `DuplicateHandle`), so the read pass, the
-  overlapped/IOCP bulk read, and the cache-write pass all succeed without
-  re-requesting.
-
-Verified on a Windows 11 VM: a non-elevated `uffs "<query>"` spawns a
-non-elevated daemon, which obtains a broker handle (PID-correlated:
-`daemon_pid` == broker audit `pid`) and reads the MFT through it.
+  (`warm_up_broker_handles`); the broker `DuplicateHandle`s an elevated,
+  overlapped volume handle in; the daemon registers it.
+- `VolumeHandle::open` adopts a **duplicate** of the registered handle on every
+  open (peek + `DuplicateHandle`), so the read pass, the IOCP bulk read, and the
+  cache-write pass all succeed without re-requesting.
 
 ---
 
-## Follow-up 1 — Windows Service dispatcher (run as `LocalSystem`)
+## 1. Tracking board
 
-**Priority: HIGH** (required for the advertised "install once, no future UAC").
+Update the **Status** cell as you go. Status legend:
+`⬜ Not started` · `🟦 In progress` · `🟩 Done (merged)` · `🟥 Blocked`.
+Fill **PR** with the merged PR number and **Owner** with your handle when you
+pick an item up. `Depends on` must be `🟩` before you start.
 
-### Problem
-`uffs-broker` implements `--install` / `--uninstall` / `--run` but has **no
-Windows Service control dispatcher**. When the Service Control Manager (SCM)
-starts the registered service, it launches the binary with **no arguments**;
-`run()` then falls through to `print_usage()` and exits 0. The service never
-calls `StartServiceCtrlDispatcher` / reports `SERVICE_RUNNING`, so it never
-actually runs as a service — only the foreground `--run` mode works.
+| ID | Title | Priority | Effort | Status | Owner | PR | Depends on |
+|----|-------|----------|--------|--------|-------|----|-----------|
+| FU-9 | Gate warm-up on `!is_elevated()` | HIGH | XS | ⬜ | — | — | — |
+| FU-2 | USN journal through broker + backoff | HIGH | M | ⬜ | — | — | SBB-1 |
+| FU-3 | `get_mft_extents` through broker | MEDIUM | M | ⬜ | — | — | SBB-1 |
+| FU-8 | `$UpCase` overlapped-handle read | LOW–MED | M | ⬜ | — | — | — |
+| FU-1 | Windows Service dispatcher | HIGH | M | ⬜ | — | — | — |
+| FU-4 | `WinVerifyTrust` + Authenticode cache | MEDIUM | M | ⬜ | — | — | — |
+| FU-5 | Async multi-instance broker + `OwnedHandle` | MEDIUM | L | ⬜ | — | — | SBB-2 |
+| FU-6 | Non-connecting client pipe probe | LOW | S | ⬜ | — | — | — |
+| FU-7 | Volume-data FSCTL overlapped | LOW–MED | S | ⬜ | — | — | — |
 
-### Evidence
-`sc.exe start UffsAccessBroker` → service reaches `STOPPED`, exit code 0
-(graceful, "never started"); `sc query` shows `WIN32_EXIT_CODE: 0` with no
-running process.
+**Shared building blocks** (land these as their own PRs first; several items
+depend on them — see [§3](#3-shared-building-blocks)):
 
-### Fix approach
-Implement the standard service entry point in `crates/uffs-broker`:
-1. No-arg invocation → `StartServiceCtrlDispatcherW` with a
-   `SERVICE_TABLE_ENTRYW` pointing at a `ServiceMain` callback.
-2. `ServiceMain` → `RegisterServiceCtrlHandlerW` (handle `SERVICE_CONTROL_STOP`
-   / `SHUTDOWN`), `SetServiceStatus(SERVICE_RUNNING)`, then run
-   `serve_pipe_requests()` until a stop is signalled, then
-   `SetServiceStatus(SERVICE_STOPPED)`.
-3. Keep `--run` as the foreground/debug path (shares `serve_pipe_requests`).
+| ID | Title | Status | PR |
+|----|-------|--------|----|
+| SBB-1 | `adopt_or_open_volume(drive, access)` helper in `uffs-mft` | ⬜ | — |
+| SBB-2 | `OwnedHandle` Send-safe RAII wrapper | ⬜ | — |
 
-Use the raw `windows` crate FFI (the crate already depends on it) or the
-`windows-service` crate (idiomatic, but a new dependency → cargo-vet +
-manifest-audit cost). Prefer raw FFI to avoid the dependency unless the
-boilerplate proves error-prone.
-
-### Effort / risk
-Moderate. Unsafe FFI (`SetServiceStatus`, control handler), Windows-only,
-untestable off-Windows — needs iterative validation on a real box.
+Effort key: `XS` <1h · `S` ~half-day · `M` ~1–2 days · `L` ~3–5 days (all
+including tests + a VM validation round).
 
 ---
 
-## Follow-up 2 — USN journal read through the broker
+## 2. How to work an item
 
-**Priority: HIGH** (resident daemons rely on incremental refresh).
+1. **Branch** off `main` (after the broker branch merges) named
+   `broker/fu-<id>-<slug>`, e.g. `broker/fu-9-elevation-gate`.
+2. **Read the item's section** below in full, plus any `Depends on` building
+   block in [§3](#3-shared-building-blocks).
+3. **Follow the fix guidelines** (these are hard rules on this repo):
+   - **No suppression hacks.** Do not add blanket `#[allow(...)]`, disable
+     lints, comment out tests, or hide problems behind `cfg`. A targeted,
+     commented `#[expect(...)]` with a `reason` is acceptable only when truly
+     necessary (the codebase uses `#[expect]`, not `#[allow]`, so the lint fires
+     if the suppression becomes unnecessary).
+   - **Surgical, root-cause fixes.** Minimal, idiomatic Rust that fixes the
+     actual ownership/type/semantics problem.
+   - **Preserve public API & behavior** unless the work proves it wrong — then
+     update docs + tests in the same PR.
+   - **Strengthen tests, never dodge them.**
+   - **Small atomic commits**, message `fix:`/`feat:`/`refactor:` naming the
+     root cause. **Never** `--no-verify`; fix the failing gate at its root.
+4. **The gate you must pass before pushing** (Windows-target lints — most broker
+   code is `#[cfg(windows)]` and is *only* checked under this target):
+   ```bash
+   cargo xwin clippy --workspace --all-targets --all-features \
+       --no-deps --target x86_64-pc-windows-msvc -- -D warnings
+   cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings   # host
+   cargo nextest run --workspace            # host-runnable tests
+   just fmt                                  # rustfmt
+   ```
+   The pre-push hook runs `lint-fast` / `lint-pre-push`; let it. If a Windows-only
+   change can't be exercised on the host, that's expected — see the VM steps in
+   [§5](#5-testing-strategy).
+5. **Validate on a Windows VM** for anything touching the live broker/MFT path
+   (most items). The host build *cannot* exercise it. Capture the daemon log
+   (`%UFFS_LOG_DIR%\uffsd.log`) and the broker terminal in the PR description.
+6. **Update the tracking board** row (Status/Owner/PR) in this file as part of
+   the PR.
 
-### Problem
-The USN journal open (`crates/uffs-mft/src/usn/windows.rs::open_volume_handle`)
-opens its **own** volume handle via direct `CreateFileW`, which a non-elevated
-daemon can't do. So the broker-backed daemon logs
-`USN journal unavailable; full rebuild ... Access is denied` and falls back to
-a **full MFT rebuild** on every refresh instead of a cheap incremental USN
-update. Correct results, wrong cost.
+### Watch out for (lints that bite on this codebase)
 
-### Fix approach
-USN control codes (`FSCTL_QUERY_USN_JOURNAL`, `FSCTL_READ_USN_JOURNAL`) operate
-on a **volume** handle — and the broker already supplies one. Route the USN
-volume open through the same registry the MFT read uses:
-`peek_broker_handle(drive)` + `DuplicateHandle`, falling back to direct
-`CreateFileW` when no broker handle is registered (elevated path). Factor the
-"adopt a registered broker handle, else open directly" logic so both
-`VolumeHandle::open` and the USN path share it (DRY; today only `VolumeHandle`
-has it).
-
-**Also fix the retry storm (observed 2026-06-14):** once a drive loads, the
-per-shard journal loop polls the USN journal every ~500 ms and, when the open
-is access-denied, logs `Journal poll failed; retrying next tick` **forever** —
-flooding the log and burning cycles. Until the USN open is brokered, the loop
-should detect a persistent access-denied and **back off / disable** for that
-drive (e.g. exponential backoff to a long ceiling, or mark USN-unavailable and
-rely on periodic full rebuilds) instead of retrying at 500 ms indefinitely.
-
-### Effort / risk
-Small–moderate. The handle-acquisition logic already exists; the work is
-sharing it and threading it into `usn/windows.rs`.
-
----
-
-## Follow-up 3 — `get_mft_extents` through the broker (fragmented MFTs)
-
-**Priority: MEDIUM** (correctness on fragmented volumes).
-
-### Problem
-`VolumeHandle::get_mft_extents` opens `<drive>:\$MFT` directly to fetch the
-MFT's retrieval pointers (`FSCTL_GET_RETRIEVAL_POINTERS`). On open failure it
-**falls back to a single contiguous extent** derived from
-`NTFS_VOLUME_DATA` (`mft_start_lcn` + `mft_valid_data_length`). That fallback
-is correct for an **unfragmented** MFT but **silently incomplete for a
-fragmented MFT** — it misses every fragment beyond the first, producing a
-partial index with no error.
-
-### Note / unknown
-`$MFT` is opened with **zero desired access** (metadata only), which *may*
-succeed for a non-elevated caller — in which case the real retrieval pointers
-are read and the fallback never fires. The next VM test's log will confirm
-whether the fallback is hit. Either way, relying on a silent
-contiguous-assumption fallback for correctness is fragile.
-
-### Fix approach
-Two options:
-1. **Broker an `$MFT` handle**: extend the broker to open `<drive>:\$MFT` (it's
-   elevated) and vend it alongside the volume handle. Requires a protocol/
-   registry extension to carry a second handle per drive.
-2. **Bootstrap from the volume handle** (no extra handle): read FRS 0 (the
-   `$MFT` record) from the known MFT location via the broker *volume* handle,
-   parse its `$DATA` runlist, and derive the full extent map. Self-contained,
-   no protocol change, but more reader work.
-
-Prefer (2) if feasible — it keeps the broker protocol at one handle per drive.
-Make the fallback **loud** (warn) in the interim so a partial index is never
-silent.
-
-### Effort / risk
-Moderate. Option 2 touches the MFT bootstrap logic; needs a fragmented-MFT
-test fixture to validate.
+- `missing_docs_in_private_items = "deny"` — **every** item, including private
+  fns/fields/consts, needs a doc comment.
+- `cognitive_complexity` ceiling 25 — split big fns into helpers (you'll see
+  this pattern everywhere; mirror it).
+- `multiple_unsafe_ops_per_block` — **one** FFI op per `unsafe {}` block. E.g.
+  `GetCurrentProcess()` and `DuplicateHandle()` go in *separate* `unsafe`
+  blocks, each with its own `// SAFETY:` note.
+- `unsafe_code = "deny"` at the lint level — wrap FFI in
+  `#[expect(unsafe_code, reason = "FFI: …")]` with a `// SAFETY:` comment.
+- `print_stdout` / `print_stderr` denied in library code (the broker `main.rs`
+  is the deliberate exception — it uses `eprintln!` because there's no tracing
+  subscriber yet at `--install` time).
+- File-size ceiling 800 LOC (`volume.rs` already has a permanent exception entry;
+  if you grow a file past the cap, extract a submodule rather than bumping the
+  exception).
 
 ---
 
-## Follow-up 4 — Authenticode verification caching (per-PID)
+## 3. Shared building blocks
 
-**Priority: MEDIUM** (multi-drive latency).
+Two pieces are needed by multiple follow-ups. Build each as its own small PR so
+the dependent items can just call into them.
 
-### Problem
-`verify_authenticode` (broker side) shells out to PowerShell
-(`Get-AuthenticodeSignature`) **per request**, costing hundreds of
-milliseconds each. The daemon requests handles **sequentially, one per drive**
-in `warm_up_broker_handles`, so an N-drive estate pays ~N × that cost up front
-(e.g. 10 drives ≈ several seconds of signature checks before any load starts).
+### SBB-1 — `adopt_or_open_volume(drive, access)` helper
 
-### Fix approach
-There are **two** stacked fixes here; do both, the second first if forced to
-choose:
+**Why:** today only `VolumeHandle::open` knows the "adopt a registered broker
+handle, else `CreateFileW` directly" dance. FU-2 (USN) and FU-3 (`$MFT`) need the
+exact same logic. Duplicating it invites drift. Factor it once.
 
-**(a) Move off the PowerShell subprocess to `WinVerifyTrust` (the bigger win).**
-Shelling out to `powershell.exe Get-AuthenticodeSignature` spins up an entire
-PowerShell runtime per request — hundreds of ms, plus the process-spawn tax and
-a dependency on PowerShell being present and on PATH. A world-class Windows
-implementation never does this for a service hot path. Replace it with a direct
-`WinVerifyTrust` FFI call (the `windows` crate already exposes
-`Win32::Security::WinTrust`): build a `WINTRUST_FILE_INFO` for the client image,
-call `WinVerifyTrust(INVALID_HANDLE_VALUE, &WINTRUST_ACTION_GENERIC_VERIFY_V2,
-&data)`, and map the `TRUST_E_*` / `CERT_E_*` HRESULTs to the same
-accept/reject policy the PowerShell path uses today (accept `NotSigned` for dev,
-reject `HashMismatch`). In-process, no subprocess, ~single-digit ms, no external
-dependency. This alone removes the dominant startup latency.
+**Where:** `crates/uffs-mft/src/platform/volume.rs`. The registry lives here:
+- `BROKER_HANDLES: OnceLock<Mutex<HashMap<char, u64>>>` (≈ line 62)
+- `register_broker_handle(drive, raw_handle)` (≈ line 74, `pub`, re-exported from
+  `uffs-mft/src/lib.rs:318`)
+- `peek_broker_handle(drive) -> Option<u64>` (≈ line 90, private)
+- the adopt logic currently inlined in `VolumeHandle::open` (≈ line 284–342) and
+  `from_broker_handle` (≈ line 364)
 
-**(b) Cache the result keyed by client PID + exe path** (and ideally the image's
-last-write time / a content hash, so PID reuse can't smuggle in a different
-binary): verify once per client process, reuse for that process's subsequent
-drive requests. Entry lifetime = the client process lifetime; the broker already
-opens the client process handle once (WI-8.1), so it can detect process identity
-reliably. Do **not** weaken the verification — only avoid re-running it for an
-already-verified `(pid, exe, mtime)`.
+**What to build:**
 
-With (a) in place each check is cheap enough that (b) is a smaller win, but
-together they take an N-drive estate from ~N × hundreds-of-ms down to a single
-fast verify per client process.
+```rust
+/// Result of resolving a volume handle: a duplicate of a registered broker
+/// handle when one exists for `drive`, otherwise a freshly opened handle.
+/// `broker_backed` tells the caller whether overlapped semantics apply (the
+/// broker vends `FILE_FLAG_OVERLAPPED` handles; a direct open here does not).
+#[cfg(windows)]
+pub(crate) struct ResolvedVolume {
+    /// Owned handle the caller must close (or wrap in `HandleGuard`).
+    pub handle: HANDLE,
+    /// `true` when `handle` is a duplicate of a broker-supplied overlapped handle.
+    pub broker_backed: bool,
+}
 
-### Effort / risk
-Moderate. The `WinVerifyTrust` FFI is unsafe and Windows-only (untestable
-off-Windows; needs validation on a real box against signed *and* unsigned
-images). The cache is small but security-sensitive — the key must make a
-substituted binary a cache miss.
+/// Adopt a duplicate of the registered broker handle for `drive` if present,
+/// else open the volume directly with `access`. Centralises the policy so the
+/// MFT read, the USN path, and the `$MFT` extent read share one implementation.
+#[cfg(windows)]
+pub(crate) fn adopt_or_open_volume(
+    drive: super::DriveLetter,
+    access: u32,          // e.g. GENERIC_READ.0, or 0 for metadata-only
+) -> Result<ResolvedVolume> {
+    if let Some(raw) = peek_broker_handle(drive) {
+        let handle = duplicate_registered_handle(raw, drive)?;  // existing dup logic, extracted
+        return Ok(ResolvedVolume { handle, broker_backed: true });
+    }
+    let handle = create_file_volume(drive, access)?;            // existing CreateFileW path, extracted
+    Ok(ResolvedVolume { handle, broker_backed: false })
+}
+```
 
----
+**Steps:**
+1. Extract the `DuplicateHandle` block from `from_broker_handle` into
+   `duplicate_registered_handle(raw_handle: u64, drive) -> Result<HANDLE>`
+   (keep the two-separate-`unsafe`-blocks structure for
+   `GetCurrentProcess` / `DuplicateHandle`).
+2. Extract the `CreateFileW` block from `VolumeHandle::open` into
+   `create_file_volume(drive, access: u32) -> Result<HANDLE>`. Keep the existing
+   `InsufficientPrivileges` mapping (the access-denied → `InsufficientPrivileges`
+   translation currently at ≈ line 326).
+3. Add `adopt_or_open_volume` as above.
+4. Rewrite `VolumeHandle::open` and `from_broker_handle` to go through it (no
+   behavior change — this is a pure refactor; the existing VM-validated path must
+   produce identical logs).
 
-## Follow-up 5 — Concurrent broker (multi-instance pipe + per-connection handling)
+**Acceptance:** `VolumeHandle::open` still adopts the broker handle when present
+and still falls back to direct open + `InsufficientPrivileges` when not; all
+existing `uffs-mft` tests pass; `cargo xwin clippy` clean. No observable change
+on the VM (same log lines as the 2026-06-14 baseline run).
 
-**Priority: MEDIUM** (scale; not needed for the common one-daemon flow).
+### SBB-2 — `OwnedHandle` Send-safe RAII wrapper
 
-### Problem
-The broker serves a **single** pipe instance (`max_instances = 1`) in a
-**serial** loop: create instance → wait for client → handle → disconnect →
-repeat. Concurrent clients queue (`PIPE_WAIT`) or hit `ERROR_PIPE_BUSY`. The
-normal flow (one daemon requesting drives sequentially) is fine, but genuinely
-concurrent load (multiple daemons, or a future parallelized warm-up)
-serializes — and combined with the per-request Authenticode spawn (Follow-up
-4), throughput is poor at scale.
+**Why:** the broker and the daemon registry pass kernel handles around as bare
+`u64` / `windows::Win32::Foundation::HANDLE`, neither of which is `Send` or
+self-closing. Every call site re-implements
+`with_exposed_provenance_mut(u64 as usize)` reconstruction and is on the hook for
+`CloseHandle`. FU-5 (moving a connected pipe handle into a worker task) needs a
+`Send` handle; everyone benefits from RAII.
 
-> Historical note: an earlier symptom of the single-instance design was that a
-> daemon's `GetFileAttributesW` *availability probe* consumed the only pipe
-> instance and starved the real request (`ERROR_PIPE_BUSY`). That probe has
-> been removed; the broker now sees only real requests. This follow-up is
-> about *concurrency capacity*, not that (resolved) starvation.
+**Where:** new module, e.g. `crates/uffs-mft/src/platform/owned_handle.rs`
+(or a shared spot both `uffs-mft` and `uffs-broker` can see — if it must be
+shared across crates, put it in `uffs-broker-protocol` or a small new
+`uffs-winhandle` crate; prefer keeping it in `uffs-mft` first and only promoting
+it if FU-5 genuinely needs the same type).
 
-### Fix approach
-**Preferred — go async with tokio's named pipes.** The community-standard way to
-write a scalable Windows pipe server in Rust is
-[`tokio::net::windows::named_pipe`] (`ServerOptions` + `NamedPipeServer`), not a
-hand-rolled serial thread loop over raw `CreateNamedPipeW`. The idiomatic shape:
+**What to build:**
 
-1. `ServerOptions::new().max_instances(N).create(PIPE_NAME)` for the first
-   listener, applying the same SDDL/security attributes as today.
-2. `server.connect().await`; **immediately** build the *next* listening instance
-   (`ServerOptions…create`) before handling the current connection, so there's
-   always an instance waiting (this is the documented tokio accept-loop pattern
-   and removes the "between connections we're deaf" window).
-3. `tokio::spawn` the per-connection handler (read request, verify identity,
-   `DuplicateHandle`, write response). The connected `NamedPipeServer` is
-   `Send`, so it moves into the task cleanly — no raw-`HANDLE` `Send` newtype
-   needed on the connection itself.
-4. Share the rate-limit / audit state behind `Arc<Mutex<…>>` (or an actor task
-   owning it); the per-connection tasks take clones of the `Arc`.
+```rust
+/// Owns a Win32 kernel handle and closes it on drop.
+///
+/// SAFETY (Send): a Win32 kernel handle is a process-wide value with no
+/// thread affinity; moving the integer between threads is sound. Concurrent
+/// *use* still requires external synchronisation, exactly as with the raw API.
+pub struct OwnedHandle(HANDLE);
 
-This makes multi-instance concurrency natural, keeps the I/O off the parsing,
-and aligns the broker with the daemon's existing async runtime. Raw-FFI
-multi-instance + a worker thread pool is the fallback if pulling tokio into the
-broker is unwanted, but it reintroduces the `HANDLE`-`Send` problem (below) that
-the async path avoids.
+// SAFETY: see type-level note — kernel handles have no thread affinity.
+unsafe impl Send for OwnedHandle {}
 
-**Wrap raw handles in a `Send`-safe RAII type.** Independent of the async move:
-the broker (and the daemon-side registry) pass volume/process handles around as
-bare `u64` / `HANDLE`, which are neither `Send` nor self-closing — every call
-site re-implements "reconstruct `HANDLE` from `u64`" and is responsible for not
-leaking it. Introduce a small newtype, e.g. `struct OwnedHandle(HANDLE)` with
-`unsafe impl Send` (documented SAFETY: a Win32 kernel handle is process-wide and
-safe to move between threads), `Drop` calling `CloseHandle`, and `as_raw()` /
-`into_raw()` accessors. Thread *that* through the registry and the broker
-instead of raw integers. This removes the scattered
-`with_exposed_provenance_mut` reconstructions, makes ownership/lifetime explicit,
-and is what a Rust master would reach for before adding concurrency.
+impl OwnedHandle {
+    /// Wrap a raw handle, taking ownership of its lifetime.
+    pub fn from_raw(handle: HANDLE) -> Self { Self(handle) }
+    /// Borrow the raw handle for an FFI call without giving up ownership.
+    pub fn as_raw(&self) -> HANDLE { self.0 }
+    /// Reconstruct from the `u64` wire form used by the broker protocol.
+    pub fn from_u64(raw: u64) -> Self { /* with_exposed_provenance_mut */ }
+    /// Release ownership (e.g. when handing to an API that closes it).
+    pub fn into_raw(self) -> HANDLE { /* ManuallyDrop */ }
+}
 
-Pair the whole follow-up with Follow-up 4 so each concurrent connection isn't
-independently paying the Authenticode cost.
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        // SAFETY: we own `self.0`; closed exactly once.
+        let _ = unsafe { CloseHandle(self.0) };
+    }
+}
+```
 
-[`tokio::net::windows::named_pipe`]: https://docs.rs/tokio/latest/tokio/net/windows/named_pipe/index.html
-
-### Effort / risk
-Moderate. Bringing tokio into the broker (or a worker-thread model) plus the
-handle-ownership refactor; the rate-limiter and audit paths must stay correct
-under parallelism. The `OwnedHandle` wrapper is a low-risk, high-clarity
-refactor that can land independently and first.
-
----
-
-## Follow-up 6 — Client-side pipe probe still connects (`broker_pipe_present`)
-
-**Priority: LOW** (cosmetic; works due to timing).
-
-### Problem
-`uffs-client`'s `broker_pipe_present` (gates the non-elevated daemon spawn)
-uses `GetFileAttributesW`, which **connects to** the pipe — the broker logs a
-rejected `uffs.exe` connection on every search. It happens ~1 s before the
-daemon's real request, so the single-instance broker recovers in time and it's
-currently harmless, but it's wasteful and fragile under load.
-
-### Fix approach
-Switch the client probe to a **non-connecting** check (e.g. `WaitNamedPipeW`
-with a short timeout), or accept a brief false-negative and rely on the spawn's
-fallback. Re-evaluate after Follow-up 5 (a multi-instance broker tolerates the
-probe connection cleanly, possibly making this moot).
-
-### Effort / risk
-Small.
+**Acceptance:** `OwnedHandle` unit-tested (open a handle to a temp file via the
+`windows` crate, wrap, drop, assert no leak by reopening); the registry and at
+least one broker call site migrated off raw `u64`/`HANDLE` to it without behavior
+change.
 
 ---
 
-## Follow-up 7 — Volume-data FSCTL on the adopted overlapped handle
+## 4. The follow-ups
 
-**Priority: LOW–MEDIUM** (verify under test; correctness if it misbehaves).
-
-### Problem
-`get_ntfs_volume_data` issues `FSCTL_GET_NTFS_VOLUME_DATA` with a **NULL**
-`OVERLAPPED`. The broker handle is opened `FILE_FLAG_OVERLAPPED`; per the Win32
-docs, a synchronous `DeviceIoControl` (NULL overlapped) on an overlapped handle
-is technically undefined, though this particular FSCTL completes synchronously
-and tends to work in practice. The "simple-first" choice was deliberate.
-
-### Fix approach
-If VM testing shows a `NotNtfs` / volume-data failure on the broker-backed
-path, add an overlapped-safe variant: pass a real `OVERLAPPED` with an event
-and `GetOverlappedResult`, used by `from_broker_handle`. Otherwise leave as-is
-and note the dependence on the FSCTL's synchronous completion.
-
-### Effort / risk
-Small (~15 lines) if needed.
+Each section is self-contained. **Where** gives file/function anchors (line
+numbers are "as of 2026-06-13" and will drift — trust the function names).
 
 ---
 
-## Follow-up 8 — `$UpCase` read on the overlapped broker handle
+### FU-9 — Gate broker warm-up on `!is_elevated()`
 
-**Priority: LOW–MEDIUM** (graceful fallback today; correctness on non-standard
-case tables).
+**Priority: HIGH · Effort: XS · Self-inflicted regression — do this first.**
 
-### Problem
-Reading `$UpCase` (the NTFS uppercase-mapping table, used for
-case-insensitive name comparison) does a **synchronous `SetFilePointerEx`
-seek** on the volume handle. The broker handle is opened `FILE_FLAG_OVERLAPPED`,
-and overlapped handles don't maintain a synchronous file pointer — so the seek
-fails. Observed 2026-06-14:
+#### Why
+While fixing the `ERROR_PIPE_BUSY` starvation we made `warm_up_broker_handles`
+run **unconditionally**, for every daemon. Correct for killing the racy
+`broker_available()` probe — but now an **elevated** daemon with no broker makes
+a futile broker pipe-open **per drive**, each failing fast and logging a `WARN`
+("Access Broker handle request FAILED"). On a 7-drive elevated load that's 7
+pointless opens + 7 WARNs. An elevated daemon never needs the broker — it can
+open volumes directly.
+
+The MFT **read** path is *not* regressed when elevated: `VolumeHandle::open`
+finds the registry empty (cheap mutex check) and falls through to direct
+`CreateFileW`. Only the warm-up probe is wrong.
+
+#### Where
+- `crates/uffs-daemon/src/lib.rs` → `load_live_drives_if_windows` (≈ line 289);
+  the `warm_up_broker_handles(drives)` call is at ≈ line 309.
+- `uffs_mft::is_elevated` is already public and re-exported
+  (`uffs-mft/src/lib.rs:307`).
+
+#### What to change
+Wrap the call:
+
+```rust
+if uffs_mft::is_elevated() {
+    tracing::debug!(
+        "Daemon is elevated; skipping broker warm-up (direct volume open)."
+    );
+} else {
+    warm_up_broker_handles(drives);
+}
+```
+
+That's the whole fix. `is_elevated()` is a token query — cheap, **no pipe
+interaction**, and free of the race that made the old `broker_available()` probe
+dangerous (it never touches the broker's single pipe instance).
+
+#### Gotchas
+- `is_elevated` is Windows-only; this whole fn is already `#[cfg(windows)]`, so
+  no extra gating needed.
+- Don't reintroduce a pipe-touching probe — the point is to gate on the daemon's
+  *own* token, not on broker presence.
+
+#### Acceptance
+- Elevated daemon (run `uffsd` from an elevated shell): **no** "Access Broker
+  handle request" lines in `uffsd.log`; drives still load.
+- Non-elevated daemon with broker running: unchanged — warm-up runs, handles
+  register, MFT loads (the 2026-06-14 baseline).
+
+#### Tests
+- **Core (host unit):** factor the decision into a pure helper
+  `fn should_warm_up_broker(is_elevated: bool) -> bool { !is_elevated }` and unit-test
+  both arms. (Keeps the policy testable without a live token.)
+- **Edge:** N/A logic-wise; the elevation query itself isn't unit-testable
+  cross-platform.
+- **Manual/VM:** elevated-shell run (expect no broker WARNs) **and**
+  non-elevated run (expect broker adoption) — capture both logs.
+
+---
+
+### FU-2 — USN journal through the broker (+ stop the retry storm)
+
+**Priority: HIGH · Effort: M · Depends on: SBB-1.**
+
+#### Why
+Two problems, observed together on 2026-06-14:
+
+1. **Wrong cost.** The USN journal open uses its own direct `CreateFileW`, which
+   a non-elevated daemon can't do → `USN journal unavailable; full rebuild ...
+   Access is denied`. The daemon then does a **full MFT rebuild** on every
+   refresh instead of a cheap incremental USN read. Results are correct; the cost
+   is not.
+2. **Log/CPU storm.** Once a drive loads, the per-shard journal loop polls every
+   ~500 ms and, on the access-denied open, logs `Journal poll failed; retrying
+   next tick` **forever** — flooding the log and burning cycles.
+
+#### Where
+- USN open: `crates/uffs-mft/src/usn/windows.rs` → `open_volume_handle`
+  (≈ line 128). It does a direct `CreateFileW(\\.\X:, GENERIC_READ, …,
+  FILE_FLAG_BACKUP_SEMANTICS, …)`.
+- USN ioctls: same file, `FSCTL_QUERY_USN_JOURNAL` (≈ line 191),
+  `FSCTL_READ_USN_JOURNAL`, and `read_usn_journal` (≈ line 227).
+- Retry storm: `crates/uffs-daemon/src/cache/journal_loop.rs` → `poll_blocking`
+  (≈ line 540); the `Ok(Err(io_err)) =>` arm logs at ≈ line 547 and returns
+  `None` every tick. The sleep/tick driver is just above (`tokio::time::sleep`).
+- Loop spawn / poll interval: `crates/uffs-daemon/src/lib.rs` ≈ line 560
+  ("Spawning per-shard journal loops", `poll_interval`).
+
+#### What to change
+
+**Part A — broker the USN handle (SBB-1).**
+1. Replace the body of `open_volume_handle` with a call to
+   `adopt_or_open_volume(volume, GENERIC_READ.0)` (SBB-1). USN FSCTLs operate on
+   a **volume** handle, which the broker already vends — a duplicate of the
+   registered handle works for `FSCTL_QUERY_USN_JOURNAL` /
+   `FSCTL_READ_USN_JOURNAL`.
+2. **Overlapped caveat:** the broker handle is `FILE_FLAG_OVERLAPPED`. The USN
+   `DeviceIoControl` calls currently pass `None` for `OVERLAPPED`. These FSCTLs
+   complete synchronously and generally tolerate a NULL overlapped, but if VM
+   testing shows `ERROR_INVALID_PARAMETER` (same class as FU-7/FU-8), switch
+   those `DeviceIoControl` calls to the overlapped-event + `GetOverlappedResult`
+   pattern when `broker_backed` is true. Plumb `broker_backed` out of SBB-1 so
+   the USN code can branch.
+
+**Part B — stop the retry storm.**
+In the journal loop, when the source repeatedly fails with access-denied (or any
+persistent error), **back off** instead of hammering at the fixed
+`poll_interval`. Minimal, deterministic approach:
+1. Track a per-drive consecutive-failure count and a current backoff.
+2. On success → reset backoff to the base `poll_interval` and log at `debug`.
+3. On failure → exponential backoff (e.g. `interval * 2`) capped at a ceiling
+   (e.g. 5 min). Log the **first** failure at `warn`, subsequent identical
+   failures at `debug`, and emit a single `warn` "USN unavailable for drive X;
+   backing off to Ns" on each backoff escalation — not one per tick.
+4. Optional: if the error is specifically access-denied **and** the daemon is
+   non-elevated **and** no broker handle is registered for the drive, mark USN
+   "unavailable" for that drive and stop polling entirely until the next full
+   reload (cleanest — no storm at all). Prefer this when SBB-1 confirms there's
+   genuinely no broker handle to adopt.
+
+#### Gotchas
+- The poll runs on `spawn_blocking`; keep the backoff state in the async loop
+  (the `tick` driver), not in the blocking closure.
+- Don't change the cursor/save-threshold semantics — only the *cadence* and
+  *logging* of failures.
+- USN journal may be legitimately disabled on a volume (`ERROR_JOURNAL_NOT_ACTIVE`,
+  ≈ line 176 handles this). That's distinct from access-denied; keep that branch.
+
+#### Acceptance
+- Non-elevated, broker-backed daemon: USN poll **succeeds** (incremental
+  refresh), no full-rebuild-every-time, no `Access is denied` spam.
+- A drive with genuinely no USN access: at most a handful of WARNs, then quiet
+  (backoff/disabled) — **not** two lines per second.
+
+#### Tests
+- **Core (host unit):** a `BackoffSchedule` (or similar) pure type — assert
+  base→2x→4x→…→cap progression, reset-on-success, and the "log first WARN then
+  demote to debug" decision. This is the bulk of the testable logic; isolate it
+  from Windows.
+- **Core (host, mock source):** the journal loop already abstracts
+  `JournalSource` (`Arc<dyn JournalSource>`); add a mock that returns
+  `Err(access-denied)` K times then `Ok(...)`, and assert the loop backs off then
+  recovers and resets. No Windows needed.
+- **Edge:** error that is `ERROR_JOURNAL_NOT_ACTIVE` (should *not* be treated as
+  the access-denied storm); zero-drive case; success-immediately case (backoff
+  never engages).
+- **Manual/VM:** non-elevated broker-backed run — confirm incremental USN poll
+  works (mutate a file, see it reflected) and the log is quiet.
+
+---
+
+### FU-3 — `get_mft_extents` through the broker (fragmented MFTs)
+
+**Priority: MEDIUM · Effort: M · Depends on: SBB-1.**
+
+#### Why
+`get_mft_extents` opens `<drive>:\$MFT` directly to read its retrieval pointers
+(`FSCTL_GET_RETRIEVAL_POINTERS`). On open failure it **silently falls back to a
+single contiguous extent** computed from `NTFS_VOLUME_DATA`
+(`mft_start_lcn` + `mft_valid_data_length`). Correct for an **unfragmented** MFT;
+**silently wrong for a fragmented one** — it misses every fragment past the
+first, producing a partial index with no error.
+
+On the 2026-06-14 VM the MFT happened to be contiguous (`num_extents=1`), so this
+didn't bite — but we can't rely on that.
+
+#### Where
+- `crates/uffs-mft/src/platform/volume.rs` → `get_mft_extents` (≈ line 736).
+  The direct `CreateFileW("<drive>:\$MFT", 0, …)` is the `let Ok(mft_handle) = …`
+  block; the `else` arm is the silent single-extent fallback (≈ line 758).
+- Retrieval pointers helper: `get_retrieval_pointers(mft_handle)` (called at end
+  of the fn).
+
+#### What to change
+Two options — **prefer Option 2** (keeps the protocol at one handle per drive):
+
+**Option 2 — bootstrap from the volume handle (no protocol change).**
+1. Read FRS 0 (the `$MFT`'s own record) from the known MFT location using the
+   **broker volume handle** we already hold (`self.handle`). The MFT byte offset
+   is available (`mft_byte_offset()` / `volume_data.mft_start_lcn *
+   bytes_per_cluster`); FRS 0 is the first record.
+2. Parse its `$DATA` attribute runlist (there is already runlist-parsing code for
+   `$UpCase` in `platform/upcase.rs::parse_data_runs` — reuse/share it) to derive
+   the full extent map: `(vcn, lcn, cluster_count)` per run.
+3. Return that as `Vec<MftExtent>`. This is exactly what
+   `FSCTL_GET_RETRIEVAL_POINTERS` would have given us, derived from on-disk data
+   we can already read through the broker handle.
+
+**Option 1 — broker an `$MFT` handle (fallback if Option 2 is too invasive).**
+Extend the protocol to vend a second handle (an `$MFT` handle the elevated broker
+opens) per drive. More moving parts (protocol + registry changes); only do this
+if reading FRS 0 + parsing runs proves impractical.
+
+**Interim safety (do this regardless):** make the current fallback **loud** — log
+a `warn!` "MFT extents: $MFT open failed; assuming single contiguous extent
+(index may be incomplete on a fragmented MFT)" so a partial index is never
+silent while Option 2 is pending.
+
+#### Gotchas
+- `$MFT` is opened with **zero** desired access (metadata only) — that *may*
+  already succeed for a non-elevated caller, in which case the real pointers are
+  read and the fallback never fires. **Verify on the VM which path runs** before
+  assuming Option 2 is even needed; the loud-warn step tells you.
+- Runlist parsing must handle multi-fragment runs and sparse/negative LCN deltas
+  correctly — this is the crux; test it hard (see below).
+
+#### Acceptance
+- On a **fragmented** MFT, `get_mft_extents` returns **all** fragments (verify
+  against `fsutil` / a known-fragmented test volume), not just the first.
+- On a contiguous MFT, identical result to today.
+- No silent partial index — any fallback is `warn`-logged.
+
+#### Tests
+- **Core (host unit):** feed `parse_data_runs` golden `$DATA` runlist byte
+  vectors (contiguous; 2-fragment; 5-fragment; sparse) and assert the decoded
+  `(vcn, lcn, cluster_count)` set. This is platform-agnostic and the highest-value
+  test here.
+- **Edge:** single-cluster MFT; run with a negative LCN delta (backwards
+  fragment); a runlist with a sparse hole; truncated/malformed runlist → clean
+  `MftError`, not a panic.
+- **Manual/VM:** create a fragmented MFT (`fsutil` or fill+delete churn) and
+  compare extent count against `fsutil file layout` for `$MFT`.
+
+---
+
+### FU-8 — `$UpCase` read on the overlapped handle
+
+**Priority: LOW–MEDIUM · Effort: M.**
+
+#### Why
+Reading `$UpCase` (the NTFS uppercase table, used for case-insensitive name
+comparison) does a **synchronous `SetFilePointerEx`** seek on the volume handle.
+The broker handle is `FILE_FLAG_OVERLAPPED`, which has **no synchronous file
+pointer** — so the seek fails. Observed 2026-06-14:
 
 ```
 WARN $UpCase live read failed — falling back to compiled-in default table
@@ -335,91 +573,502 @@ WARN $UpCase live read failed — falling back to compiled-in default table
            The parameter is incorrect. (0x80070057)
 ```
 
-It falls back to the **compiled-in default Unicode case table**, which is
-correct for standard NTFS volumes, so search results are unaffected today. But
-a volume with a customised `$UpCase` would silently use the wrong table, and
-the warning is noise on every broker-backed load.
+It falls back to the compiled-in default Unicode case table (correct for standard
+NTFS, so search is unaffected today), but a volume with a customised `$UpCase`
+would silently use the wrong table, and the WARN is noise on every broker-backed
+load.
 
-### Fix approach
-Either (a) read `$UpCase` through a **non-overlapped** handle (the broker would
-need to vend one, or this specific read uses a synchronous duplicate with the
-overlapped flag cleared — not directly possible via `DuplicateHandle`, so more
-likely a second broker handle or a synchronous re-open), or (b) issue the
-`$UpCase` read using the **overlapped offset mechanism** (offset in the
-`OVERLAPPED` struct + `GetOverlappedResult`) instead of `SetFilePointerEx`,
-matching how the MFT bulk read already addresses the overlapped handle. Option
-(b) keeps the single-handle model and is preferred.
+#### Where
+- `crates/uffs-mft/src/platform/upcase.rs` → `read_upcase_table` (≈ line 336),
+  which calls `volume_read_at` (≈ line 398) and `read_clusters`. `volume_read_at`
+  does `SetFilePointerEx(handle, seek_pos, None, FILE_BEGIN)` then `ReadFile`
+  (≈ line 404–415) — **this** is the failing seek.
+- The fallback/WARN site: `crates/uffs-core/src/compact.rs` ≈ line 1052–1058.
 
-### Effort / risk
-Small–moderate. Localised to the `$UpCase` read path; needs a volume with a
-non-default `$UpCase` to fully validate the correctness angle.
+#### What to change
+Make the volume reads **overlapped-aware**. Preferred (Option b in the prior
+notes): replace the `SetFilePointerEx` + `ReadFile` pair with an offset-carrying
+overlapped read whenever the handle is overlapped:
+1. Build an `OVERLAPPED` with the 64-bit `offset` split into
+   `Offset` / `OffsetHigh` (and a manual-reset event in `hEvent`).
+2. `ReadFile(handle, buf, len, None, Some(&mut overlapped))`; if it returns
+   `ERROR_IO_PENDING`, wait and call `GetOverlappedResult`.
+3. Close the event.
+
+This matches how the MFT bulk read already addresses an overlapped handle, and
+keeps the single-handle model (no extra broker handle). Apply the same treatment
+to `read_clusters` (it does the same seek+read per run).
+
+Detection: thread the `broker_backed` flag (from SBB-1 /
+`VolumeHandle`) so the non-broker (elevated, synchronous) path keeps using the
+simpler `SetFilePointerEx` if you prefer — or just always use the overlapped
+offset form (it works on both overlapped and non-overlapped handles when you pass
+the offset in `OVERLAPPED`, simplest to keep one path).
+
+#### Gotchas
+- `Offset`/`OffsetHigh` are the low/high 32 bits of the byte offset — get the
+  split right (`offset as u32`, `(offset >> 32) as u32`).
+- One `unsafe` op per block (event create, ReadFile, GetOverlappedResult, close —
+  separate blocks).
+- Don't regress the elevated/synchronous path (covered by existing
+  `uffs-mft save --upcase` usage).
+
+#### Acceptance
+- Broker-backed load: `Read $UpCase table from live volume` (success), **no**
+  `$UpCase live read failed` WARN.
+- Elevated load: still works (no regression).
+
+#### Tests
+- **Core (host unit):** the offset-split logic (`offset → (low, high)`) as a pure
+  function with boundary values (0, `0xFFFF_FFFF`, `0x1_0000_0000`,
+  `3_221_235_712` from the actual failure). The parse of the 128 KB table into
+  `[u16; 65_536]` already has coverage — extend if needed.
+- **Edge:** offset exactly at a 4 GB boundary; a short read (fewer bytes than
+  requested) → loop/again rather than silently truncate.
+- **Manual/VM:** confirm the WARN is gone on a broker-backed load and the live
+  table matches the compiled-in default on a standard volume (they should be
+  identical on a default install — a good correctness check).
 
 ---
 
-## Follow-up 9 — Gate broker warm-up on `!is_elevated()` (self-inflicted regression)
+### FU-1 — Windows Service dispatcher
 
-**Priority: HIGH** (trivial fix; removes a regression introduced while fixing the
-probe-race).
+**Priority: HIGH · Effort: M.**
 
-### Problem
-While solving the `ERROR_PIPE_BUSY` starvation, `warm_up_broker_handles` was
-changed to run **unconditionally** — for *any* daemon, elevated or not. That was
-correct for killing the racy `broker_available()` probe, but it means an
-**elevated** daemon with no broker now makes a futile broker pipe-open attempt
-**per drive**, each failing fast and logging a `WARN`. On a 7-drive elevated
-load that's 7 failed `OpenOptions::open` calls + 7 WARNs. Microseconds of cost,
-but real log noise and conceptually wrong: **an elevated daemon never needs the
-broker** — it can open volumes directly.
+#### Why
+`uffs-broker` implements `--install` / `--uninstall` / `--run` but has **no
+service control dispatcher**. When the SCM starts the registered service it
+launches the binary with **no arguments**; `run()` falls through to
+`print_usage()` and exits 0. The service never calls
+`StartServiceCtrlDispatcher` or reports `SERVICE_RUNNING`, so it only actually
+runs in foreground `--run` mode. Without this, "install once, no future UAC
+across reboots" isn't real.
 
-### Evidence
-The MFT *read* path is unaffected when elevated (`VolumeHandle::open` finds the
-registry empty via a cheap mutex check and falls through to direct
-`CreateFileW`, full-speed IOCP as before). The regression is confined to the
-warm-up probe: an elevated daemon that previously did nothing broker-related now
-emits per-drive "opening broker pipe" → failure WARNs.
+#### Where
+- `crates/uffs-broker/src/main.rs` (arg dispatch; `eprintln!` error path).
+- `crates/uffs-broker/src/broker.rs` → `serve_pipe_requests` (≈ line 129) — the
+  loop the service must drive.
+- `crates/uffs-broker/src/broker/service.rs` — install/uninstall (`sc.exe`,
+  `binPath=` handling). The service name lives here.
 
-### Fix approach
-Gate the warm-up on elevation, not on a pipe probe:
+#### What to change
+Implement the standard service entry point (raw `windows`-crate FFI — the crate
+already depends on it; avoid the `windows-service` crate to dodge a new
+cargo-vet/manifest-audit cost unless the boilerplate proves error-prone):
+1. **No-arg invocation** (how the SCM launches it) →
+   `StartServiceCtrlDispatcherW` with a `SERVICE_TABLE_ENTRYW` pointing at a
+   `ServiceMain` callback. Keep `--run` as the foreground/debug path; both share
+   `serve_pipe_requests`.
+2. **`ServiceMain`** → `RegisterServiceCtrlHandlerW` (handle
+   `SERVICE_CONTROL_STOP` / `SERVICE_CONTROL_SHUTDOWN`), then
+   `SetServiceStatus(SERVICE_START_PENDING)` → run the serve loop →
+   `SetServiceStatus(SERVICE_RUNNING)`.
+3. **Stop handling:** the control handler signals the serve loop to exit (an
+   `AtomicBool` / event the loop checks between connections), then
+   `SetServiceStatus(SERVICE_STOPPED)` with the right `dwWin32ExitCode`.
+4. Make `serve_pipe_requests` cooperatively cancellable (today it's an infinite
+   `loop`). If FU-5 lands first, the async serve loop gives you a clean cancel
+   token; otherwise add a stop flag checked each iteration.
 
-```rust
-// in load_live_drives_if_windows, before warm_up_broker_handles(...)
-if uffs_mft::is_elevated() {
-    // Elevated daemons open volumes directly; the broker is only for the
-    // non-elevated path. Skip the futile probe entirely.
-} else {
-    warm_up_broker_handles(&drives);
-}
+#### Gotchas
+- The SCM gives the service ~30 s to report `SERVICE_RUNNING` — report
+  `START_PENDING` quickly, do slow setup after.
+- `ServiceMain` runs on an SCM-spawned thread; the control handler on another —
+  share state via atomics/events, not `&mut`.
+- Logging: at service start there may be no console; ensure the tracing
+  subscriber writes to the file sink (`%UFFS_LOG_DIR%`) not stdout.
+- Test the **stop** path (`sc stop`) — a service that won't stop cleanly is its
+  own bug.
+
+#### Acceptance
+- `sc start UffsAccessBroker` → `sc query` shows `RUNNING` with a live process;
+  the pipe is served; a non-elevated daemon gets handles **after a reboot** with
+  no `--run` terminal.
+- `sc stop UffsAccessBroker` → clean `STOPPED`, exit code 0, process gone.
+
+#### Tests
+- **Core (host unit):** factor arg-parsing (`no args → ServiceDispatch`,
+  `--run → Foreground`, `--install → Install`, …) into a pure
+  `parse_mode(args) -> Mode` and unit-test it. The FFI itself isn't host-testable.
+- **Edge:** unknown arg → usage + non-zero exit; double-start; stop while a
+  client is mid-request (should finish or cleanly abort that connection).
+- **Manual/VM:** install → reboot → confirm auto-start (`start= auto`) and a
+  cold non-elevated search works with no broker terminal open; then `sc stop`.
+
+---
+
+### FU-4 — `WinVerifyTrust` + Authenticode caching
+
+**Priority: MEDIUM · Effort: M.**
+
+#### Why
+`verify_authenticode` shells out to **PowerShell**
+(`Get-AuthenticodeSignature`) **per request** — hundreds of ms each, plus a
+hard dependency on PowerShell being present/on PATH. The daemon requests handles
+**sequentially, one per drive**, so an N-drive estate pays ~N × that up front
+(10 drives ≈ several seconds before any load starts). A service hot path should
+never spawn PowerShell.
+
+#### Where
+- `crates/uffs-broker/src/broker.rs` → `verify_authenticode(exe_path: &str)`
+  (≈ line 281). Called from `check_client_identity` (≈ line 207).
+- The client process is already opened exactly once in `handle_one_connection`
+  (≈ line 165, `OwnedProcessHandle::open_client`) — reuse that identity for the
+  cache key.
+
+#### What to change
+
+**(a) Replace PowerShell with `WinVerifyTrust` (the big win).**
+1. Use `windows::Win32::Security::WinTrust`. Build a `WINTRUST_FILE_INFO`
+   pointing at the client image path (UTF-16), wrap it in `WINTRUST_DATA` with
+   `dwUnionChoice = WTD_CHOICE_FILE`, `dwUIChoice = WTD_UI_NONE`,
+   `dwStateAction = WTD_STATEACTION_VERIFY`.
+2. Call `WinVerifyTrust(HWND(0)/INVALID_HANDLE_VALUE,
+   &WINTRUST_ACTION_GENERIC_VERIFY_V2, &mut data)`.
+3. Map the result HRESULT to the **same policy** as today:
+   - `S_OK` (0) → Valid → accept.
+   - `TRUST_E_NOSIGNATURE` → NotSigned → accept (dev builds), matching current
+     behavior. (If policy later tightens to require signing in release, gate this
+     on a build flag — but **preserve today's behavior** in this PR.)
+   - `TRUST_E_BAD_DIGEST` → HashMismatch (tampered) → **reject**.
+   - Other `TRUST_E_*` / `CERT_E_*` → reject (fail closed).
+4. **Always** call `WinVerifyTrust` again with
+   `dwStateAction = WTD_STATEACTION_CLOSE` to free the state data (do this in all
+   paths — use a guard).
+5. Remove the PowerShell `Command` spawn entirely.
+
+**(b) Cache per client process.**
+Key on `(pid, exe_path, image_mtime_or_hash)` so PID reuse can't smuggle a
+different binary past a cached "valid". Verify once per client process; reuse for
+that process's later drive requests. Lifetime = client process lifetime. Do
+**not** weaken verification — only skip re-running it for an already-verified key.
+
+#### Gotchas
+- `WinVerifyTrust` FFI is unsafe + Windows-only; one op per `unsafe` block,
+  `// SAFETY:` notes.
+- **Fail closed** on any decode/HRESULT you don't explicitly accept. The current
+  code's "PowerShell missing → allow" graceful degradation goes away (good —
+  that was a soft spot); there's no external dependency to be missing now.
+- The cache must make a substituted binary a **miss** — include mtime or a
+  content hash, not just `(pid, path)`.
+- Preserve the audit-log outcomes (`REJECTED ... Authenticode verification
+  failed`) exactly.
+
+#### Acceptance
+- Signed `uffsd.exe` → accepted; unsigned dev build → accepted; a **tampered**
+  binary (flip a byte) → rejected with the same audit line.
+- No `powershell.exe` child process spawned (check Process Monitor / no PATH
+  dependency).
+- Multi-drive warm-up: one verify per client process, not per drive (visible as a
+  single verify in the broker debug log).
+
+#### Tests
+- **Core (host unit):** the HRESULT→decision mapping as a pure function
+  (`fn classify_trust(hr: i32) -> TrustDecision`) — table-test `S_OK`,
+  `TRUST_E_NOSIGNATURE`, `TRUST_E_BAD_DIGEST`, an arbitrary `CERT_E_*`, and an
+  unknown code (→ reject). High value, fully host-testable.
+- **Core (host unit):** the cache key + lookup (`insert`, `hit on same key`,
+  `miss on changed mtime`, `miss on changed path`).
+- **Edge:** path with spaces/unicode; very large image; concurrent verifies of
+  the same PID (cache must not race — guard the map).
+- **Manual/VM:** sign a build, verify accept; flip a byte, verify reject; confirm
+  no PowerShell spawn and the per-process single-verify.
+
+---
+
+### FU-5 — Async multi-instance broker + `OwnedHandle`
+
+**Priority: MEDIUM · Effort: L · Depends on: SBB-2.**
+
+#### Why
+The broker serves a **single** pipe instance (`max_instances = 1`) in a **serial**
+loop (`serve_pipe_requests`: create → wait → handle → disconnect → repeat).
+Concurrent clients queue or hit `ERROR_PIPE_BUSY`. The common one-daemon flow is
+fine, but genuinely concurrent load (multiple daemons, or a future parallel
+warm-up) serializes — and combined with the per-request Authenticode cost
+(FU-4), throughput is poor at scale. The serial design is also what made the old
+client probe starve the real request (now removed; historical).
+
+#### Where
+- `crates/uffs-broker/src/broker.rs` → `serve_pipe_requests` (≈ line 129),
+  `handle_one_connection` (≈ line 151), `create_broker_pipe` (≈ line 336),
+  `wait_for_client` / `disconnect_and_close`. Rate-limit map is the
+  `HashMap<char, Instant>` owned by `serve_pipe_requests`.
+
+#### What to change
+
+**Preferred — go async with tokio's named pipes.** The community-standard
+scalable Windows pipe server in Rust is
+[`tokio::net::windows::named_pipe`](https://docs.rs/tokio/latest/tokio/net/windows/named_pipe/)
+(`ServerOptions` + `NamedPipeServer`), not a hand-rolled serial thread loop:
+1. `ServerOptions::new().max_instances(N).create(PIPE_NAME)` for the first
+   listener, applying the **same** security attributes (SDDL) as
+   `create_broker_pipe` does today.
+2. `server.connect().await`; **immediately** build the *next* listening instance
+   before handling the current connection (the documented tokio accept-loop
+   pattern — there's always an instance waiting, closing the "between connections
+   we're deaf" gap).
+3. `tokio::spawn` the per-connection handler (read request → verify identity →
+   `DuplicateHandle` → write response). A connected `NamedPipeServer` is `Send`,
+   so it moves into the task cleanly.
+4. Share rate-limit/audit state behind `Arc<Mutex<…>>` (or an actor task that
+   owns it); per-connection tasks hold `Arc` clones.
+
+Raw-FFI multi-instance + a worker-thread pool is the fallback if pulling tokio
+into the broker is unwanted, but it reintroduces the `HANDLE`-`Send` problem that
+the async path avoids — which is what **SBB-2 (`OwnedHandle`)** is for.
+
+**Pair with FU-4** so each concurrent connection isn't independently paying the
+Authenticode cost.
+
+#### Gotchas
+- Keep `max_instances` bounded (DoS surface — a flood of clients shouldn't
+  exhaust the system). A tuned cap (e.g. 16) is safer than `PIPE_UNLIMITED_INSTANCES`.
+- The rate limiter and audit log must stay correct under parallelism — they're
+  now shared mutable state.
+- Don't lose the WI-8.1 invariant: open the client process **once** and use that
+  same handle for verify **and** `DuplicateHandle` (PID-reuse safety). That logic
+  moves into the per-connection task intact.
+- Pipe security attributes must be applied to **every** instance, not just the
+  first.
+
+#### Acceptance
+- Two daemons (or a scripted N parallel clients) get handles concurrently with no
+  `ERROR_PIPE_BUSY` and no serialized stall.
+- Single-daemon flow unchanged.
+- Rate limiting still enforced per drive across concurrent connections.
+
+#### Tests
+- **Core (host unit):** the rate-limiter as a pure type (`allow(drive, now)` with
+  injected time) — within-window reject, after-window allow, per-drive
+  independence. Fully host-testable.
+- **Core (host):** `OwnedHandle` (SBB-2) Drop/Send tests.
+- **Edge:** N concurrent connections > `max_instances` (excess must queue
+  cleanly, not error); a client that connects then hangs without sending (don't
+  let one stuck client block others — per-connection timeout); a connection that
+  drops mid-handshake (no leaked handle, audited as FAILED).
+- **Manual/VM:** launch two non-elevated daemons (or a loop spawning several
+  clients) and confirm concurrent grants in the audit log with interleaved PIDs.
+
+---
+
+### FU-6 — Non-connecting client pipe probe
+
+**Priority: LOW · Effort: S.**
+
+#### Why
+`uffs-client`'s `broker_pipe_present` (gates the non-elevated daemon spawn) uses
+`GetFileAttributesW`, which **connects to** the pipe — the broker logs a rejected
+`uffs.exe` connection on every search (you can see this in the 2026-06-14 log:
+`REJECTED ... exe="...uffs.exe" ... identity verification failed`). It happens
+~1 s before the daemon's real request, so the single-instance broker recovers in
+time and it's currently harmless, but it's wasteful and fragile under load.
+
+#### Where
+- `crates/uffs-client/src/broker_probe.rs` → `broker_pipe_present()`
+  (`GetFileAttributesW`).
+- Consumed by `crates/uffs-client/src/daemon_spawn.rs`
+  (`spawn_unelevated_or_refuse`).
+
+#### What to change
+Switch to a **non-connecting** existence check:
+- `WaitNamedPipeW(PIPE_NAME, small_timeout)` returns success/`ERROR_FILE_NOT_FOUND`
+  without consuming an instance, **or**
+- Accept a brief false-negative and rely on the spawn's existing fallback.
+
+Re-evaluate after FU-5: a multi-instance broker tolerates the probe connection
+cleanly, possibly making this moot — if FU-5 lands first, this may reduce to "stop
+logging the probe as a rejection."
+
+#### Gotchas
+- `WaitNamedPipeW` semantics: it waits for an **instance to become available**,
+  not merely for existence — pick a tiny timeout and treat
+  `ERROR_FILE_NOT_FOUND` as "no broker", other errors as "assume present, let the
+  real request decide".
+
+#### Acceptance
+- No `REJECTED ... uffs.exe` line in the broker audit log on a normal search.
+- Daemon-spawn gating behaves identically (spawns when broker present, refuses/falls
+  back when not).
+
+#### Tests
+- **Core (host unit):** the decision mapping (`probe_result → present/absent`) as
+  a pure function.
+- **Edge:** broker present but momentarily busy (don't false-negative into
+  refusing to spawn); broker absent (clean "no broker").
+- **Manual/VM:** run a search, grep the broker audit log — no `uffs.exe`
+  rejection line.
+
+---
+
+### FU-7 — Volume-data FSCTL on the overlapped handle
+
+**Priority: LOW–MEDIUM · Effort: S.**
+
+#### Why
+`get_ntfs_volume_data` issues `FSCTL_GET_NTFS_VOLUME_DATA` with a **NULL**
+`OVERLAPPED`. The broker handle is `FILE_FLAG_OVERLAPPED`; per Win32 docs a
+synchronous `DeviceIoControl` on an overlapped handle is technically undefined,
+though this FSCTL completes synchronously and worked on the 2026-06-14 VM. Same
+root cause family as FU-8. "Simple-first" was deliberate.
+
+#### Where
+- `crates/uffs-mft/src/platform/volume.rs` → `get_ntfs_volume_data(handle, volume)`
+  (≈ line 405). Called from both `VolumeHandle::open` and `from_broker_handle`
+  (≈ line 398).
+
+#### What to change
+Only if VM testing shows a `NotNtfs` / volume-data failure on the broker-backed
+path: add an overlapped-safe variant — pass a real `OVERLAPPED` with an event and
+`GetOverlappedResult`, used when the handle is overlapped (`broker_backed`).
+Otherwise leave as-is and add a one-line code comment noting the dependence on
+this FSCTL's synchronous completion. **Do not** speculatively complicate a path
+that works; this is a "fix if it breaks" item.
+
+#### Acceptance
+- Broker-backed `from_broker_handle` reads valid `NTFS_VOLUME_DATA`
+  (`bytes_per_cluster`, `mft_start_lcn`, … sane) — already true on the baseline;
+  this item just hardens it if a future failure appears.
+
+#### Tests
+- **Core (host unit):** N/A (pure FFI); if you add the overlapped path, reuse the
+  offset/overlapped helper from FU-8 and test that helper.
+- **Manual/VM:** confirm `from_broker_handle` volume-data fields match the
+  elevated direct-open values on the same volume.
+
+---
+
+## 5. Testing strategy
+
+The hard constraint: **the live broker + MFT path cannot run off Windows**
+(needs Windows + a real volume; the broker needs elevation). So the strategy is a
+pyramid — push as much logic as possible *below* the Windows line into pure,
+host-runnable units, and keep the irreducible Windows surface thin and
+VM-validated.
+
+### Layer 1 — Core unit tests (host, every PR)
+
+Run on macOS/Linux/CI with `cargo nextest run --workspace`. For **each** item,
+extract the decision logic into a pure function/type and test it here. The
+recurring pattern: *"pull the policy out of the FFI."* Concretely:
+
+- FU-9 → `should_warm_up_broker(is_elevated)`.
+- FU-2 → backoff schedule + the mock-`JournalSource` loop recovery.
+- FU-3 → `parse_data_runs` golden runlists (the single most valuable test in this
+  whole effort — runlist decode is where fragmented-MFT correctness lives).
+- FU-4 → `classify_trust(hr)` + cache key/lookup.
+- FU-5 → rate-limiter with injected clock; `OwnedHandle` drop/send.
+- FU-6 → probe-result → present/absent mapping.
+- FU-8 → 64-bit offset → `(Offset, OffsetHigh)` split, boundary values.
+- FU-1 → `parse_mode(args)`.
+
+These must be **deterministic** (inject time, feed fixtures — no sleeps, no real
+clocks, no live handles).
+
+### Layer 2 — Edge-case units (host)
+
+For every Layer-1 unit, add the nasty inputs. A checklist to apply per item:
+
+- **Boundaries:** 0, max, and the exact value from a real observed failure (e.g.
+  offset `3_221_235_712` for FU-8).
+- **Malformed/hostile input:** truncated runlists, invalid drive bytes, unknown
+  HRESULTs, non-UTF-8 — must return a structured error, **never panic** (panics
+  are denied by lint anyway, but assert it).
+- **Error vs. error:** distinguish *kinds* — access-denied (storm) vs.
+  journal-not-active (legitimate) in FU-2; tampered vs. unsigned in FU-4.
+- **Concurrency:** shared mutable state (FU-5 rate limiter, FU-4 cache) under
+  parallel access — exercise with threads and assert no race/corruption.
+- **Idempotency/cleanup:** every handle/event/overlapped allocated is freed on
+  *all* paths including error (use RAII guards; assert no leak where feasible).
+
+### Layer 3 — Windows host-build checks (every PR touching `#[cfg(windows)]`)
+
+These don't *run* the logic but catch the bulk of breakage:
+
+```bash
+cargo xwin clippy --workspace --all-targets --all-features \
+    --no-deps --target x86_64-pc-windows-msvc -- -D warnings
+cargo xwin check  --workspace --all-targets --all-features \
+    --target x86_64-pc-windows-msvc
 ```
 
-`is_elevated()` is cheap (a token query), involves **no pipe interaction**, and
-has **none** of the race that made the old `broker_available()` probe dangerous —
-it never touches the broker's single pipe instance. This restores the
-pre-broker behavior for elevated daemons while keeping the non-elevated path
-exactly as it works today.
+Cross-compiling for `x86_64-pc-windows-msvc` compiles the Windows-only code your
+host `cargo build` skips — **always** run this for broker work or you'll merge
+code that doesn't compile on the only platform it runs on.
 
-### Effort / risk
-Trivial (a few lines, one import). Validate that a non-elevated daemon still
-warms up (broker present) and an elevated daemon emits no broker WARNs.
+### Layer 4 — Manual VM validation (per item, before merge)
+
+On a Windows 11 VM with the three binaries in `C:\uffs-test`:
+
+```powershell
+# Terminal A (elevated): the broker
+$env:UFFS_LOG = 'debug'; $env:UFFS_LOG_DIR = 'C:\uffs-test\logs'
+C:\uffs-test\uffs-broker.exe --run        # (or: sc start UffsAccessBroker once FU-1 lands)
+
+# Terminal B (NON-elevated): a search → spawns the daemon → exercises the broker
+$env:UFFS_LOG = 'debug'; $env:UFFS_LOG_DIR = 'C:\uffs-test\logs'
+C:\uffs-test\uffs.exe "hallo"
+
+# Inspect
+Get-Content C:\uffs-test\logs\uffsd.log       -Tail 120
+Get-Content C:\uffs-test\logs\uffs-broker.log -Tail 80
+```
+
+**Per-item VM acceptance** is listed in each section's *Acceptance*. The
+universal "did not regress the baseline" check, from the 2026-06-14 known-good
+run:
+
+- broker: `AUDIT action="GRANTED" ... exe="...uffsd.exe" drive=C`.
+- daemon: `Adopted Access Broker volume handle for MFT read`, `Live drive loaded
+  drive=C records=...`, daemon **stays resident**, search returns rows, **no UAC
+  prompt**.
+
+Always capture **both** logs in the PR. For elevation-sensitive items (FU-9,
+FU-1) run **both** an elevated and a non-elevated daemon and diff the behavior.
+
+### What "done" means for an item
+
+A PR is mergeable when: Layer-1/2 units cover the extracted logic (and pass on
+CI), Layer-3 cross-compile is clean, the item's *Acceptance* bullets are verified
+on the VM with logs attached, the tracking-board row is updated, and the fix
+guidelines in [§2](#2-how-to-work-an-item) are honored (no suppression, atomic
+commits, gates green without `--no-verify`).
 
 ---
 
-## Suggested sequencing
+## 6. Suggested sequencing
 
-1. **Land the basic read** (current branch) — confirm one drive loads and the
-   daemon stays resident. ✅ (verified 2026-06-14)
-2. **Quick regression cleanup:** Follow-up 9 (`!is_elevated()` warm-up gate) —
-   tiny, removes log noise, do it first.
-3. **Correctness tier:** Follow-up 2 (USN through broker) and Follow-up 3
-   (`get_mft_extents` / fragmented MFTs).
-4. **Productionization tier:** Follow-up 1 (service dispatcher) so it runs
-   without `--run`.
-5. **Performance / scale tier:** Follow-up 4 (`WinVerifyTrust` + Authenticode
-   cache) + Follow-up 5 (async multi-instance broker + `OwnedHandle` refactor),
-   then Follow-up 6.
-6. **Verify / opportunistic:** Follow-up 7 and Follow-up 8 if the tests surface
-   them.
+1. **FU-9** (warm-up gate) — XS, removes a live regression. Do it first.
+2. **SBB-1** (`adopt_or_open_volume`) then **SBB-2** (`OwnedHandle`) — unblock the
+   correctness + concurrency tiers.
+3. **Correctness tier:** **FU-2** (USN through broker + backoff), **FU-3**
+   (`get_mft_extents` / fragmented MFTs), **FU-8** (`$UpCase`). These remove
+   silent-wrongness and log noise.
+4. **Productionization tier:** **FU-1** (service dispatcher) — makes "install
+   once, survive reboots" real.
+5. **Performance / scale tier:** **FU-4** (`WinVerifyTrust` + cache), then **FU-5**
+   (async multi-instance broker + `OwnedHandle`), then **FU-6**.
+6. **Verify-if-it-breaks:** **FU-7** only if a VM run surfaces a volume-data
+   failure on the broker handle.
 
-Each should be its own atomic commit with a `fix:`/`feat:` message naming the
-root cause, cross-compiled clean for `x86_64-pc-windows-msvc` and host, and
-validated on a real Windows box (the broker path can't be exercised off
-Windows).
+Each item is its own atomic PR with a `fix:`/`feat:`/`refactor:` message naming
+the root cause, cross-compiled clean for `x86_64-pc-windows-msvc` **and** host,
+and VM-validated (the broker path can't be exercised off Windows).
+
+---
+
+## 7. Glossary
+
+| Term | Meaning |
+|---|---|
+| **Access Broker** | The elevated `uffs-broker` service that vends NTFS volume handles to the non-elevated daemon. |
+| **MFT** | Master File Table — the NTFS metadata structure UFFS reads directly instead of using file-enumeration APIs. |
+| **FRS** | File Record Segment — one MFT record (FRS 0 = `$MFT` itself, FRS 10 = `$UpCase`). |
+| **USN journal** | NTFS change journal; lets the daemon refresh incrementally instead of re-reading the whole MFT. |
+| **Overlapped handle** | A handle opened `FILE_FLAG_OVERLAPPED` (async I/O). Has **no** synchronous file pointer, so `SetFilePointerEx` fails on it — offsets must travel in an `OVERLAPPED` struct. The broker vends overlapped handles. |
+| **`DuplicateHandle`** | Win32 call that copies a handle from one process into another (how the broker injects its volume handle into the daemon). |
+| **Authenticode** | Windows code-signing; the broker checks the client's signature before granting a handle. |
+| **SDDL** | Security Descriptor Definition Language — the string form of the pipe's DACL/integrity label. |
+| **SCM** | Service Control Manager — Windows component that starts/stops services (launches the binary with no args; see FU-1). |
+| **xwin / `cargo xwin`** | Cross-compiles MSVC-target Windows binaries from macOS/Linux. The only way to compile the `#[cfg(windows)]` code off Windows. |
+| **SBB** | Shared Building Block (this doc) — a prerequisite refactor several follow-ups depend on. |

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -168,21 +168,39 @@ in `warm_up_broker_handles`, so an N-drive estate pays ~N × that cost up front
 (e.g. 10 drives ≈ several seconds of signature checks before any load starts).
 
 ### Fix approach
-Cache the verification result keyed by **client PID + exe path** (and ideally
-the image's last-write time / a content hash, so PID reuse can't smuggle in a
-different binary): verify once per client process, reuse for that process's
-subsequent drive requests. Entry lifetime = the client process lifetime; the
-broker already opens the client process handle once (WI-8.1), so it can detect
-process identity reliably. Do **not** weaken the verification — only avoid
-re-running it for an already-verified `(pid, exe, mtime)`.
+There are **two** stacked fixes here; do both, the second first if forced to
+choose:
 
-Replacing the PowerShell spawn with a direct `WinVerifyTrust` FFI call is a
-separate, larger optimization (removes the subprocess entirely) and could
-fold in here.
+**(a) Move off the PowerShell subprocess to `WinVerifyTrust` (the bigger win).**
+Shelling out to `powershell.exe Get-AuthenticodeSignature` spins up an entire
+PowerShell runtime per request — hundreds of ms, plus the process-spawn tax and
+a dependency on PowerShell being present and on PATH. A world-class Windows
+implementation never does this for a service hot path. Replace it with a direct
+`WinVerifyTrust` FFI call (the `windows` crate already exposes
+`Win32::Security::WinTrust`): build a `WINTRUST_FILE_INFO` for the client image,
+call `WinVerifyTrust(INVALID_HANDLE_VALUE, &WINTRUST_ACTION_GENERIC_VERIFY_V2,
+&data)`, and map the `TRUST_E_*` / `CERT_E_*` HRESULTs to the same
+accept/reject policy the PowerShell path uses today (accept `NotSigned` for dev,
+reject `HashMismatch`). In-process, no subprocess, ~single-digit ms, no external
+dependency. This alone removes the dominant startup latency.
+
+**(b) Cache the result keyed by client PID + exe path** (and ideally the image's
+last-write time / a content hash, so PID reuse can't smuggle in a different
+binary): verify once per client process, reuse for that process's subsequent
+drive requests. Entry lifetime = the client process lifetime; the broker already
+opens the client process handle once (WI-8.1), so it can detect process identity
+reliably. Do **not** weaken the verification — only avoid re-running it for an
+already-verified `(pid, exe, mtime)`.
+
+With (a) in place each check is cheap enough that (b) is a smaller win, but
+together they take an N-drive estate from ~N × hundreds-of-ms down to a single
+fast verify per client process.
 
 ### Effort / risk
-Small (cache) to moderate (if also moving off PowerShell). Security-sensitive
-— the cache key must make a substituted binary a cache miss.
+Moderate. The `WinVerifyTrust` FFI is unsafe and Windows-only (untestable
+off-Windows; needs validation on a real box against signed *and* unsigned
+images). The cache is small but security-sensitive — the key must make a
+substituted binary a cache miss.
 
 ---
 
@@ -206,23 +224,52 @@ serializes — and combined with the per-request Authenticode spawn (Follow-up
 > about *concurrency capacity*, not that (resolved) starvation.
 
 ### Fix approach
-Restructure `serve_pipe_requests` so multiple instances listen at once:
-- `CreateNamedPipeW` with `PIPE_UNLIMITED_INSTANCES` (or a tuned cap).
-- After `ConnectNamedPipe` returns for one client, **immediately create the
-  next listening instance** before handling the current connection, and handle
-  each connection on its own thread (or async task).
-- Share the rate-limit map behind `Arc<Mutex<…>>`; `handle_one_connection`
-  takes a shared reference.
-- Mind `HANDLE` `Send`-ness when moving a connected pipe handle into a worker
-  thread (wrap in a `Send` newtype with a documented SAFETY note, or use an
-  IOCP/overlapped accept model).
+**Preferred — go async with tokio's named pipes.** The community-standard way to
+write a scalable Windows pipe server in Rust is
+[`tokio::net::windows::named_pipe`] (`ServerOptions` + `NamedPipeServer`), not a
+hand-rolled serial thread loop over raw `CreateNamedPipeW`. The idiomatic shape:
 
-Pair with Follow-up 4 so each concurrent connection isn't independently paying
-the Authenticode cost.
+1. `ServerOptions::new().max_instances(N).create(PIPE_NAME)` for the first
+   listener, applying the same SDDL/security attributes as today.
+2. `server.connect().await`; **immediately** build the *next* listening instance
+   (`ServerOptions…create`) before handling the current connection, so there's
+   always an instance waiting (this is the documented tokio accept-loop pattern
+   and removes the "between connections we're deaf" window).
+3. `tokio::spawn` the per-connection handler (read request, verify identity,
+   `DuplicateHandle`, write response). The connected `NamedPipeServer` is
+   `Send`, so it moves into the task cleanly — no raw-`HANDLE` `Send` newtype
+   needed on the connection itself.
+4. Share the rate-limit / audit state behind `Arc<Mutex<…>>` (or an actor task
+   owning it); the per-connection tasks take clones of the `Arc`.
+
+This makes multi-instance concurrency natural, keeps the I/O off the parsing,
+and aligns the broker with the daemon's existing async runtime. Raw-FFI
+multi-instance + a worker thread pool is the fallback if pulling tokio into the
+broker is unwanted, but it reintroduces the `HANDLE`-`Send` problem (below) that
+the async path avoids.
+
+**Wrap raw handles in a `Send`-safe RAII type.** Independent of the async move:
+the broker (and the daemon-side registry) pass volume/process handles around as
+bare `u64` / `HANDLE`, which are neither `Send` nor self-closing — every call
+site re-implements "reconstruct `HANDLE` from `u64`" and is responsible for not
+leaking it. Introduce a small newtype, e.g. `struct OwnedHandle(HANDLE)` with
+`unsafe impl Send` (documented SAFETY: a Win32 kernel handle is process-wide and
+safe to move between threads), `Drop` calling `CloseHandle`, and `as_raw()` /
+`into_raw()` accessors. Thread *that* through the registry and the broker
+instead of raw integers. This removes the scattered
+`with_exposed_provenance_mut` reconstructions, makes ownership/lifetime explicit,
+and is what a Rust master would reach for before adding concurrency.
+
+Pair the whole follow-up with Follow-up 4 so each concurrent connection isn't
+independently paying the Authenticode cost.
+
+[`tokio::net::windows::named_pipe`]: https://docs.rs/tokio/latest/tokio/net/windows/named_pipe/index.html
 
 ### Effort / risk
-Moderate. Concurrency + Windows handle `Send` semantics; the rate-limiter and
-audit paths must stay correct under parallelism.
+Moderate. Bringing tokio into the broker (or a worker-thread model) plus the
+handle-ownership refactor; the rate-limiter and audit paths must stay correct
+under parallelism. The `OwnedHandle` wrapper is a low-risk, high-clarity
+refactor that can land independently and first.
 
 ---
 
@@ -309,17 +356,68 @@ non-default `$UpCase` to fully validate the correctness angle.
 
 ---
 
+## Follow-up 9 — Gate broker warm-up on `!is_elevated()` (self-inflicted regression)
+
+**Priority: HIGH** (trivial fix; removes a regression introduced while fixing the
+probe-race).
+
+### Problem
+While solving the `ERROR_PIPE_BUSY` starvation, `warm_up_broker_handles` was
+changed to run **unconditionally** — for *any* daemon, elevated or not. That was
+correct for killing the racy `broker_available()` probe, but it means an
+**elevated** daemon with no broker now makes a futile broker pipe-open attempt
+**per drive**, each failing fast and logging a `WARN`. On a 7-drive elevated
+load that's 7 failed `OpenOptions::open` calls + 7 WARNs. Microseconds of cost,
+but real log noise and conceptually wrong: **an elevated daemon never needs the
+broker** — it can open volumes directly.
+
+### Evidence
+The MFT *read* path is unaffected when elevated (`VolumeHandle::open` finds the
+registry empty via a cheap mutex check and falls through to direct
+`CreateFileW`, full-speed IOCP as before). The regression is confined to the
+warm-up probe: an elevated daemon that previously did nothing broker-related now
+emits per-drive "opening broker pipe" → failure WARNs.
+
+### Fix approach
+Gate the warm-up on elevation, not on a pipe probe:
+
+```rust
+// in load_live_drives_if_windows, before warm_up_broker_handles(...)
+if uffs_mft::is_elevated() {
+    // Elevated daemons open volumes directly; the broker is only for the
+    // non-elevated path. Skip the futile probe entirely.
+} else {
+    warm_up_broker_handles(&drives);
+}
+```
+
+`is_elevated()` is cheap (a token query), involves **no pipe interaction**, and
+has **none** of the race that made the old `broker_available()` probe dangerous —
+it never touches the broker's single pipe instance. This restores the
+pre-broker behavior for elevated daemons while keeping the non-elevated path
+exactly as it works today.
+
+### Effort / risk
+Trivial (a few lines, one import). Validate that a non-elevated daemon still
+warms up (broker present) and an elevated daemon emits no broker WARNs.
+
+---
+
 ## Suggested sequencing
 
 1. **Land the basic read** (current branch) — confirm one drive loads and the
-   daemon stays resident.
-2. **Correctness tier:** Follow-up 2 (USN through broker) and Follow-up 3
+   daemon stays resident. ✅ (verified 2026-06-14)
+2. **Quick regression cleanup:** Follow-up 9 (`!is_elevated()` warm-up gate) —
+   tiny, removes log noise, do it first.
+3. **Correctness tier:** Follow-up 2 (USN through broker) and Follow-up 3
    (`get_mft_extents` / fragmented MFTs).
-3. **Productionization tier:** Follow-up 1 (service dispatcher) so it runs
+4. **Productionization tier:** Follow-up 1 (service dispatcher) so it runs
    without `--run`.
-4. **Performance / scale tier:** Follow-up 4 (Authenticode cache) + Follow-up 5
-   (concurrent broker), then Follow-up 6.
-5. **Verify:** Follow-up 7 only if the test surfaces it.
+5. **Performance / scale tier:** Follow-up 4 (`WinVerifyTrust` + Authenticode
+   cache) + Follow-up 5 (async multi-instance broker + `OwnedHandle` refactor),
+   then Follow-up 6.
+6. **Verify / opportunistic:** Follow-up 7 and Follow-up 8 if the tests surface
+   them.
 
 Each should be its own atomic commit with a `fix:`/`feat:` message naming the
 root cause, cross-compiled clean for `x86_64-pc-windows-msvc` and host, and

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -102,6 +102,14 @@ volume open through the same registry the MFT read uses:
 `VolumeHandle::open` and the USN path share it (DRY; today only `VolumeHandle`
 has it).
 
+**Also fix the retry storm (observed 2026-06-14):** once a drive loads, the
+per-shard journal loop polls the USN journal every ~500 ms and, when the open
+is access-denied, logs `Journal poll failed; retrying next tick` **forever** —
+flooding the log and burning cycles. Until the USN open is brokered, the loop
+should detect a persistent access-denied and **back off / disable** for that
+drive (e.g. exponential backoff to a long ceiling, or mark USN-unavailable and
+rely on periodic full rebuilds) instead of retrying at 500 ms indefinitely.
+
 ### Effort / risk
 Small–moderate. The handle-acquisition logic already exists; the work is
 sharing it and threading it into `usn/windows.rs`.
@@ -259,6 +267,45 @@ and note the dependence on the FSCTL's synchronous completion.
 
 ### Effort / risk
 Small (~15 lines) if needed.
+
+---
+
+## Follow-up 8 — `$UpCase` read on the overlapped broker handle
+
+**Priority: LOW–MEDIUM** (graceful fallback today; correctness on non-standard
+case tables).
+
+### Problem
+Reading `$UpCase` (the NTFS uppercase-mapping table, used for
+case-insensitive name comparison) does a **synchronous `SetFilePointerEx`
+seek** on the volume handle. The broker handle is opened `FILE_FLAG_OVERLAPPED`,
+and overlapped handles don't maintain a synchronous file pointer — so the seek
+fails. Observed 2026-06-14:
+
+```
+WARN $UpCase live read failed — falling back to compiled-in default table
+     error=$UpCase: seek to offset 3221235712 failed:
+           The parameter is incorrect. (0x80070057)
+```
+
+It falls back to the **compiled-in default Unicode case table**, which is
+correct for standard NTFS volumes, so search results are unaffected today. But
+a volume with a customised `$UpCase` would silently use the wrong table, and
+the warning is noise on every broker-backed load.
+
+### Fix approach
+Either (a) read `$UpCase` through a **non-overlapped** handle (the broker would
+need to vend one, or this specific read uses a synchronous duplicate with the
+overlapped flag cleared — not directly possible via `DuplicateHandle`, so more
+likely a second broker handle or a synchronous re-open), or (b) issue the
+`$UpCase` read using the **overlapped offset mechanism** (offset in the
+`OVERLAPPED` struct + `GetOverlappedResult`) instead of `SetFilePointerEx`,
+matching how the MFT bulk read already addresses the overlapped handle. Option
+(b) keeps the single-handle model and is preferred.
+
+### Effort / risk
+Small–moderate. Localised to the `$UpCase` read path; needs a volume with a
+non-default `$UpCase` to fully validate the correctness angle.
 
 ---
 

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -1,0 +1,280 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 SKY, LLC.
+SPDX-License-Identifier: MPL-2.0
+-->
+# UFFS Access Broker — follow-up work
+
+**Status:** the broker's core path works end to end as of branch
+`fix/broker-service-and-elevation` (2026-06-14). This document captures the
+deliberate follow-ups that remain before the broker is production-grade for
+**multi-drive, resident, at-scale** use. None of them block the basic
+single-drive read; each is a scoped, root-cause piece of work.
+
+> **Design reference:** `docs/dev/architecture/DAEMON_SERVICE_ARCHITECTURE.md`
+> (intent: an elevated `LocalSystem` service vends duplicated NTFS volume
+> handles to a non-elevated daemon, so the daemon reads the MFT with zero UAC)
+> and `docs/dev/architecture/SECURITY_IMPLEMENTATION_PLAN.md` §S5 (broker
+> hardening). Both live under gitignored `docs/dev/`.
+
+---
+
+## What works today (baseline)
+
+The elevation model and handle plumbing are functional:
+
+- The broker registers and starts as a service (`uffs-broker --install`) and
+  runs in foreground for debugging (`uffs-broker --run`).
+- Pipe security lets a **non-elevated** daemon connect (explicit SDDL:
+  `D:(A;;GRGW;;;AU)S:(ML;;NW;;;LW)` — Authenticated-Users connect + low
+  mandatory-integrity label), while the broker still verifies the client is
+  `uffsd` + Authenticode before granting a handle.
+- The daemon requests **one handle per drive** at load
+  (`warm_up_broker_handles`), the broker `DuplicateHandle`s an elevated,
+  overlapped volume handle into the daemon, and the daemon registers it.
+- `uffs_mft::VolumeHandle::open` adopts a **duplicate** of the registered
+  handle on every open (peek + `DuplicateHandle`), so the read pass, the
+  overlapped/IOCP bulk read, and the cache-write pass all succeed without
+  re-requesting.
+
+Verified on a Windows 11 VM: a non-elevated `uffs "<query>"` spawns a
+non-elevated daemon, which obtains a broker handle (PID-correlated:
+`daemon_pid` == broker audit `pid`) and reads the MFT through it.
+
+---
+
+## Follow-up 1 — Windows Service dispatcher (run as `LocalSystem`)
+
+**Priority: HIGH** (required for the advertised "install once, no future UAC").
+
+### Problem
+`uffs-broker` implements `--install` / `--uninstall` / `--run` but has **no
+Windows Service control dispatcher**. When the Service Control Manager (SCM)
+starts the registered service, it launches the binary with **no arguments**;
+`run()` then falls through to `print_usage()` and exits 0. The service never
+calls `StartServiceCtrlDispatcher` / reports `SERVICE_RUNNING`, so it never
+actually runs as a service — only the foreground `--run` mode works.
+
+### Evidence
+`sc.exe start UffsAccessBroker` → service reaches `STOPPED`, exit code 0
+(graceful, "never started"); `sc query` shows `WIN32_EXIT_CODE: 0` with no
+running process.
+
+### Fix approach
+Implement the standard service entry point in `crates/uffs-broker`:
+1. No-arg invocation → `StartServiceCtrlDispatcherW` with a
+   `SERVICE_TABLE_ENTRYW` pointing at a `ServiceMain` callback.
+2. `ServiceMain` → `RegisterServiceCtrlHandlerW` (handle `SERVICE_CONTROL_STOP`
+   / `SHUTDOWN`), `SetServiceStatus(SERVICE_RUNNING)`, then run
+   `serve_pipe_requests()` until a stop is signalled, then
+   `SetServiceStatus(SERVICE_STOPPED)`.
+3. Keep `--run` as the foreground/debug path (shares `serve_pipe_requests`).
+
+Use the raw `windows` crate FFI (the crate already depends on it) or the
+`windows-service` crate (idiomatic, but a new dependency → cargo-vet +
+manifest-audit cost). Prefer raw FFI to avoid the dependency unless the
+boilerplate proves error-prone.
+
+### Effort / risk
+Moderate. Unsafe FFI (`SetServiceStatus`, control handler), Windows-only,
+untestable off-Windows — needs iterative validation on a real box.
+
+---
+
+## Follow-up 2 — USN journal read through the broker
+
+**Priority: HIGH** (resident daemons rely on incremental refresh).
+
+### Problem
+The USN journal open (`crates/uffs-mft/src/usn/windows.rs::open_volume_handle`)
+opens its **own** volume handle via direct `CreateFileW`, which a non-elevated
+daemon can't do. So the broker-backed daemon logs
+`USN journal unavailable; full rebuild ... Access is denied` and falls back to
+a **full MFT rebuild** on every refresh instead of a cheap incremental USN
+update. Correct results, wrong cost.
+
+### Fix approach
+USN control codes (`FSCTL_QUERY_USN_JOURNAL`, `FSCTL_READ_USN_JOURNAL`) operate
+on a **volume** handle — and the broker already supplies one. Route the USN
+volume open through the same registry the MFT read uses:
+`peek_broker_handle(drive)` + `DuplicateHandle`, falling back to direct
+`CreateFileW` when no broker handle is registered (elevated path). Factor the
+"adopt a registered broker handle, else open directly" logic so both
+`VolumeHandle::open` and the USN path share it (DRY; today only `VolumeHandle`
+has it).
+
+### Effort / risk
+Small–moderate. The handle-acquisition logic already exists; the work is
+sharing it and threading it into `usn/windows.rs`.
+
+---
+
+## Follow-up 3 — `get_mft_extents` through the broker (fragmented MFTs)
+
+**Priority: MEDIUM** (correctness on fragmented volumes).
+
+### Problem
+`VolumeHandle::get_mft_extents` opens `<drive>:\$MFT` directly to fetch the
+MFT's retrieval pointers (`FSCTL_GET_RETRIEVAL_POINTERS`). On open failure it
+**falls back to a single contiguous extent** derived from
+`NTFS_VOLUME_DATA` (`mft_start_lcn` + `mft_valid_data_length`). That fallback
+is correct for an **unfragmented** MFT but **silently incomplete for a
+fragmented MFT** — it misses every fragment beyond the first, producing a
+partial index with no error.
+
+### Note / unknown
+`$MFT` is opened with **zero desired access** (metadata only), which *may*
+succeed for a non-elevated caller — in which case the real retrieval pointers
+are read and the fallback never fires. The next VM test's log will confirm
+whether the fallback is hit. Either way, relying on a silent
+contiguous-assumption fallback for correctness is fragile.
+
+### Fix approach
+Two options:
+1. **Broker an `$MFT` handle**: extend the broker to open `<drive>:\$MFT` (it's
+   elevated) and vend it alongside the volume handle. Requires a protocol/
+   registry extension to carry a second handle per drive.
+2. **Bootstrap from the volume handle** (no extra handle): read FRS 0 (the
+   `$MFT` record) from the known MFT location via the broker *volume* handle,
+   parse its `$DATA` runlist, and derive the full extent map. Self-contained,
+   no protocol change, but more reader work.
+
+Prefer (2) if feasible — it keeps the broker protocol at one handle per drive.
+Make the fallback **loud** (warn) in the interim so a partial index is never
+silent.
+
+### Effort / risk
+Moderate. Option 2 touches the MFT bootstrap logic; needs a fragmented-MFT
+test fixture to validate.
+
+---
+
+## Follow-up 4 — Authenticode verification caching (per-PID)
+
+**Priority: MEDIUM** (multi-drive latency).
+
+### Problem
+`verify_authenticode` (broker side) shells out to PowerShell
+(`Get-AuthenticodeSignature`) **per request**, costing hundreds of
+milliseconds each. The daemon requests handles **sequentially, one per drive**
+in `warm_up_broker_handles`, so an N-drive estate pays ~N × that cost up front
+(e.g. 10 drives ≈ several seconds of signature checks before any load starts).
+
+### Fix approach
+Cache the verification result keyed by **client PID + exe path** (and ideally
+the image's last-write time / a content hash, so PID reuse can't smuggle in a
+different binary): verify once per client process, reuse for that process's
+subsequent drive requests. Entry lifetime = the client process lifetime; the
+broker already opens the client process handle once (WI-8.1), so it can detect
+process identity reliably. Do **not** weaken the verification — only avoid
+re-running it for an already-verified `(pid, exe, mtime)`.
+
+Replacing the PowerShell spawn with a direct `WinVerifyTrust` FFI call is a
+separate, larger optimization (removes the subprocess entirely) and could
+fold in here.
+
+### Effort / risk
+Small (cache) to moderate (if also moving off PowerShell). Security-sensitive
+— the cache key must make a substituted binary a cache miss.
+
+---
+
+## Follow-up 5 — Concurrent broker (multi-instance pipe + per-connection handling)
+
+**Priority: MEDIUM** (scale; not needed for the common one-daemon flow).
+
+### Problem
+The broker serves a **single** pipe instance (`max_instances = 1`) in a
+**serial** loop: create instance → wait for client → handle → disconnect →
+repeat. Concurrent clients queue (`PIPE_WAIT`) or hit `ERROR_PIPE_BUSY`. The
+normal flow (one daemon requesting drives sequentially) is fine, but genuinely
+concurrent load (multiple daemons, or a future parallelized warm-up)
+serializes — and combined with the per-request Authenticode spawn (Follow-up
+4), throughput is poor at scale.
+
+> Historical note: an earlier symptom of the single-instance design was that a
+> daemon's `GetFileAttributesW` *availability probe* consumed the only pipe
+> instance and starved the real request (`ERROR_PIPE_BUSY`). That probe has
+> been removed; the broker now sees only real requests. This follow-up is
+> about *concurrency capacity*, not that (resolved) starvation.
+
+### Fix approach
+Restructure `serve_pipe_requests` so multiple instances listen at once:
+- `CreateNamedPipeW` with `PIPE_UNLIMITED_INSTANCES` (or a tuned cap).
+- After `ConnectNamedPipe` returns for one client, **immediately create the
+  next listening instance** before handling the current connection, and handle
+  each connection on its own thread (or async task).
+- Share the rate-limit map behind `Arc<Mutex<…>>`; `handle_one_connection`
+  takes a shared reference.
+- Mind `HANDLE` `Send`-ness when moving a connected pipe handle into a worker
+  thread (wrap in a `Send` newtype with a documented SAFETY note, or use an
+  IOCP/overlapped accept model).
+
+Pair with Follow-up 4 so each concurrent connection isn't independently paying
+the Authenticode cost.
+
+### Effort / risk
+Moderate. Concurrency + Windows handle `Send` semantics; the rate-limiter and
+audit paths must stay correct under parallelism.
+
+---
+
+## Follow-up 6 — Client-side pipe probe still connects (`broker_pipe_present`)
+
+**Priority: LOW** (cosmetic; works due to timing).
+
+### Problem
+`uffs-client`'s `broker_pipe_present` (gates the non-elevated daemon spawn)
+uses `GetFileAttributesW`, which **connects to** the pipe — the broker logs a
+rejected `uffs.exe` connection on every search. It happens ~1 s before the
+daemon's real request, so the single-instance broker recovers in time and it's
+currently harmless, but it's wasteful and fragile under load.
+
+### Fix approach
+Switch the client probe to a **non-connecting** check (e.g. `WaitNamedPipeW`
+with a short timeout), or accept a brief false-negative and rely on the spawn's
+fallback. Re-evaluate after Follow-up 5 (a multi-instance broker tolerates the
+probe connection cleanly, possibly making this moot).
+
+### Effort / risk
+Small.
+
+---
+
+## Follow-up 7 — Volume-data FSCTL on the adopted overlapped handle
+
+**Priority: LOW–MEDIUM** (verify under test; correctness if it misbehaves).
+
+### Problem
+`get_ntfs_volume_data` issues `FSCTL_GET_NTFS_VOLUME_DATA` with a **NULL**
+`OVERLAPPED`. The broker handle is opened `FILE_FLAG_OVERLAPPED`; per the Win32
+docs, a synchronous `DeviceIoControl` (NULL overlapped) on an overlapped handle
+is technically undefined, though this particular FSCTL completes synchronously
+and tends to work in practice. The "simple-first" choice was deliberate.
+
+### Fix approach
+If VM testing shows a `NotNtfs` / volume-data failure on the broker-backed
+path, add an overlapped-safe variant: pass a real `OVERLAPPED` with an event
+and `GetOverlappedResult`, used by `from_broker_handle`. Otherwise leave as-is
+and note the dependence on the FSCTL's synchronous completion.
+
+### Effort / risk
+Small (~15 lines) if needed.
+
+---
+
+## Suggested sequencing
+
+1. **Land the basic read** (current branch) — confirm one drive loads and the
+   daemon stays resident.
+2. **Correctness tier:** Follow-up 2 (USN through broker) and Follow-up 3
+   (`get_mft_extents` / fragmented MFTs).
+3. **Productionization tier:** Follow-up 1 (service dispatcher) so it runs
+   without `--run`.
+4. **Performance / scale tier:** Follow-up 4 (Authenticode cache) + Follow-up 5
+   (concurrent broker), then Follow-up 6.
+5. **Verify:** Follow-up 7 only if the test surfaces it.
+
+Each should be its own atomic commit with a `fix:`/`feat:` message naming the
+root cause, cross-compiled clean for `x86_64-pc-windows-msvc` and host, and
+validated on a real Windows box (the broker path can't be exercised off
+Windows).


### PR DESCRIPTION
## What this does

Takes the Windows Access Broker from non-functional to **working end to end**, verified on a Windows 11 VM (2026-06-14): a non-elevated `uffs "<query>"` spawns a non-elevated daemon, which obtains an elevated NTFS volume handle from the broker, reads the live MFT through it (**zero UAC**), builds the index, stays resident, and serves queries in milliseconds.

## The fixes (root-cause, stacked)

1. **`fix(broker): make the Access Broker actually work end-to-end`** — baseline wiring.
2. **`fix(broker): open the pipe with a daemon-reachable security descriptor`** — explicit SDDL (`D:(A;;GRGW;;;AU)S:(ML;;NW;;;LW)`) so a non-elevated daemon can connect while the broker still verifies client identity.
3. **`fix(broker): run the warm-up unconditionally; the request is the only probe`** — the handle request is the authoritative broker-presence test.
4. **`fix(broker): remove the GetFileAttributesW probe that starved the request`** — the availability probe was consuming the single pipe instance → `ERROR_PIPE_BUSY` on the real request.
5. **`fix(daemon): log the full error chain when a live-drive load fails`** — surfaces the real cause (`{err:#}`) to the log file.
6. **`fix(broker): make the broker handle reusable across a multi-open MFT read`** — registry changed from take-once to peek+`DuplicateHandle`, so the read pass, IOCP bulk read, and cache-write pass all adopt the elevated handle instead of falling back to a direct (access-denied) open.

## Docs

`docs/architecture/access-broker-followups.md` — a junior-ready implementation playbook for the remaining production hardening: a tracking board (9 follow-ups + 2 shared building blocks), per-item file/function anchors + step-by-step changes + acceptance criteria, a 4-layer testing strategy (host core/edge units → xwin cross-compile → manual VM), sequencing, and a glossary. **No follow-up code is in this PR** — they are deliberately deferred and tracked.

## Verification

VM log (known-good): broker `AUDIT action="GRANTED" ... exe="...uffsd.exe" drive=C`; daemon `Adopted Access Broker volume handle for MFT read` → `Live drive loaded drive=C records=243203` → search returns rows in 3 ms, daemon resident, no UAC prompt.

Cross-compiled clean for `x86_64-pc-windows-msvc` and host; pre-push gates green (no `--no-verify`).

## Known follow-ups (tracked in the playbook, not in this PR)

FU-9 elevated warm-up gate (self-inflicted regression, XS), FU-2 USN through broker + backoff, FU-3 `get_mft_extents` for fragmented MFTs, FU-1 service dispatcher, FU-4 `WinVerifyTrust`, FU-5 async multi-instance broker, FU-6/7/8.