### PR TITLE
fix(mft): read $UpCase through the overlapped handle (FU-8)

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -87,7 +87,7 @@ fn print_usage() {
 /// `uffs-daemon/src/startup.rs`.  Grep `TEMP-BROKER-FLOW` and delete every hit
 /// when the broker follow-ups land — this is NOT a real version.
 #[cfg(windows)]
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #4 (+ FU-3 MFT-extents bootstrap)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #5 (+ FU-8 $UpCase overlapped)";
 
 /// Run the broker in foreground mode.
 #[cfg(windows)]

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -56,7 +56,7 @@ pub(crate) fn validate_data_sources(
 /// every build you intend to validate**, and keep it identical to the broker's
 /// tag in `uffs-broker/src/broker.rs`.  Grep `TEMP-BROKER-FLOW` and delete
 /// every hit when the broker follow-ups land — this is NOT a real version.
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #4 (+ FU-3 MFT-extents bootstrap)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #5 (+ FU-8 $UpCase overlapped)";
 
 /// Emit the startup `tracing::info!` line with every config field
 /// the operator might want to grep for.  Extracted so the orchestrator

--- a/crates/uffs-mft/src/platform/upcase.rs
+++ b/crates/uffs-mft/src/platform/upcase.rs
@@ -343,9 +343,11 @@ pub fn read_upcase_table(drive: crate::platform::DriveLetter) -> Result<Box<[u16
     let mft_offset = handle.mft_byte_offset();
     let frs10_offset = mft_offset + UPCASE_FRS * rs as u64;
 
-    // Read FRS 10 from the MFT on disk.
+    // Read FRS 10 from the MFT on disk.  Uses the overlapped-aware read so the
+    // broker's `FILE_FLAG_OVERLAPPED` handle works (a `SetFilePointerEx` seek
+    // fails on it — the old "$UpCase: parameter is incorrect" failure).
     let mut record = vec![0_u8; rs];
-    volume_read_at(handle.raw_handle(), frs10_offset, &mut record)?;
+    super::volume::read_handle_at(handle.raw_handle(), frs10_offset, &mut record)?;
     apply_fixup(&mut record);
 
     // Parse data runs.
@@ -394,45 +396,6 @@ pub fn read_upcase_table(drive: crate::platform::DriveLetter) -> Result<Box<[u16
 
 // ── Windows I/O helpers ───────────────────────────────────────────────
 
-/// Seek + read from a raw volume handle.
-#[cfg(windows)]
-fn volume_read_at(
-    handle: windows::Win32::Foundation::HANDLE,
-    offset: u64,
-    buf: &mut [u8],
-) -> Result<()> {
-    use windows::Win32::Storage::FileSystem::{FILE_BEGIN, ReadFile, SetFilePointerEx};
-
-    let seek_pos = i64::try_from(offset).map_err(|err| {
-        MftError::InvalidData(format!("$UpCase: offset {offset} exceeds i64::MAX ({err})"))
-    })?;
-
-    // SAFETY: SetFilePointerEx is a well-defined Win32 API.
-    #[expect(unsafe_code, reason = "FFI: SetFilePointerEx")]
-    unsafe {
-        SetFilePointerEx(handle, seek_pos, None, FILE_BEGIN).map_err(|err| {
-            MftError::InvalidData(format!("$UpCase: seek to offset {offset} failed: {err}"))
-        })
-    }?;
-
-    let mut bytes_read = 0_u32;
-    // SAFETY: ReadFile writes into valid writable `buf`.
-    #[expect(unsafe_code, reason = "FFI: ReadFile")]
-    unsafe {
-        ReadFile(handle, Some(buf), Some(&raw mut bytes_read), None).map_err(|err| {
-            MftError::InvalidData(format!("$UpCase: read {} bytes failed: {err}", buf.len()))
-        })
-    }?;
-
-    if (bytes_read as usize) < buf.len() {
-        return Err(MftError::InvalidData(format!(
-            "$UpCase: short read: got {bytes_read}/{}",
-            buf.len()
-        )));
-    }
-    Ok(())
-}
-
 /// Read clusters from data runs into a contiguous buffer.
 #[cfg(windows)]
 fn read_clusters(
@@ -471,7 +434,7 @@ fn read_clusters(
                  {UPCASE_SIZE_BYTES}"
             )));
         };
-        volume_read_at(handle, disk_offset, read_window)?;
+        super::volume::read_handle_at(handle, disk_offset, read_window)?;
         offset += read_len;
     }
 

--- a/crates/uffs-mft/src/platform/volume.rs
+++ b/crates/uffs-mft/src/platform/volume.rs
@@ -157,6 +157,60 @@ pub(crate) fn try_adopt_broker_handle(drive: super::DriveLetter) -> Result<Optio
     }
 }
 
+/// Read `buf.len()` bytes from a raw volume `handle` at byte `offset`, carrying
+/// the offset in an `OVERLAPPED`.
+///
+/// Works on the broker's `FILE_FLAG_OVERLAPPED` handle — which has **no
+/// synchronous file pointer**, so a `SetFilePointerEx` seek fails on it (the
+/// `$UpCase` "parameter is incorrect" failure) — as well as on a plain
+/// synchronous handle (the offset in the `OVERLAPPED` is honoured either way).
+/// These are single, non-concurrent metadata reads, so completion is awaited
+/// via `GetOverlappedResult` on the handle without a dedicated event.  Shared
+/// by the MFT-extent bootstrap (FU-3) and the `$UpCase` read (FU-8).
+///
+/// # Errors
+///
+/// [`MftError::Io`] if `ReadFile` / `GetOverlappedResult` fail, or
+/// [`MftError::InvalidData`] on a short read.
+#[cfg(windows)]
+#[expect(unsafe_code, reason = "FFI: overlapped ReadFile + GetOverlappedResult")]
+pub(crate) fn read_handle_at(handle: HANDLE, offset: u64, buf: &mut [u8]) -> Result<()> {
+    use windows::Win32::Foundation::ERROR_IO_PENDING;
+    use windows::Win32::Storage::FileSystem::ReadFile;
+    use windows::Win32::System::IO::{GetOverlappedResult, OVERLAPPED};
+
+    let mut overlapped = OVERLAPPED::default();
+    crate::io::readers::set_overlapped_offset(&mut overlapped, offset);
+
+    let mut bytes_read = 0_u32;
+    // SAFETY: `buf` is valid and writable for its length; `overlapped` outlives
+    // the call and the wait below; `handle` is a live volume handle.
+    let read = unsafe {
+        ReadFile(
+            handle,
+            Some(buf),
+            Some(&raw mut bytes_read),
+            Some(&raw mut overlapped),
+        )
+    };
+    if let Err(err) = read {
+        if err.code() != ERROR_IO_PENDING.to_hresult() {
+            return Err(MftError::Io(hresult_to_io_error(&err)));
+        }
+        // SAFETY: `overlapped` is the in-flight struct from the pending
+        // `ReadFile` and is still alive; `bWait = true` blocks to completion.
+        unsafe { GetOverlappedResult(handle, &raw const overlapped, &raw mut bytes_read, true) }
+            .map_err(|wait_err| MftError::Io(hresult_to_io_error(&wait_err)))?;
+    }
+    if (bytes_read as usize) < buf.len() {
+        return Err(MftError::InvalidData(format!(
+            "overlapped read short: {bytes_read} of {} bytes",
+            buf.len()
+        )));
+    }
+    Ok(())
+}
+
 /// Convert a `windows::core::Error` into the equivalent `std::io::Error`,
 /// **unwrapping** the `HRESULT_FROM_WIN32` envelope so std's
 /// `decode_error_kind` table (keyed on bare Win32 codes like
@@ -840,7 +894,7 @@ impl VolumeHandle {
 
         let record_size = self.volume_data.bytes_per_file_record_segment as usize;
         let mut record = vec![0_u8; record_size];
-        if let Err(err) = self.read_volume_at(self.mft_byte_offset(), &mut record) {
+        if let Err(err) = read_handle_at(self.handle, self.mft_byte_offset(), &mut record) {
             tracing::warn!(
                 drive = %self.volume, error = %err,
                 "FRS 0 read failed; assuming single contiguous MFT extent (index may be partial on a fragmented MFT)"
@@ -885,65 +939,6 @@ impl VolumeHandle {
                 / u64::from(self.volume_data.bytes_per_cluster),
             lcn: super::Lcn::new(self.volume_data.mft_start_lcn.cast_signed()),
         }]
-    }
-
-    /// Read `buf.len()` bytes from the volume handle at byte `offset`, carrying
-    /// the offset in an `OVERLAPPED` so it works on the broker's
-    /// `FILE_FLAG_OVERLAPPED` handle — which has no synchronous file pointer,
-    /// the same reason `$UpCase`'s `SetFilePointerEx` fails on it.  This is
-    /// a single, non-concurrent bootstrap read (before the IOCP bulk read
-    /// starts), so completion is awaited via `GetOverlappedResult` on the
-    /// handle without a dedicated event.
-    ///
-    /// # Errors
-    ///
-    /// [`MftError::Io`] if `ReadFile` / `GetOverlappedResult` fail, or
-    /// [`MftError::InvalidData`] on a short read.
-    #[cfg(windows)]
-    #[expect(unsafe_code, reason = "FFI: overlapped ReadFile + GetOverlappedResult")]
-    fn read_volume_at(&self, offset: u64, buf: &mut [u8]) -> Result<()> {
-        use windows::Win32::Foundation::ERROR_IO_PENDING;
-        use windows::Win32::Storage::FileSystem::ReadFile;
-        use windows::Win32::System::IO::{GetOverlappedResult, OVERLAPPED};
-
-        let mut overlapped = OVERLAPPED::default();
-        crate::io::readers::set_overlapped_offset(&mut overlapped, offset);
-
-        let mut bytes_read = 0_u32;
-        // SAFETY: `buf` is valid and writable for its length; `overlapped`
-        // outlives the call and the wait below; `self.handle` is a live volume
-        // handle.
-        let read = unsafe {
-            ReadFile(
-                self.handle,
-                Some(buf),
-                Some(&raw mut bytes_read),
-                Some(&raw mut overlapped),
-            )
-        };
-        if let Err(err) = read {
-            if err.code() != ERROR_IO_PENDING.to_hresult() {
-                return Err(MftError::Io(hresult_to_io_error(&err)));
-            }
-            // SAFETY: `overlapped` is the in-flight struct from the pending
-            // `ReadFile` and is still alive; `bWait = true` blocks to completion.
-            unsafe {
-                GetOverlappedResult(
-                    self.handle,
-                    &raw const overlapped,
-                    &raw mut bytes_read,
-                    true,
-                )
-            }
-            .map_err(|wait_err| MftError::Io(hresult_to_io_error(&wait_err)))?;
-        }
-        if (bytes_read as usize) < buf.len() {
-            return Err(MftError::InvalidData(format!(
-                "short FRS read: {bytes_read} of {} bytes",
-                buf.len()
-            )));
-        }
-        Ok(())
     }
 
     /// Gets the MFT bitmap which indicates which records are in use.

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -121,8 +121,8 @@ pick an item up. `Depends on` must be `🟩` before you start.
 | FU-9 | Gate warm-up on `!is_elevated()` | HIGH | XS | 🟩 | claude | #404 | — |
 | FU-2a | Journal-poll backoff (stop the storm) | HIGH | S | 🟩 | claude | #407 | — |
 | FU-2b | USN journal read through broker | HIGH | M | 🟩 | claude | #408 | SBB-1 |
-| FU-3 | `get_mft_extents` through broker | HIGH | M | 🟦 | claude | — | SBB-1 |
-| FU-8 | `$UpCase` overlapped-handle read | LOW–MED | M | ⬜ | — | — | — |
+| FU-3 | `get_mft_extents` through broker | HIGH | M | 🟩 | claude | #409 | SBB-1 |
+| FU-8 | `$UpCase` overlapped-handle read | LOW–MED | S | 🟦 | claude | — | FU-3 |
 | FU-1 | Windows Service dispatcher | HIGH | M | ⬜ | — | — | — |
 | FU-4 | `WinVerifyTrust` + Authenticode cache | MEDIUM | M | ⬜ | — | — | — |
 | FU-5 | Async multi-instance broker + `OwnedHandle` | MEDIUM | L | ⬜ | — | — | SBB-2 |


### PR DESCRIPTION
## What & why

`$UpCase`'s live read used `SetFilePointerEx`, which **fails on the broker's `FILE_FLAG_OVERLAPPED` handle** (no synchronous file pointer) — the `$UpCase: seek to offset ... The parameter is incorrect. (0x80070057)` warning on every broker-backed load, after which it fell back to the compiled-in default table (correct for standard volumes, but noisy, and wrong for a customised `$UpCase`).

## The fix

Extract FU-3's overlapped read into a shared `pub(crate) read_handle_at(handle, offset, buf)` and route both the `$UpCase` FRS-10 read and its cluster reads through it (deleting `upcase`'s `SetFilePointerEx`-based `volume_read_at`). The MFT-extent bootstrap (FU-3) uses the same function. The overlapped-offset `ReadFile` works on **both** the broker's overlapped handle and a plain synchronous (elevated) handle, so one path covers both.

This removes the **last** broker-flow warning; a live `$UpCase` read now succeeds non-elevated.

## Validation

Reuses the `read_handle_at` path already VM-confirmed by FU-3 (the FRS-0 read works through the broker's overlapped handle). Exact `cargo xwin clippy --workspace --all-features` clean; **222 host mft tests pass**. Build tag → `#5`. On the next VM run, expect **no** `$UpCase live read failed` warning and a `Read $UpCase table from live volume` success line.

Also flips FU-3 to ✅ on the tracking board (#409, VM-confirmed: `num_extents=2`, `records=403209`).