### PR TITLE
fix(daemon): back off the journal poll instead of storming on failure (FU-2a)

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -87,7 +87,7 @@ fn print_usage() {
 /// `uffs-daemon/src/startup.rs`.  Grep `TEMP-BROKER-FLOW` and delete every hit
 /// when the broker follow-ups land — this is NOT a real version.
 #[cfg(windows)]
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #1 (FU-9 + SBB-1)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #2 (FU-9 + SBB-1 + FU-2a backoff)";
 
 /// Run the broker in foreground mode.
 #[cfg(windows)]

--- a/crates/uffs-daemon/src/cache/journal_loop.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop.rs
@@ -449,13 +449,27 @@ impl JournalLoop {
             0 => self.config.initial_cursor,
             persisted => persisted,
         };
+        let mut backoff = PollBackoff::new(self.config.poll_interval, MAX_POLL_BACKOFF);
         loop {
-            if !wait_for_next_tick(&mut self.cancel_rx, self.config.poll_interval, letter).await {
+            if !wait_for_next_tick(&mut self.cancel_rx, backoff.current(), letter).await {
                 return;
             }
 
-            let Some(result) = poll_blocking(Arc::clone(&self.source), cursor, letter).await else {
-                continue;
+            let result = match poll_blocking(Arc::clone(&self.source), cursor).await {
+                Ok(result) => {
+                    if backoff.on_success() {
+                        tracing::info!(
+                            drive = %letter,
+                            "Journal poll recovered; resuming normal cadence"
+                        );
+                    }
+                    result
+                }
+                Err(failure) => {
+                    let streak = backoff.on_failure();
+                    log_poll_failure(letter, &failure, streak, backoff.current());
+                    continue;
+                }
             };
 
             // Wrap-detection (Phase 7 task 7.7): if the journal_id
@@ -531,35 +545,133 @@ async fn wait_for_next_tick(
     }
 }
 
+/// Upper bound on the journal-poll backoff cadence.
+///
+/// When the journal is unavailable the loop backs its cadence off geometrically
+/// (see [`PollBackoff`]) up to this ceiling, so a persistently unavailable
+/// journal — e.g. a non-elevated daemon whose USN handle isn't brokered yet
+/// (FU-2b) — polls at most this often instead of every `poll_interval`.  Small
+/// enough that a recovered journal is picked up promptly; large enough that an
+/// unavailable one stops flooding the log and the blocking pool.
+const MAX_POLL_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Why a journal poll tick produced no result.
+struct PollFailure {
+    /// Human-readable cause for the log line.
+    cause: String,
+    /// `true` when the `spawn_blocking` task itself failed (panicked /
+    /// cancelled) rather than the source returning an I/O error.
+    aborted: bool,
+}
+
+/// Geometric backoff for the journal poll cadence.
+///
+/// The journal can be transiently unavailable (volume revocation, broker
+/// reconnect) or — for a non-elevated daemon without a brokered USN handle —
+/// persistently access-denied.  Polling every `base` interval in that state
+/// floods the log with one WARN per tick (~2/s) and burns a `spawn_blocking`
+/// plus an FSCTL per tick for nothing.  This doubles the cadence from `base`
+/// toward `cap` on each consecutive failure and snaps back to `base` on the
+/// first success, so a healthy journal keeps its tight cadence while an
+/// unavailable one goes quiet.
+struct PollBackoff {
+    /// Healthy cadence (the configured `poll_interval`).
+    base: Duration,
+    /// Maximum backed-off cadence.
+    cap: Duration,
+    /// Cadence the next tick will wait.
+    current: Duration,
+    /// Consecutive failures since the last success.
+    consecutive_failures: u32,
+}
+
+impl PollBackoff {
+    /// Start at the healthy `base` cadence, backing off no slower than `cap`.
+    const fn new(base: Duration, cap: Duration) -> Self {
+        Self {
+            base,
+            cap,
+            current: base,
+            consecutive_failures: 0,
+        }
+    }
+
+    /// Cadence the next tick should wait.
+    const fn current(&self) -> Duration {
+        self.current
+    }
+
+    /// Record a successful poll: reset to `base`.  Returns `true` when the loop
+    /// was previously backed off, so the caller can log a one-shot recovery.
+    const fn on_success(&mut self) -> bool {
+        let was_backed_off = self.consecutive_failures > 0;
+        self.consecutive_failures = 0;
+        self.current = self.base;
+        was_backed_off
+    }
+
+    /// Record a failed poll: double the cadence (saturating at `cap`).  Returns
+    /// the 1-based failure count in the current streak so the caller can log
+    /// the first failure loudly and demote the rest.
+    fn on_failure(&mut self) -> u32 {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        self.current = self.current.saturating_mul(2).min(self.cap);
+        self.consecutive_failures
+    }
+}
+
 /// Run one journal poll on the blocking pool.
 ///
-/// **Returns** `Some(result)` on success, `None` when the source
-/// or the spawn-blocking task itself failed (warn-logged at the
-/// call site so the loop can `continue` cleanly).
+/// **Returns** `Ok(result)` on success, or `Err(PollFailure)` describing the
+/// cause — the caller logs it (with backoff-aware severity) and `continue`s.
 async fn poll_blocking(
     source: Arc<dyn JournalSource>,
     cursor: u64,
+) -> Result<JournalPollResult, PollFailure> {
+    match tokio::task::spawn_blocking(move || source.poll(cursor)).await {
+        Ok(Ok(res)) => Ok(res),
+        Ok(Err(io_err)) => Err(PollFailure {
+            cause: io_err.to_string(),
+            aborted: false,
+        }),
+        Err(join_err) => Err(PollFailure {
+            cause: join_err.to_string(),
+            aborted: true,
+        }),
+    }
+}
+
+/// Log a journal poll failure with backoff-aware severity: the **first**
+/// failure of a streak is a WARN (the operator should see the journal went
+/// away), every subsequent tick is DEBUG so an unavailable journal doesn't
+/// storm the log.
+fn log_poll_failure(
     letter: uffs_mft::platform::DriveLetter,
-) -> Option<JournalPollResult> {
-    let poll_result = tokio::task::spawn_blocking(move || source.poll(cursor)).await;
-    match poll_result {
-        Ok(Ok(res)) => Some(res),
-        Ok(Err(io_err)) => {
-            tracing::warn!(
-                drive = %letter,
-                error = %io_err,
-                "Journal poll failed; retrying next tick"
-            );
-            None
-        }
-        Err(join_err) => {
-            tracing::warn!(
-                drive = %letter,
-                error = %join_err,
-                "Journal poll task aborted; retrying next tick"
-            );
-            None
-        }
+    failure: &PollFailure,
+    streak: u32,
+    next_interval: Duration,
+) {
+    let next_ms = u64::try_from(next_interval.as_millis()).unwrap_or(u64::MAX);
+    let what = if failure.aborted {
+        "Journal poll task aborted"
+    } else {
+        "Journal poll failed"
+    };
+    if streak <= 1 {
+        tracing::warn!(
+            drive = %letter,
+            error = %failure.cause,
+            next_poll_ms = next_ms,
+            "{what}; backing off until the journal recovers"
+        );
+    } else {
+        tracing::debug!(
+            drive = %letter,
+            error = %failure.cause,
+            streak,
+            next_poll_ms = next_ms,
+            "{what}; still backed off"
+        );
     }
 }
 

--- a/crates/uffs-daemon/src/cache/journal_loop/tests.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests.rs
@@ -45,6 +45,7 @@ use super::{
     CursorStore, JournalLoopConfig, JournalPollResult, JournalSource, PatchSink, SaveReason,
 };
 
+mod backoff;
 mod basics;
 mod integration;
 mod save_log_message;

--- a/crates/uffs-daemon/src/cache/journal_loop/tests/backoff.rs
+++ b/crates/uffs-daemon/src/cache/journal_loop/tests/backoff.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! FU-2a unit tests for the journal-poll backoff schedule.
+//!
+//! The journal can be persistently unavailable (a non-elevated daemon whose USN
+//! handle isn't brokered yet) — polling every `poll_interval` in that state
+//! storms the log and the blocking pool.  [`super::super::PollBackoff`] doubles
+//! the cadence from `base` toward `cap` on consecutive failures and snaps back
+//! to `base` on the first success.  These tests pin that schedule
+//! deterministically (no async, no clock).
+
+use core::time::Duration;
+
+use super::super::{MAX_POLL_BACKOFF, PollBackoff};
+
+/// Cadence doubles on each failure and saturates at `cap`.
+#[test]
+fn doubles_then_caps() {
+    let base = Duration::from_millis(500);
+    let cap = Duration::from_secs(30);
+    let mut backoff = PollBackoff::new(base, cap);
+
+    assert_eq!(backoff.current(), base, "starts at base");
+
+    // 500ms -> 1s -> 2s -> 4s -> 8s -> 16s -> (32s capped to) 30s.
+    let expected = [
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+        Duration::from_secs(4),
+        Duration::from_secs(8),
+        Duration::from_secs(16),
+        cap,
+    ];
+    for (tick, want) in expected.into_iter().enumerate() {
+        let streak = backoff.on_failure();
+        assert_eq!(
+            u32::try_from(tick).expect("tick fits u32") + 1,
+            streak,
+            "streak is 1-based and monotonic"
+        );
+        assert_eq!(backoff.current(), want, "cadence after failure {streak}");
+    }
+
+    // Further failures stay pinned at the cap.
+    for _ in 0_u32..5 {
+        backoff.on_failure();
+        assert_eq!(backoff.current(), cap, "stays capped");
+    }
+}
+
+/// A success resets the cadence to `base` and reports the recovery once.
+#[test]
+fn resets_on_success() {
+    let base = Duration::from_millis(500);
+    let mut backoff = PollBackoff::new(base, Duration::from_secs(30));
+
+    backoff.on_failure();
+    backoff.on_failure();
+    assert!(backoff.current() > base, "backed off after failures");
+
+    assert!(
+        backoff.on_success(),
+        "first success after failures reports recovery"
+    );
+    assert_eq!(backoff.current(), base, "snaps back to base");
+
+    assert!(
+        !backoff.on_success(),
+        "a success while already healthy is not a recovery"
+    );
+    assert_eq!(backoff.current(), base, "stays at base");
+}
+
+/// The failure streak restarts after a success — so the next outage logs its
+/// first failure loudly again (`streak == 1`).
+#[test]
+fn streak_restarts_after_success() {
+    let mut backoff = PollBackoff::new(Duration::from_millis(500), Duration::from_secs(30));
+
+    assert_eq!(backoff.on_failure(), 1);
+    assert_eq!(backoff.on_failure(), 2);
+    backoff.on_success();
+    assert_eq!(backoff.on_failure(), 1, "streak restarts after recovery");
+}
+
+/// The production cap is a sane, finite ceiling (sanity-pins the const so a
+/// future edit to `MAX_POLL_BACKOFF` is a deliberate, reviewed change).
+#[test]
+fn production_cap_is_bounded() {
+    assert_eq!(MAX_POLL_BACKOFF, Duration::from_secs(30));
+}

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -56,7 +56,7 @@ pub(crate) fn validate_data_sources(
 /// every build you intend to validate**, and keep it identical to the broker's
 /// tag in `uffs-broker/src/broker.rs`.  Grep `TEMP-BROKER-FLOW` and delete
 /// every hit when the broker follow-ups land — this is NOT a real version.
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #1 (FU-9 + SBB-1)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #2 (FU-9 + SBB-1 + FU-2a backoff)";
 
 /// Emit the startup `tracing::info!` line with every config field
 /// the operator might want to grep for.  Extracted so the orchestrator

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -119,7 +119,8 @@ pick an item up. `Depends on` must be `🟩` before you start.
 | ID | Title | Priority | Effort | Status | Owner | PR | Depends on |
 |----|-------|----------|--------|--------|-------|----|-----------|
 | FU-9 | Gate warm-up on `!is_elevated()` | HIGH | XS | 🟩 | claude | #404 | — |
-| FU-2 | USN journal through broker + backoff | HIGH | M | ⬜ | — | — | SBB-1 |
+| FU-2a | Journal-poll backoff (stop the storm) | HIGH | S | 🟦 | claude | — | — |
+| FU-2b | USN journal read through broker | HIGH | M | ⬜ | — | — | SBB-1 |
 | FU-3 | `get_mft_extents` through broker | MEDIUM | M | ⬜ | — | — | SBB-1 |
 | FU-8 | `$UpCase` overlapped-handle read | LOW–MED | M | ⬜ | — | — | — |
 | FU-1 | Windows Service dispatcher | HIGH | M | ⬜ | — | — | — |
@@ -133,7 +134,7 @@ depend on them — see [§3](#3-shared-building-blocks)):
 
 | ID | Title | Status | PR |
 |----|-------|--------|----|
-| SBB-1 | `try_adopt_broker_handle` shared peek+duplicate in `uffs-mft` | 🟦 | — |
+| SBB-1 | `try_adopt_broker_handle` shared peek+duplicate in `uffs-mft` | 🟩 | #405 |
 | SBB-2 | `OwnedHandle` Send-safe RAII wrapper | ⬜ | — |
 
 Effort key: `XS` <1h · `S` ~half-day · `M` ~1–2 days · `L` ~3–5 days (all


### PR DESCRIPTION
## What & why

The daemon-side half of **FU-2** (`docs/architecture/access-broker-followups.md`). A non-elevated daemon whose USN handle isn't brokered yet (FU-2b) gets access-denied on **every** journal poll, and the loop retried at the fixed 500ms cadence **forever** — one WARN per tick (~2/s) plus a `spawn_blocking` + FSCTL each time, for nothing. This flooded the VM logs in every broker-flow run.

## The fix

`PollBackoff`: a geometric backoff that doubles the poll cadence from the configured interval toward a **30s cap** on consecutive failures and snaps back to base on the first success. Logging is backoff-aware:
- first failure of a streak → **WARN** (operator should see the journal went away),
- every subsequent tick → **DEBUG** (no storm),
- recovery → one-shot **INFO**.

Cancellation still races the (now longer) sleep, so shutdown stays prompt.

## Why split from FU-2b

This half is **pure logic, host-testable, low-risk** — no Windows FFI. FU-2b (routing the USN open through the broker handle so the poll actually *succeeds* non-elevated) is the FFI half and needs a VM round; it lands next.

## Tests

4 deterministic `PollBackoff` unit tests (doubling, cap, reset-on-success, streak restart) — no async, no clock. All pass on host. Exact `cargo xwin clippy --workspace --all-features` gate clean; host clippy clean.

Bumps the `TEMP-BROKER-FLOW` build tag to `#2` so a VM run confirms the backoff is live (the storm becomes one WARN then quiet).