### PR TITLE
docs: document the Access Broker (CHANGELOG, README, CLAUDE.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Windows Access Broker: non-elevated search with no UAC prompts
+
+`uffs-broker --install` (one-time, from an elevated shell) registers a small
+`LocalSystem` Windows service that vends elevated NTFS volume handles to the
+non-elevated daemon over a named pipe. After that, **every `uffs` search reads
+the live MFT with no UAC prompt**, surviving reboots — removing the
+"elevate every session" friction that Windows file-search tools normally carry.
+The service verifies the client is the UFFS daemon (name allow-list +
+Authenticode) before granting any handle, and is removed cleanly with
+`uffs-broker --uninstall`.
+
+On the non-elevated path this reaches full parity with an elevated read:
+
+- **Complete MFT index, including fragmented MFTs** — the extent map is
+  bootstrapped from the `$MFT` record's own run list when the file can't be
+  opened directly.
+- **Incremental USN-journal refresh** through the brokered handle (no more
+  full rebuild on every refresh), with a backoff so an unavailable journal
+  never floods the log.
+- **In-process Authenticode verification** (`WinVerifyTrust`) replacing a
+  per-request PowerShell spawn — faster, and no dependency on PowerShell.
+- **Concurrent multi-instance pipe** and a real Windows service lifecycle
+  (install / auto-start on boot / graceful `sc stop` / uninstall).
+
+### Performance — bounded live-drive load fan-out
+
+Loading many drives at once is now capped at roughly the CPU-core count, so a
+large estate (≈25+ drives) no longer fans out into a memory / I-O / thread
+spike during startup. Small estates (drives ≤ cores) load fully in parallel
+exactly as before — no change for typical setups.
+
 ### Fixed — ship pipeline: force `cargo clean` after a `rustc` toolchain bump
 
 `just ship` step `00-toolchain-ensure` can bump the pinned nightly, but

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,19 +58,35 @@ This is a Cargo workspace with a strict compilation isolation strategy:
 
 ```
 crates/
-├── uffs-polars/   Polars facade — all other crates depend on this, NOT polars directly.
-│                  Exists solely to cache Polars compilation (~4 min → ~25 sec rebuilds).
-├── uffs-mft/      Core MFT reading library. Windows-only I/O (#[cfg(windows)]).
-│                  Reads raw NTFS MFT → Polars DataFrame. Key types: MftReader, MftIndex.
-├── uffs-core/     Query engine using Polars lazy API. Platform-agnostic.
-│                  Key types: MftQuery (fluent builder), FastPathResolver, IndexSearch.
-├── uffs-cli/      CLI binary (`uffs`). Built on clap. Subcommands: search, index, info, stats.
-└── uffs-diag/     Diagnostic tools (temporarily in workspace members for analysis).
+├── uffs-polars/           Polars facade — all other crates depend on this, NOT polars
+│                          directly. Caches Polars compilation (~4 min → ~25 sec rebuilds).
+├── uffs-broker-protocol/  Cross-platform broker wire-protocol types (1-byte drive request,
+│                          9-byte status+handle response). Pure logic, zero unsafe.
+├── uffs-mft/              Core MFT reading library. Windows-only I/O (#[cfg(windows)]).
+│                          Reads raw NTFS MFT → Polars DataFrame. Key types: MftReader,
+│                          MftIndex, VolumeHandle. Holds the Access Broker handle registry
+│                          (register/try_adopt_broker_handle).
+├── uffs-core/             Query engine using Polars lazy API. Platform-agnostic.
+│                          Key types: MftQuery (builder), FastPathResolver, IndexSearch.
+├── uffs-client/           Client-side daemon connect/spawn + broker-presence probe.
+├── uffs-daemon/           Resident index server (`uffsd`). Loads MFTs, serves clients over
+│                          IPC, runs the per-shard USN journal loop + memory tiering.
+│                          Adopts broker handles for non-elevated MFT reads.
+├── uffs-broker/           Windows-only LocalSystem service (`uffs-broker.exe`). Vends
+│                          elevated, duplicated NTFS volume handles to the non-elevated
+│                          daemon over a named pipe, so searches run with zero UAC. bin-only.
+├── uffs-mcp/              MCP server (`uffsmcp`) exposing UFFS search as model tools.
+├── uffs-cli/              CLI binary (`uffs`). Built on clap. Subcommands: search, index, …
+└── uffs-diag/             Diagnostic tools (temporarily in workspace members for analysis).
 ```
 
+> Support crates (`uffs-security`, `uffs-format`, `uffs-text`, `uffs-time`) and the full
+> layered dependency table live in `docs/architecture/crate-graph.md`.
 > **Note:** `uffs-tui` and `uffs-gui` have moved to the private `uffs-products` repo.
 
-**Dependency graph:** `uffs-polars` ← `uffs-mft` ← `uffs-core` ← `uffs-cli`
+**Dependency graph (read path):** `uffs-polars` ← `uffs-mft` ← `uffs-core` ← `uffs-cli`.
+The service tier sits on top: `uffs-daemon` ← `uffs-core` + `uffs-broker-protocol`;
+`uffs-broker` ← `uffs-broker-protocol` + `uffs-mft`; `uffs-client` ← `uffs-broker-protocol`.
 
 **Never import `polars` directly** — always use `uffs-polars` as the dependency.
 
@@ -92,6 +108,9 @@ Records are parsed with `parse_record_zero_alloc` (thread-local buffers, zero he
 
 ### Fast vs Full Mode
 Default ("fast") skips extension MFT records (~1% of files with many hard links/ADS), giving 15–25% faster reads. `--full` mode merges extension records for complete data.
+
+### Access Broker (Windows — non-elevated MFT reads)
+Reading the live MFT normally needs Administrator. The **Access Broker** (`uffs-broker`, a `LocalSystem` Windows service) lets the daemon run **non-elevated**: the broker opens the volume, `DuplicateHandle`s an elevated, `FILE_FLAG_OVERLAPPED` handle into the daemon over a named pipe (after verifying the client is `uffsd` + Authenticode via `WinVerifyTrust`), and the daemon adopts a duplicate of it for every MFT/USN/`$MFT`-extent read. The handle registry + `try_adopt_broker_handle` live in `uffs-mft::platform::volume`; the daemon warms up handles in `warm_up_broker_handles` only when **not** already elevated. On the broker handle, use overlapped-offset reads (`read_handle_at`), not `SetFilePointerEx` (which has no synchronous file pointer there). One-time setup: `uffs-broker --install` → no UAC on any later search. Full design + the production follow-ups (all landed) are in `docs/architecture/access-broker-followups.md`.
 
 ### Cross-Compilation
 Binaries for Windows are cross-compiled from macOS using `cargo xwin`. The `xwin-dev` profile reduces Polars debug info to stay under COFF archive size limits. See `docs/xwin-msvc-rlib-size-root-cause-and-workarounds.md`.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Each release ships pre-built binaries, a `CHECKSUMS.txt` (SHA256), per-crate SBO
 
 | Platform | Download | Notes |
 |---|---|---|
-| **Windows x64** | [`uffs-windows-x64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | CLI + daemon + MCP + MFT tools + `uffs-tui` demo. Recommended. |
+| **Windows x64** | [`uffs-windows-x64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | CLI + daemon + Access Broker + MCP + MFT tools + `uffs-tui` demo. Recommended. |
 | **macOS Apple Silicon** | [`uffs-macos-arm64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | Offline MFT analysis only. Includes `UFFS.app` bundle + `uffs-tui` demo. |
 | **Linux x64** | [`uffs-linux-x64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | Offline MFT analysis only. Includes `install.sh` + `uffs-tui` demo. |
 
@@ -163,10 +163,14 @@ cargo build --release
 
 ## Quick Start
 
-> On Windows, reading the live MFT needs Administrator. Run from an **elevated** terminal, or the first search prints a one-time prompt offering `uffs daemon start --elevate` (a single UAC prompt) or the broker service for no future prompts. macOS/Linux offline analysis needs no elevation.
+> **Windows elevation — three ways.** Reading the live MFT needs Administrator. Easiest: install the **Access Broker** once (`uffs-broker --install`, from an elevated shell) and every later non-elevated `uffs` search runs with **no UAC prompt**, surviving reboots. Otherwise, run from an **elevated** terminal, or let the first search offer a one-time `uffs daemon start --elevate` (a single UAC prompt). macOS/Linux offline analysis needs no elevation.
 
 ```bash
-# Search all drives (daemon auto-starts on first query in an elevated shell)
+# One-time (elevated): install the Access Broker → no UAC on any later search
+uffs-broker --install
+
+# Search all drives (with the broker installed this runs non-elevated;
+# otherwise the daemon auto-starts on first query in an elevated shell)
 uffs "*.rs"
 
 # Search a specific drive
@@ -293,7 +297,7 @@ The older C++ implementation remains useful as a parity and regression baseline,
 
 ## Requirements
 
-- **Windows** for live NTFS MFT reading (Administrator privileges required)
+- **Windows** for live NTFS MFT reading. Administrator is needed to read the MFT — but only **once**: install the Access Broker (`uffs-broker --install`) and every later search runs **non-elevated with no UAC**. Without the broker, run from an elevated shell (or accept a per-session UAC prompt).
 - **macOS / Linux** for offline MFT analysis (no admin needed)
 - **Rust nightly** (Edition 2024) to build from source — channel pinned in `rust-toolchain.toml`; the workspace has no stable MSRV (see CONTRIBUTING.md → "Toolchain policy")
 


### PR DESCRIPTION
The Access Broker changes the Windows UX from "elevate every session" to "install once, no UAC ever," but the docs hadn't caught up.

## CHANGELOG (`[Unreleased]`)
- **Added — Windows Access Broker**: `uffs-broker --install` → non-elevated, no-UAC search; full fragmented-MFT index, incremental USN refresh, in-process `WinVerifyTrust`, multi-instance pipe, real service lifecycle.
- **Performance — bounded live-drive load fan-out** (large-estate safety; small estates unchanged).

## README
- **Quick Start** now leads with `uffs-broker --install` as the easiest elevation path and shows the command.
- **Requirements** nuanced from "Administrator required" → "admin **once** for the broker, then non-elevated, no UAC."
- The **Windows download row** now lists the Access Broker among the ZIP contents (it was omitted — users wouldn't know `uffs-broker.exe` ships).

## CLAUDE.md
- The crate tree + dependency graph were stale (only `polars/mft/core/cli/diag`). Added `uffs-broker`, `uffs-broker-protocol`, `uffs-daemon`, `uffs-client`, `uffs-mcp`, a service-tier dep graph, and an "Access Broker" architectural-pattern note.

## Deliberately left out (separate release decision)
- **Version bump** (`0.5.x` vs `0.6.0`).
- **Release/winget mechanics** — worth verifying separately that `uffs-broker.exe` is in the release artifacts and the `publishing.md` "15 binaries" count is still accurate.