### PR TITLE
feat(cli): self-update Phase A — multi-anchor install detection (`uffs update`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4426,6 +4426,7 @@ version = "0.6.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "dirs-next",
  "serde_json",
  "uffs-client",
  "uffs-format",

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -94,6 +94,10 @@ serde_json.workspace = true
 # Locates executables on `PATH` (e.g. the daemon binary when auto-spawning).
 which.workspace = true
 
+# Resolve the daemon lifecycle dir (`%LOCALAPPDATA%\uffs`) for self-update
+# detection — mirrors uffs-daemon so the PID-file path matches exactly.
+dirs-next.workspace = true
+
 # FILETIME arithmetic only — zero-dep crate extracted from uffs-mft so
 # the CLI does not transitively link polars, tokio/net, reqwest, or
 # object_store.  Use `uffs_time::{filetime_to_calendar,

--- a/crates/uffs-cli/src/commands.rs
+++ b/crates/uffs-cli/src/commands.rs
@@ -33,6 +33,8 @@ pub mod search;
 pub mod stats;
 /// Combined `uffs status` command.
 pub(crate) mod system_status;
+/// `uffs update` — self-update detection (Phase A of the self-update design).
+pub(crate) mod update;
 
 /// Render a one-line version summary suitable for `daemon status`,
 /// `daemon stats`, and `uffs status` output.

--- a/crates/uffs-cli/src/commands/update/binaries.rs
+++ b/crates/uffs-cli/src/commands/update/binaries.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Known UFFS binaries, per-root vicinity enumeration, and on-disk
+//! version probing (Phase A.2 + A.4 of the self-update design).
+//!
+//! A root is updated as a *coherent set*: every UFFS binary present in
+//! it is a target, not only the one that happened to be running. We
+//! never assume a binary is present — we enumerate what is actually on
+//! disk and record each one's `--version`.
+
+use std::path::Path;
+use std::process::Command;
+
+use super::model::BinaryInfo;
+
+/// Logical stems of every UFFS binary the updater knows about. The
+/// platform `.exe` suffix is added by [`exe_file_name`].
+pub(crate) const KNOWN_BINARIES: [&str; 6] = [
+    "uffs",        // CLI
+    "uffsd",       // daemon
+    "uffsmcp",     // MCP server
+    "uffs-broker", // elevated handle broker (Windows service)
+    "uffs-tui",    // interactive TUI (optional)
+    "uffs-mft",    // diagnostics (optional)
+];
+
+/// Append the platform executable suffix to a binary stem
+/// (`uffsd` → `uffsd.exe` on Windows, `uffsd` elsewhere).
+pub(crate) fn exe_file_name(stem: &str) -> String {
+    if cfg!(windows) {
+        format!("{stem}.exe")
+    } else {
+        stem.to_owned()
+    }
+}
+
+/// Enumerate the UFFS binaries actually present in `dir`, probing each
+/// one's version. Binaries that are not present are simply absent from
+/// the result (honor-what-is-installed).
+pub(crate) fn enumerate(dir: &Path) -> Vec<BinaryInfo> {
+    KNOWN_BINARIES
+        .iter()
+        .filter_map(|stem| {
+            let path = dir.join(exe_file_name(stem));
+            path.is_file().then(|| BinaryInfo {
+                name: (*stem).to_owned(),
+                version: probe_version(&path),
+            })
+        })
+        .collect()
+}
+
+/// Run `<path> --version` and parse a semantic-version token from its
+/// output. Returns `None` if the binary cannot be launched or no
+/// version token is found.
+pub(crate) fn probe_version(path: &Path) -> Option<String> {
+    let output = Command::new(path).arg("--version").output().ok()?;
+    let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+    if text.trim().is_empty() {
+        // Some tools print `--version` to stderr; fall back to it.
+        text = String::from_utf8_lossy(&output.stderr).into_owned();
+    }
+    parse_version(&text)
+}
+
+/// Extract the first `MAJOR.MINOR.PATCH` token from arbitrary
+/// `--version` output (e.g. `"uffs 0.6.2"` → `"0.6.2"`).
+///
+/// Kept pure (no I/O) so it is unit-testable without launching a
+/// process.
+pub(crate) fn parse_version(text: &str) -> Option<String> {
+    text.split(|ch: char| ch.is_whitespace() || ch == '(' || ch == ')' || ch == ',')
+        .find_map(|token| {
+            let trimmed = token.trim_start_matches('v');
+            is_dotted_triple(trimmed).then(|| trimmed.to_owned())
+        })
+}
+
+/// Return `true` when `token` looks like `N.N.N` where each `N` is a
+/// non-empty run of ASCII digits.
+fn is_dotted_triple(token: &str) -> bool {
+    let mut parts = token.split('.');
+    let (Some(major), Some(minor), Some(patch), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return false;
+    };
+    [major, minor, patch]
+        .iter()
+        .all(|seg| !seg.is_empty() && seg.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KNOWN_BINARIES, parse_version};
+
+    #[test]
+    fn parses_plain_semver() {
+        assert_eq!(parse_version("0.6.2").as_deref(), Some("0.6.2"));
+    }
+
+    #[test]
+    fn parses_named_version_line() {
+        assert_eq!(parse_version("uffs 0.6.2").as_deref(), Some("0.6.2"));
+        assert_eq!(parse_version("uffsd 0.6.10\n").as_deref(), Some("0.6.10"));
+    }
+
+    #[test]
+    fn parses_v_prefixed_and_parenthesised() {
+        assert_eq!(
+            parse_version("uffs v0.6.2 (abc123)").as_deref(),
+            Some("0.6.2")
+        );
+    }
+
+    #[test]
+    fn rejects_non_triples() {
+        assert_eq!(parse_version("uffs"), None);
+        assert_eq!(parse_version("1.2"), None);
+        assert_eq!(parse_version("1.2.3.4"), None);
+        assert_eq!(parse_version("a.b.c"), None);
+        assert_eq!(parse_version(""), None);
+    }
+
+    #[test]
+    fn known_set_contains_core_and_optional() {
+        for stem in ["uffs", "uffsd", "uffsmcp", "uffs-broker"] {
+            assert!(KNOWN_BINARIES.contains(&stem), "missing core binary {stem}");
+        }
+    }
+}

--- a/crates/uffs-cli/src/commands/update/channel.rs
+++ b/crates/uffs-cli/src/commands/update/channel.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Per-root install-channel classification — pure, path-based, and
+//! testable (Phase A.3 of the self-update design).
+//!
+//! Each discovered install *root* is classified independently: a `WinGet`
+//! root and a hand-placed root can coexist in one update run, so the
+//! update strategy is chosen per root, not globally.
+
+use std::path::Path;
+
+use super::model::{Channel, Scope};
+
+/// Classify the install [`Channel`] and [`Scope`] of a directory purely
+/// from its path.
+///
+/// Heuristics (case-insensitive):
+/// - `…\WinGet\Packages\…` → [`Channel::WinGet`] (scope from the path root).
+/// - a `…\target\debug\…` or `…\target\release\…` segment →
+///   [`Channel::DevBuild`].
+/// - anything else → [`Channel::Unmanaged`].
+pub(crate) fn classify(dir: &Path) -> (Channel, Scope) {
+    let lower = dir.to_string_lossy().to_ascii_lowercase();
+    if lower.contains("\\winget\\packages\\") || lower.contains("/winget/packages/") {
+        return (Channel::WinGet, winget_scope(&lower));
+    }
+    if is_dev_build(&lower) {
+        return (Channel::DevBuild, Scope::Unknown);
+    }
+    (Channel::Unmanaged, Scope::Unknown)
+}
+
+/// Infer `WinGet` install scope from a lower-cased path.
+///
+/// Machine-wide installs live under `Program Files`; per-user installs
+/// under the local app-data tree.
+fn winget_scope(lower: &str) -> Scope {
+    if lower.contains("program files") {
+        Scope::Machine
+    } else if lower.contains("\\appdata\\local\\") || lower.contains("/appdata/local/") {
+        Scope::User
+    } else {
+        Scope::Unknown
+    }
+}
+
+/// Return `true` when the lower-cased path contains a cargo
+/// `target/{debug,release}` segment — either as the final segment
+/// (`…\target\release`) or with children (`…/target/debug/deps`).
+///
+/// Separators are normalised to `/` first; the marker must be followed
+/// by end-of-string or `/` so `target/release-notes` does not match.
+fn is_dev_build(lower: &str) -> bool {
+    let norm = lower.replace('\\', "/");
+    ["/target/debug", "/target/release"].iter().any(|marker| {
+        norm.find(marker).is_some_and(|pos| {
+            norm.get(pos + marker.len()..)
+                .is_some_and(|after| after.is_empty() || after.starts_with('/'))
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{Channel, Scope, classify};
+
+    #[test]
+    fn winget_user_scope() {
+        let path = Path::new(
+            r"C:\Users\me\AppData\Local\Microsoft\WinGet\Packages\Sky.UFFS_abc\uffs-windows-x64",
+        );
+        assert_eq!(classify(path), (Channel::WinGet, Scope::User));
+    }
+
+    #[test]
+    fn winget_machine_scope() {
+        let path = Path::new(r"C:\Program Files\WinGet\Packages\Sky.UFFS_abc");
+        assert_eq!(classify(path), (Channel::WinGet, Scope::Machine));
+    }
+
+    #[test]
+    fn unmanaged_plain_dir() {
+        assert_eq!(
+            classify(Path::new(r"C:\uffs-test")),
+            (Channel::Unmanaged, Scope::Unknown)
+        );
+    }
+
+    #[test]
+    fn dev_build_target_tree() {
+        assert_eq!(
+            classify(Path::new(r"D:\src\uffs\target\release")),
+            (Channel::DevBuild, Scope::Unknown)
+        );
+        assert_eq!(
+            classify(Path::new("/home/me/uffs/target/debug")),
+            (Channel::DevBuild, Scope::Unknown)
+        );
+    }
+
+    #[test]
+    fn forward_slash_winget() {
+        let path = Path::new("/c/Users/me/AppData/Local/Microsoft/WinGet/Packages/Sky.UFFS_x");
+        assert_eq!(classify(path), (Channel::WinGet, Scope::User));
+    }
+}

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! `uffs update` — self-update **Phase A: detect & capture** (design in
+//! `docs/dev/architecture/UFFS-Self-Update-Feasibility-and-Design.md` §5).
+//!
+//! This is the **detection slice only**: it discovers every install
+//! *root* from the live anchors (invoking CLI + running daemon / MCP /
+//! broker), enumerates the UFFS binaries in each, classifies the channel
+//! that placed them, validates each binary's on-disk version, and
+//! captures the running processes' launch recipes. It **mutates
+//! nothing** — stopping, replacing, and restoring land in later phases.
+//!
+//! Entry point: `run_update` (wired to `uffs update` in `main`).
+
+mod binaries;
+mod channel;
+mod model;
+mod procinfo;
+mod report;
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use model::{Anchor, Channel, Component, DetectionReport, InstallRoot, RunningProcess, Scope};
+
+/// Run `uffs update`. Phase A only: prints the detection report.
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "matches the command-handler signature; later self-update phases return errors"
+)]
+pub(crate) fn run_update(args: &[String]) -> Result<()> {
+    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+        print_help();
+        return Ok(());
+    }
+    let report = detect();
+    report::print_human(&report);
+    print_phase_a_footer();
+    Ok(())
+}
+
+/// Phase A orchestration: anchors → roots → channel + versions, plus the
+/// running-process map.
+fn detect() -> DetectionReport {
+    let mut roots: Vec<InstallRoot> = Vec::new();
+    let mut running: Vec<RunningProcess> = Vec::new();
+
+    // A.1 anchor #1 — the invoking CLI.
+    if let Some(dir) = current_exe_dir() {
+        upsert_root(&mut roots, dir, Anchor::Cli);
+    }
+    // A.1 anchor #2 — the running daemon. Prefer its persisted launch
+    // state (reliable command line); fall back to native introspection.
+    capture_daemon(&mut roots, &mut running);
+    // A.1 anchor #3 — running MCP gateway(s).
+    for pid in procinfo::find_pids_by_name("uffsmcp") {
+        capture_native(&mut roots, &mut running, Component::Mcp, Anchor::Mcp, pid);
+    }
+    // A.1 anchor #4 — the broker service (Windows-only).
+    capture_broker(&mut roots, &mut running);
+
+    // A.2 + A.3 + A.4 — per root: enumerate binaries, classify, version.
+    for root in &mut roots {
+        root.binaries = binaries::enumerate(&root.dir);
+        let (chan, scope) = channel::classify(&root.dir);
+        root.channel = chan;
+        root.scope = scope;
+    }
+
+    DetectionReport { roots, running }
+}
+
+/// Directory of the currently-running `uffs` executable.
+fn current_exe_dir() -> Option<PathBuf> {
+    std::env::current_exe()
+        .ok()?
+        .parent()
+        .map(Path::to_path_buf)
+}
+
+/// Resolve the running daemon's pid — PID file first, then a name scan.
+fn daemon_pid() -> Option<u32> {
+    procinfo::daemon_pid_from_file()
+        .or_else(|| procinfo::find_pids_by_name("uffsd").into_iter().next())
+}
+
+/// Insert `dir` as an install root (deduplicated by canonical path) and
+/// record that `anchor` surfaced it.
+fn upsert_root(roots: &mut Vec<InstallRoot>, dir: PathBuf, anchor: Anchor) {
+    let key = std::fs::canonicalize(&dir).unwrap_or(dir);
+    if let Some(existing) = roots.iter_mut().find(|root| root.dir == key) {
+        existing.note_anchor(anchor);
+        return;
+    }
+    roots.push(InstallRoot {
+        dir: key,
+        channel: Channel::Unknown,
+        scope: Scope::Unknown,
+        anchored_by: vec![anchor],
+        binaries: Vec::new(),
+    });
+}
+
+/// Capture the daemon anchor: prefer its persisted launch state (which
+/// carries a reliable command line); otherwise fall back to native
+/// introspection of the pid from the PID file.
+fn capture_daemon(roots: &mut Vec<InstallRoot>, running: &mut Vec<RunningProcess>) {
+    if let Some((pid, state)) = procinfo::daemon_launch_state() {
+        let image_path = state.image_path;
+        if let Some(dir) = image_path.as_deref().and_then(Path::parent) {
+            upsert_root(roots, dir.to_path_buf(), Anchor::Daemon);
+        }
+        let version = state
+            .version
+            .or_else(|| image_path.as_deref().and_then(binaries::probe_version));
+        running.push(RunningProcess {
+            component: Component::Daemon,
+            pid,
+            image_path,
+            command_line: state.command_line,
+            version,
+        });
+    } else if let Some(pid) = daemon_pid() {
+        capture_native(roots, running, Component::Daemon, Anchor::Daemon, pid);
+    }
+}
+
+/// Capture a live process via native introspection: contribute its image
+/// directory as a root and record it in the running-process map.
+fn capture_native(
+    roots: &mut Vec<InstallRoot>,
+    running: &mut Vec<RunningProcess>,
+    component: Component,
+    anchor: Anchor,
+    pid: u32,
+) {
+    let image_path = procinfo::image_path(pid);
+    if let Some(dir) = image_path.as_deref().and_then(Path::parent) {
+        upsert_root(roots, dir.to_path_buf(), anchor);
+    }
+    let version = image_path.as_deref().and_then(binaries::probe_version);
+    running.push(RunningProcess {
+        component,
+        pid,
+        image_path,
+        command_line: procinfo::command_line(pid),
+        version,
+    });
+}
+
+/// Surface the broker service's install root + running process.
+///
+/// Cross-platform: `procinfo::broker_service()` returns `None` off
+/// Windows, so this is an early no-op there — but the `Anchor::Broker` /
+/// `Component::Broker` constructions stay in-source on every target
+/// (no platform-conditional dead code).
+fn capture_broker(roots: &mut Vec<InstallRoot>, running: &mut Vec<RunningProcess>) {
+    let Some((bin_path, service_pid)) = procinfo::broker_service() else {
+        return;
+    };
+    if let Some(dir) = bin_path.parent() {
+        upsert_root(roots, dir.to_path_buf(), Anchor::Broker);
+    }
+    let version = binaries::probe_version(&bin_path);
+    if let Some(pid) = service_pid {
+        running.push(RunningProcess {
+            component: Component::Broker,
+            pid,
+            image_path: Some(bin_path),
+            command_line: procinfo::command_line(pid),
+            version,
+        });
+    }
+}
+
+/// Print the `uffs update` help text.
+#[expect(clippy::print_stdout, reason = "intentional help output")]
+fn print_help() {
+    println!(
+        "uffs update — self-update (Phase A: detect & capture)\n\n\
+         USAGE:\n  uffs update [--check]\n\n\
+         Phase A discovers where UFFS is installed (from the running CLI,\n\
+         daemon, MCP gateway, and broker service), lists the binaries and\n\
+         their versions per location, and shows the running processes'\n\
+         launch recipes. It does not change anything yet.\n"
+    );
+}
+
+/// Footer clarifying that only detection is implemented so far.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_phase_a_footer() {
+    println!(
+        "\n(Phase A — detection only. Stop / replace / restore land in later phases; \
+         nothing was changed.)"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::model::{Anchor, InstallRoot};
+    use super::upsert_root;
+
+    fn root_dirs(roots: &[InstallRoot]) -> Vec<String> {
+        roots
+            .iter()
+            .map(|root| root.dir.display().to_string())
+            .collect()
+    }
+
+    fn anchors_of(root: &InstallRoot) -> Vec<Anchor> {
+        root.anchored_by.clone()
+    }
+
+    #[test]
+    fn upsert_dedupes_same_dir_and_merges_anchors() {
+        let mut roots: Vec<InstallRoot> = Vec::new();
+        // A non-existent path won't canonicalise, so the raw path is the key.
+        let dir = std::path::PathBuf::from("/nonexistent/uffs/root");
+        upsert_root(&mut roots, dir.clone(), Anchor::Cli);
+        upsert_root(&mut roots, dir, Anchor::Daemon);
+        assert_eq!(roots.len(), 1, "same dir must not create a second root");
+        let first = roots.first().expect("one root");
+        assert_eq!(anchors_of(first), vec![Anchor::Cli, Anchor::Daemon]);
+    }
+
+    #[test]
+    fn upsert_keeps_distinct_dirs_separate() {
+        let mut roots: Vec<InstallRoot> = Vec::new();
+        upsert_root(&mut roots, "/nonexistent/a".into(), Anchor::Cli);
+        upsert_root(&mut roots, "/nonexistent/b".into(), Anchor::Daemon);
+        assert_eq!(roots.len(), 2);
+        assert_eq!(root_dirs(&roots), vec!["/nonexistent/a", "/nonexistent/b"]);
+    }
+
+    #[test]
+    fn upsert_same_anchor_twice_is_idempotent() {
+        let mut roots: Vec<InstallRoot> = Vec::new();
+        upsert_root(&mut roots, "/nonexistent/a".into(), Anchor::Cli);
+        upsert_root(&mut roots, "/nonexistent/a".into(), Anchor::Cli);
+        let first = roots.first().expect("one root");
+        assert_eq!(anchors_of(first), vec![Anchor::Cli]);
+    }
+}

--- a/crates/uffs-cli/src/commands/update/model.rs
+++ b/crates/uffs-cli/src/commands/update/model.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Data model for self-update **Phase A — detect & capture** (see
+//! `docs/dev/architecture/UFFS-Self-Update-Feasibility-and-Design.md` §5).
+//!
+//! Phase A discovers every install *root* (a directory holding ≥1 UFFS
+//! binary) from three independent anchors — the invoking CLI, the
+//! running daemon, and the running broker — then records, per root, the
+//! channel that put it there and the on-disk version of each binary.
+//! These types are the in-memory shape of that result; nothing here
+//! mutates the system.
+
+use std::path::PathBuf;
+
+/// Install channel that placed the binaries at a discovered root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Channel {
+    /// Windows Package Manager (portable nested package under
+    /// `…\WinGet\Packages\…`).
+    WinGet,
+    /// Hand-placed: a manual GitHub-release extract, a copied build, etc.
+    Unmanaged,
+    /// A cargo `target/{debug,release}` build tree — never auto-updated.
+    DevBuild,
+    /// Could not be classified from the path.
+    Unknown,
+}
+
+impl Channel {
+    /// Short human label for report output.
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::WinGet => "winget",
+            Self::Unmanaged => "unmanaged",
+            Self::DevBuild => "dev-build",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Install scope for a `WinGet` root (user- vs machine-wide).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Scope {
+    /// Per-user install (`%LOCALAPPDATA%`).
+    User,
+    /// Machine-wide install (`%PROGRAMFILES%`).
+    Machine,
+    /// Scope not determined.
+    Unknown,
+}
+
+impl Scope {
+    /// Short human label for report output.
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Machine => "machine",
+            Self::Unknown => "-",
+        }
+    }
+}
+
+/// Which live anchor surfaced an install root (a root may be surfaced by
+/// more than one).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Anchor {
+    /// The `uffs.exe` that invoked `--update` (`current_exe()`).
+    Cli,
+    /// The running daemon's image directory.
+    Daemon,
+    /// The running MCP gateway's image directory.
+    Mcp,
+    /// The registered broker-service `binPath` directory.
+    Broker,
+}
+
+impl Anchor {
+    /// Short human label for report output.
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Daemon => "daemon",
+            Self::Mcp => "mcp",
+            Self::Broker => "broker",
+        }
+    }
+}
+
+/// One UFFS binary found inside an install root. Its on-disk path is
+/// `root.dir.join(exe_file_name(name))` — derived on demand by later
+/// phases rather than stored here.
+#[derive(Debug, Clone)]
+pub(crate) struct BinaryInfo {
+    /// Logical stem (e.g. `uffsd`), without the platform `.exe` suffix.
+    pub(crate) name: String,
+    /// Parsed `--version` (e.g. `0.6.2`), or `None` if it could not be read.
+    pub(crate) version: Option<String>,
+}
+
+/// A discovered install location (directory) holding ≥1 UFFS binary.
+#[derive(Debug, Clone)]
+pub(crate) struct InstallRoot {
+    /// The directory itself (canonicalised where possible).
+    pub(crate) dir: PathBuf,
+    /// Channel that placed these binaries.
+    pub(crate) channel: Channel,
+    /// Install scope (meaningful mainly for `WinGet`).
+    pub(crate) scope: Scope,
+    /// Anchors that surfaced this root (deduplicated, insertion order).
+    pub(crate) anchored_by: Vec<Anchor>,
+    /// The UFFS binaries present in this root.
+    pub(crate) binaries: Vec<BinaryInfo>,
+}
+
+impl InstallRoot {
+    /// Record that `anchor` also surfaced this root, without duplicating.
+    pub(crate) fn note_anchor(&mut self, anchor: Anchor) {
+        if !self.anchored_by.contains(&anchor) {
+            self.anchored_by.push(anchor);
+        }
+    }
+}
+
+/// Kind of running UFFS component discovered during anchor scanning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Component {
+    /// The resident index server (`uffsd`).
+    Daemon,
+    /// The elevated handle broker service (`uffs-broker` / `UffsAccessBroker`).
+    Broker,
+    /// The MCP server (`uffsmcp`), when run as the HTTP gateway.
+    Mcp,
+}
+
+impl Component {
+    /// Short human label for report output.
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Daemon => "daemon",
+            Self::Broker => "broker",
+            Self::Mcp => "mcp",
+        }
+    }
+}
+
+/// A live UFFS process captured during Phase A — the basis for the
+/// later stop/restart recipe.
+#[derive(Debug, Clone)]
+pub(crate) struct RunningProcess {
+    /// Which component this process is.
+    pub(crate) component: Component,
+    /// Operating-system process id.
+    pub(crate) pid: u32,
+    /// Full path to the running image, if it could be resolved.
+    pub(crate) image_path: Option<PathBuf>,
+    /// The exact launch command line (image + all switches), if available.
+    pub(crate) command_line: Option<String>,
+    /// Parsed running version, if it could be read.
+    pub(crate) version: Option<String>,
+}
+
+/// Full Phase-A detection result: the update *targets* (roots) plus the
+/// live-process map (what to stop / how to restart).
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DetectionReport {
+    /// Deduplicated install roots = the update targets.
+    pub(crate) roots: Vec<InstallRoot>,
+    /// Live UFFS processes found via the anchors.
+    pub(crate) running: Vec<RunningProcess>,
+}

--- a/crates/uffs-cli/src/commands/update/procinfo.rs
+++ b/crates/uffs-cli/src/commands/update/procinfo.rs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Live-process & service discovery for the daemon / broker / MCP
+//! anchors (Phase A.1 of the self-update design).
+//!
+//! **No PowerShell.** Sources, by reliability:
+//!
+//! - **Command line:** the component's own persisted launch state (the daemon
+//!   writes `daemon.state.json` next to its PID file). This is more trustworthy
+//!   than scraping another process's command line — and needs no `Win32`/PEB
+//!   hack.
+//! - **Image path + pid enumeration:** native Win32 via
+//!   `uffs_mft::platform::process` on Windows; `/proc` + `pgrep` on Unix.
+//! - **Broker service:** `sc.exe qc/queryex` (documented, not EDR-noisy).
+//!
+//! Everything is best-effort: a failed probe yields `None`.
+
+use std::path::PathBuf;
+
+/// Launch facts for a component — from its persisted state where
+/// available, else derived natively.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LaunchState {
+    /// Full path to the running image, if known.
+    pub(crate) image_path: Option<PathBuf>,
+    /// Exact launch command line (image + all switches), if known.
+    pub(crate) command_line: Option<String>,
+    /// Reported version, if known.
+    pub(crate) version: Option<String>,
+}
+
+/// Broker-service facts surfaced from `sc.exe`: `(registered binPath,
+/// running pid if started)`. A plain tuple so there is no Windows-only
+/// type to go dead off-Windows.
+pub(crate) type BrokerService = (PathBuf, Option<u32>);
+
+/// The daemon's lifecycle directory (`%LOCALAPPDATA%\uffs` on Windows),
+/// mirroring `uffs_daemon::startup` so the file paths match exactly.
+pub(crate) fn lifecycle_dir() -> PathBuf {
+    dirs_next::data_local_dir().map_or_else(|| PathBuf::from("/tmp/uffs"), |base| base.join("uffs"))
+}
+
+/// Read the daemon PID from `<lifecycle_dir>/daemon.pid`, if present.
+pub(crate) fn daemon_pid_from_file() -> Option<u32> {
+    let text = std::fs::read_to_string(lifecycle_dir().join("daemon.pid")).ok()?;
+    text.trim().parse::<u32>().ok()
+}
+
+/// Read the daemon's persisted launch state (`daemon.state.json`), which
+/// the daemon writes next to its PID file at startup. Returns
+/// `(pid, launch_state)`.
+pub(crate) fn daemon_launch_state() -> Option<(u32, LaunchState)> {
+    let text = std::fs::read_to_string(lifecycle_dir().join("daemon.state.json")).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let pid = u32::try_from(value.get("pid")?.as_u64()?).ok()?;
+    Some((pid, launch_state_from_json(&value)))
+}
+
+/// Extract a [`LaunchState`] from the daemon-state JSON object.
+fn launch_state_from_json(value: &serde_json::Value) -> LaunchState {
+    let string_field = |key: &str| {
+        value
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .filter(|text| !text.is_empty())
+            .map(ToOwned::to_owned)
+    };
+    LaunchState {
+        image_path: string_field("image_path").map(PathBuf::from),
+        command_line: string_field("command_line"),
+        version: string_field("version"),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Image path + pid enumeration — native, per platform.
+// ─────────────────────────────────────────────────────────────────────
+
+/// Native image path for a pid (Win32 `QueryFullProcessImageNameW`).
+#[cfg(windows)]
+pub(crate) fn image_path(pid: u32) -> Option<PathBuf> {
+    uffs_mft::platform::process::process_image_path(pid)
+}
+
+/// Image path for a pid via `/proc` then `ps`.
+#[cfg(unix)]
+pub(crate) fn image_path(pid: u32) -> Option<PathBuf> {
+    unix_image_path(pid)
+}
+
+/// Best-effort command line for a pid. **Windows returns `None`** — the
+/// command line comes from persisted launch state, never OS scraping.
+#[cfg(windows)]
+pub(crate) const fn command_line(_pid: u32) -> Option<String> {
+    None
+}
+
+/// Command line for a pid via `/proc` then `ps` (Unix).
+#[cfg(unix)]
+pub(crate) fn command_line(pid: u32) -> Option<String> {
+    unix_cmdline(pid)
+}
+
+/// Find pids by image stem (native Win32 process snapshot).
+#[cfg(windows)]
+pub(crate) fn find_pids_by_name(stem: &str) -> Vec<u32> {
+    uffs_mft::platform::process::pids_by_image_name(&format!("{stem}.exe"))
+}
+
+/// Find pids by exact process name via `pgrep -x`.
+#[cfg(unix)]
+pub(crate) fn find_pids_by_name(stem: &str) -> Vec<u32> {
+    std::process::Command::new("pgrep")
+        .args(["-x", stem])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| {
+            String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .filter_map(|line| line.trim().parse::<u32>().ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Broker service (Windows `sc.exe`).
+// ─────────────────────────────────────────────────────────────────────
+
+/// The broker service's registered binary path + running pid, via
+/// `sc.exe`. `None` when the service is not installed.
+#[cfg(windows)]
+pub(crate) fn broker_service() -> Option<BrokerService> {
+    let qc = sc_output(&["qc", "UffsAccessBroker"])?;
+    let bin_path = qc
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("BINARY_PATH_NAME").map(str::trim))
+        .and_then(|rest| rest.strip_prefix(':').map(str::trim))
+        .map(PathBuf::from)?;
+    let pid = sc_output(&["queryex", "UffsAccessBroker"]).and_then(|queryex| {
+        queryex.lines().find_map(|line| {
+            line.trim()
+                .strip_prefix("PID")
+                .and_then(|rest| rest.trim().strip_prefix(':'))
+                .and_then(|num| num.trim().parse::<u32>().ok())
+                .filter(|parsed| *parsed != 0)
+        })
+    });
+    Some((bin_path, pid))
+}
+
+/// Non-Windows: there is no broker service.
+#[cfg(not(windows))]
+pub(crate) const fn broker_service() -> Option<BrokerService> {
+    None
+}
+
+/// Run `sc.exe <args>` and return trimmed stdout on success.
+#[cfg(windows)]
+fn sc_output(args: &[&str]) -> Option<String> {
+    let out = std::process::Command::new("sc.exe")
+        .args(args)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout).into_owned();
+    (!text.trim().is_empty()).then_some(text)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Unix helpers (macOS / Linux).
+// ─────────────────────────────────────────────────────────────────────
+
+/// Best-effort command line for a unix pid (`/proc` then `ps`).
+#[cfg(unix)]
+fn unix_cmdline(pid: u32) -> Option<String> {
+    if let Ok(raw) = std::fs::read(format!("/proc/{pid}/cmdline")) {
+        // `/proc/<pid>/cmdline` is NUL-separated.
+        let joined = raw
+            .split(|byte| *byte == 0)
+            .filter(|seg| !seg.is_empty())
+            .map(|seg| String::from_utf8_lossy(seg).into_owned())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if !joined.is_empty() {
+            return Some(joined);
+        }
+    }
+    ps_field(pid, "args=")
+}
+
+/// Best-effort image path for a unix pid (`/proc/<pid>/exe` then `ps comm=`).
+#[cfg(unix)]
+fn unix_image_path(pid: u32) -> Option<PathBuf> {
+    if let Ok(target) = std::fs::read_link(format!("/proc/{pid}/exe")) {
+        return Some(target);
+    }
+    ps_field(pid, "comm=").map(PathBuf::from)
+}
+
+/// Run `ps -p <pid> -o <field>` and return the trimmed single-line value.
+#[cfg(unix)]
+fn ps_field(pid: u32, field: &str) -> Option<String> {
+    let out = std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", field])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    (!text.is_empty()).then_some(text)
+}

--- a/crates/uffs-cli/src/commands/update/report.rs
+++ b/crates/uffs-cli/src/commands/update/report.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Human-readable rendering of the Phase-A [`DetectionReport`].
+//!
+//! Pure formatting: it never mutates the system, it only prints what
+//! detection found (the `--check` view of the self-update flow).
+
+use super::model::{DetectionReport, RunningProcess};
+
+/// Print the detection report to stdout.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+pub(crate) fn print_human(report: &DetectionReport) {
+    println!("UFFS self-update — Phase A (detect & capture)\n");
+
+    println!("Install roots / update targets ({}):", report.roots.len());
+    if report.roots.is_empty() {
+        println!("  (none found — is UFFS on PATH / installed?)");
+    }
+    for (idx, root) in report.roots.iter().enumerate() {
+        let anchors = root
+            .anchored_by
+            .iter()
+            .map(|anchor| anchor.label())
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("  [{}] {}", idx + 1, root.dir.display());
+        println!(
+            "      channel: {}   scope: {}   anchored-by: {anchors}",
+            root.channel.label(),
+            root.scope.label(),
+        );
+        for binary in &root.binaries {
+            println!(
+                "      - {:<12} {}",
+                binary.name,
+                binary.version.as_deref().unwrap_or("?")
+            );
+        }
+    }
+
+    println!("\nRunning components ({}):", report.running.len());
+    if report.running.is_empty() {
+        println!("  (none running)");
+    }
+    for proc in &report.running {
+        print_running(proc);
+    }
+
+    print_skew(report);
+}
+
+/// Print one running component's image + launch recipe.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_running(proc: &RunningProcess) {
+    println!(
+        "  {:<7} pid={:<7} version={}",
+        proc.component.label(),
+        proc.pid,
+        proc.version.as_deref().unwrap_or("?"),
+    );
+    if let Some(image) = &proc.image_path {
+        println!("      image: {}", image.display());
+    }
+    if let Some(cmd) = &proc.command_line {
+        println!("      cmd:   {cmd}");
+    }
+}
+
+/// Print a one-line version-skew summary: the distinct versions seen
+/// across every discovered binary. More than one ⇒ the install is
+/// skewed and an update would realign it.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_skew(report: &DetectionReport) {
+    let mut versions: Vec<&str> = Vec::new();
+    for root in &report.roots {
+        for binary in &root.binaries {
+            versions.extend(binary.version.as_deref());
+        }
+    }
+    for proc in &report.running {
+        versions.extend(proc.version.as_deref());
+    }
+    versions.sort_unstable();
+    versions.dedup();
+
+    println!();
+    match versions.as_slice() {
+        [] => println!("Version skew: (no versions could be read)"),
+        [only] => println!("Version skew: none — all components at {only}"),
+        many => println!(
+            "Version skew: ⚠ multiple versions present: {}",
+            many.join(", ")
+        ),
+    }
+}

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -81,6 +81,7 @@ fn run() -> Result<()> {
         "aggregate" | "agg" => run_aggregate(subcmd_args)?,
         "daemon" => run_daemon(subcmd_args)?,
         "mcp" => commands::mcp_mgmt::mcp_from_args(subcmd_args)?,
+        "update" => commands::update::run_update(subcmd_args)?,
         "status" => {
             if subcmd_args.iter().any(|arg| arg == "--help" || arg == "-h") {
                 args::print_status_help();

--- a/crates/uffs-daemon/src/lifecycle.rs
+++ b/crates/uffs-daemon/src/lifecycle.rs
@@ -271,6 +271,52 @@ impl LifecycleManager {
         }
     }
 
+    /// Path to the launch-state sidecar (next to the PID file).
+    fn launch_state_path(&self) -> PathBuf {
+        self.pid_path.with_file_name("daemon.state.json")
+    }
+
+    /// Persist this daemon's launch recipe next to the PID file.
+    ///
+    /// The self-updater reads this back to restart the daemon faithfully
+    /// (same image + same switches) without scraping the OS for another
+    /// process's command line — more reliable than `Win32`/PEB
+    /// introspection and free of any PowerShell shell-out.
+    pub(crate) fn write_launch_state(&self) {
+        let path = self.launch_state_path();
+        let image = std::env::current_exe()
+            .ok()
+            .map(|exe| exe.display().to_string())
+            .unwrap_or_default();
+        let command_line = std::env::args().collect::<Vec<_>>().join(" ");
+        let started_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |dur| dur.as_secs());
+        let state = serde_json::json!({
+            "pid": std::process::id(),
+            "image_path": image,
+            "command_line": command_line,
+            "version": env!("CARGO_PKG_VERSION"),
+            "started_unix": started_unix,
+        });
+        let Ok(content) = serde_json::to_string_pretty(&state) else {
+            return;
+        };
+        if std::fs::write(&path, content).is_err() {
+            return;
+        }
+        let _ignore = uffs_security::fs::set_file_permissions_owner_only(&path);
+        tracing::info!(path = %path.display(), "launch-state file written");
+    }
+
+    /// Remove the launch-state sidecar (called on shutdown).
+    pub(crate) fn remove_launch_state(&self) {
+        let path = self.launch_state_path();
+        if path.exists() {
+            let _ignore = std::fs::remove_file(&path);
+        }
+    }
+
     /// Remove the IPC socket file (called on shutdown).
     ///
     /// Without this, a stale socket file remains after graceful stop and
@@ -691,6 +737,7 @@ impl Drop for LifecycleManager {
         // wrote a PID file, so we must not delete the other daemon's files.
         if self.owns_pid_file {
             self.remove_pid_file();
+            self.remove_launch_state();
             self.remove_socket_file();
         }
     }

--- a/crates/uffs-daemon/src/startup.rs
+++ b/crates/uffs-daemon/src/startup.rs
@@ -157,6 +157,7 @@ pub(crate) fn bootstrap_lifecycle_manager(
     }
 
     lifecycle_mgr.write_pid_file()?;
+    lifecycle_mgr.write_launch_state();
     tracing::info!("PID file written");
     Ok(lifecycle_mgr)
 }

--- a/crates/uffs-mft/src/platform.rs
+++ b/crates/uffs-mft/src/platform.rs
@@ -37,6 +37,11 @@ mod extents;
 /// detection through [`Lcn::is_hole`] / [`Lcn::is_zero`] instead of
 /// open-coded `< 0` / `== 0` checks at every call site.
 pub mod lcn;
+/// Native Windows process introspection for the self-update detector.
+///
+/// Image path + pid enumeration — keeps the `unsafe` FFI out of `uffs-cli`.
+#[cfg(windows)]
+pub mod process;
 mod system;
 /// `$UpCase` table reading from live NTFS volume.
 pub mod upcase;

--- a/crates/uffs-mft/src/platform/process.rs
+++ b/crates/uffs-mft/src/platform/process.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Native Windows process introspection for the self-update detector.
+//!
+//! Exposes a pid's full image path and enumeration of pids by image file
+//! name.
+//!
+//! Lives here (not in `uffs-cli`) so the `unsafe` Win32 FFI stays in the
+//! crate that already owns it; `uffs-cli` calls the safe wrappers and
+//! stays `unsafe`-free. Replaces the earlier PowerShell `Get-CimInstance`
+//! shell-out (EDR-noisy, lockdown-fragile, slow) with documented Win32
+//! calls. Uses only already-enabled `windows`-crate features
+//! (`Win32_System_Threading` + `Win32_System_ProcessStatus`).
+
+#![cfg(windows)]
+
+use std::path::PathBuf;
+
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::System::ProcessStatus::EnumProcesses;
+use windows::Win32::System::Threading::{
+    OpenProcess, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
+};
+use windows::core::PWSTR;
+
+/// Buffer size (in UTF-16 code units) for an extended-length image path.
+const PATH_CAP: usize = 32_768;
+
+/// Resolve a process's full image path from its pid, or `None` if the
+/// process cannot be opened (e.g. exited, or access denied).
+#[must_use]
+pub fn process_image_path(pid: u32) -> Option<PathBuf> {
+    let handle = open_for_query(pid)?;
+    let result = image_path_of(handle);
+    close_handle(handle);
+    result
+}
+
+/// Enumerate the pids whose image **file name** equals `file_name`
+/// (case-insensitive, e.g. `"uffsmcp.exe"`).
+#[must_use]
+pub fn pids_by_image_name(file_name: &str) -> Vec<u32> {
+    enum_pids()
+        .into_iter()
+        .filter(|&pid| {
+            process_image_path(pid).is_some_and(|path| {
+                path.file_name()
+                    .is_some_and(|name| name.to_string_lossy().eq_ignore_ascii_case(file_name))
+            })
+        })
+        .collect()
+}
+
+/// Open a process handle with the minimal query-only access right.
+fn open_for_query(pid: u32) -> Option<HANDLE> {
+    // SAFETY: `OpenProcess` is a documented Win32 call; the access mask
+    // and pid are plain values and it returns `Err` on failure.
+    #[expect(unsafe_code, reason = "Win32 FFI — OpenProcess")]
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
+    (!handle.is_invalid()).then_some(handle)
+}
+
+/// Query the full Win32 image path for an open process handle.
+fn image_path_of(handle: HANDLE) -> Option<PathBuf> {
+    let mut buf = vec![0_u16; PATH_CAP];
+    let mut size = u32::try_from(buf.len()).ok()?;
+    // SAFETY: `buf`/`size` are a valid writable buffer + length pair;
+    // `PROCESS_NAME_WIN32` requests a Win32-format path. On success
+    // `size` is updated to the number of code units written.
+    #[expect(unsafe_code, reason = "Win32 FFI — QueryFullProcessImageNameW")]
+    let outcome = unsafe {
+        QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_WIN32,
+            PWSTR(buf.as_mut_ptr()),
+            core::ptr::from_mut(&mut size),
+        )
+    };
+    outcome.ok()?;
+    let written = usize::try_from(size).ok()?;
+    let slice = buf.get(..written)?;
+    Some(PathBuf::from(String::from_utf16_lossy(slice)))
+}
+
+/// Snapshot all process ids on the system via `EnumProcesses`, growing
+/// the buffer until it is not saturated.
+fn enum_pids() -> Vec<u32> {
+    let mut pids = vec![0_u32; 4_096];
+    loop {
+        let Ok(cap_bytes) = u32::try_from(pids.len() * size_of::<u32>()) else {
+            return Vec::new();
+        };
+        let mut needed_bytes = 0_u32;
+        // SAFETY: `pids` is a valid writable buffer of `cap_bytes` bytes;
+        // `needed_bytes` receives the bytes actually used.
+        #[expect(unsafe_code, reason = "Win32 FFI — EnumProcesses")]
+        let outcome = unsafe {
+            EnumProcesses(
+                pids.as_mut_ptr(),
+                cap_bytes,
+                core::ptr::from_mut(&mut needed_bytes),
+            )
+        };
+        if outcome.is_err() {
+            return Vec::new();
+        }
+        let Ok(needed) = usize::try_from(needed_bytes) else {
+            return Vec::new();
+        };
+        let count = needed / size_of::<u32>();
+        if count < pids.len() {
+            pids.truncate(count);
+            return pids;
+        }
+        // Buffer was saturated — grow and retry to avoid truncation.
+        pids.resize(pids.len() * 2, 0_u32);
+    }
+}
+
+/// Close a process handle obtained from [`open_for_query`].
+fn close_handle(handle: HANDLE) {
+    // SAFETY: `handle` came from `OpenProcess` and is closed exactly once.
+    #[expect(unsafe_code, reason = "Win32 FFI — CloseHandle")]
+    let _closed = unsafe { CloseHandle(handle) };
+}


### PR DESCRIPTION
First slice of the self-update design (`docs/dev/architecture/UFFS-Self-Update-Feasibility-and-Design.md` §5) — **detection only, no mutation.**

## What `uffs update` does
Discovers every install **root** from the live anchors — the invoking CLI plus the running **daemon / MCP / broker**, which can live in *different* directories — then per root:
- enumerates the UFFS binaries present (coherent-set, honor-what's-installed),
- classifies the channel: **winget / unmanaged / dev-build**,
- validates each binary's **on-disk version** (surfacing skew),
- captures each running process's **launch recipe** (image + command line).

Validated live on macOS — it correctly surfaced a real skewed dev box (0.6.2 in `target/debug`, an old 0.5.119 in `~/bin`, and the running gateways with their exact command lines).

## Native, PowerShell-free introspection
Per the design discussion, this avoids shelling PowerShell (EDR-noisy, lockdown-fragile, slow):
- **Image path + pid enumeration** → new `uffs_mft::platform::process` (`QueryFullProcessImageNameW` + `EnumProcesses`). Keeps the `unsafe` Win32 FFI in `uffs-mft`; **`uffs-cli` stays `unsafe`-free**. Uses only already-enabled `windows`-crate features (no Cargo change).
- **Command line** → the daemon's **own persisted launch state**: the daemon now writes `daemon.state.json` next to its PID file (removed on shutdown). More reliable than scraping another process's command line — no PEB / WMI / PowerShell.
- **Broker** → `sc.exe qc/queryex` (documented service tooling, not an EDR red flag).

## Tests / gates
- Unit tests: channel classification, version parsing, root dedup + anchor-merge.
- Host clippy (prod + tests) ✅, **Windows xwin clippy ✅** (all three crates), rustdoc ✅, fmt ✅, full pre-push gate ✅.

## Scope
Detection is the safe, standalone slice. Stop / acquire / replace / restore + self-heal land in later phases (the `procinfo` interface stays stable — only later phases add mutation).