### PR TITLE
fix(search): scope bare & path-anchored drive patterns (C:, C:\, C:\path)

### DIFF
--- a/crates/uffs-client/src/protocol/cli_args.rs
+++ b/crates/uffs-client/src/protocol/cli_args.rs
@@ -16,7 +16,7 @@
 pub use super::cli_args_helpers::CliArgsError as Error;
 use super::cli_args_helpers::{
     CliArgsError, drives_csv, extract_extensions_from_regex, flag_val, is_pure_ext_glob, non_empty,
-    parse_bare_drive_prefix, parse_bool, parse_i32, parse_size, parse_u16, parse_u32, parse_u64,
+    parse_bool, parse_i32, parse_size, parse_u16, parse_u32, parse_u64,
 };
 use super::{SearchFilterMode, SearchParams, SearchResponseMode};
 
@@ -425,7 +425,7 @@ impl RawCliArgs {
         } else if let Some(rest) = raw_pattern.strip_prefix("file:") {
             self.files_only = true;
             (false, rest.to_owned())
-        } else if let Some((letter, rest)) = parse_bare_drive_prefix(&raw_pattern) {
+        } else if let Some((letter, rest)) = uffs_mft::platform::split_drive_prefix(&raw_pattern) {
             if self.drive.is_none() && self.drives.is_none() {
                 self.drive = Some(letter);
             }

--- a/crates/uffs-client/src/protocol/cli_args_helpers.rs
+++ b/crates/uffs-client/src/protocol/cli_args_helpers.rs
@@ -308,52 +308,12 @@ pub(super) fn extract_extensions_from_regex(pattern: &str) -> Option<Vec<String>
         .then_some(exts)
 }
 
-/// Parse a bare drive-letter prefix from a pattern.
-///
-/// Returns `Some((letter_upper, rest))` when `pattern` matches exactly:
-/// - a single ASCII alphabetic character (the drive letter), followed by
-/// - a literal `:`, followed by
-/// - a non-empty `rest` that does **not** start with `\` or `/` (if it does,
-///   the pattern is path-anchored and must route through the tree walker in
-///   `uffs_core::search::tree`, which already scopes its walk to the drive
-///   root).
-///
-/// Examples that parse:
-/// - `C:*.dll`       → `('C', "*.dll")`
-/// - `D:notepad.exe` → `('D', "notepad.exe")`
-/// - `c:*.log`       → `('C', "*.log")` — letter is uppercased
-///
-/// Examples that return `None`:
-/// - `C:\*.dll`      — rest starts with `\` (path pattern, tree walker).
-/// - `C:/home/*.dll` — rest starts with `/` (path pattern).
-/// - `C:`            — empty rest.
-/// - `C`             — no colon.
-/// - `*.dll`         — no drive prefix.
-/// - `12:34`         — letter is not alphabetic.
-///
-/// Mirrored by `uffs_core::search::backend::parse_bare_drive_prefix`
-/// (the daemon's belt-and-suspenders safety net at dispatch time).
-/// Keep the two definitions in sync.
-pub(super) fn parse_bare_drive_prefix(pattern: &str) -> Option<(DriveLetter, &str)> {
-    let bytes = pattern.as_bytes();
-    let letter = *bytes.first()?;
-    if !letter.is_ascii_alphabetic() {
-        return None;
-    }
-    if *bytes.get(1)? != b':' {
-        return None;
-    }
-    // Drive-letter + ':' are both ASCII → the byte offset to `rest` is 2.
-    let rest = pattern.get(2..)?;
-    if rest.is_empty() || rest.starts_with(['\\', '/']) {
-        return None;
-    }
-    // The `is_ascii_alphabetic` guard above proves the `try_from`
-    // cannot fail; using `?` keeps the API a `Option` and avoids an
-    // unwrap.
-    let drive_letter = DriveLetter::try_from(letter).ok()?;
-    Some((drive_letter, rest))
-}
+// NOTE: the bare-drive-prefix parser used to live here as
+// `parse_bare_drive_prefix`.  It moved to the single canonical
+// `uffs_mft::platform::split_drive_prefix`, shared with the daemon
+// dispatch safety net, so both layers agree on what a leading `X:`
+// means (including the previously-broken `C:`, `C:\`, and
+// `C:\path\…` forms).
 
 #[cfg(test)]
 mod cli_args_error_tests {

--- a/crates/uffs-client/src/protocol/tests.rs
+++ b/crates/uffs-client/src/protocol/tests.rs
@@ -1593,22 +1593,22 @@ fn from_cli_args_drive_prefix_with_literal_preserves_pattern() {
     );
 }
 
-/// Path-anchored: `C:\*.dll` keeps the backslash and must NOT trigger
-/// the drive-prefix sugar — the tree walker already scopes to the
-/// drive root and expects the full `C:\<glob>` form intact.
+/// `C:\*.dll` scopes to drive C and globs.  (Previously this returned
+/// nothing: the `c:` token was mistaken for a directory segment by the
+/// tree walker.)  The drive prefix is split off, the single leftover
+/// segment `*.dll` collapses to a name glob, and ext-glob promotion then
+/// rewrites it to `pattern="*"` + `ext="dll"`.
 #[test]
-fn from_cli_args_drive_prefix_with_separator_not_promoted() {
+fn from_cli_args_drive_root_glob_scopes_drive_and_promotes_ext() {
     let args: Vec<String> = vec!["C:\\*.dll".into()];
     let params = SearchParams::from_cli_args(&args).expect("parse");
-    assert!(
-        params.drives.is_empty(),
-        "path-anchored C:\\*.dll must NOT populate drives filter"
-    );
     assert_eq!(
-        params.pattern, "C:\\*.dll",
-        "path-anchored pattern must be preserved verbatim for tree walker"
+        params.drives,
+        vec![uffs_mft::platform::DriveLetter::C],
+        "C:\\*.dll must scope to drive C"
     );
-    assert!(params.ext.is_none());
+    assert_eq!(params.pattern, "*");
+    assert_eq!(params.ext.as_deref(), Some("dll"));
 }
 
 /// Case normalisation: `c:*.log` → drive uppercased to `'C'`, ext
@@ -2078,4 +2078,57 @@ fn hibernate_request_envelope_round_trip() {
         uffs_mft::platform::DriveLetter::C,
         uffs_mft::platform::DriveLetter::D
     ]);
+}
+
+// ── Drive-prefix pattern parsing (split_drive_prefix front door) ───
+//
+// Regression tests for the `C:` / `C:\` / `C:\path` forms that used to
+// fall through to a literal `c:` substring (matching `.heiC:${…}` ADS
+// streams) or to the tree walker's bogus `c:` directory segment.
+
+/// `C:` → drive C + everything (match-all).
+#[test]
+fn from_cli_args_bare_drive_is_match_all_on_drive() {
+    let args: Vec<String> = vec!["C:".into()];
+    let params = SearchParams::from_cli_args(&args).expect("parse");
+    assert_eq!(params.pattern, "*");
+    assert_eq!(params.drives, vec![uffs_mft::platform::DriveLetter::C]);
+}
+
+/// `C:\` and `C:/` are identical to `C:` — drive C + match-all.
+#[test]
+fn from_cli_args_drive_root_is_match_all_on_drive() {
+    for raw in ["C:\\", "C:/"] {
+        let args: Vec<String> = vec![raw.into()];
+        let params = SearchParams::from_cli_args(&args).expect("parse");
+        assert_eq!(params.pattern, "*", "`{raw}` → match-all");
+        assert_eq!(params.drives, vec![uffs_mft::platform::DriveLetter::C]);
+    }
+}
+
+/// `C:\report` collapses to the same query as `C:report`.
+#[test]
+fn from_cli_args_drive_root_single_segment_matches_bare_drive_name() {
+    let args: Vec<String> = vec!["C:\\report".into()];
+    let params = SearchParams::from_cli_args(&args).expect("parse");
+    assert_eq!(params.pattern, "report");
+    assert_eq!(params.drives, vec![uffs_mft::platform::DriveLetter::C]);
+}
+
+/// `C:\report\*` → drive C + tree-walk body `report\*`.
+#[test]
+fn from_cli_args_drive_plus_multi_segment_is_tree_body() {
+    let args: Vec<String> = vec!["C:\\report\\*".into()];
+    let params = SearchParams::from_cli_args(&args).expect("parse");
+    assert_eq!(params.pattern, "report\\*");
+    assert_eq!(params.drives, vec![uffs_mft::platform::DriveLetter::C]);
+}
+
+/// No-drive path patterns are untouched and stay un-scoped.
+#[test]
+fn from_cli_args_no_drive_path_pattern_unscoped() {
+    let args: Vec<String> = vec!["\\rnio\\*".into()];
+    let params = SearchParams::from_cli_args(&args).expect("parse");
+    assert_eq!(params.pattern, "\\rnio\\*");
+    assert!(params.drives.is_empty());
 }

--- a/crates/uffs-core/src/search/backend_tests.rs
+++ b/crates/uffs-core/src/search/backend_tests.rs
@@ -1926,32 +1926,40 @@ fn search_index_path_only_sort_respects_limit() {
     );
 }
 
-/// Path-anchored `C:\*.txt` must NOT trigger the drive-prefix safety
-/// net — the tree walker already scopes to the drive root and expects
-/// the full `C:\<glob>` form intact.  We verify non-promotion by
-/// checking that `filters.extensions` stays empty (drive-prefix would
-/// strip to `\*.txt` which is still not a pure ext glob, so this is
-/// an indirect but deterministic observation: the result set must
-/// match what we'd get by running the same pattern with an explicit
-/// `drives_filter=[]` on an unchanged backend).
+/// `C:\*.txt` now scopes to drive C and globs.  The drive prefix is
+/// split off, the single `*.txt` segment collapses to a name glob, and
+/// the ext-glob safety net promotes it to `ext=["txt"]`.  (Previously
+/// the `c:` token was mistaken for a directory segment by the tree
+/// walker and the search returned nothing.)
 #[test]
-fn search_index_drive_prefix_with_separator_not_promoted() {
+fn search_index_drive_root_glob_scopes_drive_and_promotes_ext() {
     let index = build_two_drive_index();
     let mut filters = super::super::filters::SearchFilters::default();
-    let _result = search_index(
+    let result = search_index(
         &index,
         SearchRequest::new("C:\\*.txt", &mut filters),
         FieldId::Modified,
         true,
         &[],
     );
-    // Primary observation: ext-filter must stay empty — neither the
-    // drive-prefix safety net nor the ext-glob safety net should fire
-    // on a path-anchored pattern.
+    assert_eq!(
+        filters.extensions,
+        vec!["txt".to_owned()],
+        "drive-prefix split + ext-glob promotion must fire on C:\\*.txt"
+    );
     assert!(
-        filters.extensions.is_empty(),
-        "path-anchored pattern must not trigger any safety-net promotion; filters.extensions = {:?}",
-        filters.extensions
+        result
+            .rows
+            .iter()
+            .all(|row| row.drive == uffs_mft::platform::DriveLetter::C),
+        "results must be scoped to drive C"
+    );
+    assert!(
+        result
+            .rows
+            .iter()
+            .any(|row| row.path.ends_with("report.txt")),
+        "C:\\*.txt must find report.txt on drive C"
     );
 }
 

--- a/crates/uffs-core/src/search/dispatch.rs
+++ b/crates/uffs-core/src/search/dispatch.rs
@@ -16,9 +16,10 @@
 //!    `uffs_client::protocol::cli_args::into_search_params`.  Direct JSON-RPC
 //!    `search` callers and library users that build `SearchParams` manually
 //!    skip the parse-time layer; these catch the two rewrites at dispatch time
-//!    so every entry point lands on the same hot paths.  `is_pure_ext_glob` and
-//!    `parse_bare_drive_prefix` are internal helpers consumed by
-//!    `apply_dispatch_safety_nets` — kept private to this module.
+//!    so every entry point lands on the same hot paths.  `is_pure_ext_glob` is
+//!    an internal helper consumed by `apply_dispatch_safety_nets`; the
+//!    drive-prefix split is the shared `uffs_mft::platform::split_drive_prefix`
+//!    (same primitive the CLI parse layer uses, so both agree).
 //!
 //! 2. **Per-branch dispatchers** ([`dispatch_match_all`], [`dispatch_regex`],
 //!    [`dispatch_trigram_or_tree`]) — the three leaf dispatch paths +
@@ -167,39 +168,6 @@ fn extract_extensions_from_regex(pattern: &str) -> Option<Vec<String>> {
         .then_some(exts)
 }
 
-/// Parse a bare drive-letter prefix from a pattern.
-///
-/// Returns `Some((letter_upper, rest))` when the pattern matches
-/// `<letter>:<rest>` where `<letter>` is a single ASCII alphabetic
-/// character and `<rest>` is non-empty and does NOT start with `\` or
-/// `/` (path-anchored forms like `C:\*.dll` must keep routing through
-/// the tree walker).
-///
-/// Used by the search-dispatch safety net: if a caller (e.g. direct
-/// JSON-RPC `search` method) supplies `pattern="C:*.dll"` with an
-/// empty `drives_filter`, we can still narrow the search to drive `C`
-/// and (via the ext-glob follow-up) route through the `ExtensionIndex`.
-///
-/// Mirror of `uffs_client::protocol::cli_args::parse_bare_drive_prefix` —
-/// keep the two in sync.  See that function's doc for the full
-/// acceptance matrix.
-fn parse_bare_drive_prefix(pattern: &str) -> Option<(uffs_mft::platform::DriveLetter, &str)> {
-    let bytes = pattern.as_bytes();
-    let letter = *bytes.first()?;
-    if !letter.is_ascii_alphabetic() {
-        return None;
-    }
-    if *bytes.get(1)? != b':' {
-        return None;
-    }
-    let rest = pattern.get(2..)?;
-    if rest.is_empty() || rest.starts_with(['\\', '/']) {
-        return None;
-    }
-    let dl = uffs_mft::platform::DriveLetter::parse(letter as char).ok()?;
-    Some((dl, rest))
-}
-
 /// Apply dispatch-time pattern-rewrite safety nets, in canonical order.
 ///
 /// Mirrors the parse-time rewrites in
@@ -213,9 +181,12 @@ fn parse_bare_drive_prefix(pattern: &str) -> Option<(uffs_mft::platform::DriveLe
 ///
 /// 1. `<letter>:<rest>` → `drives_filter = [<letter>]`, `pattern = <rest>`.
 ///    Only fires when the caller's `drives_filter_empty` and not `match_path`.
-///    Path-anchored forms (`C:\*.dll`) are excluded by
-///    `parse_bare_drive_prefix`.  The promoted letter is pushed into
-///    `drive_buf` (which the caller uses as backing storage for a
+///    Delegates to `uffs_mft::platform::split_drive_prefix`, so the bare
+///    (`C:`), drive-root (`C:\`), and path-anchored (`C:\Users\*.pdf`) forms
+///    are all handled — the drive-relative remainder (`*` for the bare forms)
+///    becomes the new pattern and downstream classification routes it to
+///    match-all / name / tree as appropriate.  The promoted letter is pushed
+///    into `drive_buf` (which the caller uses as backing storage for a
 ///    `&[DriveLetter]` slice that lives for the rest of the dispatch).
 ///
 /// 2. `*.<ext>` → `pattern = "*"`, `extensions += [<ext_lower>]`. Only fires
@@ -238,7 +209,7 @@ fn parse_bare_drive_prefix(pattern: &str) -> Option<(uffs_mft::platform::DriveLe
 /// `drive=C` + `ext=dll` + match-all — exactly the shape the
 /// `numeric_top_n::ext_fast_path` expects.  Rewrite #3 does not
 /// compose with rewrite #1 because regex patterns start with `>` (not
-/// a drive letter), so `parse_bare_drive_prefix` rejects them; path
+/// a drive letter), so `split_drive_prefix` rejects them; path
 /// anchors inside the regex (`>C:\\Users\\.*\.dll$`) stay on the regex
 /// scan path by design — the ext-index would widen the match to all
 /// `.dll` files drive-wide.
@@ -252,7 +223,7 @@ pub(super) fn apply_dispatch_safety_nets(
 ) {
     if drives_filter_empty
         && !match_path
-        && let Some((letter, rest)) = parse_bare_drive_prefix(pattern)
+        && let Some((letter, rest)) = uffs_mft::platform::split_drive_prefix(pattern)
     {
         tracing::debug!(
             original_pattern = *pattern,
@@ -668,5 +639,68 @@ mod tests {
             vec!["exe".to_owned()],
             "explicit --ext filter must stay untouched"
         );
+    }
+
+    // ── apply_dispatch_safety_nets (drive-prefix branch) ───────────
+
+    #[test]
+    fn safety_net_bare_drive_promotes_to_match_all() {
+        let mut filters = SearchFilters::default();
+        let (pat, drives) = run_safety_nets("C:", &mut filters);
+        assert_eq!(pat, "*", "bare `C:` becomes match-all on drive C");
+        assert_eq!(drives, vec![uffs_mft::platform::DriveLetter::C]);
+    }
+
+    #[test]
+    fn safety_net_drive_root_promotes_to_match_all() {
+        for raw in ["C:\\", "C:/"] {
+            let mut filters = SearchFilters::default();
+            let (pat, drives) = run_safety_nets(raw, &mut filters);
+            assert_eq!(pat, "*", "`{raw}` becomes match-all on drive C");
+            assert_eq!(drives, vec![uffs_mft::platform::DriveLetter::C]);
+        }
+    }
+
+    #[test]
+    fn safety_net_drive_plus_name_keeps_name_body() {
+        let mut filters = SearchFilters::default();
+        let (pat, drives) = run_safety_nets("C:report", &mut filters);
+        assert_eq!(pat, "report");
+        assert_eq!(drives, vec![uffs_mft::platform::DriveLetter::C]);
+    }
+
+    #[test]
+    fn safety_net_drive_root_single_segment_collapses_to_name() {
+        // `C:\report` must behave identically to `C:report`.
+        let mut filters = SearchFilters::default();
+        let (pat, drives) = run_safety_nets("C:\\report", &mut filters);
+        assert_eq!(pat, "report");
+        assert_eq!(drives, vec![uffs_mft::platform::DriveLetter::C]);
+    }
+
+    #[test]
+    fn safety_net_drive_plus_glob_segment_promotes_to_ext() {
+        // `C:\*.pdf` → drive C + (via ext-glob compose) pattern="*" + ext=pdf.
+        let mut filters = SearchFilters::default();
+        let (pat, drives) = run_safety_nets("C:\\*.pdf", &mut filters);
+        assert_eq!(pat, "*");
+        assert_eq!(drives, vec![uffs_mft::platform::DriveLetter::C]);
+        assert_eq!(filters.extensions, vec!["pdf".to_owned()]);
+    }
+
+    #[test]
+    fn safety_net_drive_plus_multi_segment_keeps_tree_body() {
+        let mut filters = SearchFilters::default();
+        let (pat, drives) = run_safety_nets("C:\\report\\*", &mut filters);
+        assert_eq!(pat, "report\\*", "multi-segment stays a tree path");
+        assert_eq!(drives, vec![uffs_mft::platform::DriveLetter::C]);
+    }
+
+    #[test]
+    fn safety_net_leaves_no_drive_path_pattern_alone() {
+        let mut filters = SearchFilters::default();
+        let (pat, drives) = run_safety_nets("\\rnio\\*", &mut filters);
+        assert_eq!(pat, "\\rnio\\*", "no drive prefix → untouched");
+        assert!(drives.is_empty());
     }
 }

--- a/crates/uffs-mft/src/platform.rs
+++ b/crates/uffs-mft/src/platform.rs
@@ -22,6 +22,12 @@ mod bitmap;
 /// workspace with a `#[repr(transparent)]` newtype that canonicalises
 /// case and rejects non-ASCII-letter input at the parse boundary.
 pub mod drive_letter;
+/// Drive-prefix splitting for search patterns.
+///
+/// The single canonical parser shared by the CLI parse layer and the
+/// daemon dispatch safety net, so both agree on what a leading `X:`
+/// means.
+pub mod drive_pattern;
 mod extents;
 /// Logical Cluster Number newtype — signed cluster identifier used
 /// by `FSCTL_GET_RETRIEVAL_POINTERS` and the on-disk data-run decoder.
@@ -39,6 +45,7 @@ mod volume;
 
 pub use bitmap::MftBitmap;
 pub use drive_letter::{DriveLetter, DriveLetterError};
+pub use drive_pattern::split_drive_prefix;
 pub use extents::MftExtent;
 pub use lcn::Lcn;
 // Export DriveType unconditionally (needed for tests), but Windows-specific functions only on

--- a/crates/uffs-mft/src/platform/drive_pattern.rs
+++ b/crates/uffs-mft/src/platform/drive_pattern.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Drive-prefix splitting for search patterns.
+//!
+//! The single canonical front door shared by the CLI parse layer
+//! (`uffs_client::protocol::cli_args`) and the daemon dispatch safety
+//! net (`uffs_core::search::dispatch`), so both agree on what a leading
+//! `X:` means.
+//!
+//! Historically each layer carried its own `parse_bare_drive_prefix`
+//! copy, and *neither* understood the bare (`C:`), drive-root (`C:\`),
+//! or path-anchored (`C:\Users\*.pdf`) forms — those fell through to a
+//! literal substring match (`c:` accidentally matched `.heiC:${…}` ADS
+//! streams) or to the tree walker, which mistook the `c:` token for a
+//! directory name and matched nothing.  This module is the one place
+//! that owns the `DRIVE:` concept, so both entry points agree.
+//!
+//! ## Rule
+//!
+//! A leading `X:` (single ASCII letter + colon) is split off into a
+//! [`DriveLetter`] filter; the remainder becomes a **drive-relative**
+//! body that the normal name/glob/tree/regex classifier then handles:
+//!
+//! | Pattern | Drive | Body | Downstream meaning |
+//! | --- | --- | --- | --- |
+//! | `C:` / `C:\` / `C:/` | `C` | `*` | everything on C (match-all) |
+//! | `C:report` | `C` | `report` | name substring on C |
+//! | `C:\report` | `C` | `report` | name substring on C (same as above) |
+//! | `C:rep*` / `C:\*.pdf` | `C` | `rep*` / `*.pdf` | name glob on C |
+//! | `C:\report\*` | `C` | `report\*` | tree walk on C |
+//! | `\path\*` / `report*` / `>re` | — | — | no drive prefix → `None` |
+//!
+//! The leading separator is trimmed from the body, so a **single**
+//! segment after the drive (`C:\report`, `C:\*.pdf`) collapses to a
+//! plain name pattern (and globs correctly), while a **multi**-segment
+//! body keeps its internal separators and stays a path pattern that the
+//! tree walker picks up via `is_path_pattern`.  Forward and back slashes
+//! are equivalent.
+
+use super::drive_letter::DriveLetter;
+
+/// Match-all body returned for the bare / drive-root forms (`C:`,
+/// `C:\`, `C:/`).
+const MATCH_ALL: &str = "*";
+
+/// Split a leading `X:` drive prefix off a search `pattern`.
+///
+/// Returns `Some((drive, body))` when `pattern` begins with a single
+/// ASCII-alphabetic drive letter followed by `:`.  `body` is the
+/// **drive-relative** remainder with any leading path separators
+/// trimmed, or `*` (match-all) when nothing usable follows the colon.
+/// See the module docs for the full acceptance matrix.
+///
+/// Returns `None` when there is no `X:` prefix (plain names, path-
+/// anchored `\path\…` patterns, and `>`-prefixed regex all fall here),
+/// so the caller leaves the pattern untouched.
+#[must_use]
+pub fn split_drive_prefix(pattern: &str) -> Option<(DriveLetter, &str)> {
+    let bytes = pattern.as_bytes();
+    let letter = *bytes.first()?;
+    if !letter.is_ascii_alphabetic() {
+        return None;
+    }
+    if *bytes.get(1)? != b':' {
+        return None;
+    }
+    // Drive-letter + ':' are both ASCII → `rest` starts at byte 2.
+    let rest = pattern.get(2..)?;
+    // The `is_ascii_alphabetic` guard above guarantees this parses.
+    let drive = DriveLetter::parse(letter as char).ok()?;
+
+    let core = rest.trim_start_matches(['\\', '/']);
+    let body = if core.is_empty() { MATCH_ALL } else { core };
+    Some((drive, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DriveLetter, split_drive_prefix};
+
+    #[test]
+    fn bare_drive_is_match_all() {
+        assert_eq!(split_drive_prefix("C:"), Some((DriveLetter::C, "*")));
+    }
+
+    #[test]
+    fn drive_root_backslash_and_slash_are_match_all() {
+        assert_eq!(split_drive_prefix("C:\\"), Some((DriveLetter::C, "*")));
+        assert_eq!(split_drive_prefix("C:/"), Some((DriveLetter::C, "*")));
+    }
+
+    #[test]
+    fn drive_plus_name_is_substring_body() {
+        assert_eq!(
+            split_drive_prefix("C:report"),
+            Some((DriveLetter::C, "report"))
+        );
+    }
+
+    #[test]
+    fn drive_root_single_segment_collapses_to_name() {
+        // `C:\report` must behave identically to `C:report`.
+        assert_eq!(
+            split_drive_prefix("C:\\report"),
+            Some((DriveLetter::C, "report"))
+        );
+    }
+
+    #[test]
+    fn drive_root_single_glob_segment_stays_a_name_glob() {
+        // The leading separator is trimmed, so the leaf globs instead of
+        // hitting the tree walker's single-segment substring path.
+        assert_eq!(
+            split_drive_prefix("C:\\*.pdf"),
+            Some((DriveLetter::C, "*.pdf"))
+        );
+    }
+
+    #[test]
+    fn drive_plus_multi_segment_keeps_path_body() {
+        // Internal separator retained → downstream `is_path_pattern`
+        // routes this to the tree walker, drive-scoped.
+        assert_eq!(
+            split_drive_prefix("C:\\report\\*"),
+            Some((DriveLetter::C, "report\\*"))
+        );
+    }
+
+    #[test]
+    fn lowercase_letter_is_canonicalised() {
+        assert_eq!(split_drive_prefix("d:logs"), Some((DriveLetter::D, "logs")));
+    }
+
+    #[test]
+    fn no_drive_prefix_returns_none() {
+        assert_eq!(split_drive_prefix("report*"), None);
+        assert_eq!(split_drive_prefix("\\path\\*"), None);
+        assert_eq!(split_drive_prefix("/path/*"), None);
+        assert_eq!(split_drive_prefix(">regex"), None);
+        assert_eq!(split_drive_prefix("*"), None);
+    }
+
+    #[test]
+    fn non_alpha_first_byte_returns_none() {
+        assert_eq!(split_drive_prefix("12:34"), None);
+        assert_eq!(split_drive_prefix(":foo"), None);
+    }
+
+    #[test]
+    fn single_char_without_colon_returns_none() {
+        assert_eq!(split_drive_prefix("C"), None);
+    }
+}

--- a/docs/architecture/engine/06-pattern-search.md
+++ b/docs/architecture/engine/06-pattern-search.md
@@ -37,12 +37,28 @@ pub enum PatternType {
 
 ### Parsing Rules
 
+The leading `X:` drive prefix is split off by the single canonical
+`uffs_mft::platform::split_drive_prefix` (shared by the CLI parse layer
+and the daemon dispatch safety net). The drive becomes a filter and the
+**drive-relative** remainder becomes the pattern; any leading path
+separator is trimmed, so a single trailing segment collapses to a name
+pattern while multi-segment bodies stay path-anchored.
+
 ```
-Input: "c:/pro*"
-  → drive=Some('C'), pattern="/pro*", type=Glob, is_path=true
+Input: "c:"  /  "c:\"  /  "c:/"
+  → drive=Some('C'), pattern="*", type=Glob, is_path=false   (everything on C)
+
+Input: "c:/pro*"  /  "c:\pro*"  /  "c:pro*"
+  → drive=Some('C'), pattern="pro*", type=Glob, is_path=false
+
+Input: "c:\proj\*.rs"
+  → drive=Some('C'), pattern="proj\*.rs", type=Glob, is_path=true  (tree walk, scoped to C)
 
 Input: "*.rs"
   → drive=None, pattern="*.rs", type=Glob, is_path=false
+
+Input: "\proj\*.rs"
+  → drive=None, pattern="\proj\*.rs", type=Glob, is_path=true  (tree walk, all drives)
 
 Input: ">C:\\Temp.*\.txt"
   → drive=None, pattern="C:\\Temp.*\.txt", type=Regex, is_path=true


### PR DESCRIPTION
## Problem

Drive-letter search patterns were broken for everything except the `C:<name>` form:

| Pattern | Before | Result |
|---|---|---|
| `C:` | substring `c:` | matched `.heiC:${…}` ADS streams ❌ |
| `C:\` / `C:/` | tree seg `c:` | same `.heic:` junk ❌ |
| `C:\Users\*.pdf` | tree looks for a dir literally named `c:` | **zero results** ❌ |

Root cause: the `DRIVE:` concept lived in **three drifting places** (two `parse_bare_drive_prefix` copies + an implicit, *wrong* assumption that the tree walker "scopes to the drive root" — it actually treats `c:` as a directory-name segment), none of which handled the bare / drive-root / path-anchored forms.

## Fix

One canonical front-door parser — `uffs_mft::platform::split_drive_prefix` — shared by the CLI parse layer (`uffs-client`) and the daemon dispatch safety net (`uffs-core`). The drive is split into a filter and the **drive-relative** remainder is classified normally. Trimming the leading separator makes the single-segment collapse and the tree-vs-name distinction fall out for free:

| Pattern | Drive | Body | Meaning |
|---|---|---|---|
| `C:` / `C:\` / `C:/` | C | `*` | everything on C |
| `C:report` / `C:\report` | C | `report` | name substring (identical) |
| `C:\*.pdf` | C | `*.pdf` | name glob (ext-glob promoted) |
| `C:\Users\*.pdf` | C | `Users\*.pdf` | tree walk, scoped to C |
| `\path\*` / `/path/*` | — | — | tree walk, all drives (unchanged) |

Forward/back slashes are equivalent. Removes both dead mirrors and the false tree-walker comment.

## Tests

- New `split_drive_prefix` unit tests (every form) in `uffs-mft`.
- New dispatch safety-net tests + CLI `from_cli_args` integration tests.
- Updated the two pre-existing tests that pinned the old buggy `C:\…` contract.

All gates green locally: 1283 tests, host clippy (prod+tests), Windows xwin clippy, rustdoc, fmt.