### PR TITLE
chore(broker): remove TEMP build tag + harden service install/uninstall (closing)

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -117,15 +117,6 @@ fn print_usage() {
     eprintln!("  --run         Run in foreground (debugging)");
 }
 
-/// TEMP-BROKER-FLOW: manually-bumped build tag so VM logs reveal WHICH dev
-/// build is running.  The dev version is pinned at `0.5.123` across iterations,
-/// so it can't distinguish builds; this string can.  **Bump it on every build
-/// you intend to validate**, and keep it identical to the daemon's tag in
-/// `uffs-daemon/src/startup.rs`.  Grep `TEMP-BROKER-FLOW` and delete every hit
-/// when the broker follow-ups land — this is NOT a real version.
-#[cfg(windows)]
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #10 (+ FU-5 first-instance fix)";
-
 /// Run the broker in foreground mode.
 #[cfg(windows)]
 fn run_foreground() -> anyhow::Result<()> {
@@ -134,9 +125,6 @@ fn run_foreground() -> anyhow::Result<()> {
         pid = std::process::id(),
         "uffs-broker starting (foreground mode)"
     );
-    // TEMP-BROKER-FLOW: build-identity line for VM validation; remove with the
-    // `BROKER_FLOW_BUILD_TAG` const above when the broker work lands.
-    tracing::info!(build_tag = BROKER_FLOW_BUILD_TAG, "BROKER-FLOW BUILD TAG");
     warn_if_not_elevated();
     serve_pipe_requests()?;
     tracing::info!("uffs-broker stopped");

--- a/crates/uffs-broker/src/broker/service.rs
+++ b/crates/uffs-broker/src/broker/service.rs
@@ -38,6 +38,19 @@ fn wide(text: &str) -> Vec<u16> {
     text.encode_utf16().chain(core::iter::once(0)).collect()
 }
 
+/// Combine an `sc.exe` invocation's stdout + stderr for an error message.
+///
+/// `sc.exe` writes most of its diagnostics to **stdout**, not stderr, so a
+/// stderr-only message comes out empty (as seen on a failed `sc create`).
+#[cfg(windows)]
+fn sc_output(output: &std::process::Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    format!("{} {}", stdout.trim(), stderr.trim())
+        .trim()
+        .to_owned()
+}
+
 /// Register the broker as an auto-start Windows Service and start it.
 ///
 /// # Why the argv is split the way it is
@@ -69,7 +82,7 @@ pub(super) fn install_service() -> anyhow::Result<()> {
     let create = std::process::Command::new("sc.exe")
         .args([
             "create",
-            "UffsAccessBroker",
+            SERVICE_NAME,
             "binPath=",
             &exe.display().to_string(),
             "start=",
@@ -80,17 +93,20 @@ pub(super) fn install_service() -> anyhow::Result<()> {
         .output()?;
 
     if !create.status.success() {
-        // AUDIT-OK(bytes): `sc` stderr surfaced verbatim to the operator —
+        // AUDIT-OK(bytes): `sc` output surfaced verbatim to the operator —
         // display only, no decision.
-        let stderr = String::from_utf8_lossy(&create.stderr);
-        anyhow::bail!("Install failed (sc create): {stderr}");
+        anyhow::bail!(
+            "Install failed (sc create): {}\n(If the service already exists, run \
+             `uffs-broker --uninstall` first.)",
+            sc_output(&create)
+        );
     }
 
     // Start it now so the broker is usable immediately — the whole point
     // is "no future UAC", which only holds once the service is running.
     // `start= auto` also brings it back on every boot.
     let start = std::process::Command::new("sc.exe")
-        .args(["start", "UffsAccessBroker"])
+        .args(["start", SERVICE_NAME])
         .output()?;
 
     if start.status.success() {
@@ -100,12 +116,12 @@ pub(super) fn install_service() -> anyhow::Result<()> {
              access — no more UAC prompts."
         );
     } else {
-        // AUDIT-OK(bytes): `sc` stderr surfaced verbatim to the operator.
-        let stderr = String::from_utf8_lossy(&start.stderr);
+        // AUDIT-OK(bytes): `sc` output surfaced verbatim to the operator.
         println!(
             "Service installed (auto-start on boot), but starting it failed: \
-             {stderr}\nStart it manually from an elevated shell with:\n    \
-             sc.exe start UffsAccessBroker"
+             {}\nStart it manually from an elevated shell with:\n    \
+             sc.exe start UffsAccessBroker",
+            sc_output(&start)
         );
     }
     Ok(())
@@ -126,17 +142,24 @@ pub(super) fn uninstall_service() -> anyhow::Result<()> {
              Open an elevated terminal and re-run:\n    uffs-broker --uninstall"
         );
     }
+    // Stop the service before deleting it.  `sc delete` on a RUNNING service
+    // only MARKS it for deletion (deferred until it stops), which then makes a
+    // later `--install` fail with a cryptic `sc create` error.  Stopping first
+    // makes the delete take effect immediately.  Ignore the stop result — the
+    // service may already be stopped or not exist.
+    let _stopped = std::process::Command::new("sc.exe")
+        .args(["stop", SERVICE_NAME])
+        .output();
     let output = std::process::Command::new("sc.exe")
-        .args(["delete", "UffsAccessBroker"])
+        .args(["delete", SERVICE_NAME])
         .output()?;
 
     if output.status.success() {
         println!("Service uninstalled.");
     } else {
-        // AUDIT-OK(bytes): `sc` command stderr surfaced verbatim in an
-        // error message for the operator — display only, no decision.
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Uninstall failed: {stderr}");
+        // AUDIT-OK(bytes): `sc` command output surfaced verbatim in an error
+        // message for the operator — display only, no decision.
+        anyhow::bail!("Uninstall failed: {}", sc_output(&output));
     }
     Ok(())
 }

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -50,21 +50,10 @@ pub(crate) fn validate_data_sources(
     Ok(())
 }
 
-/// TEMP-BROKER-FLOW: manually-bumped build tag so VM logs reveal WHICH dev
-/// build is running.  The dev version is pinned at `0.5.123` across iterations,
-/// so `--version` can't distinguish builds; this string can.  **Bump it on
-/// every build you intend to validate**, and keep it identical to the broker's
-/// tag in `uffs-broker/src/broker.rs`.  Grep `TEMP-BROKER-FLOW` and delete
-/// every hit when the broker follow-ups land — this is NOT a real version.
-const BROKER_FLOW_BUILD_TAG: &str = "broker-flow 2026-06-14 #10 (+ FU-5 first-instance fix)";
-
 /// Emit the startup `tracing::info!` line with every config field
 /// the operator might want to grep for.  Extracted so the orchestrator
 /// stays under clippy's `cognitive_complexity` budget.
 pub(crate) fn log_daemon_starting(config: &DaemonConfig) {
-    // TEMP-BROKER-FLOW: build-identity line for VM validation; remove with the
-    // `BROKER_FLOW_BUILD_TAG` const above when the broker work lands.
-    tracing::info!(build_tag = BROKER_FLOW_BUILD_TAG, "BROKER-FLOW BUILD TAG");
     // NOTE: do NOT probe the Access Broker here.  The previous
     // `broker_available()` call used `GetFileAttributesW`, which *connects to*
     // the broker's single pipe instance and leaves it busy — so the real

--- a/docs/architecture/access-broker-followups.md
+++ b/docs/architecture/access-broker-followups.md
@@ -123,10 +123,10 @@ pick an item up. `Depends on` must be `🟩` before you start.
 | FU-2b | USN journal read through broker | HIGH | M | 🟩 | Robert | #408 | SBB-1 |
 | FU-3 | `get_mft_extents` through broker | HIGH | M | 🟩 | Robert | #409 | SBB-1 |
 | FU-8 | `$UpCase` overlapped-handle read | LOW–MED | S | 🟩 | Robert | #410 | FU-3 |
-| FU-1 | Windows Service dispatcher | HIGH | M | 🟦 | Robert | — | — |
-| FU-4 | `WinVerifyTrust` + Authenticode cache | MEDIUM | M | ⬜ | — | — | — |
-| FU-5 | Multi-instance threaded broker + `OwnedHandle` | MEDIUM | L | 🟦 | Robert | — | SBB-2 |
-| FU-6 | Non-connecting client pipe probe | LOW | S | 🟦 | Robert | — | — |
+| FU-1 | Windows Service dispatcher | HIGH | M | 🟩 | Robert | #414 | — |
+| FU-4 | `WinVerifyTrust` + Authenticode cache | MEDIUM | M | 🟩 | Robert | #412 | — |
+| FU-5 | Multi-instance threaded broker + `OwnedHandle` | MEDIUM | L | 🟩 | Robert | #413 #415 | SBB-2 |
+| FU-6 | Non-connecting client pipe probe | LOW | S | 🟩 | Robert | #411 | — |
 | FU-7 | Volume-data FSCTL overlapped | LOW–MED | S | ✅ moot | Robert | — | — |
 
 **Shared building blocks** (land these as their own PRs first; several items
@@ -135,7 +135,7 @@ depend on them — see [§3](#3-shared-building-blocks)):
 | ID | Title | Status | PR |
 |----|-------|--------|----|
 | SBB-1 | `try_adopt_broker_handle` shared peek+duplicate in `uffs-mft` | 🟩 | #405 |
-| SBB-2 | `OwnedHandle` Send-safe RAII wrapper | 🟦 | (with FU-5) |
+| SBB-2 | `OwnedHandle` Send-safe RAII wrapper | 🟩 | #413 |
 
 Effort key: `XS` <1h · `S` ~half-day · `M` ~1–2 days · `L` ~3–5 days (all
 including tests + a VM validation round).


### PR DESCRIPTION
## Closing PR — the broker follow-up effort is complete & VM-validated

### Remove the TEMP scaffold
Drops the `TEMP-BROKER-FLOW` build-tag const + `BROKER-FLOW BUILD TAG` log line from `uffs-broker` and `uffsd`. `grep -rn TEMP-BROKER-FLOW` is now empty. (It served its purpose — caught stale binaries repeatedly during VM bring-up.)

### Harden install/uninstall (rough edges the VM run exposed)
- **`uninstall_service` stops before `sc delete`.** Deleting a *running* service only marks it for deletion (deferred until stop), which then made a later `--install` fail with a cryptic `sc create` error. Stop-first deletes immediately.
- **Error messages surface `sc.exe`'s stdout, not just stderr** — `sc` writes its diagnostics to stdout, so the old messages came out empty (`Install failed (sc create):` with nothing after it).
- install/uninstall now use the shared `SERVICE_NAME` const.

### Finalize the board
All follow-ups → 🟩 (FU-1 #414, FU-4 #412, FU-5 #413/#415, FU-6 #411), correcting rows that drifted from out-of-order merges. FU-7 ✅ moot; SBB-1/SBB-2 done.

## State of the world

| | |
|---|---|
| Correctness (FU-9, SBB-1, FU-2a/2b, FU-3) | ✅ implemented + VM-confirmed |
| FU-4 / FU-6 | ✅ implemented + VM-confirmed |
| FU-1 (service: install/boot/no-UAC/**graceful stop**/uninstall) | ✅ implemented + VM-confirmed via `sc.exe` |
| FU-5 + SBB-2 | ✅ implemented; single-daemon VM-confirmed; multi-instance fix gate-verified |
| FU-7 | ✅ verified moot |

Exact `cargo xwin clippy --workspace --all-features` clean.