### PR TITLE
fix(client): probe the broker pipe without connecting (FU-6)

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -87,7 +87,7 @@ fn print_usage() {
 /// `uffs-daemon/src/startup.rs`.  Grep `TEMP-BROKER-FLOW` and delete every hit
 /// when the broker follow-ups land — this is NOT a real version.
 #[cfg(windows)]
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #5 (+ FU-8 $UpCase overlapped)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #6 (+ FU-6 non-connecting probe)";
 
 /// Run the broker in foreground mode.
 #[cfg(windows)]

--- a/crates/uffs-client/src/broker_probe.rs
+++ b/crates/uffs-client/src/broker_probe.rs
@@ -16,15 +16,24 @@
 /// Return `true` when the UFFS Access Broker named pipe exists — i.e. the
 /// broker Windows service is installed and running.
 ///
-/// Mirrors `uffs-daemon::broker_client::broker_available` (the daemon
-/// can't be a dependency of the client), using a single
-/// `GetFileAttributesW` probe on [`uffs_broker_protocol::PIPE_NAME`] —
-/// cheap, opens no handle, no side effects.
+/// Uses `WaitNamedPipeW`, which checks pipe **availability without
+/// connecting**. The previous `GetFileAttributesW` probe *opened* the pipe to
+/// read its attributes, which the broker saw as a real connection and logged as
+/// a rejected `uffs.exe` client on **every** search (FU-6) — wasteful, and it
+/// consumed a pipe instance the single-instance broker then had to recover.
+/// `WaitNamedPipeW` never opens the pipe, so the broker sees nothing.
+///
+/// Presence semantics: an available instance → `Ok`; an existing-but-busy pipe
+/// → `ERROR_SEM_TIMEOUT`; a missing pipe → `ERROR_FILE_NOT_FOUND`.  Only
+/// `ERROR_FILE_NOT_FOUND` is treated as "no broker"; everything else is
+/// present, so a momentarily-busy broker isn't a false negative (the daemon's
+/// real handle request is the authoritative test either way).
 pub(crate) fn broker_pipe_present() -> bool {
     use std::os::windows::ffi::OsStrExt as _;
 
     use uffs_broker_protocol::PIPE_NAME;
-    use windows::Win32::Storage::FileSystem::GetFileAttributesW;
+    use windows::Win32::Foundation::ERROR_FILE_NOT_FOUND;
+    use windows::Win32::System::Pipes::WaitNamedPipeW;
     use windows::core::PCWSTR;
 
     let wide: Vec<u16> = std::ffi::OsStr::new(PIPE_NAME)
@@ -32,11 +41,18 @@ pub(crate) fn broker_pipe_present() -> bool {
         .chain(Some(0))
         .collect();
 
-    #[expect(unsafe_code, reason = "GetFileAttributesW probe for pipe existence")]
-    // SAFETY: `wide` is a null-terminated UTF-16 buffer that outlives the
-    // call; `GetFileAttributesW` only reads through the pointer.
-    let attrs = unsafe { GetFileAttributesW(PCWSTR(wide.as_ptr())) };
+    // 1 ms: we only need existence, not to actually wait for a free instance.
+    #[expect(unsafe_code, reason = "WaitNamedPipeW non-connecting existence probe")]
+    // SAFETY: `wide` is a null-terminated UTF-16 buffer that outlives the call;
+    // `WaitNamedPipeW` only reads through the pointer and opens no handle.
+    let available = unsafe { WaitNamedPipeW(PCWSTR(wide.as_ptr()), 1) };
 
-    // INVALID_FILE_ATTRIBUTES (u32::MAX) means the pipe does not exist.
-    attrs != u32::MAX
+    // `BOOL::ok()` maps `true` → `Ok(())` and `false` → `Err` carrying
+    // `GetLastError`.  Only a missing pipe (`ERROR_FILE_NOT_FOUND`) means "no
+    // broker"; an existing-but-busy pipe (`ERROR_SEM_TIMEOUT`) or any other
+    // error is treated as present.
+    match available.ok() {
+        Ok(()) => true,
+        Err(err) => err.code() != ERROR_FILE_NOT_FOUND.to_hresult(),
+    }
 }

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -56,7 +56,7 @@ pub(crate) fn validate_data_sources(
 /// every build you intend to validate**, and keep it identical to the broker's
 /// tag in `uffs-broker/src/broker.rs`.  Grep `TEMP-BROKER-FLOW` and delete
 /// every hit when the broker follow-ups land — this is NOT a real version.
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #5 (+ FU-8 $UpCase overlapped)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #6 (+ FU-6 non-connecting probe)";
 
 /// Emit the startup `tracing::info!` line with every config field
 /// the operator might want to grep for.  Extracted so the orchestrator

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -122,12 +122,12 @@ pick an item up. `Depends on` must be `🟩` before you start.
 | FU-2a | Journal-poll backoff (stop the storm) | HIGH | S | 🟩 | claude | #407 | — |
 | FU-2b | USN journal read through broker | HIGH | M | 🟩 | claude | #408 | SBB-1 |
 | FU-3 | `get_mft_extents` through broker | HIGH | M | 🟩 | claude | #409 | SBB-1 |
-| FU-8 | `$UpCase` overlapped-handle read | LOW–MED | S | 🟦 | claude | — | FU-3 |
+| FU-8 | `$UpCase` overlapped-handle read | LOW–MED | S | 🟩 | claude | #410 | FU-3 |
 | FU-1 | Windows Service dispatcher | HIGH | M | ⬜ | — | — | — |
 | FU-4 | `WinVerifyTrust` + Authenticode cache | MEDIUM | M | ⬜ | — | — | — |
 | FU-5 | Async multi-instance broker + `OwnedHandle` | MEDIUM | L | ⬜ | — | — | SBB-2 |
-| FU-6 | Non-connecting client pipe probe | LOW | S | ⬜ | — | — | — |
-| FU-7 | Volume-data FSCTL overlapped | LOW–MED | S | ⬜ | — | — | — |
+| FU-6 | Non-connecting client pipe probe | LOW | S | 🟦 | claude | — | — |
+| FU-7 | Volume-data FSCTL overlapped | LOW–MED | S | ✅ moot | claude | — | — |
 
 **Shared building blocks** (land these as their own PRs first; several items
 depend on them — see [§3](#3-shared-building-blocks)):
@@ -946,7 +946,17 @@ logging the probe as a rejection."
 
 ### FU-7 — Volume-data FSCTL on the overlapped handle
 
-**Priority: LOW–MEDIUM · Effort: S.**
+**Priority: LOW–MEDIUM · Effort: S · ✅ RESOLVED — moot (no fix needed).**
+
+> **Resolution (2026-06-14):** this was an "if it breaks, fix it" verify item.
+> It does **not** break. `get_ntfs_volume_data` (`FSCTL_GET_NTFS_VOLUME_DATA`
+> with a NULL `OVERLAPPED`) succeeded on the broker's `FILE_FLAG_OVERLAPPED`
+> handle in **every** VM run — the daemon read valid `NtfsVolumeData`
+> (`bytes_per_cluster`, `mft_start_lcn`, …) on the broker path each time, and
+> the same is true of the USN FSCTLs (FU-2b). This FSCTL completes
+> synchronously, so the NULL-overlapped call is fine in practice. No code
+> change; closing the item. (The synchronous-completion dependence is noted
+> below should a future Windows build ever regress it.)
 
 #### Why
 `get_ntfs_volume_data` issues `FSCTL_GET_NTFS_VOLUME_DATA` with a **NULL**


### PR DESCRIPTION
## What & why

`broker_pipe_present` used `GetFileAttributesW` on the pipe path, which **opens** the pipe to read attributes — the broker saw a real connection and logged a **rejected `uffs.exe` client on every search** (and the single-instance broker had to recover the consumed instance).

Switch to `WaitNamedPipeW`, which checks instance availability **without opening** the pipe, so the broker sees nothing. Presence = `Ok` (instance ready) or any error except `ERROR_FILE_NOT_FOUND` (e.g. `ERROR_SEM_TIMEOUT` = exists-but-busy); only `FILE_NOT_FOUND` means no broker. The daemon's real handle request stays the authoritative test, so a momentarily-busy broker isn't a false negative.

## Housekeeping in the same PR

- Board: **FU-8 → done** (#410, VM-confirmed `num_extents=2` / `403209`).
- **FU-7 closed as RESOLVED/moot**: the NULL-overlapped `FSCTL_GET_NTFS_VOLUME_DATA` succeeded on the broker handle in *every* VM run, so no fix is needed.
- Build tag → `#6`.

## Validation

Exact `cargo xwin clippy --workspace --all-features` clean; host clippy clean. On the next VM run, expect **no** `REJECTED ... uffs.exe` line in the broker log.