### PR TITLE
chore: release v0.6.3 — ship pipeline auto-commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4373,7 +4373,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uffs-bench"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "clap",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4401,14 +4401,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "itoa",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4570,7 +4570,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -4602,7 +4602,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4641,14 +4641,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4663,18 +4663,18 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.6.2"
+version = "0.6.3"
 
 [[package]]
 name = "uffs-update"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -4691,7 +4691,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-winsvc"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "windows 0.62.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -126,28 +126,28 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.6.2" }
-uffs-security = { path = "crates/uffs-security", version = "0.6.2" }
-uffs-text = { path = "crates/uffs-text", version = "0.6.2" }
-uffs-time = { path = "crates/uffs-time", version = "0.6.2" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.6.2" }
-uffs-format = { path = "crates/uffs-format", version = "0.6.2" }
-uffs-core = { path = "crates/uffs-core", version = "0.6.2" }
-uffs-client = { path = "crates/uffs-client", version = "0.6.2" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.6.3" }
+uffs-security = { path = "crates/uffs-security", version = "0.6.3" }
+uffs-text = { path = "crates/uffs-text", version = "0.6.3" }
+uffs-time = { path = "crates/uffs-time", version = "0.6.3" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.6.3" }
+uffs-format = { path = "crates/uffs-format", version = "0.6.3" }
+uffs-core = { path = "crates/uffs-core", version = "0.6.3" }
+uffs-client = { path = "crates/uffs-client", version = "0.6.3" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.2" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.3" }
 # `uffs-winsvc` — native Windows service control (SCM query/start/stop) +
 # the non-connecting broker-pipe readiness probe.  Layer-0 leaf: its only
 # dependency is the `windows` crate (windows-target), with non-Windows
 # stubs so cross-platform consumers (uffs-update, uffs-cli) compile.
 # Single source of truth for the `sc`/SCM mechanics previously duplicated
 # across uffs-broker, uffs-update, and uffs-cli.
-uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.2" }
+uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.3" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/main.rs"
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-client = { path = "../uffs-client", version = "0.6.2", default-features = false }
+uffs-client = { path = "../uffs-client", version = "0.6.3", default-features = false }
 
 # Canonical CSV / parity / legacy-footer writer.  Direct dep (not a
 # re-export chain through `uffs-client`) so the CLI and the daemon
@@ -77,7 +77,7 @@ uffs-client = { path = "../uffs-client", version = "0.6.2", default-features = f
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-format = { path = "../uffs-format", version = "0.6.2" }
+uffs-format = { path = "../uffs-format", version = "0.6.3" }
 
 # Typed drive-letter newtype.  Direct dep so the CLI command signatures
 # (`daemon_load`, `daemon_tiering`, etc.) name `DriveLetter` natively


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.6.3** — the `[workspace.package].version` bump in `Cargo.toml`.  This PR routes that commit through branch-protection rules.  Once it merges to `main`, run `just release-tag` to cut the signed `v0.6.3` tag, which fires `release.yml` and builds the cross-platform binaries + GitHub Release v0.6.3.  (No auto-tag on merge — the tag step is manual on-demand, Path B.)

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

The auto-commit lived only on `release/v0.6.3`, so local `main` never drifted — sync it with a plain `git pull --ff-only origin main` (no `reset --hard` needed).