### PR TITLE
refactor(mft): centralize broker-handle adoption into one primitive (SBB-1)

### DIFF
--- a/crates/uffs-mft/src/platform/volume.rs
+++ b/crates/uffs-mft/src/platform/volume.rs
@@ -93,6 +93,69 @@ fn peek_broker_handle(drive: super::DriveLetter) -> Option<u64> {
     guard.get(&drive.as_char()).copied()
 }
 
+/// `DuplicateHandle` a registered broker volume handle into an independent,
+/// caller-owned handle.
+///
+/// `raw` is the registry's `u64` (the handle `uffs-broker` duplicated into this
+/// process).  The returned handle is a *separate* duplicate, so closing it does
+/// not invalidate the registry entry — every open in a load can adopt its own
+/// copy.  Centralised here so the MFT read (`VolumeHandle::open` /
+/// [`VolumeHandle::from_broker_handle`]), the USN journal open, and the `$MFT`
+/// extent read share one `DuplicateHandle` implementation instead of each
+/// re-deriving the `with_exposed_provenance_mut` reconstruction.
+#[cfg(windows)]
+#[expect(unsafe_code, reason = "FFI: DuplicateHandle / GetCurrentProcess")]
+fn duplicate_registered_handle(raw: u64, drive: super::DriveLetter) -> Result<HANDLE> {
+    use windows::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle};
+    use windows::Win32::System::Threading::GetCurrentProcess;
+
+    let registered = HANDLE(core::ptr::with_exposed_provenance_mut::<core::ffi::c_void>(
+        usize::try_from(raw).unwrap_or(0),
+    ));
+    let mut handle = HANDLE::default();
+    // SAFETY: returns the current-process pseudo-handle; no preconditions.
+    let process = unsafe { GetCurrentProcess() };
+    // SAFETY: `process` is valid; `registered` is the broker handle owned by
+    // this process; `&raw mut handle` is a valid out-pointer.  On success the
+    // duplicate is owned by the caller.
+    let dup = unsafe {
+        DuplicateHandle(
+            process,
+            registered,
+            process,
+            &raw mut handle,
+            0,
+            false,
+            DUPLICATE_SAME_ACCESS,
+        )
+    };
+    dup.map_err(|err| MftError::VolumeOpen {
+        volume: drive,
+        source: hresult_to_io_error(&err),
+    })?;
+    Ok(handle)
+}
+
+/// Adopt a duplicate of the registered broker volume handle for `drive`, if one
+/// is registered.
+///
+/// Returns `Ok(Some(handle))` with a caller-owned duplicate when the Access
+/// Broker has deposited a handle for `drive`, or `Ok(None)` when none is
+/// registered (the caller should then open the volume directly with its own
+/// access/flags).  This is the single policy seam shared by the MFT read, the
+/// USN journal open, and the `$MFT` extent read: the *adoption* is uniform, but
+/// each caller's *direct-open* flags differ, so only this half is centralised.
+///
+/// Currently private (only [`VolumeHandle::open`] calls it); FU-2 / FU-3 will
+/// raise its visibility and re-export it for the USN and `$MFT` paths.
+#[cfg(windows)]
+fn try_adopt_broker_handle(drive: super::DriveLetter) -> Result<Option<HANDLE>> {
+    match peek_broker_handle(drive) {
+        Some(raw) => Ok(Some(duplicate_registered_handle(raw, drive)?)),
+        None => Ok(None),
+    }
+}
+
 /// Convert a `windows::core::Error` into the equivalent `std::io::Error`,
 /// **unwrapping** the `HRESULT_FROM_WIN32` envelope so std's
 /// `decode_error_kind` table (keyed on bare Win32 codes like
@@ -285,10 +348,11 @@ impl VolumeHandle {
         // Access Broker fast-path: if the (elevated) broker has deposited a
         // pre-opened, duplicated volume handle for this drive, adopt a
         // duplicate of it instead of calling `CreateFileW` — which would fail
-        // with access-denied in a non-elevated daemon.  See the registry
-        // above; the entry stays so later opens in the same load succeed.
-        if let Some(raw_handle) = peek_broker_handle(volume) {
-            return Self::from_broker_handle(volume, raw_handle);
+        // with access-denied in a non-elevated daemon.  The registry entry
+        // stays so later opens in the same load succeed (see
+        // `try_adopt_broker_handle`).
+        if let Some(handle) = try_adopt_broker_handle(volume)? {
+            return Self::from_adopted_handle(handle, volume);
         }
 
         // `DriveLetter` is already validated (`A..=Z`), so no fallible
@@ -360,36 +424,27 @@ impl VolumeHandle {
     /// Returns [`MftError`] if the handle cannot be duplicated or the volume
     /// descriptor cannot be read from it.
     #[cfg(windows)]
-    #[expect(unsafe_code, reason = "FFI: DuplicateHandle / GetCurrentProcess")]
     pub fn from_broker_handle(volume: super::DriveLetter, raw_handle: u64) -> Result<Self> {
-        use windows::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle};
-        use windows::Win32::System::Threading::GetCurrentProcess;
+        let handle = duplicate_registered_handle(raw_handle, volume)?;
+        Self::from_adopted_handle(handle, volume)
+    }
 
-        let registered = HANDLE(core::ptr::with_exposed_provenance_mut::<core::ffi::c_void>(
-            usize::try_from(raw_handle).unwrap_or(0),
-        ));
-        let mut handle = HANDLE::default();
-        // SAFETY: returns the current-process pseudo-handle; no preconditions.
-        let process = unsafe { GetCurrentProcess() };
-        // SAFETY: `process` is valid; `registered` is the broker handle owned
-        // by this process; `&raw mut handle` is a valid out-pointer.  On
-        // success the duplicate is owned by the returned `VolumeHandle`.
-        let dup = unsafe {
-            DuplicateHandle(
-                process,
-                registered,
-                process,
-                &raw mut handle,
-                0,
-                false,
-                DUPLICATE_SAME_ACCESS,
-            )
-        };
-        dup.map_err(|err| MftError::VolumeOpen {
-            volume,
-            source: hresult_to_io_error(&err),
-        })?;
-
+    /// Build a broker-backed `VolumeHandle` from an already-duplicated,
+    /// caller-owned volume `handle` (the output of
+    /// [`duplicate_registered_handle`] / [`try_adopt_broker_handle`]).
+    ///
+    /// Reads the volume descriptor from the handle and marks the result
+    /// `broker_backed` so [`Self::open_overlapped_handle`] duplicates the
+    /// handle rather than re-opening `\\.\X:`.  Shared by [`Self::open`]'s
+    /// fast-path and [`Self::from_broker_handle`] so the descriptor read +
+    /// `broker_backed` construction live in one place.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MftError`] if the volume descriptor cannot be read from
+    /// `handle`.
+    #[cfg(windows)]
+    fn from_adopted_handle(handle: HANDLE, volume: super::DriveLetter) -> Result<Self> {
         let volume_data = Self::get_ntfs_volume_data(handle, volume)?;
         tracing::info!(drive = %volume, "Adopted Access Broker volume handle for MFT read");
         Ok(Self {

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -118,7 +118,7 @@ pick an item up. `Depends on` must be `🟩` before you start.
 
 | ID | Title | Priority | Effort | Status | Owner | PR | Depends on |
 |----|-------|----------|--------|--------|-------|----|-----------|
-| FU-9 | Gate warm-up on `!is_elevated()` | HIGH | XS | 🟦 | claude | — | — |
+| FU-9 | Gate warm-up on `!is_elevated()` | HIGH | XS | 🟩 | claude | #404 | — |
 | FU-2 | USN journal through broker + backoff | HIGH | M | ⬜ | — | — | SBB-1 |
 | FU-3 | `get_mft_extents` through broker | MEDIUM | M | ⬜ | — | — | SBB-1 |
 | FU-8 | `$UpCase` overlapped-handle read | LOW–MED | M | ⬜ | — | — | — |
@@ -133,7 +133,7 @@ depend on them — see [§3](#3-shared-building-blocks)):
 
 | ID | Title | Status | PR |
 |----|-------|--------|----|
-| SBB-1 | `adopt_or_open_volume(drive, access)` helper in `uffs-mft` | ⬜ | — |
+| SBB-1 | `try_adopt_broker_handle` shared peek+duplicate in `uffs-mft` | 🟦 | — |
 | SBB-2 | `OwnedHandle` Send-safe RAII wrapper | ⬜ | — |
 
 Effort key: `XS` <1h · `S` ~half-day · `M` ~1–2 days · `L` ~3–5 days (all
@@ -203,7 +203,33 @@ including tests + a VM validation round).
 Two pieces are needed by multiple follow-ups. Build each as its own small PR so
 the dependent items can just call into them.
 
-### SBB-1 — `adopt_or_open_volume(drive, access)` helper
+### SBB-1 — shared broker-handle adoption primitive
+
+> **Landed shape (differs from the original sketch below).** The first sketch
+> proposed `adopt_or_open_volume(drive, access: u32) -> ResolvedVolume` — one
+> function owning both the adopt and the direct-open. Reading the real code
+> showed the three call sites use **genuinely different** open flags (`open()`:
+> `FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE` + `BACKUP_SEMANTICS |
+> SEQUENTIAL_SCAN`; USN: `GENERIC_READ` + `BACKUP_SEMANTICS`; `$MFT`: `0`
+> access), so a single `access` param can't express them. Only the **adoption**
+> half is truly uniform. What landed (in `crates/uffs-mft/src/platform/volume.rs`):
+> - `duplicate_registered_handle(raw, drive) -> Result<HANDLE>` — the
+>   `DuplicateHandle` FFI, extracted once.
+> - `try_adopt_broker_handle(drive) -> Result<Option<HANDLE>>` — peek registry +
+>   duplicate; `Ok(None)` means "no broker handle, caller opens directly with its
+>   own flags". **This is the seam FU-2/FU-3 call.** Currently **private** (only
+>   `VolumeHandle::open` uses it); FU-2/FU-3 raise it to `pub(crate)` and
+>   re-export it from `platform.rs` when they wire the USN / `$MFT` paths.
+> - `VolumeHandle::from_adopted_handle(handle, volume)` — descriptor read +
+>   `broker_backed` construction, shared by `open()` and `from_broker_handle`.
+>
+> Pure refactor: no behavior change; the existing VM-validated path produces
+> identical logs. Validated by the exact `cargo xwin clippy --workspace
+> --all-features` gate + 219 host `uffs-mft` tests green. No host *unit* test —
+> the module is `#[cfg(windows)]` FFI; its validation is cross-compile + the VM
+> baseline.
+>
+> The original sketch is kept below for the design rationale.
 
 **Why:** today only `VolumeHandle::open` knows the "adopt a registered broker
 handle, else `CreateFileW` directly" dance. FU-2 (USN) and FU-3 (`$MFT`) need the


### PR DESCRIPTION
## What this does

Shared building block **SBB-1** from `docs/architecture/access-broker-followups.md`. Extracts the peek+`DuplicateHandle` policy — that `VolumeHandle::open` and `from_broker_handle` both relied on — into a single seam, so the upcoming USN (FU-2) and `$MFT`-extent (FU-3) paths can adopt a broker handle without re-deriving the `with_exposed_provenance_mut` reconstruction or the `DuplicateHandle` FFI.

## The shape (in `crates/uffs-mft/src/platform/volume.rs`)

- `duplicate_registered_handle(raw, drive) -> Result<HANDLE>` — the `DuplicateHandle` FFI, extracted once.
- `try_adopt_broker_handle(drive) -> Result<Option<HANDLE>>` — peek the registry + duplicate; `Ok(None)` = no broker handle, caller opens directly. **The seam FU-2/FU-3 call** (private for now; those PRs raise visibility + re-export).
- `VolumeHandle::from_adopted_handle(handle, volume)` — descriptor read + `broker_backed` construction, shared by `open()` and `from_broker_handle`.

## Design note

The playbook's original `adopt_or_open_volume(drive, access: u32)` sketch was dropped: the three call sites use **genuinely different** open flags (`open()`: `FILE_READ_DATA|...`; USN: `GENERIC_READ`; `$MFT`: `0`), so a single `access` param can't express them — only the *adoption* half is uniform. `from_broker_handle` stays `pub` (API preserved) and now delegates to the shared primitives. The playbook's SBB-1 section is updated with the landed shape.

## Validation

Pure refactor — **no behavior change**, identical logs on the VM-validated path. Exact pre-push Windows clippy gate (`cargo xwin clippy --workspace --all-targets --all-features --target x86_64-pc-windows-msvc --no-deps -- -D warnings`) clean; **219 host `uffs-mft` tests pass**; host clippy clean. No host *unit* test — the module is `#[cfg(windows)]` FFI; validation is cross-compile + the VM baseline (batched with the rest of the tier).