### PR TITLE
fix(mft): open the USN journal through the broker handle (FU-2b) [HOLD: needs VM validation]

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -87,7 +87,7 @@ fn print_usage() {
 /// `uffs-daemon/src/startup.rs`.  Grep `TEMP-BROKER-FLOW` and delete every hit
 /// when the broker follow-ups land — this is NOT a real version.
 #[cfg(windows)]
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #2 (FU-9 + SBB-1 + FU-2a backoff)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #3 (+ FU-2b USN-through-broker)";
 
 /// Run the broker in foreground mode.
 #[cfg(windows)]

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -56,7 +56,7 @@ pub(crate) fn validate_data_sources(
 /// every build you intend to validate**, and keep it identical to the broker's
 /// tag in `uffs-broker/src/broker.rs`.  Grep `TEMP-BROKER-FLOW` and delete
 /// every hit when the broker follow-ups land — this is NOT a real version.
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #2 (FU-9 + SBB-1 + FU-2a backoff)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #3 (+ FU-2b USN-through-broker)";
 
 /// Emit the startup `tracing::info!` line with every config field
 /// the operator might want to grep for.  Extracted so the orchestrator

--- a/crates/uffs-mft/src/platform.rs
+++ b/crates/uffs-mft/src/platform.rs
@@ -67,6 +67,10 @@ pub use system::{
     detect_boot_drive, detect_drive_type, detect_ntfs_drives, infer_drive_from_path, is_boot_drive,
     volume_root_path,
 };
+// Crate-internal: the USN journal open (FU-2b) and `$MFT` extent read (FU-3)
+// adopt the same broker volume handle the MFT read uses.
+#[cfg(windows)]
+pub(crate) use volume::try_adopt_broker_handle;
 #[cfg(windows)]
 pub(crate) use volume::{
     IOCP_WAIT_COMPLETION_DEADLINE, IOCP_WAIT_POLL_INTERVAL_MS, WAIT_TIMEOUT_ERROR_CODE,

--- a/crates/uffs-mft/src/platform/volume.rs
+++ b/crates/uffs-mft/src/platform/volume.rs
@@ -146,10 +146,11 @@ fn duplicate_registered_handle(raw: u64, drive: super::DriveLetter) -> Result<HA
 /// USN journal open, and the `$MFT` extent read: the *adoption* is uniform, but
 /// each caller's *direct-open* flags differ, so only this half is centralised.
 ///
-/// Currently private (only [`VolumeHandle::open`] calls it); FU-2 / FU-3 will
-/// raise its visibility and re-export it for the USN and `$MFT` paths.
+/// `pub(crate)` so the USN journal open (FU-2b) and, later, the `$MFT` extent
+/// read (FU-3) can adopt the same broker handle the MFT read uses — re-exported
+/// as `crate::platform::try_adopt_broker_handle`.
 #[cfg(windows)]
-fn try_adopt_broker_handle(drive: super::DriveLetter) -> Result<Option<HANDLE>> {
+pub(crate) fn try_adopt_broker_handle(drive: super::DriveLetter) -> Result<Option<HANDLE>> {
     match peek_broker_handle(drive) {
         Some(raw) => Ok(Some(duplicate_registered_handle(raw, drive)?)),
         None => Ok(None),

--- a/crates/uffs-mft/src/usn/windows.rs
+++ b/crates/uffs-mft/src/usn/windows.rs
@@ -125,7 +125,28 @@ const USN_JOURNAL_DATA_V0_SIZE: u32 = u32_size_of::<UsnJournalDataV0>();
 const READ_USN_JOURNAL_DATA_V0_SIZE: u32 = u32_size_of::<ReadUsnJournalDataV0>();
 
 /// Open a `\\.\X:` volume handle with read access for USN-journal ioctls.
+///
+/// Adopts a broker-supplied volume handle when one is registered for `volume`
+/// (the non-elevated daemon path): `FSCTL_QUERY_USN_JOURNAL` /
+/// `FSCTL_READ_USN_JOURNAL` operate on a **volume** handle, which the Access
+/// Broker already vends, so a non-elevated daemon that can't `CreateFileW` the
+/// raw volume can still poll the journal through a duplicate of the broker
+/// handle.  Falls back to a direct `CreateFileW` when no broker handle is
+/// registered (the elevated path).
+///
+/// The returned handle is owned by the caller and closed via
+/// [`close_volume_handle`] after the ioctl — for a broker-backed handle that
+/// closes only the duplicate, leaving the registry entry intact for the next
+/// poll (mirrors the MFT read's per-open duplicate).
 fn open_volume_handle(volume: crate::platform::DriveLetter) -> Result<HANDLE, std::io::Error> {
+    // Broker fast-path: adopt a duplicate of the registered broker handle if
+    // present; otherwise open the volume directly below.
+    if let Some(handle) = crate::platform::try_adopt_broker_handle(volume)
+        .map_err(|err| std::io::Error::other(err.to_string()))?
+    {
+        return Ok(handle);
+    }
+
     let path = format!("\\\\.\\{volume}:");
     let wide: Vec<u16> = OsStr::new(&path)
         .encode_wide()

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -120,7 +120,7 @@ pick an item up. `Depends on` must be `🟩` before you start.
 |----|-------|----------|--------|--------|-------|----|-----------|
 | FU-9 | Gate warm-up on `!is_elevated()` | HIGH | XS | 🟩 | claude | #404 | — |
 | FU-2a | Journal-poll backoff (stop the storm) | HIGH | S | 🟦 | claude | — | — |
-| FU-2b | USN journal read through broker | HIGH | M | ⬜ | — | — | SBB-1 |
+| FU-2b | USN journal read through broker | HIGH | M | 🟦 | claude | — | SBB-1 |
 | FU-3 | `get_mft_extents` through broker | MEDIUM | M | ⬜ | — | — | SBB-1 |
 | FU-8 | `$UpCase` overlapped-handle read | LOW–MED | M | ⬜ | — | — | — |
 | FU-1 | Windows Service dispatcher | HIGH | M | ⬜ | — | — | — |


### PR DESCRIPTION
## ⚠️ Do not merge until VM-validated

Unlike the prior broker PRs, this one carries a risk gates can't catch (see below). Hold the merge until the VM run confirms the USN poll works through the broker handle.

## What & why

The USN journal open used a direct `CreateFileW`, which a non-elevated daemon can't do — so the broker-backed daemon fell back to a **full MFT rebuild on every refresh** (`USN Journal unavailable - Access is denied`) instead of a cheap incremental USN read. (You saw this in every VM log as the `Journal poll failed ... Access is denied` storm.)

Route `open_volume_handle` (`usn/windows.rs`) through SBB-1's `try_adopt_broker_handle`: `FSCTL_QUERY/READ_USN_JOURNAL` operate on a **volume** handle, which the Access Broker already vends, so a non-elevated daemon polls the journal through a duplicate of the broker handle, falling back to a direct open only when no broker handle is registered (the elevated path). `try_adopt_broker_handle` is now `pub(crate)` + re-exported from `platform.rs`.

## The risk (why VM validation gates this)

The broker handle is `FILE_FLAG_OVERLAPPED`, and the USN `DeviceIoControl` calls pass a **NULL** `OVERLAPPED`. The volume-data FSCTL works that way on the broker handle (precedent), but the USN FSCTLs **might** return `ERROR_INVALID_PARAMETER` like `$UpCase`'s `SetFilePointerEx` did. This commit ships the minimal adoption first (per the playbook's staged approach); if the VM shows the error, a follow-up switches the USN ioctls to overlapped-event + `GetOverlappedResult` when broker-backed.

## How FU-2a + FU-2b interact

With FU-2a (#407) already merged, even if FU-2b's USN open fails, the daemon no longer storms — it backs off quietly. If FU-2b **succeeds**, the journal poll succeeds and the backoff never engages at all. Either way the log is clean; the VM tells us which.

Gate: exact `cargo xwin clippy --workspace --all-features` clean; host clippy clean. Build tag bumped to `#3`.