### PR TITLE
feat: native Windows service control (uffs-winsvc) — broker --status/--start/--stop, uffs status broker, sc-free updater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,6 +4395,7 @@ dependencies = [
  "tracing-subscriber",
  "uffs-broker-protocol",
  "uffs-security",
+ "uffs-winsvc",
  "windows 0.62.2",
 ]
 
@@ -4430,10 +4431,12 @@ dependencies = [
  "assert_cmd",
  "dirs-next",
  "serde_json",
+ "uffs-broker-protocol",
  "uffs-client",
  "uffs-format",
  "uffs-mft",
  "uffs-time",
+ "uffs-winsvc",
  "which",
  "winresource",
 ]
@@ -4682,6 +4685,15 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "uffs-broker-protocol",
+ "uffs-winsvc",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "uffs-winsvc"
+version = "0.6.2"
+dependencies = [
+ "anyhow",
  "windows 0.62.2",
 ]
 
@@ -4793,9 +4805,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "crates/uffs-text",            # 📝 Unicode text processing, i18n foundation
   "crates/uffs-time",            # ⏱️ NTFS FILETIME arithmetic (pure, zero deps)
   "crates/uffs-broker-protocol", # 📟 Cross-platform broker wire-protocol types (F5)
+  "crates/uffs-winsvc",          # 🪟 Native Windows service control + broker-pipe probe (leaf)
   "crates/uffs-mft",             # 📦 MFT reading → Polars DataFrame
   "crates/uffs-format",          # 🧾 Shared CSV formatter (daemon + thin CLI)
   "crates/uffs-core",            # 🎯 Query engine + compact search engine
@@ -140,6 +141,13 @@ uffs-client = { path = "crates/uffs-client", version = "0.6.2" }
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
 uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.2" }
+# `uffs-winsvc` — native Windows service control (SCM query/start/stop) +
+# the non-connecting broker-pipe readiness probe.  Layer-0 leaf: its only
+# dependency is the `windows` crate (windows-target), with non-Windows
+# stubs so cross-platform consumers (uffs-update, uffs-cli) compile.
+# Single source of truth for the `sc`/SCM mechanics previously duplicated
+# across uffs-broker, uffs-update, and uffs-cli.
+uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.2" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,7 +318,7 @@ hostname = "0.4.2"
 num_cpus = "1.17.0"
 # Random unique identifiers.  Only the `v4` (random) feature is enabled
 # workspace-wide; consumers that need v1/v5/v7 etc. re-add the feature.
-uuid = { version = "1.23.2", features = ["v4"] }
+uuid = { version = "1.23.3", features = ["v4"] }
 
 # ───── Security / Crypto ─────
 aes-gcm = "0.10"

--- a/crates/uffs-broker-protocol/src/lib.rs
+++ b/crates/uffs-broker-protocol/src/lib.rs
@@ -59,6 +59,19 @@ use thiserror::Error;
 /// daemon's stub compiles), but no kernel object exists at that path.
 pub const PIPE_NAME: &str = r"\\.\pipe\uffs-broker";
 
+/// Registered Windows service name of the Access Broker.
+///
+/// The single source of truth shared by everything that names the
+/// service: `uffs-broker` (install / control), `uffs-update`
+/// (quiesce / restore), and `uffs-cli` (`uffs status` + update
+/// detection). It belongs here, next to [`PIPE_NAME`], because both are
+/// the broker's *identity* on the wire / on the box — the SCM control
+/// *mechanism* lives separately in `uffs-winsvc`.
+///
+/// Defined on every platform so cross-platform consumers compile; only
+/// Windows has an actual service registered under it.
+pub const SERVICE_NAME: &str = "UffsAccessBroker";
+
 /// Total size of an encoded [`HandleRequest`] on the wire.
 pub const REQUEST_WIRE_LEN: usize = 1;
 

--- a/crates/uffs-broker/Cargo.toml
+++ b/crates/uffs-broker/Cargo.toml
@@ -66,6 +66,9 @@ uffs-broker-protocol.workspace = true
 # single implementation now lives in `uffs-security` (DRY with the
 # self-updater) instead of a broker-local copy.
 uffs-security.workspace = true
+# Native SCM control for the operator-facing `--status` / `--start` /
+# `--stop` commands — the same locale-proof primitive the updater uses.
+uffs-winsvc.workspace = true
 
 [lints]
 workspace = true

--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -29,6 +29,13 @@ mod service;
 #[cfg(windows)]
 use service::{install_service, uninstall_service};
 
+// Operator-facing `--status` / `--start` / `--stop` via native SCM
+// (`uffs-winsvc`), split out to keep this file under the 800-LOC ceiling.
+// Windows-only: `uffs-winsvc` is a `cfg(windows)` dependency of the broker.
+#[cfg(windows)]
+#[path = "broker/control.rs"]
+mod control;
+
 // Client process-handle acquisition + identity verification (WI-8.1), split
 // out to keep this file under the 800-LOC ceiling. See
 // `broker/process_handle.rs`.
@@ -89,6 +96,16 @@ pub(crate) fn run() -> anyhow::Result<()> {
     if args.iter().any(|arg| arg == "--uninstall") {
         return uninstall_service();
     }
+    if args.iter().any(|arg| arg == "--status") {
+        control::status();
+        return Ok(());
+    }
+    if args.iter().any(|arg| arg == "--start") {
+        return control::start();
+    }
+    if args.iter().any(|arg| arg == "--stop") {
+        return control::stop();
+    }
     if args.iter().any(|arg| arg == "--run") {
         return run_foreground();
     }
@@ -109,9 +126,12 @@ pub(crate) fn run() -> anyhow::Result<()> {
     reason = "CLI help text written before tracing subscriber init"
 )]
 fn print_usage() {
-    eprintln!("uffs-broker: use --install, --uninstall, or --run");
+    eprintln!("uffs-broker: use --install, --uninstall, --status, --start, --stop, or --run");
     eprintln!("  --install     Install as Windows Service");
     eprintln!("  --uninstall   Remove Windows Service");
+    eprintln!("  --status      Show service state, pid, and pipe-serving status");
+    eprintln!("  --start       Start the service (waits for RUNNING)");
+    eprintln!("  --stop        Stop the service (waits for STOPPED)");
     eprintln!("  --run         Run in foreground (debugging)");
 }
 

--- a/crates/uffs-broker/src/broker/control.rs
+++ b/crates/uffs-broker/src/broker/control.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Operator-facing service control: `--status` / `--start` / `--stop`.
+//!
+//! All three use native SCM via `uffs-winsvc` (numeric, locale-proof
+//! states), so they behave identically regardless of the console's
+//! language — unlike parsing `sc query` text. `--install` / `--uninstall`
+//! stay in [`super::service`]; these are the day-to-day control verbs.
+
+use anyhow::Result;
+use uffs_broker_protocol::{PIPE_NAME, SERVICE_NAME};
+
+/// Short pipe-probe budget for `--status` (ms) — a snapshot, not a wait.
+const STATUS_PIPE_PROBE_MS: u32 = 1_000;
+
+/// Print the broker service's status: state, pid, and whether its pipe is
+/// actually serving (the probe is skipped unless the service is running).
+#[expect(clippy::print_stdout, reason = "operator-facing status output")]
+pub(crate) fn status() {
+    let info = uffs_winsvc::query(SERVICE_NAME);
+    println!("Service : {SERVICE_NAME}");
+    println!("State   : {}", info.state.label());
+    match info.pid {
+        Some(pid) => println!("PID     : {pid}"),
+        None => println!("PID     : -"),
+    }
+    let serving =
+        info.state.is_running() && uffs_winsvc::pipe_serving(PIPE_NAME, STATUS_PIPE_PROBE_MS);
+    println!(
+        "Pipe    : {}",
+        if serving { "serving" } else { "not serving" }
+    );
+}
+
+/// Start the broker service and wait until it reports RUNNING.
+///
+/// # Errors
+///
+/// Propagates an SCM open/start failure or a start timeout.
+pub(crate) fn start() -> Result<()> {
+    uffs_winsvc::start(SERVICE_NAME)
+}
+
+/// Stop the broker service and wait until it reports STOPPED.
+///
+/// # Errors
+///
+/// Propagates an SCM open/control failure or a stop timeout.
+pub(crate) fn stop() -> Result<()> {
+    uffs_winsvc::stop(SERVICE_NAME)
+}

--- a/crates/uffs-broker/src/broker/service.rs
+++ b/crates/uffs-broker/src/broker/service.rs
@@ -9,10 +9,11 @@
 //! `LocalSystem` entry point the SCM invokes at boot — so the broker runs as a
 //! real service without the `--run` terminal.
 
-/// Registered service name — must match the `sc create` name and the
-/// `service_main` table entry.
+/// Registered service name — the single source of truth shared with the
+/// updater + CLI. Used for `sc create`/`delete` and the `service_main`
+/// table entry.
 #[cfg(windows)]
-const SERVICE_NAME: &str = "UffsAccessBroker";
+use uffs_broker_protocol::SERVICE_NAME;
 
 /// Set by the SCM control handler on STOP / SHUTDOWN; polled by the broker's
 /// accept loop ([`stop_requested`]) so it exits between connections.

--- a/crates/uffs-broker/src/main.rs
+++ b/crates/uffs-broker/src/main.rs
@@ -11,6 +11,7 @@
 //! ```bash
 //! uffs-broker --install     # Install as Windows Service
 //! uffs-broker --uninstall   # Remove Windows Service
+//! uffs-broker --status      # Show state, pid, and pipe-serving status
 //! uffs-broker --start       # Start the service
 //! uffs-broker --stop        # Stop the service
 //! uffs-broker --run         # Run in foreground (for debugging)

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -104,6 +104,12 @@ dirs-next.workspace = true
 # filetime_with_tz_bias}` for timestamp formatting.
 uffs-time.workspace = true
 
+# Broker identity (`SERVICE_NAME` / `PIPE_NAME`) + native SCM status so
+# `uffs status` can report the Access Broker. Both Layer-0 leaves:
+# broker-protocol is pure; uffs-winsvc stubs to "not installed" off Windows.
+uffs-broker-protocol.workspace = true
+uffs-winsvc.workspace = true
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Features (contract documented per playbook §988 — see
 # `crates/uffs-cli/src/main.rs` `# Features` rustdoc and

--- a/crates/uffs-cli/src/commands/system_status.rs
+++ b/crates/uffs-cli/src/commands/system_status.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! `uffs status` — combined daemon + MCP server status in one view.
+//! `uffs status` — combined daemon + broker + MCP status in one view.
 //!
-//! Shows three sections:
+//! Shows four sections:
 //! - **Daemon**: PID, uptime, drives, queries
+//! - **Access Broker**: SCM state, pid, pipe-serving (native, locale-proof)
 //! - **MCP HTTP Gateway**: PID, transport, health, sessions, tool calls
 //! - **MCP Stdio Sessions**: active `uffs mcp run` processes (one per AI host)
 
@@ -24,9 +25,40 @@ pub(crate) fn system_status() {
     println!();
     print_daemon_status();
     println!();
+    print_broker_status();
+    println!();
     print_mcp_http_status();
     println!();
     print_mcp_stdio_sessions();
+}
+
+/// Short pipe-probe budget for the status line (ms).
+const BROKER_PIPE_PROBE_MS: u32 = 1_000;
+
+/// Print the Access Broker section: SCM state + pid + whether its pipe is
+/// serving. Native `uffs-winsvc` (locale-proof); reports "not installed"
+/// off Windows.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_broker_status() {
+    use uffs_broker_protocol::{PIPE_NAME, SERVICE_NAME};
+
+    println!("── Access Broker ──");
+    let info = uffs_winsvc::query(SERVICE_NAME);
+    if !info.state.is_installed() {
+        println!("  Status:      not installed");
+        println!("  Install:     uffs-broker --install  (one-time; removes UAC prompts)");
+        return;
+    }
+    match info.pid {
+        Some(pid) => println!("  Status:      {} (PID {pid})", info.state.label()),
+        None => println!("  Status:      {}", info.state.label()),
+    }
+    let serving =
+        info.state.is_running() && uffs_winsvc::pipe_serving(PIPE_NAME, BROKER_PIPE_PROBE_MS);
+    println!(
+        "  Pipe:        {}",
+        if serving { "serving" } else { "not serving" }
+    );
 }
 
 /// Print daemon status section.

--- a/crates/uffs-cli/src/commands/update/procinfo.rs
+++ b/crates/uffs-cli/src/commands/update/procinfo.rs
@@ -131,15 +131,21 @@ pub(crate) fn find_pids_by_name(stem: &str) -> Vec<u32> {
 
 /// The broker service's registered binary path + running pid, via
 /// `sc.exe`. `None` when the service is not installed.
+///
+/// This is config *discovery* (the registered `BINARY_PATH_NAME`), distinct
+/// from the state control consolidated in `uffs-winsvc`; the service name
+/// is the shared `uffs_broker_protocol::SERVICE_NAME`. Migrating the binPath
+/// read to native `QueryServiceConfigW` is a future follow-up.
 #[cfg(windows)]
 pub(crate) fn broker_service() -> Option<BrokerService> {
-    let qc = sc_output(&["qc", "UffsAccessBroker"])?;
+    let service = uffs_broker_protocol::SERVICE_NAME;
+    let qc = sc_output(&["qc", service])?;
     let bin_path = qc
         .lines()
         .find_map(|line| line.trim().strip_prefix("BINARY_PATH_NAME").map(str::trim))
         .and_then(|rest| rest.strip_prefix(':').map(str::trim))
         .map(PathBuf::from)?;
-    let pid = sc_output(&["queryex", "UffsAccessBroker"]).and_then(|queryex| {
+    let pid = sc_output(&["queryex", service]).and_then(|queryex| {
         queryex.lines().find_map(|line| {
             line.trim()
                 .strip_prefix("PID")

--- a/crates/uffs-update/Cargo.toml
+++ b/crates/uffs-update/Cargo.toml
@@ -43,14 +43,18 @@ dirs-next.workspace = true
 # so the feature set lives in one place. A one-shot CLI step, so the async
 # runtime overhead of a full client is unwarranted.
 reqwest.workspace = true
+# Broker identity (`SERVICE_NAME` / `PIPE_NAME`) for quiesce/restore — pure
+# cross-platform crate, so it lives here, not under cfg(windows).
+uffs-broker-protocol.workspace = true
+# Native Windows service control (quiesce stop / restore start) + the
+# broker-pipe readiness probe. Cross-platform (stubs off Windows), so the
+# quiesce/restore logic compiles everywhere without `sc.exe` text parsing.
+uffs-winsvc.workspace = true
 
 # Native owner-PID liveness for Phase H (no fragile `tasklist`/`kill`
-# shell-outs). Both are already in the lock → cargo-vet stays green.
+# shell-outs). Already in the lock → cargo-vet stays green.
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
-# Broker pipe name for the non-connecting WaitNamedPipe readiness probe
-# (R10, §19.13). Windows-only — a pure-logic workspace crate.
-uffs-broker-protocol.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/uffs-update/src/plan.rs
+++ b/crates/uffs-update/src/plan.rs
@@ -56,8 +56,8 @@ pub(crate) struct SnapRunning {
     /// Component kind: `daemon` / `broker` / `mcp`.
     pub(crate) component: String,
     /// OS process id at snapshot time. The doctor probes its liveness;
-    /// quiesce/restore act via the PID file + `sc.exe` + the captured
-    /// command line, never this (stale-by-restart) raw pid.
+    /// quiesce/restore act via the PID file + native SCM (`uffs-winsvc`) +
+    /// the captured command line, never this (stale-by-restart) raw pid.
     pub(crate) pid: u32,
     /// Image path.
     #[serde(default)]

--- a/crates/uffs-update/src/quiesce.rs
+++ b/crates/uffs-update/src/quiesce.rs
@@ -5,19 +5,20 @@
 //! unlock, recording each stop in the journal so Phase H can restart them
 //! (INV-1).
 //!
-//! Robust by construction — **no fragile external tools, no FFI**:
+//! Robust by construction — **no fragile external tools, no `sc` text
+//! parsing**:
 //! - daemon / MCP: graceful via our **own** in-tree `uffs daemon stop` / `uffs
-//!   mcp stop`;
-//! - broker: `sc.exe stop` (a core OS component on every Windows);
-//! - "is it down yet": poll the daemon **PID file** (the daemon deletes it on
-//!   clean exit) and `sc query` for the broker.
+//!   mcp stop`, then poll the daemon **PID file** (deleted on clean exit);
+//! - broker: native SCM stop via `uffs-winsvc` (numeric, locale-proof state —
+//!   never `sc query` text, which is localized).
 
 use core::time::Duration;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Instant;
 
-use anyhow::{Result, bail};
+use anyhow::{Context as _, Result, bail};
+use uffs_broker_protocol::SERVICE_NAME;
 
 use crate::journal::{Journal, UpdateState};
 use crate::orchestrate::exe_name;
@@ -27,8 +28,6 @@ use crate::plan::{SnapRunning, Snapshot};
 const STOP_TIMEOUT: Duration = Duration::from_secs(20);
 /// Poll interval while waiting.
 const POLL: Duration = Duration::from_millis(200);
-/// The broker Windows service name.
-pub(crate) const BROKER_SERVICE: &str = "UffsAccessBroker";
 
 /// Stop every running core component in dependency order (consumers
 /// before providers: MCP → daemon → broker), recording each in
@@ -100,16 +99,11 @@ fn stop_daemon(running: &SnapRunning) -> Result<()> {
     }
 }
 
-/// Stop the broker service, then wait until `sc query` reports STOPPED.
+/// Stop the broker service via native SCM and wait until it reports STOPPED
+/// (numeric state — `uffs-winsvc` waits internally). A no-op if it is not
+/// installed or already stopped.
 fn stop_broker() -> Result<()> {
-    let _ignore = Command::new("sc.exe")
-        .args(["stop", BROKER_SERVICE])
-        .status();
-    if wait_until(STOP_TIMEOUT, || sc_query_stopped(BROKER_SERVICE)) {
-        Ok(())
-    } else {
-        bail!("broker service did not reach STOPPED within {STOP_TIMEOUT:?}")
-    }
+    uffs_winsvc::stop(SERVICE_NAME).context("stopping the broker service")
 }
 
 /// Best-effort MCP gateway stop (a client just reconnects later).
@@ -132,31 +126,9 @@ pub(crate) fn wait_until(timeout: Duration, done: impl Fn() -> bool) -> bool {
     }
 }
 
-/// `true` when `sc query <service>` reports the service STOPPED (or it
-/// isn't installed — also "not running").
-fn sc_query_stopped(service: &str) -> bool {
-    let Ok(out) = Command::new("sc.exe").args(["query", service]).output() else {
-        return false;
-    };
-    if !out.status.success() {
-        // Non-zero typically means "service does not exist" → not running.
-        return true;
-    }
-    let text = String::from_utf8_lossy(&out.stdout);
-    sc_state_is_stopped(&text)
-}
-
-/// Parse `sc query` stdout for a STOPPED state (pure — testable).
-fn sc_state_is_stopped(sc_output: &str) -> bool {
-    sc_output.lines().any(|line| {
-        let trimmed = line.trim();
-        trimmed.starts_with("STATE") && trimmed.contains("STOPPED")
-    })
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{sc_state_is_stopped, uffs_sibling, wait_until};
+    use super::{uffs_sibling, wait_until};
     use crate::plan::SnapRunning;
 
     fn running_with_image(image: &std::path::Path) -> SnapRunning {
@@ -178,17 +150,6 @@ mod tests {
             sib.file_name()
                 .is_some_and(|name| name.to_string_lossy().starts_with("uffs"))
         );
-    }
-
-    #[test]
-    fn sc_state_parsing() {
-        assert!(sc_state_is_stopped(
-            "        STATE              : 1  STOPPED"
-        ));
-        assert!(!sc_state_is_stopped(
-            "        STATE              : 4  RUNNING"
-        ));
-        assert!(!sc_state_is_stopped("no state line here"));
     }
 
     #[test]

--- a/crates/uffs-update/src/restore.rs
+++ b/crates/uffs-update/src/restore.rs
@@ -11,8 +11,10 @@
 
 use std::process::Command;
 
+use uffs_broker_protocol::{PIPE_NAME, SERVICE_NAME};
+
 use crate::plan::{SnapRunning, Snapshot};
-use crate::quiesce::{BROKER_SERVICE, daemon_pid_file, wait_until};
+use crate::quiesce::{daemon_pid_file, wait_until};
 
 /// How long to wait for a service to come back up.
 const START_TIMEOUT: core::time::Duration = core::time::Duration::from_secs(20);
@@ -48,45 +50,19 @@ fn start_component(component: &str, running: &SnapRunning) -> bool {
     }
 }
 
-/// `sc start` the broker, wait until `sc query` reports RUNNING, **then**
+/// Start the broker via native SCM (waits for RUNNING internally), **then**
 /// wait until the pipe is actually serving (R10, §19.13). Service-RUNNING
 /// is necessary but not sufficient: the daemon's warm-up hits
 /// `ERROR_PIPE_BUSY` if it connects before the broker's pipe is listening.
 fn start_broker() -> bool {
-    let _ignore = Command::new("sc.exe")
-        .args(["start", BROKER_SERVICE])
-        .status();
-    wait_until(START_TIMEOUT, || sc_query_running(BROKER_SERVICE))
-        && broker_pipe_ready(PIPE_READY_TIMEOUT_MS)
+    uffs_winsvc::start(SERVICE_NAME).is_ok() && broker_pipe_ready(PIPE_READY_TIMEOUT_MS)
 }
 
-/// Wait up to `timeout_ms` for the broker's named pipe to serve via a
-/// **non-connecting** `WaitNamedPipe` probe (R10, §19.13). Unlike a
-/// connecting open (or `GetFileAttributesW`), it never consumes the single
-/// pipe instance — so it cannot itself cause the `ERROR_PIPE_BUSY` it
-/// guards against. `true` when the pipe is available within the timeout.
-#[cfg(windows)]
+/// Wait up to `timeout_ms` for the broker's named pipe to begin serving,
+/// via `uffs-winsvc`'s non-connecting `WaitNamedPipe` probe (R10, §19.13).
+/// `true` off Windows (no pipe exists).
 pub(crate) fn broker_pipe_ready(timeout_ms: u32) -> bool {
-    use uffs_broker_protocol::PIPE_NAME;
-    use windows::Win32::System::Pipes::WaitNamedPipeW;
-    use windows::core::PCWSTR;
-
-    let wide: Vec<u16> = PIPE_NAME
-        .encode_utf16()
-        .chain(core::iter::once(0))
-        .collect();
-    // SAFETY: `wide` is a valid NUL-terminated UTF-16 buffer that outlives
-    // the call; the timeout is a plain millisecond count. `WaitNamedPipe`
-    // only waits for availability — it opens nothing.
-    #[expect(unsafe_code, reason = "Win32 FFI — WaitNamedPipeW")]
-    let ready = unsafe { WaitNamedPipeW(PCWSTR(wide.as_ptr()), timeout_ms) };
-    ready.as_bool()
-}
-
-/// Non-Windows: there is no broker pipe, so readiness is vacuously true.
-#[cfg(not(windows))]
-pub(crate) const fn broker_pipe_ready(_timeout_ms: u32) -> bool {
-    true
+    uffs_winsvc::pipe_serving(PIPE_NAME, timeout_ms)
 }
 
 /// Relaunch a process from its captured `command_line`, detached, then
@@ -113,25 +89,9 @@ pub(crate) fn parse_command_line(cmd: &str) -> Option<(String, Vec<String>)> {
     Some((program, parts.collect()))
 }
 
-/// `true` when `sc query <service>` reports RUNNING.
-fn sc_query_running(service: &str) -> bool {
-    let Ok(out) = Command::new("sc.exe").args(["query", service]).output() else {
-        return false;
-    };
-    out.status.success() && sc_state_is_running(&String::from_utf8_lossy(&out.stdout))
-}
-
-/// Parse `sc query` stdout for a RUNNING state (pure — testable).
-fn sc_state_is_running(sc_output: &str) -> bool {
-    sc_output.lines().any(|line| {
-        let trimmed = line.trim();
-        trimmed.starts_with("STATE") && trimmed.contains("RUNNING")
-    })
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{parse_command_line, sc_state_is_running};
+    use super::parse_command_line;
 
     #[test]
     fn parses_switch_style_command_line() {
@@ -150,11 +110,5 @@ mod tests {
     #[test]
     fn empty_command_line_is_none() {
         assert!(parse_command_line("   ").is_none());
-    }
-
-    #[test]
-    fn sc_running_parsing() {
-        assert!(sc_state_is_running("    STATE  : 4  RUNNING"));
-        assert!(!sc_state_is_running("    STATE  : 1  STOPPED"));
     }
 }

--- a/crates/uffs-winsvc/Cargo.toml
+++ b/crates/uffs-winsvc/Cargo.toml
@@ -1,0 +1,55 @@
+# ============================================================================
+# uffs-winsvc: native Windows service control + broker-pipe readiness probe
+# ============================================================================
+# Layer-0 foundation crate. Its ONLY dependency is the `windows` crate
+# (windows-target), plus `anyhow` for ergonomic errors; non-Windows builds
+# are pure stubs so the cross-platform consumers (uffs-update, uffs-cli)
+# compile everywhere.
+#
+# WHY THIS CRATE EXISTS
+# ---------------------
+# Service control (`sc.exe`) for the Access Broker used to be hand-rolled in
+# three places — uffs-broker (install/control), uffs-update (quiesce/restore),
+# uffs-cli (status/detection) — each parsing `sc query` output. That text is
+# LOCALIZED on non-English Windows, so the state-word matching silently broke.
+# This crate replaces all of that with native SCM (`QueryServiceStatusEx`,
+# `ControlService`, `StartServiceW`) returning numeric, locale-proof states,
+# and is the single source of truth for the mechanism. The broker's *identity*
+# (service name, pipe name) lives in `uffs-broker-protocol`; this crate is the
+# pure mechanism — it takes the name as a parameter.
+#
+# Mirrors the `uffs-broker-protocol` pattern (issue #205): replace textual
+# coupling with a compile-enforced single source of truth.
+# ============================================================================
+
+[package]
+name = "uffs-winsvc"
+description = "Native Windows service control (SCM) + broker named-pipe readiness probe for UFFS"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+# Internal foundation crate — name reserved, never published with content.
+publish.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+# Windows-specific FFI — render the Windows target so the real impl is documented.
+targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
+
+[dependencies]
+# Ergonomic error context for the fallible start/stop operations.
+anyhow.workspace = true
+
+# Native SCM + named-pipe FFI. Only on Windows targets; non-Windows builds
+# use the stub paths in `lib.rs`, so nothing is linked off-Windows.
+[target.'cfg(windows)'.dependencies]
+windows.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uffs-winsvc/src/lib.rs
+++ b/crates/uffs-winsvc/src/lib.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Native Windows **service control** (SCM) plus the broker **named-pipe
+//! readiness** probe — the single source of truth for the mechanics that
+//! were previously hand-rolled with `sc.exe` across `uffs-broker`,
+//! `uffs-update`, and `uffs-cli`.
+//!
+//! Why native, not `sc.exe`: `sc query` prints **localized** state words
+//! (`RUNNING`/`STOPPED`), so text-matching them silently breaks on a
+//! non-English Windows. The SCM APIs here return the **numeric**
+//! `SERVICE_RUNNING` (4) etc., which are locale-proof. This crate is pure
+//! *mechanism* and takes the service/pipe name as a parameter; the broker's
+//! *identity* (its `SERVICE_NAME` / `PIPE_NAME`) lives in
+//! `uffs-broker-protocol`.
+//!
+//! Cross-platform: every public function compiles everywhere. Off Windows
+//! there is no SCM, so [`query`] reports [`ServiceState::NotInstalled`],
+//! [`stop`] is a no-op, [`start`] errors, and [`pipe_serving`] is `true`.
+
+use anyhow::Result;
+
+#[cfg(windows)]
+#[path = "windows.rs"]
+mod sys;
+#[cfg(not(windows))]
+#[path = "stub.rs"]
+mod sys;
+
+/// The current run state of a Windows service — numeric and locale-proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceState {
+    /// No service is registered under the queried name.
+    NotInstalled,
+    /// Installed and stopped.
+    Stopped,
+    /// A start was requested but has not completed.
+    StartPending,
+    /// A stop was requested but has not completed.
+    StopPending,
+    /// Running.
+    Running,
+    /// Any other SCM state (paused, continue-pending, …), value verbatim.
+    Other(u32),
+}
+
+impl ServiceState {
+    /// Map a raw `SERVICE_STATUS_CURRENT_STATE` value to a [`ServiceState`].
+    #[cfg(windows)]
+    pub(crate) const fn from_raw(raw: u32) -> Self {
+        match raw {
+            1 => Self::Stopped,
+            2 => Self::StartPending,
+            3 => Self::StopPending,
+            4 => Self::Running,
+            other => Self::Other(other),
+        }
+    }
+
+    /// `true` only when the service is fully running.
+    #[must_use]
+    pub const fn is_running(self) -> bool {
+        matches!(self, Self::Running)
+    }
+
+    /// `true` when a service is registered (any state but `NotInstalled`).
+    #[must_use]
+    pub const fn is_installed(self) -> bool {
+        !matches!(self, Self::NotInstalled)
+    }
+
+    /// A short human-readable label for display.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::NotInstalled => "not installed",
+            Self::Stopped => "stopped",
+            Self::StartPending => "start pending",
+            Self::StopPending => "stop pending",
+            Self::Running => "running",
+            Self::Other(_) => "other",
+        }
+    }
+}
+
+/// A snapshot of a service: its [`ServiceState`] and, when running, its pid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServiceInfo {
+    /// Current run state.
+    pub state: ServiceState,
+    /// The service process id when running, else `None`.
+    pub pid: Option<u32>,
+}
+
+impl ServiceInfo {
+    /// The "no such service" snapshot.
+    #[must_use]
+    pub const fn not_installed() -> Self {
+        Self {
+            state: ServiceState::NotInstalled,
+            pid: None,
+        }
+    }
+}
+
+/// Query a service's state + pid. **Best-effort**: any failure to open or
+/// query it (including "no such service") yields
+/// [`ServiceInfo::not_installed`].
+#[must_use]
+pub fn query(service: &str) -> ServiceInfo {
+    sys::query(service)
+}
+
+/// The service's [`ServiceState`] — a convenience over [`query`].
+#[must_use]
+pub fn status(service: &str) -> ServiceState {
+    sys::query(service).state
+}
+
+/// `true` when a service is registered under `service`.
+#[must_use]
+pub fn is_installed(service: &str) -> bool {
+    sys::query(service).state.is_installed()
+}
+
+/// Start `service` and wait until it reports Running (or a timeout). A
+/// no-op if it is already running.
+///
+/// # Errors
+///
+/// Open/start failures, or the service not reaching Running in time. Always
+/// errors off Windows (there is no SCM).
+pub fn start(service: &str) -> Result<()> {
+    sys::start(service)
+}
+
+/// Stop `service` and wait until it reports Stopped (or a timeout). A no-op
+/// if it is already stopped or not installed.
+///
+/// # Errors
+///
+/// Open/control failures, or the service not reaching Stopped in time.
+pub fn stop(service: &str) -> Result<()> {
+    sys::stop(service)
+}
+
+/// Wait up to `timeout_ms` for `pipe_name` to be serving.
+///
+/// Uses a **non-connecting** `WaitNamedPipe` probe — it never consumes a
+/// pipe instance, so it cannot itself cause `ERROR_PIPE_BUSY`. Always
+/// `true` off Windows; `false` on timeout or if no pipe exists.
+#[must_use]
+pub fn pipe_serving(pipe_name: &str, timeout_ms: u32) -> bool {
+    sys::pipe_serving(pipe_name, timeout_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ServiceInfo, ServiceState};
+
+    #[test]
+    fn state_predicates() {
+        assert!(ServiceState::Running.is_running());
+        assert!(ServiceState::Running.is_installed());
+        assert!(!ServiceState::NotInstalled.is_installed());
+        assert!(!ServiceState::Stopped.is_running());
+        assert!(ServiceState::Stopped.is_installed());
+    }
+
+    #[test]
+    fn not_installed_snapshot() {
+        let info = ServiceInfo::not_installed();
+        assert_eq!(info.state, ServiceState::NotInstalled);
+        assert!(info.pid.is_none());
+    }
+
+    #[test]
+    fn labels_are_distinct_and_nonempty() {
+        for state in [
+            ServiceState::NotInstalled,
+            ServiceState::Stopped,
+            ServiceState::Running,
+        ] {
+            assert!(!state.label().is_empty());
+        }
+    }
+
+    // On non-Windows hosts the stub path is active: an improbable service
+    // is "not installed", stop is a no-op, and the pipe is vacuously ready.
+    #[cfg(not(windows))]
+    #[test]
+    fn stub_behaviour_off_windows() {
+        assert_eq!(
+            super::status("UffsNoSuchService"),
+            ServiceState::NotInstalled
+        );
+        assert!(!super::is_installed("UffsNoSuchService"));
+        super::stop("UffsNoSuchService").expect("stub stop is a no-op");
+        super::start("UffsNoSuchService").expect_err("stub start has no SCM");
+        assert!(super::pipe_serving(r"\\.\pipe\nope", 10));
+    }
+}

--- a/crates/uffs-winsvc/src/stub.rs
+++ b/crates/uffs-winsvc/src/stub.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Non-Windows stubs. There is no Service Control Manager and no broker
+//! named pipe off Windows, so the operations degrade to sensible no-ops:
+//! every service is "not installed", `stop` succeeds trivially, `start`
+//! reports the platform has no SCM, and a pipe is vacuously "serving".
+//!
+//! These are deliberately **not** `const fn`, even though their bodies
+//! could be: the Windows implementations are genuinely non-const (SCM /
+//! pipe FFI), and keeping the stub signatures identical means the public
+//! wrappers in `lib.rs` have one uniform callability profile across
+//! platforms instead of being `const`-only off Windows.
+
+use anyhow::{Result, bail};
+
+use crate::ServiceInfo;
+
+/// Always reports "no such service" off Windows.
+#[expect(
+    clippy::missing_const_for_fn,
+    reason = "mirrors the non-const Windows impl so the public wrapper is uniform"
+)]
+pub(crate) fn query(_service: &str) -> ServiceInfo {
+    ServiceInfo::not_installed()
+}
+
+/// Nothing to start — there is no SCM here.
+pub(crate) fn start(_service: &str) -> Result<()> {
+    bail!("Windows service control is unavailable on this platform")
+}
+
+/// Nothing to stop — idempotent no-op.
+#[expect(
+    clippy::missing_const_for_fn,
+    reason = "mirrors the non-const Windows impl so the public wrapper is uniform"
+)]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "signature parity with the fallible Windows stop()"
+)]
+pub(crate) fn stop(_service: &str) -> Result<()> {
+    Ok(())
+}
+
+/// No broker pipe exists, so readiness is vacuously `true`.
+#[expect(
+    clippy::missing_const_for_fn,
+    reason = "mirrors the non-const Windows impl so the public wrapper is uniform"
+)]
+pub(crate) fn pipe_serving(_pipe_name: &str, _timeout_ms: u32) -> bool {
+    true
+}

--- a/crates/uffs-winsvc/src/windows.rs
+++ b/crates/uffs-winsvc/src/windows.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Windows implementation: native SCM control + the `WaitNamedPipe` probe.
+//!
+//! All states are read as the **numeric** `SERVICE_STATUS_CURRENT_STATE`
+//! via `QueryServiceStatusEx`, never by parsing `sc query` text (which is
+//! localized). Handles are closed by [`ScHandle`]'s `Drop`.
+
+use core::time::Duration;
+
+use anyhow::{Context as _, Result, bail};
+use windows::Win32::System::Services::{
+    CloseServiceHandle, ControlService, OpenSCManagerW, OpenServiceW, QueryServiceStatusEx,
+    SC_HANDLE, SC_MANAGER_CONNECT, SC_STATUS_PROCESS_INFO, SERVICE_CONTROL_STOP,
+    SERVICE_QUERY_STATUS, SERVICE_START, SERVICE_STATUS, SERVICE_STATUS_PROCESS, SERVICE_STOP,
+    StartServiceW,
+};
+use windows::core::PCWSTR;
+
+use crate::{ServiceInfo, ServiceState};
+
+/// Poll interval while waiting for a service state transition.
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+/// Overall budget for a service to reach the requested state.
+const WAIT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// NUL-terminated UTF-16 encoding of `text` for the `*W` Win32 calls.
+fn wide(text: &str) -> Vec<u16> {
+    text.encode_utf16().chain(core::iter::once(0)).collect()
+}
+
+/// RAII wrapper that closes its SC handle exactly once on drop.
+struct ScHandle(
+    /// The owned `SC_HANDLE` from a successful `Open*` call.
+    SC_HANDLE,
+);
+
+impl Drop for ScHandle {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` came from a successful Open* call and is closed
+        // exactly once (here, at end of scope).
+        #[expect(unsafe_code, reason = "Win32 FFI — CloseServiceHandle")]
+        let _closed = unsafe { CloseServiceHandle(self.0) };
+    }
+}
+
+/// Open the local Service Control Manager with connect access.
+fn open_scm() -> Result<ScHandle> {
+    // SAFETY: documented Win32 call; null machine + database select the
+    // local SCM. Returns `Err` on failure.
+    #[expect(unsafe_code, reason = "Win32 FFI — OpenSCManagerW")]
+    let handle = unsafe { OpenSCManagerW(PCWSTR::null(), PCWSTR::null(), SC_MANAGER_CONNECT) }
+        .context("OpenSCManagerW")?;
+    Ok(ScHandle(handle))
+}
+
+/// Open `service` with `access`. `Err` (typically "does not exist") when
+/// the service is not registered.
+fn open_service(scm: &ScHandle, service: &str, access: u32) -> Result<ScHandle> {
+    let name = wide(service);
+    // SAFETY: `scm.0` is a valid SCM handle; `name` is a NUL-terminated
+    // UTF-16 buffer living across the call.
+    #[expect(unsafe_code, reason = "Win32 FFI — OpenServiceW")]
+    let handle =
+        unsafe { OpenServiceW(scm.0, PCWSTR(name.as_ptr()), access) }.context("OpenServiceW")?;
+    Ok(ScHandle(handle))
+}
+
+/// Read an open service's current state + (when running) its pid.
+fn query_status(service: &ScHandle) -> Result<(ServiceState, Option<u32>)> {
+    let mut info = SERVICE_STATUS_PROCESS::default();
+    let size = size_of::<SERVICE_STATUS_PROCESS>();
+    // SAFETY: `info` is a live, properly-aligned `SERVICE_STATUS_PROCESS`;
+    // we expose exactly its byte length for the kernel to fill in place.
+    #[expect(unsafe_code, reason = "view the status struct as its byte buffer")]
+    let buf = unsafe {
+        core::slice::from_raw_parts_mut(core::ptr::from_mut(&mut info).cast::<u8>(), size)
+    };
+    let mut needed = 0_u32;
+    // SAFETY: `service.0` is a valid service handle; `buf` is exactly one
+    // `SERVICE_STATUS_PROCESS`; `needed` is a live `u32`.
+    #[expect(unsafe_code, reason = "Win32 FFI — QueryServiceStatusEx")]
+    unsafe {
+        QueryServiceStatusEx(
+            service.0,
+            SC_STATUS_PROCESS_INFO,
+            Some(buf),
+            core::ptr::from_mut(&mut needed),
+        )
+    }
+    .context("QueryServiceStatusEx")?;
+
+    let state = ServiceState::from_raw(info.dwCurrentState.0);
+    let pid = (state == ServiceState::Running && info.dwProcessId != 0).then_some(info.dwProcessId);
+    Ok((state, pid))
+}
+
+/// Best-effort state + pid; any failure (including "no such service") maps
+/// to [`ServiceInfo::not_installed`].
+pub(crate) fn query(service: &str) -> ServiceInfo {
+    match query_inner(service) {
+        Ok((state, pid)) => ServiceInfo { state, pid },
+        Err(_unavailable) => ServiceInfo::not_installed(),
+    }
+}
+
+/// Fallible inner of [`query`].
+fn query_inner(service: &str) -> Result<(ServiceState, Option<u32>)> {
+    let scm = open_scm()?;
+    let svc = open_service(&scm, service, SERVICE_QUERY_STATUS)?;
+    query_status(&svc)
+}
+
+/// Start the service and wait for Running; a no-op if already running.
+pub(crate) fn start(service: &str) -> Result<()> {
+    let scm = open_scm()?;
+    let svc = open_service(&scm, service, SERVICE_START | SERVICE_QUERY_STATUS)?;
+    if query_status(&svc)?.0 == ServiceState::Running {
+        return Ok(());
+    }
+    // SAFETY: `svc.0` is a valid service handle; no start argv.
+    #[expect(unsafe_code, reason = "Win32 FFI — StartServiceW")]
+    unsafe { StartServiceW(svc.0, None) }.context("StartServiceW")?;
+    wait_for(&svc, ServiceState::Running)
+}
+
+/// Stop the service and wait for Stopped; a no-op if already stopped or not
+/// installed.
+pub(crate) fn stop(service: &str) -> Result<()> {
+    let scm = open_scm()?;
+    let Ok(svc) = open_service(&scm, service, SERVICE_STOP | SERVICE_QUERY_STATUS) else {
+        return Ok(()); // not installed → nothing to stop
+    };
+    if query_status(&svc)?.0 == ServiceState::Stopped {
+        return Ok(());
+    }
+    let mut status = SERVICE_STATUS::default();
+    // SAFETY: `svc.0` is a valid service handle; `status` is a live
+    // `SERVICE_STATUS` the call fills in.
+    #[expect(unsafe_code, reason = "Win32 FFI — ControlService(STOP)")]
+    unsafe {
+        ControlService(
+            svc.0,
+            SERVICE_CONTROL_STOP,
+            core::ptr::from_mut(&mut status),
+        )
+    }
+    .context("ControlService(STOP)")?;
+    wait_for(&svc, ServiceState::Stopped)
+}
+
+/// Poll the open service until it reaches `target` or the timeout elapses.
+fn wait_for(service: &ScHandle, target: ServiceState) -> Result<()> {
+    let deadline = std::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        if query_status(service)?.0 == target {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            bail!(
+                "service did not reach {} within {}s",
+                target.label(),
+                WAIT_TIMEOUT.as_secs()
+            );
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Non-connecting `WaitNamedPipe` readiness probe.
+pub(crate) fn pipe_serving(pipe_name: &str, timeout_ms: u32) -> bool {
+    use windows::Win32::System::Pipes::WaitNamedPipeW;
+
+    let name = wide(pipe_name);
+    // SAFETY: `name` is a NUL-terminated UTF-16 buffer living across the
+    // call; `WaitNamedPipe` only waits for availability — it opens nothing.
+    #[expect(unsafe_code, reason = "Win32 FFI — WaitNamedPipeW")]
+    let ready = unsafe { WaitNamedPipeW(PCWSTR(name.as_ptr()), timeout_ms) };
+    ready.as_bool()
+}

--- a/docs/architecture/crate-graph.md
+++ b/docs/architecture/crate-graph.md
@@ -46,7 +46,8 @@ UFFS uses a strict layered architecture with **5 layers** plus a parallel **tool
                                ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ Layer 0 — Foundation (zero internal deps; only external crates)             │
-│   uffs-polars   uffs-security   uffs-text   uffs-time   uffs-broker-protocol│
+│   uffs-polars  uffs-security  uffs-text  uffs-time  uffs-broker-protocol     │
+│   uffs-winsvc                                                                │
 └─────────────────────────────────────────────────────────────────────────────┘
 
 ┌──── Parallel tree (not part of the layer hierarchy) ────┐
@@ -57,7 +58,7 @@ UFFS uses a strict layered architecture with **5 layers** plus a parallel **tool
 
 ## 2. Per-layer crate inventory
 
-### Layer 0 — Foundation (5 crates, all publishable)
+### Layer 0 — Foundation (6 crates, all publishable)
 
 | Crate | Description | External-dep footprint |
 |---|---|---|
@@ -65,7 +66,8 @@ UFFS uses a strict layered architecture with **5 layers** plus a parallel **tool
 | `uffs-security` | Crypto, keystore, secure FS ops, FILE_FLAG_RANDOM_ACCESS handling | Windows DPAPI / DACL, libc flock, memmap2 |
 | `uffs-text` | Unicode/NTFS case folding, trigram keys, i18n primitives | Pure logic; zero unsafe |
 | `uffs-time` | NTFS FILETIME arithmetic (`const fn`) | Pure logic; zero deps |
-| `uffs-broker-protocol` | Cross-platform broker wire-protocol types | Pure logic; zero unsafe |
+| `uffs-broker-protocol` | Cross-platform broker wire-protocol types (`PIPE_NAME`, `SERVICE_NAME`) | Pure logic; zero unsafe |
+| `uffs-winsvc` | Native Windows service control (SCM) + broker-pipe readiness probe; the single home for the `sc`/SCM mechanics shared by uffs-broker, uffs-update, uffs-cli | `windows` (windows-target only); pure stubs off Windows |
 
 **Layer-0 contract:** Zero internal-crate dependencies.  Any new Layer-0 crate must compile against `cargo check -p <crate>` with no `uffs-*` deps in `[dependencies]`.
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -361,6 +361,12 @@ criteria = "safe-to-deploy"
 delta = "1.23.1 -> 1.23.2"
 notes = "Delta audit (cargo vet diff 1.23.1 -> 1.23.2). Files: Cargo.toml(.orig) version bump, README, src/{error,fmt,parser,lib,external/serde_support}.rs. Patch release by KodrAus (uuid maintainer): formatting/parser refinements + serde tweak. The single unsafe is std::str::from_utf8_unchecked(self.0) on the crate's own fixed-size format buffer, which uuid populates exclusively with ASCII hex digits + hyphens before formatting — sound zero-copy formatting (same pattern as the vetted 1.23.1). No new I/O / FFI / process / network / ambient capability."
 
+[[audits.uuid]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.23.2 -> 1.23.3"
+notes = "Patch bump reviewed: src/error.rs REMOVES an unsafe std::str::from_utf8_unchecked in the parse-error formatter (uses the already-safe &str input instead) — a net safety improvement; equivalent slice-pattern refactor; parser.rs adds parse-error tests; remainder is version/doc/WASM-dev-fixture bumps. No new unsafe, network, fs, or process surface."
+
 [[audits.which]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Adds the missing broker control surface and consolidates the broker `sc.exe` mechanics that were hand-rolled in three places — one of which had a real locale bug.

## The problem (existing spaghetti)
- The service name `"UffsAccessBroker"` was hardcoded in **3 places**.
- `sc.exe` broker control/query was hand-rolled in **3 crates** (uffs-broker, uffs-update, uffs-cli) with divergent parsers.
- The updater parsed `sc query`'s **localized** state words (`RUNNING`/`STOPPED`) → silently broke on non-English Windows.
- `uffs-broker` advertised `--start`/`--stop` in its docs but never implemented them; there was no `--status` and `uffs status` ignored the broker.

## The fix — split identity / mechanism / policy (a clean DAG)
- **Identity** → `uffs-broker-protocol` gains `SERVICE_NAME` (next to `PIPE_NAME`). The literal now lives in **exactly one place**.
- **Mechanism** → new **`uffs-winsvc`** Layer-0 leaf crate (only dep: the `windows` crate; pure stubs off Windows): native `query/status/start/stop/is_installed` via `QueryServiceStatusEx`/`ControlService`/`StartServiceW` (numeric, **locale-proof** states) + the non-connecting `WaitNamedPipe` readiness probe.
- **Policy** → each consumer calls the shared primitive:
  - `uffs-broker`: implements `--status` / `--start` / `--stop` (and the docs now match).
  - `uffs-update`: quiesce/restore via native SCM — **drops all `sc`-text parsing** (locale bug fixed).
  - `uffs-cli`: `uffs status` now has an **Access Broker** section; detection uses the shared name.

It's the same pattern the repo already used for `uffs-broker-protocol` (issue #205): replace textual coupling with a compile-enforced single source of truth. Net: **2 single-sources-of-truth, 3 scattered `sc` implementations removed, 1 locale bug fixed** — one leaf edge per consumer, no cycles, no Polars, lean updater stays lean.

`uffs-broker --install`/`--uninstall` keep their `sc create`/`delete` flow (no native SCM equivalent); the cli's broker binPath *discovery* stays on `sc qc` for now (a documented `QueryServiceConfigW` follow-up, distinct from state control).

6 commits · host + Windows-MSVC clippy clean · 128 unit tests green · vet-neutral. Full pre-push gate passed.