### PR TITLE
fix(mft): bootstrap MFT extents from FRS 0 on the non-elevated path (FU-3)

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -87,7 +87,7 @@ fn print_usage() {
 /// `uffs-daemon/src/startup.rs`.  Grep `TEMP-BROKER-FLOW` and delete every hit
 /// when the broker follow-ups land — this is NOT a real version.
 #[cfg(windows)]
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #3 (+ FU-2b USN-through-broker)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #4 (+ FU-3 MFT-extents bootstrap)";
 
 /// Run the broker in foreground mode.
 #[cfg(windows)]

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -56,7 +56,7 @@ pub(crate) fn validate_data_sources(
 /// every build you intend to validate**, and keep it identical to the broker's
 /// tag in `uffs-broker/src/broker.rs`.  Grep `TEMP-BROKER-FLOW` and delete
 /// every hit when the broker follow-ups land — this is NOT a real version.
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #3 (+ FU-2b USN-through-broker)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #4 (+ FU-3 MFT-extents bootstrap)";
 
 /// Emit the startup `tracing::info!` line with every config field
 /// the operator might want to grep for.  Extracted so the orchestrator

--- a/crates/uffs-mft/src/io/readers/mod.rs
+++ b/crates/uffs-mft/src/io/readers/mod.rs
@@ -65,7 +65,7 @@ pub mod parallel;
 #[cfg(windows)]
 pub(crate) use basic::MftRecordReader;
 #[cfg(windows)]
-pub(crate) use iocp::{IoCompletionPort, OverlappedRead};
+pub(crate) use iocp::{IoCompletionPort, OverlappedRead, set_overlapped_offset};
 #[cfg(windows)]
 pub use iocp::{
     IocpMftReader, MultiVolumeIoOp, MultiVolumeIocpReader, VolumeState, prepare_volume_state,

--- a/crates/uffs-mft/src/platform/extents.rs
+++ b/crates/uffs-mft/src/platform/extents.rs
@@ -49,6 +49,31 @@ impl MftExtent {
     }
 }
 
+/// Convert NTFS `$DATA` data runs into [`MftExtent`]s, dropping sparse runs.
+///
+/// Used by the non-elevated MFT-extent bootstrap: FRS 0's `$DATA` runlist
+/// describes the MFT's own physical layout, so its runs map directly to the
+/// extent map the kernel's `FSCTL_GET_RETRIEVAL_POINTERS` would return.  Sparse
+/// runs (the MFT has none in practice, but a corrupt record could encode one)
+/// are filtered so seek arithmetic never lands on a hole.  Pure — no I/O / FFI
+/// — so it is unit-tested directly against golden runlists.
+///
+/// `cfg(any(windows, test))`: the only production caller is the Windows
+/// MFT-read path, but the conversion is platform-agnostic and exercised by the
+/// host test below.
+#[cfg(any(windows, test))]
+#[must_use]
+pub(crate) fn data_runs_to_extents(runs: &[crate::ntfs::DataRun]) -> Vec<MftExtent> {
+    runs.iter()
+        .filter(|run| !run.is_sparse())
+        .map(|run| MftExtent {
+            vcn: run.vcn.cast_unsigned(),
+            cluster_count: run.cluster_count,
+            lcn: run.lcn,
+        })
+        .collect()
+}
+
 /// Retrieves the extent map for a file using `FSCTL_GET_RETRIEVAL_POINTERS`.
 #[cfg(windows)]
 #[expect(
@@ -193,7 +218,65 @@ fn parse_retrieval_pointers(buffer: &[u8], size: usize, extents: &mut Vec<MftExt
 #[cfg(test)]
 mod tests {
     use super::super::Lcn;
-    use super::MftExtent;
+    use super::{MftExtent, data_runs_to_extents};
+
+    #[test]
+    fn data_runs_map_to_extents_and_drop_sparse() {
+        use crate::ntfs::DataRun;
+        // Two real MFT fragments with a sparse run between them (the sparse run
+        // must be dropped so the read plan never seeks into a hole).
+        let runs = [
+            DataRun {
+                vcn: 0,
+                cluster_count: 100,
+                lcn: Lcn::new(5_000),
+            },
+            DataRun {
+                vcn: 100,
+                cluster_count: 50,
+                lcn: Lcn::ZERO, // sparse → filtered
+            },
+            DataRun {
+                vcn: 150,
+                cluster_count: 200,
+                lcn: Lcn::new(9_000),
+            },
+        ];
+        assert_eq!(data_runs_to_extents(&runs), vec![
+            MftExtent {
+                vcn: 0,
+                cluster_count: 100,
+                lcn: Lcn::new(5_000),
+            },
+            MftExtent {
+                vcn: 150,
+                cluster_count: 200,
+                lcn: Lcn::new(9_000),
+            },
+        ],);
+    }
+
+    #[test]
+    fn data_runs_single_contiguous_fragment() {
+        use crate::ntfs::DataRun;
+        // The common case: a contiguous MFT is one run → one extent (identity
+        // mapping of the fields).
+        let runs = [DataRun {
+            vcn: 0,
+            cluster_count: 98_752,
+            lcn: Lcn::new(786_432),
+        }];
+        assert_eq!(data_runs_to_extents(&runs), vec![MftExtent {
+            vcn: 0,
+            cluster_count: 98_752,
+            lcn: Lcn::new(786_432),
+        }],);
+    }
+
+    #[test]
+    fn data_runs_empty_yields_no_extents() {
+        assert!(data_runs_to_extents(&[]).is_empty());
+    }
 
     #[test]
     fn byte_offset_returns_zero_for_sparse_extents() {

--- a/crates/uffs-mft/src/platform/volume.rs
+++ b/crates/uffs-mft/src/platform/volume.rs
@@ -795,10 +795,12 @@ impl VolumeHandle {
             .chain(core::iter::once(0))
             .collect();
 
-        // SAFETY: `mft_path` is UTF-16 and NUL-terminated for the duration of
-        // the call, optional pointers are `None`, and any returned handle is
-        // wrapped in `HandleGuard` before use.
-        let Ok(mft_handle) = (unsafe {
+        // Fast path (elevated): open $MFT and ask the kernel for its retrieval
+        // pointers.  A non-elevated daemon can't open $MFT at all, so this open
+        // fails and we bootstrap the real layout from FRS 0 below.
+        // SAFETY: `mft_path` is UTF-16 + NUL-terminated for the call; optional
+        // pointers are `None`; any returned handle is wrapped in `HandleGuard`.
+        if let Ok(mft_handle) = unsafe {
             CreateFileW(
                 PCWSTR::from_raw(mft_path.as_ptr()),
                 0,
@@ -808,17 +810,140 @@ impl VolumeHandle {
                 FILE_FLAGS_AND_ATTRIBUTES(0),
                 None,
             )
-        }) else {
-            return Ok(vec![MftExtent {
-                vcn: 0,
-                cluster_count: self.volume_data.mft_valid_data_length
-                    / u64::from(self.volume_data.bytes_per_cluster),
-                lcn: super::Lcn::new(self.volume_data.mft_start_lcn.cast_signed()),
-            }]);
-        };
+        } {
+            let _guard = HandleGuard(mft_handle);
+            return get_retrieval_pointers(mft_handle);
+        }
 
-        let _guard = HandleGuard(mft_handle);
-        get_retrieval_pointers(mft_handle)
+        // Non-elevated (broker-backed) path: `$MFT` can't be opened directly.
+        // The old fallback was a SINGLE assumed-contiguous extent — silently
+        // wrong on a fragmented MFT (it reads the wrong physical region past the
+        // first fragment, producing a partial index).  Bootstrap the REAL
+        // extents from FRS 0's `$DATA` runlist, read through our volume handle.
+        Ok(self.mft_extents_from_frs0())
+    }
+
+    /// Bootstrap the MFT extent map from FRS 0 ($MFT's own record), read
+    /// through the volume handle — the non-elevated / broker path where
+    /// `$MFT` can't be opened for `FSCTL_GET_RETRIEVAL_POINTERS`.
+    ///
+    /// FRS 0 always lives at the start of the MFT ([`Self::mft_byte_offset`],
+    /// the first fragment), and its non-resident `$DATA` runlist *is* the
+    /// MFT's physical layout — so the extents it yields match what the
+    /// kernel would return, fragmented or not.  Degrades **loudly** to the
+    /// legacy single-contiguous assumption only if FRS 0 can't be read or
+    /// parsed, so a non-elevated load still produces an index rather than
+    /// failing outright.
+    #[cfg(windows)]
+    fn mft_extents_from_frs0(&self) -> Vec<MftExtent> {
+        use crate::ntfs::{AttributeIterator, AttributeType};
+
+        let record_size = self.volume_data.bytes_per_file_record_segment as usize;
+        let mut record = vec![0_u8; record_size];
+        if let Err(err) = self.read_volume_at(self.mft_byte_offset(), &mut record) {
+            tracing::warn!(
+                drive = %self.volume, error = %err,
+                "FRS 0 read failed; assuming single contiguous MFT extent (index may be partial on a fragmented MFT)"
+            );
+            return self.single_contiguous_extent();
+        }
+        crate::parse::apply_fixup(&mut record);
+
+        let runs = AttributeIterator::new(&record)
+            .and_then(|mut attrs| {
+                attrs.find(|attr| {
+                    attr.attribute_type() == Some(AttributeType::Data)
+                        && attr.is_non_resident()
+                        && attr.header.name_length == 0
+                })
+            })
+            .map(|attr| attr.data_runs())
+            .unwrap_or_default();
+        let extents = super::extents::data_runs_to_extents(&runs);
+
+        if extents.is_empty() {
+            tracing::warn!(
+                drive = %self.volume,
+                "FRS 0 $DATA parse yielded no extents; assuming single contiguous MFT extent"
+            );
+            return self.single_contiguous_extent();
+        }
+        tracing::info!(
+            drive = %self.volume, num_extents = extents.len(),
+            "MFT extents bootstrapped from FRS 0 $DATA runlist (broker path)"
+        );
+        extents
+    }
+
+    /// The legacy single-contiguous MFT extent derived from `NTFS_VOLUME_DATA`,
+    /// kept as the loud fallback for [`Self::mft_extents_from_frs0`].
+    #[cfg(windows)]
+    fn single_contiguous_extent(&self) -> Vec<MftExtent> {
+        vec![MftExtent {
+            vcn: 0,
+            cluster_count: self.volume_data.mft_valid_data_length
+                / u64::from(self.volume_data.bytes_per_cluster),
+            lcn: super::Lcn::new(self.volume_data.mft_start_lcn.cast_signed()),
+        }]
+    }
+
+    /// Read `buf.len()` bytes from the volume handle at byte `offset`, carrying
+    /// the offset in an `OVERLAPPED` so it works on the broker's
+    /// `FILE_FLAG_OVERLAPPED` handle — which has no synchronous file pointer,
+    /// the same reason `$UpCase`'s `SetFilePointerEx` fails on it.  This is
+    /// a single, non-concurrent bootstrap read (before the IOCP bulk read
+    /// starts), so completion is awaited via `GetOverlappedResult` on the
+    /// handle without a dedicated event.
+    ///
+    /// # Errors
+    ///
+    /// [`MftError::Io`] if `ReadFile` / `GetOverlappedResult` fail, or
+    /// [`MftError::InvalidData`] on a short read.
+    #[cfg(windows)]
+    #[expect(unsafe_code, reason = "FFI: overlapped ReadFile + GetOverlappedResult")]
+    fn read_volume_at(&self, offset: u64, buf: &mut [u8]) -> Result<()> {
+        use windows::Win32::Foundation::ERROR_IO_PENDING;
+        use windows::Win32::Storage::FileSystem::ReadFile;
+        use windows::Win32::System::IO::{GetOverlappedResult, OVERLAPPED};
+
+        let mut overlapped = OVERLAPPED::default();
+        crate::io::readers::set_overlapped_offset(&mut overlapped, offset);
+
+        let mut bytes_read = 0_u32;
+        // SAFETY: `buf` is valid and writable for its length; `overlapped`
+        // outlives the call and the wait below; `self.handle` is a live volume
+        // handle.
+        let read = unsafe {
+            ReadFile(
+                self.handle,
+                Some(buf),
+                Some(&raw mut bytes_read),
+                Some(&raw mut overlapped),
+            )
+        };
+        if let Err(err) = read {
+            if err.code() != ERROR_IO_PENDING.to_hresult() {
+                return Err(MftError::Io(hresult_to_io_error(&err)));
+            }
+            // SAFETY: `overlapped` is the in-flight struct from the pending
+            // `ReadFile` and is still alive; `bWait = true` blocks to completion.
+            unsafe {
+                GetOverlappedResult(
+                    self.handle,
+                    &raw const overlapped,
+                    &raw mut bytes_read,
+                    true,
+                )
+            }
+            .map_err(|wait_err| MftError::Io(hresult_to_io_error(&wait_err)))?;
+        }
+        if (bytes_read as usize) < buf.len() {
+            return Err(MftError::InvalidData(format!(
+                "short FRS read: {bytes_read} of {} bytes",
+                buf.len()
+            )));
+        }
+        Ok(())
     }
 
     /// Gets the MFT bitmap which indicates which records are in use.

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -119,9 +119,9 @@ pick an item up. `Depends on` must be `🟩` before you start.
 | ID | Title | Priority | Effort | Status | Owner | PR | Depends on |
 |----|-------|----------|--------|--------|-------|----|-----------|
 | FU-9 | Gate warm-up on `!is_elevated()` | HIGH | XS | 🟩 | claude | #404 | — |
-| FU-2a | Journal-poll backoff (stop the storm) | HIGH | S | 🟦 | claude | — | — |
-| FU-2b | USN journal read through broker | HIGH | M | 🟦 | claude | — | SBB-1 |
-| FU-3 | `get_mft_extents` through broker | MEDIUM | M | ⬜ | — | — | SBB-1 |
+| FU-2a | Journal-poll backoff (stop the storm) | HIGH | S | 🟩 | claude | #407 | — |
+| FU-2b | USN journal read through broker | HIGH | M | 🟩 | claude | #408 | SBB-1 |
+| FU-3 | `get_mft_extents` through broker | HIGH | M | 🟦 | claude | — | SBB-1 |
 | FU-8 | `$UpCase` overlapped-handle read | LOW–MED | M | ⬜ | — | — | — |
 | FU-1 | Windows Service dispatcher | HIGH | M | ⬜ | — | — | — |
 | FU-4 | `WinVerifyTrust` + Authenticode cache | MEDIUM | M | ⬜ | — | — | — |


### PR DESCRIPTION
## What & why

**Confirmed live correctness bug.** A non-elevated daemon can't open `\$MFT` at all, so `get_mft_extents` fell back to a SINGLE assumed-contiguous extent. On a fragmented MFT that reads the wrong physical region past the first fragment, **silently producing a partial index**. On the VM: non-elevated broker load got `num_extents=1` / `records=215282` where the elevated load got `num_extents=2` / `records=399869` — **only ~54% of the drive indexed**.

## The fix (playbook Option 2, no protocol change)

When the `\$MFT` open fails, bootstrap the **real** extent map from FRS 0's `$DATA` runlist, read through the volume handle we already hold. FRS 0 lives at the MFT start (always the first fragment), and its non-resident `$DATA` runlist *is* the MFT's physical layout — so the extents match what `FSCTL_GET_RETRIEVAL_POINTERS` would return, fragmented or not. The single-contiguous assumption survives only as a **loud (warn-logged)** last resort.

The FRS-0 read uses an **overlapped-offset `ReadFile` + `GetOverlappedResult`** (via the existing `set_overlapped_offset` helper, now re-exported at `io::readers`) because the broker handle is `FILE_FLAG_OVERLAPPED` and has no synchronous file pointer — the same reason `$UpCase`'s `SetFilePointerEx` fails on it.

## Risk is bounded (safe to land + validate from main)

The **elevated path is untouched** (still direct `$MFT` open + retrieval pointers). Only the non-elevated broker path changes — and that path was *already* broken (the 215K partial). So this can only improve or equal it; it cannot regress the working elevated flow.

## Tests

The `DataRun → MftExtent` conversion (`data_runs_to_extents`) is pure and lives in cross-platform `extents.rs` with **3 host unit tests** (fragmented + sparse filtering, contiguous, empty). The read/parse FFI is Windows-only. Exact `cargo xwin clippy --workspace --all-features` clean; **222 host mft tests pass**. Build tag → `#4`.

## VM validation (build from main after merge)

Expect the non-elevated broker load to now log `num_extents=2` and `records=399869` (matching elevated), plus `MFT extents bootstrapped from FRS 0 $DATA runlist`.