### PR TITLE
docs(readme): link the benchmarking blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Every clip runs the **real binary** against real NTFS data with unedited timings
 
 ## Benchmark snapshot (v0.5.120 · June 2026)
 
+📖 **The story behind these numbers:** [*I benchmarked my Rust file search engine against Everything until I ran out of excuses*](https://skyllc-ai.github.io/blog/benchmarking-against-everything/) — the methodology I had to fix first, the bulk-export workload Everything's CLI can't run, and the two regressions published anyway.
+
 Measured 2026-06-11 on AMD Ryzen 9 3900XT, 64 GB RAM, Windows 11 Pro 24H2 — cross-tool on four NTFS volumes (C/D/F/G, 12.8 M records, the Everything-RAM-budget-negotiated set), full-scan on all seven (25.9 M records; that workload is UFFS-only, so the negotiation doesn't constrain it). Raw data: [`cross-tool-summary.csv`](docs/benchmarks/raw/2026-06-v0.5.120_cross-tool-summary.csv) · [`full-scan-all-drives.csv`](docs/benchmarks/raw/2026-06-v0.5.120_full-scan-all-drives.csv). Publication-grade report: [**docs/benchmarks/**](docs/benchmarks/).
 
 **vs the competition** (10 rounds per cell, p50, file sink):


### PR DESCRIPTION
Adds the methodology story link to the benchmark-snapshot section of the README — *"I benchmarked my Rust file search engine against Everything until I ran out of excuses"* (the workload Everything's CLI can't run + the two regressions published anyway).

This was an uncommitted working-tree edit; committing it so the tree is clean and the link goes live.