### PR TITLE
fix(build): include uffs-update in local build/install/deploy flows

### DIFF
--- a/just/build.just
+++ b/just/build.just
@@ -92,7 +92,11 @@ copy-binary profile:
     if [[ "$OSTYPE" == "msys"* ]] || [[ "$OSTYPE" == "cygwin"* ]] || [[ -n "$WINDIR" ]]; then EXT=".exe"; printf "\033[0;34m  → Windows detected\033[0m\n"; else EXT=""; printf "\033[0;34m  → Unix-like system detected\033[0m\n"; fi
     SOURCE_DIR="target/{{ profile }}"
     mkdir -p ~/bin
-    for BIN in uffs uffsd uffsmcp; do
+    # uffs-update is the self-update helper (`uffs update` spawns it as a
+    # sibling). uffs-broker is the elevated handle service — Windows only.
+    BINS=(uffs uffsd uffsmcp uffs-mft uffs-update)
+    if [[ -n "$EXT" ]]; then BINS+=(uffs-broker); fi
+    for BIN in "${BINS[@]}"; do
         SOURCE_PATH="$SOURCE_DIR/${BIN}${EXT}"
         DEST_PATH="$HOME/bin/${BIN}${EXT}"
         if [[ ! -f "$SOURCE_PATH" ]]; then
@@ -236,11 +240,14 @@ use:
     extract_ver() { grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true; }
 
     BIN_DIR="$HOME/bin"
+    # uffs-update is the self-update helper, shipped on every platform.
+    # (uffs-broker is Windows-only, so there is no macOS asset to install.)
     declare -A BINARIES=(
         ["uffs-macos-arm64"]="uffs"
         ["uffsd-macos-arm64"]="uffsd"
         ["uffsmcp-macos-arm64"]="uffsmcp"
         ["uffs-mft-macos-arm64"]="uffs-mft"
+        ["uffs-update-macos-arm64"]="uffs-update"
     )
 
     # 1. What origin/main wants (informational + offline-fallback target).

--- a/scripts/ci/build-cross-all.rs
+++ b/scripts/ci/build-cross-all.rs
@@ -70,12 +70,22 @@ const HOST_TRIPLE: &str = "aarch64-apple-darwin";
 /// Binaries uploaded to GitHub Release (the shipping set).
 ///
 /// NOTE: uffs_tui and uffs_gui have moved to the private uffs-products repo.
+/// `uffs-broker` is **Windows-only** — it is staged for the Windows target
+/// only (see [`is_windows_only`]); off Windows it would just be a no-op stub.
 const RELEASE_BINARIES: &[(&str, &str)] = &[
     ("uffs", "uffs-cli"),
     ("uffsd", "uffs-daemon"),
     ("uffsmcp", "uffs-mcp"),
     ("uffs-mft", "uffs-mft"),
+    ("uffs-update", "uffs-update"),
+    ("uffs-broker", "uffs-broker"),
 ];
+
+/// Binaries that only make sense on Windows — staged for the Windows target
+/// only, never the macOS/Linux ones.
+fn is_windows_only(binary: &str) -> bool {
+    binary == "uffs-broker"
+}
 
 /// All workspace binaries — release + diagnostic tools.
 /// Everything here gets built (via `--workspace`) and copied to `dist/`.
@@ -86,6 +96,8 @@ const ALL_BINARIES: &[(&str, &str)] = &[
     ("uffsd", "uffs-daemon"),
     ("uffsmcp", "uffs-mcp"),
     ("uffs-mft", "uffs-mft"),
+    ("uffs-update", "uffs-update"),
+    ("uffs-broker", "uffs-broker"), // Windows-only (see is_windows_only)
     // Diagnostic binaries (all hyphenated per issue #213 / F1.13).
     ("analyze-mft-parents", "uffs-diag"),
     ("dump-mft-records", "uffs-diag"),
@@ -448,6 +460,10 @@ fn stage_host_binaries(version: &str, target_dir: &Path) {
     let _ = fs::create_dir_all(&staging_dir);
 
     for (binary, _) in RELEASE_BINARIES {
+        // Windows-only binaries (the broker) are never staged for macOS.
+        if is_windows_only(binary) {
+            continue;
+        }
         let source = target_dir.join("release").join(binary);
         let dest_name = format!("{}-macos-arm64", binary);
         let dest = staging_dir.join(&dest_name);
@@ -1011,6 +1027,10 @@ fn stage_binaries(version: &str, target: &Target, target_dir: &Path) -> bool {
     let mut all_success = true;
 
     for (binary, _) in RELEASE_BINARIES {
+        // The broker only ships on Windows — skip it for mac/linux targets.
+        if is_windows_only(binary) && !target.triple.contains("windows") {
+            continue;
+        }
         let bin_name = if target.triple.contains("windows") {
             format!("{}.exe", binary)
         } else {

--- a/scripts/dev/build-local.rs
+++ b/scripts/dev/build-local.rs
@@ -44,13 +44,31 @@ fn build_profile() -> &'static str {
 /// - uffsd: Background daemon (holds MFT index, serves queries via IPC)
 /// - uffsmcp: MCP HTTP/stdio server (bridges AI agents to daemon)
 /// - uffs_mft: Low-level MFT reading tool
+/// - uffs-update: self-update helper (`uffs update` spawns it as a sibling)
+/// - uffs-broker: Windows elevated handle broker (real service on Windows;
+///   a no-op stub off Windows)
 ///
 /// NOTE: uffs_tui and uffs_gui have moved to the private uffs-products repo.
+/// `uffs-broker` is **Windows-only** (the elevated handle service); it is
+/// not built/installed on macOS/Linux, where it would only be a no-op stub.
+#[cfg(windows)]
 const BINARIES: &[(&str, &str)] = &[
     ("uffs", "uffs-cli"),
     ("uffsd", "uffs-daemon"),
     ("uffsmcp", "uffs-mcp"),
     ("uffs-mft", "uffs-mft"),
+    ("uffs-update", "uffs-update"),
+    ("uffs-broker", "uffs-broker"),
+];
+
+/// Non-Windows host: the same set minus the Windows-only broker.
+#[cfg(not(windows))]
+const BINARIES: &[(&str, &str)] = &[
+    ("uffs", "uffs-cli"),
+    ("uffsd", "uffs-daemon"),
+    ("uffsmcp", "uffs-mcp"),
+    ("uffs-mft", "uffs-mft"),
+    ("uffs-update", "uffs-update"),
 ];
 
 fn main() {


### PR DESCRIPTION
`release.yml` ships `uffs-update` (every platform) + `uffs-broker` (Windows), but the local "use it" flows still enumerated the old binary set — so a locally-built or release-installed UFFS had **no `uffs-update` next to `uffs`**, and `uffs update` / `uffs update doctor` couldn't find their helper.

Brings the lockstep partners current, with correct platform scoping (**uffs-update = all platforms; uffs-broker = Windows only**):

- **`build-local.rs`** — `BINARIES` gains `uffs-update` (all hosts) + `uffs-broker` (`cfg(windows)` only; a no-op stub elsewhere).
- **`build-cross-all.rs`** — `RELEASE_BINARIES` + `ALL_BINARIES` gain both, plus an `is_windows_only` filter so the broker stages for the **Windows target only** (never the macOS/Linux assets) — matching `release.yml`.
- **`just/build.just`** — `copy-binary` deploys `uffs-update` everywhere + `uffs-broker` only when Windows is detected; `just use` (macOS install-from-release) pulls `uffs-update-macos-arm64`. (`use-local` already copies `target/release/*` dynamically.)

Both rust-scripts parse-check clean; `just --list` parses; no other stale deploy list (the other uffsd/uffsmcp hits are doc comments + the seeder, which reads `nested-aliases.yaml`).