### PR TITLE
feat(update): crash-proof self-update — apply resilience, doctor, per-binary release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -519,7 +519,7 @@ jobs:
           # Gated on `apple-darwin` so Windows / Linux artifact paths
           # stay untouched.
           set -euo pipefail
-          for bin in uffs uffsd uffsmcp uffs-mft; do
+          for bin in uffs uffsd uffsmcp uffs-mft uffs-update; do
             path="target/${{ matrix.target }}/release/$bin"
             if [[ -f "$path" ]]; then
               codesign --force --sign - "$path"
@@ -540,10 +540,13 @@ jobs:
                      target/${{ matrix.target }}/release/uffsd \
                      target/${{ matrix.target }}/release/uffsmcp \
                      target/${{ matrix.target }}/release/uffs-mft \
+                     target/${{ matrix.target }}/release/uffs-update \
                      target/${{ matrix.target }}/release/uffs.exe \
                      target/${{ matrix.target }}/release/uffsd.exe \
                      target/${{ matrix.target }}/release/uffsmcp.exe \
-                     target/${{ matrix.target }}/release/uffs-mft.exe; do
+                     target/${{ matrix.target }}/release/uffs-mft.exe \
+                     target/${{ matrix.target }}/release/uffs-broker.exe \
+                     target/${{ matrix.target }}/release/uffs-update.exe; do
             if [[ -f "$bin" ]]; then
               ls -lh "$bin"
             fi
@@ -557,14 +560,17 @@ jobs:
           # Shipping set — kept in lockstep with `RELEASE_BINARIES` in
           # scripts/ci/build-cross-all.rs.  Diagnostic binaries are NOT
           # shipped; they live in uffs-diag and stay workspace-only.
+          # uffs-update (the self-update helper) ships on every platform so
+          # `uffs update` has its sibling; uffs-broker is a Windows-only
+          # service, so its raw binary ships on Windows only.
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            for binary in uffs.exe uffsd.exe uffsmcp.exe uffs-mft.exe; do
+            for binary in uffs.exe uffsd.exe uffsmcp.exe uffs-mft.exe uffs-broker.exe uffs-update.exe; do
               if [[ -f "target/${{ matrix.target }}/release/$binary" ]]; then
                 cp "target/${{ matrix.target }}/release/$binary" release-artifacts/
               fi
             done
           else
-            for binary in uffs uffsd uffsmcp uffs-mft; do
+            for binary in uffs uffsd uffsmcp uffs-mft uffs-update; do
               if [[ -f "target/${{ matrix.target }}/release/$binary" ]]; then
                 cp "target/${{ matrix.target }}/release/$binary" release-artifacts/
               fi
@@ -641,11 +647,14 @@ jobs:
             # Engine binaries per tier.  ALL tiers include uffs + uffsd:
             # the CLI auto-spawns the SEPARATE uffsd binary (find_daemon_exe
             # in uffs-client) — `uffs` alone cannot search.
+            # uffs-update (self-update helper) is bundled in EVERY tier so
+            # `uffs update` / `uffs update doctor` work wherever uffs is
+            # installed — including the winget package (the normal-tier zip).
             local engine_bins=()
             case "$tier" in
-              min)    engine_bins=(uffs uffsd) ;;
-              normal) engine_bins=(uffs uffsd uffsmcp uffs-mft) ;;
-              full)   engine_bins=(uffs uffsd uffsmcp uffs-mft "${DIAG_BINS[@]}") ;;
+              min)    engine_bins=(uffs uffsd uffs-update) ;;
+              normal) engine_bins=(uffs uffsd uffsmcp uffs-mft uffs-update) ;;
+              full)   engine_bins=(uffs uffsd uffsmcp uffs-mft uffs-update "${DIAG_BINS[@]}") ;;
             esac
             for b in "${engine_bins[@]}"; do
               if [[ -f "${BINDIR}/${b}${EXT}" ]]; then
@@ -920,7 +929,17 @@ jobs:
           # that could be parsed as options by sha256sum (SC2035).
           sha256sum ./* > CHECKSUMS.txt
 
-          echo "📦 Final release assets (SBOMs + checksums included):"
+          # SHA256SUMS — the conventionally-named manifest the self-update
+          # helper (`uffs-update acquire`) fetches by exact name.  It lists
+          # every raw per-binary asset by its platform-suffixed name (e.g.
+          # `uffsd-windows-x64.exe`), which is what the acquire verifier
+          # matches on.  A copy of CHECKSUMS.txt is the simplest correct
+          # source: identical sha256sum format, and the verifier matches by
+          # basename so the extra zip/SBOM lines are harmless.  Generated
+          # here (before the attestation step) so it is covered by SLSA.
+          cp CHECKSUMS.txt SHA256SUMS
+
+          echo "📦 Final release assets (SBOMs + checksums + SHA256SUMS included):"
           ls -la
 
       - name: Generate SLSA build-provenance attestation
@@ -985,7 +1004,8 @@ jobs:
             embedded.  Also: `uffs-windows-x64-min.zip`,
             `uffs-windows-x64-full.zip`.
           - Raw binaries: `uffs-windows-x64.exe`, `uffsd-windows-x64.exe`,
-            `uffsmcp-windows-x64.exe`, `uffs-mft-windows-x64.exe`.
+            `uffsmcp-windows-x64.exe`, `uffs-mft-windows-x64.exe`,
+            `uffs-broker-windows-x64.exe`, `uffs-update-windows-x64.exe`.
 
           ### 🍏 macOS Apple Silicon — offline MFT analysis
           - **`uffs-macos-arm64.zip`** — recommended (normal tier): raw
@@ -993,7 +1013,7 @@ jobs:
             + icns + docs + `packaging/macos/bundle.sh` for rebuilding.
             Also: `uffs-macos-arm64-min.zip`, `uffs-macos-arm64-full.zip`.
           - Raw binaries: `uffs-macos-arm64`, `uffsd-macos-arm64`,
-            `uffsmcp-macos-arm64`, `uffs-mft-macos-arm64`.
+            `uffsmcp-macos-arm64`, `uffs-mft-macos-arm64`, `uffs-update-macos-arm64`.
           - Intel Macs: run the arm64 build under Rosetta 2.
 
           ### 🐧 Linux x86_64 — offline MFT analysis
@@ -1003,13 +1023,14 @@ jobs:
             icons under `/usr/local` with one `sudo` invocation) + docs.
             Also: `uffs-linux-x64-min.zip`, `uffs-linux-x64-full.zip`.
           - Raw binaries: `uffs-linux-x64`, `uffsd-linux-x64`,
-            `uffsmcp-linux-x64`, `uffs-mft-linux-x64`.
+            `uffsmcp-linux-x64`, `uffs-mft-linux-x64`, `uffs-update-linux-x64`.
           - Use with `--mft-file` to analyse captured MFT snapshots on servers, forensics VMs, or in Docker.
 
           ## 🔐 Verification
 
-          All binaries are accompanied by SHA256 checksums in `CHECKSUMS.txt`.
-          Verify with:
+          All binaries are accompanied by SHA256 checksums in `CHECKSUMS.txt`
+          (and `SHA256SUMS`, the conventionally-named copy the in-app
+          self-update helper fetches).  Verify with:
           ```bash
           sha256sum -c CHECKSUMS.txt
           ```

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -20,14 +20,15 @@
 # ── nested-alias seed contract ───────────────────────────────────────
 # komac PRESERVES NestedInstallerFiles across version bumps but does NOT
 # auto-add executables it finds in the zip.  Each binary bundled beyond
-# the founding four (uffs/uffsd/uffsmcp/uffs-mft) — currently uffs-tui
-# and uffs-broker — must be SEEDED into the manifest ONCE, into the
-# auto-generated PR for the first release whose uffs-windows-x64.zip
+# the founding four (uffs/uffsd/uffsmcp/uffs-mft) — currently uffs-tui,
+# uffs-broker, and uffs-update — must be SEEDED into the manifest ONCE,
+# into the auto-generated PR for the first release whose uffs-windows-x64.zip
 # actually contains it; thereafter komac carries it forward.  Canonical
 # alias list + idempotent seeder: packaging/winget/nested-aliases.yaml,
 # scripts/dev/winget_seed_aliases.sh (see packaging/winget/README.md).
-# NOTE: uffs-broker shipped in the zip at v0.5.122 but is NOT yet seeded
-# in the manifest — do it on the next SkyLLC.UFFS winget PR.
+# NOTE: uffs-broker (shipped in the zip at v0.5.122) and uffs-update (the
+# self-update helper, added to every zip tier here) are NOT yet seeded in
+# the manifest — seed BOTH on the next SkyLLC.UFFS winget PR.
 #
 # ── Required secret ──────────────────────────────────────────────────
 # `WINGET_TOKEN` — a **classic** Personal Access Token with the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4681,6 +4681,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "uffs-broker-protocol",
  "windows 0.62.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,6 +4674,7 @@ name = "uffs-update"
 version = "0.6.2"
 dependencies = [
  "anyhow",
+ "dirs-next",
  "hex",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4677,6 +4677,7 @@ dependencies = [
  "hex",
  "reqwest",
  "serde",
+ "serde_json",
  "sha2 0.11.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4676,10 +4676,12 @@ dependencies = [
  "anyhow",
  "dirs-next",
  "hex",
+ "libc",
  "reqwest",
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/crates/uffs-cli/src/commands/update/acquire.rs
+++ b/crates/uffs-cli/src/commands/update/acquire.rs
@@ -42,17 +42,21 @@ fn find_helper() -> Result<PathBuf> {
         .with_context(|| format!("cannot find `{name}` — install it alongside `uffs`"))
 }
 
-/// Spawn the acquire helper for an optional target version tag.
+/// Spawn the acquire helper against a written snapshot, for an optional
+/// target version tag. The helper reads the snapshot to know the
+/// installed subset and downloads each binary individually.
 ///
 /// # Errors
 ///
 /// Fails if the helper cannot be located or it exits non-zero.
-pub(crate) fn spawn(version: Option<&str>) -> Result<()> {
+pub(crate) fn spawn(snapshot_path: &std::path::Path, version: Option<&str>) -> Result<()> {
     let helper = find_helper()?;
     let stage = snapshot::update_dir().join("stage");
     let mut command = Command::new(&helper);
     command
-        .args(["acquire", "--repo", DEFAULT_REPO, "--stage"])
+        .args(["acquire", "--repo", DEFAULT_REPO, "--snapshot"])
+        .arg(snapshot_path)
+        .arg("--stage")
         .arg(&stage);
     if let Some(tag) = version {
         command.args(["--version", tag]);

--- a/crates/uffs-cli/src/commands/update/acquire.rs
+++ b/crates/uffs-cli/src/commands/update/acquire.rs
@@ -16,7 +16,7 @@ use anyhow::{Context as _, Result, bail};
 use super::snapshot;
 
 /// Default upstream repository for self-update artifacts.
-const DEFAULT_REPO: &str = "skyllc-ai/UltraFastFileSearch";
+pub(super) const DEFAULT_REPO: &str = "skyllc-ai/UltraFastFileSearch";
 
 /// Platform file name of the helper binary.
 const fn helper_file_name() -> &'static str {

--- a/crates/uffs-cli/src/commands/update/acquire.rs
+++ b/crates/uffs-cli/src/commands/update/acquire.rs
@@ -29,7 +29,7 @@ const fn helper_file_name() -> &'static str {
 
 /// Locate the `uffs-update` helper — next to the running `uffs` first,
 /// then on `PATH`.
-fn find_helper() -> Result<PathBuf> {
+pub(super) fn find_helper() -> Result<PathBuf> {
     let name = helper_file_name();
     if let Some(sibling) = std::env::current_exe()
         .ok()

--- a/crates/uffs-cli/src/commands/update/apply.rs
+++ b/crates/uffs-cli/src/commands/update/apply.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! `uffs update --apply` — run the **mutating** update end to end.
+//!
+//! The CLI freezes a snapshot and hands off to the `uffs-update` helper,
+//! which performs the journaled flow: pre-flight → quiesce → backup/swap/
+//! smoke → commit → restore → prune, rolling back on any pre-commit
+//! failure (and never leaving a service down, INV-1). Acquire must have
+//! staged + verified the binaries first; the CLI chains the two.
+
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context as _, Result, bail};
+
+use super::acquire::find_helper;
+use super::snapshot;
+
+/// Spawn `uffs-update apply` against a written snapshot, streaming its
+/// output. The staging dir is the one acquire filled.
+///
+/// # Errors
+///
+/// Fails if the helper cannot be located or the apply exits non-zero (in
+/// which case the helper has already rolled back + restored services).
+pub(crate) fn spawn(snapshot_path: &Path) -> Result<()> {
+    let helper = find_helper()?;
+    let stage = snapshot::update_dir().join("stage");
+    let status = Command::new(&helper)
+        .args(["apply", "--snapshot"])
+        .arg(snapshot_path)
+        .arg("--stage")
+        .arg(&stage)
+        .status()
+        .with_context(|| format!("spawning {}", helper.display()))?;
+    if !status.success() {
+        bail!(
+            "uffs-update apply failed (exit {:?}) — the helper rolled back + restored services",
+            status.code()
+        );
+    }
+    Ok(())
+}

--- a/crates/uffs-cli/src/commands/update/binaries.rs
+++ b/crates/uffs-cli/src/commands/update/binaries.rs
@@ -14,15 +14,21 @@ use std::process::Command;
 
 use super::model::BinaryInfo;
 
-/// Logical stems of every UFFS binary the updater knows about. The
-/// platform `.exe` suffix is added by [`exe_file_name`].
+/// Logical stems of every UFFS binary the updater knows about — i.e. the
+/// engine binaries this repo builds and publishes as release assets, so
+/// each can be acquired + swapped. The platform `.exe` suffix is added by
+/// [`exe_file_name`].
+///
+/// `uffs-tui` is deliberately **excluded**: it ships from the separate
+/// `uffs-products` / `uffs-demo` repo with its own versioning and is not a
+/// release asset here, so the engine updater must not chase it.
 pub(crate) const KNOWN_BINARIES: [&str; 6] = [
     "uffs",        // CLI
     "uffsd",       // daemon
     "uffsmcp",     // MCP server
     "uffs-broker", // elevated handle broker (Windows service)
-    "uffs-tui",    // interactive TUI (optional)
-    "uffs-mft",    // diagnostics (optional)
+    "uffs-update", // the self-update helper itself
+    "uffs-mft",    // MFT diagnostics binary (optional)
 ];
 
 /// Append the platform executable suffix to a binary stem
@@ -124,9 +130,29 @@ mod tests {
     }
 
     #[test]
-    fn known_set_contains_core_and_optional() {
-        for stem in ["uffs", "uffsd", "uffsmcp", "uffs-broker"] {
-            assert!(KNOWN_BINARIES.contains(&stem), "missing core binary {stem}");
+    fn known_set_contains_engine_binaries_and_the_helper() {
+        for stem in [
+            "uffs",
+            "uffsd",
+            "uffsmcp",
+            "uffs-broker",
+            "uffs-update",
+            "uffs-mft",
+        ] {
+            assert!(
+                KNOWN_BINARIES.contains(&stem),
+                "missing engine binary {stem}"
+            );
         }
+    }
+
+    #[test]
+    fn known_set_excludes_the_demo_tui() {
+        // `uffs-tui` ships from the separate uffs-demo repo with its own
+        // versioning; the engine updater must never try to acquire it.
+        assert!(
+            !KNOWN_BINARIES.contains(&"uffs-tui"),
+            "uffs-tui is not an engine release asset and must not be auto-updated"
+        );
     }
 }

--- a/crates/uffs-cli/src/commands/update/doctor.rs
+++ b/crates/uffs-cli/src/commands/update/doctor.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! `uffs update doctor` — end-to-end health check of the self-update flow.
+//!
+//! The CLI is the thin half: it runs Phase-A detection, freezes a snapshot
+//! (so the helper has full install/version/service context), and spawns
+//! `uffs-update doctor` with it. The helper (which owns the HTTP stack and
+//! every repair primitive) runs the actual checks and prints the report;
+//! we inherit its stdio and exit code.
+
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context as _, Result, bail};
+
+use super::acquire::{DEFAULT_REPO, find_helper};
+use super::snapshot;
+
+/// Spawn `uffs-update doctor` against a written snapshot, forwarding the
+/// pass-through flags (`--repair`, `--offline`, `--version <tag>`).
+///
+/// # Errors
+///
+/// Fails if the helper cannot be located or it exits non-zero (the latter
+/// means the doctor found a hard failure).
+pub(crate) fn spawn(snapshot_path: &Path, args: &[String]) -> Result<()> {
+    let helper = find_helper()?;
+    let stage = snapshot::update_dir().join("stage");
+    let mut command = Command::new(&helper);
+    command
+        .args(["doctor", "--repo", DEFAULT_REPO, "--snapshot"])
+        .arg(snapshot_path)
+        .arg("--stage")
+        .arg(&stage);
+    if args.iter().any(|arg| arg == "--repair") {
+        command.arg("--repair");
+    }
+    if args.iter().any(|arg| arg == "--offline") {
+        command.arg("--offline");
+    }
+    if let Some(tag) = flag_value(args, "--version") {
+        command.args(["--version", &tag]);
+    }
+    let status = command
+        .status()
+        .with_context(|| format!("spawning {}", helper.display()))?;
+    if !status.success() {
+        bail!(
+            "uffs-update doctor reported failures (exit {:?})",
+            status.code()
+        );
+    }
+    Ok(())
+}
+
+/// Return the value following `name` in `args` (`--name value`).
+fn flag_value(args: &[String], name: &str) -> Option<String> {
+    args.iter()
+        .position(|arg| arg == name)
+        .and_then(|idx| args.get(idx + 1))
+        .cloned()
+}

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -40,7 +40,9 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
     }
     print_phase_a_footer();
     if args.iter().any(|arg| arg == "--acquire") {
-        acquire::spawn(flag_value(args, "--version").as_deref())?;
+        // Acquire reads a snapshot to know the installed subset.
+        let snapshot_path = snapshot::write_snapshot(&report)?;
+        acquire::spawn(&snapshot_path, flag_value(args, "--version").as_deref())?;
     }
     Ok(())
 }

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -19,6 +19,7 @@ mod channel;
 mod model;
 mod procinfo;
 mod report;
+mod self_heal;
 mod snapshot;
 
 use std::path::{Path, PathBuf};
@@ -45,6 +46,13 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
         acquire::spawn(&snapshot_path, flag_value(args, "--version").as_deref())?;
     }
     Ok(())
+}
+
+/// Phase H self-heal entry: spawn `uffs-update recover` if a live update
+/// journal is present. Best-effort and non-blocking, so a crash mid-update
+/// is healed on the next `uffs` invocation. Called once at CLI startup.
+pub(crate) fn maybe_self_heal() {
+    self_heal::trigger();
 }
 
 /// Return the value following `name` in `args` (`--name value`).

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -16,6 +16,7 @@
 mod acquire;
 mod binaries;
 mod channel;
+mod doctor;
 mod model;
 mod procinfo;
 mod report;
@@ -33,6 +34,13 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
     if args.iter().any(|arg| arg == "--help" || arg == "-h") {
         print_help();
         return Ok(());
+    }
+    // `uffs update doctor [...]` — detect, freeze a snapshot, then hand off
+    // to the helper's end-to-end health check (which prints its own report).
+    if args.first().is_some_and(|arg| arg == "doctor") {
+        let report = detect();
+        let snapshot_path = snapshot::write_snapshot(&report)?;
+        return doctor::spawn(&snapshot_path, args);
     }
     let report = detect();
     report::print_human(&report);
@@ -216,7 +224,9 @@ fn capture_broker(roots: &mut Vec<InstallRoot>, running: &mut Vec<RunningProcess
 fn print_help() {
     println!(
         "uffs update — self-update\n\n\
-         USAGE:\n  uffs update [--snapshot] [--acquire [--version <tag>]]\n\n\
+         USAGE:\n\
+         \x20 uffs update [--snapshot] [--acquire [--version <tag>]]\n\
+         \x20 uffs update doctor [--repair] [--offline] [--version <tag>]\n\n\
          Discovers where UFFS is installed (from the running CLI, daemon,\n\
          MCP gateway, and broker service), lists binaries + versions per\n\
          location, and shows the running processes' launch recipes.\n\n\
@@ -224,7 +234,12 @@ fn print_help() {
          \x20 --snapshot          Persist the detection + live daemon state to JSON.\n\
          \x20 --acquire           Download + SHA-256-verify the release into staging\n\
          \x20                     (via the uffs-update helper). Does NOT replace.\n\
-         \x20 --version <tag>     Acquire a specific release tag (default: latest).\n"
+         \x20 --version <tag>     Acquire a specific release tag (default: latest).\n\n\
+         SUBCOMMANDS:\n\
+         \x20 doctor              End-to-end health check of the update flow\n\
+         \x20                     (versions, dirs, journal, backups, services,\n\
+         \x20                     broker pipe, release reachability). `--repair`\n\
+         \x20                     self-heals; `--offline` skips network checks.\n"
     );
 }
 

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -14,6 +14,7 @@
 //! Entry point: `run_update` (wired to `uffs update` in `main`).
 
 mod acquire;
+mod apply;
 mod binaries;
 mod channel;
 mod doctor;
@@ -48,10 +49,16 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
         write_and_report_snapshot(&report);
     }
     print_phase_a_footer();
-    if args.iter().any(|arg| arg == "--acquire") {
-        // Acquire reads a snapshot to know the installed subset.
+    // `--apply` runs the full mutating update (acquire → apply); `--acquire`
+    // only stages + verifies. `--apply` implies the acquire step.
+    let do_apply = args.iter().any(|arg| arg == "--apply");
+    if do_apply || args.iter().any(|arg| arg == "--acquire") {
+        // Both read a snapshot to know the installed subset.
         let snapshot_path = snapshot::write_snapshot(&report)?;
         acquire::spawn(&snapshot_path, flag_value(args, "--version").as_deref())?;
+        if do_apply {
+            apply::spawn(&snapshot_path)?;
+        }
     }
     Ok(())
 }
@@ -225,7 +232,7 @@ fn print_help() {
     println!(
         "uffs update — self-update\n\n\
          USAGE:\n\
-         \x20 uffs update [--snapshot] [--acquire [--version <tag>]]\n\
+         \x20 uffs update [--snapshot] [--acquire | --apply] [--version <tag>]\n\
          \x20 uffs update doctor [--repair] [--offline] [--version <tag>]\n\n\
          Discovers where UFFS is installed (from the running CLI, daemon,\n\
          MCP gateway, and broker service), lists binaries + versions per\n\
@@ -234,7 +241,10 @@ fn print_help() {
          \x20 --snapshot          Persist the detection + live daemon state to JSON.\n\
          \x20 --acquire           Download + SHA-256-verify the release into staging\n\
          \x20                     (via the uffs-update helper). Does NOT replace.\n\
-         \x20 --version <tag>     Acquire a specific release tag (default: latest).\n\n\
+         \x20 --apply             Run the FULL mutating update: acquire, then stop\n\
+         \x20                     services, atomically swap + smoke-test, commit,\n\
+         \x20                     and restart. Journaled + auto-rollback on failure.\n\
+         \x20 --version <tag>     Acquire/apply a specific release tag (default: latest).\n\n\
          SUBCOMMANDS:\n\
          \x20 doctor              End-to-end health check of the update flow\n\
          \x20                     (versions, dirs, journal, backups, services,\n\

--- a/crates/uffs-cli/src/commands/update/self_heal.rs
+++ b/crates/uffs-cli/src/commands/update/self_heal.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase H self-heal trigger (design §19.4).
+//!
+//! On every `uffs` invocation, if a **live** update journal is present —
+//! meaning an update is in-flight or was interrupted by a crash, kill, or
+//! power loss — spawn the `uffs-update recover` helper to deterministically
+//! finish it (roll forward past the commit point, else roll back) and bring
+//! any stopped service back up (INV-1).
+//!
+//! It is **best-effort and non-blocking**: it never delays or fails a
+//! normal command. The steady-state cost is a single `stat` (no live
+//! journal → no spawn). The helper itself no-ops when the owning updater
+//! is still alive, so a concurrent in-flight update is never disturbed.
+
+use std::process::{Command, Stdio};
+
+use super::acquire::find_helper;
+use super::snapshot;
+
+/// Live-journal file name written by the apply phase (`uffs-update apply`).
+const LIVE_JOURNAL: &str = "journal.json";
+
+/// Spawn `uffs-update recover` detached when a live journal exists.
+pub(crate) fn trigger() {
+    let journal = snapshot::update_dir().join(LIVE_JOURNAL);
+    if !journal.exists() {
+        return; // steady state: one stat, no spawn
+    }
+    let Ok(helper) = find_helper() else {
+        return; // helper not installed → nothing we can self-heal with
+    };
+    // Detached + silenced: the heal runs in the background so this command
+    // returns immediately; we never wait on or inspect the child.
+    let _child = Command::new(helper)
+        .arg("recover")
+        .arg("--journal")
+        .arg(&journal)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+}

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -73,6 +73,10 @@ fn run() -> Result<()> {
         _ => {}
     }
 
+    // Phase H self-heal: if a prior update crashed mid-flight, finish or
+    // roll it back in the background. Costs one `stat` in steady state.
+    commands::update::maybe_self_heal();
+
     // Detect subcommand as first non-flag token.
     let first = tokens.first().copied().unwrap_or("");
     let subcmd_args = raw_args.get(2..).unwrap_or_default();

--- a/crates/uffs-update/Cargo.toml
+++ b/crates/uffs-update/Cargo.toml
@@ -44,5 +44,13 @@ dirs-next.workspace = true
 # runtime overhead of a full client is unwarranted.
 reqwest.workspace = true
 
+# Native owner-PID liveness for Phase H (no fragile `tasklist`/`kill`
+# shell-outs). Both are already in the lock → cargo-vet stays green.
+[target.'cfg(windows)'.dependencies]
+windows.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [lints]
 workspace = true

--- a/crates/uffs-update/Cargo.toml
+++ b/crates/uffs-update/Cargo.toml
@@ -36,6 +36,9 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true
 hex.workspace = true
+# Resolve the daemon lifecycle dir (`%LOCALAPPDATA%\uffs`) so quiesce can
+# poll the PID file as the "daemon stopped" signal — no process FFI.
+dirs-next.workspace = true
 # Blocking HTTP with rustls + the system trust store — workspace-inherited
 # so the feature set lives in one place. A one-shot CLI step, so the async
 # runtime overhead of a full client is unwarranted.

--- a/crates/uffs-update/Cargo.toml
+++ b/crates/uffs-update/Cargo.toml
@@ -33,6 +33,7 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 [dependencies]
 anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 sha2.workspace = true
 hex.workspace = true
 # Blocking HTTP with rustls + the system trust store — workspace-inherited

--- a/crates/uffs-update/Cargo.toml
+++ b/crates/uffs-update/Cargo.toml
@@ -48,6 +48,9 @@ reqwest.workspace = true
 # shell-outs). Both are already in the lock → cargo-vet stays green.
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
+# Broker pipe name for the non-connecting WaitNamedPipe readiness probe
+# (R10, §19.13). Windows-only — a pure-logic workspace crate.
+uffs-broker-protocol.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/uffs-update/src/acquire.rs
+++ b/crates/uffs-update/src/acquire.rs
@@ -1,97 +1,86 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! Acquire orchestration (self-update Phase C).
+//! Acquire (self-update Phase C) — **per-binary**, no archive.
 //!
-//! Fetch the target GitHub release, download the platform bundle plus its
-//! `SHA256SUMS`, verify the bundle's SHA-256, and leave the verified
-//! bundle staged. Extraction, Authenticode, stopping services, and the
-//! actual replace are the **apply** phase's job — acquire never touches a
-//! live install.
+//! For each binary the install actually has, download that binary as an
+//! individual release asset (`uffsd.exe`, `uffs.exe`, …) and verify its
+//! SHA-256 against the release's `SHA256SUMS`, straight into the staging
+//! dir — which is exactly the loose-binary layout the apply phase reads.
+//!
+//! Why per-binary, not a bundle zip: it needs **no in-process archive
+//! crate** (zip/tar pull unaudited deps and, shelled, aren't on every
+//! Windows), each binary is **individually** SHA- and (at apply time)
+//! Authenticode-verifiable, and we only fetch the installed subset.
+//!
+//! Requires the release to publish per-binary assets + `SHA256SUMS` (a
+//! release-pipeline follow-up; the code is ready for it).
 
 use std::path::PathBuf;
 
 use anyhow::{Context as _, Result, bail};
 
+use crate::orchestrate::exe_name;
 use crate::{github, verify};
 
 /// Inputs for one acquire run.
 pub(crate) struct AcquirePlan {
-    /// GitHub `owner/repo` to fetch from.
+    /// GitHub `owner/repo`.
     pub(crate) repo: String,
-    /// Release tag (e.g. `v0.6.2`), or `None` for the latest release.
+    /// Release tag (e.g. `v0.6.2`), or `None` for latest.
     pub(crate) tag: Option<String>,
-    /// Directory to stage downloads into.
+    /// Directory to stage verified binaries into.
     pub(crate) stage: PathBuf,
-    /// Platform bundle asset name.
-    pub(crate) bundle: String,
     /// Checksums asset name.
     pub(crate) sums: String,
+    /// Binary stems to fetch (e.g. `["uffs", "uffsd"]`).
+    pub(crate) binaries: Vec<String>,
 }
 
-impl AcquirePlan {
-    /// Default bundle asset name for the current OS/arch.
-    pub(crate) const fn default_bundle() -> &'static str {
-        if cfg!(windows) {
-            "uffs-windows-x64.zip"
-        } else if cfg!(target_os = "macos") {
-            "uffs-macos-arm64.tar.gz"
-        } else {
-            "uffs-linux-x64.tar.gz"
-        }
-    }
-}
-
-/// Run the acquire and return the path to the verified, staged bundle.
+/// Download + SHA-verify every requested binary into the staging dir.
+/// Returns the staged paths. Aborts (leaving nothing trusted) on a
+/// missing asset, a missing checksum, or a SHA mismatch.
 ///
 /// # Errors
 ///
-/// Fails on network/HTTP errors, a missing asset, a missing checksum
-/// entry, or a SHA-256 mismatch (in which case nothing is left trusted).
-pub(crate) fn run(plan: &AcquirePlan) -> Result<PathBuf> {
+/// Network/HTTP errors, missing assets/checksums, or hash mismatch.
+pub(crate) fn run(plan: &AcquirePlan) -> Result<Vec<PathBuf>> {
     std::fs::create_dir_all(&plan.stage)
         .with_context(|| format!("creating stage dir {}", plan.stage.display()))?;
 
     let release = github::fetch_release(&plan.repo, plan.tag.as_deref())?;
-    let bundle_url = release
-        .asset(&plan.bundle)
-        .with_context(|| {
-            format!(
-                "release {} has no asset named {}",
-                release.tag_name, plan.bundle
-            )
-        })?
-        .browser_download_url
-        .clone();
+
+    // Checksums first.
     let sums_url = release
         .asset(&plan.sums)
-        .with_context(|| {
-            format!(
-                "release {} has no asset named {}",
-                release.tag_name, plan.sums
-            )
-        })?
+        .with_context(|| format!("release {} has no asset {}", release.tag_name, plan.sums))?
         .browser_download_url
         .clone();
-
-    let bundle_path = plan.stage.join(&plan.bundle);
     let sums_path = plan.stage.join(&plan.sums);
     github::download_to(&sums_url, &sums_path)?;
-    github::download_to(&bundle_url, &bundle_path)?;
-
     let sums_text = std::fs::read_to_string(&sums_path)
         .with_context(|| format!("reading {}", sums_path.display()))?;
     let sums = verify::parse_sha256sums(&sums_text);
-    let expected = verify::expected_hash(&sums, &plan.bundle)
-        .with_context(|| format!("{} is not listed in {}", plan.bundle, plan.sums))?;
 
-    if !verify::verify_sha256(&bundle_path, expected)? {
-        // Remove the unverified download so it can never be mistaken for trusted.
-        let _ignore = std::fs::remove_file(&bundle_path);
-        bail!(
-            "SHA-256 mismatch for {} — download rejected, nothing staged",
-            plan.bundle
-        );
+    // Each binary as an individual asset.
+    let mut staged = Vec::with_capacity(plan.binaries.len());
+    for stem in &plan.binaries {
+        let asset = exe_name(stem);
+        let url = release
+            .asset(&asset)
+            .with_context(|| format!("release {} has no asset {asset}", release.tag_name))?
+            .browser_download_url
+            .clone();
+        let dest = plan.stage.join(&asset);
+        github::download_to(&url, &dest)?;
+
+        let expected = verify::expected_hash(&sums, &asset)
+            .with_context(|| format!("{asset} is not listed in {}", plan.sums))?;
+        if !verify::verify_sha256(&dest, expected)? {
+            let _ignore = std::fs::remove_file(&dest);
+            bail!("SHA-256 mismatch for {asset} — download rejected, nothing staged");
+        }
+        staged.push(dest);
     }
-    Ok(bundle_path)
+    Ok(staged)
 }

--- a/crates/uffs-update/src/acquire.rs
+++ b/crates/uffs-update/src/acquire.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context as _, Result, bail};
 
-use crate::orchestrate::exe_name;
+use crate::orchestrate::{asset_name, exe_name};
 use crate::{github, verify};
 
 /// Inputs for one acquire run.
@@ -62,16 +62,18 @@ pub(crate) fn run(plan: &AcquirePlan) -> Result<Vec<PathBuf>> {
         .with_context(|| format!("reading {}", sums_path.display()))?;
     let sums = verify::parse_sha256sums(&sums_text);
 
-    // Each binary as an individual asset.
+    // Each binary as an individual asset. We download the platform-
+    // suffixed release asset (`uffsd-windows-x64.exe`) but stage it under
+    // the plain on-disk name (`uffsd.exe`) so the apply phase finds it.
     let mut staged = Vec::with_capacity(plan.binaries.len());
     for stem in &plan.binaries {
-        let asset = exe_name(stem);
+        let asset = asset_name(stem);
         let url = release
             .asset(&asset)
             .with_context(|| format!("release {} has no asset {asset}", release.tag_name))?
             .browser_download_url
             .clone();
-        let dest = plan.stage.join(&asset);
+        let dest = plan.stage.join(exe_name(stem));
         github::download_to(&url, &dest)?;
 
         let expected = verify::expected_hash(&sums, &asset)

--- a/crates/uffs-update/src/apply.rs
+++ b/crates/uffs-update/src/apply.rs
@@ -51,12 +51,51 @@ pub(crate) fn backup(binary: &Path) -> Result<PathBuf> {
 /// Move a staged new image into place at `target` (atomic rename). The
 /// caller must have [`backup`]'d `target` first.
 ///
+/// **Self-replacement (§19.7):** when `target` is the running
+/// orchestrator's *own* image, this still succeeds — Windows permits
+/// renaming a running `.exe` aside (the prior [`backup`]) and creating a
+/// new file at the freed name; the process keeps executing from the
+/// renamed image's section. The only residue is the `.bak` the live
+/// process cannot delete during its own run; [`sweep_stale_backups`]
+/// reclaims it on the next orchestrator launch (we deliberately do **not**
+/// re-exec mid-run — finishing with the code we started is predictable;
+/// hot-swapping a running orchestrator's code mid-flight is not).
+///
 /// # Errors
 ///
 /// Propagates a rename failure.
 pub(crate) fn swap_in(staged: &Path, target: &Path) -> Result<()> {
     std::fs::rename(staged, target)
         .with_context(|| format!("swapping {} → {}", staged.display(), target.display()))
+}
+
+/// Sweep orphaned `<name>.bak` files in `dir`: remove each `.bak` whose
+/// live sibling (`<name>`) currently exists — i.e. a *completed* swap
+/// whose backup a prior run could not prune (the self-replacement case,
+/// §19.7). A `.bak` with **no** live sibling is left untouched: that is a
+/// mid-rollback state owned by recovery, never a stray to reclaim here.
+///
+/// Best-effort: a still-locked `.bak` (the prior process not yet exited)
+/// is skipped silently and reclaimed on a later launch. Returns the count
+/// removed. The caller must only invoke this when **no** update is
+/// in-flight (no live journal), so it never races an active swap.
+pub(crate) fn sweep_stale_backups(dir: &Path) -> usize {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut removed = 0_usize;
+    for entry in entries.flatten() {
+        let bak = entry.path();
+        if bak.extension().is_none_or(|ext| ext != "bak") {
+            continue;
+        }
+        // The live sibling is the path with `.bak` stripped.
+        let live = bak.with_extension("");
+        if live.exists() && std::fs::remove_file(&bak).is_ok() {
+            removed = removed.saturating_add(1);
+        }
+    }
+    removed
 }
 
 /// Restore `binary` from its `.bak` (rollback). Idempotent: a no-op if no
@@ -124,7 +163,9 @@ pub(crate) fn backup_and_swap(staged: &Path, target: &Path) -> Result<PathBuf> {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use super::{backup, backup_and_swap, backup_path, prune_backup, restore, swap_in};
+    use super::{
+        backup, backup_and_swap, backup_path, prune_backup, restore, swap_in, sweep_stale_backups,
+    };
 
     fn scratch(tag: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!("uffs-apply-{}-{tag}", std::process::id()));
@@ -217,6 +258,33 @@ mod tests {
         write(&backup_path(&target), "OLD");
         prune_backup(&target).expect("prune");
         assert!(!backup_path(&target).exists());
+    }
+
+    #[test]
+    fn sweep_reclaims_orphaned_backup_but_spares_rollback_state() {
+        let dir = scratch("sweep");
+        // Completed swap: live `uffs-update.exe` + its unprunable `.bak`.
+        let live = dir.join("uffs-update.exe");
+        write(&live, "NEW");
+        write(&backup_path(&live), "OLD");
+        // Mid-rollback state: a `.bak` whose live sibling is GONE.
+        let orphan_bak = dir.join("uffsd.exe.bak");
+        write(&orphan_bak, "OLD-ROLLBACK");
+
+        let removed = sweep_stale_backups(&dir);
+        assert_eq!(removed, 1, "only the completed-swap backup is reclaimed");
+        assert!(!backup_path(&live).exists(), "completed-swap .bak removed");
+        assert!(live.exists(), "the live binary is untouched");
+        assert!(
+            orphan_bak.exists(),
+            "a .bak with no live sibling is rollback state — must be spared"
+        );
+    }
+
+    #[test]
+    fn sweep_missing_dir_is_zero() {
+        let dir = scratch("sweep-missing").join("does-not-exist");
+        assert_eq!(sweep_stale_backups(&dir), 0);
     }
 
     #[test]

--- a/crates/uffs-update/src/apply.rs
+++ b/crates/uffs-update/src/apply.rs
@@ -17,14 +17,6 @@
 //! confirm the new image *executes on this host* before betting services
 //! on it.
 
-// Built ahead of the journal-driven apply/recover orchestration (the
-// next slice). For now these primitives are exercised by the unit tests
-// below; the `expect` is removed once the orchestration wires them.
-#![expect(
-    dead_code,
-    reason = "apply primitives built ahead of the journal-driven orchestration (next slice)"
-)]
-
 use std::path::{Path, PathBuf};
 use std::process::Command;
 

--- a/crates/uffs-update/src/apply.rs
+++ b/crates/uffs-update/src/apply.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Apply primitives: atomic **backup → swap → smoke** and **restore**
+//! (design §9 / §19.3 / §19.8).
+//!
+//! The crash-sensitive core. Every file transition is an **atomic
+//! same-volume rename** (`std::fs::rename` replaces atomically on Windows
+//! and Unix), and the original is always renamed aside to `<file>.bak`
+//! **before** the new image moves in — so a crash at any point leaves
+//! either the old file, the `.bak`, or the new file in place, never a
+//! torn one (INV-2), and rollback is always possible (INV-3).
+//!
+//! These operate on already-staged binaries; extracting the verified
+//! bundle into the staging dir is a separate step. Smoke-testing
+//! (`--self-check` / `--version`) gates the commit point (§19.8): we
+//! confirm the new image *executes on this host* before betting services
+//! on it.
+
+// Built ahead of the journal-driven apply/recover orchestration (the
+// next slice). For now these primitives are exercised by the unit tests
+// below; the `expect` is removed once the orchestration wires them.
+#![expect(
+    dead_code,
+    reason = "apply primitives built ahead of the journal-driven orchestration (next slice)"
+)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context as _, Result, bail};
+
+/// The `.bak` path for a binary (same directory ⇒ same volume ⇒ atomic
+/// rename).
+pub(crate) fn backup_path(binary: &Path) -> PathBuf {
+    let mut name = binary.as_os_str().to_os_string();
+    name.push(".bak");
+    PathBuf::from(name)
+}
+
+/// Rename `binary` aside to its `.bak`. Idempotent: if the `.bak` already
+/// exists (a prior interrupted run), this is a no-op so recovery can
+/// re-run it safely (INV-5).
+///
+/// # Errors
+///
+/// Propagates a rename failure (e.g. the file is still locked — Quiesce
+/// should have prevented that).
+pub(crate) fn backup(binary: &Path) -> Result<PathBuf> {
+    let bak = backup_path(binary);
+    if bak.exists() {
+        return Ok(bak); // already backed up
+    }
+    std::fs::rename(binary, &bak)
+        .with_context(|| format!("backing up {} → {}", binary.display(), bak.display()))?;
+    Ok(bak)
+}
+
+/// Move a staged new image into place at `target` (atomic rename). The
+/// caller must have [`backup`]'d `target` first.
+///
+/// # Errors
+///
+/// Propagates a rename failure.
+pub(crate) fn swap_in(staged: &Path, target: &Path) -> Result<()> {
+    std::fs::rename(staged, target)
+        .with_context(|| format!("swapping {} → {}", staged.display(), target.display()))
+}
+
+/// Restore `binary` from its `.bak` (rollback). Idempotent: a no-op if no
+/// `.bak` exists (nothing was backed up, or already restored).
+///
+/// # Errors
+///
+/// Propagates a rename failure.
+pub(crate) fn restore(binary: &Path) -> Result<()> {
+    let bak = backup_path(binary);
+    if !bak.exists() {
+        return Ok(());
+    }
+    // Remove a half-swapped new image first so the restore rename can land.
+    if binary.exists() {
+        std::fs::remove_file(binary)
+            .with_context(|| format!("clearing {} before restore", binary.display()))?;
+    }
+    std::fs::rename(&bak, binary)
+        .with_context(|| format!("restoring {} → {}", bak.display(), binary.display()))
+}
+
+/// Smoke-test a binary: run `<binary> <check_arg>` and require exit `0`.
+///
+/// Confirms the image *executes on this host* (right arch, no missing
+/// runtime DLL, not corrupt) **before** the commit point. `check_arg` is
+/// `--self-check` where supported, else `--version`.
+pub(crate) fn smoke_ok(binary: &Path, check_arg: &str) -> bool {
+    Command::new(binary)
+        .arg(check_arg)
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+/// Prune a binary's `.bak` after a committed, verified update.
+///
+/// # Errors
+///
+/// Propagates a remove failure.
+pub(crate) fn prune_backup(binary: &Path) -> Result<()> {
+    let bak = backup_path(binary);
+    if bak.exists() {
+        std::fs::remove_file(&bak).with_context(|| format!("pruning backup {}", bak.display()))?;
+    }
+    Ok(())
+}
+
+/// Backup-then-swap a single binary from `staged` into `target`, leaving
+/// a `.bak` for rollback. Fails (without swapping) if the staged image is
+/// missing.
+///
+/// # Errors
+///
+/// Propagates backup/swap failures; bails if `staged` is absent.
+pub(crate) fn backup_and_swap(staged: &Path, target: &Path) -> Result<PathBuf> {
+    if !staged.is_file() {
+        bail!("staged image missing: {}", staged.display());
+    }
+    let bak = backup(target)?;
+    swap_in(staged, target)?;
+    Ok(bak)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::{backup, backup_and_swap, backup_path, prune_backup, restore, swap_in};
+
+    fn scratch(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("uffs-apply-{}-{tag}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        dir
+    }
+
+    fn write(path: &Path, content: &str) {
+        std::fs::write(path, content).expect("write");
+    }
+
+    fn read(path: &Path) -> String {
+        std::fs::read_to_string(path).expect("read")
+    }
+
+    #[test]
+    fn backup_swap_round_trip() {
+        let dir = scratch("swap");
+        let target = dir.join("uffsd");
+        let staged = dir.join("uffsd.new");
+        write(&target, "OLD");
+        write(&staged, "NEW");
+
+        let bak = backup_and_swap(&staged, &target).expect("apply");
+        assert_eq!(read(&target), "NEW", "target holds the new image");
+        assert_eq!(read(&bak), "OLD", "backup holds the old image");
+        assert!(!staged.exists(), "staged consumed by the rename");
+
+        // Rollback restores the old image.
+        restore(&target).expect("restore");
+        assert_eq!(read(&target), "OLD");
+        assert!(!bak.exists(), "backup consumed by the restore");
+    }
+
+    #[test]
+    fn backup_is_idempotent() {
+        let dir = scratch("idem");
+        let target = dir.join("uffs");
+        write(&target, "OLD");
+        let bak1 = backup(&target).expect("first backup");
+        // Simulate a re-run: a new image now sits at target.
+        write(&target, "NEW");
+        let bak2 = backup(&target).expect("second backup is a no-op");
+        assert_eq!(bak1, bak2);
+        assert_eq!(
+            read(&bak1),
+            "OLD",
+            "idempotent backup never clobbers the saved old image"
+        );
+    }
+
+    #[test]
+    fn restore_clears_half_swapped_new_image() {
+        let dir = scratch("half");
+        let target = dir.join("uffsmcp");
+        write(&target, "OLD");
+        let _bak = backup(&target).expect("backup");
+        // Crash simulated *after* a new image landed but before commit.
+        write(&target, "HALF-NEW");
+        restore(&target).expect("restore over the half-new image");
+        assert_eq!(read(&target), "OLD");
+    }
+
+    #[test]
+    fn restore_without_backup_is_noop() {
+        let dir = scratch("noop");
+        let target = dir.join("uffs-tui");
+        write(&target, "CURRENT");
+        restore(&target).expect("noop restore");
+        assert_eq!(read(&target), "CURRENT");
+    }
+
+    #[test]
+    fn missing_staged_image_aborts_before_backup() {
+        let dir = scratch("missing");
+        let target = dir.join("uffsd");
+        write(&target, "OLD");
+        let staged = dir.join("absent.new");
+        backup_and_swap(&staged, &target).expect_err("missing staged image must abort");
+        // The original must be untouched (no backup, no swap) on a pre-check fail.
+        assert_eq!(read(&target), "OLD");
+        assert!(!backup_path(&target).exists(), "no backup created on abort");
+    }
+
+    #[test]
+    fn prune_removes_backup() {
+        let dir = scratch("prune");
+        let target = dir.join("uffs");
+        write(&target, "NEW");
+        write(&backup_path(&target), "OLD");
+        prune_backup(&target).expect("prune");
+        assert!(!backup_path(&target).exists());
+    }
+
+    #[test]
+    fn swap_in_is_a_plain_rename() {
+        let dir = scratch("plain");
+        let staged = dir.join("x.new");
+        let target = dir.join("x");
+        write(&staged, "Z");
+        swap_in(&staged, &target).expect("swap");
+        assert_eq!(read(&target), "Z");
+    }
+}

--- a/crates/uffs-update/src/doctor.rs
+++ b/crates/uffs-update/src/doctor.rs
@@ -1,0 +1,501 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! `uffs-update doctor` — an end-to-end health check for the self-update
+//! flow, in the spirit of `brew doctor`.
+//!
+//! It inspects every moving part the update touches — install detection
+//! (via the snapshot the CLI hands us), version alignment, the update
+//! working dir and staging, a stale or in-flight journal, leftover `.bak`
+//! files, live services, the broker pipe, plus GitHub release
+//! reachability and per-binary asset presence — and prints a `[ OK ]` /
+//! `[WARN]` / `[FAIL]` report. With `--repair` it actively self-heals the
+//! conditions it can (resume/rollback an interrupted update, sweep stale
+//! backups, restart a stopped service) by calling the same in-crate
+//! primitives the real update uses, so the repair path is exercised
+//! identically.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::orchestrate::exe_name;
+use crate::{apply, github, journal, plan, proc, restore};
+
+/// How long the doctor waits on the broker pipe before calling it down
+/// (short — this is a probe, not the restore-time readiness gate; off
+/// Windows the probe is a vacuous `true` and ignores this).
+const DOCTOR_PIPE_PROBE_MS: u32 = 1_000;
+
+/// Options for a doctor run.
+pub(crate) struct DoctorOpts {
+    /// Snapshot to read install/version/service context from (optional —
+    /// without it the install-specific checks are skipped).
+    pub(crate) snapshot: Option<PathBuf>,
+    /// Staging dir (locates the update working dir if no snapshot).
+    pub(crate) stage: Option<PathBuf>,
+    /// Upstream `owner/repo` for the release-reachability check.
+    pub(crate) repo: String,
+    /// Specific release tag, or `None` for latest.
+    pub(crate) tag: Option<String>,
+    /// Actively repair what we can, not just report.
+    pub(crate) repair: bool,
+    /// Skip the network checks entirely.
+    pub(crate) offline: bool,
+}
+
+/// Severity of a single finding.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Health {
+    /// All good.
+    Ok,
+    /// Works, but worth attention (or healed by `--repair`).
+    Warn,
+    /// Broken — the update would not succeed in this state.
+    Fail,
+}
+
+impl Health {
+    /// Fixed-width tag for aligned output.
+    const fn tag(self) -> &'static str {
+        match self {
+            Self::Ok => "[ OK ]",
+            Self::Warn => "[WARN]",
+            Self::Fail => "[FAIL]",
+        }
+    }
+}
+
+/// One line of the report.
+struct Finding {
+    /// Severity.
+    health: Health,
+    /// Short title.
+    title: String,
+    /// Optional detail / remedy.
+    detail: Option<String>,
+}
+
+/// Accumulates findings and renders the report.
+#[derive(Default)]
+struct Report {
+    /// Findings in check order.
+    findings: Vec<Finding>,
+}
+
+impl Report {
+    /// Record a finding.
+    fn add(&mut self, health: Health, title: impl Into<String>, detail: Option<String>) {
+        self.findings.push(Finding {
+            health,
+            title: title.into(),
+            detail,
+        });
+    }
+
+    /// `true` if no finding is a hard failure.
+    fn healthy(&self) -> bool {
+        self.findings
+            .iter()
+            .all(|finding| finding.health != Health::Fail)
+    }
+
+    /// Counts of (ok, warn, fail).
+    fn tally(&self) -> (usize, usize, usize) {
+        self.findings
+            .iter()
+            .fold((0, 0, 0), |(ok, warn, fail), finding| {
+                match finding.health {
+                    Health::Ok => (ok + 1, warn, fail),
+                    Health::Warn => (ok, warn + 1, fail),
+                    Health::Fail => (ok, warn, fail + 1),
+                }
+            })
+    }
+
+    /// Print the report.
+    #[expect(clippy::print_stdout, reason = "doctor user-facing report")]
+    fn render(&self, repair: bool) {
+        println!(
+            "UFFS update doctor (uffs-update {})\n",
+            env!("CARGO_PKG_VERSION")
+        );
+        for item in &self.findings {
+            println!("{} {}", item.health.tag(), item.title);
+            if let Some(detail) = &item.detail {
+                println!("        {detail}");
+            }
+        }
+        let (ok, warn, fail) = self.tally();
+        println!("\nsummary: {ok} ok, {warn} warning(s), {fail} failure(s)");
+        if !repair && (warn > 0 || fail > 0) {
+            println!("hint: re-run with `--repair` to self-heal what can be fixed automatically.");
+        }
+    }
+}
+
+/// Run the doctor. Returns `true` when no hard failure was found. Never
+/// errors out — every check degrades to a `[WARN]`/`[FAIL]` finding.
+pub(crate) fn run(opts: &DoctorOpts) -> bool {
+    let mut report = Report::default();
+
+    check_helper(&mut report);
+    let snapshot = check_snapshot(opts, &mut report);
+    if let Some(snap) = snapshot.as_ref() {
+        check_version_alignment(snap, &mut report);
+    }
+    let update_dir = resolve_update_dir(opts);
+    check_dirs(update_dir.as_deref(), opts.stage.as_deref(), &mut report);
+    check_journal(update_dir.as_deref(), opts.repair, &mut report);
+    if let Some(snap) = snapshot.as_ref() {
+        check_stale_backups(snap, opts.repair, &mut report);
+        check_services(snap, opts.repair, &mut report);
+    }
+    check_broker(&mut report);
+    if opts.offline {
+        report.add(
+            Health::Warn,
+            "Release reachability skipped (--offline)",
+            None,
+        );
+    } else {
+        check_release(opts, snapshot.as_ref(), &mut report);
+    }
+
+    report.render(opts.repair);
+    report.healthy()
+}
+
+/// Locate the running helper itself.
+fn check_helper(report: &mut Report) {
+    match std::env::current_exe() {
+        Ok(path) => report.add(
+            Health::Ok,
+            "Update helper present",
+            Some(path.display().to_string()),
+        ),
+        Err(err) => report.add(
+            Health::Fail,
+            "Update helper path unresolved",
+            Some(err.to_string()),
+        ),
+    }
+}
+
+/// Load the snapshot (if any) and summarise it.
+fn check_snapshot(opts: &DoctorOpts, report: &mut Report) -> Option<plan::Snapshot> {
+    let Some(path) = opts.snapshot.as_ref() else {
+        report.add(
+            Health::Warn,
+            "No snapshot — install/version/service checks skipped",
+            Some("run via `uffs update doctor` to include them".to_owned()),
+        );
+        return None;
+    };
+    match plan::Snapshot::load(path) {
+        Ok(snap) => {
+            let detail = format!(
+                "{} unmanaged binary target(s), {} running component(s)",
+                snap.installed_binaries().len(),
+                snap.running.len()
+            );
+            report.add(Health::Ok, "Snapshot loaded", Some(detail));
+            Some(snap)
+        }
+        Err(err) => {
+            report.add(Health::Fail, "Snapshot unreadable", Some(err.to_string()));
+            None
+        }
+    }
+}
+
+/// All installed binaries should be at the same on-disk version.
+fn check_version_alignment(snapshot: &plan::Snapshot, report: &mut Report) {
+    let mut versions: Vec<String> = snapshot
+        .unmanaged_targets()
+        .flat_map(|target| target.binaries.iter())
+        .filter_map(|binary| binary.on_disk_version.clone())
+        .collect();
+    versions.sort();
+    versions.dedup();
+    match versions.as_slice() {
+        [] => report.add(Health::Warn, "No on-disk versions recorded", None),
+        [one] => report.add(Health::Ok, "Versions aligned", Some(one.clone())),
+        many => report.add(
+            Health::Warn,
+            "Version drift across binaries",
+            Some(format!("found: {}", many.join(", "))),
+        ),
+    }
+}
+
+/// The update working dir + staging must be writable.
+fn check_dirs(update_dir: Option<&Path>, stage: Option<&Path>, report: &mut Report) {
+    match update_dir {
+        Some(dir) => match writable(dir) {
+            Ok(()) => report.add(
+                Health::Ok,
+                "Update dir writable",
+                Some(dir.display().to_string()),
+            ),
+            Err(err) => report.add(
+                Health::Fail,
+                "Update dir not writable",
+                Some(err.to_string()),
+            ),
+        },
+        None => report.add(Health::Warn, "Update dir unknown (no snapshot/stage)", None),
+    }
+    if let Some(dir) = stage {
+        match writable(dir) {
+            Ok(()) => report.add(
+                Health::Ok,
+                "Stage dir writable",
+                Some(dir.display().to_string()),
+            ),
+            Err(err) => report.add(
+                Health::Warn,
+                "Stage dir not writable yet",
+                Some(err.to_string()),
+            ),
+        }
+    }
+}
+
+/// Probe-write + delete a temp file to confirm a dir accepts writes.
+fn writable(dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(dir)?;
+    let probe = dir.join(format!(".uffs-doctor-{}", std::process::id()));
+    std::fs::write(&probe, b"")?;
+    let _removed = std::fs::remove_file(&probe);
+    Ok(())
+}
+
+/// Report (and optionally heal) an in-flight or interrupted update.
+fn check_journal(update_dir: Option<&Path>, repair: bool, report: &mut Report) {
+    let Some(dir) = update_dir else { return };
+    let path = dir.join("journal.json");
+    if !path.exists() {
+        report.add(Health::Ok, "No in-flight update", None);
+        return;
+    }
+    let Ok(jrnl) = journal::Journal::load(&path) else {
+        report.add(
+            Health::Warn,
+            "Journal present but unreadable",
+            Some(path.display().to_string()),
+        );
+        return;
+    };
+    let owner_alive = proc::is_alive(jrnl.owner_pid);
+    if owner_alive {
+        report.add(
+            Health::Warn,
+            "An update is in progress",
+            Some("owner process alive".to_owned()),
+        );
+        return;
+    }
+    if !repair {
+        report.add(
+            Health::Warn,
+            "Interrupted update found",
+            Some("owner gone — re-run with `--repair` to resume or roll back".to_owned()),
+        );
+        return;
+    }
+    match crate::recover::recover(&path) {
+        Ok(outcome) => report.add(
+            Health::Ok,
+            "Interrupted update healed",
+            Some(format!("{outcome:?}")),
+        ),
+        Err(err) => report.add(Health::Fail, "Recovery failed", Some(err.to_string())),
+    }
+}
+
+/// Count (and optionally sweep) leftover `.bak` files in install roots.
+fn check_stale_backups(snapshot: &plan::Snapshot, repair: bool, report: &mut Report) {
+    let roots: Vec<&Path> = snapshot
+        .unmanaged_targets()
+        .map(|target| target.root.as_path())
+        .collect();
+    if repair {
+        let swept: usize = roots
+            .iter()
+            .map(|root| apply::sweep_stale_backups(root))
+            .sum();
+        report.add(
+            Health::Ok,
+            "Stale backups swept",
+            Some(format!("{swept} leftover .bak removed")),
+        );
+        return;
+    }
+    let stale: usize = roots.iter().map(|root| count_stale_backups(root)).sum();
+    if stale == 0 {
+        report.add(Health::Ok, "No leftover backups", None);
+    } else {
+        report.add(
+            Health::Warn,
+            "Leftover .bak files",
+            Some(format!("{stale} present — `--repair` reclaims them")),
+        );
+    }
+}
+
+/// Count `.bak` files in `dir` whose live sibling exists (sweepable).
+fn count_stale_backups(dir: &Path) -> usize {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter(|entry| {
+            let bak = entry.path();
+            bak.extension().is_some_and(|ext| ext == "bak") && bak.with_extension("").exists()
+        })
+        .count()
+}
+
+/// Report each running component's liveness, and (optionally) restart any
+/// that have died using the captured restore recipe.
+fn check_services(snapshot: &plan::Snapshot, repair: bool, report: &mut Report) {
+    let mut down = Vec::new();
+    for running in &snapshot.running {
+        if proc::is_alive(running.pid) {
+            report.add(
+                Health::Ok,
+                format!("Service up: {}", running.component),
+                None,
+            );
+        } else {
+            down.push(running.component.clone());
+        }
+    }
+    if down.is_empty() {
+        return;
+    }
+    if !repair {
+        report.add(
+            Health::Warn,
+            "Service(s) not running",
+            Some(format!("{} — `--repair` restarts them", down.join(", "))),
+        );
+        return;
+    }
+    let failed = restore::restore(snapshot);
+    if failed.is_empty() {
+        report.add(
+            Health::Ok,
+            "Stopped service(s) restarted",
+            Some(down.join(", ")),
+        );
+    } else {
+        report.add(
+            Health::Fail,
+            "Service restart failed",
+            Some(failed.join(", ")),
+        );
+    }
+}
+
+/// Broker pipe readiness (Windows-only; vacuous elsewhere).
+fn check_broker(report: &mut Report) {
+    if !cfg!(windows) {
+        report.add(Health::Ok, "Broker check skipped (non-Windows)", None);
+        return;
+    }
+    if restore::broker_pipe_ready(DOCTOR_PIPE_PROBE_MS) {
+        report.add(Health::Ok, "Broker pipe serving", None);
+    } else {
+        report.add(
+            Health::Warn,
+            "Broker pipe not serving",
+            Some("broker stopped or not installed (`uffs-broker --install`)".to_owned()),
+        );
+    }
+}
+
+/// Reach the release, report update availability, and confirm every
+/// installed binary has a downloadable asset + a checksum entry.
+fn check_release(opts: &DoctorOpts, snapshot: Option<&plan::Snapshot>, report: &mut Report) {
+    let release = match github::fetch_release(&opts.repo, opts.tag.as_deref()) {
+        Ok(rel) => rel,
+        Err(err) => {
+            report.add(
+                Health::Warn,
+                "Release unreachable (offline?)",
+                Some(err.to_string()),
+            );
+            return;
+        }
+    };
+    let installed = snapshot.map(plan::Snapshot::prior_version);
+    let detail = installed.map_or_else(
+        || format!("latest = {}", release.tag_name),
+        |cur| format!("installed = {cur}, latest = {}", release.tag_name),
+    );
+    report.add(Health::Ok, "Release reachable", Some(detail));
+
+    let Some(snap) = snapshot else { return };
+    let sums_present = release.asset("SHA256SUMS").is_some();
+    let mut missing = Vec::new();
+    for stem in snap.installed_binaries() {
+        if release.asset(&exe_name(&stem)).is_none() {
+            missing.push(exe_name(&stem));
+        }
+    }
+    if !sums_present {
+        report.add(Health::Fail, "SHA256SUMS asset missing from release", None);
+    }
+    if missing.is_empty() {
+        report.add(Health::Ok, "All per-binary assets present", None);
+    } else {
+        report.add(
+            Health::Fail,
+            "Release missing binary asset(s)",
+            Some(missing.join(", ")),
+        );
+    }
+}
+
+/// Resolve the update working dir from the snapshot or stage path.
+fn resolve_update_dir(opts: &DoctorOpts) -> Option<PathBuf> {
+    if let Some(stage) = opts.stage.as_ref() {
+        return stage.parent().map(Path::to_path_buf);
+    }
+    opts.snapshot
+        .as_ref()
+        .and_then(|snap| snap.parent())
+        .map(Path::to_path_buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Health, Report, count_stale_backups};
+
+    #[test]
+    fn report_healthy_until_a_failure() {
+        let mut report = Report::default();
+        report.add(Health::Ok, "a", None);
+        report.add(Health::Warn, "b", None);
+        assert!(report.healthy(), "warnings do not make it unhealthy");
+        report.add(Health::Fail, "c", None);
+        assert!(!report.healthy(), "a failure flips it unhealthy");
+        assert_eq!(report.tally(), (1, 1, 1));
+    }
+
+    #[test]
+    fn counts_only_sweepable_backups() {
+        let dir = std::env::temp_dir().join(format!("uffs-doctor-bak-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        // Completed swap: live + .bak → sweepable.
+        std::fs::write(dir.join("uffsd.exe"), "NEW").expect("live");
+        std::fs::write(dir.join("uffsd.exe.bak"), "OLD").expect("bak");
+        // Orphan .bak (no live sibling) → not counted.
+        std::fs::write(dir.join("gone.exe.bak"), "OLD").expect("orphan");
+        assert_eq!(count_stale_backups(&dir), 1);
+        let _cleanup = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/uffs-update/src/doctor.rs
+++ b/crates/uffs-update/src/doctor.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
-use crate::orchestrate::exe_name;
+use crate::orchestrate::asset_name;
 use crate::{apply, github, journal, plan, proc, restore};
 
 /// How long the doctor waits on the broker pipe before calling it down
@@ -442,8 +442,9 @@ fn check_release(opts: &DoctorOpts, snapshot: Option<&plan::Snapshot>, report: &
     let sums_present = release.asset("SHA256SUMS").is_some();
     let mut missing = Vec::new();
     for stem in snap.installed_binaries() {
-        if release.asset(&exe_name(&stem)).is_none() {
-            missing.push(exe_name(&stem));
+        let asset = asset_name(&stem);
+        if release.asset(&asset).is_none() {
+            missing.push(asset);
         }
     }
     if !sums_present {

--- a/crates/uffs-update/src/github.rs
+++ b/crates/uffs-update/src/github.rs
@@ -8,13 +8,37 @@
 //! follow off-host redirects beyond what `reqwest` validates against the
 //! pinned `api.github.com` / release host.
 
+use core::time::Duration;
+use std::io::{Read, Write};
 use std::path::Path;
 
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, bail};
 use serde::Deserialize;
 
 /// User-agent GitHub requires for API requests.
 const USER_AGENT: &str = concat!("uffs-update/", env!("CARGO_PKG_VERSION"));
+
+/// Cap on how long we wait to establish a TCP/TLS connection.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Per-operation (connect/read/write) inactivity cap. On the blocking
+/// client this is a socket-level read/write timeout, so a stalled socket
+/// is killed without bounding the total time of a large download.
+const READ_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Total attempts (initial + retries) for a transient HTTP failure.
+const MAX_ATTEMPTS: u32 = 4;
+
+/// Base back-off; the delay before attempt *n* is `BASE_BACKOFF * 2^(n-1)`.
+const BASE_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Hard ceiling on a single downloaded asset, defending the disk against
+/// a truncated, malicious, or runaway response. Our largest binary is a
+/// few tens of MiB; 512 MiB is generous head-room.
+const MAX_ASSET_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Streaming copy buffer size.
+const CHUNK_BYTES: usize = 64 * 1024;
 
 /// A GitHub release (only the fields we use).
 #[derive(Debug, Deserialize)]
@@ -41,12 +65,69 @@ impl Release {
     }
 }
 
-/// Build a blocking client with the required user agent.
+/// Build a blocking client with the required user agent and the connect
+/// + read timeouts (a hung socket can never wedge an update forever).
 fn client() -> Result<reqwest::blocking::Client> {
     reqwest::blocking::Client::builder()
         .user_agent(USER_AGENT)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(READ_TIMEOUT)
         .build()
         .context("building HTTP client")
+}
+
+/// Whether a `reqwest` failure is worth retrying: a connect/read timeout
+/// or a server-side (5xx / 429) status. Client (4xx) errors and decode
+/// errors are deterministic, so they fail fast.
+fn is_retryable(err: &reqwest::Error) -> bool {
+    if err.is_timeout() || err.is_connect() {
+        return true;
+    }
+    err.status()
+        .is_some_and(|status| status.as_u16() == 429 || status.is_server_error())
+}
+
+/// Run `op` with bounded exponential back-off, retrying only transient
+/// failures (see [`is_retryable`]). `label` describes the operation for
+/// the final error context.
+fn with_retry<T, F>(label: &str, mut op: F) -> Result<T>
+where
+    F: FnMut() -> reqwest::Result<T>,
+{
+    let mut attempt: u32 = 1;
+    loop {
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(err) if attempt < MAX_ATTEMPTS && is_retryable(&err) => {
+                let backoff = BASE_BACKOFF * 2_u32.pow(attempt.saturating_sub(1));
+                std::thread::sleep(backoff);
+                attempt = attempt.saturating_add(1);
+            }
+            Err(err) => {
+                return Err(err).with_context(|| format!("{label} (after {attempt} attempt(s))"));
+            }
+        }
+    }
+}
+
+/// Stream `reader` into `writer`, aborting if the total exceeds `cap`.
+/// Returns the number of bytes written.
+fn copy_capped<R: Read, W: Write>(reader: &mut R, writer: &mut W, cap: u64) -> Result<u64> {
+    let mut buf = vec![0_u8; CHUNK_BYTES];
+    let mut total: u64 = 0;
+    loop {
+        let read = reader.read(&mut buf).context("reading response body")?;
+        if read == 0 {
+            break;
+        }
+        total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
+        if total > cap {
+            bail!("asset exceeds the {cap}-byte cap — aborting download");
+        }
+        let chunk = buf.get(..read).context("response chunk out of range")?;
+        writer.write_all(chunk).context("writing to disk")?;
+    }
+    Ok(total)
 }
 
 /// Fetch a release from `owner/repo`: the `latest` release, or the
@@ -60,13 +141,14 @@ pub(crate) fn fetch_release(repo: &str, tag: Option<&str>) -> Result<Release> {
         || format!("https://api.github.com/repos/{repo}/releases/latest"),
         |wanted| format!("https://api.github.com/repos/{repo}/releases/tags/{wanted}"),
     );
-    let response = client()?
-        .get(&url)
-        .header("Accept", "application/vnd.github+json")
-        .send()
-        .with_context(|| format!("requesting {url}"))?
-        .error_for_status()
-        .with_context(|| format!("GitHub returned an error for {url}"))?;
+    let client = client()?;
+    let response = with_retry(&format!("requesting {url}"), || {
+        client
+            .get(&url)
+            .header("Accept", "application/vnd.github+json")
+            .send()?
+            .error_for_status()
+    })?;
     response.json::<Release>().context("parsing release JSON")
 }
 
@@ -76,15 +158,46 @@ pub(crate) fn fetch_release(repo: &str, tag: Option<&str>) -> Result<Release> {
 ///
 /// Propagates HTTP, status, and file-write failures.
 pub(crate) fn download_to(url: &str, dest: &Path) -> Result<()> {
-    let mut response = client()?
-        .get(url)
-        .send()
-        .with_context(|| format!("downloading {url}"))?
-        .error_for_status()
-        .with_context(|| format!("download failed for {url}"))?;
+    let client = client()?;
+    let mut response = with_retry(&format!("downloading {url}"), || {
+        client.get(url).send()?.error_for_status()
+    })?;
     let mut file =
         std::fs::File::create(dest).with_context(|| format!("creating {}", dest.display()))?;
-    std::io::copy(&mut response, &mut file)
+    copy_capped(&mut response, &mut file, MAX_ASSET_BYTES)
         .with_context(|| format!("writing {}", dest.display()))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::copy_capped;
+
+    #[test]
+    fn copy_capped_writes_all_under_cap() {
+        let src = vec![7_u8; 200];
+        let mut reader = src.as_slice();
+        let mut sink: Vec<u8> = Vec::new();
+        let written = copy_capped(&mut reader, &mut sink, 1024).expect("under cap copies");
+        assert_eq!(written, 200);
+        assert_eq!(sink, src);
+    }
+
+    #[test]
+    fn copy_capped_aborts_over_cap() {
+        let src = vec![0_u8; 4096];
+        let mut reader = src.as_slice();
+        let mut sink: Vec<u8> = Vec::new();
+        let err = copy_capped(&mut reader, &mut sink, 100).expect_err("over cap must abort");
+        assert!(err.to_string().contains("cap"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn copy_capped_handles_empty_body() {
+        let mut reader: &[u8] = &[];
+        let mut sink: Vec<u8> = Vec::new();
+        let written = copy_capped(&mut reader, &mut sink, 100).expect("empty copies");
+        assert_eq!(written, 0);
+        assert!(sink.is_empty());
+    }
 }

--- a/crates/uffs-update/src/journal.rs
+++ b/crates/uffs-update/src/journal.rs
@@ -14,16 +14,6 @@
 //! recover phases drive it. Keeping it side-effect-free (besides its own
 //! file) makes the invariants in §19.0 unit-testable.
 
-// The journal API is built ahead of its consumers: the apply and
-// recover phases (the next slices on this branch) call `commit`,
-// `set_binary_status`, `needs_recovery`, etc. Until they land, those are
-// exercised only by the unit tests below. Each `expect` is removed as
-// its method gets wired in.
-#![expect(
-    dead_code,
-    reason = "journal API built ahead of its apply/recover consumers (next slices on this branch)"
-)]
-
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result};

--- a/crates/uffs-update/src/journal.rs
+++ b/crates/uffs-update/src/journal.rs
@@ -206,6 +206,17 @@ impl Journal {
         Ok(())
     }
 
+    /// Archive a terminal journal: rename the live `journal.json` to a
+    /// sibling `journal.json.last` (overwriting any prior). This keeps an
+    /// audit copy while freeing the live path as the unambiguous
+    /// "an update is in-flight or crashed" signal that the CLI self-heal
+    /// trigger checks (§19.4). Best-effort — a failure to archive is not
+    /// fatal to an already-completed update.
+    pub(crate) fn archive(&self) {
+        let dest = self.path.with_extension("json.last");
+        let _archived = std::fs::rename(&self.path, &dest);
+    }
+
     /// Record an event, transition to `state`, and persist atomically.
     ///
     /// # Errors
@@ -345,5 +356,18 @@ mod tests {
         assert!(UpdateState::Aborted.is_terminal());
         assert!(!UpdateState::Swapping.is_terminal());
         assert!(!UpdateState::SmokeOk.is_terminal());
+    }
+
+    #[test]
+    fn archive_frees_live_path_and_keeps_audit_copy() {
+        let path = temp_path("archive");
+        let journal = sample(path.clone());
+        journal.save().expect("save");
+        assert!(path.exists(), "live journal should exist before archive");
+        journal.archive();
+        assert!(!path.exists(), "live journal must be gone after archive");
+        let last = path.with_extension("json.last");
+        assert!(last.exists(), "audit copy must exist after archive");
+        let _removed = std::fs::remove_file(&last);
     }
 }

--- a/crates/uffs-update/src/journal.rs
+++ b/crates/uffs-update/src/journal.rs
@@ -139,6 +139,12 @@ pub(crate) struct Journal {
     pub(crate) targets: Vec<TargetEntry>,
     /// Services stopped during Quiesce that Phase H must restart (INV-1).
     pub(crate) services_stopped: Vec<String>,
+    /// `WinGet`-managed roots this run **delegated** (did not swap, §19.6).
+    /// Recorded so `--status`/support can see a winget install that the
+    /// updater intentionally left for `winget upgrade` — never a silent
+    /// version mismatch.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) delegated_winget: Vec<String>,
     /// Append-only event trail.
     pub(crate) events: Vec<JournalEvent>,
     /// Where this journal persists. Not serialised.
@@ -168,6 +174,7 @@ impl Journal {
             commit_point_passed: false,
             targets: Vec::new(),
             services_stopped: Vec::new(),
+            delegated_winget: Vec::new(),
             events: Vec::new(),
             path,
         }

--- a/crates/uffs-update/src/journal.rs
+++ b/crates/uffs-update/src/journal.rs
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! The update **journal** — the crash-consistency spine (design §19.2/19.3).
+//!
+//! A single JSON file, updated **atomically** (write a `.tmp`, then
+//! `rename` over the target — `std::fs::rename` replaces atomically on
+//! both Windows and Unix) at *every* state transition. It is both the
+//! recovery substrate (Phase H reads it to finish-or-undo an interrupted
+//! run) and the audit trail (`--status`).
+//!
+//! This module owns the data model + atomic persistence + the state
+//! machine. It performs **no** mutation of the install — the apply /
+//! recover phases drive it. Keeping it side-effect-free (besides its own
+//! file) makes the invariants in §19.0 unit-testable.
+
+// The journal API is built ahead of its consumers: the apply and
+// recover phases (the next slices on this branch) call `commit`,
+// `set_binary_status`, `needs_recovery`, etc. Until they land, those are
+// exercised only by the unit tests below. Each `expect` is removed as
+// its method gets wired in.
+#![expect(
+    dead_code,
+    reason = "journal API built ahead of its apply/recover consumers (next slices on this branch)"
+)]
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result};
+use serde::{Deserialize, Serialize};
+
+/// Overall state of an update run (the §19.3 state machine).
+///
+/// Ordering matters: everything up to and **including** [`Self::SmokeOk`]
+/// is *before* the commit point; [`Self::Restored`] onward is *after*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum UpdateState {
+    /// Journal created; nothing done yet.
+    Init,
+    /// Pre-flight checks passed (disk, perms, backup-dir).
+    PreflightOk,
+    /// Payload downloaded + verified into staging.
+    Acquired,
+    /// Core services stopped + files unlocked.
+    Quiesced,
+    /// Mid-swap (at least one binary replaced).
+    Swapping,
+    /// All targeted binaries replaced.
+    Swapped,
+    /// All replaced binaries passed `--self-check` (the commit point).
+    SmokeOk,
+    /// Services relaunched into the new binaries.
+    Restored,
+    /// Post-flight liveness verified.
+    Verified,
+    /// Successful, finished.
+    Done,
+    /// A failure before the commit point is being undone.
+    RollingBack,
+    /// Rollback complete; services restored to the old binaries.
+    RolledBack,
+    /// Terminal failure state after a completed rollback.
+    Aborted,
+}
+
+impl UpdateState {
+    /// `true` once the run has reached a terminal state — nothing for
+    /// Phase H to do.
+    pub(crate) const fn is_terminal(self) -> bool {
+        matches!(self, Self::Done | Self::Aborted)
+    }
+}
+
+/// Per-binary progress within a target root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum BinaryStatus {
+    /// Not yet touched.
+    Pending,
+    /// Original renamed aside to its `.bak`.
+    BackedUp,
+    /// New image moved into place.
+    Swapped,
+    /// New image passed `--self-check`.
+    SmokeOk,
+    /// Restored from `.bak` during rollback.
+    RolledBack,
+}
+
+/// One binary's journal entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct BinaryEntry {
+    /// Logical stem (e.g. `uffsd`).
+    pub(crate) name: String,
+    /// Per-binary swap/rollback progress.
+    pub(crate) status: BinaryStatus,
+    /// Backup file name (in `backup_dir`) once backed up.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) backup: Option<String>,
+}
+
+/// One install root being updated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct TargetEntry {
+    /// Install directory.
+    pub(crate) root: PathBuf,
+    /// Channel that placed it (`winget` / `unmanaged`).
+    pub(crate) channel: String,
+    /// The binaries to update in this root.
+    pub(crate) binaries: Vec<BinaryEntry>,
+}
+
+/// One append-only journal event (the debug/audit trail).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JournalEvent {
+    /// Seconds since the Unix epoch when the step was recorded.
+    pub(crate) unix: u64,
+    /// Dotted step name, e.g. `quiesce.daemon.stopped`.
+    pub(crate) step: String,
+}
+
+/// The update journal (the §19.2 schema).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Journal {
+    /// Unique id for this run.
+    pub(crate) update_id: String,
+    /// When the run started (unix seconds).
+    pub(crate) started_unix: u64,
+    /// PID that owns the run — used by Phase H to detect a dead owner.
+    pub(crate) owner_pid: u32,
+    /// Whether the run is elevated (broker step needs it).
+    pub(crate) elevated: bool,
+    /// Version before the update.
+    pub(crate) from_version: String,
+    /// Target version.
+    pub(crate) to_version: String,
+    /// File name of the Phase-B snapshot this run is based on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) snapshot_ref: Option<String>,
+    /// Backup directory for this run's `.bak` files.
+    pub(crate) backup_dir: PathBuf,
+    /// Current overall state.
+    pub(crate) state: UpdateState,
+    /// `true` once every targeted binary is swapped **and** smoke-tested —
+    /// the point of no return (§19.3).
+    pub(crate) commit_point_passed: bool,
+    /// Roots + per-binary status.
+    pub(crate) targets: Vec<TargetEntry>,
+    /// Services stopped during Quiesce that Phase H must restart (INV-1).
+    pub(crate) services_stopped: Vec<String>,
+    /// Append-only event trail.
+    pub(crate) events: Vec<JournalEvent>,
+    /// Where this journal persists. Not serialised.
+    #[serde(skip)]
+    path: PathBuf,
+}
+
+impl Journal {
+    /// Create a fresh journal in [`UpdateState::Init`].
+    pub(crate) fn new(
+        path: PathBuf,
+        from_version: &str,
+        to_version: &str,
+        backup_dir: PathBuf,
+    ) -> Self {
+        let started_unix = unix_now();
+        Self {
+            update_id: format!("{started_unix:x}-{}", std::process::id()),
+            started_unix,
+            owner_pid: std::process::id(),
+            elevated: false,
+            from_version: from_version.to_owned(),
+            to_version: to_version.to_owned(),
+            snapshot_ref: None,
+            backup_dir,
+            state: UpdateState::Init,
+            commit_point_passed: false,
+            targets: Vec::new(),
+            services_stopped: Vec::new(),
+            events: Vec::new(),
+            path,
+        }
+    }
+
+    /// Load a journal from `path` (Phase H).
+    ///
+    /// # Errors
+    ///
+    /// Fails if the file is missing or not valid journal JSON.
+    pub(crate) fn load(path: &Path) -> Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("reading journal {}", path.display()))?;
+        let mut journal: Self = serde_json::from_str(&text)
+            .with_context(|| format!("parsing journal {}", path.display()))?;
+        journal.path = path.to_path_buf();
+        Ok(journal)
+    }
+
+    /// Atomically persist the journal (write `.tmp`, then `rename` over
+    /// the target — never leaves a torn file, INV-2).
+    ///
+    /// # Errors
+    ///
+    /// Propagates any write/rename failure.
+    pub(crate) fn save(&self) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let body = serde_json::to_string_pretty(self).context("serialising journal")?;
+        let tmp = self.path.with_extension("json.tmp");
+        std::fs::write(&tmp, body).with_context(|| format!("writing {}", tmp.display()))?;
+        std::fs::rename(&tmp, &self.path)
+            .with_context(|| format!("renaming {} → {}", tmp.display(), self.path.display()))?;
+        Ok(())
+    }
+
+    /// Record an event, transition to `state`, and persist atomically.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the persistence failure.
+    pub(crate) fn transition(&mut self, state: UpdateState, step: &str) -> Result<()> {
+        self.state = state;
+        self.events.push(JournalEvent {
+            unix: unix_now(),
+            step: step.to_owned(),
+        });
+        self.save()
+    }
+
+    /// Cross the commit point — the point of no return (§19.3). After
+    /// this, recovery rolls *forward*; before it, *back*.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the persistence failure.
+    pub(crate) fn commit(&mut self) -> Result<()> {
+        self.commit_point_passed = true;
+        self.transition(UpdateState::SmokeOk, "commit_point.passed")
+    }
+
+    /// Update one binary's status (no-op if the binary isn't tracked).
+    pub(crate) fn set_binary_status(&mut self, root: &Path, name: &str, status: BinaryStatus) {
+        for target in &mut self.targets {
+            if target.root == root {
+                for binary in &mut target.binaries {
+                    if binary.name == name {
+                        binary.status = status;
+                    }
+                }
+            }
+        }
+    }
+
+    /// `true` when this journal describes an interrupted run that Phase H
+    /// should finish or undo: not terminal **and** its owner is gone.
+    pub(crate) const fn needs_recovery(&self, owner_alive: bool) -> bool {
+        !self.state.is_terminal() && !owner_alive
+    }
+}
+
+/// Seconds since the Unix epoch (0 if the clock predates it).
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |dur| dur.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BinaryEntry, BinaryStatus, Journal, TargetEntry, UpdateState};
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir()
+            .join(format!("uffs-journal-test-{}-{name}", std::process::id()))
+            .join("journal.json")
+    }
+
+    fn sample(path: std::path::PathBuf) -> Journal {
+        let mut journal = Journal::new(path, "0.6.1", "0.6.2", "/tmp/backup".into());
+        journal.targets = vec![TargetEntry {
+            root: "/opt/uffs".into(),
+            channel: "unmanaged".to_owned(),
+            binaries: vec![BinaryEntry {
+                name: "uffsd".to_owned(),
+                status: BinaryStatus::Pending,
+                backup: None,
+            }],
+        }];
+        journal
+    }
+
+    #[test]
+    fn atomic_round_trip_preserves_state() {
+        let path = temp_path("roundtrip");
+        let mut journal = sample(path.clone());
+        journal
+            .transition(UpdateState::Acquired, "acquire.done")
+            .expect("save");
+        journal.set_binary_status(
+            std::path::Path::new("/opt/uffs"),
+            "uffsd",
+            BinaryStatus::Swapped,
+        );
+        journal.save().expect("save");
+
+        let loaded = Journal::load(&path).expect("load");
+        assert_eq!(loaded.state, UpdateState::Acquired);
+        assert_eq!(loaded.from_version, "0.6.1");
+        let binary = loaded
+            .targets
+            .first()
+            .and_then(|target| target.binaries.first())
+            .expect("one binary");
+        assert_eq!(binary.status, BinaryStatus::Swapped);
+        assert!(
+            loaded
+                .events
+                .iter()
+                .any(|event| event.step == "acquire.done")
+        );
+        let _removed = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn commit_point_sets_flag_and_state() {
+        let path = temp_path("commit");
+        let mut journal = sample(path.clone());
+        assert!(!journal.commit_point_passed);
+        journal.commit().expect("commit");
+        assert!(journal.commit_point_passed);
+        assert_eq!(journal.state, UpdateState::SmokeOk);
+        let _removed = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn needs_recovery_only_when_interrupted_and_owner_dead() {
+        let path = temp_path("recover");
+        let mut journal = sample(path);
+        journal.state = UpdateState::Swapping;
+        // owner alive → defer, don't recover
+        assert!(!journal.needs_recovery(true));
+        // owner dead + non-terminal → recover
+        assert!(journal.needs_recovery(false));
+        // terminal → never recover
+        journal.state = UpdateState::Done;
+        assert!(!journal.needs_recovery(false));
+    }
+
+    #[test]
+    fn terminal_states() {
+        assert!(UpdateState::Done.is_terminal());
+        assert!(UpdateState::Aborted.is_terminal());
+        assert!(!UpdateState::Swapping.is_terminal());
+        assert!(!UpdateState::SmokeOk.is_terminal());
+    }
+}

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -14,6 +14,7 @@
 
 mod acquire;
 mod apply;
+mod doctor;
 mod github;
 mod journal;
 mod orchestrate;
@@ -37,12 +38,17 @@ fn main() -> Result<()> {
         Some("acquire") => run_acquire(args.get(1..).unwrap_or_default()),
         Some("apply") => run_apply(args.get(1..).unwrap_or_default()),
         Some("recover") => run_recover(args.get(1..).unwrap_or_default()),
+        Some("doctor") => run_doctor(args.get(1..).unwrap_or_default()),
+        Some("--version" | "-V") => {
+            print_version();
+            Ok(())
+        }
         Some("--help" | "-h") | None => {
             print_usage();
             Ok(())
         }
         Some(other) => {
-            bail!("unknown subcommand `{other}` (try `acquire` / `apply` / `recover`)")
+            bail!("unknown subcommand `{other}` (try `acquire` / `apply` / `recover` / `doctor`)")
         }
     }
 }
@@ -161,6 +167,30 @@ fn run_recover(args: &[String]) -> Result<()> {
 /// Default upstream repository for self-update artifacts.
 const DEFAULT_REPO: &str = "skyllc-ai/UltraFastFileSearch";
 
+/// Parse the `doctor` flags and run the end-to-end health check. Exits
+/// non-zero when a hard failure is found so it composes in scripts/CI.
+fn run_doctor(args: &[String]) -> Result<()> {
+    let opts = doctor::DoctorOpts {
+        snapshot: flag(args, "--snapshot").map(PathBuf::from),
+        stage: flag(args, "--stage").map(PathBuf::from),
+        repo: flag(args, "--repo").unwrap_or_else(|| DEFAULT_REPO.to_owned()),
+        tag: flag(args, "--version"),
+        repair: has_flag(args, "--repair"),
+        offline: has_flag(args, "--offline"),
+    };
+    if doctor::run(&opts) {
+        Ok(())
+    } else {
+        bail!("doctor found one or more failures")
+    }
+}
+
+/// Print the helper version.
+#[expect(clippy::print_stdout, reason = "intentional version output")]
+fn print_version() {
+    println!("uffs-update {}", env!("CARGO_PKG_VERSION"));
+}
+
 /// Parse the `acquire` flags and download + verify the installed-subset
 /// binaries from the snapshot.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
@@ -178,12 +208,7 @@ fn run_acquire(args: &[String]) -> Result<()> {
     let snapshot = plan::Snapshot::load(&snapshot_path)?;
 
     // The installed subset across every unmanaged root, deduplicated.
-    let mut binaries: Vec<String> = snapshot
-        .unmanaged_targets()
-        .flat_map(|target| target.binaries.iter().map(|binary| binary.name.clone()))
-        .collect();
-    binaries.sort();
-    binaries.dedup();
+    let binaries = snapshot.installed_binaries();
     if binaries.is_empty() {
         bail!("no unmanaged binaries to acquire (WinGet roots are delegated to winget)");
     }
@@ -212,6 +237,11 @@ fn flag(args: &[String], name: &str) -> Option<String> {
         .cloned()
 }
 
+/// `true` if the bare flag `name` is present.
+fn has_flag(args: &[String], name: &str) -> bool {
+    args.iter().any(|arg| arg == name)
+}
+
 /// Turn a missing required flag into a clear error.
 fn required(value: Option<String>, what: &str) -> Result<String> {
     value.ok_or_else(|| anyhow::anyhow!("missing required {what}"))
@@ -221,14 +251,19 @@ fn required(value: Option<String>, what: &str) -> Result<String> {
 #[expect(clippy::print_stdout, reason = "intentional help output")]
 fn print_usage() {
     println!(
-        "uffs-update — self-update acquire + apply + recover helper\n\n\
+        "uffs-update — self-update acquire + apply + recover + doctor helper\n\n\
          USAGE:\n\
          \x20 uffs-update acquire --snapshot <path> --stage <dir> \\\n\
          \x20                     [--repo <owner/name>] [--version <tag>] [--sums <asset>]\n\
          \x20 uffs-update apply   --snapshot <path> --stage <dir>\n\
-         \x20 uffs-update recover --journal <path>\n\n\
+         \x20 uffs-update recover --journal <path>\n\
+         \x20 uffs-update doctor  [--snapshot <path>] [--stage <dir>] \\\n\
+         \x20                     [--repo <owner/name>] [--version <tag>] [--repair] [--offline]\n\n\
          acquire: per the snapshot's installed subset, downloads each binary\n\
          as an individual release asset + SHA256SUMS, SHA-256-verifies each,\n\
-         and leaves them staged. It does not replace anything (apply phase).\n"
+         and leaves them staged. It does not replace anything (apply phase).\n\
+         doctor:  end-to-end health check of the update flow; `--repair`\n\
+         resumes/rolls-back an interrupted update, sweeps stale backups, and\n\
+         restarts any stopped service. Exits non-zero on a hard failure.\n"
     );
 }

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -13,6 +13,7 @@
 //! ```
 
 mod acquire;
+mod apply;
 mod github;
 mod journal;
 mod verify;

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -18,6 +18,8 @@ mod github;
 mod journal;
 mod orchestrate;
 mod plan;
+mod quiesce;
+mod restore;
 mod verify;
 
 use std::path::{Path, PathBuf};
@@ -40,10 +42,10 @@ fn main() -> Result<()> {
     }
 }
 
-/// Parse the `apply` flags and run the journal-driven swap+verify.
-///
-/// Slice 3: assumes services are already stopped (Quiesce wraps this in a
-/// later slice). Swaps + smoke-tests + commits, rolling back on failure.
+/// Parse the `apply` flags and run the full journal-driven flow:
+/// quiesce → backup/swap/smoke → commit → restore → prune. On any
+/// pre-commit failure the binaries are rolled back **and** the stopped
+/// services are restarted (INV-1: never leave a service down).
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
 fn run_apply(args: &[String]) -> Result<()> {
     let snapshot_path = PathBuf::from(required(flag(args, "--snapshot"), "--snapshot <path>")?);
@@ -58,9 +60,35 @@ fn run_apply(args: &[String]) -> Result<()> {
     let mut journal = orchestrate::journal_from_snapshot(journal_path, &snapshot, backup_dir);
     journal.transition(journal::UpdateState::Acquired, "apply.acquired")?;
 
-    orchestrate::apply_all(&mut journal, &stage, |target| {
+    // Stop the resident services so their files unlock.
+    quiesce::quiesce(&mut journal, &snapshot)?;
+
+    // Swap + smoke + commit; on failure the binaries are already rolled
+    // back — now restart the services we stopped (INV-1) and abort.
+    if let Err(err) = orchestrate::apply_all(&mut journal, &stage, |target| {
         apply::smoke_ok(target, orchestrate::SMOKE_ARG)
-    })?;
+    }) {
+        let failed = restore::restore(&snapshot);
+        journal.transition(
+            journal::UpdateState::Aborted,
+            &format!("apply.aborted; restart_failed=[{}]", failed.join(", ")),
+        )?;
+        return Err(err);
+    }
+
+    // Committed: relaunch services into the new binaries.
+    let failed = restore::restore(&snapshot);
+    journal.transition(journal::UpdateState::Restored, "restore.done")?;
+    if !failed.is_empty() {
+        #[expect(clippy::print_stderr, reason = "CLI user-facing warning")]
+        {
+            eprintln!(
+                "warning: components failed to restart: [{}]",
+                failed.join(", ")
+            );
+        }
+    }
+
     orchestrate::prune_all(&journal);
     journal.transition(journal::UpdateState::Done, "apply.done")?;
     println!("Applied + committed → {}", journal.to_version);

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -72,6 +72,7 @@ fn run_apply(args: &[String]) -> Result<()> {
     // zero-downtime — nothing is quiesced or swapped yet (§19, Phase D).
     if let Err(err) = orchestrate::preflight(&journal, &stage) {
         journal.transition(journal::UpdateState::Aborted, "preflight.failed")?;
+        journal.archive();
         return Err(err);
     }
     journal.transition(journal::UpdateState::PreflightOk, "preflight.ok")?;
@@ -89,6 +90,7 @@ fn run_apply(args: &[String]) -> Result<()> {
             journal::UpdateState::Aborted,
             &format!("apply.aborted; restart_failed=[{}]", failed.join(", ")),
         )?;
+        journal.archive();
         return Err(err);
     }
 
@@ -107,6 +109,7 @@ fn run_apply(args: &[String]) -> Result<()> {
 
     orchestrate::prune_all(&journal);
     journal.transition(journal::UpdateState::Done, "apply.done")?;
+    journal.archive();
     println!("Applied + committed → {}", journal.to_version);
     Ok(())
 }

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -87,6 +87,16 @@ fn run_apply(args: &[String]) -> Result<()> {
     journal.snapshot_ref = Some(snapshot_path.display().to_string());
     journal.transition(journal::UpdateState::Acquired, "apply.acquired")?;
 
+    // R3 (§19.6): WinGet roots are delegated, not swapped — tell the user
+    // so a winget-managed install is never silently left at the old version.
+    if !journal.delegated_winget.is_empty() {
+        println!(
+            "note: {} WinGet-managed root(s) are delegated — run `winget upgrade` to update them:\n  {}",
+            journal.delegated_winget.len(),
+            journal.delegated_winget.join("\n  ")
+        );
+    }
+
     // Pre-flight BEFORE touching any service: prove every staged binary
     // is present and every target dir is writable. A failure here is
     // zero-downtime — nothing is quiesced or swapped yet (§19, Phase D).

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -47,6 +47,22 @@ fn main() -> Result<()> {
     }
 }
 
+/// Reclaim a prior self-replacement's leftover `.bak` (§19.7, R4) from the
+/// running orchestrator's own directory — but **only** when no update is
+/// in-flight (`update_dir/journal.json` absent), since a live journal means
+/// recovery owns those backups. Best-effort; never fails the caller.
+fn sweep_self_backups_if_idle(update_dir: &Path) {
+    if update_dir.join("journal.json").exists() {
+        return; // recovery owns the .bak files — do not touch
+    }
+    if let Some(self_dir) = std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(Path::to_path_buf))
+    {
+        let _swept = apply::sweep_stale_backups(&self_dir);
+    }
+}
+
 /// Parse the `apply` flags and run the full journal-driven flow:
 /// quiesce → backup/swap/smoke → commit → restore → prune. On any
 /// pre-commit failure the binaries are rolled back **and** the stopped
@@ -58,6 +74,10 @@ fn run_apply(args: &[String]) -> Result<()> {
     let update_dir = stage
         .parent()
         .map_or_else(|| stage.clone(), Path::to_path_buf);
+
+    // R4: reclaim any prior self-replacement's leftover `.bak` before we
+    // begin (no live journal yet for this run).
+    sweep_self_backups_if_idle(&update_dir);
 
     let snapshot = plan::Snapshot::load(&snapshot_path)?;
     let backup_dir = update_dir.join(format!("backup-{}", std::process::id()));
@@ -137,6 +157,14 @@ const DEFAULT_REPO: &str = "skyllc-ai/UltraFastFileSearch";
 fn run_acquire(args: &[String]) -> Result<()> {
     let snapshot_path = PathBuf::from(required(flag(args, "--snapshot"), "--snapshot <path>")?);
     let stage = PathBuf::from(required(flag(args, "--stage"), "--stage <dir>")?);
+
+    // R4: a fresh acquire is the natural moment to reclaim a prior
+    // self-replacement's leftover `.bak` (the prior process has long
+    // exited), gated on no in-flight journal.
+    if let Some(update_dir) = stage.parent() {
+        sweep_self_backups_if_idle(update_dir);
+    }
+
     let snapshot = plan::Snapshot::load(&snapshot_path)?;
 
     // The installed subset across every unmanaged root, deduplicated.

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -18,7 +18,9 @@ mod github;
 mod journal;
 mod orchestrate;
 mod plan;
+mod proc;
 mod quiesce;
+mod recover;
 mod restore;
 mod verify;
 
@@ -34,11 +36,14 @@ fn main() -> Result<()> {
     match args.first().map(String::as_str) {
         Some("acquire") => run_acquire(args.get(1..).unwrap_or_default()),
         Some("apply") => run_apply(args.get(1..).unwrap_or_default()),
+        Some("recover") => run_recover(args.get(1..).unwrap_or_default()),
         Some("--help" | "-h") | None => {
             print_usage();
             Ok(())
         }
-        Some(other) => bail!("unknown subcommand `{other}` (try `acquire` / `apply`)"),
+        Some(other) => {
+            bail!("unknown subcommand `{other}` (try `acquire` / `apply` / `recover`)")
+        }
     }
 }
 
@@ -58,6 +63,8 @@ fn run_apply(args: &[String]) -> Result<()> {
     let backup_dir = update_dir.join(format!("backup-{}", std::process::id()));
     let journal_path = update_dir.join("journal.json");
     let mut journal = orchestrate::journal_from_snapshot(journal_path, &snapshot, backup_dir);
+    // Record the snapshot so Phase H can restore service state on recovery.
+    journal.snapshot_ref = Some(snapshot_path.display().to_string());
     journal.transition(journal::UpdateState::Acquired, "apply.acquired")?;
 
     // Stop the resident services so their files unlock.
@@ -92,6 +99,20 @@ fn run_apply(args: &[String]) -> Result<()> {
     orchestrate::prune_all(&journal);
     journal.transition(journal::UpdateState::Done, "apply.done")?;
     println!("Applied + committed → {}", journal.to_version);
+    Ok(())
+}
+
+/// Parse the `recover` flags and run Phase H against a journal.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn run_recover(args: &[String]) -> Result<()> {
+    let journal_path = PathBuf::from(required(flag(args, "--journal"), "--journal <path>")?);
+    let message = match recover::recover(&journal_path)? {
+        recover::Recovery::NothingToDo => "nothing to do",
+        recover::Recovery::InProgress => "another update is in progress (owner alive)",
+        recover::Recovery::RolledForward => "interrupted update resumed → completed",
+        recover::Recovery::RolledBack => "interrupted update rolled back to the previous version",
+    };
+    println!("recover: {message}");
     Ok(())
 }
 

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -14,6 +14,7 @@
 
 mod acquire;
 mod github;
+mod journal;
 mod verify;
 
 use anyhow::{Result, bail};

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -8,8 +8,8 @@
 //! download/verify step only; detect + snapshot stay in `uffs-cli`.
 //!
 //! ```text
-//! uffs-update acquire --repo <owner/name> --stage <dir>
-//!                     [--version <tag>] [--bundle <asset>] [--sums <asset>]
+//! uffs-update acquire --snapshot <path> --stage <dir>
+//!                     [--repo <owner/name>] [--version <tag>] [--sums <asset>]
 //! ```
 
 mod acquire;
@@ -116,20 +116,41 @@ fn run_recover(args: &[String]) -> Result<()> {
     Ok(())
 }
 
-/// Parse the `acquire` flags and run it.
+/// Default upstream repository for self-update artifacts.
+const DEFAULT_REPO: &str = "skyllc-ai/UltraFastFileSearch";
+
+/// Parse the `acquire` flags and download + verify the installed-subset
+/// binaries from the snapshot.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
 fn run_acquire(args: &[String]) -> Result<()> {
-    let repo = required(flag(args, "--repo"), "--repo <owner/name>")?;
-    let stage = required(flag(args, "--stage"), "--stage <dir>")?;
+    let snapshot_path = PathBuf::from(required(flag(args, "--snapshot"), "--snapshot <path>")?);
+    let stage = PathBuf::from(required(flag(args, "--stage"), "--stage <dir>")?);
+    let snapshot = plan::Snapshot::load(&snapshot_path)?;
+
+    // The installed subset across every unmanaged root, deduplicated.
+    let mut binaries: Vec<String> = snapshot
+        .unmanaged_targets()
+        .flat_map(|target| target.binaries.iter().map(|binary| binary.name.clone()))
+        .collect();
+    binaries.sort();
+    binaries.dedup();
+    if binaries.is_empty() {
+        bail!("no unmanaged binaries to acquire (WinGet roots are delegated to winget)");
+    }
+
     let plan = AcquirePlan {
-        repo,
+        repo: flag(args, "--repo").unwrap_or_else(|| DEFAULT_REPO.to_owned()),
         tag: flag(args, "--version"),
-        stage: PathBuf::from(stage),
-        bundle: flag(args, "--bundle").unwrap_or_else(|| AcquirePlan::default_bundle().to_owned()),
+        stage: stage.clone(),
         sums: flag(args, "--sums").unwrap_or_else(|| "SHA256SUMS".to_owned()),
+        binaries,
     };
     let staged = acquire::run(&plan)?;
-    println!("Acquired + verified: {}", staged.display());
+    println!(
+        "Acquired + verified {} binaries into {}",
+        staged.len(),
+        stage.display()
+    );
     Ok(())
 }
 
@@ -150,11 +171,14 @@ fn required(value: Option<String>, what: &str) -> Result<String> {
 #[expect(clippy::print_stdout, reason = "intentional help output")]
 fn print_usage() {
     println!(
-        "uffs-update — self-update acquire helper\n\n\
-         USAGE:\n  uffs-update acquire --repo <owner/name> --stage <dir> \\\n\
-         \x20                     [--version <tag>] [--bundle <asset>] [--sums <asset>]\n\n\
-         Fetches the release, downloads the platform bundle + SHA256SUMS,\n\
-         verifies the bundle's SHA-256, and leaves it staged. It does not\n\
-         extract, verify Authenticode, or replace anything (apply phase).\n"
+        "uffs-update — self-update acquire + apply + recover helper\n\n\
+         USAGE:\n\
+         \x20 uffs-update acquire --snapshot <path> --stage <dir> \\\n\
+         \x20                     [--repo <owner/name>] [--version <tag>] [--sums <asset>]\n\
+         \x20 uffs-update apply   --snapshot <path> --stage <dir>\n\
+         \x20 uffs-update recover --journal <path>\n\n\
+         acquire: per the snapshot's installed subset, downloads each binary\n\
+         as an individual release asset + SHA256SUMS, SHA-256-verifies each,\n\
+         and leaves them staged. It does not replace anything (apply phase).\n"
     );
 }

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -67,6 +67,15 @@ fn run_apply(args: &[String]) -> Result<()> {
     journal.snapshot_ref = Some(snapshot_path.display().to_string());
     journal.transition(journal::UpdateState::Acquired, "apply.acquired")?;
 
+    // Pre-flight BEFORE touching any service: prove every staged binary
+    // is present and every target dir is writable. A failure here is
+    // zero-downtime — nothing is quiesced or swapped yet (§19, Phase D).
+    if let Err(err) = orchestrate::preflight(&journal, &stage) {
+        journal.transition(journal::UpdateState::Aborted, "preflight.failed")?;
+        return Err(err);
+    }
+    journal.transition(journal::UpdateState::PreflightOk, "preflight.ok")?;
+
     // Stop the resident services so their files unlock.
     quiesce::quiesce(&mut journal, &snapshot)?;
 

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -16,7 +16,11 @@ mod acquire;
 mod apply;
 mod github;
 mod journal;
+mod orchestrate;
+mod plan;
 mod verify;
+
+use std::path::{Path, PathBuf};
 
 use anyhow::{Result, bail};
 
@@ -27,12 +31,40 @@ fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     match args.first().map(String::as_str) {
         Some("acquire") => run_acquire(args.get(1..).unwrap_or_default()),
+        Some("apply") => run_apply(args.get(1..).unwrap_or_default()),
         Some("--help" | "-h") | None => {
             print_usage();
             Ok(())
         }
-        Some(other) => bail!("unknown subcommand `{other}` (try `acquire`)"),
+        Some(other) => bail!("unknown subcommand `{other}` (try `acquire` / `apply`)"),
     }
+}
+
+/// Parse the `apply` flags and run the journal-driven swap+verify.
+///
+/// Slice 3: assumes services are already stopped (Quiesce wraps this in a
+/// later slice). Swaps + smoke-tests + commits, rolling back on failure.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn run_apply(args: &[String]) -> Result<()> {
+    let snapshot_path = PathBuf::from(required(flag(args, "--snapshot"), "--snapshot <path>")?);
+    let stage = PathBuf::from(required(flag(args, "--stage"), "--stage <dir>")?);
+    let update_dir = stage
+        .parent()
+        .map_or_else(|| stage.clone(), Path::to_path_buf);
+
+    let snapshot = plan::Snapshot::load(&snapshot_path)?;
+    let backup_dir = update_dir.join(format!("backup-{}", std::process::id()));
+    let journal_path = update_dir.join("journal.json");
+    let mut journal = orchestrate::journal_from_snapshot(journal_path, &snapshot, backup_dir);
+    journal.transition(journal::UpdateState::Acquired, "apply.acquired")?;
+
+    orchestrate::apply_all(&mut journal, &stage, |target| {
+        apply::smoke_ok(target, orchestrate::SMOKE_ARG)
+    })?;
+    orchestrate::prune_all(&journal);
+    journal.transition(journal::UpdateState::Done, "apply.done")?;
+    println!("Applied + committed → {}", journal.to_version);
+    Ok(())
 }
 
 /// Parse the `acquire` flags and run it.
@@ -43,7 +75,7 @@ fn run_acquire(args: &[String]) -> Result<()> {
     let plan = AcquirePlan {
         repo,
         tag: flag(args, "--version"),
-        stage: std::path::PathBuf::from(stage),
+        stage: PathBuf::from(stage),
         bundle: flag(args, "--bundle").unwrap_or_else(|| AcquirePlan::default_bundle().to_owned()),
         sums: flag(args, "--sums").unwrap_or_else(|| "SHA256SUMS".to_owned()),
     };

--- a/crates/uffs-update/src/orchestrate.rs
+++ b/crates/uffs-update/src/orchestrate.rs
@@ -8,7 +8,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 
 use crate::apply;
 use crate::journal::{BinaryEntry, BinaryStatus, Journal, TargetEntry, UpdateState};
@@ -56,6 +56,40 @@ pub(crate) fn journal_from_snapshot(
         })
         .collect();
     journal
+}
+
+/// Pre-flight guard (§19, Phase D): prove the update *can* succeed
+/// **before** any service is stopped — every staged binary is present,
+/// and every target directory is writable. A failure here is zero-
+/// downtime: nothing has been quiesced or swapped yet.
+///
+/// # Errors
+///
+/// A missing staged binary, or a target directory we cannot write to
+/// (typically: needs elevation).
+pub(crate) fn preflight(journal: &Journal, staged_dir: &Path) -> Result<()> {
+    for (root, stem, _target) in collect_plan(journal) {
+        let staged = staged_dir.join(exe_name(&stem));
+        if !staged.is_file() {
+            return Err(anyhow!(
+                "staged binary missing: {} (acquire incomplete?)",
+                staged.display()
+            ));
+        }
+        ensure_writable_dir(&root)?;
+    }
+    Ok(())
+}
+
+/// Confirm `dir` accepts writes by round-tripping a uniquely-named probe
+/// file. A failure means the swap would later fail mid-flight (after a
+/// service is already stopped) — so we surface it up front.
+fn ensure_writable_dir(dir: &Path) -> Result<()> {
+    let probe = dir.join(format!(".uffs-update-probe-{}", std::process::id()));
+    std::fs::write(&probe, b"")
+        .with_context(|| format!("target dir not writable: {} (try elevated)", dir.display()))?;
+    let _removed = std::fs::remove_file(&probe);
+    Ok(())
 }
 
 /// (root, stem, on-disk target path) for every targeted binary.
@@ -140,7 +174,7 @@ pub(crate) fn prune_all(journal: &Journal) {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use super::{apply_all, exe_name, journal_from_snapshot};
+    use super::{apply_all, exe_name, journal_from_snapshot, preflight};
     use crate::journal::{BinaryStatus, UpdateState};
     use crate::plan::Snapshot;
 
@@ -200,6 +234,21 @@ mod tests {
             std::fs::read_to_string(root.join(exe_name("uffsd"))).expect("read"),
             "OLD"
         );
+    }
+
+    #[test]
+    fn preflight_passes_when_staged_present_and_writable() {
+        let (_root, stage, _base, journal) = setup("pf-ok");
+        preflight(&journal, &stage).expect("preflight should pass");
+    }
+
+    #[test]
+    fn preflight_fails_when_staged_binary_missing() {
+        let (_root, _stage, base, journal) = setup("pf-missing");
+        let empty_stage = base.join("empty-stage");
+        std::fs::create_dir_all(&empty_stage).expect("mkdir");
+        let err = preflight(&journal, &empty_stage).expect_err("missing staged must fail");
+        assert!(err.to_string().contains("staged binary missing"), "{err}");
     }
 
     #[test]

--- a/crates/uffs-update/src/orchestrate.rs
+++ b/crates/uffs-update/src/orchestrate.rs
@@ -55,6 +55,12 @@ pub(crate) fn journal_from_snapshot(
                 .collect(),
         })
         .collect();
+    // Record WinGet roots we intentionally delegate (§19.6, R3) so they
+    // are visible in the journal rather than silently dropped.
+    journal.delegated_winget = snapshot
+        .winget_targets()
+        .map(|target| target.root.display().to_string())
+        .collect();
     journal
 }
 
@@ -233,6 +239,24 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(root.join(exe_name("uffsd"))).expect("read"),
             "OLD"
+        );
+    }
+
+    #[test]
+    fn journal_records_delegated_winget_roots() {
+        let json = r#"{ "to_version": "0.6.2", "targets": [
+             { "root": "/opt/uffs", "channel": "unmanaged",
+               "binaries": [ { "name": "uffsd", "on_disk_version": "0.6.1" } ] },
+             { "root": "/winget/uffs", "channel": "winget",
+               "binaries": [ { "name": "uffs", "on_disk_version": "0.6.1" } ] } ],
+           "running": [] }"#;
+        let snapshot: Snapshot = serde_json::from_str(json).expect("snap");
+        let journal = journal_from_snapshot("/tmp/j.json".into(), &snapshot, "/tmp/bak".into());
+        assert_eq!(journal.targets.len(), 1, "only unmanaged is swapped");
+        assert_eq!(
+            journal.delegated_winget,
+            vec!["/winget/uffs".to_owned()],
+            "winget root recorded for visibility, not silently dropped"
         );
     }
 

--- a/crates/uffs-update/src/orchestrate.rs
+++ b/crates/uffs-update/src/orchestrate.rs
@@ -17,12 +17,29 @@ use crate::plan::Snapshot;
 /// Smoke-check argument (`--self-check` where supported, §19.8).
 pub(crate) const SMOKE_ARG: &str = "--version";
 
-/// Platform executable file name for a binary stem.
+/// Platform executable file name for a binary stem — the **on-disk**
+/// name an installed binary has (`uffsd` → `uffsd.exe` on Windows).
 pub(crate) fn exe_name(stem: &str) -> String {
     if cfg!(windows) {
         format!("{stem}.exe")
     } else {
         stem.to_owned()
+    }
+}
+
+/// Release **asset** name for a binary stem — the platform-suffixed name
+/// the release publishes (e.g. `uffsd-windows-x64.exe`), matching the
+/// `final-release/` naming in `.github/workflows/release.yml`. Distinct
+/// from [`exe_name`]: we download the suffixed asset but stage it under
+/// the plain on-disk name so the apply phase finds it. The suffix tracks
+/// the release build matrix (`x86_64` Windows/Linux, `aarch64` macOS).
+pub(crate) fn asset_name(stem: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("{stem}-windows-x64.exe")
+    } else if cfg!(target_os = "macos") {
+        format!("{stem}-macos-arm64")
+    } else {
+        format!("{stem}-linux-x64")
     }
 }
 
@@ -180,9 +197,25 @@ pub(crate) fn prune_all(journal: &Journal) {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use super::{apply_all, exe_name, journal_from_snapshot, preflight};
+    use super::{apply_all, asset_name, exe_name, journal_from_snapshot, preflight};
     use crate::journal::{BinaryStatus, UpdateState};
     use crate::plan::Snapshot;
+
+    #[test]
+    fn asset_name_is_platform_suffixed_and_differs_from_on_disk_name() {
+        let asset = asset_name("uffsd");
+        // The release publishes platform-suffixed assets; the on-disk name
+        // is plain. Acquire downloads the former, stages as the latter.
+        assert_ne!(asset, exe_name("uffsd"), "asset must be platform-suffixed");
+        let expected = if cfg!(target_os = "windows") {
+            "uffsd-windows-x64.exe"
+        } else if cfg!(target_os = "macos") {
+            "uffsd-macos-arm64"
+        } else {
+            "uffsd-linux-x64"
+        };
+        assert_eq!(asset, expected);
+    }
 
     fn scratch(tag: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!("uffs-orch-{}-{tag}", std::process::id()));

--- a/crates/uffs-update/src/orchestrate.rs
+++ b/crates/uffs-update/src/orchestrate.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Journal-driven apply orchestration (design §19.3): build a journal
+//! from the snapshot, then `backup → swap → smoke → commit`, rolling back
+//! on any **pre-commit** failure. After the commit point the new binaries
+//! are good; only forward motion (restore + verify) remains.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+
+use crate::apply;
+use crate::journal::{BinaryEntry, BinaryStatus, Journal, TargetEntry, UpdateState};
+use crate::plan::Snapshot;
+
+/// Smoke-check argument (`--self-check` where supported, §19.8).
+pub(crate) const SMOKE_ARG: &str = "--version";
+
+/// Platform executable file name for a binary stem.
+pub(crate) fn exe_name(stem: &str) -> String {
+    if cfg!(windows) {
+        format!("{stem}.exe")
+    } else {
+        stem.to_owned()
+    }
+}
+
+/// Build a fresh journal from a snapshot: one target per **unmanaged**
+/// root (`WinGet` is delegated elsewhere), every binary `Pending`.
+pub(crate) fn journal_from_snapshot(
+    journal_path: PathBuf,
+    snapshot: &Snapshot,
+    backup_dir: PathBuf,
+) -> Journal {
+    let mut journal = Journal::new(
+        journal_path,
+        &snapshot.prior_version(),
+        snapshot.to_version(),
+        backup_dir,
+    );
+    journal.targets = snapshot
+        .unmanaged_targets()
+        .map(|target| TargetEntry {
+            root: target.root.clone(),
+            channel: target.channel.clone(),
+            binaries: target
+                .binaries
+                .iter()
+                .map(|binary| BinaryEntry {
+                    name: binary.name.clone(),
+                    status: BinaryStatus::Pending,
+                    backup: None,
+                })
+                .collect(),
+        })
+        .collect();
+    journal
+}
+
+/// (root, stem, on-disk target path) for every targeted binary.
+fn collect_plan(journal: &Journal) -> Vec<(PathBuf, String, PathBuf)> {
+    journal
+        .targets
+        .iter()
+        .flat_map(|target| {
+            target.binaries.iter().map(move |binary| {
+                let path = target.root.join(exe_name(&binary.name));
+                (target.root.clone(), binary.name.clone(), path)
+            })
+        })
+        .collect()
+}
+
+/// Apply every targeted binary from `staged_dir`, smoke-test all, then
+/// cross the commit point. `smoke` is injected so both paths are
+/// testable; production passes [`apply::smoke_ok`].
+///
+/// On any failure **before** the commit point, rolls back fully and
+/// returns the error (the originals are restored, INV-3).
+///
+/// # Errors
+///
+/// Returns the underlying swap/smoke failure (after rollback).
+pub(crate) fn apply_all<F>(journal: &mut Journal, staged_dir: &Path, smoke: F) -> Result<()>
+where
+    F: Fn(&Path) -> bool,
+{
+    journal.transition(UpdateState::Swapping, "apply.begin")?;
+    let plan = collect_plan(journal);
+
+    // backup + swap each
+    for (root, stem, target) in &plan {
+        let staged = staged_dir.join(exe_name(stem));
+        if let Err(err) = apply::backup_and_swap(&staged, target) {
+            rollback_all(journal)?;
+            return Err(err);
+        }
+        journal.set_binary_status(root, stem, BinaryStatus::Swapped);
+        journal.save()?;
+    }
+    journal.transition(UpdateState::Swapped, "apply.all_swapped")?;
+
+    // smoke each new image before the commit point
+    for (root, stem, target) in &plan {
+        if !smoke(target) {
+            rollback_all(journal)?;
+            return Err(anyhow!("smoke test failed for {stem}; rolled back"));
+        }
+        journal.set_binary_status(root, stem, BinaryStatus::SmokeOk);
+    }
+
+    journal.commit()?; // point of no return
+    Ok(())
+}
+
+/// Restore every backed-up binary (pre-commit rollback, INV-3).
+///
+/// # Errors
+///
+/// Propagates a restore failure.
+pub(crate) fn rollback_all(journal: &mut Journal) -> Result<()> {
+    journal.transition(UpdateState::RollingBack, "rollback.begin")?;
+    for (root, stem, target) in collect_plan(journal) {
+        apply::restore(&target)?;
+        journal.set_binary_status(&root, &stem, BinaryStatus::RolledBack);
+    }
+    journal.transition(UpdateState::RolledBack, "rollback.done")?;
+    Ok(())
+}
+
+/// Prune every backup after a committed, verified update (best-effort).
+pub(crate) fn prune_all(journal: &Journal) {
+    for (_, _, target) in collect_plan(journal) {
+        let _pruned = apply::prune_backup(&target);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::{apply_all, exe_name, journal_from_snapshot};
+    use crate::journal::{BinaryStatus, UpdateState};
+    use crate::plan::Snapshot;
+
+    fn scratch(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("uffs-orch-{}-{tag}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        dir
+    }
+
+    fn snapshot_for(root: &Path) -> Snapshot {
+        let json = format!(
+            r#"{{ "to_version": "0.6.2", "targets": [
+                 {{ "root": {root:?}, "channel": "unmanaged",
+                    "binaries": [ {{ "name": "uffsd", "on_disk_version": "0.6.1" }} ] }} ],
+               "running": [] }}"#,
+        );
+        serde_json::from_str(&json).expect("snap")
+    }
+
+    fn setup(tag: &str) -> (PathBuf, PathBuf, PathBuf, crate::journal::Journal) {
+        let base = scratch(tag);
+        let root = base.join("install");
+        let stage = base.join("stage");
+        std::fs::create_dir_all(&root).expect("root");
+        std::fs::create_dir_all(&stage).expect("stage");
+        std::fs::write(root.join(exe_name("uffsd")), "OLD").expect("old");
+        std::fs::write(stage.join(exe_name("uffsd")), "NEW").expect("new");
+        let journal = journal_from_snapshot(
+            base.join("journal.json"),
+            &snapshot_for(&root),
+            base.join("backup"),
+        );
+        (root, stage, base, journal)
+    }
+
+    #[test]
+    fn apply_success_swaps_and_commits() {
+        let (root, stage, _base, mut journal) = setup("ok");
+        apply_all(&mut journal, &stage, |_| true).expect("apply");
+        assert!(journal.commit_point_passed);
+        assert_eq!(journal.state, UpdateState::SmokeOk);
+        assert_eq!(
+            std::fs::read_to_string(root.join(exe_name("uffsd"))).expect("read"),
+            "NEW"
+        );
+    }
+
+    #[test]
+    fn smoke_failure_rolls_back_to_old() {
+        let (root, stage, _base, mut journal) = setup("rollback");
+        let result = apply_all(&mut journal, &stage, |_| false);
+        assert!(result.is_err());
+        assert_eq!(journal.state, UpdateState::RolledBack);
+        assert!(!journal.commit_point_passed);
+        // Original restored.
+        assert_eq!(
+            std::fs::read_to_string(root.join(exe_name("uffsd"))).expect("read"),
+            "OLD"
+        );
+    }
+
+    #[test]
+    fn journal_built_from_unmanaged_targets() {
+        let (root, _stage, _base, journal) = setup("build");
+        assert_eq!(journal.to_version, "0.6.2");
+        assert_eq!(journal.from_version, "0.6.1");
+        assert_eq!(journal.targets.len(), 1);
+        let target = journal.targets.first().expect("one target");
+        assert_eq!(target.root, root);
+        let binary = target.binaries.first().expect("one binary");
+        assert_eq!(binary.status, BinaryStatus::Pending);
+    }
+}

--- a/crates/uffs-update/src/plan.rs
+++ b/crates/uffs-update/src/plan.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Typed read of the Phase-B snapshot (design §13) — the input to apply,
+//! quiesce, and restore.
+//!
+//! The snapshot is written by `uffs update --snapshot` (in `uffs-cli`);
+//! the apply helper reads it back here. Only the fields the mutating
+//! phases need are modelled; unknown fields are ignored so the schema can
+//! grow without breaking older helpers.
+
+// The `running[]` entries (component / pid / image_path / command_line)
+// are consumed by the quiesce + restore slice; until then they are
+// parsed and exercised only by the tests below.
+#![expect(
+    dead_code,
+    reason = "snapshot `running[]` consumed by the quiesce/restore slice (next)"
+)]
+
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result};
+use serde::Deserialize;
+
+/// A parsed Phase-B snapshot.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Snapshot {
+    /// Target version the snapshot was captured against (if recorded).
+    #[serde(default)]
+    pub(crate) to_version: Option<String>,
+    /// Install roots = update targets.
+    #[serde(default)]
+    pub(crate) targets: Vec<SnapTarget>,
+    /// Live processes (how to stop + restart each).
+    #[serde(default)]
+    pub(crate) running: Vec<SnapRunning>,
+}
+
+/// One install root from the snapshot.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SnapTarget {
+    /// Install directory.
+    pub(crate) root: PathBuf,
+    /// Channel (`winget` / `unmanaged` / `dev-build`).
+    pub(crate) channel: String,
+    /// Binaries present in this root.
+    #[serde(default)]
+    pub(crate) binaries: Vec<SnapBinary>,
+}
+
+/// One binary entry from the snapshot.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SnapBinary {
+    /// Logical stem (e.g. `uffsd`).
+    pub(crate) name: String,
+    /// On-disk version at snapshot time.
+    #[serde(default)]
+    pub(crate) on_disk_version: Option<String>,
+}
+
+/// One live process from the snapshot (the restart recipe).
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SnapRunning {
+    /// Component kind: `daemon` / `broker` / `mcp`.
+    pub(crate) component: String,
+    /// OS process id at snapshot time.
+    pub(crate) pid: u32,
+    /// Image path.
+    #[serde(default)]
+    pub(crate) image_path: Option<PathBuf>,
+    /// Exact launch command line (the restart recipe).
+    #[serde(default)]
+    pub(crate) command_line: Option<String>,
+}
+
+impl Snapshot {
+    /// Load + parse a snapshot file.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the file is missing or not valid snapshot JSON.
+    pub(crate) fn load(path: &std::path::Path) -> Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("reading snapshot {}", path.display()))?;
+        serde_json::from_str(&text).with_context(|| format!("parsing snapshot {}", path.display()))
+    }
+
+    /// The version this update is moving *to* (falls back to `unknown`).
+    pub(crate) fn to_version(&self) -> &str {
+        self.to_version.as_deref().unwrap_or("unknown")
+    }
+
+    /// Roots the **updater** owns: `unmanaged` only. `WinGet` roots are
+    /// delegated to `winget upgrade` by `uffs-cli`; dev-build roots are
+    /// never auto-updated.
+    pub(crate) fn unmanaged_targets(&self) -> impl Iterator<Item = &SnapTarget> {
+        self.targets
+            .iter()
+            .filter(|target| target.channel == "unmanaged")
+    }
+
+    /// The lowest `on_disk_version` across all targets (the "from" version),
+    /// or `unknown` if none recorded.
+    pub(crate) fn prior_version(&self) -> String {
+        self.targets
+            .iter()
+            .flat_map(|target| target.binaries.iter())
+            .filter_map(|binary| binary.on_disk_version.clone())
+            .min()
+            .unwrap_or_else(|| "unknown".to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Snapshot;
+
+    const SNAP: &str = r#"{
+      "schema": 2, "to_version": "0.6.2",
+      "targets": [
+        { "root": "C:\\uffs", "channel": "unmanaged",
+          "binaries": [ { "name": "uffsd", "on_disk_version": "0.6.1" } ] },
+        { "root": "C:\\wg", "channel": "winget",
+          "binaries": [ { "name": "uffs", "on_disk_version": "0.6.2" } ] }
+      ],
+      "running": [
+        { "component": "daemon", "pid": 42, "image_path": "C:\\uffs\\uffsd.exe",
+          "command_line": "uffsd --no-retire" }
+      ]
+    }"#;
+
+    #[test]
+    fn parses_and_filters_unmanaged() {
+        let snap: Snapshot = serde_json::from_str(SNAP).expect("parse");
+        assert_eq!(snap.to_version(), "0.6.2");
+        assert_eq!(snap.prior_version(), "0.6.1");
+        let unmanaged: Vec<_> = snap.unmanaged_targets().collect();
+        assert_eq!(unmanaged.len(), 1, "winget root excluded");
+        let binary = unmanaged
+            .first()
+            .and_then(|target| target.binaries.first())
+            .expect("one binary");
+        assert_eq!(binary.name, "uffsd");
+        let running = snap.running.first().expect("one running");
+        assert_eq!(running.component, "daemon");
+        assert_eq!(running.command_line.as_deref(), Some("uffsd --no-retire"));
+    }
+
+    #[test]
+    fn tolerates_missing_optional_fields() {
+        let snap: Snapshot = serde_json::from_str(r#"{ "targets": [] }"#).expect("parse");
+        assert_eq!(snap.to_version(), "unknown");
+        assert_eq!(snap.prior_version(), "unknown");
+        assert_eq!(snap.unmanaged_targets().count(), 0);
+    }
+}

--- a/crates/uffs-update/src/plan.rs
+++ b/crates/uffs-update/src/plan.rs
@@ -55,13 +55,9 @@ pub(crate) struct SnapBinary {
 pub(crate) struct SnapRunning {
     /// Component kind: `daemon` / `broker` / `mcp`.
     pub(crate) component: String,
-    /// OS process id at snapshot time. Parsed for audit completeness only:
+    /// OS process id at snapshot time. The doctor probes its liveness;
     /// quiesce/restore act via the PID file + `sc.exe` + the captured
     /// command line, never this (stale-by-restart) raw pid.
-    #[expect(
-        dead_code,
-        reason = "snapshot audit field; not used by stop/start logic"
-    )]
     pub(crate) pid: u32,
     /// Image path.
     #[serde(default)]
@@ -105,6 +101,19 @@ impl Snapshot {
         self.targets
             .iter()
             .filter(|target| target.channel == "winget")
+    }
+
+    /// The deduplicated set of binary stems installed across every
+    /// **unmanaged** root (e.g. `["uffs", "uffsd"]`) — the subset the
+    /// updater acquires + applies. Sorted for stable output.
+    pub(crate) fn installed_binaries(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .unmanaged_targets()
+            .flat_map(|target| target.binaries.iter().map(|binary| binary.name.clone()))
+            .collect();
+        names.sort();
+        names.dedup();
+        names
     }
 
     /// The lowest `on_disk_version` across all targets (the "from" version),

--- a/crates/uffs-update/src/plan.rs
+++ b/crates/uffs-update/src/plan.rs
@@ -9,14 +9,6 @@
 //! phases need are modelled; unknown fields are ignored so the schema can
 //! grow without breaking older helpers.
 
-// The `running[]` entries (component / pid / image_path / command_line)
-// are consumed by the quiesce + restore slice; until then they are
-// parsed and exercised only by the tests below.
-#![expect(
-    dead_code,
-    reason = "snapshot `running[]` consumed by the quiesce/restore slice (next)"
-)]
-
 use std::path::PathBuf;
 
 use anyhow::{Context as _, Result};
@@ -63,7 +55,13 @@ pub(crate) struct SnapBinary {
 pub(crate) struct SnapRunning {
     /// Component kind: `daemon` / `broker` / `mcp`.
     pub(crate) component: String,
-    /// OS process id at snapshot time.
+    /// OS process id at snapshot time. Parsed for audit completeness only:
+    /// quiesce/restore act via the PID file + `sc.exe` + the captured
+    /// command line, never this (stale-by-restart) raw pid.
+    #[expect(
+        dead_code,
+        reason = "snapshot audit field; not used by stop/start logic"
+    )]
     pub(crate) pid: u32,
     /// Image path.
     #[serde(default)]
@@ -97,6 +95,16 @@ impl Snapshot {
         self.targets
             .iter()
             .filter(|target| target.channel == "unmanaged")
+    }
+
+    /// `WinGet`-managed roots. The updater never swaps these (§19.6): their
+    /// update path is `winget upgrade`, which is atomic and not `.bak`-
+    /// rollback-able. We surface them so a winget-managed install is never
+    /// silently left at the old version.
+    pub(crate) fn winget_targets(&self) -> impl Iterator<Item = &SnapTarget> {
+        self.targets
+            .iter()
+            .filter(|target| target.channel == "winget")
     }
 
     /// The lowest `on_disk_version` across all targets (the "from" version),
@@ -136,6 +144,9 @@ mod tests {
         assert_eq!(snap.prior_version(), "0.6.1");
         let unmanaged: Vec<_> = snap.unmanaged_targets().collect();
         assert_eq!(unmanaged.len(), 1, "winget root excluded");
+        let winget: Vec<_> = snap.winget_targets().collect();
+        assert_eq!(winget.len(), 1, "winget root surfaced separately");
+        assert_eq!(winget.first().expect("one").channel, "winget");
         let binary = unmanaged
             .first()
             .and_then(|target| target.binaries.first())

--- a/crates/uffs-update/src/proc.rs
+++ b/crates/uffs-update/src/proc.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Native process liveness — "is this PID still alive?".
+//!
+//! Used by Phase H (§19.4) to decide whether a journal's owning updater
+//! is gone (→ recover) or still running (→ defer). Native Win32 / POSIX
+//! so it is **version-independent** on every Windows (7/10/11) and Unix —
+//! no `tasklist` / `kill` shell-out, which we deliberately avoid.
+
+/// Windows sentinel exit code reported for a still-running process.
+#[cfg(windows)]
+const STILL_ACTIVE_CODE: u32 = 259;
+
+/// `true` if a process with `pid` currently exists.
+#[cfg(windows)]
+#[must_use]
+pub(crate) fn is_alive(pid: u32) -> bool {
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    // SAFETY: `OpenProcess` is a documented Win32 call; a query-only mask
+    // and a plain pid. It returns `Err` for a non-existent process.
+    #[expect(unsafe_code, reason = "Win32 FFI — OpenProcess")]
+    let Ok(handle) = (unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }) else {
+        return false;
+    };
+    if handle.is_invalid() {
+        return false;
+    }
+
+    let mut code: u32 = 0;
+    // SAFETY: `handle` is a valid process handle from `OpenProcess`;
+    // `code` is a valid writable `u32`.
+    #[expect(unsafe_code, reason = "Win32 FFI — GetExitCodeProcess")]
+    let queried = unsafe { GetExitCodeProcess(handle, core::ptr::from_mut(&mut code)) }.is_ok();
+
+    // SAFETY: `handle` came from `OpenProcess` and is closed exactly once.
+    #[expect(unsafe_code, reason = "Win32 FFI — CloseHandle")]
+    let _closed = unsafe { CloseHandle(handle) };
+
+    queried && code == STILL_ACTIVE_CODE
+}
+
+/// `true` if a process with `pid` currently exists.
+///
+/// Uses `kill(pid, 0)` — signal 0 delivers nothing, it only probes
+/// existence. The journal owner is always a prior same-user `uffs-update`,
+/// so a permission error can't arise; any non-zero result means gone.
+#[cfg(unix)]
+#[must_use]
+pub(crate) fn is_alive(pid: u32) -> bool {
+    let Ok(signed_pid) = i32::try_from(pid) else {
+        return false;
+    };
+    // SAFETY: `kill` with signal 0 performs no signal delivery; the pid is
+    // a plain integer.
+    #[expect(unsafe_code, reason = "POSIX FFI — kill(pid, 0) existence probe")]
+    let result = unsafe { libc::kill(signed_pid, 0) };
+    result == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_alive;
+
+    #[test]
+    fn current_process_is_alive() {
+        assert!(is_alive(std::process::id()));
+    }
+
+    #[test]
+    fn improbable_pid_is_dead() {
+        assert!(!is_alive(u32::MAX));
+    }
+}

--- a/crates/uffs-update/src/quiesce.rs
+++ b/crates/uffs-update/src/quiesce.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Quiesce (design §8): stop the core resident services so their files
+//! unlock, recording each stop in the journal so Phase H can restart them
+//! (INV-1).
+//!
+//! Robust by construction — **no fragile external tools, no FFI**:
+//! - daemon / MCP: graceful via our **own** in-tree `uffs daemon stop` / `uffs
+//!   mcp stop`;
+//! - broker: `sc.exe stop` (a core OS component on every Windows);
+//! - "is it down yet": poll the daemon **PID file** (the daemon deletes it on
+//!   clean exit) and `sc query` for the broker.
+
+use core::time::Duration;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use anyhow::{Result, bail};
+
+use crate::journal::{Journal, UpdateState};
+use crate::orchestrate::exe_name;
+use crate::plan::{SnapRunning, Snapshot};
+
+/// How long to wait for a service to actually stop.
+const STOP_TIMEOUT: Duration = Duration::from_secs(20);
+/// Poll interval while waiting.
+const POLL: Duration = Duration::from_millis(200);
+/// The broker Windows service name.
+pub(crate) const BROKER_SERVICE: &str = "UffsAccessBroker";
+
+/// Stop every running core component in dependency order (consumers
+/// before providers: MCP → daemon → broker), recording each in
+/// `journal.services_stopped`.
+///
+/// # Errors
+///
+/// Fails if a component will not stop within [`STOP_TIMEOUT`].
+pub(crate) fn quiesce(journal: &mut Journal, snapshot: &Snapshot) -> Result<()> {
+    for component in ["mcp", "daemon", "broker"] {
+        for running in snapshot
+            .running
+            .iter()
+            .filter(|run| run.component == component)
+        {
+            stop_component(component, running)?;
+            journal.services_stopped.push(component.to_owned());
+            journal.transition(
+                UpdateState::Quiesced,
+                &format!("quiesce.{component}.stopped"),
+            )?;
+        }
+    }
+    journal.transition(UpdateState::Quiesced, "quiesce.done")?;
+    Ok(())
+}
+
+/// Stop one component by its kind.
+fn stop_component(component: &str, running: &SnapRunning) -> Result<()> {
+    match component {
+        "daemon" => stop_daemon(running),
+        "broker" => stop_broker(),
+        "mcp" => {
+            stop_mcp(running);
+            Ok(())
+        }
+        other => bail!("unknown component to stop: {other}"),
+    }
+}
+
+/// `uffs` binary next to a component's image (else bare `uffs` on PATH).
+fn uffs_sibling(running: &SnapRunning) -> PathBuf {
+    running
+        .image_path
+        .as_deref()
+        .and_then(Path::parent)
+        .map_or_else(
+            || PathBuf::from(exe_name("uffs")),
+            |dir| dir.join(exe_name("uffs")),
+        )
+}
+
+/// Daemon PID file (`<lifecycle_dir>/daemon.pid`) — its absence is the
+/// "daemon stopped" signal (the daemon deletes it on clean exit).
+pub(crate) fn daemon_pid_file() -> PathBuf {
+    dirs_next::data_local_dir()
+        .map_or_else(|| PathBuf::from("/tmp/uffs"), |base| base.join("uffs"))
+        .join("daemon.pid")
+}
+
+/// Graceful daemon stop, then wait for the PID file to disappear.
+fn stop_daemon(running: &SnapRunning) -> Result<()> {
+    let uffs = uffs_sibling(running);
+    let _ignore = Command::new(&uffs).args(["daemon", "stop"]).status();
+    if wait_until(STOP_TIMEOUT, || !daemon_pid_file().exists()) {
+        Ok(())
+    } else {
+        bail!("daemon did not stop within {STOP_TIMEOUT:?} (PID file lingered)")
+    }
+}
+
+/// Stop the broker service, then wait until `sc query` reports STOPPED.
+fn stop_broker() -> Result<()> {
+    let _ignore = Command::new("sc.exe")
+        .args(["stop", BROKER_SERVICE])
+        .status();
+    if wait_until(STOP_TIMEOUT, || sc_query_stopped(BROKER_SERVICE)) {
+        Ok(())
+    } else {
+        bail!("broker service did not reach STOPPED within {STOP_TIMEOUT:?}")
+    }
+}
+
+/// Best-effort MCP gateway stop (a client just reconnects later).
+fn stop_mcp(running: &SnapRunning) {
+    let uffs = uffs_sibling(running);
+    let _ignore = Command::new(&uffs).args(["mcp", "stop"]).status();
+}
+
+/// Poll `done` every [`POLL`] until it returns `true` or `timeout` elapses.
+pub(crate) fn wait_until(timeout: Duration, done: impl Fn() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if done() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(POLL);
+    }
+}
+
+/// `true` when `sc query <service>` reports the service STOPPED (or it
+/// isn't installed — also "not running").
+fn sc_query_stopped(service: &str) -> bool {
+    let Ok(out) = Command::new("sc.exe").args(["query", service]).output() else {
+        return false;
+    };
+    if !out.status.success() {
+        // Non-zero typically means "service does not exist" → not running.
+        return true;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    sc_state_is_stopped(&text)
+}
+
+/// Parse `sc query` stdout for a STOPPED state (pure — testable).
+fn sc_state_is_stopped(sc_output: &str) -> bool {
+    sc_output.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with("STATE") && trimmed.contains("STOPPED")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sc_state_is_stopped, uffs_sibling, wait_until};
+    use crate::plan::SnapRunning;
+
+    fn running_with_image(image: &std::path::Path) -> SnapRunning {
+        let json = format!(
+            r#"{{ "component": "daemon", "pid": 1, "image_path": {:?} }}"#,
+            image.to_string_lossy()
+        );
+        serde_json::from_str(&json).expect("running")
+    }
+
+    #[test]
+    fn uffs_sibling_next_to_image() {
+        // Host-valid path so `Path::parent` works on the test runner.
+        let dir = std::env::temp_dir();
+        let run = running_with_image(&dir.join("uffsd"));
+        let sib = uffs_sibling(&run);
+        assert_eq!(sib.parent(), Some(dir.as_path()));
+        assert!(
+            sib.file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with("uffs"))
+        );
+    }
+
+    #[test]
+    fn sc_state_parsing() {
+        assert!(sc_state_is_stopped(
+            "        STATE              : 1  STOPPED"
+        ));
+        assert!(!sc_state_is_stopped(
+            "        STATE              : 4  RUNNING"
+        ));
+        assert!(!sc_state_is_stopped("no state line here"));
+    }
+
+    #[test]
+    fn wait_until_returns_true_when_predicate_holds() {
+        let hits = core::cell::Cell::new(0_u8);
+        let ok = wait_until(core::time::Duration::from_secs(2), || {
+            hits.set(hits.get() + 1);
+            hits.get() >= 2
+        });
+        assert!(ok);
+        assert!(hits.get() >= 2);
+    }
+
+    #[test]
+    fn wait_until_times_out() {
+        let ok = wait_until(core::time::Duration::from_millis(10), || false);
+        assert!(!ok);
+    }
+}

--- a/crates/uffs-update/src/recover.rs
+++ b/crates/uffs-update/src/recover.rs
@@ -76,6 +76,7 @@ fn roll_forward(journal: &mut Journal, snapshot: &plan::Snapshot) -> Result<()> 
     journal.transition(UpdateState::Restored, "recover.roll_forward")?;
     orchestrate::prune_all(journal);
     journal.transition(UpdateState::Done, "recover.done")?;
+    journal.archive();
     Ok(())
 }
 
@@ -85,6 +86,7 @@ fn roll_back(journal: &mut Journal, snapshot: &plan::Snapshot) -> Result<()> {
     orchestrate::rollback_all(journal)?;
     let _failed = restore::restore(snapshot); // INV-1
     journal.transition(UpdateState::Aborted, "recover.roll_back")?;
+    journal.archive();
     Ok(())
 }
 

--- a/crates/uffs-update/src/recover.rs
+++ b/crates/uffs-update/src/recover.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Phase H — recover / resume (design §19.4).
+//!
+//! Reads the journal and, when its owning updater is **gone** (crashed,
+//! killed, powered-off) and the run is **not terminal**, deterministically
+//! finishes it: roll **forward** if past the commit point (the new
+//! binaries are good — just restart services), else roll **back** (restore
+//! `.bak`, restart services). Either branch ends by ensuring every service
+//! the run stopped is running again (INV-1).
+//!
+//! Decided **solely** by `state` vs `commit_point_passed` — no guessing.
+
+use std::path::Path;
+
+use anyhow::{Context as _, Result};
+
+use crate::journal::{Journal, UpdateState};
+use crate::{orchestrate, plan, proc, restore};
+
+/// What a recovery run did (for the caller's report).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Recovery {
+    /// No journal, or the run already finished — nothing to do.
+    NothingToDo,
+    /// The owning updater is still alive — another run owns this; defer.
+    InProgress,
+    /// Past the commit point: finished the update (restart + verify).
+    RolledForward,
+    /// Before the commit point: restored the old binaries.
+    RolledBack,
+}
+
+/// Run Phase H against the journal at `journal_path`.
+///
+/// # Errors
+///
+/// Propagates a rollback / restore failure (rare — both are best-effort
+/// where possible).
+pub(crate) fn recover(journal_path: &Path) -> Result<Recovery> {
+    let Ok(mut journal) = Journal::load(journal_path) else {
+        return Ok(Recovery::NothingToDo); // no/invalid journal
+    };
+    if journal.state.is_terminal() {
+        return Ok(Recovery::NothingToDo);
+    }
+    let owner_alive = proc::is_alive(journal.owner_pid);
+    if !journal.needs_recovery(owner_alive) {
+        return Ok(Recovery::InProgress); // owner still running
+    }
+
+    let snapshot = load_snapshot(&journal)?;
+    if journal.commit_point_passed {
+        roll_forward(&mut journal, &snapshot)?;
+        Ok(Recovery::RolledForward)
+    } else {
+        roll_back(&mut journal, &snapshot)?;
+        Ok(Recovery::RolledBack)
+    }
+}
+
+/// Load the snapshot the journal was built against.
+fn load_snapshot(journal: &Journal) -> Result<plan::Snapshot> {
+    let snapshot_ref = journal
+        .snapshot_ref
+        .as_deref()
+        .context("journal has no snapshot_ref; cannot recover service state")?;
+    plan::Snapshot::load(Path::new(snapshot_ref))
+}
+
+/// Past the commit point: the new binaries are good. Restart services into
+/// them, prune backups, finish.
+fn roll_forward(journal: &mut Journal, snapshot: &plan::Snapshot) -> Result<()> {
+    let _failed = restore::restore(snapshot); // INV-1: bring services back up
+    journal.transition(UpdateState::Restored, "recover.roll_forward")?;
+    orchestrate::prune_all(journal);
+    journal.transition(UpdateState::Done, "recover.done")?;
+    Ok(())
+}
+
+/// Before the commit point: restore the old binaries, then restart
+/// services so nothing is left down (INV-1).
+fn roll_back(journal: &mut Journal, snapshot: &plan::Snapshot) -> Result<()> {
+    orchestrate::rollback_all(journal)?;
+    let _failed = restore::restore(snapshot); // INV-1
+    journal.transition(UpdateState::Aborted, "recover.roll_back")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Recovery, recover};
+    use crate::journal::{Journal, UpdateState};
+
+    fn journal_path(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir()
+            .join(format!("uffs-recover-{}-{tag}", std::process::id()))
+            .join("journal.json")
+    }
+
+    #[test]
+    fn missing_journal_is_nothing_to_do() {
+        let path = journal_path("missing");
+        assert_eq!(recover(&path).expect("recover"), Recovery::NothingToDo);
+    }
+
+    #[test]
+    fn live_owner_defers() {
+        // A journal owned by THIS (alive) process must not be recovered.
+        let path = journal_path("live");
+        let mut journal = Journal::new(path.clone(), "0.6.1", "0.6.2", "/tmp/bak".into());
+        journal.state = UpdateState::Swapping; // non-terminal, owner = us (alive)
+        journal.save().expect("save");
+        assert_eq!(recover(&path).expect("recover"), Recovery::InProgress);
+        let _removed = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn terminal_journal_is_nothing_to_do() {
+        let path = journal_path("done");
+        let mut journal = Journal::new(path.clone(), "0.6.1", "0.6.2", "/tmp/bak".into());
+        journal.state = UpdateState::Done;
+        journal.save().expect("save");
+        assert_eq!(recover(&path).expect("recover"), Recovery::NothingToDo);
+        let _removed = std::fs::remove_file(&path);
+    }
+}

--- a/crates/uffs-update/src/restore.rs
+++ b/crates/uffs-update/src/restore.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Restore (design §10): relaunch services from the captured snapshot
+//! recipe, **providers before consumers** (broker → daemon → MCP).
+//!
+//! This is also the INV-1 backstop: the apply rollback path and Phase H
+//! call it to make sure nothing the run stopped is left down. So it is
+//! **best-effort per component** — a failure to restart one is reported
+//! but never blocks restarting the others.
+
+use std::process::Command;
+
+use crate::plan::{SnapRunning, Snapshot};
+use crate::quiesce::{BROKER_SERVICE, daemon_pid_file, wait_until};
+
+/// How long to wait for a service to come back up.
+const START_TIMEOUT: core::time::Duration = core::time::Duration::from_secs(20);
+
+/// Restart every component that was running, provider→consumer. Returns
+/// the components that failed to restart (empty = all good).
+pub(crate) fn restore(snapshot: &Snapshot) -> Vec<String> {
+    let mut failed = Vec::new();
+    for component in ["broker", "daemon", "mcp"] {
+        for running in snapshot
+            .running
+            .iter()
+            .filter(|run| run.component == component)
+        {
+            if !start_component(component, running) {
+                failed.push(component.to_owned());
+            }
+        }
+    }
+    failed
+}
+
+/// Start one component; `true` on (best-effort) success.
+fn start_component(component: &str, running: &SnapRunning) -> bool {
+    match component {
+        "broker" => start_broker(),
+        "daemon" => start_from_command_line(running, || daemon_pid_file().exists()),
+        "mcp" => start_from_command_line(running, || true),
+        _ => false,
+    }
+}
+
+/// `sc start` the broker, then wait until `sc query` reports RUNNING.
+fn start_broker() -> bool {
+    let _ignore = Command::new("sc.exe")
+        .args(["start", BROKER_SERVICE])
+        .status();
+    wait_until(START_TIMEOUT, || sc_query_running(BROKER_SERVICE))
+}
+
+/// Relaunch a process from its captured `command_line`, detached, then
+/// wait for `ready` (e.g. the daemon's PID file to reappear).
+fn start_from_command_line(running: &SnapRunning, ready: impl Fn() -> bool) -> bool {
+    let Some(cmd) = running.command_line.as_deref() else {
+        return false;
+    };
+    let Some((program, args)) = parse_command_line(cmd) else {
+        return false;
+    };
+    // Spawn detached: don't wait, so the relaunched service outlives us.
+    let spawned = Command::new(&program).args(&args).spawn().is_ok();
+    spawned && wait_until(START_TIMEOUT, &ready)
+}
+
+/// Split a captured command line into `(program, args)`.
+///
+/// Naive whitespace split — sufficient for UFFS's switch-style argv
+/// (`uffsd --no-retire --drive C,D`). Pure → testable.
+pub(crate) fn parse_command_line(cmd: &str) -> Option<(String, Vec<String>)> {
+    let mut parts = cmd.split_whitespace().map(ToOwned::to_owned);
+    let program = parts.next()?;
+    Some((program, parts.collect()))
+}
+
+/// `true` when `sc query <service>` reports RUNNING.
+fn sc_query_running(service: &str) -> bool {
+    let Ok(out) = Command::new("sc.exe").args(["query", service]).output() else {
+        return false;
+    };
+    out.status.success() && sc_state_is_running(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Parse `sc query` stdout for a RUNNING state (pure — testable).
+fn sc_state_is_running(sc_output: &str) -> bool {
+    sc_output.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with("STATE") && trimmed.contains("RUNNING")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_command_line, sc_state_is_running};
+
+    #[test]
+    fn parses_switch_style_command_line() {
+        let (program, args) = parse_command_line("uffsd --no-retire --drive C,D").expect("parse");
+        assert_eq!(program, "uffsd");
+        assert_eq!(args, vec!["--no-retire", "--drive", "C,D"]);
+    }
+
+    #[test]
+    fn parses_program_only() {
+        let (program, args) = parse_command_line("uffsmcp").expect("parse");
+        assert_eq!(program, "uffsmcp");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn empty_command_line_is_none() {
+        assert!(parse_command_line("   ").is_none());
+    }
+
+    #[test]
+    fn sc_running_parsing() {
+        assert!(sc_state_is_running("    STATE  : 4  RUNNING"));
+        assert!(!sc_state_is_running("    STATE  : 1  STOPPED"));
+    }
+}

--- a/crates/uffs-update/src/restore.rs
+++ b/crates/uffs-update/src/restore.rs
@@ -17,6 +17,10 @@ use crate::quiesce::{BROKER_SERVICE, daemon_pid_file, wait_until};
 /// How long to wait for a service to come back up.
 const START_TIMEOUT: core::time::Duration = core::time::Duration::from_secs(20);
 
+/// How long to wait for the broker's named pipe to begin serving (ms).
+#[cfg(windows)]
+const PIPE_READY_TIMEOUT_MS: u32 = 10_000;
+
 /// Restart every component that was running, provider→consumer. Returns
 /// the components that failed to restart (empty = all good).
 pub(crate) fn restore(snapshot: &Snapshot) -> Vec<String> {
@@ -45,12 +49,47 @@ fn start_component(component: &str, running: &SnapRunning) -> bool {
     }
 }
 
-/// `sc start` the broker, then wait until `sc query` reports RUNNING.
+/// `sc start` the broker, wait until `sc query` reports RUNNING, **then**
+/// wait until the pipe is actually serving (R10, §19.13). Service-RUNNING
+/// is necessary but not sufficient: the daemon's warm-up hits
+/// `ERROR_PIPE_BUSY` if it connects before the broker's pipe is listening.
 fn start_broker() -> bool {
     let _ignore = Command::new("sc.exe")
         .args(["start", BROKER_SERVICE])
         .status();
-    wait_until(START_TIMEOUT, || sc_query_running(BROKER_SERVICE))
+    wait_until(START_TIMEOUT, || sc_query_running(BROKER_SERVICE)) && broker_pipe_ready()
+}
+
+/// Wait until the broker's named pipe is serving via a **non-connecting**
+/// `WaitNamedPipe` probe (R10, §19.13). Unlike a connecting open (or
+/// `GetFileAttributesW`), it never consumes the single pipe instance — so
+/// it cannot itself cause the `ERROR_PIPE_BUSY` it guards against. `true`
+/// when the pipe becomes available within the timeout.
+#[cfg(windows)]
+fn broker_pipe_ready() -> bool {
+    use uffs_broker_protocol::PIPE_NAME;
+    use windows::Win32::System::Pipes::WaitNamedPipeW;
+    use windows::core::PCWSTR;
+
+    let wide: Vec<u16> = PIPE_NAME
+        .encode_utf16()
+        .chain(core::iter::once(0))
+        .collect();
+    // SAFETY: `wide` is a valid NUL-terminated UTF-16 buffer that outlives
+    // the call; the timeout is a plain millisecond count. `WaitNamedPipe`
+    // only waits for availability — it opens nothing.
+    #[expect(
+        unsafe_code,
+        reason = "Win32 FFI — WaitNamedPipeW non-connecting probe"
+    )]
+    let ready = unsafe { WaitNamedPipeW(PCWSTR(wide.as_ptr()), PIPE_READY_TIMEOUT_MS) };
+    ready.as_bool()
+}
+
+/// Non-Windows: there is no broker pipe, so readiness is vacuously true.
+#[cfg(not(windows))]
+const fn broker_pipe_ready() -> bool {
+    true
 }
 
 /// Relaunch a process from its captured `command_line`, detached, then

--- a/crates/uffs-update/src/restore.rs
+++ b/crates/uffs-update/src/restore.rs
@@ -78,10 +78,7 @@ fn broker_pipe_ready() -> bool {
     // SAFETY: `wide` is a valid NUL-terminated UTF-16 buffer that outlives
     // the call; the timeout is a plain millisecond count. `WaitNamedPipe`
     // only waits for availability — it opens nothing.
-    #[expect(
-        unsafe_code,
-        reason = "Win32 FFI — WaitNamedPipeW non-connecting probe"
-    )]
+    #[expect(unsafe_code, reason = "Win32 FFI — WaitNamedPipeW")]
     let ready = unsafe { WaitNamedPipeW(PCWSTR(wide.as_ptr()), PIPE_READY_TIMEOUT_MS) };
     ready.as_bool()
 }

--- a/crates/uffs-update/src/restore.rs
+++ b/crates/uffs-update/src/restore.rs
@@ -18,7 +18,6 @@ use crate::quiesce::{BROKER_SERVICE, daemon_pid_file, wait_until};
 const START_TIMEOUT: core::time::Duration = core::time::Duration::from_secs(20);
 
 /// How long to wait for the broker's named pipe to begin serving (ms).
-#[cfg(windows)]
 const PIPE_READY_TIMEOUT_MS: u32 = 10_000;
 
 /// Restart every component that was running, provider→consumer. Returns
@@ -57,16 +56,17 @@ fn start_broker() -> bool {
     let _ignore = Command::new("sc.exe")
         .args(["start", BROKER_SERVICE])
         .status();
-    wait_until(START_TIMEOUT, || sc_query_running(BROKER_SERVICE)) && broker_pipe_ready()
+    wait_until(START_TIMEOUT, || sc_query_running(BROKER_SERVICE))
+        && broker_pipe_ready(PIPE_READY_TIMEOUT_MS)
 }
 
-/// Wait until the broker's named pipe is serving via a **non-connecting**
-/// `WaitNamedPipe` probe (R10, §19.13). Unlike a connecting open (or
-/// `GetFileAttributesW`), it never consumes the single pipe instance — so
-/// it cannot itself cause the `ERROR_PIPE_BUSY` it guards against. `true`
-/// when the pipe becomes available within the timeout.
+/// Wait up to `timeout_ms` for the broker's named pipe to serve via a
+/// **non-connecting** `WaitNamedPipe` probe (R10, §19.13). Unlike a
+/// connecting open (or `GetFileAttributesW`), it never consumes the single
+/// pipe instance — so it cannot itself cause the `ERROR_PIPE_BUSY` it
+/// guards against. `true` when the pipe is available within the timeout.
 #[cfg(windows)]
-fn broker_pipe_ready() -> bool {
+pub(crate) fn broker_pipe_ready(timeout_ms: u32) -> bool {
     use uffs_broker_protocol::PIPE_NAME;
     use windows::Win32::System::Pipes::WaitNamedPipeW;
     use windows::core::PCWSTR;
@@ -79,13 +79,13 @@ fn broker_pipe_ready() -> bool {
     // the call; the timeout is a plain millisecond count. `WaitNamedPipe`
     // only waits for availability — it opens nothing.
     #[expect(unsafe_code, reason = "Win32 FFI — WaitNamedPipeW")]
-    let ready = unsafe { WaitNamedPipeW(PCWSTR(wide.as_ptr()), PIPE_READY_TIMEOUT_MS) };
+    let ready = unsafe { WaitNamedPipeW(PCWSTR(wide.as_ptr()), timeout_ms) };
     ready.as_bool()
 }
 
 /// Non-Windows: there is no broker pipe, so readiness is vacuously true.
 #[cfg(not(windows))]
-const fn broker_pipe_ready() -> bool {
+pub(crate) const fn broker_pipe_ready(_timeout_ms: u32) -> bool {
     true
 }
 

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -12,7 +12,8 @@ through `NestedInstallerFiles` / `PortableCommandAlias`.
 
 The founding manifest (`microsoft/winget-pkgs#378294`) seeded the four engine
 aliases `uffs`, `uffsd`, `uffsmcp`, `uffs-mft`. Everything bundled **after** that
-— currently `uffs-tui` and `uffs-broker` — must be seeded once each.
+— currently `uffs-tui`, `uffs-broker`, and `uffs-update` (the self-update helper)
+— must be seeded once each.
 
 ## Why this needs a one-time seed per binary
 
@@ -42,7 +43,8 @@ forward.
 Only seed an alias whose binary is **actually in** `uffs-windows-x64.zip` for the
 version being patched — seeding an absent file fails the winget install-validation
 bot. `release.yml` bundles `uffs-tui.exe` and `uffs-broker.exe` into the Windows
-`normal`/`full` tiers; `uffs-broker.exe` first shipped in **v0.5.122**.
+`normal`/`full` tiers (`uffs-broker.exe` first shipped in **v0.5.122**), and
+`uffs-update.exe` into **every** tier (min/normal/full).
 
 Confirm before seeding:
 

--- a/packaging/winget/nested-aliases.yaml
+++ b/packaging/winget/nested-aliases.yaml
@@ -35,3 +35,12 @@
 # first winget PR built from that release or later.
 - RelativeFilePath: uffs-windows-x64/uffs-broker.exe
   PortableCommandAlias: uffs-broker
+
+# uffs-update: the self-update helper that `uffs update` / `uffs update
+# doctor` spawn (it finds itself next to uffs.exe). Declaring it as a
+# NestedInstallerFile guarantees winget actually installs it alongside the
+# CLI, so the in-app updater works for winget users too. Bundled into EVERY
+# zip tier by release.yml; seed on the first winget PR from the release that
+# adds it (the same PR that finally seeds uffs-broker).
+- RelativeFilePath: uffs-windows-x64/uffs-update.exe
+  PortableCommandAlias: uffs-update


### PR DESCRIPTION
Builds the crash-consistent self-update flow end to end, adds a `brew doctor`-style health check, and wires the release + winget pipelines to actually publish what the updater consumes.

## Apply resilience (slices 3–7, design §19)
- **Journal spine** — resumable state machine, atomic write-temp→rename, commit point, owner-PID staleness.
- **Atomic apply** — `.bak` backup, same-volume swap, restore, prune, smoke.
- **Orchestration** — journal-driven swap/smoke/commit with full pre-commit rollback (INV-3).
- **Quiesce/restore** — MCP→daemon→broker ordering, INV-1 restart backstop.
- **Phase H recover** — roll-forward vs roll-back decided solely by the commit point.
- **Download hardening** — connect/read timeouts, transient-only retry + backoff, 512 MiB cap.
- **Zero-downtime pre-flight** — staged-present + writable-dir probe *before* any service stops.
- **CLI self-heal** — every `uffs` launch heals a crashed update (one `stat` in steady state) + journal archival.

## Deferred resilience items (now landed)
- **R4** self-replacement leftover sweep (rename-based swap already works for the running orchestrator; reclaim the `.bak` on next launch — no fragile mid-run re-exec).
- **R10** broker-ready gating via a non-connecting `WaitNamedPipeW` probe (the `ERROR_PIPE_BUSY` fix).
- **R3** WinGet delegation surfaced + recorded (delegation is full, so the rollback-ordering risk is structurally absent).

## `uffs update doctor` (+ `--apply`)
End-to-end health check: helper presence, version alignment, dirs, journal, stale `.bak`, live services, broker pipe, and GitHub release reachability + per-binary asset presence. `--repair` self-heals via the same in-crate primitives the real update uses. `uffs update --apply` runs the whole flow from one command.

## Release + winget pipeline
- Ship `uffs-update` (all platforms) + `uffs-broker` (Windows) as raw per-binary assets; emit a `SHA256SUMS` manifest (covered by SLSA); bundle `uffs-update` into every zip tier; re-codesign it on macOS.
- Seed `uffs-update` into the winget `NestedInstallerFiles` canonical list so the helper installs beside `uffs.exe` for winget users.

## Also
- Fixed `KNOWN_BINARIES`: removed `uffs-tui` (separate demo repo, not a release asset), added `uffs-update`.
- Acquire now requests the platform-suffixed asset name the release publishes, staging under the plain on-disk name.

Shell-dependency policy honored throughout: in-process Rust + native Win32 (`OpenProcess`/`WaitNamedPipeW`); only `sc.exe` is shelled out (on every Win7/10/11).

18 commits · host + Windows-MSVC clippy clean · 110 unit tests green · vet-neutral. Full pre-push gate passed.