### PR TITLE
feat: self-update Phases B & C — snapshot + acquire (+ DRY Authenticode)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3329,6 +3329,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -4667,6 +4668,17 @@ dependencies = [
 [[package]]
 name = "uffs-time"
 version = "0.6.2"
+
+[[package]]
+name = "uffs-update"
+version = "0.6.2"
+dependencies = [
+ "anyhow",
+ "hex",
+ "reqwest",
+ "serde",
+ "sha2 0.11.0",
+]
 
 [[package]]
 name = "unarray"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4393,6 +4393,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uffs-broker-protocol",
+ "uffs-security",
  "windows 0.62.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ members = [
   "crates/uffs-mcp",    # 🤖 MCP stdio adapter for AI agents
   "crates/uffs-broker", # 🔑 Windows elevated handle broker (optional)
   # ── Surfaces ──
-  "crates/uffs-cli", # 🖥️  Command-line interface
+  "crates/uffs-cli",    # 🖥️  Command-line interface
+  "crates/uffs-update", # ⬆️  Self-update acquire helper (HTTP/TLS isolated from the CLI)
   # NOTE: uffs-tui and uffs-gui have moved to the private uffs-products repo.
   # ── Tools ──
   "crates/uffs-diag",          # 🔬 Retained workspace-only diagnostic tools (not shipped in dist/)
@@ -281,6 +282,15 @@ rustc-hash = "2.1.2"
 itoa = "1.0.18"
 sha2 = "0.11.0"
 hex = "0.4.3"
+
+# ───── Network (self-update acquire helper only) ─────
+# Blocking HTTP with rustls + the system trust store. `rustls-tls-native-roots`
+# matches the existing transitive reqwest config so no new crate enters the lock.
+reqwest = { version = "0.12", default-features = false, features = [
+  "blocking",
+  "rustls-tls-native-roots",
+  "json",
+] }
 
 # ───── Parallelism ─────
 rayon = "1.12.0"

--- a/crates/uffs-broker/Cargo.toml
+++ b/crates/uffs-broker/Cargo.toml
@@ -62,6 +62,10 @@ windows.workspace = true
 # pure-logic protocol module is cross-platform-testable without
 # dragging the Windows FFI surface along.
 uffs-broker-protocol.workspace = true
+# Shared in-process Authenticode (`WinVerifyTrust`) verification — the
+# single implementation now lives in `uffs-security` (DRY with the
+# self-updater) instead of a broker-local copy.
+uffs-security.workspace = true
 
 [lints]
 workspace = true

--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -36,13 +36,11 @@ use service::{install_service, uninstall_service};
 mod process_handle;
 #[cfg(windows)]
 use process_handle::{OwnedProcessHandle, query_process_image_name, verify_client_handle};
-
-// S5.2 Authenticode verification (WinVerifyTrust + per-image cache), split out
-// to keep this file under the 800-LOC ceiling. See `broker/authenticode.rs`.
-#[path = "broker/authenticode.rs"]
-mod authenticode;
+// S5.2 Authenticode verification (WinVerifyTrust + per-image cache). The single
+// implementation now lives in `uffs_security::authenticode`, shared with the
+// self-updater (DRY) instead of a broker-local copy.
 #[cfg(windows)]
-use authenticode::verify_authenticode;
+use uffs_security::authenticode::verify_authenticode;
 
 // `Send`-safe RAII handle wrapper (SBB-2) — lets a connected pipe instance move
 // into a per-connection worker thread (FU-5). See `broker/owned_handle.rs`.

--- a/crates/uffs-cli/src/commands/update/acquire.rs
+++ b/crates/uffs-cli/src/commands/update/acquire.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase C trigger: spawn the `uffs-update` helper to download + verify a
+//! release into the staging dir.
+//!
+//! The HTTP/TLS stack lives in the separate `uffs-update` binary, so the
+//! lean `uffs` CLI just locates it (next to `uffs`, else on `PATH`) and
+//! shells out — keeping reqwest/rustls out of `uffs.exe`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{Context as _, Result, bail};
+
+use super::snapshot;
+
+/// Default upstream repository for self-update artifacts.
+const DEFAULT_REPO: &str = "skyllc-ai/UltraFastFileSearch";
+
+/// Platform file name of the helper binary.
+const fn helper_file_name() -> &'static str {
+    if cfg!(windows) {
+        "uffs-update.exe"
+    } else {
+        "uffs-update"
+    }
+}
+
+/// Locate the `uffs-update` helper — next to the running `uffs` first,
+/// then on `PATH`.
+fn find_helper() -> Result<PathBuf> {
+    let name = helper_file_name();
+    if let Some(sibling) = std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(|dir| dir.join(name)))
+        .filter(|path| path.exists())
+    {
+        return Ok(sibling);
+    }
+    which::which(name)
+        .with_context(|| format!("cannot find `{name}` — install it alongside `uffs`"))
+}
+
+/// Spawn the acquire helper for an optional target version tag.
+///
+/// # Errors
+///
+/// Fails if the helper cannot be located or it exits non-zero.
+pub(crate) fn spawn(version: Option<&str>) -> Result<()> {
+    let helper = find_helper()?;
+    let stage = snapshot::update_dir().join("stage");
+    let mut command = Command::new(&helper);
+    command
+        .args(["acquire", "--repo", DEFAULT_REPO, "--stage"])
+        .arg(&stage);
+    if let Some(tag) = version {
+        command.args(["--version", tag]);
+    }
+    let status = command
+        .status()
+        .with_context(|| format!("spawning {}", helper.display()))?;
+    if !status.success() {
+        bail!("uffs-update acquire failed (exit {:?})", status.code());
+    }
+    Ok(())
+}

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -13,6 +13,7 @@
 //!
 //! Entry point: `run_update` (wired to `uffs update` in `main`).
 
+mod acquire;
 mod binaries;
 mod channel;
 mod model;
@@ -25,11 +26,8 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use model::{Anchor, Channel, Component, DetectionReport, InstallRoot, RunningProcess, Scope};
 
-/// Run `uffs update`. Phase A only: prints the detection report.
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "matches the command-handler signature; later self-update phases return errors"
-)]
+/// Run `uffs update`: detect (Phase A), optional snapshot (Phase B), and
+/// optional acquire (Phase C, via the `uffs-update` helper).
 pub(crate) fn run_update(args: &[String]) -> Result<()> {
     if args.iter().any(|arg| arg == "--help" || arg == "-h") {
         print_help();
@@ -41,7 +39,18 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
         write_and_report_snapshot(&report);
     }
     print_phase_a_footer();
+    if args.iter().any(|arg| arg == "--acquire") {
+        acquire::spawn(flag_value(args, "--version").as_deref())?;
+    }
     Ok(())
+}
+
+/// Return the value following `name` in `args` (`--name value`).
+fn flag_value(args: &[String], name: &str) -> Option<String> {
+    args.iter()
+        .position(|arg| arg == name)
+        .and_then(|idx| args.get(idx + 1))
+        .cloned()
 }
 
 /// Write a Phase-B snapshot and report where it landed.
@@ -196,21 +205,25 @@ fn capture_broker(roots: &mut Vec<InstallRoot>, running: &mut Vec<RunningProcess
 #[expect(clippy::print_stdout, reason = "intentional help output")]
 fn print_help() {
     println!(
-        "uffs update — self-update (Phase A: detect & capture)\n\n\
-         USAGE:\n  uffs update [--check]\n\n\
-         Phase A discovers where UFFS is installed (from the running CLI,\n\
-         daemon, MCP gateway, and broker service), lists the binaries and\n\
-         their versions per location, and shows the running processes'\n\
-         launch recipes. It does not change anything yet.\n"
+        "uffs update — self-update\n\n\
+         USAGE:\n  uffs update [--snapshot] [--acquire [--version <tag>]]\n\n\
+         Discovers where UFFS is installed (from the running CLI, daemon,\n\
+         MCP gateway, and broker service), lists binaries + versions per\n\
+         location, and shows the running processes' launch recipes.\n\n\
+         FLAGS:\n\
+         \x20 --snapshot          Persist the detection + live daemon state to JSON.\n\
+         \x20 --acquire           Download + SHA-256-verify the release into staging\n\
+         \x20                     (via the uffs-update helper). Does NOT replace.\n\
+         \x20 --version <tag>     Acquire a specific release tag (default: latest).\n"
     );
 }
 
-/// Footer clarifying that only detection is implemented so far.
+/// Footer clarifying which mutating phases are not yet implemented.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
 fn print_phase_a_footer() {
     println!(
-        "\n(Phase A — detection only. Stop / replace / restore land in later phases; \
-         nothing was changed.)"
+        "\n(Detect + snapshot + acquire are non-mutating. Stop / replace / restore \
+         land in the apply phase; nothing on a live install was changed.)"
     );
 }
 

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -18,6 +18,7 @@ mod channel;
 mod model;
 mod procinfo;
 mod report;
+mod snapshot;
 
 use std::path::{Path, PathBuf};
 
@@ -36,8 +37,25 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
     }
     let report = detect();
     report::print_human(&report);
+    if args.iter().any(|arg| arg == "--snapshot") {
+        write_and_report_snapshot(&report);
+    }
     print_phase_a_footer();
     Ok(())
+}
+
+/// Write a Phase-B snapshot and report where it landed.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn write_and_report_snapshot(report: &DetectionReport) {
+    match snapshot::write_snapshot(report) {
+        Ok(path) => println!("\nSnapshot written: {}", path.display()),
+        Err(err) => {
+            #[expect(clippy::print_stderr, reason = "CLI user-facing error")]
+            {
+                eprintln!("\nSnapshot failed: {err}");
+            }
+        }
+    }
 }
 
 /// Phase A orchestration: anchors → roots → channel + versions, plus the

--- a/crates/uffs-cli/src/commands/update/snapshot.rs
+++ b/crates/uffs-cli/src/commands/update/snapshot.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase B — snapshot: freeze the Phase-A detection plus the daemon's
+//! live drive/tier state into a timestamped JSON file under the update
+//! working directory (`<lifecycle_dir>/update/snapshot-<unix>.json`).
+//!
+//! This is the durable record the later acquire / stop / replace /
+//! restore phases read back. Writing it costs nothing and lets a failed
+//! later step abort with a faithful "what was here before" picture.
+
+use std::path::PathBuf;
+
+use serde_json::{Value, json};
+
+use super::model::DetectionReport;
+use super::procinfo;
+
+/// Directory that holds update snapshots + staging
+/// (`<lifecycle_dir>/update`).
+pub(crate) fn update_dir() -> PathBuf {
+    procinfo::lifecycle_dir().join("update")
+}
+
+/// Capture + persist a snapshot for `report`. Returns the file path.
+///
+/// # Errors
+///
+/// Propagates any directory-create or file-write failure.
+pub(crate) fn write_snapshot(report: &DetectionReport) -> std::io::Result<PathBuf> {
+    let dir = update_dir();
+    std::fs::create_dir_all(&dir)?;
+    let captured_unix = unix_now();
+    let value = build_snapshot_value(report, &daemon_drive_state(), captured_unix);
+    let path = dir.join(format!("snapshot-{captured_unix}.json"));
+    let body = serde_json::to_string_pretty(&value)
+        .unwrap_or_else(|_| "{\"schema\":2,\"error\":\"serialize\"}".to_owned());
+    std::fs::write(&path, body)?;
+    Ok(path)
+}
+
+/// Seconds since the Unix epoch (0 if the clock is before it).
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |dur| dur.as_secs())
+}
+
+/// Query the daemon's live drive/tier state via the `status_drives`
+/// RPC. Empty when no daemon is running (best-effort).
+fn daemon_drive_state() -> Vec<Value> {
+    let Ok(mut client) = uffs_client::connect_sync::UffsClientSync::connect_raw() else {
+        return Vec::new();
+    };
+    let Ok(response) = client.status_drives() else {
+        return Vec::new();
+    };
+    response
+        .drives
+        .into_iter()
+        .map(|drive| {
+            json!({
+                "letter": drive.letter.to_string(),
+                "tier": drive.tier,
+                "resident_bytes": drive.resident_bytes,
+                "pin_until_unix_ms": drive.pin_until_unix_ms,
+            })
+        })
+        .collect()
+}
+
+/// Build the snapshot JSON (pure — unit-testable without I/O).
+fn build_snapshot_value(
+    report: &DetectionReport,
+    daemon_drives: &[Value],
+    captured_unix: u64,
+) -> Value {
+    let targets: Vec<Value> = report
+        .roots
+        .iter()
+        .map(|root| {
+            json!({
+                "root": root.dir.display().to_string(),
+                "channel": root.channel.label(),
+                "scope": root.scope.label(),
+                "anchored_by": root.anchored_by.iter().map(|anchor| anchor.label()).collect::<Vec<_>>(),
+                "binaries": root.binaries.iter().map(|binary| json!({
+                    "name": binary.name,
+                    "on_disk_version": binary.version,
+                })).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+
+    let running: Vec<Value> = report
+        .running
+        .iter()
+        .map(|proc| {
+            json!({
+                "component": proc.component.label(),
+                "pid": proc.pid,
+                "image_path": proc.image_path.as_ref().map(|path| path.display().to_string()),
+                "command_line": proc.command_line,
+                "version": proc.version,
+            })
+        })
+        .collect();
+
+    json!({
+        "schema": 2,
+        "captured_unix": captured_unix,
+        "targets": targets,
+        "running": running,
+        "daemon": { "drives": daemon_drives },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::super::model::{
+        Anchor, BinaryInfo, Channel, Component, DetectionReport, InstallRoot, RunningProcess, Scope,
+    };
+    use super::build_snapshot_value;
+
+    fn sample_report() -> DetectionReport {
+        DetectionReport {
+            roots: vec![InstallRoot {
+                dir: "/opt/uffs".into(),
+                channel: Channel::Unmanaged,
+                scope: Scope::Unknown,
+                anchored_by: vec![Anchor::Cli, Anchor::Daemon],
+                binaries: vec![BinaryInfo {
+                    name: "uffsd".to_owned(),
+                    version: Some("0.6.2".to_owned()),
+                }],
+            }],
+            running: vec![RunningProcess {
+                component: Component::Daemon,
+                pid: 4242,
+                image_path: Some("/opt/uffs/uffsd".into()),
+                command_line: Some("uffsd --no-retire".to_owned()),
+                version: Some("0.6.2".to_owned()),
+            }],
+        }
+    }
+
+    #[test]
+    fn snapshot_shape_is_stable() {
+        let drives = vec![json!({"letter": "C", "tier": "warm"})];
+        let value = build_snapshot_value(&sample_report(), &drives, 1_700_000_000_u64);
+        // `pointer` avoids panicking index ops; `json!(typed)` pins the
+        // expected literal type (no default numeric fallback).
+        let probe = |path: &str, expected: serde_json::Value| {
+            assert_eq!(value.pointer(path), Some(&expected), "mismatch at {path}");
+        };
+        probe("/schema", json!(2_u64));
+        probe("/captured_unix", json!(1_700_000_000_u64));
+        probe("/targets/0/channel", json!("unmanaged"));
+        probe("/targets/0/anchored_by/1", json!("daemon"));
+        probe("/targets/0/binaries/0/on_disk_version", json!("0.6.2"));
+        probe("/running/0/component", json!("daemon"));
+        probe("/running/0/pid", json!(4242_u32));
+        probe("/running/0/command_line", json!("uffsd --no-retire"));
+        probe("/daemon/drives/0/letter", json!("C"));
+    }
+}

--- a/crates/uffs-security/src/authenticode.rs
+++ b/crates/uffs-security/src/authenticode.rs
@@ -1,56 +1,41 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! S5.2 Authenticode verification of the broker's client image.
+//! In-process Authenticode (`WinVerifyTrust`) signature verification.
 //!
-//! In-process `WinVerifyTrust` (replacing the old per-request PowerShell
-//! `Get-AuthenticodeSignature` spawn — hundreds of ms each, plus a hard
-//! dependency on PowerShell), with a per-`(exe_path, mtime)` result cache so a
-//! client's repeated drive requests verify once.  Split out of `broker.rs` to
-//! keep that file under the 800-LOC ceiling (alongside `service.rs` and
-//! `process_handle.rs`).
+//! The single shared implementation used by both the Access Broker
+//! (verifying its client image) and the self-updater (verifying a
+//! downloaded binary before it is allowed to replace anything).
+//!
+//! Consolidated here so the one piece of `WinVerifyTrust` FFI lives in a
+//! single audited place rather than drifting across crates. Includes a
+//! per-`(exe_path, mtime)` result cache so repeated checks of the same
+//! image verify once; a replaced binary (different mtime) is a cache
+//! **miss** and is re-verified — a substituted image can never inherit
+//! an old "trusted" verdict.
+
+#![cfg(windows)]
 
 /// Map of `exe_path` → (image mtime, verdict) backing [`AUTHENTICODE_CACHE`].
-#[cfg(windows)]
 type AuthenticodeCache = std::collections::HashMap<String, (Option<std::time::SystemTime>, bool)>;
 
-/// Per-`exe_path` cache of Authenticode results, invalidated by image mtime.
-///
-/// Keyed by path; the value carries the image's last-write time so a replaced
-/// binary (different mtime) is a cache **miss** and gets re-verified — a
-/// substituted image can never inherit an old "trusted" verdict.
-#[cfg(windows)]
+/// Per-`exe_path` cache of verification results, invalidated by image mtime.
 static AUTHENTICODE_CACHE: std::sync::OnceLock<std::sync::Mutex<AuthenticodeCache>> =
     std::sync::OnceLock::new();
 
-/// Read a cached verification for `exe_path`, valid only while the stored mtime
-/// still matches the image's current mtime.
-#[cfg(windows)]
-fn cached_authenticode(exe_path: &str, mtime: Option<std::time::SystemTime>) -> Option<bool> {
-    let cache = AUTHENTICODE_CACHE.get()?;
-    // Copy the entry out and release the lock before comparing.
-    let (stored_mtime, result) = cache.lock().ok()?.get(exe_path).copied()?;
-    (stored_mtime == mtime).then_some(result)
-}
-
-/// Store a verification result for `exe_path` keyed by its current mtime.
-#[cfg(windows)]
-fn store_authenticode(exe_path: &str, mtime: Option<std::time::SystemTime>, result: bool) {
-    let cache =
-        AUTHENTICODE_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-    if let Ok(mut guard) = cache.lock() {
-        guard.insert(exe_path.to_owned(), (mtime, result));
-    }
-}
-
-/// S5.2: Verify the Authenticode signature of the client executable.
+/// Verify the Authenticode signature of the executable at `exe_path`.
 ///
-/// In-process `WinVerifyTrust` — replaces the old per-request PowerShell
-/// `Get-AuthenticodeSignature` spawn (hundreds of ms each, plus a hard
-/// dependency on PowerShell being present and on PATH).  Result is cached per
-/// `(exe_path, mtime)` so a client's repeated drive requests verify once.
-#[cfg(windows)]
-pub(super) fn verify_authenticode(exe_path: &str) -> bool {
+/// In-process `WinVerifyTrust`. The result is cached per `(exe_path,
+/// mtime)` so repeated checks of the same image verify only once.
+///
+/// **Policy:** reject only a **tampered** image (`TRUST_E_BAD_DIGEST` /
+/// hash mismatch); accept `Valid`, `NotSigned` (unsigned dev builds),
+/// and any other non-tamper state. Callers that require a *valid*
+/// signature (not merely "untampered") must layer that on top — this
+/// primitive matches the broker's long-standing "reject only tamper"
+/// contract so the unsigned dev daemon still passes.
+#[must_use]
+pub fn verify_authenticode(exe_path: &str) -> bool {
     let mtime = std::fs::metadata(exe_path)
         .and_then(|meta| meta.modified())
         .ok();
@@ -62,13 +47,25 @@ pub(super) fn verify_authenticode(exe_path: &str) -> bool {
     trusted
 }
 
+/// Read a cached verification for `exe_path`, valid only while the stored
+/// mtime still matches the image's current mtime.
+fn cached_authenticode(exe_path: &str, mtime: Option<std::time::SystemTime>) -> Option<bool> {
+    let cache = AUTHENTICODE_CACHE.get()?;
+    // Copy the entry out and release the lock before comparing.
+    let (stored_mtime, result) = cache.lock().ok()?.get(exe_path).copied()?;
+    (stored_mtime == mtime).then_some(result)
+}
+
+/// Store a verification result for `exe_path` keyed by its current mtime.
+fn store_authenticode(exe_path: &str, mtime: Option<std::time::SystemTime>, result: bool) {
+    let cache =
+        AUTHENTICODE_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(exe_path.to_owned(), (mtime, result));
+    }
+}
+
 /// In-process Authenticode verification of `exe_path` via `WinVerifyTrust`.
-///
-/// Policy is **preserved** from the old PowerShell check: reject only a
-/// **tampered** image (`TRUST_E_BAD_DIGEST` / `HashMismatch`); accept `Valid`
-/// and `NotSigned` (dev builds) and any other non-tamper state — so the
-/// unsigned dev daemon still passes.
-#[cfg(windows)]
 #[expect(unsafe_code, reason = "FFI: WinVerifyTrust signature verification")]
 fn win_verify_trust(exe_path: &str) -> bool {
     use core::mem::size_of;

--- a/crates/uffs-security/src/lib.rs
+++ b/crates/uffs-security/src/lib.rs
@@ -47,6 +47,11 @@ pub mod keystore;
 pub mod log_dir;
 pub mod runtime_dir;
 
+/// In-process Authenticode (`WinVerifyTrust`) signature verification —
+/// shared by the Access Broker and the self-updater. Windows-only.
+#[cfg(windows)]
+pub mod authenticode;
+
 /// Windows named-pipe security helpers (DACL, SID resolution, pipe naming).
 ///
 /// Only compiled on Windows.  See [`pipe`] module docs for the security

--- a/crates/uffs-update/Cargo.toml
+++ b/crates/uffs-update/Cargo.toml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025-2026 SKY, LLC.
+# SPDX-License-Identifier: MPL-2.0
+
+# uffs-update: self-update **acquire** helper binary.
+#
+# Deliberately a SEPARATE binary from `uffs` so the HTTP/TLS stack
+# (reqwest + rustls) never bloats the lean, fast-starting CLI. `uffs
+# update` spawns this only for the download/verify step; everything else
+# (detect, snapshot) stays in `uffs-cli`.
+
+[package]
+name = "uffs-update"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+# Internal tooling binary — not published to crates.io.
+publish.workspace = true
+
+[[bin]]
+name = "uffs-update"
+path = "src/main.rs"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+
+[dependencies]
+anyhow.workspace = true
+serde = { workspace = true, features = ["derive"] }
+sha2.workspace = true
+hex.workspace = true
+# Blocking HTTP with rustls + the system trust store — workspace-inherited
+# so the feature set lives in one place. A one-shot CLI step, so the async
+# runtime overhead of a full client is unwarranted.
+reqwest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uffs-update/src/acquire.rs
+++ b/crates/uffs-update/src/acquire.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Acquire orchestration (self-update Phase C).
+//!
+//! Fetch the target GitHub release, download the platform bundle plus its
+//! `SHA256SUMS`, verify the bundle's SHA-256, and leave the verified
+//! bundle staged. Extraction, Authenticode, stopping services, and the
+//! actual replace are the **apply** phase's job — acquire never touches a
+//! live install.
+
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result, bail};
+
+use crate::{github, verify};
+
+/// Inputs for one acquire run.
+pub(crate) struct AcquirePlan {
+    /// GitHub `owner/repo` to fetch from.
+    pub(crate) repo: String,
+    /// Release tag (e.g. `v0.6.2`), or `None` for the latest release.
+    pub(crate) tag: Option<String>,
+    /// Directory to stage downloads into.
+    pub(crate) stage: PathBuf,
+    /// Platform bundle asset name.
+    pub(crate) bundle: String,
+    /// Checksums asset name.
+    pub(crate) sums: String,
+}
+
+impl AcquirePlan {
+    /// Default bundle asset name for the current OS/arch.
+    pub(crate) const fn default_bundle() -> &'static str {
+        if cfg!(windows) {
+            "uffs-windows-x64.zip"
+        } else if cfg!(target_os = "macos") {
+            "uffs-macos-arm64.tar.gz"
+        } else {
+            "uffs-linux-x64.tar.gz"
+        }
+    }
+}
+
+/// Run the acquire and return the path to the verified, staged bundle.
+///
+/// # Errors
+///
+/// Fails on network/HTTP errors, a missing asset, a missing checksum
+/// entry, or a SHA-256 mismatch (in which case nothing is left trusted).
+pub(crate) fn run(plan: &AcquirePlan) -> Result<PathBuf> {
+    std::fs::create_dir_all(&plan.stage)
+        .with_context(|| format!("creating stage dir {}", plan.stage.display()))?;
+
+    let release = github::fetch_release(&plan.repo, plan.tag.as_deref())?;
+    let bundle_url = release
+        .asset(&plan.bundle)
+        .with_context(|| {
+            format!(
+                "release {} has no asset named {}",
+                release.tag_name, plan.bundle
+            )
+        })?
+        .browser_download_url
+        .clone();
+    let sums_url = release
+        .asset(&plan.sums)
+        .with_context(|| {
+            format!(
+                "release {} has no asset named {}",
+                release.tag_name, plan.sums
+            )
+        })?
+        .browser_download_url
+        .clone();
+
+    let bundle_path = plan.stage.join(&plan.bundle);
+    let sums_path = plan.stage.join(&plan.sums);
+    github::download_to(&sums_url, &sums_path)?;
+    github::download_to(&bundle_url, &bundle_path)?;
+
+    let sums_text = std::fs::read_to_string(&sums_path)
+        .with_context(|| format!("reading {}", sums_path.display()))?;
+    let sums = verify::parse_sha256sums(&sums_text);
+    let expected = verify::expected_hash(&sums, &plan.bundle)
+        .with_context(|| format!("{} is not listed in {}", plan.bundle, plan.sums))?;
+
+    if !verify::verify_sha256(&bundle_path, expected)? {
+        // Remove the unverified download so it can never be mistaken for trusted.
+        let _ignore = std::fs::remove_file(&bundle_path);
+        bail!(
+            "SHA-256 mismatch for {} — download rejected, nothing staged",
+            plan.bundle
+        );
+    }
+    Ok(bundle_path)
+}

--- a/crates/uffs-update/src/github.rs
+++ b/crates/uffs-update/src/github.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! GitHub Releases fetch + asset download (blocking `reqwest` + rustls).
+//!
+//! One-shot HTTP for the acquire step — a release lookup plus streaming
+//! asset downloads. TLS is rustls with the system trust store; we never
+//! follow off-host redirects beyond what `reqwest` validates against the
+//! pinned `api.github.com` / release host.
+
+use std::path::Path;
+
+use anyhow::{Context as _, Result};
+use serde::Deserialize;
+
+/// User-agent GitHub requires for API requests.
+const USER_AGENT: &str = concat!("uffs-update/", env!("CARGO_PKG_VERSION"));
+
+/// A GitHub release (only the fields we use).
+#[derive(Debug, Deserialize)]
+pub(crate) struct Release {
+    /// The release tag (e.g. `v0.6.2`).
+    pub(crate) tag_name: String,
+    /// Downloadable assets attached to the release.
+    pub(crate) assets: Vec<Asset>,
+}
+
+/// One downloadable release asset.
+#[derive(Debug, Deserialize)]
+pub(crate) struct Asset {
+    /// Asset file name (e.g. `uffs-windows-x64.zip`).
+    pub(crate) name: String,
+    /// Direct download URL.
+    pub(crate) browser_download_url: String,
+}
+
+impl Release {
+    /// Find an asset by exact file name.
+    pub(crate) fn asset(&self, name: &str) -> Option<&Asset> {
+        self.assets.iter().find(|asset| asset.name == name)
+    }
+}
+
+/// Build a blocking client with the required user agent.
+fn client() -> Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .user_agent(USER_AGENT)
+        .build()
+        .context("building HTTP client")
+}
+
+/// Fetch a release from `owner/repo`: the `latest` release, or the
+/// specific `tag` when given.
+///
+/// # Errors
+///
+/// Propagates HTTP, status, and JSON-decode failures.
+pub(crate) fn fetch_release(repo: &str, tag: Option<&str>) -> Result<Release> {
+    let url = tag.map_or_else(
+        || format!("https://api.github.com/repos/{repo}/releases/latest"),
+        |wanted| format!("https://api.github.com/repos/{repo}/releases/tags/{wanted}"),
+    );
+    let response = client()?
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .with_context(|| format!("requesting {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GitHub returned an error for {url}"))?;
+    response.json::<Release>().context("parsing release JSON")
+}
+
+/// Stream an asset URL to `dest`.
+///
+/// # Errors
+///
+/// Propagates HTTP, status, and file-write failures.
+pub(crate) fn download_to(url: &str, dest: &Path) -> Result<()> {
+    let mut response = client()?
+        .get(url)
+        .send()
+        .with_context(|| format!("downloading {url}"))?
+        .error_for_status()
+        .with_context(|| format!("download failed for {url}"))?;
+    let mut file =
+        std::fs::File::create(dest).with_context(|| format!("creating {}", dest.display()))?;
+    std::io::copy(&mut response, &mut file)
+        .with_context(|| format!("writing {}", dest.display()))?;
+    Ok(())
+}

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! `uffs-update` — the self-update **acquire** helper binary.
+//!
+//! A separate binary from `uffs` so the HTTP/TLS stack (reqwest + rustls)
+//! never bloats the lean CLI. `uffs update` spawns this for the
+//! download/verify step only; detect + snapshot stay in `uffs-cli`.
+//!
+//! ```text
+//! uffs-update acquire --repo <owner/name> --stage <dir>
+//!                     [--version <tag>] [--bundle <asset>] [--sums <asset>]
+//! ```
+
+mod acquire;
+mod github;
+mod verify;
+
+use anyhow::{Result, bail};
+
+use crate::acquire::AcquirePlan;
+
+/// Entry point. Returns a non-zero exit on any failure.
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        Some("acquire") => run_acquire(args.get(1..).unwrap_or_default()),
+        Some("--help" | "-h") | None => {
+            print_usage();
+            Ok(())
+        }
+        Some(other) => bail!("unknown subcommand `{other}` (try `acquire`)"),
+    }
+}
+
+/// Parse the `acquire` flags and run it.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn run_acquire(args: &[String]) -> Result<()> {
+    let repo = required(flag(args, "--repo"), "--repo <owner/name>")?;
+    let stage = required(flag(args, "--stage"), "--stage <dir>")?;
+    let plan = AcquirePlan {
+        repo,
+        tag: flag(args, "--version"),
+        stage: std::path::PathBuf::from(stage),
+        bundle: flag(args, "--bundle").unwrap_or_else(|| AcquirePlan::default_bundle().to_owned()),
+        sums: flag(args, "--sums").unwrap_or_else(|| "SHA256SUMS".to_owned()),
+    };
+    let staged = acquire::run(&plan)?;
+    println!("Acquired + verified: {}", staged.display());
+    Ok(())
+}
+
+/// Return the value following `name` in `args` (`--name value`).
+fn flag(args: &[String], name: &str) -> Option<String> {
+    args.iter()
+        .position(|arg| arg == name)
+        .and_then(|idx| args.get(idx + 1))
+        .cloned()
+}
+
+/// Turn a missing required flag into a clear error.
+fn required(value: Option<String>, what: &str) -> Result<String> {
+    value.ok_or_else(|| anyhow::anyhow!("missing required {what}"))
+}
+
+/// Print usage to stdout.
+#[expect(clippy::print_stdout, reason = "intentional help output")]
+fn print_usage() {
+    println!(
+        "uffs-update — self-update acquire helper\n\n\
+         USAGE:\n  uffs-update acquire --repo <owner/name> --stage <dir> \\\n\
+         \x20                     [--version <tag>] [--bundle <asset>] [--sums <asset>]\n\n\
+         Fetches the release, downloads the platform bundle + SHA256SUMS,\n\
+         verifies the bundle's SHA-256, and leaves it staged. It does not\n\
+         extract, verify Authenticode, or replace anything (apply phase).\n"
+    );
+}

--- a/crates/uffs-update/src/verify.rs
+++ b/crates/uffs-update/src/verify.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Verification of downloaded artifacts.
+//!
+//! This phase (acquire) applies the **SHA-256** integrity gate against
+//! the release's published `SHA256SUMS`. The **Authenticode** authenticity
+//! gate — the now-shared `uffs_security::authenticode` — is applied to the
+//! extracted `.exe`s just before they replace anything (the apply phase),
+//! so it is wired in there, not here.
+
+use std::io::Read as _;
+use std::path::Path;
+
+use anyhow::{Context as _, Result};
+use sha2::{Digest as _, Sha256};
+
+/// Compute the lowercase hex SHA-256 of a file, streaming it in chunks so
+/// large bundles don't load into memory at once.
+///
+/// # Errors
+///
+/// Propagates any read error.
+pub(crate) fn sha256_file(path: &Path) -> Result<String> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("opening {} for hashing", path.display()))?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0_u8; 64 * 1024];
+    loop {
+        let read = reader.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(buf.get(..read).unwrap_or(&[]));
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Parse a `SHA256SUMS` file (`<hex>  <filename>` per line, the standard
+/// `sha256sum` format) into `(filename, lowercase-hex)` pairs.
+///
+/// Pure — unit-testable without I/O.
+#[must_use]
+pub(crate) fn parse_sha256sums(text: &str) -> Vec<(String, String)> {
+    text.lines()
+        .filter_map(|line| {
+            let mut parts = line.split_whitespace();
+            let hash = parts.next()?;
+            // `sha256sum` separates with two spaces; the name may itself
+            // contain spaces, so re-join the remainder.
+            let name = line
+                .get(hash.len()..)
+                .map(str::trim_start)
+                .map(|rest| rest.trim_start_matches('*')) // binary-mode marker
+                .filter(|name| !name.is_empty())?;
+            is_hex_sha256(hash).then(|| (name.to_owned(), hash.to_ascii_lowercase()))
+        })
+        .collect()
+}
+
+/// Return the expected hash for `file_name` from parsed sums, matching on
+/// the base file name only (sums may list paths).
+#[must_use]
+pub(crate) fn expected_hash<'a>(sums: &'a [(String, String)], file_name: &str) -> Option<&'a str> {
+    sums.iter().find_map(|(name, hash)| {
+        let base = Path::new(name).file_name().and_then(|os| os.to_str());
+        (base == Some(file_name)).then_some(hash.as_str())
+    })
+}
+
+/// Verify a downloaded file's SHA-256 matches `expected` (case-insensitive
+/// hex). Returns `Ok(true)` only on an exact match.
+///
+/// # Errors
+///
+/// Propagates a hashing/read error.
+pub(crate) fn verify_sha256(path: &Path, expected: &str) -> Result<bool> {
+    let actual = sha256_file(path)?;
+    Ok(actual.eq_ignore_ascii_case(expected))
+}
+
+/// `true` when `token` is exactly 64 lowercase-or-uppercase hex digits.
+fn is_hex_sha256(token: &str) -> bool {
+    token.len() == 64 && token.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{expected_hash, is_hex_sha256, parse_sha256sums};
+
+    const HASH_A: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    #[test]
+    fn parses_standard_sha256sums() {
+        let text = format!("{HASH_A}  uffs-windows-x64.zip\n");
+        let sums = parse_sha256sums(&text);
+        assert_eq!(sums.len(), 1);
+        assert_eq!(expected_hash(&sums, "uffs-windows-x64.zip"), Some(HASH_A));
+    }
+
+    #[test]
+    fn matches_on_base_name_when_sums_list_paths() {
+        let text = format!("{HASH_A} *dist/uffs-windows-x64.zip\n");
+        let sums = parse_sha256sums(&text);
+        assert_eq!(expected_hash(&sums, "uffs-windows-x64.zip"), Some(HASH_A));
+    }
+
+    #[test]
+    fn skips_garbage_lines() {
+        let text = format!("# a comment\n\nnot-a-hash file\n{HASH_A}  ok.zip\n");
+        let sums = parse_sha256sums(&text);
+        assert_eq!(sums.len(), 1);
+        assert_eq!(expected_hash(&sums, "ok.zip"), Some(HASH_A));
+    }
+
+    #[test]
+    fn hex_validation() {
+        assert!(is_hex_sha256(HASH_A));
+        assert!(!is_hex_sha256("abc"));
+        assert!(!is_hex_sha256(&"z".repeat(64)));
+    }
+}


### PR DESCRIPTION
Builds on the merged Phase A (#425). Three commits:

## B — snapshot persistence (`uffs update --snapshot`)
Freezes the Phase-A detection + the daemon's live drive/tier state (via the `status_drives` RPC) into a timestamped JSON snapshot under `<lifecycle_dir>/update/snapshot-<unix>.json` — the durable record the later phases read back. Pure `build_snapshot_value` is unit-tested. No new deps.

## refactor — DRY Authenticode → `uffs-security`
The in-process `WinVerifyTrust` check lived only in `uffs-broker`; the updater needs the same primitive. Rather than copy it, the single implementation (FFI + `(exe_path, mtime)` cache) moves to **`uffs_security::authenticode`** — the natural home for a signature-trust primitive. `uffs-broker` now depends on `uffs-security` and calls the shared fn; the broker-local copy is deleted. **Behavior-preserving** (reject only `TRUST_E_BAD_DIGEST`). One audited verifier instead of two.

## C — acquire (`uffs-update` helper + `uffs update --acquire`)
New **`uffs-update` binary crate**, deliberately separate from `uffs` so reqwest+rustls never bloat the lean CLI. `uffs update --acquire` locates the helper (sibling of `uffs`, else PATH) and shells out.

`uffs-update acquire --repo <o/r> --stage <dir> [--version <tag>]`:
- fetch the GitHub release (latest or a tag) — blocking reqwest, **rustls + system trust store**,
- download the platform bundle + `SHA256SUMS`,
- verify the bundle's **SHA-256** (reject + delete on mismatch — nothing untrusted is left staged).

It never extracts, verifies Authenticode, or replaces anything — that's the apply phase. SHA-256 = acquire-time **integrity** gate; Authenticode (the now-shared module) = apply-time **authenticity** gate.

### Dependency hygiene
- `rustls-tls-native-roots` matches the workspace's existing reqwest config → **zero new third-party crates** in the lock (cargo-vet green).
- `reqwest` declared in `[workspace.dependencies]` and inherited; `uffs-update` carries the standard `docs.rs` metadata (manifest-audit gate green).

## Validation
- Unit tests: snapshot shape, SHA256SUMS parsing / hash-match / hex validation.
- Host clippy (prod+tests) ✅, **Windows xwin clippy ✅** (cli + update + security + broker), rustdoc ✅, fmt ✅, full pre-push gate ✅ (incl. manifest-audit + deny + lint-ci-windows).

## Not in scope (apply phase / later PR)
Extraction, Authenticode-at-replace, stop/replace/restore, self-heal. The `uffs-update` crate is intentionally not yet wired into the release artifact matrix / winget manifest (it builds + ships logic; deployment wiring lands with apply).