### PR TITLE
feat(broker): multi-instance threaded serve loop + OwnedHandle (FU-5, SBB-2)

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -44,6 +44,34 @@ mod authenticode;
 #[cfg(windows)]
 use authenticode::verify_authenticode;
 
+// `Send`-safe RAII handle wrapper (SBB-2) — lets a connected pipe instance move
+// into a per-connection worker thread (FU-5). See `broker/owned_handle.rs`.
+#[path = "broker/owned_handle.rs"]
+mod owned_handle;
+#[cfg(windows)]
+use owned_handle::OwnedHandle;
+
+// Named-pipe creation + SDDL security descriptor, split out to keep this file
+// under the 800-LOC ceiling. See `broker/pipe.rs`.
+#[path = "broker/pipe.rs"]
+mod pipe;
+#[cfg(windows)]
+use pipe::create_broker_pipe;
+
+/// Per-drive rate-limit state (`drive → last grant time`), shared across the
+/// FU-5 per-connection worker threads behind a `Mutex`.
+#[cfg(windows)]
+type RateLimit = std::sync::Mutex<std::collections::HashMap<char, std::time::Instant>>;
+
+/// Maximum concurrent named-pipe instances the broker serves (FU-5).
+///
+/// One instance is always listening in the accept loop; the rest can be
+/// in-flight on worker threads.  Bounded (not `PIPE_UNLIMITED_INSTANCES`) so a
+/// flood of clients can't exhaust threads/handles — excess clients simply wait
+/// for a free instance.
+#[cfg(windows)]
+const MAX_PIPE_INSTANCES: u32 = 16;
+
 /// Run the broker (called from main).
 ///
 /// Scope is `pub(crate)` because `broker` is a private module of the
@@ -94,7 +122,7 @@ fn print_usage() {
 /// `uffs-daemon/src/startup.rs`.  Grep `TEMP-BROKER-FLOW` and delete every hit
 /// when the broker follow-ups land — this is NOT a real version.
 #[cfg(windows)]
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #7 (+ FU-4 WinVerifyTrust)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #8 (+ FU-5 multi-instance broker)";
 
 /// Run the broker in foreground mode.
 #[cfg(windows)]
@@ -145,18 +173,52 @@ fn warn_if_not_elevated() {
 /// - S5.4: Rate limiting (1 request per drive per 10s)
 /// - S5.5: Read-only handles only (enforced in `handle_pipe_request`)
 #[cfg(windows)]
+#[expect(
+    clippy::infinite_loop,
+    reason = "the broker serves connections until the process is stopped"
+)]
 fn serve_pipe_requests() -> anyhow::Result<()> {
-    tracing::info!(pipe = PIPE_NAME, "Listening for handle requests");
+    use alloc::sync::Arc;
+    use core::time::Duration;
 
-    // S5.4: Rate limiter — tracks last request time per drive letter
-    let mut rate_limit: std::collections::HashMap<char, std::time::Instant> =
-        std::collections::HashMap::new();
+    tracing::info!(
+        pipe = PIPE_NAME,
+        max_instances = MAX_PIPE_INSTANCES,
+        "Listening for handle requests"
+    );
+
+    // S5.4: rate-limit state, shared across per-connection workers.
+    let rate_limit: Arc<RateLimit> =
+        Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
 
     loop {
-        let pipe = create_broker_pipe()?;
-        wait_for_client(pipe)?;
-        handle_one_connection(pipe, &mut rate_limit);
-        disconnect_and_close(pipe);
+        // Create the next listening instance.  If all instances are busy this
+        // fails transiently — back off briefly and retry rather than exit.
+        let pipe = match create_broker_pipe() {
+            Ok(pipe) => pipe,
+            Err(err) => {
+                tracing::warn!(error = %err, "pipe instance unavailable; retrying shortly");
+                std::thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+        };
+        if let Err(err) = wait_for_client(pipe) {
+            tracing::warn!(error = %err, "wait_for_client failed; dropping instance");
+            disconnect_pipe(pipe);
+            close_pipe(pipe);
+            continue;
+        }
+
+        // Hand the connected instance to a worker and immediately loop to
+        // create the next listener, so there's always an instance accepting.
+        let owned = OwnedHandle::new(pipe);
+        let worker_rate_limit = Arc::clone(&rate_limit);
+        std::thread::spawn(move || {
+            handle_one_connection(owned.raw(), &worker_rate_limit);
+            disconnect_pipe(owned.raw());
+            // `owned` drops here → CloseHandle frees the pipe instance, even if
+            // `handle_one_connection` panicked.
+        });
     }
 }
 
@@ -167,10 +229,7 @@ fn serve_pipe_requests() -> anyhow::Result<()> {
 /// GRANTED / FAILED) inside this function so the caller only needs to
 /// disconnect and loop.
 #[cfg(windows)]
-fn handle_one_connection(
-    pipe: windows::Win32::Foundation::HANDLE,
-    rate_limit: &mut std::collections::HashMap<char, std::time::Instant>,
-) {
+fn handle_one_connection(pipe: windows::Win32::Foundation::HANDLE, rate_limit: &RateLimit) {
     let Some(pid) = get_pipe_client_pid(pipe) else {
         audit_log("REJECTED", 0, None, None, "could not determine client PID");
         tracing::warn!("Could not determine client PID — rejecting");
@@ -243,7 +302,7 @@ fn process_drive_request(
     client_process: &OwnedProcessHandle,
     pid: u32,
     exe: Option<&str>,
-    rate_limit: &mut std::collections::HashMap<char, std::time::Instant>,
+    rate_limit: &RateLimit,
 ) {
     match handle_pipe_request_with_rate_limit(pipe, client_process, pid, rate_limit) {
         Ok(drive) => {
@@ -262,7 +321,7 @@ fn handle_pipe_request_with_rate_limit(
     pipe: windows::Win32::Foundation::HANDLE,
     client_process: &OwnedProcessHandle,
     client_pid: u32,
-    rate_limit: &mut std::collections::HashMap<char, std::time::Instant>,
+    rate_limit: &RateLimit,
 ) -> anyhow::Result<char> {
     // Peek at the 1-byte request via the shared protocol parser.
     // `HandleRequest::parse` rejects non-ASCII bytes and non-alphabetic
@@ -280,15 +339,26 @@ fn handle_pipe_request_with_rate_limit(
         }
     };
 
-    // S5.4: Rate limit — 1 request per drive per 10 seconds
+    // S5.4: Rate limit — 1 request per drive per 10 seconds.  Decide under the
+    // lock (recovering a poisoned mutex), then act without holding it so no
+    // pipe I/O happens while the shared map is locked.
     let now = std::time::Instant::now();
-    if let Some(last) = rate_limit.get(&drive_letter)
-        && now.duration_since(*last).as_secs() < 10
-    {
+    let rate_limited = {
+        let mut guard = rate_limit
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let limited = guard
+            .get(&drive_letter)
+            .is_some_and(|last| now.duration_since(*last).as_secs() < 10);
+        if !limited {
+            guard.insert(drive_letter, now);
+        }
+        limited
+    };
+    if rate_limited {
         write_pipe(pipe, &HandleResponse::error().encode())?;
         anyhow::bail!("Rate limited: drive {drive_letter} requested too recently");
     }
-    rate_limit.insert(drive_letter, now);
 
     // Delegate to actual handle brokering (drive letter already read)
     handle_pipe_request_inner(pipe, client_process, client_pid, drive_letter)?;
@@ -314,140 +384,6 @@ fn audit_log(action: &str, pid: u32, exe: Option<&str>, drive: Option<char>, det
 
 // ── D7.3: Named Pipe Operations ─────────────────────────────────────────
 
-/// Create a named pipe with owner-only access.
-#[cfg(windows)]
-#[expect(unsafe_code, reason = "CreateNamedPipeW is an FFI call")]
-fn create_broker_pipe() -> anyhow::Result<windows::Win32::Foundation::HANDLE> {
-    use std::os::windows::ffi::OsStrExt as _;
-
-    use windows::Win32::Security::SECURITY_ATTRIBUTES;
-    use windows::Win32::Storage::FileSystem::{FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_ACCESS_DUPLEX};
-    use windows::Win32::System::Pipes::{
-        CreateNamedPipeW, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_WAIT,
-    };
-    use windows::core::PCWSTR;
-
-    let pipe_name: Vec<u16> = std::ffi::OsStr::new(PIPE_NAME)
-        .encode_wide()
-        .chain(Some(0))
-        .collect();
-
-    // The whole point of the broker is to serve a NON-elevated daemon.  With
-    // `None` security, an elevated/SYSTEM creator gets an owner-only DACL AND
-    // a high mandatory-integrity label, so the medium-integrity daemon can't
-    // even open the pipe.  Build an explicit descriptor that lets the daemon
-    // connect; the broker still verifies the client is uffsd + Authenticode
-    // before granting any handle (`check_client_identity`), so a permissive
-    // *connect* ACL is not a privilege leak.
-    let security = PipeSecurity::build()?;
-    let sa = SECURITY_ATTRIBUTES {
-        nLength: u32::try_from(size_of::<SECURITY_ATTRIBUTES>()).unwrap_or(0),
-        lpSecurityDescriptor: security.descriptor_ptr(),
-        bInheritHandle: false.into(),
-    };
-
-    // SAFETY: `pipe_name` is a NUL-terminated UTF-16 buffer and `sa` (with its
-    // security descriptor) both live until after this call returns; the pipe
-    // copies the descriptor, so `security` may be dropped afterwards.
-    let handle = unsafe {
-        CreateNamedPipeW(
-            PCWSTR(pipe_name.as_ptr()),
-            PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
-            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
-            1,    // max instances
-            1024, // out buffer
-            1024, // in buffer
-            0,    // default timeout
-            Some(&raw const sa),
-        )
-    };
-    drop(security);
-
-    if handle.is_invalid() {
-        anyhow::bail!(
-            "CreateNamedPipeW failed: {}",
-            std::io::Error::last_os_error()
-        );
-    }
-
-    Ok(handle)
-}
-
-/// Owns a self-relative security descriptor built from SDDL, for the broker
-/// pipe.  Frees the descriptor (`LocalFree`) on drop.
-///
-/// SDDL: `D:(A;;GRGW;;;AU)S:(ML;;NW;;;LW)`
-/// - DACL grants Authenticated Users generic read+write (enough to open and
-///   talk to the pipe — identity is checked at the app layer per request).
-/// - SACL sets a **low** mandatory-integrity label so the medium-integrity
-///   (non-elevated) daemon is not blocked by the high label an elevated/SYSTEM
-///   creator would otherwise stamp on the object.
-#[cfg(windows)]
-struct PipeSecurity {
-    /// `LocalAlloc`-ed self-relative security descriptor; freed on drop.
-    descriptor: windows::Win32::Security::PSECURITY_DESCRIPTOR,
-}
-
-#[cfg(windows)]
-impl PipeSecurity {
-    /// Build the broker-pipe security descriptor from SDDL (see the type docs).
-    #[expect(
-        unsafe_code,
-        reason = "FFI: ConvertStringSecurityDescriptorToSecurityDescriptorW"
-    )]
-    fn build() -> anyhow::Result<Self> {
-        use windows::Win32::Security::Authorization::{
-            ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
-        };
-        use windows::Win32::Security::PSECURITY_DESCRIPTOR;
-        use windows::core::PCWSTR;
-
-        let sddl: Vec<u16> = "D:(A;;GRGW;;;AU)S:(ML;;NW;;;LW)"
-            .encode_utf16()
-            .chain(Some(0))
-            .collect();
-        let mut descriptor = PSECURITY_DESCRIPTOR::default();
-        // SAFETY: `sddl` is a NUL-terminated UTF-16 string valid for the call;
-        // `descriptor` is a valid out-pointer that receives a `LocalAlloc`-ed
-        // descriptor we free in `Drop`.
-        unsafe {
-            ConvertStringSecurityDescriptorToSecurityDescriptorW(
-                PCWSTR(sddl.as_ptr()),
-                SDDL_REVISION_1,
-                &raw mut descriptor,
-                None,
-            )
-        }
-        .map_err(|err| anyhow::anyhow!("failed to build pipe security descriptor: {err}"))?;
-        Ok(Self { descriptor })
-    }
-
-    /// Raw pointer to the descriptor, for `SECURITY_ATTRIBUTES`.
-    const fn descriptor_ptr(&self) -> *mut core::ffi::c_void {
-        self.descriptor.0
-    }
-}
-
-#[cfg(windows)]
-impl Drop for PipeSecurity {
-    #[expect(
-        unsafe_code,
-        reason = "FFI: LocalFree of the SDDL-allocated descriptor"
-    )]
-    fn drop(&mut self) {
-        if !self.descriptor.0.is_null() {
-            // SAFETY: `descriptor.0` was allocated by
-            // `ConvertStringSecurityDescriptorToSecurityDescriptorW` via
-            // `LocalAlloc`; freeing it once on drop is the documented contract.
-            _ = unsafe {
-                windows::Win32::Foundation::LocalFree(Some(windows::Win32::Foundation::HLOCAL(
-                    self.descriptor.0,
-                )))
-            };
-        }
-    }
-}
-
 /// Wait for a client to connect to the pipe.
 #[cfg(windows)]
 #[expect(unsafe_code, reason = "ConnectNamedPipe is an FFI call")]
@@ -468,14 +404,11 @@ fn wait_for_client(pipe: windows::Win32::Foundation::HANDLE) -> anyhow::Result<(
     Ok(())
 }
 
-/// Disconnect client and close pipe handle.
+/// Disconnect any connected client from a pipe instance (the handle itself is
+/// closed separately — by [`close_pipe`] or the worker's [`OwnedHandle`] drop).
 #[cfg(windows)]
-#[expect(
-    unsafe_code,
-    reason = "DisconnectNamedPipe + CloseHandle are FFI calls"
-)]
-fn disconnect_and_close(pipe: windows::Win32::Foundation::HANDLE) {
-    use windows::Win32::Foundation::CloseHandle;
+#[expect(unsafe_code, reason = "DisconnectNamedPipe is an FFI call")]
+fn disconnect_pipe(pipe: windows::Win32::Foundation::HANDLE) {
     use windows::Win32::System::Pipes::DisconnectNamedPipe;
 
     // SAFETY: `pipe` is a valid HANDLE created by create_broker_pipe; the
@@ -483,6 +416,16 @@ fn disconnect_and_close(pipe: windows::Win32::Foundation::HANDLE) {
     if let Err(err) = unsafe { DisconnectNamedPipe(pipe) } {
         tracing::debug!(err = ?err, "DisconnectNamedPipe failed (may be already disconnected)");
     }
+}
+
+/// Close a pipe instance handle.  Used on the accept-loop error path where the
+/// instance isn't wrapped in an [`OwnedHandle`]; the worker path closes via the
+/// `OwnedHandle` drop instead.
+#[cfg(windows)]
+#[expect(unsafe_code, reason = "CloseHandle is an FFI call")]
+fn close_pipe(pipe: windows::Win32::Foundation::HANDLE) {
+    use windows::Win32::Foundation::CloseHandle;
+
     // SAFETY: `pipe` is about to be discarded; CloseHandle releases its OS
     // kernel-object reference.  Failure is logged but non-fatal.
     if let Err(err) = unsafe { CloseHandle(pipe) } {

--- a/crates/uffs-broker/src/broker/owned_handle.rs
+++ b/crates/uffs-broker/src/broker/owned_handle.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! `Send`-safe RAII wrapper for an owned Win32 `HANDLE` (SBB-2).
+//!
+//! The broker's multi-instance serve loop (FU-5) hands a **connected pipe
+//! instance** off to a worker thread.  A raw `HANDLE` is neither `Send` (so it
+//! can't move into the thread) nor self-closing (so every path must remember
+//! `CloseHandle`).  `OwnedHandle` wraps it with a documented `Send` impl and a
+//! `Drop` that closes exactly once — so a worker that panics still releases the
+//! pipe instance.
+
+#[cfg(windows)]
+use windows::Win32::Foundation::HANDLE;
+
+/// Owns a Win32 kernel handle and closes it on drop.
+#[cfg(windows)]
+pub(super) struct OwnedHandle(HANDLE);
+
+#[cfg(windows)]
+#[expect(
+    unsafe_code,
+    reason = "kernel HANDLE has no thread affinity; safe to move between threads"
+)]
+// SAFETY: a Win32 kernel handle is a process-wide value with no thread
+// affinity, so moving it between threads is sound.  Concurrent *use* of the
+// same handle still requires external synchronisation, exactly as with the raw
+// Win32 API — `OwnedHandle` only makes the *move* type-safe.
+unsafe impl Send for OwnedHandle {}
+
+#[cfg(windows)]
+impl OwnedHandle {
+    /// Take ownership of `handle`; its lifetime is now tied to this value.
+    pub(super) const fn new(handle: HANDLE) -> Self {
+        Self(handle)
+    }
+
+    /// Borrow the raw handle for an FFI call without giving up ownership.
+    ///
+    /// The returned `HANDLE` must not outlive `self` (which closes it on drop).
+    pub(super) const fn raw(&self) -> HANDLE {
+        self.0
+    }
+}
+
+#[cfg(windows)]
+impl Drop for OwnedHandle {
+    #[expect(unsafe_code, reason = "CloseHandle for the owned handle")]
+    fn drop(&mut self) {
+        // SAFETY: `self.0` was handed to `new` as an owned, still-open handle
+        // and is closed exactly once here.
+        if let Err(err) = unsafe { windows::Win32::Foundation::CloseHandle(self.0) } {
+            tracing::debug!(err = ?err, "CloseHandle failed dropping OwnedHandle");
+        }
+    }
+}

--- a/crates/uffs-broker/src/broker/pipe.rs
+++ b/crates/uffs-broker/src/broker/pipe.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Broker named-pipe creation with its SDDL security descriptor.
+//!
+//! Split out of `broker.rs` to keep that file under the 800-LOC ceiling
+//! (alongside `service.rs`, `process_handle.rs`, `authenticode.rs`,
+//! `owned_handle.rs`).  The accept loop, connection handling, and pipe I/O
+//! stay in `broker.rs`; this module owns only *creating* a listening instance
+//! with the right ACL + integrity label.
+
+#[cfg(windows)]
+use uffs_broker_protocol::PIPE_NAME;
+
+/// Create a broker named-pipe instance reachable by the non-elevated daemon.
+#[cfg(windows)]
+#[expect(unsafe_code, reason = "CreateNamedPipeW is an FFI call")]
+pub(super) fn create_broker_pipe() -> anyhow::Result<windows::Win32::Foundation::HANDLE> {
+    use std::os::windows::ffi::OsStrExt as _;
+
+    use windows::Win32::Security::SECURITY_ATTRIBUTES;
+    use windows::Win32::Storage::FileSystem::{FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_ACCESS_DUPLEX};
+    use windows::Win32::System::Pipes::{
+        CreateNamedPipeW, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_WAIT,
+    };
+    use windows::core::PCWSTR;
+
+    let pipe_name: Vec<u16> = std::ffi::OsStr::new(PIPE_NAME)
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+
+    // The whole point of the broker is to serve a NON-elevated daemon.  With
+    // `None` security, an elevated/SYSTEM creator gets an owner-only DACL AND
+    // a high mandatory-integrity label, so the medium-integrity daemon can't
+    // even open the pipe.  Build an explicit descriptor that lets the daemon
+    // connect; the broker still verifies the client is uffsd + Authenticode
+    // before granting any handle (`check_client_identity`), so a permissive
+    // *connect* ACL is not a privilege leak.
+    let security = PipeSecurity::build()?;
+    let sa = SECURITY_ATTRIBUTES {
+        nLength: u32::try_from(size_of::<SECURITY_ATTRIBUTES>()).unwrap_or(0),
+        lpSecurityDescriptor: security.descriptor_ptr(),
+        bInheritHandle: false.into(),
+    };
+
+    // SAFETY: `pipe_name` is a NUL-terminated UTF-16 buffer and `sa` (with its
+    // security descriptor) both live until after this call returns; the pipe
+    // copies the descriptor, so `security` may be dropped afterwards.
+    let handle = unsafe {
+        CreateNamedPipeW(
+            PCWSTR(pipe_name.as_ptr()),
+            PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+            super::MAX_PIPE_INSTANCES, // max instances (FU-5)
+            1024,                      // out buffer
+            1024,                      // in buffer
+            0,                         // default timeout
+            Some(&raw const sa),
+        )
+    };
+    drop(security);
+
+    if handle.is_invalid() {
+        anyhow::bail!(
+            "CreateNamedPipeW failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    Ok(handle)
+}
+
+/// Owns a self-relative security descriptor built from SDDL, for the broker
+/// pipe.  Frees the descriptor (`LocalFree`) on drop.
+///
+/// SDDL: `D:(A;;GRGW;;;AU)S:(ML;;NW;;;LW)`
+/// - DACL grants Authenticated Users generic read+write (enough to open and
+///   talk to the pipe — identity is checked at the app layer per request).
+/// - SACL sets a **low** mandatory-integrity label so the medium-integrity
+///   (non-elevated) daemon is not blocked by the high label an elevated/SYSTEM
+///   creator would otherwise stamp on the object.
+#[cfg(windows)]
+struct PipeSecurity {
+    /// `LocalAlloc`-ed self-relative security descriptor; freed on drop.
+    descriptor: windows::Win32::Security::PSECURITY_DESCRIPTOR,
+}
+
+#[cfg(windows)]
+impl PipeSecurity {
+    /// Build the broker-pipe security descriptor from SDDL (see the type docs).
+    #[expect(
+        unsafe_code,
+        reason = "FFI: ConvertStringSecurityDescriptorToSecurityDescriptorW"
+    )]
+    fn build() -> anyhow::Result<Self> {
+        use windows::Win32::Security::Authorization::{
+            ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+        };
+        use windows::Win32::Security::PSECURITY_DESCRIPTOR;
+        use windows::core::PCWSTR;
+
+        let sddl: Vec<u16> = "D:(A;;GRGW;;;AU)S:(ML;;NW;;;LW)"
+            .encode_utf16()
+            .chain(Some(0))
+            .collect();
+        let mut descriptor = PSECURITY_DESCRIPTOR::default();
+        // SAFETY: `sddl` is a NUL-terminated UTF-16 string valid for the call;
+        // `descriptor` is a valid out-pointer that receives a `LocalAlloc`-ed
+        // descriptor we free in `Drop`.
+        unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                PCWSTR(sddl.as_ptr()),
+                SDDL_REVISION_1,
+                &raw mut descriptor,
+                None,
+            )
+        }
+        .map_err(|err| anyhow::anyhow!("failed to build pipe security descriptor: {err}"))?;
+        Ok(Self { descriptor })
+    }
+
+    /// Raw pointer to the descriptor, for `SECURITY_ATTRIBUTES`.
+    const fn descriptor_ptr(&self) -> *mut core::ffi::c_void {
+        self.descriptor.0
+    }
+}
+
+#[cfg(windows)]
+impl Drop for PipeSecurity {
+    #[expect(
+        unsafe_code,
+        reason = "FFI: LocalFree of the SDDL-allocated descriptor"
+    )]
+    fn drop(&mut self) {
+        if !self.descriptor.0.is_null() {
+            // SAFETY: `descriptor.0` was allocated by
+            // `ConvertStringSecurityDescriptorToSecurityDescriptorW` via
+            // `LocalAlloc`; freeing it once on drop is the documented contract.
+            _ = unsafe {
+                windows::Win32::Foundation::LocalFree(Some(windows::Win32::Foundation::HLOCAL(
+                    self.descriptor.0,
+                )))
+            };
+        }
+    }
+}

--- a/crates/uffs-broker/src/main.rs
+++ b/crates/uffs-broker/src/main.rs
@@ -26,6 +26,14 @@
 // in `Cargo.toml`, so they don't even exist as `extern crate`s on
 // non-Windows targets — the bin's non-Windows compilation produces no
 // `unused_crate_dependencies` warnings without any markers.
+
+// The workspace prefers `alloc::` over `std::` for smart pointers (clippy
+// `std_instead_of_alloc`); the broker's FU-5 serve loop uses
+// `alloc::sync::Arc`, so bring the crate into scope (Windows-only, like
+// `broker`).
+#[cfg(windows)]
+extern crate alloc;
+
 #[cfg(windows)]
 mod broker;
 

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -56,7 +56,7 @@ pub(crate) fn validate_data_sources(
 /// every build you intend to validate**, and keep it identical to the broker's
 /// tag in `uffs-broker/src/broker.rs`.  Grep `TEMP-BROKER-FLOW` and delete
 /// every hit when the broker follow-ups land — this is NOT a real version.
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #7 (+ FU-4 WinVerifyTrust)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #8 (+ FU-5 multi-instance broker)";
 
 /// Emit the startup `tracing::info!` line with every config field
 /// the operator might want to grep for.  Extracted so the orchestrator

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -125,7 +125,7 @@ pick an item up. `Depends on` must be `🟩` before you start.
 | FU-8 | `$UpCase` overlapped-handle read | LOW–MED | S | 🟩 | claude | #410 | FU-3 |
 | FU-1 | Windows Service dispatcher | HIGH | M | ⬜ | — | — | — |
 | FU-4 | `WinVerifyTrust` + Authenticode cache | MEDIUM | M | ⬜ | — | — | — |
-| FU-5 | Async multi-instance broker + `OwnedHandle` | MEDIUM | L | ⬜ | — | — | SBB-2 |
+| FU-5 | Multi-instance threaded broker + `OwnedHandle` | MEDIUM | L | 🟦 | claude | — | SBB-2 |
 | FU-6 | Non-connecting client pipe probe | LOW | S | 🟦 | claude | — | — |
 | FU-7 | Volume-data FSCTL overlapped | LOW–MED | S | ✅ moot | claude | — | — |
 
@@ -135,7 +135,7 @@ depend on them — see [§3](#3-shared-building-blocks)):
 | ID | Title | Status | PR |
 |----|-------|--------|----|
 | SBB-1 | `try_adopt_broker_handle` shared peek+duplicate in `uffs-mft` | 🟩 | #405 |
-| SBB-2 | `OwnedHandle` Send-safe RAII wrapper | ⬜ | — |
+| SBB-2 | `OwnedHandle` Send-safe RAII wrapper | 🟦 | (with FU-5) |
 
 Effort key: `XS` <1h · `S` ~half-day · `M` ~1–2 days · `L` ~3–5 days (all
 including tests + a VM validation round).


### PR DESCRIPTION
## What & why

The broker served a **single** pipe instance in a serial loop (create → wait → handle → disconnect → repeat). Concurrent clients (multiple daemons, or a future parallel warm-up) queued or hit `ERROR_PIPE_BUSY`.

## SBB-2 — `OwnedHandle` (`broker/owned_handle.rs`)

A `Send`-safe RAII wrapper for a Win32 `HANDLE` — documented `unsafe impl Send` (kernel handles have no thread affinity), `Drop` closes once. Lets a connected pipe instance move into a worker thread and frees it even if the worker panics.

## FU-5 — multi-instance threaded serve loop

- Pipe bumped to `MAX_PIPE_INSTANCES` (16).
- After a client connects, the instance is handed to a **worker thread** (handle + disconnect; `OwnedHandle` drop closes) and the accept loop **immediately creates the next listener**, so there's always an instance accepting.
- The per-drive rate limiter is now a shared `Arc<Mutex<…>>` (decide under the lock, act without holding it — no pipe I/O while locked).
- Pipe create / wait failures are logged + retried instead of killing the broker.

**Threads, not tokio:** the broker is a tiny handle vendor and the common case is one daemon, so a thread per connection (bounded by 16 instances) is proportionate and avoids pulling an async runtime into the binary.

Extracted `create_broker_pipe` + `PipeSecurity` into `broker/pipe.rs` to keep `broker.rs` under the 800-LOC ceiling (now 691).

## Validation

Exact `cargo xwin clippy --workspace --all-features` clean. The single-daemon flow is unchanged (sequential requests still serialize naturally); concurrency is the new capability. Build tag → `#8`. On the VM, the broker should still grant handles normally, now logging `max_instances=16`.