### PR TITLE
fix(broker): FILE_FLAG_FIRST_PIPE_INSTANCE only on the first instance (FU-5 fix)

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -124,7 +124,7 @@ fn print_usage() {
 /// `uffs-daemon/src/startup.rs`.  Grep `TEMP-BROKER-FLOW` and delete every hit
 /// when the broker follow-ups land — this is NOT a real version.
 #[cfg(windows)]
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #9 (+ FU-1 service dispatcher)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #10 (+ FU-5 first-instance fix)";
 
 /// Run the broker in foreground mode.
 #[cfg(windows)]
@@ -188,6 +188,9 @@ fn serve_pipe_requests() -> anyhow::Result<()> {
     // S5.4: rate-limit state, shared across per-connection workers.
     let rate_limit: Arc<RateLimit> =
         Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+    // Only the very first instance gets FILE_FLAG_FIRST_PIPE_INSTANCE; the rest
+    // must omit it or CreateNamedPipeW fails ERROR_ACCESS_DENIED against it.
+    let mut first_instance = true;
 
     loop {
         // FU-1: exit cleanly when the service control handler requests a stop.
@@ -197,8 +200,11 @@ fn serve_pipe_requests() -> anyhow::Result<()> {
 
         // Create the next listening instance.  If all instances are busy this
         // fails transiently — back off briefly and retry rather than exit.
-        let pipe = match create_broker_pipe() {
-            Ok(pipe) => pipe,
+        let pipe = match create_broker_pipe(first_instance) {
+            Ok(pipe) => {
+                first_instance = false;
+                pipe
+            }
             Err(err) => {
                 tracing::warn!(error = %err, "pipe instance unavailable; retrying shortly");
                 std::thread::sleep(Duration::from_millis(100));

--- a/crates/uffs-broker/src/broker/pipe.rs
+++ b/crates/uffs-broker/src/broker/pipe.rs
@@ -13,9 +13,18 @@
 use uffs_broker_protocol::PIPE_NAME;
 
 /// Create a broker named-pipe instance reachable by the non-elevated daemon.
+///
+/// `first_instance` sets `FILE_FLAG_FIRST_PIPE_INSTANCE`, which fails the call
+/// (`ERROR_ACCESS_DENIED`) if an instance of the name already exists.  The
+/// **first** instance the accept loop creates passes `true` (anti-squatting:
+/// fail loudly if another process already owns `\\.\pipe\uffs-broker`); every
+/// subsequent instance passes `false`, or it would fail against the instance we
+/// just made.
 #[cfg(windows)]
 #[expect(unsafe_code, reason = "CreateNamedPipeW is an FFI call")]
-pub(super) fn create_broker_pipe() -> anyhow::Result<windows::Win32::Foundation::HANDLE> {
+pub(super) fn create_broker_pipe(
+    first_instance: bool,
+) -> anyhow::Result<windows::Win32::Foundation::HANDLE> {
     use std::os::windows::ffi::OsStrExt as _;
 
     use windows::Win32::Security::SECURITY_ATTRIBUTES;
@@ -44,13 +53,20 @@ pub(super) fn create_broker_pipe() -> anyhow::Result<windows::Win32::Foundation:
         bInheritHandle: false.into(),
     };
 
+    // FIRST_PIPE_INSTANCE only on the first instance — see the fn doc.
+    let open_mode = if first_instance {
+        PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE
+    } else {
+        PIPE_ACCESS_DUPLEX
+    };
+
     // SAFETY: `pipe_name` is a NUL-terminated UTF-16 buffer and `sa` (with its
     // security descriptor) both live until after this call returns; the pipe
     // copies the descriptor, so `security` may be dropped afterwards.
     let handle = unsafe {
         CreateNamedPipeW(
             PCWSTR(pipe_name.as_ptr()),
-            PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
+            open_mode,
             PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
             super::MAX_PIPE_INSTANCES, // max instances (FU-5)
             1024,                      // out buffer

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -56,7 +56,7 @@ pub(crate) fn validate_data_sources(
 /// every build you intend to validate**, and keep it identical to the broker's
 /// tag in `uffs-broker/src/broker.rs`.  Grep `TEMP-BROKER-FLOW` and delete
 /// every hit when the broker follow-ups land — this is NOT a real version.
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #9 (+ FU-1 service dispatcher)";
+const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #10 (+ FU-5 first-instance fix)";
 
 /// Emit the startup `tracing::info!` line with every config field
 /// the operator might want to grep for.  Extracted so the orchestrator

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -118,16 +118,16 @@ pick an item up. `Depends on` must be `🟩` before you start.
 
 | ID | Title | Priority | Effort | Status | Owner | PR | Depends on |
 |----|-------|----------|--------|--------|-------|----|-----------|
-| FU-9 | Gate warm-up on `!is_elevated()` | HIGH | XS | 🟩 | claude | #404 | — |
-| FU-2a | Journal-poll backoff (stop the storm) | HIGH | S | 🟩 | claude | #407 | — |
-| FU-2b | USN journal read through broker | HIGH | M | 🟩 | claude | #408 | SBB-1 |
-| FU-3 | `get_mft_extents` through broker | HIGH | M | 🟩 | claude | #409 | SBB-1 |
-| FU-8 | `$UpCase` overlapped-handle read | LOW–MED | S | 🟩 | claude | #410 | FU-3 |
-| FU-1 | Windows Service dispatcher | HIGH | M | 🟦 | claude | — | — |
+| FU-9 | Gate warm-up on `!is_elevated()` | HIGH | XS | 🟩 | Robert | #404 | — |
+| FU-2a | Journal-poll backoff (stop the storm) | HIGH | S | 🟩 | Robert | #407 | — |
+| FU-2b | USN journal read through broker | HIGH | M | 🟩 | Robert | #408 | SBB-1 |
+| FU-3 | `get_mft_extents` through broker | HIGH | M | 🟩 | Robert | #409 | SBB-1 |
+| FU-8 | `$UpCase` overlapped-handle read | LOW–MED | S | 🟩 | Robert | #410 | FU-3 |
+| FU-1 | Windows Service dispatcher | HIGH | M | 🟦 | Robert | — | — |
 | FU-4 | `WinVerifyTrust` + Authenticode cache | MEDIUM | M | ⬜ | — | — | — |
-| FU-5 | Multi-instance threaded broker + `OwnedHandle` | MEDIUM | L | 🟦 | claude | — | SBB-2 |
-| FU-6 | Non-connecting client pipe probe | LOW | S | 🟦 | claude | — | — |
-| FU-7 | Volume-data FSCTL overlapped | LOW–MED | S | ✅ moot | claude | — | — |
+| FU-5 | Multi-instance threaded broker + `OwnedHandle` | MEDIUM | L | 🟦 | Robert | — | SBB-2 |
+| FU-6 | Non-connecting client pipe probe | LOW | S | 🟦 | Robert | — | — |
+| FU-7 | Volume-data FSCTL overlapped | LOW–MED | S | ✅ moot | Robert | — | — |
 
 **Shared building blocks** (land these as their own PRs first; several items
 depend on them — see [§3](#3-shared-building-blocks)):

--- a/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
+++ b/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
@@ -26,7 +26,7 @@ every WI you will find:
 - **Tests** — the test(s) you must add/update (we never reduce coverage).
 - **Verify** — the exact commands to run.
 
-### Working rules (non-negotiable — from `CLAUDE.md` + repo user rules)
+### Working rules (non-negotiable — from `Robert.md` + repo user rules)
 
 1. **One WI = one commit.** Commit message: `fix(security): <root cause>` /
    `refactor(mft): <root cause>` etc. Small, atomic commits.


### PR DESCRIPTION
## Bug (caught on the VM #9 run)

FU-5's multi-instance serve loop called `create_broker_pipe` with `PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE` on **every** instance. That flag makes `CreateNamedPipeW` fail `ERROR_ACCESS_DENIED` if an instance of the name already exists — so the **first** instance succeeded but instances 2..N all failed:

```
WARN pipe instance unavailable; retrying shortly error=CreateNamedPipeW failed: Access is denied. (os error 5)
```

The single-daemon flow still worked (one instance is enough, and the daemon got `GRANTED`), but the concurrency FU-5 added never actually functioned.

## Fix

`create_broker_pipe(first_instance: bool)` sets the flag only when `true`. The accept loop passes `true` for the first instance (anti-squatting — fail loudly if another process already owns `\\.\pipe\uffs-broker`) and `false` for every instance after, so 2..16 are created normally.

## Validation

Exact `cargo xwin clippy --workspace --all-features` clean. Build tag → `#10`. On the VM, expect **no** `pipe instance unavailable` warnings, and concurrent daemons should now get handles in parallel.

(Also confirmed on the #9 run: **FU-6** ✅ no `REJECTED ... uffs.exe`, **FU-4** ✅ instant grant = no PowerShell.)