### PR TITLE
feat(broker): Windows Service control dispatcher (FU-1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,7 @@ windows = { version = "0.62.2", features = [
   "Win32_System_Memory",
   "Win32_System_Pipes",
   "Win32_System_ProcessStatus",
+  "Win32_System_Services",
   "Win32_System_SystemInformation",
   "Win32_System_Threading",
   "Win32_System_Time",

--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -95,8 +95,10 @@ pub(crate) fn run() -> anyhow::Result<()> {
         return run_foreground();
     }
 
-    print_usage();
-    Ok(())
+    // No recognised flag: this is how the Service Control Manager launches the
+    // service at boot.  Hand control to the dispatcher; when run interactively
+    // (no SCM) it falls back to printing usage (FU-1).
+    service::run_as_service()
 }
 
 /// Print CLI usage help to stderr.
@@ -122,7 +124,7 @@ fn print_usage() {
 /// `uffs-daemon/src/startup.rs`.  Grep `TEMP-BROKER-FLOW` and delete every hit
 /// when the broker follow-ups land — this is NOT a real version.
 #[cfg(windows)]
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #8 (+ FU-5 multi-instance broker)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #9 (+ FU-1 service dispatcher)";
 
 /// Run the broker in foreground mode.
 #[cfg(windows)]
@@ -173,10 +175,6 @@ fn warn_if_not_elevated() {
 /// - S5.4: Rate limiting (1 request per drive per 10s)
 /// - S5.5: Read-only handles only (enforced in `handle_pipe_request`)
 #[cfg(windows)]
-#[expect(
-    clippy::infinite_loop,
-    reason = "the broker serves connections until the process is stopped"
-)]
 fn serve_pipe_requests() -> anyhow::Result<()> {
     use alloc::sync::Arc;
     use core::time::Duration;
@@ -192,6 +190,11 @@ fn serve_pipe_requests() -> anyhow::Result<()> {
         Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
 
     loop {
+        // FU-1: exit cleanly when the service control handler requests a stop.
+        if service::stop_requested() {
+            return Ok(());
+        }
+
         // Create the next listening instance.  If all instances are busy this
         // fails transiently — back off briefly and retry rather than exit.
         let pipe = match create_broker_pipe() {
@@ -207,6 +210,14 @@ fn serve_pipe_requests() -> anyhow::Result<()> {
             disconnect_pipe(pipe);
             close_pipe(pipe);
             continue;
+        }
+
+        // FU-1: a connection arriving after a stop was requested is the control
+        // handler's wake-up `CreateFile` — drop it and exit.
+        if service::stop_requested() {
+            disconnect_pipe(pipe);
+            close_pipe(pipe);
+            return Ok(());
         }
 
         // Hand the connected instance to a worker and immediately loop to

--- a/crates/uffs-broker/src/broker/service.rs
+++ b/crates/uffs-broker/src/broker/service.rs
@@ -1,13 +1,42 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! Windows Service registration helpers for the access broker.
+//! Windows Service registration + control dispatcher for the access broker.
 //!
-//! Extracted from `broker.rs` (which sits at the 800-LOC file-size ceiling) as
-//! a self-contained, behavior-neutral unit: `install_service` /
-//! `uninstall_service` shell out to `sc` and share no state with the
-//! pipe-serving or client-verification logic. Both are admin-only CLI commands
-//! invoked from `broker::run`.
+//! Extracted from `broker.rs` (which sits at the 800-LOC file-size ceiling).
+//! `install_service` / `uninstall_service` shell out to `sc`; the FU-1
+//! dispatcher (`run_as_service`, `service_main`, the control handler) is the
+//! `LocalSystem` entry point the SCM invokes at boot — so the broker runs as a
+//! real service without the `--run` terminal.
+
+/// Registered service name — must match the `sc create` name and the
+/// `service_main` table entry.
+#[cfg(windows)]
+const SERVICE_NAME: &str = "UffsAccessBroker";
+
+/// Set by the SCM control handler on STOP / SHUTDOWN; polled by the broker's
+/// accept loop ([`stop_requested`]) so it exits between connections.
+#[cfg(windows)]
+static STOP_REQUESTED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+/// `SERVICE_STATUS_HANDLE` from `RegisterServiceCtrlHandlerW`, stored so the
+/// control handler (a C callback with no user context) can report status.
+/// Null until `service_main` registers it.
+#[cfg(windows)]
+static STATUS_HANDLE: core::sync::atomic::AtomicPtr<core::ffi::c_void> =
+    core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
+
+/// `true` once a service stop has been requested; the accept loop checks this.
+#[cfg(windows)]
+pub(super) fn stop_requested() -> bool {
+    STOP_REQUESTED.load(core::sync::atomic::Ordering::Relaxed)
+}
+
+/// Encode `text` as a NUL-terminated UTF-16 buffer for Win32 wide-string APIs.
+#[cfg(windows)]
+fn wide(text: &str) -> Vec<u16> {
+    text.encode_utf16().chain(core::iter::once(0)).collect()
+}
 
 /// Register the broker as an auto-start Windows Service and start it.
 ///
@@ -110,4 +139,169 @@ pub(super) fn uninstall_service() -> anyhow::Result<()> {
         anyhow::bail!("Uninstall failed: {stderr}");
     }
     Ok(())
+}
+
+// ── FU-1: Windows Service control dispatcher ────────────────────────────────
+
+/// Hand control to the SCM via `StartServiceCtrlDispatcherW`; blocks until the
+/// service stops.
+///
+/// When the binary is launched **interactively** (no SCM), the dispatcher fails
+/// with `ERROR_FAILED_SERVICE_CONTROLLER_CONNECT` (1063) — in that case we
+/// print usage, so a bare `uffs-broker` is still helpful instead of hanging.
+#[cfg(windows)]
+#[expect(unsafe_code, reason = "FFI: StartServiceCtrlDispatcherW")]
+pub(super) fn run_as_service() -> anyhow::Result<()> {
+    use windows::Win32::Foundation::ERROR_FAILED_SERVICE_CONTROLLER_CONNECT;
+    use windows::Win32::System::Services::{SERVICE_TABLE_ENTRYW, StartServiceCtrlDispatcherW};
+    use windows::core::PWSTR;
+
+    let mut name = wide(SERVICE_NAME);
+    let table = [
+        SERVICE_TABLE_ENTRYW {
+            lpServiceName: PWSTR(name.as_mut_ptr()),
+            lpServiceProc: Some(service_main),
+        },
+        SERVICE_TABLE_ENTRYW::default(), // NULL terminator
+    ];
+
+    // SAFETY: `table` is NULL-terminated and, with `name`, outlives the
+    // (blocking) dispatcher call.
+    match unsafe { StartServiceCtrlDispatcherW(table.as_ptr()) } {
+        Ok(()) => Ok(()),
+        Err(err) if err.code() == ERROR_FAILED_SERVICE_CONTROLLER_CONNECT.to_hresult() => {
+            // Not launched by the SCM → interactive invocation.
+            super::print_usage();
+            Ok(())
+        }
+        Err(err) => Err(anyhow::anyhow!("StartServiceCtrlDispatcherW failed: {err}")),
+    }
+}
+
+/// SCM service entry point: register the control handler, report RUNNING, serve
+/// until a stop is requested, then report STOPPED.
+#[cfg(windows)]
+#[expect(unsafe_code, reason = "FFI: RegisterServiceCtrlHandlerW")]
+extern "system" fn service_main(_argc: u32, _argv: *mut windows::core::PWSTR) {
+    use core::sync::atomic::Ordering;
+
+    use windows::Win32::System::Services::{
+        RegisterServiceCtrlHandlerW, SERVICE_RUNNING, SERVICE_START_PENDING, SERVICE_STOPPED,
+    };
+    use windows::core::PCWSTR;
+
+    let name = wide(SERVICE_NAME);
+    // SAFETY: `name` is a NUL-terminated wide string valid for the call.
+    let Ok(handle) =
+        (unsafe { RegisterServiceCtrlHandlerW(PCWSTR(name.as_ptr()), Some(service_ctrl_handler)) })
+    else {
+        return;
+    };
+    STATUS_HANDLE.store(handle.0, Ordering::Relaxed);
+
+    report_status(SERVICE_START_PENDING, 0);
+    super::init_tracing();
+    tracing::info!("uffs-broker starting (service mode)");
+    report_status(SERVICE_RUNNING, accepted_controls());
+
+    if let Err(err) = super::serve_pipe_requests() {
+        tracing::error!(error = %err, "broker serve loop exited with error");
+    }
+    tracing::info!("uffs-broker stopped (service mode)");
+    report_status(SERVICE_STOPPED, 0);
+}
+
+/// SCM control handler: on STOP / SHUTDOWN flag the accept loop to exit and
+/// nudge it awake (it blocks in `ConnectNamedPipe`).
+#[cfg(windows)]
+extern "system" fn service_ctrl_handler(control: u32) {
+    use core::sync::atomic::Ordering;
+
+    use windows::Win32::System::Services::{
+        SERVICE_CONTROL_INTERROGATE, SERVICE_CONTROL_SHUTDOWN, SERVICE_CONTROL_STOP,
+        SERVICE_RUNNING, SERVICE_STOP_PENDING,
+    };
+
+    if control == SERVICE_CONTROL_STOP || control == SERVICE_CONTROL_SHUTDOWN {
+        STOP_REQUESTED.store(true, Ordering::Relaxed);
+        report_status(SERVICE_STOP_PENDING, 0);
+        signal_stop();
+    } else if control == SERVICE_CONTROL_INTERROGATE {
+        report_status(SERVICE_RUNNING, accepted_controls());
+    }
+}
+
+/// Controls the broker accepts while RUNNING (operator STOP + system SHUTDOWN).
+#[cfg(windows)]
+const fn accepted_controls() -> u32 {
+    use windows::Win32::System::Services::{SERVICE_ACCEPT_SHUTDOWN, SERVICE_ACCEPT_STOP};
+    SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN
+}
+
+/// Report a service-status transition to the SCM (no-op before registration).
+#[cfg(windows)]
+#[expect(unsafe_code, reason = "FFI: SetServiceStatus")]
+fn report_status(
+    state: windows::Win32::System::Services::SERVICE_STATUS_CURRENT_STATE,
+    controls_accepted: u32,
+) {
+    use core::sync::atomic::Ordering;
+
+    use windows::Win32::System::Services::{
+        SERVICE_STATUS, SERVICE_STATUS_HANDLE, SERVICE_WIN32_OWN_PROCESS, SetServiceStatus,
+    };
+
+    let raw = STATUS_HANDLE.load(Ordering::Relaxed);
+    if raw.is_null() {
+        return;
+    }
+    let status = SERVICE_STATUS {
+        dwServiceType: SERVICE_WIN32_OWN_PROCESS,
+        dwCurrentState: state,
+        dwControlsAccepted: controls_accepted,
+        dwWin32ExitCode: 0,
+        dwServiceSpecificExitCode: 0,
+        dwCheckPoint: 0,
+        dwWaitHint: 0,
+    };
+    // SAFETY: `raw` is the handle stored by `service_main`; `status` is fully
+    // initialised and valid for the duration of the call.
+    if let Err(err) = unsafe { SetServiceStatus(SERVICE_STATUS_HANDLE(raw), &raw const status) } {
+        tracing::debug!(err = ?err, "SetServiceStatus failed");
+    }
+}
+
+/// Wake the accept loop's blocking `ConnectNamedPipe` by opening the pipe as a
+/// throwaway client, so a stop takes effect promptly.  The loop then sees
+/// [`stop_requested`] and exits without serving this connection.
+#[cfg(windows)]
+#[expect(unsafe_code, reason = "FFI: CreateFileW dummy connect + CloseHandle")]
+fn signal_stop() {
+    use uffs_broker_protocol::PIPE_NAME;
+    use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE};
+    use windows::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_MODE, OPEN_EXISTING,
+    };
+    use windows::core::PCWSTR;
+
+    let name = wide(PIPE_NAME);
+    // SAFETY: `name` is a NUL-terminated wide path valid for the call; any
+    // returned handle is closed immediately below.
+    let opened = unsafe {
+        CreateFileW(
+            PCWSTR(name.as_ptr()),
+            GENERIC_READ.0 | GENERIC_WRITE.0,
+            FILE_SHARE_MODE(0),
+            None,
+            OPEN_EXISTING,
+            FILE_FLAGS_AND_ATTRIBUTES(0),
+            None,
+        )
+    };
+    if let Ok(handle) = opened {
+        // SAFETY: `handle` is a freshly opened, valid handle owned here.
+        if let Err(err) = unsafe { CloseHandle(handle) } {
+            tracing::debug!(err = ?err, "CloseHandle failed for stop-signal pipe");
+        }
+    }
 }

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -56,7 +56,7 @@ pub(crate) fn validate_data_sources(
 /// every build you intend to validate**, and keep it identical to the broker's
 /// tag in `uffs-broker/src/broker.rs`.  Grep `TEMP-BROKER-FLOW` and delete
 /// every hit when the broker follow-ups land — this is NOT a real version.
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #8 (+ FU-5 multi-instance broker)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #9 (+ FU-1 service dispatcher)";
 
 /// Emit the startup `tracing::info!` line with every config field
 /// the operator might want to grep for.  Extracted so the orchestrator

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -123,7 +123,7 @@ pick an item up. `Depends on` must be `🟩` before you start.
 | FU-2b | USN journal read through broker | HIGH | M | 🟩 | claude | #408 | SBB-1 |
 | FU-3 | `get_mft_extents` through broker | HIGH | M | 🟩 | claude | #409 | SBB-1 |
 | FU-8 | `$UpCase` overlapped-handle read | LOW–MED | S | 🟩 | claude | #410 | FU-3 |
-| FU-1 | Windows Service dispatcher | HIGH | M | ⬜ | — | — | — |
+| FU-1 | Windows Service dispatcher | HIGH | M | 🟦 | claude | — | — |
 | FU-4 | `WinVerifyTrust` + Authenticode cache | MEDIUM | M | ⬜ | — | — | — |
 | FU-5 | Multi-instance threaded broker + `OwnedHandle` | MEDIUM | L | 🟦 | claude | — | SBB-2 |
 | FU-6 | Non-connecting client pipe probe | LOW | S | 🟦 | claude | — | — |


### PR DESCRIPTION
## What & why

The broker had `--install`/`--uninstall`/`--run` but **no service-control dispatcher**: when the SCM started the registered service (no args), `run()` fell through to `print_usage()` and exited — so it only ever ran via the `--run` terminal. "Install once, no future UAC across reboots" wasn't actually true.

## The dispatcher (`broker/service.rs`, new `Win32_System_Services` feature)

- `run()` no-arg path → `run_as_service()` → `StartServiceCtrlDispatcherW`. Launched **interactively** (no SCM) it fails `ERROR_FAILED_SERVICE_CONTROLLER_CONNECT` (1063) → prints usage instead of hanging.
- `service_main`: `RegisterServiceCtrlHandlerW`, report `START_PENDING` → `RUNNING`, run the serve loop, report `STOPPED`.
- **Control handler:** on STOP/SHUTDOWN, set a stop flag, report `STOP_PENDING`, and wake the accept loop's blocking `ConnectNamedPipe` via a throwaway `CreateFile` self-connect; the loop sees `stop_requested()` and exits cleanly.
- Status via `SetServiceStatus`; the `SERVICE_STATUS_HANDLE` lives in an `AtomicPtr` so the contextless C control-handler callback can reach it.

`serve_pipe_requests` now checks `stop_requested()` at the loop top and right after a connection arrives (the wake-up connection is dropped). `--run` is unchanged.

## Validation

Exact `cargo xwin clippy --workspace --all-features` clean. **This one needs a reboot/`sc start` VM round** to validate end to end (it's the only item whose real test is the service lifecycle, not a log grep). Build tag → `#9`.

VM check: `uffs-broker --install` → reboot → a cold non-elevated `uffs` search works with **no broker terminal open**; `sc query UffsAccessBroker` shows `RUNNING`; `sc stop UffsAccessBroker` → clean `STOPPED`.

## 🎉 This is the last playbook item

With FU-1, all broker follow-ups are implemented (FU-1/2a/2b/3/4/5/6/8/9 + SBB-1/SBB-2; FU-7 closed as moot).