### PR TITLE
chore(broker): TEMP build-tag line in daemon + broker logs (VM validation)

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -80,6 +80,15 @@ fn print_usage() {
     eprintln!("  --run         Run in foreground (debugging)");
 }
 
+/// TEMP-BROKER-FLOW: manually-bumped build tag so VM logs reveal WHICH dev
+/// build is running.  The dev version is pinned at `0.5.123` across iterations,
+/// so it can't distinguish builds; this string can.  **Bump it on every build
+/// you intend to validate**, and keep it identical to the daemon's tag in
+/// `uffs-daemon/src/startup.rs`.  Grep `TEMP-BROKER-FLOW` and delete every hit
+/// when the broker follow-ups land — this is NOT a real version.
+#[cfg(windows)]
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #1 (FU-9 + SBB-1)";
+
 /// Run the broker in foreground mode.
 #[cfg(windows)]
 fn run_foreground() -> anyhow::Result<()> {
@@ -88,6 +97,9 @@ fn run_foreground() -> anyhow::Result<()> {
         pid = std::process::id(),
         "uffs-broker starting (foreground mode)"
     );
+    // TEMP-BROKER-FLOW: build-identity line for VM validation; remove with the
+    // `BROKER_FLOW_BUILD_TAG` const above when the broker work lands.
+    tracing::info!(build_tag = BROKER_FLOW_BUILD_TAG, "BROKER-FLOW BUILD TAG");
     warn_if_not_elevated();
     serve_pipe_requests()?;
     tracing::info!("uffs-broker stopped");

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -50,10 +50,21 @@ pub(crate) fn validate_data_sources(
     Ok(())
 }
 
+/// TEMP-BROKER-FLOW: manually-bumped build tag so VM logs reveal WHICH dev
+/// build is running.  The dev version is pinned at `0.5.123` across iterations,
+/// so `--version` can't distinguish builds; this string can.  **Bump it on
+/// every build you intend to validate**, and keep it identical to the broker's
+/// tag in `uffs-broker/src/broker.rs`.  Grep `TEMP-BROKER-FLOW` and delete
+/// every hit when the broker follow-ups land — this is NOT a real version.
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #1 (FU-9 + SBB-1)";
+
 /// Emit the startup `tracing::info!` line with every config field
 /// the operator might want to grep for.  Extracted so the orchestrator
 /// stays under clippy's `cognitive_complexity` budget.
 pub(crate) fn log_daemon_starting(config: &DaemonConfig) {
+    // TEMP-BROKER-FLOW: build-identity line for VM validation; remove with the
+    // `BROKER_FLOW_BUILD_TAG` const above when the broker work lands.
+    tracing::info!(build_tag = BROKER_FLOW_BUILD_TAG, "BROKER-FLOW BUILD TAG");
     // NOTE: do NOT probe the Access Broker here.  The previous
     // `broker_available()` call used `GetFileAttributesW`, which *connects to*
     // the broker's single pipe instance and leaves it busy — so the real


### PR DESCRIPTION
## What & why

The dev version is pinned at `0.5.123` across iterations, so the logs can't tell which build is actually running on the VM — we hit this **twice**, validating a stale binary by mistake. This adds a manually-bumped `const BROKER_FLOW_BUILD_TAG` and emits one greppable `BROKER-FLOW BUILD TAG` INFO line at startup in **uffsd** and **uffs-broker**:

```powershell
Select-String -Path C:\uffs-test\logs\uffsd.log, C:\uffs-test\logs\uffs-broker.log -Pattern "BROKER-FLOW BUILD TAG"
```

Bump the const (identically in both files) on each build to validate; the log then proves freshness.

## Deliberately NOT a build.rs / git-SHA / env mechanism

That would trip the build-codegen policy (`docs/architecture/code-quality/build_codegen_policy.md` §5 env registry) + the drift gates, and is a real build change. This is a plain `const &str` — zero policy surface, per the "no real build change" requirement.

## TEMPORARY

Every hit is marked `TEMP-BROKER-FLOW`. When the broker follow-ups land: `grep -rn TEMP-BROKER-FLOW` → delete all (the two consts + the two log lines).

Validated: exact `cargo xwin clippy --workspace --all-features` gate clean; pre-push gates green.