### PR TITLE
feat(cli): search-first grammar (`uffs --<command>`) + full doc/code alignment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -561,7 +561,7 @@ jobs:
           # scripts/ci/build-cross-all.rs.  Diagnostic binaries are NOT
           # shipped; they live in uffs-diag and stay workspace-only.
           # uffs-update (the self-update helper) ships on every platform so
-          # `uffs update` has its sibling; uffs-broker is a Windows-only
+          # `uffs --update` has its sibling; uffs-broker is a Windows-only
           # service, so its raw binary ships on Windows only.
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             for binary in uffs.exe uffsd.exe uffsmcp.exe uffs-mft.exe uffs-broker.exe uffs-update.exe; do
@@ -648,7 +648,7 @@ jobs:
             # the CLI auto-spawns the SEPARATE uffsd binary (find_daemon_exe
             # in uffs-client) — `uffs` alone cannot search.
             # uffs-update (self-update helper) is bundled in EVERY tier so
-            # `uffs update` / `uffs update doctor` work wherever uffs is
+            # `uffs --update` / `uffs --update doctor` work wherever uffs is
             # installed — including the winget package (the normal-tier zip).
             local engine_bins=()
             case "$tier" in

--- a/.typos.toml
+++ b/.typos.toml
@@ -54,6 +54,14 @@ fnd = "fnd"               # internal `FileNameData` abbreviation
 Connct = "Connct"         # historical log-message identifier
 decendents = "decendents" # alt-English of descendants (used in internal docs)
 
+# ── Intentional example typos for the command-suggestion feature ─────
+# `dispatch::suggest_command` maps a near-miss `--`-flag to its command
+# (cli-grammar.md §6). These fragments appear *on purpose* in its doc
+# comments, tests, and the integration test that proves the hint fires —
+# they are the typos the feature exists to catch, not real misspellings.
+updat = "updat" # `--updat` → suggests `--update`
+statu = "statu" # `--statu` → suggests `--stats`/`--status`
+
 [files]
 # Frozen / historical / third-party-metadata locations — not subject
 # to spelling review.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4431,6 +4431,7 @@ dependencies = [
  "assert_cmd",
  "dirs-next",
  "serde_json",
+ "strsim",
  "uffs-broker-protocol",
  "uffs-client",
  "uffs-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,6 +283,12 @@ dirs-next = "2.0.0"
 # when async spawn lands).
 which = "8.0.3"
 
+# `strsim` — small, zero-dep Levenshtein impl (already in the tree +
+# audited by Google/Mozilla).  Used by `uffs-cli` to suggest the nearest
+# management command for a `--`-flag typo (`--updat` → `--update`) without
+# the thin CLI duplicating the daemon's search-flag registry.
+strsim = "0.11.1"
+
 # ───── Hashing ─────
 rustc-hash = "2.1.2"
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ cargo build --release
 
 ## Quick Start
 
-> **Windows elevation — three ways.** Reading the live MFT needs Administrator. Easiest: install the **Access Broker** once (`uffs-broker --install`, from an elevated shell) and every later non-elevated `uffs` search runs with **no UAC prompt**, surviving reboots. Otherwise, run from an **elevated** terminal, or let the first search offer a one-time `uffs daemon start --elevate` (a single UAC prompt). macOS/Linux offline analysis needs no elevation.
+> **Windows elevation — three ways.** Reading the live MFT needs Administrator. Easiest: install the **Access Broker** once (`uffs-broker --install`, from an elevated shell) and every later non-elevated `uffs` search runs with **no UAC prompt**, surviving reboots. Otherwise, run from an **elevated** terminal, or let the first search offer a one-time `uffs --daemon start --elevate` (a single UAC prompt). macOS/Linux offline analysis needs no elevation.
 
 ```bash
 # One-time (elevated): install the Access Broker → no UAC on any later search
@@ -184,15 +184,15 @@ uffs "*.log" --min-size 100MB --newer 7d --files-only
 # macOS/Linux: search offline MFT captures
 uffs "*.txt" --data-dir ~/uffs_data
 
-# Daemon management
-uffs daemon status
-uffs daemon restart
+# Daemon management ( `--<command>` = management; bare words are searches )
+uffs --daemon status
+uffs --daemon restart
 
 # Memory tiering — operator-driven controls (Phase 8)
-uffs daemon status_drives                 # per-drive tier + telemetry table
-uffs daemon hibernate                     # demote every drive to Cold (free RAM)
-uffs daemon preload C --pin-minutes 60    # pin a hot drive in RAM
-uffs daemon forget C --force              # evict + delete on-disk caches
+uffs --daemon status_drives               # per-drive tier + telemetry table
+uffs --daemon hibernate                   # demote every drive to Cold (free RAM)
+uffs --daemon preload C --pin-minutes 60  # pin a hot drive in RAM
+uffs --daemon forget C --force            # evict + delete on-disk caches
 ```
 
 > 📖 **[Installation](docs/user-manual/installation.md)** · **[5-minute tutorial](docs/user-manual/getting-started.md)** · **[CLI reference](docs/user-manual/cli-overview.md)** · **[40+ filters](docs/user-manual/filters.md)**

--- a/crates/uffs-bench/src/cards.rs
+++ b/crates/uffs-bench/src/cards.rs
@@ -220,8 +220,8 @@ pub(crate) fn uffs_restart_card(capable_drives: &[char], step_num: u32, step_tot
          The bench will kill it and restart it with only those drives so index RAM, \
          warmup time, and query routing are confined to the drives under test."
     );
-    let cmd_kill = "uffs daemon kill".to_owned();
-    let cmd_start = format!("uffs daemon start {drive_args}");
+    let cmd_kill = "uffs --daemon kill".to_owned();
+    let cmd_start = format!("uffs --daemon start {drive_args}");
     Card {
         id: "uffs-daemon-restart".to_owned(),
         stage: "STAGE 0: PREFLIGHT".to_owned(),
@@ -234,12 +234,12 @@ pub(crate) fn uffs_restart_card(capable_drives: &[char], step_num: u32, step_tot
             .iter()
             .map(|ch| format!("{ch}: (UFFS index)"))
             .collect(),
-        backups: vec!["uffs daemon run-state: restored to as-found state on teardown".to_owned()],
+        backups: vec!["uffs --daemon run-state: restored to as-found state on teardown".to_owned()],
         est_time: "~10-60 s (index load)".to_owned(),
         recovery: "Aborting here keeps the daemon in its current state — all drives remain loaded."
             .to_owned(),
         long_why: format!(
-            "{why}\n\nThe daemon is stopped with `uffs daemon kill` (hard stop) rather than \
+            "{why}\n\nThe daemon is stopped with `uffs --daemon kill` (hard stop) rather than \
              `restart` because `restart` reloads with the previous drive set. \
              On teardown the bench will stop the restricted instance so your normal \
              daemon session can reload with all drives on next use."

--- a/crates/uffs-bench/src/preflight/mod.rs
+++ b/crates/uffs-bench/src/preflight/mod.rs
@@ -269,7 +269,7 @@ fn poll_result_count(
     0
 }
 
-/// Parse the set of drive letters UFFS knows about from `uffs daemon status`
+/// Parse the set of drive letters UFFS knows about from `uffs --daemon status`
 /// stdout, regardless of tier or record count.
 ///
 /// Parked drives appear without a record count (`[Parked]  C:`) so
@@ -297,7 +297,7 @@ pub(crate) fn parse_daemon_known_drives(status: &str) -> alloc::collections::BTr
     set
 }
 
-/// Parse per-drive record counts from `uffs daemon status` stdout.
+/// Parse per-drive record counts from `uffs --daemon status` stdout.
 ///
 /// Each loaded drive appears as a line matching:
 /// ```text
@@ -339,9 +339,9 @@ pub(crate) fn parse_daemon_status_drives(status: &str) -> alloc::collections::BT
 
 /// Probe one drive's ES state.
 ///
-/// `uffs_record_count` is sourced from the already-parsed `uffs daemon status`
-/// output (passed in by the caller) — no additional UFFS IPC call is made.
-/// Returns early with zeroed ES fields if the daemon is unavailable.
+/// `uffs_record_count` is sourced from the already-parsed `uffs --daemon
+/// status` output (passed in by the caller) — no additional UFFS IPC call is
+/// made. Returns early with zeroed ES fields if the daemon is unavailable.
 /// Otherwise polls `es.exe -get-result-count` (with backoff for configured
 /// drives, once for unconfigured drives).
 fn probe_drive(
@@ -434,7 +434,7 @@ fn feasibility_cells(
 /// Capture a [`PreflightResult`] for the given [`PreflightSpec`].
 ///
 /// Reads `Everything.ini` (never writes it), fetches drive record counts from
-/// `uffs daemon status` in a single call, probes each candidate drive's ES
+/// `uffs --daemon status` in a single call, probes each candidate drive's ES
 /// state, then estimates per-pattern feasibility for the loaded drives.
 #[must_use]
 pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
@@ -508,20 +508,20 @@ pub fn capture(host: &dyn Host, spec: &PreflightSpec) -> PreflightResult {
     PreflightResult { drives, cells }
 }
 
-/// Run `uffs daemon status` once and return the raw stdout (`""` on failure).
+/// Run `uffs --daemon status` once and return the raw stdout (`""` on failure).
 fn daemon_status_output(host: &dyn Host, uffs_exe: &str) -> String {
-    host.run(uffs_exe, &["daemon", "status"])
+    host.run(uffs_exe, &["--daemon", "status"])
         .map(|out| out.stdout)
         .unwrap_or_default()
 }
 
 /// Preload any candidate drive that is absent from `warm_counts` (i.e. parked
-/// or cold) so the follow-up `uffs daemon status` returns a `[Warm]` line with
-/// a live record count.
+/// or cold) so the follow-up `uffs --daemon status` returns a `[Warm]` line
+/// with a live record count.
 ///
-/// Fires `uffs daemon preload <DRIVE>` for each such drive and prints a status
-/// line so the operator knows the tool is promoting drives.  A preload failure
-/// is non-fatal — the drive will still appear with count = 0.
+/// Fires `uffs --daemon preload <DRIVE>` for each such drive and prints a
+/// status line so the operator knows the tool is promoting drives.  A preload
+/// failure is non-fatal — the drive will still appear with count = 0.
 fn warm_parked_drives(
     host: &dyn Host,
     uffs_exe: &str,
@@ -540,7 +540,7 @@ fn warm_parked_drives(
             "[preflight] Preloading parked drive {drive}: into Warm tier …"
         ));
         let drive_s = drive.to_string();
-        if let Err(err) = host.run(uffs_exe, &["daemon", "preload", &drive_s]) {
+        if let Err(err) = host.run(uffs_exe, &["--daemon", "preload", &drive_s]) {
             host.out(&format!(
                 "[preflight] WARNING: could not preload drive {drive}: {err}"
             ));

--- a/crates/uffs-bench/src/preflight/tests.rs
+++ b/crates/uffs-bench/src/preflight/tests.rs
@@ -82,7 +82,7 @@ fn parse_drives_absent_key_is_empty() {
     assert_eq!(parse_drives_from_ini("a=1\nb=2\n"), Vec::<char>::new());
 }
 
-/// Fake `uffs daemon status` output with C (3 M records) and D (7 M records).
+/// Fake `uffs --daemon status` output with C (3 M records) and D (7 M records).
 fn daemon_status_cd() -> &'static str {
     "Version:       0.0.0\n\
      Status:        Ready\n\
@@ -125,14 +125,14 @@ fn parse_daemon_status_drives_handles_hot_and_parked_tiers() {
 fn capture_is_read_only_and_records_state() {
     // Call order:
     //  1. check_es_available: es -get-everything-version (daemon running)
-    //  2. daemon_status_output: uffs daemon status (record counts)
+    //  2. daemon_status_output: uffs --daemon status (record counts)
     //  3. C: es result-count poll → loaded
     //  4. D: es result-count poll → not loaded
     //  5. feasibility estimate for (C, all_dlls)
     let host = MockHost::new()
         .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\,D:\\".to_vec())
         .with_run_result(stdout_of("1.4.1.1032"))       // 1: es availability
-        .with_run_result(stdout_of(daemon_status_cd())) // 2: uffs daemon status
+        .with_run_result(stdout_of(daemon_status_cd())) // 2: uffs --daemon status
         .with_run_result(stdout_of("1000"))             // 3: C es result-count
         .with_run_result(stdout_of("0"))                // 4: D es result-count
         .with_run_result(stdout_of("5000")); // 5: uffs estimate C/all_dlls
@@ -178,7 +178,7 @@ fn configured_zero_drive_is_polled_with_backoff() {
     let host = MockHost::new()
         .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
         .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
-        .with_run_result(stdout_of(                  // 2: uffs daemon status
+        .with_run_result(stdout_of(                  // 2: uffs --daemon status
             "Status: Ready\n  [Warm]   C: \u{2014}  500,000 records (live) \u{2014} 50 MB\n"
         ))
         .with_run_result(stdout_of("0"))             // 3: C es poll 1
@@ -208,7 +208,7 @@ fn drive_unknown_to_daemon_is_skipped() {
     let host = MockHost::new()
         .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
         .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
-        .with_run_result(stdout_of(                  // 2: uffs daemon status (E absent)
+        .with_run_result(stdout_of(                  // 2: uffs --daemon status (E absent)
             "Status: Ready\n  [Warm]   C: \u{2014}  100,000 records (live) \u{2014} 10 MB\n"
         ));
     // E is not in known_drives at all — no preload attempt, no re-check.
@@ -267,7 +267,7 @@ fn cell_above_ipc_ceiling_is_infeasible() {
     let host = MockHost::new()
         .with_file("/Everything.ini", b"ntfs_volume_paths=C:\\".to_vec())
         .with_run_result(stdout_of("1.4.1.1032"))    // 1: es availability
-        .with_run_result(stdout_of(                  // 2: uffs daemon status
+        .with_run_result(stdout_of(                  // 2: uffs --daemon status
             "Status: Ready\n  [Warm]   C: \u{2014}  500,000 records (live) \u{2014} 50 MB\n"
         ))
         .with_run_result(stdout_of("100"))           // 3: C es result-count → loaded

--- a/crates/uffs-bench/src/run/daemon.rs
+++ b/crates/uffs-bench/src/run/daemon.rs
@@ -29,7 +29,7 @@ pub(super) const DAEMON_READY_POLL_INTERVAL_MS: u64 = 2_000;
 /// before issuing preflight queries.
 pub(super) fn kill_and_restart_all_drives(host: &dyn Host, uffs_exe: &str) {
     host.out("[uffs-daemon] killing daemon to restart with all drives …");
-    if let Err(err) = host.run(uffs_exe, &["daemon", "kill"]) {
+    if let Err(err) = host.run(uffs_exe, &["--daemon", "kill"]) {
         host.out(&format!(
             "[uffs-daemon] WARNING: kill returned error (may not have been running): {err}"
         ));
@@ -38,7 +38,7 @@ pub(super) fn kill_and_restart_all_drives(host: &dyn Host, uffs_exe: &str) {
     // before we immediately re-launch.
     host.sleep_ms(1_500);
     host.out(&format!("[uffs-daemon] spawn: {uffs_exe} daemon start"));
-    if let Err(err) = host.run(uffs_exe, &["daemon", "start"]) {
+    if let Err(err) = host.run(uffs_exe, &["--daemon", "start"]) {
         host.out(&format!(
             "[uffs-daemon] WARNING: could not restart UFFS daemon: {err}"
         ));
@@ -48,8 +48,8 @@ pub(super) fn kill_and_restart_all_drives(host: &dyn Host, uffs_exe: &str) {
 /// Kill the running UFFS daemon (hard stop) and start a fresh instance
 /// restricted to `capable_drives`.
 ///
-/// Fires `uffs daemon kill` first, waits briefly for the process to exit,
-/// then calls `uffs daemon start --drive X --drive Y …`.  Returns immediately
+/// Fires `uffs --daemon kill` first, waits briefly for the process to exit,
+/// then calls `uffs --daemon start --drive X --drive Y …`.  Returns immediately
 /// after the start command — the caller must call [`ensure_daemon_ready`] to
 /// poll until the index is loaded.
 pub(super) fn kill_and_restart_with_drives(
@@ -65,7 +65,7 @@ pub(super) fn kill_and_restart_with_drives(
             .collect::<Vec<_>>()
             .join(", ")
     ));
-    if let Err(err) = host.run(uffs_exe, &["daemon", "kill"]) {
+    if let Err(err) = host.run(uffs_exe, &["--daemon", "kill"]) {
         host.out(&format!(
             "[uffs-daemon] WARNING: kill returned error (may not have been running): {err}"
         ));
@@ -75,7 +75,7 @@ pub(super) fn kill_and_restart_with_drives(
     host.sleep_ms(1_500);
 
     let drive_strs: Vec<String> = capable_drives.iter().map(char::to_string).collect();
-    let mut args: Vec<&str> = vec!["daemon", "start"];
+    let mut args: Vec<&str> = vec!["--daemon", "start"];
     for drive_s in &drive_strs {
         args.push("--drive");
         args.push(drive_s.as_str());
@@ -91,7 +91,7 @@ pub(super) fn kill_and_restart_with_drives(
     }
 }
 
-/// Poll `uffs daemon status` until `Status:        Ready` appears, printing a
+/// Poll `uffs --daemon status` until `Status:        Ready` appears, printing a
 /// progress line on each attempt so the operator knows the tool is waiting.
 ///
 /// # Errors
@@ -100,7 +100,7 @@ pub(super) fn kill_and_restart_with_drives(
 /// (~3 minutes).
 pub(super) fn ensure_daemon_ready(host: &dyn Host, uffs_exe: &str) -> Result<()> {
     for attempt in 1..=DAEMON_READY_POLL_ATTEMPTS {
-        match host.run(uffs_exe, &["daemon", "status"]) {
+        match host.run(uffs_exe, &["--daemon", "status"]) {
             Ok(out) if out.stdout.contains("Status:        Ready") => {
                 host.out("[preflight] UFFS daemon is Ready — proceeding");
                 return Ok(());
@@ -129,7 +129,7 @@ pub(super) fn ensure_daemon_ready(host: &dyn Host, uffs_exe: &str) -> Result<()>
     }
     Err(BenchError::Command(
         "UFFS daemon did not reach Ready within 3 minutes — \
-         check `uffs daemon status` and re-run"
+         check `uffs --daemon status` and re-run"
             .to_owned(),
     ))
 }

--- a/crates/uffs-bench/src/run/tests.rs
+++ b/crates/uffs-bench/src/run/tests.rs
@@ -35,8 +35,8 @@ const DAEMON_READY_STATUS: &str = "Version:       0.0.0\n\
 /// `ProceedNoop` so the kill/start `--drive C` are skipped; no second-pass
 /// preflight is run.
 ///
-///  1. `capture()` initial kill  -- `uffs daemon kill`
-///  2. `capture()` initial start -- `uffs daemon start` (no drives)
+///  1. `capture()` initial kill  -- `uffs --daemon kill`
+///  2. `capture()` initial start -- `uffs --daemon start` (no drives)
 ///  3. `resolve::es_exe`         -- `where.exe es.exe` (for `everything`)
 ///  4. `resolve::es_exe`         -- `where.exe es.exe` (for `everything_gui`)
 ///  5. `resolve::everything_exe` -- `where.exe Everything.exe`
@@ -50,9 +50,9 @@ const DAEMON_READY_STATUS: &str = "Version:       0.0.0\n\
 /// 13. `env::capture` es -version
 /// 14. tasklist (`everything_gui` state probe -- stopped)
 /// 15. `env::capture` es -get-everything-version
-/// 16. `ensure_daemon_ready`     -- `uffs daemon status` -> Ready
+/// 16. `ensure_daemon_ready`     -- `uffs --daemon status` -> Ready
 /// 17. `preflight`  -- `es -get-everything-version` (availability)
-/// 18. `preflight`  -- `uffs daemon status` (record counts for C)
+/// 18. `preflight`  -- `uffs --daemon status` (record counts for C)
 /// 19. `preflight`  -- `es -get-result-count C:` -> loaded
 fn dry_run_host() -> MockHost {
     let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";
@@ -80,15 +80,15 @@ fn dry_run_host() -> MockHost {
 
 /// Queue the run results needed for the autopilot (non-dry-run) path.
 ///
-/// `teardown::baseline` fires `uffs daemon status` first.  Then `capture()`
+/// `teardown::baseline` fires `uffs --daemon status` first.  Then `capture()`
 /// kills+restarts with no drives (self-discover all), env-probes,
 /// `ensure_daemon_ready`, first preflight.  After the matrix the gated
 /// UFFS restart kills+starts with `--drive C`; a second-pass preflight
 /// follows.
 ///
-///  1. `teardown::baseline`      -- `uffs daemon status`
-///  2. `capture()` initial kill  -- `uffs daemon kill`
-///  3. `capture()` initial start -- `uffs daemon start` (no drives)
+///  1. `teardown::baseline`      -- `uffs --daemon status`
+///  2. `capture()` initial kill  -- `uffs --daemon kill`
+///  3. `capture()` initial start -- `uffs --daemon start` (no drives)
 ///  4. `resolve::es_exe`         -- `where.exe es.exe` (for `everything`)
 ///  5. `resolve::es_exe`         -- `where.exe es.exe` (for `everything_gui`)
 ///  6. `resolve::everything_exe` -- `where.exe Everything.exe`
@@ -102,15 +102,15 @@ fn dry_run_host() -> MockHost {
 /// 14. `env::capture` es -version
 /// 15. tasklist (`everything_gui` state probe -- stopped)
 /// 16. `env::capture` es -get-everything-version
-/// 17. `ensure_daemon_ready`     -- `uffs daemon status` -> Ready
+/// 17. `ensure_daemon_ready`     -- `uffs --daemon status` -> Ready
 /// 18. `preflight`  -- `es -get-everything-version` (availability)
-/// 19. `preflight`  -- `uffs daemon status` (record counts for C)
+/// 19. `preflight`  -- `uffs --daemon status` (record counts for C)
 /// 20. `preflight`  -- `es -get-result-count C:` -> loaded
-/// 21. `uffs daemon kill`   (gated restart: autopilot -> proceed)
-/// 22. `uffs daemon start --drive C`
-/// 23. `ensure_daemon_ready` poll -- `uffs daemon status` -> Ready
+/// 21. `uffs --daemon kill`   (gated restart: autopilot -> proceed)
+/// 22. `uffs --daemon start --drive C`
+/// 23. `ensure_daemon_ready` poll -- `uffs --daemon status` -> Ready
 /// 24. second-pass preflight  -- `es -get-everything-version`
-/// 25. second-pass preflight  -- `uffs daemon status`
+/// 25. second-pass preflight  -- `uffs --daemon status`
 /// 26. second-pass preflight  -- `es -get-result-count C:`
 fn autopilot_host() -> MockHost {
     let evr = "C:\\Program Files (x86)\\Everything\\Everything.exe";

--- a/crates/uffs-bench/src/run_state.rs
+++ b/crates/uffs-bench/src/run_state.rs
@@ -10,7 +10,7 @@
 //! gateway was up — **before the first kill**, and register a restore that
 //! replays it at teardown.
 //!
-//! The snapshot is parsed from `uffs status` (see [`parse_status`]); the
+//! The snapshot is parsed from `uffs --status` (see [`parse_status`]); the
 //! restore shells back through the [`Host`] seam using the **resolved** UFFS
 //! binary (never a bare `uffs` off `PATH`).
 //!
@@ -66,7 +66,7 @@ fn status_is_running(value: &str) -> bool {
     !lower.contains("not running") && !lower.contains("not responding") && lower.contains("running")
 }
 
-/// Extract a drive letter from a `uffs status` drive line such as
+/// Extract a drive letter from a `uffs --status` drive line such as
 /// `"[W] G:     15,162 records"`. Returns `None` for any other line.
 fn drive_letter_from_line(line: &str) -> Option<char> {
     let after_bracket = line.strip_prefix('[')?.split_once(']')?.1.trim_start();
@@ -75,7 +75,7 @@ fn drive_letter_from_line(line: &str) -> Option<char> {
     (letter.is_ascii_alphabetic() && chars.next() == Some(':')).then(|| letter.to_ascii_uppercase())
 }
 
-/// Section of `uffs status` output currently being parsed.
+/// Section of `uffs --status` output currently being parsed.
 #[derive(PartialEq, Eq)]
 enum Section {
     /// Before the first `──` header.
@@ -88,7 +88,7 @@ enum Section {
     Other,
 }
 
-/// Parse `uffs status` stdout into a [`RunState`].
+/// Parse `uffs --status` stdout into a [`RunState`].
 ///
 /// Scopes the `Status:` line and the `[T] L:` drive lines to the `── Daemon ──`
 /// section, and the MCP gateway `Status:` to `── MCP HTTP Gateway ──`.
@@ -169,7 +169,7 @@ pub fn register_restore(guard: &mut RunGuard<'_>, uffs_exe: &str, state: RunStat
 /// drives fails. Daemon-kill and MCP commands are best-effort (ignored).
 fn restore(host: &dyn Host, uffs_exe: &str, state: &RunState) -> Result<()> {
     // Tear down whatever the bench left, then rebuild the as-found state.
-    if let Err(err) = host.run(uffs_exe, &["daemon", "kill"]) {
+    if let Err(err) = host.run(uffs_exe, &["--daemon", "kill"]) {
         host.out(&format!(
             "[run-state] daemon kill before restore failed (ok if already stopped): {err}"
         ));
@@ -183,13 +183,13 @@ fn restore(host: &dyn Host, uffs_exe: &str, state: &RunState) -> Result<()> {
         }
         Some(drives) if drives.is_empty() => {
             host.out("[run-state] restarting daemon (full discovery — none recorded)");
-            host.run(uffs_exe, &["daemon", "start"])
+            host.run(uffs_exe, &["--daemon", "start"])
                 .map(|_out| ())
                 .map_err(|err| BenchError::Command(format!("restore daemon: {err}")))?;
         }
         Some(drives) => {
             let drive_strs: Vec<String> = drives.iter().map(char::to_string).collect();
-            let mut args: Vec<&str> = vec!["daemon", "start"];
+            let mut args: Vec<&str> = vec!["--daemon", "start"];
             for drive_s in &drive_strs {
                 args.push("--drive");
                 args.push(drive_s.as_str());
@@ -210,7 +210,7 @@ fn restore(host: &dyn Host, uffs_exe: &str, state: &RunState) -> Result<()> {
     // own restore.) `mcp start` is idempotent enough to ignore when already up.
     if state.mcp_running {
         host.out("[run-state] restarting MCP gateway (was up at start)");
-        if let Err(err) = host.run(uffs_exe, &["mcp", "start"]) {
+        if let Err(err) = host.run(uffs_exe, &["--mcp", "start"]) {
             host.out(&format!("[run-state] mcp start failed: {err}"));
         }
     }
@@ -222,7 +222,7 @@ fn restore(host: &dyn Host, uffs_exe: &str, state: &RunState) -> Result<()> {
 mod tests {
     use super::*;
 
-    /// Real `uffs status` output (7 drives loaded, MCP up) — the operator's
+    /// Real `uffs --status` output (7 drives loaded, MCP up) — the operator's
     /// reported state. Drive letters must round-trip in listed order.
     const STATUS_7_DRIVES_MCP_UP: &str = "\
 ═══ UFFS System Status ═══

--- a/crates/uffs-bench/src/stages.rs
+++ b/crates/uffs-bench/src/stages.rs
@@ -163,7 +163,7 @@ impl Invocation {
 const RUST_SCRIPT_EXE: &str = "rust-script";
 
 /// Card-facing label for the daemon run-state resource (R1).
-const DAEMON_RESOURCE: &str = "uffs daemon (run-state)";
+const DAEMON_RESOURCE: &str = "uffs --daemon (run-state)";
 
 /// Everything a measurement stage needs to plan and run.
 ///

--- a/crates/uffs-broker-protocol/src/lib.rs
+++ b/crates/uffs-broker-protocol/src/lib.rs
@@ -63,7 +63,7 @@ pub const PIPE_NAME: &str = r"\\.\pipe\uffs-broker";
 ///
 /// The single source of truth shared by everything that names the
 /// service: `uffs-broker` (install / control), `uffs-update`
-/// (quiesce / restore), and `uffs-cli` (`uffs status` + update
+/// (quiesce / restore), and `uffs-cli` (`uffs --status` + update
 /// detection). It belongs here, next to [`PIPE_NAME`], because both are
 /// the broker's *identity* on the wire / on the box — the SCM control
 /// *mechanism* lives separately in `uffs-winsvc`.

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -7,8 +7,8 @@
 #
 # Usage:
 #   uffs "*.rs" --drive C
-#   uffs stats
-#   uffs daemon start
+#   uffs --stats
+#   uffs --daemon start
 # ============================================================================
 
 [package]
@@ -111,7 +111,7 @@ dirs-next.workspace = true
 uffs-time.workspace = true
 
 # Broker identity (`SERVICE_NAME` / `PIPE_NAME`) + native SCM status so
-# `uffs status` can report the Access Broker. Both Layer-0 leaves:
+# `uffs --status` can report the Access Broker. Both Layer-0 leaves:
 # broker-protocol is pure; uffs-winsvc stubs to "not installed" off Windows.
 uffs-broker-protocol.workspace = true
 uffs-winsvc.workspace = true
@@ -124,12 +124,12 @@ uffs-winsvc.workspace = true
 #
 # `mcp-http-probe` — **default-off**, **additive**.
 #
-#   * Enables `uffs status` probing the MCP HTTP gateway's `/status`
+#   * Enables `uffs --status` probing the MCP HTTP gateway's `/status`
 #     endpoint inside `commands::system_status`.
 #   * Adds no crate-graph deps; uses `std::net::TcpStream` (libstd).
 #   * Disabled by default because `std::net::TcpStream` is the sole
 #     reason `ws2_32.dll` would be linked on Windows, adding ~50 ms
-#     to cold-start launch.  Without the feature, `uffs status` still
+#     to cold-start launch.  Without the feature, `uffs --status` still
 #     reports the configured HTTP bind address — it just does not
 #     actively probe `/status`.
 #   * Semver: removing the probe behaviour or its observable output

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -94,6 +94,12 @@ serde_json.workspace = true
 # Locates executables on `PATH` (e.g. the daemon binary when auto-spawning).
 which.workspace = true
 
+# Nearest-command suggestion for a `--`-flag typo (`--updat` → `--update`).
+# Zero-dep, tiny; the CLI suggests over ITS command set only — the shared
+# `from_cli_args` parser (uffs-client) stays the single source of truth for
+# search-flag validation, so the daemon never learns CLI commands.
+strsim.workspace = true
+
 # Resolve the daemon lifecycle dir (`%LOCALAPPDATA%\uffs`) for self-update
 # detection — mirrors uffs-daemon so the PID-file path matches exactly.
 dirs-next.workspace = true

--- a/crates/uffs-cli/README.md
+++ b/crates/uffs-cli/README.md
@@ -57,14 +57,14 @@ uffs "*.rs"
 uffs "*.rs" --drive C
 
 # Daemon status, drive list, version.
-uffs status
+uffs --status
 uffs drives
 uffs version
 
 # Daemon lifecycle.
-uffs daemon start
-uffs daemon stop
-uffs daemon status
+uffs --daemon start
+uffs --daemon stop
+uffs --daemon status
 
 # Index management (build / refresh / load / unload).
 uffs index build --drive C

--- a/crates/uffs-cli/README.md
+++ b/crates/uffs-cli/README.md
@@ -56,28 +56,26 @@ uffs "*.rs"
 # Constrain the scope by drive.
 uffs "*.rs" --drive C
 
-# Daemon status, drive list, version.
+# Combined system status (daemon + broker + MCP) and version.
 uffs --status
-uffs drives
-uffs version
+uffs --version
 
 # Daemon lifecycle.
 uffs --daemon start
 uffs --daemon stop
 uffs --daemon status
 
-# Index management (build / refresh / load / unload).
-uffs index build --drive C
-uffs index refresh --drive C
-uffs index load --drive D
-uffs index unload --drive D
+# Index management is daemon-managed (load / preload / forget).
+uffs --daemon load --drive C     # hot-load a drive into the running daemon
+uffs --daemon preload C          # promote + pin a drive in RAM
+uffs --daemon forget D --force   # evict + delete a drive's on-disk cache
 
 # Output redirection (CSV to disk; byte-identical with daemon's
 # native --out=file path).
 uffs "*.rs" --out-dir /tmp/results
 ```
 
-Run `uffs --help` for the full subcommand reference.
+Run `uffs --help` for the full command reference.
 
 ## Configuration
 

--- a/crates/uffs-cli/src/args.rs
+++ b/crates/uffs-cli/src/args.rs
@@ -483,7 +483,7 @@ COMMANDS:
   --agg <PRESET>       Run aggregate analytics
   --daemon <ACTION>    Manage the UFFS daemon (start/stop/load/status)
   --mcp <ACTION>       Manage the UFFS MCP server
-  --update [ACTION]    Self-update (snapshot/acquire/apply/doctor)
+  --update [ACTION]    Self-update (snapshot/acquire/apply/doctor/recover)
   --status             Show combined system status
 
 COMMON OPTIONS:

--- a/crates/uffs-cli/src/args.rs
+++ b/crates/uffs-cli/src/args.rs
@@ -114,7 +114,7 @@ pub enum Commands {
     SystemStatus,
 }
 
-/// Actions for `uffs daemon` subcommand.
+/// Actions for `uffs --daemon` subcommand.
 pub(crate) enum DaemonAction {
     /// Start the daemon.
     Start {
@@ -164,7 +164,7 @@ pub(crate) enum DaemonAction {
     },
     /// Demote loaded shards to `Cold` (Phase 8-B).
     ///
-    /// Empty `drives` means every loaded drive.  See `uffs daemon
+    /// Empty `drives` means every loaded drive.  See `uffs --daemon
     /// hibernate --help`.
     Hibernate {
         /// Drive letter(s) to hibernate; empty = all loaded drives.
@@ -229,7 +229,7 @@ pub(crate) fn parse_daemon_action(args: &[String]) -> Result<DaemonAction, anyho
     }
 }
 
-/// Parse `uffs daemon start [flags...]`.
+/// Parse `uffs --daemon start [flags...]`.
 fn parse_daemon_start(rest: &[String]) -> DaemonAction {
     let mut mft_file = Vec::new();
     let mut data_dir = None;
@@ -289,7 +289,7 @@ fn parse_daemon_start(rest: &[String]) -> DaemonAction {
     }
 }
 
-/// Parse `uffs daemon load [flags...]`.
+/// Parse `uffs --daemon load [flags...]`.
 fn parse_daemon_load(rest: &[String]) -> DaemonAction {
     let mut mft_file = Vec::new();
     let mut data_dir = None;
@@ -331,7 +331,7 @@ fn parse_daemon_load(rest: &[String]) -> DaemonAction {
     }
 }
 
-/// Parse `uffs daemon hibernate [DRIVE...]` / `[--drive D]` /
+/// Parse `uffs --daemon hibernate [DRIVE...]` / `[--drive D]` /
 /// `[--drives A,B,...]`.
 ///
 /// Empty drive list means hibernate all loaded drives (the daemon
@@ -347,8 +347,8 @@ fn parse_daemon_hibernate(rest: &[String]) -> DaemonAction {
                 }
             }
             other => {
-                // Bare positional drive letter: `uffs daemon hibernate C D`
-                // or `uffs daemon hibernate C,D`.
+                // Bare positional drive letter: `uffs --daemon hibernate C D`
+                // or `uffs --daemon hibernate C,D`.
                 extend_drives_from_csv(&mut drives, other);
             }
         }
@@ -356,7 +356,7 @@ fn parse_daemon_hibernate(rest: &[String]) -> DaemonAction {
     DaemonAction::Hibernate { drives }
 }
 
-/// Parse `uffs daemon preload [DRIVE...]` / `--drive D` /
+/// Parse `uffs --daemon preload [DRIVE...]` / `--drive D` /
 /// `--drives A,B,...` / `--pin-minutes N`.
 ///
 /// # Errors
@@ -399,7 +399,7 @@ fn parse_daemon_preload(rest: &[String]) -> Result<DaemonAction, anyhow::Error> 
     })
 }
 
-/// Parse `uffs daemon forget <DRIVES...> [--force]` /
+/// Parse `uffs --daemon forget <DRIVES...> [--force]` /
 /// `[--drive D]` / `[--drives A,B]`.
 ///
 /// Empty drive list is rejected — the daemon would reply with
@@ -465,7 +465,7 @@ USAGE:  uffs <PATTERN> [OPTIONS]
         uffs --<COMMAND> [ACTION] [OPTIONS]
 
 Search-first: any first token that is NOT a `--command` is a search pattern,
-so `uffs update`, `uffs status`, etc. search for those words. Management is
+so `uffs --update`, `uffs --status`, etc. search for those words. Management is
 `--<command>` (below). To search a pattern that begins with `--`, use
 `uffs -- <PATTERN>`.
 
@@ -526,7 +526,7 @@ pub(crate) fn print_version() {
 
 // ── Subcommand help texts ─────────────────────────────────────────────
 
-/// Help text for `uffs daemon`.
+/// Help text for `uffs --daemon`.
 const DAEMON_HELP: &str = "\
 uffs --daemon — Manage the UFFS background daemon
 
@@ -569,7 +569,7 @@ pub(crate) fn print_daemon_help() {
     print!("{DAEMON_HELP}");
 }
 
-/// Help text for `uffs stats`.
+/// Help text for `uffs --stats`.
 const STATS_HELP: &str = "\
 uffs --stats — Show filesystem statistics
 
@@ -590,7 +590,7 @@ pub(crate) fn print_stats_help() {
     print!("{STATS_HELP}");
 }
 
-/// Help text for `uffs aggregate`.
+/// Help text for `uffs --agg`.
 const AGGREGATE_HELP: &str = "\
 uffs --agg — Run aggregate analytics on the filesystem index
 
@@ -614,7 +614,7 @@ pub(crate) fn print_aggregate_help() {
     print!("{AGGREGATE_HELP}");
 }
 
-/// Help text for `uffs status`.
+/// Help text for `uffs --status`.
 const STATUS_HELP: &str = "\
 uffs --status — Show combined system status (daemon + broker + MCP)
 

--- a/crates/uffs-cli/src/args.rs
+++ b/crates/uffs-cli/src/args.rs
@@ -202,7 +202,7 @@ pub(crate) enum DaemonAction {
     StatusDrives,
 }
 
-/// Parse `uffs daemon <action> [flags...]` from raw args.
+/// Parse `uffs --daemon <action> [flags...]` from raw args.
 ///
 /// # Errors
 ///

--- a/crates/uffs-cli/src/args.rs
+++ b/crates/uffs-cli/src/args.rs
@@ -389,8 +389,8 @@ fn parse_daemon_preload(rest: &[String]) -> Result<DaemonAction, anyhow::Error> 
     }
     if drives.is_empty() {
         anyhow::bail!(
-            "`uffs daemon preload` requires at least one drive letter; \
-             see `uffs daemon preload --help`"
+            "`uffs --daemon preload` requires at least one drive letter; \
+             see `uffs --daemon preload --help`"
         );
     }
     Ok(DaemonAction::Preload {
@@ -435,8 +435,8 @@ fn parse_daemon_forget(rest: &[String]) -> Result<DaemonAction, anyhow::Error> {
     }
     if drives.is_empty() {
         anyhow::bail!(
-            "`uffs daemon forget` requires at least one drive letter; \
-             see `uffs daemon forget --help`"
+            "`uffs --daemon forget` requires at least one drive letter; \
+             see `uffs --daemon forget --help`"
         );
     }
     Ok(DaemonAction::Forget { drives, force })
@@ -461,10 +461,13 @@ fn extend_drives_from_csv(drives: &mut Vec<DriveLetter>, value: &str) {
 const HELP: &str = "\
 uffs - Ultra Fast File Search
 
-USAGE:  uffs [OPTIONS] <PATTERN>
-        uffs <SUBCOMMAND> [OPTIONS]
+USAGE:  uffs <PATTERN> [OPTIONS]
+        uffs --<COMMAND> [ACTION] [OPTIONS]
 
-Search is the default action: pass a pattern with no subcommand.
+Search-first: any first token that is NOT a `--command` is a search pattern,
+so `uffs update`, `uffs status`, etc. search for those words. Management is
+`--<command>` (below). To search a pattern that begins with `--`, use
+`uffs -- <PATTERN>`.
 
 EXAMPLES:
   uffs '*.txt'                        Find all .txt files
@@ -472,13 +475,16 @@ EXAMPLES:
   uffs '*' --mft-file C.bin            Offline MFT search
   uffs --ext rs,toml                   Find Rust project files
   uffs --type picture --min-size 10MB  Large images
+  uffs --update doctor                 Self-update health check
 
-SUBCOMMANDS:
-  stats             Show filesystem statistics
-  aggregate|agg     Run aggregate analytics
-  daemon            Manage the UFFS daemon (start/stop/load/status)
-  mcp               Manage the UFFS MCP server
-  status            Show combined system status
+COMMANDS:
+  --search <PATTERN>   Explicit search (same as the bare default)
+  --stats [PATH]       Show filesystem statistics
+  --agg <PRESET>       Run aggregate analytics
+  --daemon <ACTION>    Manage the UFFS daemon (start/stop/load/status)
+  --mcp <ACTION>       Manage the UFFS MCP server
+  --update [ACTION]    Self-update (snapshot/acquire/apply/doctor)
+  --status             Show combined system status
 
 COMMON OPTIONS:
   -v, --verbose           Verbose output
@@ -522,9 +528,9 @@ pub(crate) fn print_version() {
 
 /// Help text for `uffs daemon`.
 const DAEMON_HELP: &str = "\
-uffs daemon — Manage the UFFS background daemon
+uffs --daemon — Manage the UFFS background daemon
 
-USAGE:  uffs daemon <ACTION> [OPTIONS]
+USAGE:  uffs --daemon <ACTION> [OPTIONS]
 
 ACTIONS:
   start              Start the daemon
@@ -565,9 +571,9 @@ pub(crate) fn print_daemon_help() {
 
 /// Help text for `uffs stats`.
 const STATS_HELP: &str = "\
-uffs stats — Show filesystem statistics
+uffs --stats — Show filesystem statistics
 
-USAGE:  uffs stats [PATH] [OPTIONS]
+USAGE:  uffs --stats [PATH] [OPTIONS]
 
 ARGUMENTS:
   [PATH]               Index file path (optional; omit to query daemon)
@@ -586,9 +592,9 @@ pub(crate) fn print_stats_help() {
 
 /// Help text for `uffs aggregate`.
 const AGGREGATE_HELP: &str = "\
-uffs aggregate — Run aggregate analytics on the filesystem index
+uffs --agg — Run aggregate analytics on the filesystem index
 
-USAGE:  uffs aggregate <PRESET> [OPTIONS]
+USAGE:  uffs --agg <PRESET> [OPTIONS]
 
 ARGUMENTS:
   <PRESET>             overview, by_type, by_extension, by_drive,
@@ -610,9 +616,9 @@ pub(crate) fn print_aggregate_help() {
 
 /// Help text for `uffs status`.
 const STATUS_HELP: &str = "\
-uffs status — Show combined system status (daemon + MCP HTTP server)
+uffs --status — Show combined system status (daemon + broker + MCP)
 
-USAGE:  uffs status
+USAGE:  uffs --status
 ";
 
 /// Print status help.

--- a/crates/uffs-cli/src/commands.rs
+++ b/crates/uffs-cli/src/commands.rs
@@ -8,7 +8,7 @@
 
 /// Aggregate analytics subcommand.
 pub mod aggregate;
-/// `uffs daemon load` — hot-load MFT file(s) into a running daemon.
+/// `uffs --daemon load` — hot-load MFT file(s) into a running daemon.
 ///
 /// Split off `daemon_mgmt` so the lifecycle file stays under the
 /// 800-LOC policy ceiling without a file-size exception (mirrors
@@ -31,13 +31,13 @@ pub mod output;
 pub mod search;
 /// Stats subcommand implementation.
 pub mod stats;
-/// Combined `uffs status` command.
+/// Combined `uffs --status` command.
 pub(crate) mod system_status;
-/// `uffs update` — self-update detection (Phase A of the self-update design).
+/// `uffs --update` — self-update detection (Phase A of the self-update design).
 pub(crate) mod update;
 
 /// Render a one-line version summary suitable for `daemon status`,
-/// `daemon stats`, and `uffs status` output.
+/// `daemon stats`, and `uffs --status` output.
 ///
 /// `daemon_version` is the daemon-reported `env!("CARGO_PKG_VERSION")`
 /// from [`uffs_client::protocol::response::StatusResponse::version`]

--- a/crates/uffs-cli/src/commands/daemon_load.rs
+++ b/crates/uffs-cli/src/commands/daemon_load.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! `uffs daemon load` — hot-load MFT file(s) into a running daemon.
+//! `uffs --daemon load` — hot-load MFT file(s) into a running daemon.
 //!
 //! Extracted from `super::daemon_mgmt` so the lifecycle file stays
 //! under the workspace 800-LOC ceiling without a file-size exception.
@@ -21,7 +21,7 @@
 use anyhow::{Context as _, Result};
 use uffs_client::connect_sync::UffsClientSync;
 
-/// `uffs daemon load` — resolve `--mft-file` / `--data-dir` /
+/// `uffs --daemon load` — resolve `--mft-file` / `--data-dir` /
 /// `--drive` arguments the same way `daemon start` does, but send
 /// them to the running daemon via the `load_drive` IPC method
 /// instead of spawning a new process.
@@ -39,7 +39,7 @@ pub(crate) fn daemon_load(
     no_cache: bool,
 ) -> Result<()> {
     let Ok(mut client) = UffsClientSync::connect_raw() else {
-        println!("Daemon is not running. Start it first with `uffs daemon start`.");
+        println!("Daemon is not running. Start it first with `uffs --daemon start`.");
         return Ok(());
     };
 

--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! `uffs daemon {status|stop|kill|restart}` subcommand handlers.
+//! `uffs --daemon {status|stop|kill|restart}` subcommand handlers.
 
 use anyhow::{Context as _, Result};
 use uffs_client::connect_sync::UffsClientSync;
@@ -52,7 +52,7 @@ pub(crate) fn daemon(action: &DaemonAction) -> Result<()> {
                  \x20 1. Relaunch PowerShell / cmd as Administrator\n\
                  \x20    (right-click \u{2192} \"Run as administrator\"), then retry.\n\
                  \x20 2. For `daemon start`, add --elevate to get a UAC prompt:\n\
-                 \x20      uffs daemon start --elevate\n\
+                 \x20      uffs --daemon start --elevate\n\
                  \x20 3. Install the broker service (one-time setup, no future UAC):\n\
                  \x20      uffs-broker --install"
             );
@@ -63,7 +63,7 @@ pub(crate) fn daemon(action: &DaemonAction) -> Result<()> {
                  A non-root process must not stop or restart it — doing so would\n\
                  kill the running daemon with no way to bring it back.\n\n\
                  To run this command, prefix it with sudo:\n\
-                 \x20  sudo uffs daemon <subcommand>"
+                 \x20  sudo uffs --daemon <subcommand>"
             );
             // Fallback for platforms that are neither Windows nor Unix
             // (e.g. WASM, bare-metal targets — should not arise in practice).
@@ -117,7 +117,7 @@ pub(crate) fn daemon(action: &DaemonAction) -> Result<()> {
     }
 }
 
-/// `uffs daemon start` — start the daemon, forwarding data-source flags
+/// `uffs --daemon start` — start the daemon, forwarding data-source flags
 /// as-is so the daemon resolves them internally (DRY).
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
 #[expect(
@@ -135,7 +135,7 @@ fn daemon_start(
 ) -> Result<()> {
     // Already running?
     if UffsClientSync::connect_raw().is_ok() {
-        println!("Daemon is already running. Use `uffs daemon restart` to reload.");
+        println!("Daemon is already running. Use `uffs --daemon restart` to reload.");
         return Ok(());
     }
 
@@ -256,7 +256,7 @@ fn daemon_start(
     Ok(())
 }
 
-/// `uffs daemon status` — show daemon status, PID, loaded drives.
+/// `uffs --daemon status` — show daemon status, PID, loaded drives.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
 fn daemon_status() -> Result<()> {
     let Ok(mut client) = UffsClientSync::connect_raw() else {
@@ -415,7 +415,7 @@ const fn tier_marker(tier: Option<ShardTier>) -> &'static str {
 /// Visible to sibling command modules (`daemon_tiering.rs`) so the
 /// graceful "daemon down" rendering stays consistent across every
 /// read-only daemon command — the operator sees the **same** stdout
-/// shape from `uffs daemon status` and `uffs daemon status_drives`
+/// shape from `uffs --daemon status` and `uffs --daemon status_drives`
 /// when the daemon happens to be down.  Mutating commands
 /// (`hibernate` / `preload` / `forget`) deliberately stay on the
 /// bail-with-error path because the operator should know their
@@ -429,7 +429,7 @@ pub(crate) fn print_not_running() {
     }
 }
 
-/// `uffs daemon stats` — show performance metrics.
+/// `uffs --daemon stats` — show performance metrics.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
 fn daemon_stats() -> Result<()> {
     if let Ok(mut client) = UffsClientSync::connect_raw() {
@@ -496,13 +496,13 @@ fn compute_hit_rate_percent(hits: u64, lookups: u64) -> f64 {
     (hits as f64 / lookups as f64) * 100.0_f64
 }
 
-/// `uffs daemon stop` — graceful shutdown via RPC.
+/// `uffs --daemon stop` — graceful shutdown via RPC.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
 fn daemon_stop() -> Result<()> {
     if let Ok(mut client) = UffsClientSync::connect_raw() {
         client
             .shutdown()
-            .with_context(|| "Shutdown RPC failed — try `uffs daemon kill` instead")?;
+            .with_context(|| "Shutdown RPC failed — try `uffs --daemon kill` instead")?;
         println!("Daemon shutdown requested.");
     } else {
         println!("Daemon is not running.");
@@ -510,7 +510,7 @@ fn daemon_stop() -> Result<()> {
     Ok(())
 }
 
-/// `uffs daemon kill` — hard kill via PID file or socket discovery + cleanup.
+/// `uffs --daemon kill` — hard kill via PID file or socket discovery + cleanup.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
 fn daemon_kill() {
     let pid_path = pid_file_path();
@@ -561,7 +561,7 @@ fn kill_pid(pid: u32) {
     }
 }
 
-/// `uffs daemon restart` — stop, capture data sources, then re-launch.
+/// `uffs --daemon restart` — stop, capture data sources, then re-launch.
 ///
 /// If the daemon is running, queries its loaded drives to extract the
 /// original `--mft-file` paths, stops it, then re-spawns with the same
@@ -587,7 +587,7 @@ fn daemon_restart() -> Result<()> {
         client.shutdown().with_context(|| {
             format!(
                 "Graceful shutdown of PID {daemon_pid} failed.\n\
-                 Run `uffs daemon kill` first, then retry."
+                 Run `uffs --daemon kill` first, then retry."
             )
         })?;
 
@@ -639,7 +639,7 @@ fn daemon_restart() -> Result<()> {
 /// `std::env::var("X")` returns `Ok("")` when a shell has left `X` set to the
 /// empty string (common in PowerShell after a sub-script unsets a variable
 /// via assignment rather than `Remove-Item Env:\X`).  Treating that as a real
-/// value is what caused the silent `uffs daemon start` failure documented in
+/// value is what caused the silent `uffs --daemon start` failure documented in
 /// `LOG/Output`: the CLI forwarded `--log-level ""` and
 /// `--log-file uffsd.log` (relative path, from `""+"/uffsd.log"`) to uffsd,
 /// uffsd's `tracing_appender::rolling::never("", "uffsd.log")` then panicked

--- a/crates/uffs-cli/src/commands/daemon_tiering.rs
+++ b/crates/uffs-cli/src/commands/daemon_tiering.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! `uffs daemon {hibernate, preload}` subcommand handlers.
+//! `uffs --daemon {hibernate, preload}` subcommand handlers.
 //!
 //! Phase 8-B / 8-C — operator-driven memory-tiering CLI commands.
 //! Split off [`crate::commands::daemon_mgmt`] so the tiering cluster
@@ -16,7 +16,7 @@ use uffs_client::protocol::response::{
     DEFAULT_PRELOAD_PIN_MINUTES, DriveTierStatus, ForgetParams, HibernateParams, PreloadParams,
 };
 
-/// `uffs daemon hibernate [DRIVES...]` — demote loaded shards to `Cold`.
+/// `uffs --daemon hibernate [DRIVES...]` — demote loaded shards to `Cold`.
 ///
 /// Releases RAM but keeps the encrypted compact cache on disk so a
 /// subsequent `preload` / search can re-warm without a full MFT
@@ -35,7 +35,7 @@ use uffs_client::protocol::response::{
 /// # Example
 ///
 /// ```bash
-/// $ uffs daemon hibernate
+/// $ uffs --daemon hibernate
 /// Daemon hibernated 2 drive(s):
 ///   Hot     -> Cold:  C
 ///   Warm    -> Cold:  D
@@ -75,7 +75,7 @@ pub(crate) fn daemon_hibernate(drives: &[uffs_mft::platform::DriveLetter]) -> Re
     Ok(())
 }
 
-/// `uffs daemon preload <DRIVES...> [--pin-minutes N]` — promote
+/// `uffs --daemon preload <DRIVES...> [--pin-minutes N]` — promote
 /// drive(s) to `Hot` and pin the tier against demote for
 /// `pin_minutes` minutes (defaults to
 /// [`DEFAULT_PRELOAD_PIN_MINUTES`] when `None`).
@@ -97,7 +97,7 @@ pub(crate) fn daemon_hibernate(drives: &[uffs_mft::platform::DriveLetter]) -> Re
 /// # Example
 ///
 /// ```bash
-/// $ uffs daemon preload C D --pin-minutes 60
+/// $ uffs --daemon preload C D --pin-minutes 60
 /// Daemon preloaded (60-min pin):
 ///   Promoted to Hot:  C, D
 ///   Pin expires at:   in 60m
@@ -145,7 +145,7 @@ pub(crate) fn daemon_preload(
     Ok(())
 }
 
-/// `uffs daemon forget <DRIVES...> [--force]` — evict drive(s) from
+/// `uffs --daemon forget <DRIVES...> [--force]` — evict drive(s) from
 /// the registry and delete every per-drive on-disk cache artefact.
 ///
 /// Without `--force` the daemon refuses non-`Cold` drives with
@@ -167,7 +167,7 @@ pub(crate) fn daemon_preload(
 /// # Example
 ///
 /// ```bash
-/// $ uffs daemon forget C --force
+/// $ uffs --daemon forget C --force
 /// Daemon forgot 1 drive(s); freed 12.4 MiB:
 ///   Forgotten:        C
 ///   Already absent:   (none)
@@ -208,7 +208,7 @@ pub(crate) fn daemon_forget(drives: &[uffs_mft::platform::DriveLetter], force: b
     Ok(())
 }
 
-/// `uffs daemon status_drives` — render the per-drive tier +
+/// `uffs --daemon status_drives` — render the per-drive tier +
 /// telemetry table.
 ///
 /// Operator-facing companion to `daemon status`: surfaces tier,
@@ -231,7 +231,7 @@ pub(crate) fn daemon_forget(drives: &[uffs_mft::platform::DriveLetter], force: b
 /// # Example
 ///
 /// ```bash
-/// $ uffs daemon status_drives
+/// $ uffs --daemon status_drives
 /// DRIVE  TIER    RESIDENT     QPM   LAST QUERY        PIN UNTIL        PROMOTIONS
 /// C      hot     1.20 GiB   45.30   3m ago            in 57m                    3
 /// D      warm    843 MiB     2.10   4m ago            -                         0
@@ -259,7 +259,7 @@ pub(crate) fn daemon_status_drives() -> Result<()> {
     // Read-only commands match `daemon status`'s graceful "daemon
     // down" rendering on connection failure — same stdout shape,
     // same exit 0 — so an operator pipeline like
-    //   `uffs daemon status_drives | grep cold`
+    //   `uffs --daemon status_drives | grep cold`
     // doesn't crash on a stopped daemon.  Mutating commands
     // (`hibernate` / `preload` / `forget`) deliberately stay on the
     // bail-with-error path because the operator needs to know their

--- a/crates/uffs-cli/src/commands/mcp_mgmt/mod.rs
+++ b/crates/uffs-cli/src/commands/mcp_mgmt/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! `uffs mcp <action>` — thin shim that delegates to the `uffsmcp` binary.
+//! `uffs --mcp <action>` — thin shim that delegates to the `uffsmcp` binary.
 //!
 //! The actual MCP server logic lives in the `uffs-mcp` crate and its
 //! standalone `uffsmcp` binary.  This module simply exec's / spawns

--- a/crates/uffs-cli/src/commands/mcp_mgmt/mod.rs
+++ b/crates/uffs-cli/src/commands/mcp_mgmt/mod.rs
@@ -11,7 +11,7 @@ use anyhow::{Context as _, Result};
 
 /// Execute an MCP management action by forwarding raw args to `uffsmcp`.
 ///
-/// This is the passthrough path — raw args after `uffs mcp` are forwarded
+/// This is the passthrough path — raw args after `uffs --mcp` are forwarded
 /// directly to the `uffsmcp` binary without any parsing.
 ///
 /// # Errors

--- a/crates/uffs-cli/src/commands/stats.rs
+++ b/crates/uffs-cli/src/commands/stats.rs
@@ -8,7 +8,7 @@
 //! lifecycle (auto-start, await_ready, data-dir forwarding).
 //!
 //! Legacy parquet-mode stats have been removed from the thin CLI.
-//! Use `uffsd` directly or `uffs stats` (daemon mode) instead.
+//! Use `uffsd` directly or `uffs --stats` (daemon mode) instead.
 
 use std::path::Path;
 
@@ -31,7 +31,7 @@ pub fn stats(path: Option<&Path>, _top: u32) -> Result<()> {
         Some(dir) => {
             anyhow::bail!(
                 "Legacy parquet stats for '{}' are no longer supported by the thin CLI.\n\
-                 Use `uffs stats` (daemon mode) instead.",
+                 Use `uffs --stats` (daemon mode) instead.",
                 dir.display()
             )
         }

--- a/crates/uffs-cli/src/commands/system_status.rs
+++ b/crates/uffs-cli/src/commands/system_status.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! `uffs status` — combined daemon + broker + MCP status in one view.
+//! `uffs --status` — combined daemon + broker + MCP status in one view.
 //!
 //! Shows four sections:
 //! - **Daemon**: PID, uptime, drives, queries
@@ -15,7 +15,7 @@ use anyhow::{Context as _, Result};
 use uffs_client::connect_sync::UffsClientSync;
 use uffs_client::protocol::response::{DaemonStatus, ShardTier};
 
-/// `uffs status` — show combined system status.
+/// `uffs --status` — show combined system status.
 ///
 /// # Errors
 ///
@@ -146,7 +146,7 @@ fn print_daemon_status() {
     }
 }
 
-/// Render the `Drives:` block of `uffs status`.
+/// Render the `Drives:` block of `uffs --status`.
 ///
 /// Phase 5 task 5.11: enumerate every shard in the registry (Hot /
 /// Warm / Parked / Cold) and tag each row with its tier marker.
@@ -204,7 +204,7 @@ fn print_drive_summary(drives: &[uffs_client::protocol::response::DriveInfo]) {
     }
 }
 
-/// Compact tier marker for `uffs status`'s drive list — fixed-width
+/// Compact tier marker for `uffs --status`'s drive list — fixed-width
 /// bracket label per tier so the per-drive lines align in the
 /// combined system view.  Phase 5 task 5.11.
 const fn compact_tier_marker(tier: Option<ShardTier>) -> &'static str {
@@ -299,7 +299,7 @@ fn print_mcp_http_status() {
         }
     }
     if gw_stale {
-        println!("  Run `uffs mcp reload` to restart with the current binary.");
+        println!("  Run `uffs --mcp reload` to restart with the current binary.");
     }
 }
 
@@ -388,7 +388,7 @@ fn print_mcp_stdio_sessions() {
         );
     }
     if any_stale {
-        println!("  Run `uffs mcp reload` to restart stale sessions.");
+        println!("  Run `uffs --mcp reload` to restart stale sessions.");
     }
 }
 

--- a/crates/uffs-cli/src/commands/system_status.rs
+++ b/crates/uffs-cli/src/commands/system_status.rs
@@ -7,7 +7,8 @@
 //! - **Daemon**: PID, uptime, drives, queries
 //! - **Access Broker**: SCM state, pid, pipe-serving (native, locale-proof)
 //! - **MCP HTTP Gateway**: PID, transport, health, sessions, tool calls
-//! - **MCP Stdio Sessions**: active `uffs mcp run` processes (one per AI host)
+//! - **MCP Stdio Sessions**: active `uffs --mcp run` processes (one per AI
+//!   host)
 
 #[cfg(feature = "mcp-http-probe")]
 use anyhow::{Context as _, Result};
@@ -355,7 +356,7 @@ fn print_mcp_stats(stats: &serde_json::Value) {
 
 /// Print MCP stdio session list.
 ///
-/// Scans for running `uffs mcp run` processes.  Each one is an AI-host
+/// Scans for running `uffs --mcp run` processes.  Each one is an AI-host
 /// (Augment, Claude Desktop, Cursor, etc.) connected via stdio transport.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
 fn print_mcp_stdio_sessions() {
@@ -403,7 +404,7 @@ struct StdioSession {
     is_stale: bool,
 }
 
-/// Find running `uffs mcp run` processes via `ps`.
+/// Find running `uffs --mcp run` processes via `ps`.
 ///
 /// Also detects stale binaries by comparing the on-disk mtime of each
 /// process's executable against the current running binary.
@@ -446,7 +447,7 @@ fn find_mcp_stdio_processes() -> Vec<StdioSession> {
         };
         let cmdline: String = fields.collect::<Vec<_>>().join(" ");
 
-        // Match `uffs mcp run` in any path.
+        // Match `uffs --mcp run` in any path.
         if !cmdline.contains("mcp") || !cmdline.contains("run") {
             continue;
         }

--- a/crates/uffs-cli/src/commands/update/apply.rs
+++ b/crates/uffs-cli/src/commands/update/apply.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! `uffs update --apply` — run the **mutating** update end to end.
+//! `uffs --update --apply` — run the **mutating** update end to end.
 //!
 //! The CLI freezes a snapshot and hands off to the `uffs-update` helper,
 //! which performs the journaled flow: pre-flight → quiesce → backup/swap/

--- a/crates/uffs-cli/src/commands/update/doctor.rs
+++ b/crates/uffs-cli/src/commands/update/doctor.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! `uffs update doctor` — end-to-end health check of the self-update flow.
+//! `uffs --update doctor` — end-to-end health check of the self-update flow.
 //!
 //! The CLI is the thin half: it runs Phase-A detection, freezes a snapshot
 //! (so the helper has full install/version/service context), and spawns

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -1,17 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! `uffs update` — self-update **Phase A: detect & capture** (design in
-//! `docs/dev/architecture/UFFS-Self-Update-Feasibility-and-Design.md` §5).
+//! `uffs --update [<action>]` — self-update (design in
+//! `docs/dev/architecture/UFFS-Self-Update-Feasibility-and-Design.md`; CLI
+//! grammar in `docs/architecture/cli-grammar.md`).
 //!
-//! This is the **detection slice only**: it discovers every install
-//! *root* from the live anchors (invoking CLI + running daemon / MCP /
-//! broker), enumerates the UFFS binaries in each, classifies the channel
-//! that placed them, validates each binary's on-disk version, and
-//! captures the running processes' launch recipes. It **mutates
-//! nothing** — stopping, replacing, and restoring land in later phases.
+//! Phase A (detect & capture) is the default (no action): it discovers
+//! every install *root* from the live anchors (invoking CLI + running
+//! daemon / MCP / broker), enumerates the UFFS binaries in each, classifies
+//! the channel that placed them, validates each binary's on-disk version,
+//! and captures the running processes' launch recipes — mutating nothing.
+//! The `snapshot` / `acquire` / `apply` / `doctor` actions add the later
+//! phases on top.
 //!
-//! Entry point: `run_update` (wired to `uffs update` in `main`).
+//! Entry point: `run_update` (dispatched from `--update` in `main`).
 
 mod acquire;
 mod apply;
@@ -26,37 +28,59 @@ mod snapshot;
 
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use model::{Anchor, Channel, Component, DetectionReport, InstallRoot, RunningProcess, Scope};
 
-/// Run `uffs update`: detect (Phase A), optional snapshot (Phase B), and
-/// optional acquire (Phase C, via the `uffs-update` helper).
+/// Run `uffs --update [<action>]` — uniform `--<command> [action] [--options]`
+/// grammar (design: `docs/architecture/cli-grammar.md`). The action is the
+/// first positional token:
+///
+/// - *(none)* → detect only (Phase A).
+/// - `snapshot` → detect + freeze a snapshot (Phase B).
+/// - `acquire`  → + download + SHA-verify into staging (Phase C).
+/// - `apply`    → + the full mutating update (stop/swap/smoke/commit/restore).
+/// - `doctor`   → end-to-end health check (`--repair` / `--offline`).
+///
+/// Options (`--version`, `--repair`, `--offline`) follow the action.
 pub(crate) fn run_update(args: &[String]) -> Result<()> {
     if args.iter().any(|arg| arg == "--help" || arg == "-h") {
         print_help();
         return Ok(());
     }
-    // `uffs update doctor [...]` — detect, freeze a snapshot, then hand off
-    // to the helper's end-to-end health check (which prints its own report).
-    if args.first().is_some_and(|arg| arg == "doctor") {
+
+    // The action is the first *positional* token (a leading flag or nothing
+    // means bare detect). Validate up front, before any detection/output.
+    let action = args
+        .first()
+        .map(String::as_str)
+        .filter(|tok| !tok.starts_with('-'));
+    if let Some(act) = action
+        && !matches!(act, "snapshot" | "acquire" | "apply" | "doctor")
+    {
+        bail!("unknown `--update` action `{act}` — expected: snapshot | acquire | apply | doctor");
+    }
+
+    // `doctor` runs its own flow: detect → freeze a snapshot → hand off to the
+    // helper's health check (which prints its own report).
+    if action == Some("doctor") {
         let report = detect();
         let snapshot_path = snapshot::write_snapshot(&report)?;
         return doctor::spawn(&snapshot_path, args);
     }
+
     let report = detect();
     report::print_human(&report);
-    if args.iter().any(|arg| arg == "--snapshot") {
+    if action == Some("snapshot") {
         write_and_report_snapshot(&report);
     }
     print_phase_a_footer();
-    // `--apply` runs the full mutating update (acquire → apply); `--acquire`
-    // only stages + verifies. `--apply` implies the acquire step.
-    let do_apply = args.iter().any(|arg| arg == "--apply");
-    if do_apply || args.iter().any(|arg| arg == "--acquire") {
-        // Both read a snapshot to know the installed subset.
+
+    // `apply` runs the full mutating update (acquire → apply); `acquire` only
+    // stages + verifies. `apply` implies the acquire step.
+    if matches!(action, Some("acquire" | "apply")) {
         let snapshot_path = snapshot::write_snapshot(&report)?;
         acquire::spawn(&snapshot_path, flag_value(args, "--version").as_deref())?;
-        if do_apply {
+        if action == Some("apply") {
             apply::spawn(&snapshot_path)?;
         }
     }
@@ -230,26 +254,29 @@ fn capture_broker(roots: &mut Vec<InstallRoot>, running: &mut Vec<RunningProcess
 #[expect(clippy::print_stdout, reason = "intentional help output")]
 fn print_help() {
     println!(
-        "uffs update — self-update\n\n\
+        "uffs --update — self-update\n\n\
          USAGE:\n\
-         \x20 uffs update [--snapshot] [--acquire | --apply] [--version <tag>]\n\
-         \x20 uffs update doctor [--repair] [--offline] [--version <tag>]\n\n\
+         \x20 uffs --update [<action>] [--options]\n\n\
          Discovers where UFFS is installed (from the running CLI, daemon,\n\
          MCP gateway, and broker service), lists binaries + versions per\n\
          location, and shows the running processes' launch recipes.\n\n\
-         FLAGS:\n\
-         \x20 --snapshot          Persist the detection + live daemon state to JSON.\n\
-         \x20 --acquire           Download + SHA-256-verify the release into staging\n\
-         \x20                     (via the uffs-update helper). Does NOT replace.\n\
-         \x20 --apply             Run the FULL mutating update: acquire, then stop\n\
-         \x20                     services, atomically swap + smoke-test, commit,\n\
-         \x20                     and restart. Journaled + auto-rollback on failure.\n\
-         \x20 --version <tag>     Acquire/apply a specific release tag (default: latest).\n\n\
-         SUBCOMMANDS:\n\
-         \x20 doctor              End-to-end health check of the update flow\n\
-         \x20                     (versions, dirs, journal, backups, services,\n\
-         \x20                     broker pipe, release reachability). `--repair`\n\
-         \x20                     self-heals; `--offline` skips network checks.\n"
+         ACTIONS:\n\
+         \x20 (none)              Detect only — non-mutating; nothing is changed.\n\
+         \x20 snapshot            Detect + persist the state to JSON.\n\
+         \x20 acquire             + download + SHA-256-verify the release into\n\
+         \x20                     staging (via the uffs-update helper). No replace.\n\
+         \x20 apply               + the FULL mutating update: stop services,\n\
+         \x20                     atomically swap + smoke-test, commit, restart.\n\
+         \x20                     Journaled + auto-rollback on failure.\n\
+         \x20 doctor              End-to-end health check (versions, dirs, journal,\n\
+         \x20                     backups, services, broker pipe, release reach).\n\n\
+         OPTIONS:\n\
+         \x20 --version <tag>     Acquire/apply a specific release tag (default: latest).\n\
+         \x20 --repair            (doctor) self-heal what can be fixed.\n\
+         \x20 --offline           (doctor) skip the network checks.\n\n\
+         EXAMPLES:\n\
+         \x20 uffs --update                 uffs --update acquire --version v0.6.3\n\
+         \x20 uffs --update apply           uffs --update doctor --repair\n"
     );
 }
 

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -11,7 +11,7 @@
 //! the channel that placed them, validates each binary's on-disk version,
 //! and captures the running processes' launch recipes — mutating nothing.
 //! The `snapshot` / `acquire` / `apply` / `doctor` actions add the later
-//! phases on top.
+//! phases on top; `recover` finishes an interrupted update on demand.
 //!
 //! Entry point: `run_update` (dispatched from `--update` in `main`).
 
@@ -40,6 +40,7 @@ use model::{Anchor, Channel, Component, DetectionReport, InstallRoot, RunningPro
 /// - `acquire`  → + download + SHA-verify into staging (Phase C).
 /// - `apply`    → + the full mutating update (stop/swap/smoke/commit/restore).
 /// - `doctor`   → end-to-end health check (`--repair` / `--offline`).
+/// - `recover`  → finish/roll back an interrupted update in the foreground.
 ///
 /// Options (`--version`, `--repair`, `--offline`) follow the action.
 pub(crate) fn run_update(args: &[String]) -> Result<()> {
@@ -55,9 +56,17 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
         .map(String::as_str)
         .filter(|tok| !tok.starts_with('-'));
     if let Some(act) = action
-        && !matches!(act, "snapshot" | "acquire" | "apply" | "doctor")
+        && !matches!(act, "snapshot" | "acquire" | "apply" | "doctor" | "recover")
     {
-        bail!("unknown `--update` action `{act}` — expected: snapshot | acquire | apply | doctor");
+        bail!(
+            "unknown `--update` action `{act}` — expected: snapshot | acquire | apply | doctor | recover"
+        );
+    }
+
+    // `recover` finishes (or rolls back) an interrupted update in the
+    // foreground — the on-demand twin of the startup best-effort self-heal.
+    if action == Some("recover") {
+        return self_heal::run_foreground();
     }
 
     // `doctor` runs its own flow: detect → freeze a snapshot → hand off to the
@@ -269,7 +278,9 @@ fn print_help() {
          \x20                     atomically swap + smoke-test, commit, restart.\n\
          \x20                     Journaled + auto-rollback on failure.\n\
          \x20 doctor              End-to-end health check (versions, dirs, journal,\n\
-         \x20                     backups, services, broker pipe, release reach).\n\n\
+         \x20                     backups, services, broker pipe, release reach).\n\
+         \x20 recover             Finish or roll back an interrupted update now\n\
+         \x20                     (foreground; the on-demand self-heal).\n\n\
          OPTIONS:\n\
          \x20 --version <tag>     Acquire/apply a specific release tag (default: latest).\n\
          \x20 --repair            (doctor) self-heal what can be fixed.\n\

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -259,7 +259,7 @@ fn capture_broker(roots: &mut Vec<InstallRoot>, running: &mut Vec<RunningProcess
     }
 }
 
-/// Print the `uffs update` help text.
+/// Print the `uffs --update` help text.
 #[expect(clippy::print_stdout, reason = "intentional help output")]
 fn print_help() {
     println!(

--- a/crates/uffs-cli/src/commands/update/self_heal.rs
+++ b/crates/uffs-cli/src/commands/update/self_heal.rs
@@ -16,6 +16,8 @@
 
 use std::process::{Command, Stdio};
 
+use anyhow::{Context as _, Result, bail};
+
 use super::acquire::find_helper;
 use super::snapshot;
 
@@ -41,4 +43,33 @@ pub(crate) fn trigger() {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn();
+}
+
+/// Run `uffs-update recover` in the **foreground** — the explicit
+/// `uffs --update recover` action. Unlike [`trigger`], this blocks and lets
+/// the helper's output through, so an operator can deterministically finish
+/// (or roll back) an interrupted update on demand rather than waiting for the
+/// next CLI invocation's best-effort heal.
+///
+/// # Errors
+///
+/// Fails if the `uffs-update` helper cannot be located or it exits non-zero.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+pub(crate) fn run_foreground() -> Result<()> {
+    let journal = snapshot::update_dir().join(LIVE_JOURNAL);
+    if !journal.exists() {
+        println!("No in-flight update journal found — nothing to recover.");
+        return Ok(());
+    }
+    let helper = find_helper()?;
+    let status = Command::new(&helper)
+        .arg("recover")
+        .arg("--journal")
+        .arg(&journal)
+        .status()
+        .with_context(|| format!("spawning {}", helper.display()))?;
+    if !status.success() {
+        bail!("uffs-update recover failed (exit {:?})", status.code());
+    }
+    Ok(())
 }

--- a/crates/uffs-cli/src/dispatch.rs
+++ b/crates/uffs-cli/src/dispatch.rs
@@ -53,6 +53,43 @@ impl Command {
     }
 }
 
+/// Every command token (incl. the `--aggregate` alias) — the canonical set
+/// the CLI suggests over for a `--`-flag typo. Kept in lock-step with
+/// [`Command::from_token`] by `command_tokens_all_resolve` (test).
+const COMMAND_TOKENS: &[&str] = &[
+    "--search",
+    "--stats",
+    "--agg",
+    "--aggregate",
+    "--daemon",
+    "--mcp",
+    "--update",
+    "--status",
+];
+
+/// Maximum edit distance for a `--`-flag typo to be read as a command miss.
+/// `2` catches a one- or two-character slip (`--updat`, `--statu`, `--mc`)
+/// while leaving an unrelated unknown flag (`--bogus`) without a (wrong)
+/// command suggestion.
+const MAX_COMMAND_TYPO_DISTANCE: usize = 2;
+
+/// If `flag` (a `--`-token the shared search parser already **rejected** as
+/// an unknown flag) is a near-miss of a management command, return that
+/// command token. The CLI suggests over its **own** command set only —
+/// search-flag validation stays in `uffs-client::from_cli_args`, so the
+/// daemon never learns CLI commands.
+///
+/// Returns the closest command within [`MAX_COMMAND_TYPO_DISTANCE`], or
+/// `None` when nothing is close enough (→ the parser's flag error stands).
+pub(crate) fn suggest_command(flag: &str) -> Option<&'static str> {
+    COMMAND_TOKENS
+        .iter()
+        .map(|cmd| (*cmd, strsim::levenshtein(flag, cmd)))
+        .filter(|&(_, dist)| dist <= MAX_COMMAND_TYPO_DISTANCE)
+        .min_by_key(|&(_, dist)| dist)
+        .map(|(cmd, _)| cmd)
+}
+
 /// Dispatch a resolved [`Command`] to its handler. `args` is everything
 /// after the `--<command>` token.
 ///
@@ -136,6 +173,42 @@ mod tests {
                 Command::from_token(flag),
                 None,
                 "search flag `{flag}` must NOT be a management command"
+            );
+        }
+    }
+
+    #[test]
+    fn command_tokens_all_resolve() {
+        // The suggestion set must stay in lock-step with the dispatcher:
+        // every COMMAND_TOKENS entry (incl. the `--aggregate` alias) must
+        // resolve via `from_token`, so a typo can never suggest a token the
+        // grammar would not actually accept.
+        for token in super::COMMAND_TOKENS {
+            assert!(
+                Command::from_token(token).is_some(),
+                "`{token}` is in COMMAND_TOKENS but is not a dispatchable command"
+            );
+        }
+    }
+
+    #[test]
+    fn suggest_command_maps_near_misses() {
+        // One- or two-character slips map to their command.
+        assert_eq!(super::suggest_command("--updat"), Some("--update"));
+        assert_eq!(super::suggest_command("--daemo"), Some("--daemon"));
+        assert_eq!(super::suggest_command("--mc"), Some("--mcp"));
+        assert_eq!(super::suggest_command("--searc"), Some("--search"));
+    }
+
+    #[test]
+    fn suggest_command_ignores_unrelated_or_valid_flags() {
+        // An unrelated unknown flag has no close command → no (wrong) hint;
+        // and a real search flag must not be mistaken for a command typo.
+        for token in ["--bogus", "--ext", "--sort", "--newer-created", "--xyz"] {
+            assert_eq!(
+                super::suggest_command(token),
+                None,
+                "`{token}` must not be suggested as a command typo"
             );
         }
     }

--- a/crates/uffs-cli/src/dispatch.rs
+++ b/crates/uffs-cli/src/dispatch.rs
@@ -153,10 +153,15 @@ mod tests {
     }
 
     #[test]
-    fn search_flags_are_never_commands() {
-        // The disjointness invariant: a search flag as the FIRST token stays
-        // in search mode (e.g. `uffs --ext pdf` is a pattern-less search), so
-        // it must never resolve to a command.
+    fn flag_only_names_are_never_commands() {
+        // Position invariant (cli-grammar.md §3.2): a *flag-only* name as the
+        // FIRST token stays in search mode (e.g. `uffs --ext pdf` is a
+        // pattern-less search), so it must never resolve to a command.
+        //
+        // NOTE: `--stats` and `--agg` are deliberately ABSENT here — they are
+        // the two dual-use names (command as first token, search modifier
+        // later), pinned by `dual_use_names_are_commands_as_first_token`.
+        // Do not add them to this list.
         for flag in [
             "--ext",
             "--sort",
@@ -175,6 +180,16 @@ mod tests {
                 "search flag `{flag}` must NOT be a management command"
             );
         }
+    }
+
+    #[test]
+    fn dual_use_names_are_commands_as_first_token() {
+        // `--stats` / `--agg` are BOTH commands (first token) and inline search
+        // modifiers (after a pattern). The grammar resolves this by position:
+        // as the first token they are their command. Pin that here so the
+        // dual-use contract (cli-grammar.md §3.2) can't silently regress.
+        assert_eq!(Command::from_token("--stats"), Some(Command::Stats));
+        assert_eq!(Command::from_token("--agg"), Some(Command::Agg));
     }
 
     #[test]

--- a/crates/uffs-cli/src/dispatch.rs
+++ b/crates/uffs-cli/src/dispatch.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! First-token command dispatch for `uffs` (design:
+//! `docs/architecture/cli-grammar.md`).
+//!
+//! UFFS is **search-first**: `uffs <anything>` searches for `<anything>`.
+//! The first token decides the mode — a known `--command` runs that command;
+//! anything else (bare word, glob, single dash, or a search flag) is a
+//! search. The command set is deliberately **disjoint** from every
+//! search-flag long name, so `uffs --ext pdf` is a (pattern-less) search
+//! while `uffs --update` is the updater.
+
+use anyhow::Result;
+
+use crate::commands;
+
+/// A management command — the ONLY first tokens that switch `uffs` out of
+/// search mode. Every variant's token is `--<command>` and is disjoint from
+/// every search-flag long name (`--sort`, `--ext`, `--drive`, …).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Command {
+    /// Explicit search (the bare positional default also routes here).
+    Search,
+    /// `--stats [path]`.
+    Stats,
+    /// `--agg <preset>`.
+    Agg,
+    /// `--daemon <action>`.
+    Daemon,
+    /// `--mcp <action>`.
+    Mcp,
+    /// `--update [action]`.
+    Update,
+    /// `--status`.
+    Status,
+}
+
+impl Command {
+    /// Map a first token to its [`Command`], or `None` when it is not a
+    /// management command (→ the token is treated as a search pattern/flag).
+    pub(crate) fn from_token(token: &str) -> Option<Self> {
+        Some(match token {
+            "--search" => Self::Search,
+            "--stats" => Self::Stats,
+            "--agg" | "--aggregate" => Self::Agg,
+            "--daemon" => Self::Daemon,
+            "--mcp" => Self::Mcp,
+            "--update" => Self::Update,
+            "--status" => Self::Status,
+            _ => return None,
+        })
+    }
+}
+
+/// Dispatch a resolved [`Command`] to its handler. `args` is everything
+/// after the `--<command>` token.
+///
+/// # Errors
+///
+/// Propagates the underlying command's failure.
+pub(crate) fn dispatch_command(command: Command, args: &[String]) -> Result<()> {
+    match command {
+        Command::Search => crate::run_search(args),
+        Command::Stats => crate::run_stats(args),
+        Command::Agg => crate::run_aggregate(args),
+        Command::Daemon => crate::run_daemon(args),
+        Command::Mcp => commands::mcp_mgmt::mcp_from_args(args),
+        Command::Update => commands::update::run_update(args),
+        Command::Status => {
+            run_status(args);
+            Ok(())
+        }
+    }
+}
+
+/// `--status` — combined daemon + broker + MCP status (never fails).
+fn run_status(args: &[String]) {
+    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+        crate::args::print_status_help();
+    } else {
+        commands::system_status::system_status();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Command;
+
+    #[test]
+    fn command_tokens_resolve() {
+        assert_eq!(Command::from_token("--update"), Some(Command::Update));
+        assert_eq!(Command::from_token("--daemon"), Some(Command::Daemon));
+        assert_eq!(Command::from_token("--mcp"), Some(Command::Mcp));
+        assert_eq!(Command::from_token("--stats"), Some(Command::Stats));
+        assert_eq!(Command::from_token("--agg"), Some(Command::Agg));
+        assert_eq!(Command::from_token("--aggregate"), Some(Command::Agg));
+        assert_eq!(Command::from_token("--status"), Some(Command::Status));
+        assert_eq!(Command::from_token("--search"), Some(Command::Search));
+    }
+
+    #[test]
+    fn bare_and_single_dash_tokens_are_patterns_not_commands() {
+        // The whole point of the grammar: the old reserved words are
+        // searchable again, and single-dash tokens stay patterns.
+        for pattern in [
+            "update", "status", "daemon", "mcp", "stats", "agg", "report", "help", "version",
+            "-update", "*.pdf", "-x",
+        ] {
+            assert_eq!(
+                Command::from_token(pattern),
+                None,
+                "`{pattern}` must be a search pattern, not a command"
+            );
+        }
+    }
+
+    #[test]
+    fn search_flags_are_never_commands() {
+        // The disjointness invariant: a search flag as the FIRST token stays
+        // in search mode (e.g. `uffs --ext pdf` is a pattern-less search), so
+        // it must never resolve to a command.
+        for flag in [
+            "--ext",
+            "--sort",
+            "--drive",
+            "--limit",
+            "--format",
+            "--tz-offset",
+            "--out",
+            "--no-output",
+            "--profile",
+            "--agg-format",
+        ] {
+            assert_eq!(
+                Command::from_token(flag),
+                None,
+                "search flag `{flag}` must NOT be a management command"
+            );
+        }
+    }
+}

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -265,6 +265,25 @@ pub(crate) fn run_search(args: &[String]) -> Result<()> {
         return Ok(());
     }
 
+    // Command-typo hint. If the first token is a `--`-flag that the shared
+    // parser rejects AND it is a near-miss of a management command, surface a
+    // "did you mean" hint up front instead of spinning up the daemon only for
+    // it to return a bare unknown-flag error. The CLI suggests over ITS own
+    // command set; flag validation stays in `uffs_client::from_cli_args`, so
+    // the daemon never learns CLI commands (design: cli-grammar.md §6).
+    if let Some(first) = args.first()
+        && first.starts_with("--")
+        && dispatch::Command::from_token(first).is_none()
+        && let Err(uffs_client::protocol::cli_args::Error::UnknownFlag { flag }) =
+            uffs_client::protocol::SearchParams::from_cli_args(args)
+        && let Some(command) = dispatch::suggest_command(&flag)
+    {
+        anyhow::bail!(
+            "`{flag}` is not a known search flag.\n\
+             Did you mean the command `uffs {command}`?  (run `uffs {command} --help`)"
+        );
+    }
+
     // Extract daemon-spawn args (--data-dir, --mft-file, --no-cache)
     // from the raw args so we can auto-start the daemon if needed.
     let spawn_args = commands::search::args::extract_spawn_args(args);

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -555,7 +555,7 @@ pub(crate) fn run_aggregate(args: &[String]) -> Result<()> {
     run_search(&synth_args)
 }
 
-/// Handle `uffs daemon <action> [flags...]`.
+/// Handle `uffs --daemon <action> [flags...]`.
 pub(crate) fn run_daemon(args: &[String]) -> Result<()> {
     if args.is_empty() || args.iter().any(|arg| arg == "--help" || arg == "-h") {
         args::print_daemon_help();

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -15,7 +15,7 @@
 //!
 //! | Feature | Default? | Enables | Adds deps | Binary-size impact | Semver |
 //! |---|:---:|---|---|---|---|
-//! | `mcp-http-probe` | **no** | Active probing of the MCP HTTP gateway's `/status` endpoint inside `uffs status` (see [`commands::system_status`]).  Without it, `uffs status` still reports the configured HTTP bind address but does not actively probe. | None on the crate graph.  Uses `std::net::TcpStream` (libstd) — but on Windows targets that drag in `ws2_32.dll`, adding ~50 ms to cold-start process launch. | Disabling drops the only `std::net` user from the CLI: `ws2_32.dll` is left unlinked.  This is **the** reason the feature is default-off — the CLI is the thin / fast-path binary. | Removing the probe behaviour or its observable output behind `mcp-http-probe` is breaking; adding richer probe output is not. |
+//! | `mcp-http-probe` | **no** | Active probing of the MCP HTTP gateway's `/status` endpoint inside `uffs --status` (see [`commands::system_status`]).  Without it, `uffs --status` still reports the configured HTTP bind address but does not actively probe. | None on the crate graph.  Uses `std::net::TcpStream` (libstd) — but on Windows targets that drag in `ws2_32.dll`, adding ~50 ms to cold-start process launch. | Disabling drops the only `std::net` user from the CLI: `ws2_32.dll` is left unlinked.  This is **the** reason the feature is default-off — the CLI is the thin / fast-path binary. | Removing the probe behaviour or its observable output behind `mcp-http-probe` is breaking; adding richer probe output is not. |
 //!
 //! ## Why `mcp-http-probe` is default-off
 //!
@@ -39,7 +39,7 @@
 //! | `CARGO_PKG_VERSION` | `string` | (set by Cargo) | Read via `env!()` for `--version` output + log preludes.  CARGO semver class. |
 //! | `RUST_LOG` | `string` | `info` | `tracing-subscriber` filter directive; consulted as a fallback when `UFFS_LOG` is unset.  STANDARD semver class (tracing convention). |
 //! | `UFFS_LOG` | `string` | `info` | UFFS-specific log level override (preferred over `RUST_LOG` for UFFS binaries).  INTERNAL semver class. |
-//! | `UFFS_LOG_DIR` | `path` | platform default (`%LOCALAPPDATA%\UFFS\logs` / `$XDG_CACHE_HOME/uffs/logs`) | Log directory override for `uffs daemon start` and `uffs search`.  Mirrors the `--log-dir` CLI flag.  INTERNAL semver class. |
+//! | `UFFS_LOG_DIR` | `path` | platform default (`%LOCALAPPDATA%\UFFS\logs` / `$XDG_CACHE_HOME/uffs/logs`) | Log directory override for `uffs --daemon start` and `uffs --search`.  Mirrors the `--log-dir` CLI flag.  INTERNAL semver class. |
 //! | `UFFS_LOG_FILE` | `path` | (none — auto-generated under `UFFS_LOG_DIR`) | Log-file path override.  Mirrors the `--log-file` CLI flag.  INTERNAL semver class. |
 
 // CLI main module uses single-call functions by design
@@ -88,7 +88,7 @@ fn run() -> Result<()> {
 
     // The first token decides the mode: a known `--command` runs that
     // command; ANYTHING else (bare word, glob, single dash, or a search flag)
-    // is a search — so `uffs update` searches for "update".
+    // is a search — so `uffs --update` searches for "update".
     match dispatch::Command::from_token(first) {
         Some(command) => {
             dispatch::dispatch_command(command, raw_args.get(2..).unwrap_or_default())?;
@@ -477,7 +477,7 @@ fn write_search_payload_to_stdout(
     Ok(())
 }
 
-/// Handle `uffs stats [path] [--top N] [--data-dir ...] [--mft-file ...]`.
+/// Handle `uffs --stats [path] [--top N] [--data-dir ...] [--mft-file ...]`.
 pub(crate) fn run_stats(args: &[String]) -> Result<()> {
     if args.iter().any(|arg| arg == "--help" || arg == "-h") {
         args::print_stats_help();
@@ -539,7 +539,7 @@ pub(crate) fn run_stats(args: &[String]) -> Result<()> {
     Ok(())
 }
 
-/// Handle `uffs aggregate|agg <preset> [--format ...] [--data-dir ...]`.
+/// Handle `uffs --agg|agg <preset> [--format ...] [--data-dir ...]`.
 pub(crate) fn run_aggregate(args: &[String]) -> Result<()> {
     if args.iter().any(|arg| arg == "--help" || arg == "-h") {
         args::print_aggregate_help();
@@ -551,7 +551,7 @@ pub(crate) fn run_aggregate(args: &[String]) -> Result<()> {
         .find(|arg| !arg.starts_with('-'))
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "Usage: uffs aggregate <PRESET>\n\
+                "Usage: uffs --agg <PRESET>\n\
                  Available presets: overview, by_type, by_extension, by_drive, by_size, by_age, count"
             )
         })?;
@@ -564,7 +564,7 @@ pub(crate) fn run_aggregate(args: &[String]) -> Result<()> {
         "--limit".to_owned(),
         "0".to_owned(),
     ];
-    // Default to table format for `uffs agg` unless user specifies --format.
+    // Default to table format for `uffs --agg` unless user specifies --format.
     let has_format = args.iter().any(|arg| arg == "--format" || arg == "-f");
     if !has_format {
         synth_args.extend(["--format".to_owned(), "table".to_owned()]);
@@ -646,7 +646,7 @@ fn format_elevation_help(daemon_path: &str) -> String {
             then retry the command.\n\
          \n  \
          2. Explicitly request a UAC prompt for this invocation:\n       \
-               uffs daemon start --elevate\n     \
+               uffs --daemon start --elevate\n     \
             Or set it as the default for the current session:\n       \
                set UFFS_ELEVATE=1     (cmd)\n       \
                $env:UFFS_ELEVATE = '1'  (PowerShell)\n\

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -255,7 +255,12 @@ fn print_client_profile(prof: &ClientProfile<'_>) {
 
 /// Forward raw search args to the daemon via `search_cli` RPC.
 pub(crate) fn run_search(args: &[String]) -> Result<()> {
-    if args.is_empty() {
+    // No pattern, or an explicit help request as the first token
+    // (`uffs --search --help`) → the search-first top-level help.
+    if matches!(
+        args.first().map(String::as_str),
+        None | Some("--help" | "-h")
+    ) {
         args::print_help();
         return Ok(());
     }

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -54,19 +54,20 @@ use assert_cmd as _;
 
 pub mod args;
 pub mod commands;
+mod dispatch;
 
 /// Run the CLI and return a result.
 fn run() -> Result<()> {
     let raw_args: Vec<String> = std::env::args().collect();
-    let tokens: Vec<&str> = raw_args.iter().skip(1).map(String::as_str).collect();
 
-    // Fast paths: help / version / no args.
-    match tokens.first().copied() {
-        None | Some("--help" | "-h" | "help") => {
+    // Global fast paths — ONLY the `--`/`-` forms (bare `help` / `version`
+    // are now ordinary search patterns, not commands).
+    match raw_args.get(1).map(String::as_str) {
+        None | Some("--help" | "-h") => {
             args::print_help();
             return Ok(());
         }
-        Some("--version" | "-V" | "version") => {
+        Some("--version" | "-V") => {
             args::print_version();
             return Ok(());
         }
@@ -77,24 +78,23 @@ fn run() -> Result<()> {
     // roll it back in the background. Costs one `stat` in steady state.
     commands::update::maybe_self_heal();
 
-    // Detect subcommand as first non-flag token.
-    let first = tokens.first().copied().unwrap_or("");
-    let subcmd_args = raw_args.get(2..).unwrap_or_default();
-    match first {
-        "stats" => run_stats(subcmd_args)?,
-        "aggregate" | "agg" => run_aggregate(subcmd_args)?,
-        "daemon" => run_daemon(subcmd_args)?,
-        "mcp" => commands::mcp_mgmt::mcp_from_args(subcmd_args)?,
-        "update" => commands::update::run_update(subcmd_args)?,
-        "status" => {
-            if subcmd_args.iter().any(|arg| arg == "--help" || arg == "-h") {
-                args::print_status_help();
-            } else {
-                commands::system_status::system_status();
-            }
+    let first = raw_args.get(1).map_or("", String::as_str);
+
+    // Bare `--` separator → force a search of everything after it (the escape
+    // hatch for a pattern that literally begins with `--`).
+    if first == "--" {
+        return run_search(raw_args.get(2..).unwrap_or_default());
+    }
+
+    // The first token decides the mode: a known `--command` runs that
+    // command; ANYTHING else (bare word, glob, single dash, or a search flag)
+    // is a search — so `uffs update` searches for "update".
+    match dispatch::Command::from_token(first) {
+        Some(command) => {
+            dispatch::dispatch_command(command, raw_args.get(2..).unwrap_or_default())?;
         }
-        _ => {
-            // Default: search — forward ALL args after "uffs" to daemon.
+        None => {
+            // Default: search — forward ALL args after `uffs` to the daemon.
             run_search(raw_args.get(1..).unwrap_or_default())?;
         }
     }
@@ -254,7 +254,7 @@ fn print_client_profile(prof: &ClientProfile<'_>) {
 }
 
 /// Forward raw search args to the daemon via `search_cli` RPC.
-fn run_search(args: &[String]) -> Result<()> {
+pub(crate) fn run_search(args: &[String]) -> Result<()> {
     if args.is_empty() {
         args::print_help();
         return Ok(());
@@ -454,7 +454,7 @@ fn write_search_payload_to_stdout(
 }
 
 /// Handle `uffs stats [path] [--top N] [--data-dir ...] [--mft-file ...]`.
-fn run_stats(args: &[String]) -> Result<()> {
+pub(crate) fn run_stats(args: &[String]) -> Result<()> {
     if args.iter().any(|arg| arg == "--help" || arg == "-h") {
         args::print_stats_help();
         return Ok(());
@@ -516,7 +516,7 @@ fn run_stats(args: &[String]) -> Result<()> {
 }
 
 /// Handle `uffs aggregate|agg <preset> [--format ...] [--data-dir ...]`.
-fn run_aggregate(args: &[String]) -> Result<()> {
+pub(crate) fn run_aggregate(args: &[String]) -> Result<()> {
     if args.iter().any(|arg| arg == "--help" || arg == "-h") {
         args::print_aggregate_help();
         return Ok(());
@@ -556,7 +556,7 @@ fn run_aggregate(args: &[String]) -> Result<()> {
 }
 
 /// Handle `uffs daemon <action> [flags...]`.
-fn run_daemon(args: &[String]) -> Result<()> {
+pub(crate) fn run_daemon(args: &[String]) -> Result<()> {
     if args.is_empty() || args.iter().any(|arg| arg == "--help" || arg == "-h") {
         args::print_daemon_help();
         return Ok(());

--- a/crates/uffs-cli/tests/cli_integration.rs
+++ b/crates/uffs-cli/tests/cli_integration.rs
@@ -96,6 +96,35 @@ mod tests {
         ]);
     }
 
+    // ── The two reserved single-dash exceptions (`-h` / `-V`) ────────
+    //
+    // Per docs/architecture/cli-grammar.md §3.4, `-h` and `-V` are the
+    // ONLY single-dash tokens that are not search patterns. Pin both that
+    // they work AND that no other single-dash token is treated as help.
+
+    #[test]
+    fn short_help_flag_prints_help() {
+        assert_success("short_help", &["-h"], &[
+            "uffs - Ultra Fast File Search",
+            "USAGE:",
+        ]);
+    }
+
+    #[test]
+    fn short_version_flag_prints_binary_version() {
+        assert_success("short_version", &["-V"], &[
+            "uffs",
+            env!("CARGO_PKG_VERSION"),
+        ]);
+    }
+
+    #[test]
+    fn other_single_dash_token_is_a_pattern_not_help() {
+        // `-x` must NOT print help/version — it is a search pattern, so with
+        // no daemon it fails trying to connect (it never exits 0 with help).
+        assert_failure("single_dash_pattern", &["-x"], &["daemon"]);
+    }
+
     // ── Validation tests ────────────────────────────────────────────
     //
     // With the thin-client approach, search-flag validation happens on

--- a/crates/uffs-cli/tests/cli_integration.rs
+++ b/crates/uffs-cli/tests/cli_integration.rs
@@ -125,6 +125,38 @@ mod tests {
         assert_failure("single_dash_pattern", &["-x"], &["daemon"]);
     }
 
+    // ── Command-typo hint (cli-grammar.md §6) ────────────────────────
+    //
+    // A `--`-flag the shared parser rejects that is a near-miss of a
+    // management command surfaces a "did you mean" hint up front — without
+    // the daemon (the CLI suggests over its own command set). Deterministic.
+
+    #[test]
+    fn flag_typo_near_a_command_suggests_it() {
+        assert_failure("flag_typo_command", &["--updat"], &[
+            "not a known search flag",
+            "Did you mean the command",
+            "uffs --update",
+        ]);
+    }
+
+    #[test]
+    fn unrelated_unknown_flag_gets_no_command_hint() {
+        // `--bogus` is not near any command, so it must NOT get a command
+        // hint — it falls through to search (here: a daemon-connect error,
+        // since there is no daemon in the test environment).
+        let output = run_cli("unrelated_unknown_flag", &["--bogus"]);
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !combined.contains("Did you mean the command"),
+            "`--bogus` must not produce a command suggestion: {combined}"
+        );
+    }
+
     // ── `--update` action surface (cli-grammar.md §5) ────────────────
     //
     // Pin the full action set — incl. `recover` — so it can't silently

--- a/crates/uffs-cli/tests/cli_integration.rs
+++ b/crates/uffs-cli/tests/cli_integration.rs
@@ -107,7 +107,7 @@ mod tests {
     fn stats_rejects_non_numeric_top() {
         assert_failure(
             "stats_invalid_top",
-            &["stats", "saved.parquet", "--top", "abc"],
+            &["--stats", "saved.parquet", "--top", "abc"],
             &["Bad --top"],
         );
     }

--- a/crates/uffs-cli/tests/cli_integration.rs
+++ b/crates/uffs-cli/tests/cli_integration.rs
@@ -125,6 +125,28 @@ mod tests {
         assert_failure("single_dash_pattern", &["-x"], &["daemon"]);
     }
 
+    // ── `--update` action surface (cli-grammar.md §5) ────────────────
+    //
+    // Pin the full action set — incl. `recover` — so it can't silently
+    // drift from the design doc. Deterministic: no filesystem/network.
+
+    #[test]
+    fn update_help_lists_every_action_including_recover() {
+        assert_success("update_help", &["--update", "--help"], &[
+            "snapshot", "acquire", "apply", "doctor", "recover",
+        ]);
+    }
+
+    #[test]
+    fn update_rejects_unknown_action_and_lists_recover() {
+        // An unknown action errors with the accepted set, which must now
+        // include `recover` (the foreground self-heal action).
+        assert_failure("update_bogus_action", &["--update", "bogus"], &[
+            "unknown `--update` action",
+            "recover",
+        ]);
+    }
+
     // ── Validation tests ────────────────────────────────────────────
     //
     // With the thin-client approach, search-flag validation happens on

--- a/crates/uffs-cli/tests/cli_integration.rs
+++ b/crates/uffs-cli/tests/cli_integration.rs
@@ -81,8 +81,10 @@ mod tests {
     #[test]
     fn help_flag_prints_examples() {
         assert_success("help_flag", &["--help"], &[
-            "Search is the default action",
+            // Search-first grammar note + an example + a `--command`.
+            "Search-first",
             "uffs '*.txt'",
+            "--update",
         ]);
     }
 

--- a/crates/uffs-client/README.md
+++ b/crates/uffs-client/README.md
@@ -95,7 +95,7 @@ CLI is invoked from a shell loop).
 ### Daemon lifecycle (`daemon_ctl`)
 
 Spawn / shutdown / status helpers for higher-level orchestration
-(used by the CLI's `uffs daemon start | stop | status` subcommands):
+(used by the CLI's `uffs --daemon start | stop | status` subcommands):
 
 ```rust,no_run
 use uffs_client::daemon_ctl;

--- a/crates/uffs-client/src/connect.rs
+++ b/crates/uffs-client/src/connect.rs
@@ -181,7 +181,7 @@ impl UffsClient {
     /// request a UAC prompt on Windows when the current process is not
     /// elevated.
     ///
-    /// This is the opt-in variant used by `uffs daemon start --elevate`.
+    /// This is the opt-in variant used by `uffs --daemon start --elevate`.
     /// All other entry points default to
     /// `ElevationPolicy::RequireExistingElevation`.
     ///
@@ -694,7 +694,7 @@ impl UffsClient {
                     "Deep health check failed: the daemon accepted the connection but did \
                      not respond correctly to a probe `status` RPC ({probe_err}). The \
                      daemon may be wedged (deadlocked worker, stuck kernel I/O); consider \
-                     `uffs daemon kill` and restart.  Set UFFS_CLIENT_SKIP_HEALTH_CHECK=1 \
+                     `uffs --daemon kill` and restart.  Set UFFS_CLIENT_SKIP_HEALTH_CHECK=1 \
                      to bypass this probe."
                 )))
             }

--- a/crates/uffs-client/src/connect_sync.rs
+++ b/crates/uffs-client/src/connect_sync.rs
@@ -176,7 +176,7 @@ impl UffsClientSync {
     /// Connect to a running daemon; if we must auto-start, request a
     /// UAC prompt on Windows when the current process is not elevated.
     ///
-    /// Used by `uffs daemon start --elevate`.  All other entry points
+    /// Used by `uffs --daemon start --elevate`.  All other entry points
     /// default to `ElevationPolicy::RequireExistingElevation`.
     ///
     /// # Errors
@@ -234,7 +234,7 @@ impl UffsClientSync {
                 return Err(ClientError::ConnectionFailed(
                     "No daemon is running and no data source was provided.\n\
                      On macOS/Linux, start the daemon first:\n\n  \
-                     uffs daemon start --data-dir ~/uffs_data\n\n\
+                     uffs --daemon start --data-dir ~/uffs_data\n\n\
                      Or pass --data-dir inline:\n\n  \
                      uffs \"notepad.exe\" --data-dir ~/uffs_data"
                         .to_owned(),
@@ -668,7 +668,7 @@ impl UffsClientSync {
                     "Deep health check failed: the daemon accepted the connection but did \
                      not respond correctly to a probe `status` RPC ({probe_err}). The \
                      daemon may be wedged (deadlocked worker, stuck kernel I/O); consider \
-                     `uffs daemon kill` and restart.  Set UFFS_CLIENT_SKIP_HEALTH_CHECK=1 \
+                     `uffs --daemon kill` and restart.  Set UFFS_CLIENT_SKIP_HEALTH_CHECK=1 \
                      to bypass this probe."
                 )))
             }

--- a/crates/uffs-client/src/connect_sync_tests.rs
+++ b/crates/uffs-client/src/connect_sync_tests.rs
@@ -135,7 +135,7 @@ fn deep_health_check_happy_path() {
 /// envelope comes back) but the response carries an `error` object.
 /// `deep_health_check` must wrap that into a
 /// [`ClientError::ConnectionFailed`] whose message includes the
-/// remediation guidance (`uffs daemon kill`, skip-env hint) so the
+/// remediation guidance (`uffs --daemon kill`, skip-env hint) so the
 /// user has an actionable next step.
 #[test]
 fn deep_health_check_maps_daemon_error_to_connection_failed() {
@@ -154,7 +154,7 @@ fn deep_health_check_maps_daemon_error_to_connection_failed() {
         "error must identify itself as a health-check failure: {msg}",
     );
     assert!(
-        msg.contains("uffs daemon kill"),
+        msg.contains("uffs --daemon kill"),
         "error must include the remediation command: {msg}",
     );
     assert!(

--- a/crates/uffs-client/src/connect_tests.rs
+++ b/crates/uffs-client/src/connect_tests.rs
@@ -192,7 +192,7 @@ async fn deep_health_check_happy_path() {
 /// envelope comes back) but the response carries an `error` object.
 /// `deep_health_check` must wrap that into a
 /// [`ClientError::ConnectionFailed`] whose message includes the
-/// remediation guidance (`uffs daemon kill`, skip-env hint) so the
+/// remediation guidance (`uffs --daemon kill`, skip-env hint) so the
 /// user has an actionable next step.
 #[tokio::test]
 async fn deep_health_check_maps_daemon_error_to_connection_failed() {
@@ -212,7 +212,7 @@ async fn deep_health_check_maps_daemon_error_to_connection_failed() {
         "error must identify itself as a health-check failure: {msg}",
     );
     assert!(
-        msg.contains("uffs daemon kill"),
+        msg.contains("uffs --daemon kill"),
         "error must include the remediation command: {msg}",
     );
     assert!(

--- a/crates/uffs-client/src/daemon_spawn.rs
+++ b/crates/uffs-client/src/daemon_spawn.rs
@@ -27,7 +27,7 @@ use crate::daemon_child::DaemonChildHandle;
 /// the spawn succeeds only if the current process is already elevated;
 /// otherwise it returns [`crate::error::ClientError::DaemonNeedsElevation`] and
 /// the CLI renders an actionable message.  Callers that actually want the
-/// UAC dialog (e.g. `uffs daemon start --elevate`) must opt in with
+/// UAC dialog (e.g. `uffs --daemon start --elevate`) must opt in with
 /// [`ElevationPolicy::AllowUacPrompt`].
 ///
 /// Has no effect on Unix — Unix spawn never triggers UAC.
@@ -45,7 +45,7 @@ pub(crate) enum ElevationPolicy {
     /// When not elevated, request a UAC prompt via `ShellExecuteW`
     /// with the `"runas"` verb.  Preserves the pre-v0.5.36 behavior.
     ///
-    /// Used by `uffs daemon start --elevate` and by auto-spawn paths
+    /// Used by `uffs --daemon start --elevate` and by auto-spawn paths
     /// when the environment variable `UFFS_ELEVATE=1` is set.
     AllowUacPrompt,
 }
@@ -54,7 +54,7 @@ pub(crate) enum ElevationPolicy {
 ///
 /// Rules, in priority order:
 ///
-/// 1. If `force_allow` is `true` (e.g. `uffs daemon start --elevate`), return
+/// 1. If `force_allow` is `true` (e.g. `uffs --daemon start --elevate`), return
 ///    [`ElevationPolicy::AllowUacPrompt`].
 /// 2. Otherwise, if `env_value` contains a truthy token (`1`, `true`, `yes`,
 ///    `on`, case-insensitive — leading/trailing whitespace is trimmed), return
@@ -269,9 +269,9 @@ fn spawn_via_uac_prompt(
 ///
 /// * An **empty** argument must become `""` — otherwise it collapses into the
 ///   separating space and disappears from the child's argv.  This is exactly
-///   what caused the silent `uffs daemon start` failure (`LOG/Output`): the CLI
-///   pushed `["--log-level", ""]` and the child saw only `--log-level`, then
-///   consumed the *next* flag as its value.
+///   what caused the silent `uffs --daemon start` failure (`LOG/Output`): the
+///   CLI pushed `["--log-level", ""]` and the child saw only `--log-level`,
+///   then consumed the *next* flag as its value.
 /// * If the arg contains no whitespace, double-quote, or control chars, emit it
 ///   verbatim — cheap and readable.
 /// * Otherwise wrap in `"..."` and, inside the quotes, double every run of

--- a/crates/uffs-client/src/mcp_pid.rs
+++ b/crates/uffs-client/src/mcp_pid.rs
@@ -91,7 +91,7 @@ pub fn remove_mcp_pid_file() {
 ///
 /// All fields are `pub` because this is a **parsed-data DTO** returned
 /// by [`parse_mcp_pid_file_full`] — callers read fields directly to
-/// render `uffs mcp status` output and to decide whether the running
+/// render `uffs --mcp status` output and to decide whether the running
 /// MCP server matches the requested transport / data sources.  No
 /// invariants are protected (the parse function is the validator).
 ///

--- a/crates/uffs-client/src/protocol/response_status.rs
+++ b/crates/uffs-client/src/protocol/response_status.rs
@@ -89,7 +89,7 @@ pub struct StatusResponse {
     pub pid: u32,
     /// Compile-time version of the daemon binary (`env!("CARGO_PKG_VERSION")`).
     ///
-    /// Surfaced to the CLI so `uffs daemon status` / `uffs status` can
+    /// Surfaced to the CLI so `uffs --daemon status` / `uffs --status` can
     /// flag a daemon-vs-CLI version mismatch when the user has an old
     /// long-running daemon and an upgraded CLI binary (or vice versa).
     /// Defaults to `""` for back-compat with pre-0.5.79 daemons that

--- a/crates/uffs-core/src/compact_cache.rs
+++ b/crates/uffs-core/src/compact_cache.rs
@@ -176,7 +176,7 @@ pub fn compact_cache_path(drive_letter: uffs_mft::platform::DriveLetter) -> Path
 /// The cursor file lives alongside the compact cache (`<letter>_compact.uffs`)
 /// in the same `cache_dir()` so a single owner-only directory holds
 /// every per-drive cache artifact, making backup / cleanup
-/// (`uffs daemon forget <drive>`) a single-directory operation.
+/// (`uffs --daemon forget <drive>`) a single-directory operation.
 ///
 /// Storage format: 8 bytes little-endian `u64`.  See
 /// `crate::cache::cursor_store::DiskCursorStore` (in `uffs-daemon`)

--- a/crates/uffs-core/src/search/field/field_tests.rs
+++ b/crates/uffs-core/src/search/field/field_tests.rs
@@ -383,8 +383,8 @@ fn aggregate_non_aggregatable_fields() {
 // client, and these tests pin that the two enums never drift.
 //
 // If they ever do drift, the symptom is a cross-crate output-format
-// divergence: "uffs search > foo.csv" (CLI / SearchRow) and "uffs
-// search --out=foo.csv" (daemon / DisplayRow) would disagree on a
+// divergence: "uffs '*' > foo.csv" (CLI / SearchRow) and "uffs
+// --out=foo.csv" (daemon / DisplayRow) would disagree on a
 // header label or misfile the column.  The byte-parity tests in
 // `uffs-core::output::tests::format_parity_*` would surface the
 // symptom, but this drift guard surfaces the root cause earlier

--- a/crates/uffs-daemon/src/cache/policy.rs
+++ b/crates/uffs-daemon/src/cache/policy.rs
@@ -31,7 +31,7 @@
 //! UFFS_HOT_TO_WARM_IDLE_SECS=60      \
 //! UFFS_WARM_TO_PARKED_IDLE_SECS=360  \
 //! UFFS_PARKED_TO_COLD_IDLE_SECS=900  \
-//!     uffs daemon start --drive C,D,E,F,G,M,S
+//!     uffs --daemon start --drive C,D,E,F,G,M,S
 //! ```
 //!
 //! ## Adaptive layer (Phase 6)

--- a/crates/uffs-daemon/src/cache/shard/drive_stats.rs
+++ b/crates/uffs-daemon/src/cache/shard/drive_stats.rs
@@ -109,7 +109,7 @@ pub(crate) struct DriveStats {
     /// Bumped from
     /// [`crate::cache::registry::ShardRegistry::promote_letter_to_hot`]
     /// only when the pre-promote tier was `Cold` — i.e. the operator
-    /// ran `uffs daemon preload <drive>` against a fully-evicted
+    /// ran `uffs --daemon preload <drive>` against a fully-evicted
     /// drive and the daemon had to re-decrypt the encrypted compact
     /// cache from disk.  Already-Warm preload calls (where the body
     /// is in RAM and only the tier marker flips Warm → Hot) do

--- a/crates/uffs-daemon/src/config.rs
+++ b/crates/uffs-daemon/src/config.rs
@@ -398,7 +398,7 @@ impl Config {
     /// Serialize back to TOML.
     ///
     /// Used by the round-trip test (task 6.5) and by future
-    /// `uffs daemon config dump` commands.  Pretty-prints with
+    /// `uffs --daemon config dump` commands.  Pretty-prints with
     /// section headers so a human can compare two configs visually.
     #[cfg_attr(
         not(test),

--- a/crates/uffs-daemon/src/index/mod.rs
+++ b/crates/uffs-daemon/src/index/mod.rs
@@ -358,10 +358,10 @@ impl IndexManager {
     /// every time [`Self::tune_concurrency`] runs, so the daemon can
     /// be re-tuned at runtime by setting the env var and invoking an
     /// operation that re-tunes (e.g. a refresh).  Typical use is to
-    /// set it before `uffs daemon start` for benchmark sweeps:
+    /// set it before `uffs --daemon start` for benchmark sweeps:
     ///
     /// ```text
-    /// UFFS_SEARCH_MAX_CONCURRENCY=12 uffs daemon start
+    /// UFFS_SEARCH_MAX_CONCURRENCY=12 uffs --daemon start
     /// ```
     const SEARCH_CONCURRENCY_ENV: &'static str = "UFFS_SEARCH_MAX_CONCURRENCY";
 

--- a/crates/uffs-daemon/src/index/tests/aggregate.rs
+++ b/crates/uffs-daemon/src/index/tests/aggregate.rs
@@ -270,11 +270,11 @@ fn multiple_specs_return_multiple_results() {
     assert_eq!(results[2].kind, "buckets");
 }
 
-// ── S1H.2: uffs stats daemon-path parity ─────────────────────────
+// ── S1H.2: uffs --stats daemon-path parity ─────────────────────────
 
 #[test]
 fn stats_overview_preset_wire_roundtrip() {
-    // Simulate the exact wire spec that `uffs stats` (no path)
+    // Simulate the exact wire spec that `uffs --stats` (no path)
     // sends to the daemon, and verify it produces correct results.
     let index = test_index();
     let specs = [AggregateSpecWire {

--- a/crates/uffs-daemon/src/index/tests/registry.rs
+++ b/crates/uffs-daemon/src/index/tests/registry.rs
@@ -410,7 +410,7 @@ fn promote_letter_already_warm_returns_none() {
 
 /// `promote_letter_to_hot` from a `Cold` source bumps the per-shard
 /// `promotions_total` counter by 1 — the canonical
-/// `uffs daemon preload <drive>`-against-evicted-drive path that
+/// `uffs --daemon preload <drive>`-against-evicted-drive path that
 /// Phase 9 wires through.
 #[test]
 fn promote_letter_to_hot_bumps_promotions_total_when_source_is_cold() {

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! This crate exposes [`run_daemon`] so the daemon logic can be invoked
 //! both from the standalone `uffs-daemon` binary and from the embedded
-//! `uffs daemon run` subcommand in the CLI.
+//! `uffs --daemon run` subcommand in the CLI.
 //!
 //! Setup helpers + shutdown coordination live in sibling modules
 //! ([`log_init`], `startup`, `shutdown` — the latter two are
@@ -150,7 +150,7 @@ pub struct DaemonConfig {
 /// Run the UFFS daemon with the given configuration.
 ///
 /// This is the main entry point shared by both the standalone
-/// `uffs-daemon` binary and the embedded `uffs daemon run` subcommand.
+/// `uffs-daemon` binary and the embedded `uffs --daemon run` subcommand.
 ///
 /// **Does not return** until the daemon shuts down (idle timeout,
 /// RPC shutdown, or signal).

--- a/crates/uffs-daemon/src/log_init.rs
+++ b/crates/uffs-daemon/src/log_init.rs
@@ -108,7 +108,7 @@ pub fn init_tracing(
         );
         let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
         // `try_init` — a subscriber may already exist when invoked via
-        // the embedded `uffs daemon run` path.
+        // the embedded `uffs --daemon run` path.
         let _ignore = tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_target(false)

--- a/crates/uffs-daemon/src/main.rs
+++ b/crates/uffs-daemon/src/main.rs
@@ -4,7 +4,7 @@
 //! UFFS Daemon binary — thin wrapper around [`uffs_daemon::run_daemon`].
 //!
 //! The actual daemon logic lives in the `uffs-daemon` library crate so it
-//! can also be invoked via `uffs daemon run` (single-binary deployment).
+//! can also be invoked via `uffs --daemon run` (single-binary deployment).
 //!
 //! # Usage
 //!

--- a/crates/uffs-format/Cargo.toml
+++ b/crates/uffs-format/Cargo.toml
@@ -3,8 +3,8 @@
 # ============================================================================
 # Layer 1 shared crate.  Holds the single canonical CSV output formatter
 # that both `uffs-core` (daemon-side `--out=file`) and `uffs-client` (CLI
-# stdout path) delegate to, so `uffs search --out=file foo.csv` and
-# `uffs search > foo.csv` produce **byte-identical output**.
+# stdout path) delegate to, so `uffs '*' --out=file foo.csv` and
+# `uffs '*' > foo.csv` produce **byte-identical output**.
 #
 # Before v0.5.62 the daemon had its own `DisplayRow` formatter in
 # `uffs_core::output::display_rows` and the CLI had a duplicate

--- a/crates/uffs-format/src/lib.rs
+++ b/crates/uffs-format/src/lib.rs
@@ -35,7 +35,7 @@
 //! `uffs_format::tests::*` and by cross-crate byte-parity tests under
 //! `uffs-client::output::tests::*` / `uffs-core::output::tests::*`.
 //! Changing the canonical output is a breaking change for any pipeline
-//! that consumes `uffs search` output — bump the version and call it
+//! that consumes `uffs --search` output — bump the version and call it
 //! out in the CHANGELOG.
 
 #![forbid(unsafe_code)]

--- a/crates/uffs-mcp/src/bin/http_gateway.rs
+++ b/crates/uffs-mcp/src/bin/http_gateway.rs
@@ -37,7 +37,7 @@ struct Args {
     bind: SocketAddr,
     /// Optional bearer token for authenticating MCP requests.
     auth_token: Option<String>,
-    /// Extra args forwarded to `uffs daemon run` on auto-start.
+    /// Extra args forwarded to `uffs --daemon run` on auto-start.
     #[expect(
         clippy::struct_field_names,
         reason = "clarity: distinguishes from other arg types"

--- a/crates/uffs-mcp/src/handler/mod.rs
+++ b/crates/uffs-mcp/src/handler/mod.rs
@@ -66,7 +66,7 @@ enum ClientSlot {
     /// Active mode — `spawn_args` are forwarded to
     /// [`UffsClient::connect_with_args`] on every daemon-backed call.
     Active {
-        /// Args forwarded to `uffs daemon run` on auto-start.
+        /// Args forwarded to `uffs --daemon run` on auto-start.
         spawn_args: Vec<std::ffi::OsString>,
     },
     /// No daemon — metadata-only / testing.

--- a/crates/uffs-mcp/src/http.rs
+++ b/crates/uffs-mcp/src/http.rs
@@ -71,7 +71,7 @@ pub struct HttpGatewayConfig {
     pub bind_addr: core::net::SocketAddr,
     /// Optional bearer token for authenticating MCP requests.
     pub auth_token: Option<String>,
-    /// Extra CLI args forwarded to `uffs daemon run` on auto-start.
+    /// Extra CLI args forwarded to `uffs --daemon run` on auto-start.
     pub daemon_spawn_args: Vec<std::ffi::OsString>,
 }
 

--- a/crates/uffs-mcp/src/lib.rs
+++ b/crates/uffs-mcp/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //! UFFS ships the HTTP gateway as a first-class transport (the
 //! stdio-only path covers Claude Desktop / Cursor / Windsurf, but
-//! `uffs daemon http` and browser-side MCP clients need the streamable
+//! `uffs --daemon http` and browser-side MCP clients need the streamable
 //! HTTP server).  Downstream MCP integrations that only want the
 //! stdio transport can pass `default-features = false` to drop
 //! axum and tower-service from their binary; both transports share
@@ -224,7 +224,7 @@ use tracing::info;
 /// `McpConfigBuilder`.
 #[derive(Debug, Clone)]
 pub struct McpConfig {
-    /// Extra CLI args forwarded to `uffs daemon run` when auto-starting
+    /// Extra CLI args forwarded to `uffs --daemon run` when auto-starting
     /// (e.g. `["--data-dir", "/path"]`).
     pub daemon_spawn_args: Vec<std::ffi::OsString>,
     /// Idle timeout in seconds.  The MCP server will auto-exit if no

--- a/crates/uffs-mcp/src/main.rs
+++ b/crates/uffs-mcp/src/main.rs
@@ -6,7 +6,7 @@
 //! Handles all MCP lifecycle commands: `run`, `serve`, `start`, `stop`,
 //! `status`, `stats`, `kill`, `restart`, `reload`.
 //!
-//! The CLI (`uffs mcp <action>`) delegates to this binary so the thin
+//! The CLI (`uffs --mcp <action>`) delegates to this binary so the thin
 //! client stays small.
 //!
 //! # MCP Configuration

--- a/crates/uffs-mcp/src/process.rs
+++ b/crates/uffs-mcp/src/process.rs
@@ -480,7 +480,7 @@ fn parse_ps_etime(etime: &str) -> core::time::Duration {
     core::time::Duration::from_secs(total_secs)
 }
 
-/// Find PIDs of running `uffs mcp run` / `uffsmcp run` processes.
+/// Find PIDs of running `uffs --mcp run` / `uffsmcp run` processes.
 #[must_use]
 pub(crate) fn find_mcp_run_pids() -> Vec<u32> {
     let Ok(raw_output) = std::process::Command::new("ps")

--- a/crates/uffs-update/src/doctor.rs
+++ b/crates/uffs-update/src/doctor.rs
@@ -188,7 +188,7 @@ fn check_snapshot(opts: &DoctorOpts, report: &mut Report) -> Option<plan::Snapsh
         report.add(
             Health::Warn,
             "No snapshot — install/version/service checks skipped",
-            Some("run via `uffs update doctor` to include them".to_owned()),
+            Some("run via `uffs --update doctor` to include them".to_owned()),
         );
         return None;
     };

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -4,7 +4,7 @@
 //! `uffs-update` — the self-update **acquire** helper binary.
 //!
 //! A separate binary from `uffs` so the HTTP/TLS stack (reqwest + rustls)
-//! never bloats the lean CLI. `uffs update` spawns this for the
+//! never bloats the lean CLI. `uffs --update` spawns this for the
 //! download/verify step only; detect + snapshot stay in `uffs-cli`.
 //!
 //! ```text

--- a/crates/uffs-update/src/plan.rs
+++ b/crates/uffs-update/src/plan.rs
@@ -4,7 +4,7 @@
 //! Typed read of the Phase-B snapshot (design §13) — the input to apply,
 //! quiesce, and restore.
 //!
-//! The snapshot is written by `uffs update --snapshot` (in `uffs-cli`);
+//! The snapshot is written by `uffs --update --snapshot` (in `uffs-cli`);
 //! the apply helper reads it back here. Only the fields the mutating
 //! phases need are modelled; unknown fields are ignored so the schema can
 //! grow without breaking older helpers.

--- a/crates/uffs-update/src/quiesce.rs
+++ b/crates/uffs-update/src/quiesce.rs
@@ -7,8 +7,9 @@
 //!
 //! Robust by construction — **no fragile external tools, no `sc` text
 //! parsing**:
-//! - daemon / MCP: graceful via our **own** in-tree `uffs daemon stop` / `uffs
-//!   mcp stop`, then poll the daemon **PID file** (deleted on clean exit);
+//! - daemon / MCP: graceful via our **own** in-tree `uffs --daemon stop` /
+//!   `uffs --mcp stop`, then poll the daemon **PID file** (deleted on clean
+//!   exit);
 //! - broker: native SCM stop via `uffs-winsvc` (numeric, locale-proof state —
 //!   never `sc query` text, which is localized).
 
@@ -91,7 +92,7 @@ pub(crate) fn daemon_pid_file() -> PathBuf {
 /// Graceful daemon stop, then wait for the PID file to disappear.
 fn stop_daemon(running: &SnapRunning) -> Result<()> {
     let uffs = uffs_sibling(running);
-    let _ignore = Command::new(&uffs).args(["daemon", "stop"]).status();
+    let _ignore = Command::new(&uffs).args(["--daemon", "stop"]).status();
     if wait_until(STOP_TIMEOUT, || !daemon_pid_file().exists()) {
         Ok(())
     } else {
@@ -109,7 +110,7 @@ fn stop_broker() -> Result<()> {
 /// Best-effort MCP gateway stop (a client just reconnects later).
 fn stop_mcp(running: &SnapRunning) {
     let uffs = uffs_sibling(running);
-    let _ignore = Command::new(&uffs).args(["mcp", "stop"]).status();
+    let _ignore = Command::new(&uffs).args(["--mcp", "stop"]).status();
 }
 
 /// Poll `done` every [`POLL`] until it returns `true` or `timeout` elapses.

--- a/docs/architecture/cli-grammar.md
+++ b/docs/architecture/cli-grammar.md
@@ -105,6 +105,28 @@ It is mildly unconventional (most CLIs use `--` for *options*), but for a
 search-first tool it is coherent and learnable, and it is the price of keeping
 `uffs <anything>` literally mean "search for anything".
 
+### 3.4 The two reserved single-dash exceptions: `-h` and `-V`
+
+There are **exactly two** single-dash tokens that are *not* patterns —
+`-h` (help) and `-V` (version) — and they are reserved **only as the first
+token**. This is a deliberate, enumerated exception to "single-dash = pattern":
+`-h`/`-V` are such universal CLI muscle-memory that the search-first leaders
+keep them too (ripgrep, fd both expose exactly `-h`/`-V` and nothing else
+short). Every *other* single-dash token stays a pattern.
+
+```
+uffs -h            → help        ✅ reserved (the only short help flag)
+uffs -V            → version     ✅ reserved (the only short version flag)
+uffs -x            → search "-x" ✅ every OTHER single dash is a pattern
+uffs -update       → search "-update"
+uffs -- -h         → search the literal "-h"   ← the escape hatch covers it
+```
+
+Searching for a file literally named `-h` is nonsensical, and `uffs -- -h`
+recovers it, so the cost of the exception is ~zero while the convenience is
+universal. The set is closed: `-h` and `-V` only — no other short flag, and
+**no** short *command* aliases (§12).
+
 ## 4. Uniform command model — every command, the same shape
 
 ```

--- a/docs/architecture/cli-grammar.md
+++ b/docs/architecture/cli-grammar.md
@@ -4,8 +4,9 @@ SPDX-License-Identifier: MPL-2.0
 -->
 # UFFS CLI Grammar — search-first, `--command` for everything else
 
-**Status:** Design approved, implementation pending. This is the design +
-implementation + tracking doc for the `uffs` command-line grammar redesign.
+**Status:** Design approved + decisions resolved (§12); **implementation in
+progress on `feat/cli-grammar`**. This is the design + implementation +
+tracking doc for the `uffs` command-line grammar redesign.
 
 **TL;DR:** `uffs <anything>` searches for `<anything>` — *any* word, with no
 reserved words. Management operations are `--<command>` (double-dash), e.g.
@@ -283,7 +284,7 @@ that internal path; only the *external* entry tokens change.
 
 ## 11. Tracking checklist
 
-- [ ] **P0 — Dispatcher.** `Command` enum + `from_token` + `run()` rewrite +
+- [x] **P0 — Dispatcher.** `Command` enum + `from_token` + `run()` rewrite +
       bare-`--` escape. Dispatcher unit tests + disjointness invariant test.
 - [ ] **P1 — Normalize `--update`.** Action-positional parsing
       (snapshot/acquire/apply/doctor/recover); options as flags. Update its
@@ -296,14 +297,12 @@ that internal path; only the *external* entry tokens change.
 - [ ] **P5 — Validate.** Host + Windows-MSVC clippy clean; full nextest; manual
       smoke of every command + a `uffs update` *search*.
 
-## 12. Open questions / decisions
+## 12. Decisions (resolved 2026-06-16)
 
-1. **Top-level `--doctor`?** Keep `uffs --update doctor` only (uniform), or add
-   a `--doctor` convenience alias? *Lean: keep it an update action; revisit if
-   users reach for `uffs --doctor`.*
-2. **`--search` explicit form** — ship it (uniformity + a clean scripting form)
-   or leave search bare-only? *Lean: ship `--search` as the explicit twin of the
-   bare default.*
-3. **Short command aliases?** e.g. `-u` for `--update`. *Lean: no — short single
-   dashes are reserved for patterns/search-short-flags; keep commands `--long`
-   only to preserve the "single dash = data" rule.*
+1. **Top-level `--doctor`? → NO.** Doctor stays solely an action of `--update`
+   (`uffs --update doctor`) — uniform. (May change with user feedback.)
+2. **`--search` explicit form? → YES.** Ship `--search` as the explicit twin of
+   the bare-positional default.
+3. **Short command aliases (e.g. `-u`)? → NO.** Commands are `--long` only, so
+   single dashes stay reserved for patterns / search short-flags and the
+   "single dash = data" rule holds. (May change with user feedback.)

--- a/docs/architecture/cli-grammar.md
+++ b/docs/architecture/cli-grammar.md
@@ -81,21 +81,29 @@ uffs --update acquire --version v1  → updater, acquire action
 uffs --daemon start                 → daemon, start action
 ```
 
-### 3.2 The precision that makes it airtight: disjoint sets
+### 3.2 The precision that makes it airtight: the first token decides
 
 Search **already uses `--` flags** (`--sort`, `--ext`, `--drive`, `--limit`,
 `--format`, …). So the rule is **not** "any `--` is a command" — it is "**the
-first token is a known *command* word**". The **command set** and the
-**search-flag set** are deliberately **disjoint**, so there is never a clash:
+*first* token is a known *command* word**". That position rule is what makes it
+airtight:
 
 ```
-uffs --ext pdf       → search (--ext is a search flag, not a command)   ✅
+uffs --ext pdf       → search (--ext is a search flag, never a command)  ✅
 uffs --update        → updater (--update is in the command set)          ✅
 uffs --sort -size    → search (--sort is a search flag)                  ✅
 ```
 
-That disjointness is the trick: it lets a *pattern-less* search like
-`uffs --ext pdf` coexist with `uffs --update`.
+Most search flags (`--ext`, `--sort`, `--drive`, …) are **disjoint** from the
+command set, so they can never be confused. The **two deliberate exceptions**
+are `--stats` and `--agg`: each is a command **as the first token**
+(`uffs --stats`, `uffs --agg <preset>`) *and* an inline search modifier
+**after a pattern** (`uffs '*.log' --stats size`, `uffs '*' --agg "…"`). That
+is intentional — it is the *same* operation (stats / aggregation) in two
+positions — and the first-token rule resolves it unambiguously: a dual-use
+name in the first slot is the command; anywhere later it is the modifier. So
+the invariant is the **position**, not strict set-disjointness, and a
+*pattern-less* search like `uffs --ext pdf` still coexists with `uffs --update`.
 
 ### 3.3 The mental model (one sentence the user learns once)
 
@@ -157,8 +165,8 @@ different (each internally-consistent) conventions.
 | `uffs <pattern>` | `uffs <pattern>` *(unchanged)* — also explicit `uffs --search <pattern>` | — | `--sort --ext --drive --limit --format …` |
 | `uffs stats [path]` | `uffs --stats [path]` | — | `--top N` `--data-dir` `--mft-file` |
 | `uffs aggregate\|agg <preset>` | `uffs --agg <preset>` | — | `--format` |
-| `uffs daemon <a>` | `uffs --daemon <a>` | `start` `stop` `restart` `status` | `--data-dir` `--mft-file` `--elevate` |
-| `uffs mcp <a>` | `uffs --mcp <a>` | `run` `serve` `stop` `status` | `--bind` `--port` `--data-dir` |
+| `uffs daemon <a>` | `uffs --daemon <a>` | `start` `status` `stats` `stop` `kill` `restart` `load` `hibernate` `preload` `forget` `status_drives` | `--data-dir` `--mft-file` `--elevate` |
+| `uffs mcp <a>` | `uffs --mcp <a>` | `run` `start` `status` `stop` `kill` `restart` `reload` | `--bind` `--port` `--data-dir` |
 | `uffs update [--acquire\|--apply\|--snapshot]` + `uffs update doctor` | `uffs --update [<a>]` | *(none=detect)* `snapshot` `acquire` `apply` `doctor` `recover` | `--version` `--repair` `--offline` `--repo` |
 | `uffs status` | `uffs --status` | — | — |
 | `uffs --help / --version` | `uffs --help / --version` *(unchanged; global)* | — | — |
@@ -266,8 +274,12 @@ impl Command {
 }
 ```
 
-A **debug-assert / unit test** enforces the disjointness invariant: no
-`Command` token may equal any known search-flag long name.
+A **unit test** (`search_flags_are_never_commands`) enforces the position
+invariant for the genuinely flag-only names: the disjoint search flags
+(`--ext`, `--sort`, `--drive`, `--limit`, …) must never resolve to a command.
+The two dual-use names (`--stats`, `--agg`) are intentionally *not* in that
+list — as a first token they ARE their command; the first-token rule (§3.2)
+keeps them unambiguous.
 
 ### 8.2 Per-command handlers (mostly re-wiring existing code)
 
@@ -314,8 +326,10 @@ that internal path; only the *external* entry tokens change.
      `uffs --update`?"), no daemon round-trip.
    - `--bogus` (near nothing) → Search mode (forwarded to the shared parser /
      daemon, which rejects the unknown flag — see §6's note; no command hint).
-2. **Disjointness invariant test**: assert no `Command` token collides with any
-   search-flag long name (fails loudly if someone adds `--sort` as a command).
+2. **Position invariant test**: assert the *flag-only* names (`--sort`, `--ext`,
+   `--drive`, …) never resolve to a command (fails loudly if someone adds
+   `--sort` as a command). The dual-use `--stats`/`--agg` are excluded by
+   design (§3.2) — first token = command, later = modifier.
 3. **Per-command parse tests**: `--update acquire --version v1` → action=acquire,
    version=v1; `--daemon start` → action=start; etc.
 4. **Golden help-text test**: the new grammar renders + lists every command.

--- a/docs/architecture/cli-grammar.md
+++ b/docs/architecture/cli-grammar.md
@@ -180,23 +180,34 @@ convenience alias is an open question, §12.)
 | `uffs -- --update` | search for the literal pattern `--update` (bare `--` = end-of-options) |
 | `uffs --search -- --update` | same, explicit search form |
 | `uffs --update --help` | update help (the `--help` after a command is command-scoped) |
-| `uffs --bogus` | forwarded to search; the daemon's arg parser rejects the unknown flag. *(See the note below — a CLI-side "unknown command, did you mean …?" hint is intentionally **not** implemented.)* |
+| `uffs --updat` (near a command) | CLI hint up front: "`--updat` is not a known search flag. Did you mean the command `uffs --update`?" — no daemon round-trip (see the note below) |
+| `uffs --bogus` (not near a command) | forwarded to search; the shared parser / daemon rejects the unknown flag with the authoritative error (no command hint) |
 
 The **only** thing not searchable bare is a filename literally beginning with
 `--` (e.g. `--update`), reachable with `uffs -- <pattern>`. Such filenames are
 pathological; the escape is the universal `--` separator.
 
-> **Why no CLI-side "unknown command" hint for `--bogus`.** `uffs` is a
-> **thin client**: it deliberately does *not* know the search-flag set — that
-> lives in the daemon, which owns all search-arg parsing. To tell `--bogus`
-> (typo'd command) apart from `--newer-created` (a real, possibly newer search
-> flag) the CLI would have to duplicate the daemon's entire flag registry and
-> keep it in lock-step — brittle, and it would risk rejecting a *valid* new
-> search flag as an "unknown command". So an unrecognized `--`-leading first
-> token is forwarded to search, and the daemon's parser returns the
-> authoritative "unknown flag" error. The disjointness invariant (§3.2) still
-> holds for the *known* command set; this only changes the error *source* for
-> truly-unknown `--flags`, not the grammar.
+> **How the "did you mean a command?" hint stays thin — and keeps the daemon
+> ignorant of CLI commands.** Each layer suggests within its *own* vocabulary,
+> and neither learns the other's:
+>
+> - **Search-flag validation** is the **shared parser's** job
+>   (`uffs_client::protocol::SearchParams::from_cli_args`, the single source of
+>   truth used by both the daemon and — on the error path only — the CLI). It
+>   already returns a *structured* `UnknownFlag { flag }`.
+> - **Command suggestions** are the **CLI's** job, over its own ~8-token
+>   command set (`dispatch::COMMAND_TOKENS`, kept in lock-step with
+>   `from_token` by a test). When a first-token `--`-flag is *rejected by the
+>   shared parser* AND is within Levenshtein ≤ 2 of a command, the CLI prints
+>   the hint and stops — no daemon round-trip.
+>
+> So the CLI never duplicates the flag registry (it *calls* the shared parser),
+> and the **daemon never needs to know CLI commands** — the command list lives
+> only in the CLI. `--updat` → "did you mean `uffs --update`?"; `--bogus`
+> (near nothing) → the parser's authoritative "unknown flag" error;
+> `--newer-created` (a real flag) → parses fine, never mistaken for a command.
+> The gate on "rejected by the shared parser" is what guarantees a *valid* new
+> search flag is never mis-flagged as a command typo.
 
 ## 7. Why not the alternatives
 
@@ -299,8 +310,10 @@ that internal path; only the *external* entry tokens change.
    - `--update` → Update command.
    - `--ext` (first token) → Search mode (search flag, not a command).
    - `--` then `--update` → Search, pattern == "--update".
-   - `--bogus` → Search mode (forwarded to the daemon parser, which rejects
-     the unknown flag — see §6's thin-client note; no CLI-side hint).
+   - `--updat` (near a command) → CLI command-typo hint ("did you mean
+     `uffs --update`?"), no daemon round-trip.
+   - `--bogus` (near nothing) → Search mode (forwarded to the shared parser /
+     daemon, which rejects the unknown flag — see §6's note; no command hint).
 2. **Disjointness invariant test**: assert no `Command` token collides with any
    search-flag long name (fails loudly if someone adds `--sort` as a command).
 3. **Per-command parse tests**: `--update acquire --version v1` → action=acquire,
@@ -349,9 +362,16 @@ that internal path; only the *external* entry tokens change.
 - [x] **P6 — Gap-closure pass.** Audited this doc against the code: wired the
       `recover` action (§5/§8.2) — `uffs --update recover` runs the
       foreground self-heal (the helper's `recover` already existed; only the
-      CLI action was missing) + tests; reconciled `--bogus` (§6/§9) to the
-      thin-client reality (the daemon owns flag validation; no duplicated
-      registry). No remaining divergence between doc and implementation.
+      CLI action was missing) + tests.
+- [x] **P7 — Command-typo hint (§6/§9).** Implemented the "did you mean a
+      command?" hint *thinly*: the CLI calls the shared `from_cli_args` parser
+      (single source of truth for flags) on the error path and, when a
+      first-token `--`-flag is rejected AND within Levenshtein ≤ 2 of a
+      command (`dispatch::suggest_command` over `COMMAND_TOKENS`, `strsim`),
+      prints the hint without a daemon round-trip. The daemon never learns CLI
+      commands; the CLI never duplicates the flag registry. Unit + integration
+      tests pin both directions (near-miss suggests; unrelated/valid flags do
+      not). Doc and implementation now fully aligned.
 
 ## 12. Decisions (resolved 2026-06-16)
 

--- a/docs/architecture/cli-grammar.md
+++ b/docs/architecture/cli-grammar.md
@@ -286,13 +286,18 @@ that internal path; only the *external* entry tokens change.
 
 - [x] **P0 — Dispatcher.** `Command` enum + `from_token` + `run()` rewrite +
       bare-`--` escape. Dispatcher unit tests + disjointness invariant test.
-- [ ] **P1 — Normalize `--update`.** Action-positional parsing
-      (snapshot/acquire/apply/doctor/recover); options as flags. Update its
+- [x] **P1 — Normalize `--update`.** Action-positional parsing
+      (snapshot/acquire/apply/doctor); options as flags. Updated its
       `print_help`. Tests.
-- [ ] **P2 — Wire the rest.** `--stats`, `--agg`, `--daemon`, `--mcp`,
-      `--status`, `--search`. Per-command help (`--<cmd> --help`).
-- [ ] **P3 — Top-level help + usage errors.** New `print_help`; "unknown command
-      `--x` (did you mean …?)"; golden help test.
+- [x] **P2 — Wire the rest.** `--stats`, `--agg`, `--daemon`, `--mcp`,
+      `--status`, `--search` all route via `dispatch_command` (the handlers
+      were already action-/positional-style; no parsing changes needed).
+- [x] **P3 — Top-level help + usage errors.** New top-level help (search-first
+      note + `--command` list); sub-command help titles/usage + the two
+      user-facing daemon error messages updated to `--daemon`; help golden
+      test updated. (A "did you mean …?" hint for `--bogus` is a nice-to-have
+      follow-up; today an unknown leading `--flag` errors via the search
+      parser, and `--update bogus` is rejected with the action list.)
 - [ ] **P4 — Docs.** CLAUDE.md, README, MCP instructions, this doc → Implemented.
 - [ ] **P5 — Validate.** Host + Windows-MSVC clippy clean; full nextest; manual
       smoke of every command + a `uffs update` *search*.

--- a/docs/architecture/cli-grammar.md
+++ b/docs/architecture/cli-grammar.md
@@ -4,9 +4,9 @@ SPDX-License-Identifier: MPL-2.0
 -->
 # UFFS CLI Grammar — search-first, `--command` for everything else
 
-**Status:** Design approved + decisions resolved (§12); **implementation in
-progress on `feat/cli-grammar`**. This is the design + implementation +
-tracking doc for the `uffs` command-line grammar redesign.
+**Status:** **Implemented** on `feat/cli-grammar` (§11 P0–P4 done; P5
+validation in progress). Decisions resolved (§12). This is the design +
+implementation + tracking doc for the `uffs` command-line grammar redesign.
 
 **TL;DR:** `uffs <anything>` searches for `<anything>` — *any* word, with no
 reserved words. Management operations are `--<command>` (double-dash), e.g.
@@ -298,7 +298,14 @@ that internal path; only the *external* entry tokens change.
       test updated. (A "did you mean …?" hint for `--bogus` is a nice-to-have
       follow-up; today an unknown leading `--flag` errors via the search
       parser, and `--update bogus` is rejected with the action list.)
-- [ ] **P4 — Docs.** CLAUDE.md, README, MCP instructions, this doc → Implemented.
+- [x] **P4 — Docs.** README command examples → `uffs --daemon …` (+ a
+      "`--command` = management; bare words search" note); CLAUDE.md and the
+      MCP server `instructions` had no old-grammar CLI refs; internal
+      doc-comments that named the conceptual `uffs daemon/mcp …` forms updated
+      to `uffs --daemon/--mcp …`; this doc → Implemented. (No internal
+      self-spawn was affected: the updater shells out to the separate
+      `uffs-update` binary, autostart to `uffsd`, MCP to `uffsmcp` — each with
+      its own grammar.)
 - [ ] **P5 — Validate.** Host + Windows-MSVC clippy clean; full nextest; manual
       smoke of every command + a `uffs update` *search*.
 

--- a/docs/architecture/cli-grammar.md
+++ b/docs/architecture/cli-grammar.md
@@ -4,9 +4,10 @@ SPDX-License-Identifier: MPL-2.0
 -->
 # UFFS CLI Grammar — search-first, `--command` for everything else
 
-**Status:** **Implemented** on `feat/cli-grammar` (§11 P0–P4 done; P5
-validation in progress). Decisions resolved (§12). This is the design +
-implementation + tracking doc for the `uffs` command-line grammar redesign.
+**Status:** **Implemented + validated** on `feat/cli-grammar` (§11 P0–P6 all
+done; doc audited against the code, no gaps). Decisions resolved (§12). This is
+the design + implementation + tracking doc for the `uffs` command-line grammar
+redesign.
 
 **TL;DR:** `uffs <anything>` searches for `<anything>` — *any* word, with no
 reserved words. Management operations are `--<command>` (double-dash), e.g.
@@ -179,11 +180,23 @@ convenience alias is an open question, §12.)
 | `uffs -- --update` | search for the literal pattern `--update` (bare `--` = end-of-options) |
 | `uffs --search -- --update` | same, explicit search form |
 | `uffs --update --help` | update help (the `--help` after a command is command-scoped) |
-| `uffs --bogus` | error: unknown command `--bogus` (a `--`-leading first token that is *not* a command + *not* a search flag is a usage error, with a "did you mean …?" hint) |
+| `uffs --bogus` | forwarded to search; the daemon's arg parser rejects the unknown flag. *(See the note below — a CLI-side "unknown command, did you mean …?" hint is intentionally **not** implemented.)* |
 
 The **only** thing not searchable bare is a filename literally beginning with
 `--` (e.g. `--update`), reachable with `uffs -- <pattern>`. Such filenames are
 pathological; the escape is the universal `--` separator.
+
+> **Why no CLI-side "unknown command" hint for `--bogus`.** `uffs` is a
+> **thin client**: it deliberately does *not* know the search-flag set — that
+> lives in the daemon, which owns all search-arg parsing. To tell `--bogus`
+> (typo'd command) apart from `--newer-created` (a real, possibly newer search
+> flag) the CLI would have to duplicate the daemon's entire flag registry and
+> keep it in lock-step — brittle, and it would risk rejecting a *valid* new
+> search flag as an "unknown command". So an unrecognized `--`-leading first
+> token is forwarded to search, and the daemon's parser returns the
+> authoritative "unknown flag" error. The disjointness invariant (§3.2) still
+> holds for the *known* command set; this only changes the error *source* for
+> truly-unknown `--flags`, not the grammar.
 
 ## 7. Why not the alternatives
 
@@ -286,7 +299,8 @@ that internal path; only the *external* entry tokens change.
    - `--update` → Update command.
    - `--ext` (first token) → Search mode (search flag, not a command).
    - `--` then `--update` → Search, pattern == "--update".
-   - `--bogus` → usage error.
+   - `--bogus` → Search mode (forwarded to the daemon parser, which rejects
+     the unknown flag — see §6's thin-client note; no CLI-side hint).
 2. **Disjointness invariant test**: assert no `Command` token collides with any
    search-flag long name (fails loudly if someone adds `--sort` as a command).
 3. **Per-command parse tests**: `--update acquire --version v1` → action=acquire,
@@ -328,8 +342,16 @@ that internal path; only the *external* entry tokens change.
       self-spawn was affected: the updater shells out to the separate
       `uffs-update` binary, autostart to `uffsd`, MCP to `uffsmcp` — each with
       its own grammar.)
-- [ ] **P5 — Validate.** Host + Windows-MSVC clippy clean; full nextest; manual
-      smoke of every command + a `uffs update` *search*.
+- [x] **P5 — Validate.** Host + Windows-MSVC prod clippy clean; full nextest
+      (uffs-cli + uffs-mcp) green; manual smoke of every command, the
+      `uffs update`/`uffs status`-as-search disambiguation, the `uffs --`
+      escape, `-h`/`-V`, and `--update recover`.
+- [x] **P6 — Gap-closure pass.** Audited this doc against the code: wired the
+      `recover` action (§5/§8.2) — `uffs --update recover` runs the
+      foreground self-heal (the helper's `recover` already existed; only the
+      CLI action was missing) + tests; reconciled `--bogus` (§6/§9) to the
+      thin-client reality (the daemon owns flag validation; no duplicated
+      registry). No remaining divergence between doc and implementation.
 
 ## 12. Decisions (resolved 2026-06-16)
 

--- a/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
+++ b/docs/architecture/code-quality/bugs-rust-wont-catch-implementation.md
@@ -1279,7 +1279,7 @@ provable**:
   gated on `rec.name_len == 0` (byte length). Both are WI-4.4 in spirit: a
   crooked name can no longer hide a file or its descendants from search/resolve.
 - **Windows proof scripted.** `scripts/windows/create-corrupted-name-tree.rs
-  --verify` now also asserts `uffs search * --malformed` returns **exactly** the
+  --verify` now also asserts `uffs '*' --malformed` returns **exactly** the
   ill-formed on-disk entries — the WI-4.4 find+open claim plus the new filter,
   checked end-to-end. **Open item:** one elevated run on a real NTFS volume to
   close the live-Windows acceptance.

--- a/docs/architecture/engine/08-cli.md
+++ b/docs/architecture/engine/08-cli.md
@@ -94,7 +94,7 @@ uffs * --files-only --min-size 1048576  # Files > 1MB
 |------------|-------------|
 | `uffs index` | Build and save a Parquet index from MFT |
 | `uffs info` | Show NTFS volume information |
-| `uffs stats` | Display index statistics |
+| `uffs --stats` | Display index statistics |
 | `uffs save-raw` | Save raw MFT data to file |
 | `uffs load-raw` | Load and display raw MFT file |
 

--- a/docs/architecture/engine/08-cli.md
+++ b/docs/architecture/engine/08-cli.md
@@ -88,41 +88,25 @@ uffs * --files-only --min-size 1048576  # Files > 1MB
 
 ---
 
-## Subcommands
+## Commands
 
-| Subcommand | Description |
-|------------|-------------|
-| `uffs index` | Build and save a Parquet index from MFT |
-| `uffs info` | Show NTFS volume information |
+| Command | Description |
+|---------|-------------|
 | `uffs --stats` | Display index statistics |
-| `uffs save-raw` | Save raw MFT data to file |
-| `uffs load-raw` | Load and display raw MFT file |
 
-### `uffs index`
+> **Historical note.** The standalone `uffs index` / `uffs info` /
+> `uffs save-raw` / `uffs load-raw` subcommands were removed when the CLI
+> became a thin daemon client. Their capabilities live on elsewhere:
+> index building/loading is **daemon-managed** (`uffs --daemon start
+> --data-dir <dir>` / `--mft-file <file>`), and low-level NTFS volume/record
+> inspection + raw-MFT capture moved to the separate `uffs-mft` tool
+> (run `uffs-mft --help`).
 
-```bash
-uffs index -d C output.parquet     # Save C: index to Parquet
-uffs index -d C,D multi.parquet    # Multi-drive index
-```
-
-### `uffs info`
-
-```bash
-uffs info -d C                     # Show NTFS volume metadata
-# Output: cluster_size, record_size, mft_capacity, mft_extents, etc.
-```
-
-### `uffs save-raw`
+### `uffs --stats`
 
 ```bash
-uffs save-raw -d C C_mft.bin       # Save raw MFT bytes
-uffs save-raw -d C C.iocp          # Save IOCP capture (with chunk metadata)
-```
-
-### `uffs load-raw`
-
-```bash
-uffs load-raw C_mft.bin            # Parse and display raw MFT file
+uffs --stats                       # Live overview via the daemon
+uffs --stats saved.parquet         # Stats from a saved parquet index
 ```
 
 ---

--- a/docs/architecture/engine/12-forensics-diagnostics.md
+++ b/docs/architecture/engine/12-forensics-diagnostics.md
@@ -383,8 +383,9 @@ Beyond forensic MFT analysis, UFFS reads the NTFS **USN Change Journal** (`$UsnJ
 ### Reading the Journal
 
 ```bash
-# Query current journal state
-uffs info --drive C
+# Query current NTFS volume / journal state (the separate uffs-mft tool;
+# the old `uffs info` subcommand was removed with the thin-client split)
+uffs-mft info --drive C
 # Shows: journal_id, first_usn, next_usn, max_size
 
 # The journal is used automatically by the caching system:

--- a/docs/architecture/memory-tiering-bake-criteria.md
+++ b/docs/architecture/memory-tiering-bake-criteria.md
@@ -137,16 +137,16 @@ Safe to run during any 24-h soak.
 
 ```bash
 # Mac (or any Unix-like host)
-uffs daemon status            # must report `Status: Ready` + `Drives: 7 of 7 ready`
-uffs daemon status_drives     # must show 7 rows, sorted ASCII ascending
+uffs --daemon status            # must report `Status: Ready` + `Drives: 7 of 7 ready`
+uffs --daemon status_drives     # must show 7 rows, sorted ASCII ascending
 uffs '*' --ext rs --limit 5   # quick search probe — must return ≥ 1 row
 ps -p $(pgrep uffsd) -o pid,rss,vsz,etime  # process snapshot
 ```
 
 ```powershell
 # Windows (production host)
-uffs daemon status
-uffs daemon status_drives
+uffs --daemon status
+uffs --daemon status_drives
 uffs '*' --ext rs --limit 5 *> $null
 Get-Process uffsd | Select-Object Id, WS, PM, NPM, VM, CPU, StartTime |
     ConvertTo-Json -Compress
@@ -207,7 +207,7 @@ steady-state operator-load Working Set we want to bound.
 
 ```powershell
 # Confirm the daemon is Ready, then start the trace.
-uffs daemon status                  # must report `Status: Ready`
+uffs --daemon status                  # must report `Status: Ready`
 just soak ws-trace
 ```
 

--- a/docs/architecture/memory-tiering-windows-host-validation.md
+++ b/docs/architecture/memory-tiering-windows-host-validation.md
@@ -59,15 +59,15 @@ close each gate.
 * The seven NTFS volumes loaded against the daemon — confirm with the
   Phase-8-E per-drive tier table:
   ```powershell
-  uffs daemon status     # expect: Status: Ready
-  uffs daemon status_drives
+  uffs --daemon status     # expect: Status: Ready
+  uffs --daemon status_drives
   ```
   `daemon status_drives` is the canonical post-Phase-8 view: a fixed-
   width table with `DRIVE / TIER / RESIDENT / QPM / LAST QUERY (ms) /
   PIN UNTIL (ms)` columns, sorted ASCII ascending by drive letter.
   Expect every drive's `TIER` column to be `warm` (default after
   load) — any `parked` / `cold` from the start means the gate setup
-  is wrong; bounce the daemon (`uffs daemon stop` → `uffs daemon
+  is wrong; bounce the daemon (`uffs --daemon stop` → `uffs --daemon
   start --drives C,D,E,F,G,M,S`).
 * Task Manager → **Details** tab → enable the **I/O priority** column
   via column-header → *Select columns…* → check `I/O priority`.  This
@@ -91,10 +91,10 @@ daemon with structured logging:
 
 ```powershell
 $env:RUST_LOG = "uffs_daemon=info,cache.pressure=info,shard.transition=info"
-uffs daemon start --drives C,D,E,F,G,M,S 2>&1 | Tee-Object -FilePath C:\Temp\uffsd-G1.log
+uffs --daemon start --drives C,D,E,F,G,M,S 2>&1 | Tee-Object -FilePath C:\Temp\uffsd-G1.log
 ```
 
-Wait until `uffs status` reports `Ready` for every drive.
+Wait until `uffs --status` reports `Ready` for every drive.
 
 #### Drive
 
@@ -241,8 +241,8 @@ the default 5 min between ticks.  In terminal A:
 ```powershell
 $env:UFFS_USN_REFRESH_INTERVAL_SECS = "30"
 $env:RUST_LOG = "uffs_daemon=info,shard.refresh=info"
-uffs daemon stop
-uffs daemon start --drives C,D,E,F,G,M,S 2>&1 | Tee-Object -FilePath C:\Temp\uffsd-G3.log
+uffs --daemon stop
+uffs --daemon start --drives C,D,E,F,G,M,S 2>&1 | Tee-Object -FilePath C:\Temp\uffsd-G3.log
 ```
 
 The 30-second cadence guarantees a refresh tick within ~1 minute of
@@ -299,10 +299,10 @@ on every per-drive worker; the wiring + the unit test
 complete the proof:
 
 ```powershell
-uffs daemon stop
+uffs --daemon stop
 Remove-Item Env:\RUST_LOG -ErrorAction SilentlyContinue
 $env:UFFS_USN_REFRESH_INTERVAL_SECS = "30"
-uffs daemon start --log-level debug --log-file C:\Temp\uffsd-G3-debug.log
+uffs --daemon start --log-level debug --log-file C:\Temp\uffsd-G3-debug.log
 
 # Re-warm so refresh has work to do.
 uffs "*" --ext rs --drive C --limit 5 > $null
@@ -412,7 +412,7 @@ Reset before moving on:
 
 ```powershell
 Remove-Item Env:\UFFS_USN_REFRESH_INTERVAL_SECS
-uffs daemon stop
+uffs --daemon stop
 ```
 
 ---
@@ -441,8 +441,8 @@ for, then holds at the target while the daemon cascades:
 # shell so RUST_LOG doesn't carry over from a previous gate.
 Remove-Item Env:\RUST_LOG -ErrorAction SilentlyContinue
 $env:RUST_LOG = "uffs_daemon=info,cache.pressure=info,shard.transition=info"
-uffs daemon stop
-uffs daemon start --log-file C:\Temp\uffsd-G4.log
+uffs --daemon stop
+uffs --daemon start --log-file C:\Temp\uffsd-G4.log
 
 # In a second shell, run the adaptive allocator.
 $targetAvailMB = 1024  # squeeze sysAvailable down to ~1 GB to fire Low
@@ -520,7 +520,7 @@ Acceptance criteria:
 * `uffsd.exe` is still running (`Get-Process uffsd | Select Id, WS`).
 * No `OutOfMemoryError` lines in `uffsd-G4.log`.
 * No `panic` lines.
-* `uffs status --drives` returns within 1 s after the soak completes;
+* `uffs --status --drives` returns within 1 s after the soak completes;
   the per-drive tier markers reflect a coherent state (some `[Parked]`,
   some `[Hot]`/`[Warm]` where the operator drove queries).
 
@@ -586,7 +586,7 @@ $cfgPath = "$env:LOCALAPPDATA\uffs\daemon.toml"
 [shards.per_drive."C:"]
 min_tier = "WARM"
 '@ | Set-Content -Encoding UTF8 -Path $cfgPath
-uffs daemon stop
+uffs --daemon stop
 # shard.ttl at TRACE (not DEBUG) is REQUIRED — see the 2026-05-11
 # soak findings in §6 ("Reference captures") sub-section §4.5b
 # below.  The DEBUG `idle-demote` /
@@ -596,7 +596,7 @@ uffs daemon stop
 # TRACE-level `below-ttl` event carries the bonused
 # `warm_ttl_sec` field that criterion 3 below scrapes for.
 $env:RUST_LOG = "uffs_daemon=info,shard.ttl=trace,shard.transition=info"
-uffs daemon start --drives C,D,E,F,G,M,S 2>&1 | Tee-Object -FilePath C:\Temp\uffsd-phase6-soak.log
+uffs --daemon start --drives C,D,E,F,G,M,S 2>&1 | Tee-Object -FilePath C:\Temp\uffsd-phase6-soak.log
 ```
 
 #### Drive
@@ -674,7 +674,7 @@ daemon's tracing fields, update these patterns in the same commit.
 
 ```powershell
 Remove-Item $cfgPath
-uffs daemon stop
+uffs --daemon stop
 ```
 
 #### Automation
@@ -715,8 +715,8 @@ New-Item -ItemType Directory -Path $churnDir -Force | Out-Null
 # 2. Bounce the daemon with the right log filter.
 Remove-Item Env:\RUST_LOG -ErrorAction SilentlyContinue
 $env:RUST_LOG = "uffs_daemon=info,shard.refresh=info,shard.transition=info,journal_loop=debug"
-uffs daemon stop
-uffs daemon start --drives C,D,E,F,G,M,S \
+uffs --daemon stop
+uffs --daemon start --drives C,D,E,F,G,M,S \
     --log-file "$env:USERPROFILE\uffs_soak\phase7-$(Get-Date -Format yyyyMMdd-HHmmss)\daemon.log"
 ```
 
@@ -746,7 +746,7 @@ Four acceptance criteria (the Phase 7 contract under
 `memory-tiering-implementation-plan.md` §3 Phase 7 Windows gate):
 
 1. **New-item latency ≤ 2 s.**  Drop a unique probe file in
-   `$churnDir`; confirm `uffs daemon status_drives` returns a
+   `$churnDir`; confirm `uffs --daemon status_drives` returns a
    non-error response within 2 s of the file's `LastWriteTime`.
    The harness probes once at T+0 and once at T+24h; both must hit
    the budget.
@@ -811,7 +811,7 @@ Four acceptance criteria (the Phase 7 contract under
 #### Reset
 
 ```powershell
-uffs daemon stop
+uffs --daemon stop
 Remove-Item -Recurse -Force "$env:USERPROFILE\uffs-soak\churn"
 ```
 
@@ -853,7 +853,7 @@ Run them in order — G7 is destructive (deletes a drive's caches)
 and the order leaves the daemon in a known-good shape for the
 final G8 render.
 
-### G5 — `uffs daemon hibernate` demotes every drive to Cold
+### G5 — `uffs --daemon hibernate` demotes every drive to Cold
 
 **Duration:** ~3 min wall-clock.
 **Plan reference:** plan task 8.1; PR #122.
@@ -869,12 +869,12 @@ state — typically the post-G4 shape after the Phase-5 soak).
 # Capture pre-hibernate state.
 "=== Pre-hibernate ==="
 Get-Process uffsd | Select Id, WS, PM, NPM, VM
-uffs daemon status_drives
+uffs --daemon status_drives
 ```
 
 ```powershell
 # Hibernate every loaded drive.
-uffs daemon hibernate
+uffs --daemon hibernate
 ```
 
 Expected stdout (drive letters depend on the registry):
@@ -892,7 +892,7 @@ Daemon hibernated 7 drive(s):
 ```powershell
 "=== Post-hibernate ==="
 Get-Process uffsd | Select Id, WS, PM, NPM, VM
-uffs daemon status_drives
+uffs --daemon status_drives
 
 # Hibernate keeps the encrypted compact caches on disk — verify
 # they're all still there (the *_compact.uffs files are the
@@ -911,7 +911,7 @@ Acceptance criteria:
   is still on disk with the same `Length` (hibernate releases RAM
   only — disk untouched).
 
-### G6 — `uffs daemon preload` pin contract survives idle TTL
+### G6 — `uffs --daemon preload` pin contract survives idle TTL
 
 **Duration:** ~10 min wall-clock.
 **Plan reference:** plan task 8.2; PR #122.
@@ -932,8 +932,8 @@ without a default-30-min wait:
 $env:UFFS_WARM_TO_PARKED_IDLE_SECS = "30"
 $env:UFFS_PARKED_TO_COLD_IDLE_SECS = "60"
 $env:RUST_LOG = "uffs_daemon=info,shard.transition=info,shard.ttl=debug"
-uffs daemon stop
-uffs daemon start --drives C,D,E,F,G,M,S 2>&1 |
+uffs --daemon stop
+uffs --daemon start --drives C,D,E,F,G,M,S 2>&1 |
     Tee-Object -FilePath C:\Temp\uffsd-G6.log
 ```
 
@@ -941,7 +941,7 @@ uffs daemon start --drives C,D,E,F,G,M,S 2>&1 |
 
 ```powershell
 # Pin C in Hot for 5 minutes.
-uffs daemon preload C --pin-minutes 5
+uffs --daemon preload C --pin-minutes 5
 ```
 
 Expected stdout:
@@ -957,7 +957,7 @@ Verify C is Hot + pinned and the others are still Cold:
 
 ```powershell
 "=== Pre-wait ==="
-uffs daemon status_drives
+uffs --daemon status_drives
 ```
 
 Wait through 1.5× the warm-to-parked TTL — total ~90 s — long
@@ -968,7 +968,7 @@ twice:
 "=== Wait 90 s for the idle-demote controller to fire ==="
 Start-Sleep -Seconds 90
 "=== Post-wait ==="
-uffs daemon status_drives
+uffs --daemon status_drives
 ```
 
 Confirm the demote-controller log shows zero `to=parked` /
@@ -1005,11 +1005,11 @@ Acceptance criteria:
 ```powershell
 Remove-Item Env:\UFFS_WARM_TO_PARKED_IDLE_SECS
 Remove-Item Env:\UFFS_PARKED_TO_COLD_IDLE_SECS
-uffs daemon stop
-uffs daemon start --drives C,D,E,F,G,M,S
+uffs --daemon stop
+uffs --daemon start --drives C,D,E,F,G,M,S
 ```
 
-### G7 — `uffs daemon forget --force` evicts + deletes caches
+### G7 — `uffs --daemon forget --force` evicts + deletes caches
 
 **Duration:** ~3 min wall-clock.
 **Plan reference:** plan task 8.3; PR #123.
@@ -1059,7 +1059,7 @@ foreach ($p in $cachePaths) {
 #### Drive
 
 ```powershell
-uffs daemon forget M --force
+uffs --daemon forget M --force
 ```
 
 Expected stdout:
@@ -1075,7 +1075,7 @@ Daemon forgot 1 drive(s); freed XX.XX MiB:
 ```powershell
 # Verify M is gone from the registry.
 "=== Post-forget status_drives — M must NOT be listed ==="
-uffs daemon status_drives
+uffs --daemon status_drives
 
 # Verify every per-drive cache file is gone.
 "=== Post-forget cache files — every Test-Path must be False ==="
@@ -1100,10 +1100,10 @@ To restore `M:` to the daemon, hot-load it (re-reads the MFT cold,
 ~30-60 s for a typical drive):
 
 ```powershell
-uffs daemon load --drive M
+uffs --daemon load --drive M
 ```
 
-### G8 — `uffs daemon status_drives` table render contract
+### G8 — `uffs --daemon status_drives` table render contract
 
 **Duration:** ~1 min wall-clock.
 **Plan reference:** plan task 8.4; PR #123.
@@ -1111,7 +1111,7 @@ uffs daemon load --drive M
 #### Drive
 
 ```powershell
-uffs daemon status_drives
+uffs --daemon status_drives
 ```
 
 #### Capture

--- a/docs/benchmarks/robust-benchmark-flow-execution-plan.md
+++ b/docs/benchmarks/robust-benchmark-flow-execution-plan.md
@@ -162,7 +162,7 @@ whether restore is *lossless* (we can put it back byte-for-byte) or *managed*
 
 | # | Resource | Mutated by | Snapshot | Restore | Lossless? |
 |---|----------|-----------|----------|---------|-----------|
-| R1 | UFFS daemon run-state (running? which drives? PID) | every stage | `uffs status` + `uffs daemon stats` parsed to JSON | restart with same drive set, or leave stopped if it was stopped | Managed |
+| R1 | UFFS daemon run-state (running? which drives? PID) | every stage | `uffs --status` + `uffs --daemon stats` parsed to JSON | restart with same drive set, or leave stopped if it was stopped | Managed |
 | R2 | UFFS cache dir `%LOCALAPPDATA%\uffs\cache` (+ legacy `%TEMP%\uffs_index_cache`) | COLD runs (`-PurgeCacheFirst`) | **copy** per-drive `*.uffs` files to bundle `backup/uffs-cache/` | copy files back, restoring the user's pre-run cache so no forced rebuild | Lossless |
 | R3 | `Everything.ini` (`%APPDATA%\Everything\Everything.ini`) | capacity/isolation probe (drive isolation) | **copy** whole file + sha256 | write file back verbatim, verify sha256 | Lossless |
 | R4 | Everything.exe process (running? minimized? with which config) | preflight / isolation restarts | record running state + path | restart Everything the way we found it (or kill if it was not running) | Managed |
@@ -356,7 +356,7 @@ table). Collected via:
 | RAM total / speed | `sysinfo` crate |
 | OS name + build | `sysinfo` crate |
 | Per-drive: filesystem, bus type (NVMe/SATA/USB), free/used | `sysinfo` disks (+ `Get-PhysicalDisk` via `Host::run` for bus type on Windows) |
-| Per-drive record counts | `uffs daemon stats` after warm-up (via `Host::run`) |
+| Per-drive record counts | `uffs --daemon stats` after warm-up (via `Host::run`) |
 | Tool versions | `Host::run`: `uffs --version`, `uffs.com --version`, `es.exe -get-everything-version` |
 | Elevation state | `Host::is_elevated()` |
 | Page-cache intent | recorded per stage (cold/warm/hot), see R8 |

--- a/docs/benchmarks/robust-benchmark-flow-implementation-guide.md
+++ b/docs/benchmarks/robust-benchmark-flow-implementation-guide.md
@@ -145,7 +145,7 @@ source (§4.7), three verbosity levels.
 ║   daemon is forced to re-read the MFT from disk (not from a warm cache).   ║
 ║                                                                            ║
 ║ WHAT I'LL RUN  (verbatim — nothing hidden)                                 ║
-║   1) uffs daemon stop                                                      ║
+║   1) uffs --daemon stop                                                      ║
 ║   2) del %LOCALAPPDATA%\uffs\cache\{C,D}_index.uffs  (+ _compact/_lock)    ║
 ║   3) uffs '*' --limit 1 --profile     # forces a full cold load            ║
 ║                                                                            ║
@@ -182,7 +182,7 @@ The other half of "no blindside" — confirm reality matches the promise:
 
 ```
 ── DONE · Stage 2 step 1 (COLD purge + warm-up) ───────────────────────────
-   ran:        uffs daemon stop  →  exit 0
+   ran:        uffs --daemon stop  →  exit 0
                purged 2 cache files (C_index.uffs, D_index.uffs)
                uffs '*' --limit 1 --profile  →  exit 0
    result:     daemon warm, 7,412,883 records loaded in 31.8 s (COLD)
@@ -232,7 +232,7 @@ let card = Card {
     title:      "COLD cache purge + daemon warm-up".into(),
     why:        "Drop UFFS cache so the daemon re-reads the MFT from disk …".into(),
     commands:   vec![                              // EXACT, shown verbatim
-        "uffs daemon stop".into(),
+        "uffs --daemon stop".into(),
         r"del %LOCALAPPDATA%\uffs\cache\{C,D}_index.uffs".into(),
         "uffs '*' --limit 1 --profile".into(),
     ],

--- a/docs/benchmarks/runbook.md
+++ b/docs/benchmarks/runbook.md
@@ -311,7 +311,7 @@ pre-filled report scaffold. To promote it to a canonical benchmark report:
 Run `just bench-fetch-competitors --keep-tools` to download and SHA-256-verify
 the pinned competitor binary into the bundle.
 
-**`uffs daemon` won't start (elevation error)**
+**`uffs --daemon` won't start (elevation error)**
 The orchestrator requires an elevated shell. Re-run from an elevated PowerShell
 or Windows Terminal.
 
@@ -320,7 +320,7 @@ Install it: `cargo install rust-script`.
 
 **Fingerprint diff after teardown shows daemon still running**
 The daemon restore undo (Stage 5) logs a crumb warning. Run
-`uffs daemon stop` manually, then `just bench-suite-verify <bundle>` to
+`uffs --daemon stop` manually, then `just bench-suite-verify <bundle>` to
 confirm the host is clean.
 
 **`restore-manifest.json` replay fails for a cache file**

--- a/docs/user-manual/aggregation.md
+++ b/docs/user-manual/aggregation.md
@@ -12,9 +12,9 @@ rows.
 
 | Without aggregation | With aggregation |
 |---------------------|------------------|
-| `uffs '*' --ext pdf` → 48 000 rows, count them yourself | `uffs agg overview --ext pdf` → `total_count: 48 000` |
-| `uffs '*' --sort -size --limit 50` → top 50, but what % is that? | `uffs agg by_type` → full breakdown with percentages |
-| Three separate queries for C:, D:, E: | `uffs agg by_drive` → all drives in one call |
+| `uffs '*' --ext pdf` → 48 000 rows, count them yourself | `uffs --agg overview --ext pdf` → `total_count: 48 000` |
+| `uffs '*' --sort -size --limit 50` → top 50, but what % is that? | `uffs --agg by_type` → full breakdown with percentages |
+| Three separate queries for C:, D:, E: | `uffs --agg by_drive` → all drives in one call |
 
 ---
 
@@ -22,31 +22,31 @@ rows.
 
 ```bash
 # Full filesystem overview — the single best first command
-uffs agg overview
+uffs --agg overview
 
 # What types of files eat the most space?
-uffs agg by_type
+uffs --agg by_type
 
 # Top 30 extensions by disk usage
-uffs agg by_extension
+uffs --agg by_extension
 
 # How much space does each drive use?
-uffs agg by_drive
+uffs --agg by_drive
 
 # Size distribution — tiny, small, medium, large, huge
-uffs agg by_size
+uffs --agg by_size
 
 # When were files last modified?
-uffs agg by_age
+uffs --agg by_age
 ```
 
-All `uffs agg` commands accept every filter from the [filters](filters.md) page.
+All `uffs --agg` commands accept every filter from the [filters](filters.md) page.
 Aggregation reuses the same search pipeline — it just changes the output.
 
 ### Inline aggregation (search + aggregate in one command)
 
 You can run aggregation alongside a search using inline flags instead
-of the `uffs agg` subcommand:
+of the `uffs --agg` subcommand:
 
 ```bash
 # Count matching files (suppresses rows)
@@ -96,22 +96,22 @@ A preset is a one-word shortcut that expands into a tuned set of analytics.
 
 ```bash
 # Basic preset
-uffs agg by_type
+uffs --agg by_type
 
 # Scoped to one drive
-uffs agg by_extension --drives C
+uffs --agg by_extension --drives C
 
 # Scoped to a file pattern
-uffs agg by_size "*.rs"
+uffs --agg by_size "*.rs"
 
 # Scoped with filters
-uffs agg by_type --newer 30d --min-size 1mb
+uffs --agg by_type --newer 30d --min-size 1mb
 
 # JSON output for piping
-uffs agg overview --format json
+uffs --agg overview --format json
 
 # CSV output for spreadsheets
-uffs agg by_extension --format csv
+uffs --agg by_extension --format csv
 ```
 
 ---
@@ -147,34 +147,34 @@ The `--agg` flag is repeatable — stack multiple specs in one command.
 
 ```bash
 # Top 20 extensions (default is 50)
-uffs search "*" --agg "terms:extension,top=20"
+uffs "*" --agg "terms:extension,top=20"
 
 # Size statistics for all files
-uffs search "*" --agg "stats:size"
+uffs "*" --agg "stats:size"
 
 # Modified date statistics
-uffs search "*" --agg "stats:modified"
+uffs "*" --agg "stats:modified"
 
 # Size histogram with 10 MB buckets
-uffs search "*" --agg "hist:size,interval=10485760"
+uffs "*" --agg "hist:size,interval=10485760"
 
 # Monthly creation timeline
-uffs search "*" --agg "datehist:created,calendar=month"
+uffs "*" --agg "datehist:created,calendar=month"
 
 # Custom size ranges
-uffs search "*" --agg "range:size,bins=0..1048576+1048576..1073741824+1073741824..∞"
+uffs "*" --agg "range:size,bins=0..1048576+1048576..1073741824+1073741824..∞"
 
 # Count files with no extension
-uffs search "*" --agg "missing:extension"
+uffs "*" --agg "missing:extension"
 
 # How many unique extensions exist?
-uffs search "*" --agg "distinct:extension"
+uffs "*" --agg "distinct:extension"
 
 # Top 10 folders at depth 2
-uffs search "*" --agg "rollup:path,depth=2,top=10"
+uffs "*" --agg "rollup:path,depth=2,top=10"
 
 # Multiple specs in one command
-uffs search "*" --agg "count" --agg "stats:size" --agg "terms:type,top=10"
+uffs "*" --agg "count" --agg "stats:size" --agg "terms:type,top=10"
 ```
 
 ---
@@ -235,7 +235,7 @@ actually in each group without a follow-up search.
 
 ```bash
 # Top 10 extensions with 3 sample files each
-uffs search "*" --agg "terms:extension,top=10,sample=3"
+uffs "*" --agg "terms:extension,top=10,sample=3"
 ```
 
 Output:
@@ -271,10 +271,10 @@ buckets than the default top-N.  Use pagination to walk through all of them:
 
 ```bash
 # First page
-uffs agg by_extension --agg-page-size 20
+uffs --agg by_extension --agg-page-size 20
 
 # Next page (use the cursor from the previous response)
-uffs agg by_extension --agg-page-size 20 --agg-cursor "eyJza..."
+uffs --agg by_extension --agg-page-size 20 --agg-cursor "eyJza..."
 ```
 
 The response includes:
@@ -291,13 +291,13 @@ The `duplicates` preset finds files that share the same **name and size**
 
 ```bash
 # Basic duplicate scan
-uffs agg duplicates
+uffs --agg duplicates
 
 # With verification (reads first 4 KB of each candidate)
-uffs search "*" --agg "duplicates:size+name,verify=first_bytes,top=50"
+uffs "*" --agg "duplicates:size+name,verify=first_bytes,top=50"
 
 # Full SHA-256 verification (slow but certain)
-uffs search "*" --agg "duplicates:size+name,verify=sha256,top=20"
+uffs "*" --agg "duplicates:size+name,verify=sha256,top=20"
 ```
 
 Output:
@@ -327,16 +327,16 @@ Groups beyond the budget are kept but marked unverified.
 
 ```bash
 # Human-readable table (default)
-uffs agg by_extension
+uffs --agg by_extension
 
 # JSON — structured, complete, pipe-friendly
-uffs agg by_extension --format json
+uffs --agg by_extension --format json
 
 # CSV — for spreadsheets and data tools
-uffs agg by_extension --format csv
+uffs --agg by_extension --format csv
 
 # TSV — tab-separated variant
-uffs agg by_extension --format tsv
+uffs --agg by_extension --format tsv
 ```
 
 ### JSON structure
@@ -372,18 +372,18 @@ Every aggregation response contains:
 
 ## 9  Combining aggregation with search
 
-By default, `uffs agg` returns **only** aggregate results and no file rows.
+By default, `uffs --agg` returns **only** aggregate results and no file rows.
 Use `--rows` to get both:
 
 ```bash
 # Aggregate + rows
-uffs search "*.rs" --agg "stats:size" --rows
+uffs "*.rs" --agg "stats:size" --rows
 
 # Count files matching a filter (no rows)
-uffs search "*.pdf" --count
+uffs "*.pdf" --count
 
 # Facet a filtered set
-uffs search "*" --newer 7d --facet type
+uffs "*" --newer 7d --facet type
 ```
 
 ### Shorthand flags
@@ -447,49 +447,49 @@ See `uffs://cookbook` in the MCP resource list for more examples.
 ### "How much space do my photos take?"
 
 ```bash
-uffs agg overview --ext pictures
+uffs --agg overview --ext pictures
 ```
 
 ### "Which drive has the most waste?"
 
 ```bash
-uffs agg storage
+uffs --agg storage
 ```
 
 ### "Are there files near the MAX_PATH limit?"
 
 ```bash
-uffs search "*" --agg "range:path_length,bins=0..100+100..200+200..260+260..500"
+uffs "*" --agg "range:path_length,bins=0..100+100..200+200..260+260..500"
 ```
 
 ### "What's the creation timeline of my music collection?"
 
 ```bash
-uffs agg activity --ext music --drives M
+uffs --agg activity --ext music --drives M
 ```
 
 ### "Show me the 10 largest top-level folders, with their type breakdown"
 
 ```bash
-uffs search "*" --agg "rollup:path,depth=1,top=10,sub=terms:type"
+uffs "*" --agg "rollup:path,depth=1,top=10,sub=terms:type"
 ```
 
 ### "How many unique extensions are on D:?"
 
 ```bash
-uffs search "*" --agg "distinct:extension" --drives D
+uffs "*" --agg "distinct:extension" --drives D
 ```
 
 ### "Find all Rust code stats in my GitHub folder"
 
 ```bash
-uffs agg overview "*.rs" --path-contains GitHub
+uffs --agg overview "*.rs" --path-contains GitHub
 ```
 
 ### "Monthly modification activity for the last 2 years"
 
 ```bash
-uffs search "*" --newer 730d --agg "datehist:modified,calendar=month"
+uffs "*" --newer 730d --agg "datehist:modified,calendar=month"
 ```
 
 ---

--- a/docs/user-manual/cache-and-data.md
+++ b/docs/user-manual/cache-and-data.md
@@ -57,7 +57,7 @@ UFFS accepts three raw MFT file formats:
 | Extension | Source | Description |
 |-----------|--------|-------------|
 | `.iocp` | UFFS cache | Serialized binary index — fastest to load |
-| `.bin` | `uffs save-raw` | Raw MFT byte dump |
+| `.bin` | `uffs-mft save` | Raw MFT byte dump |
 | `.mft` | Third-party tools | Standard raw MFT dump |
 
 When auto-discovering files in `--data-dir`, UFFS prefers `.iocp` over
@@ -91,8 +91,8 @@ name matters.
 1. On a Windows machine, capture the MFT for each drive:
 
    ```powershell
-   # Option A: UFFS native
-   uffs save-raw C C_mft.bin
+   # Option A: UFFS native (the uffs-mft tool; --raw = bare MFT bytes)
+   uffs-mft save --drive C --output C_mft.bin --raw
 
    # Option B: Third-party (e.g. RawCopy, FTK Imager)
    # Produces a .mft file

--- a/docs/user-manual/cache-and-data.md
+++ b/docs/user-manual/cache-and-data.md
@@ -139,7 +139,7 @@ raw source.
 uffs '*.dll' --no-cache --data-dir ~/uffs_data
 
 # Also available on daemon start
-uffs daemon start --data-dir ~/uffs_data --no-cache
+uffs --daemon start --data-dir ~/uffs_data --no-cache
 ```
 
 Use `--no-cache` when:

--- a/docs/user-manual/cli-overview.md
+++ b/docs/user-manual/cli-overview.md
@@ -185,25 +185,13 @@ results.  For the `uffs --agg` subcommand, see §7 below.
 
 ---
 
-## 7  Subcommands
+## 7  Commands
 
-### `uffs index`
-
-Build a Parquet index from one or more NTFS drives.
-
-```bash
-uffs index output.parquet              # Index ALL drives
-uffs index -d C output.parquet         # Index C: only
-uffs index --drives C,D,E out.parquet  # Index specific drives
-```
-
-### `uffs info`
-
-Show metadata about a saved index file.
-
-```bash
-uffs info index.parquet
-```
+> Building/loading an index is **daemon-managed** — there is no standalone
+> `uffs index` command. Point the daemon at a live drive or a raw MFT with
+> `uffs --daemon start --data-dir <dir>` / `--mft-file <file>` (see
+> [Daemon](daemon.md)). For low-level NTFS volume/record inspection, use the
+> separate `uffs-mft` tool (`uffs-mft --help`).
 
 ### `uffs --stats`
 

--- a/docs/user-manual/cli-overview.md
+++ b/docs/user-manual/cli-overview.md
@@ -5,7 +5,7 @@ NTFS Master File Tables directly and searches millions of files in
 milliseconds.
 
 **Search is the default action** — just type `uffs <pattern>`.  No
-subcommand required.
+command required; management lives under `--<command>` (§6).
 
 ![UFFS CLI: real searches, filters, and aggregations across millions of indexed files with measured latency](../../assets/demo/uffs-cli.gif)
 
@@ -22,11 +22,11 @@ subcommand required.
 
 ## 1  Search (Default Action)
 
-When no subcommand is specified, `uffs` performs a search.  The first
-positional argument is the pattern.
+When the first token is not a `--command`, `uffs` performs a search.  The
+first positional argument is the pattern.
 
 ```
-uffs [OPTIONS] <PATTERN>
+uffs <PATTERN> [OPTIONS]
 ```
 
 ### Pattern Syntax
@@ -83,7 +83,7 @@ uffs [OPTIONS] <PATTERN>
 
 ---
 
-## 3  Filters
+## 2  Filters
 
 All filters are detailed in the [Filters guide](filters.md).  Summary:
 
@@ -129,7 +129,7 @@ All filters are detailed in the [Filters guide](filters.md).  Summary:
 
 ---
 
-## 4  Sorting
+## 3  Sorting
 
 All 36+ sortable columns are detailed in the [Sorting guide](sorting.md).
 Summary:
@@ -147,7 +147,7 @@ See [Sorting §2](sorting.md) for the full list.
 
 ---
 
-## 5  Output Control
+## 4  Output Control
 
 All output options are detailed in the [Output Formats guide](output-formats.md).
 Summary:
@@ -165,10 +165,15 @@ Summary:
 
 ---
 
-## 6  Inline Aggregation Flags
+## 5  Inline Aggregation Flags
 
 These flags run server-side analytics alongside (or instead of) search
-results.  For the `uffs --agg` subcommand, see §7 below.
+results.  For the `uffs --agg` command, see §6 below.
+
+> `--stats` and `--agg` are dual-use: as the **first token**
+> (`uffs --stats`, `uffs --agg <preset>`) they are commands; **after a
+> pattern** (`uffs '*.log' --stats size`) they are inline modifiers on a
+> search.  The first token decides — see [CLI Grammar](../architecture/cli-grammar.md).
 
 | Flag | Effect |
 |------|--------|
@@ -185,7 +190,7 @@ results.  For the `uffs --agg` subcommand, see §7 below.
 
 ---
 
-## 7  Commands
+## 6  Commands
 
 > Building/loading an index is **daemon-managed** — there is no standalone
 > `uffs index` command. Point the daemon at a live drive or a raw MFT with
@@ -242,7 +247,8 @@ uffs --daemon restart                         # Stop then restart
 Manage the MCP server for AI agent integration.
 
 ```bash
-uffs --mcp start                    # Start HTTP server on :8080
+uffs --mcp run                      # Run on stdin/stdout (for AI hosts)
+uffs --mcp start                    # Start HTTP server on :8080 (background)
 uffs --mcp start --port 9090        # Custom port
 uffs --mcp status                   # Health + stats
 uffs --mcp stop                     # Graceful shutdown
@@ -262,7 +268,7 @@ uffs --status
 
 ---
 
-## 8  Advanced / Diagnostic Flags
+## 7  Advanced / Diagnostic Flags
 
 These flags are for power users, profiling, and parity testing:
 
@@ -281,7 +287,7 @@ These flags are for power users, profiling, and parity testing:
 
 ---
 
-## 9  Examples
+## 8  Examples
 
 For a comprehensive recipe gallery organized by workflow (quick find,
 cleanup, developer/admin, attribute search, output piping), see

--- a/docs/user-manual/cli-overview.md
+++ b/docs/user-manual/cli-overview.md
@@ -168,7 +168,7 @@ Summary:
 ## 6  Inline Aggregation Flags
 
 These flags run server-side analytics alongside (or instead of) search
-results.  For the `uffs aggregate` subcommand, see §7 below.
+results.  For the `uffs --agg` subcommand, see §7 below.
 
 | Flag | Effect |
 |------|--------|
@@ -205,71 +205,71 @@ Show metadata about a saved index file.
 uffs info index.parquet
 ```
 
-### `uffs stats`
+### `uffs --stats`
 
 Show file statistics.  Without a path, connects to the daemon and
 runs the `overview` aggregate preset.  With a path, loads a parquet
 index file.
 
 ```bash
-uffs stats                    # Daemon mode (live overview)
-uffs stats index.parquet      # Parquet mode (--top 20 for largest files)
+uffs --stats                    # Daemon mode (live overview)
+uffs --stats index.parquet      # Parquet mode (--top 20 for largest files)
 ```
 
-### `uffs aggregate` (alias: `uffs agg`)
+### `uffs --agg` (alias: `uffs --aggregate`)
 
 Run server-side analytics on the filesystem index.  Returns aggregate
 results only — no file rows.
 
 ```bash
-uffs aggregate overview         # Full filesystem overview
-uffs aggregate by_extension     # Top 50 extensions
-uffs aggregate by_type          # Breakdown by file type
-uffs aggregate by_drive         # Per-drive totals
-uffs aggregate by_size          # Size distribution
-uffs aggregate by_age           # Age distribution
-uffs aggregate count            # Simple total count
+uffs --agg overview         # Full filesystem overview
+uffs --agg by_extension     # Top 50 extensions
+uffs --agg by_type          # Breakdown by file type
+uffs --agg by_drive         # Per-drive totals
+uffs --agg by_size          # Size distribution
+uffs --agg by_age           # Age distribution
+uffs --agg count            # Simple total count
 ```
 
 > **Full guide:** [Aggregation](aggregation.md)
 
-### `uffs daemon`
+### `uffs --daemon`
 
 Manage the UFFS background daemon.  The daemon starts automatically on
 first search — these commands give explicit control.
 
 ```bash
-uffs daemon start --data-dir ~/uffs_data   # Start with specific data
-uffs daemon status                          # Check status
-uffs daemon stats                           # Performance statistics
-uffs daemon stop                            # Graceful shutdown
-uffs daemon kill                            # Force kill + cleanup
-uffs daemon restart                         # Stop then restart
+uffs --daemon start --data-dir ~/uffs_data   # Start with specific data
+uffs --daemon status                          # Check status
+uffs --daemon stats                           # Performance statistics
+uffs --daemon stop                            # Graceful shutdown
+uffs --daemon kill                            # Force kill + cleanup
+uffs --daemon restart                         # Stop then restart
 ```
 
 > **Full guide:** [Daemon](daemon.md)
 
-### `uffs mcp`
+### `uffs --mcp`
 
 Manage the MCP server for AI agent integration.
 
 ```bash
-uffs mcp start                    # Start HTTP server on :8080
-uffs mcp start --port 9090        # Custom port
-uffs mcp status                   # Health + stats
-uffs mcp stop                     # Graceful shutdown
-uffs mcp reload                   # Reload all MCP sessions after binary update
+uffs --mcp start                    # Start HTTP server on :8080
+uffs --mcp start --port 9090        # Custom port
+uffs --mcp status                   # Health + stats
+uffs --mcp stop                     # Graceful shutdown
+uffs --mcp reload                   # Reload all MCP sessions after binary update
 ```
 
 > **Full guide:** [MCP Server](mcp.md)
 
-### `uffs status`
+### `uffs --status`
 
 Show combined system status — daemon + MCP HTTP server health in one
 view.
 
 ```bash
-uffs status
+uffs --status
 ```
 
 ---

--- a/docs/user-manual/daemon.md
+++ b/docs/user-manual/daemon.md
@@ -18,7 +18,7 @@ Searches that would normally take 60+ seconds to load data complete in
 ┌─────────┐                          ┌─────────────┐
 │ uffs CLI ├──── JSON-RPC over ──────┤ uffs-daemon  │
 │ uffs_tui │     local IPC socket    │  (in-memory  │
-│ uffs mcp │                         │   MFT index) │
+│ uffs --mcp │                         │   MFT index) │
 └─────────┘                          └─────────────┘
 ```
 
@@ -42,10 +42,10 @@ On non-Windows platforms, the daemon works with MFT capture files (`.iocp`,
 
 ```bash
 # Start the daemon with a data directory
-uffs daemon start --data-dir ~/uffs_data
+uffs --daemon start --data-dir ~/uffs_data
 
 # Or with individual MFT files
-uffs daemon start --mft-file /path/to/C_mft.iocp --mft-file /path/to/D_mft.iocp
+uffs --daemon start --mft-file /path/to/C_mft.iocp --mft-file /path/to/D_mft.iocp
 
 # Search (daemon is already running — instant results)
 uffs "*.rs" --data-dir ~/uffs_data
@@ -64,13 +64,13 @@ directly.  No `--data-dir` or `--mft-file` needed.
 
 ```powershell
 # Start the daemon (auto-discovers C:, D:, E:, ...)
-uffs daemon start
+uffs --daemon start
 
 # Search — daemon auto-starts if not running
 uffs "*.exe"
 
 # Force specific drives only
-uffs daemon start --drive C --drive D
+uffs --daemon start --drive C --drive D
 ```
 
 > **Note:** Live MFT access requires **Administrator privileges**.
@@ -109,14 +109,14 @@ removed on exit.
 | Disable retirement | `--no-retire` | Off |
 
 These flags are passed by the auto-start mechanism.  You can also set
-them on `uffs daemon start`:
+them on `uffs --daemon start`:
 
 ```bash
 # Never retire (run indefinitely)
-uffs daemon start --data-dir ~/uffs_data --idle-timeout 0
+uffs --daemon start --data-dir ~/uffs_data --idle-timeout 0
 
 # Retire after 30 minutes
-uffs daemon start --data-dir ~/uffs_data --idle-timeout 1800
+uffs --daemon start --data-dir ~/uffs_data --idle-timeout 1800
 ```
 
 ---
@@ -125,17 +125,17 @@ uffs daemon start --data-dir ~/uffs_data --idle-timeout 1800
 
 | Command | Description |
 |---------|-------------|
-| `uffs daemon start` | Start the daemon (with data sources) |
-| `uffs daemon status` | Show PID, uptime, loaded drives, record counts |
-| `uffs daemon stats` | Show performance metrics (queries, timing, startup) |
-| `uffs daemon stop` | Graceful shutdown via RPC |
-| `uffs daemon kill` | Hard kill + remove PID/socket files |
-| `uffs daemon restart` | Stop → re-start with same data sources |
+| `uffs --daemon start` | Start the daemon (with data sources) |
+| `uffs --daemon status` | Show PID, uptime, loaded drives, record counts |
+| `uffs --daemon stats` | Show performance metrics (queries, timing, startup) |
+| `uffs --daemon stop` | Graceful shutdown via RPC |
+| `uffs --daemon kill` | Hard kill + remove PID/socket files |
+| `uffs --daemon restart` | Stop → re-start with same data sources |
 
-### `uffs daemon status`
+### `uffs --daemon status`
 
 ```
-$ uffs daemon status
+$ uffs --daemon status
 Daemon PID:    72558
 Uptime:        145s
 Status:        Ready
@@ -146,10 +146,10 @@ Connections:   1
   ...
 ```
 
-### `uffs daemon stats`
+### `uffs --daemon stats`
 
 ```
-$ uffs daemon stats
+$ uffs --daemon stats
 ═══ Daemon Performance Stats ═══
 Uptime:            591s
 Startup duration:  10871ms
@@ -168,7 +168,7 @@ The daemon runs detached — its stdout is `/dev/null`.  To capture logs,
 use `--log-file` and `--log-level`:
 
 ```bash
-uffs daemon start --data-dir ~/uffs_data \
+uffs --daemon start --data-dir ~/uffs_data \
     --log-level debug \
     --log-file ~/uffs_daemon.log
 ```
@@ -200,7 +200,7 @@ logging — see [Advanced Diagnostics](advanced-diagnostics.md) for details.
 | Linux | `$XDG_RUNTIME_DIR/uffs/uffs-daemon.sock` or `/tmp/uffs/uffs-daemon.sock` |
 | Windows | `\\.\pipe\uffs-daemon` |
 
-PID files are stored alongside the socket.  `uffs daemon kill` removes
+PID files are stored alongside the socket.  `uffs --daemon kill` removes
 both if a graceful stop fails.
 
 ---
@@ -236,11 +236,11 @@ stdout formatting.
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| "Connection refused" on search | Daemon not running | Let auto-start handle it, or `uffs daemon start` |
-| Stale PID file | Previous daemon crashed | `uffs daemon kill` removes PID + socket |
+| "Connection refused" on search | Daemon not running | Let auto-start handle it, or `uffs --daemon start` |
+| Stale PID file | Previous daemon crashed | `uffs --daemon kill` removes PID + socket |
 | First search slow after restart | MFT being loaded | Normal — ~7 s warm cache (or ~66 s cold), sub-second after |
 | "Permission denied" (Windows) | Not running as Admin | Right-click terminal → "Run as administrator" |
-| Multiple daemons running | Rare race condition | `uffs daemon kill` + `uffs daemon start` |
+| Multiple daemons running | Rare race condition | `uffs --daemon kill` + `uffs --daemon start` |
 
 > **More troubleshooting:** [Troubleshooting](troubleshooting.md)
 

--- a/docs/user-manual/faq.md
+++ b/docs/user-manual/faq.md
@@ -102,7 +102,7 @@ The daemon loads the MFT at startup and holds it in memory.  Files
 created after startup are not visible until you restart the daemon:
 
 ```bash
-uffs daemon restart
+uffs --daemon restart
 ```
 
 ---
@@ -132,10 +132,10 @@ the raw MFT data.
 
 ```bash
 # Restart daemon (re-reads MFT or cache)
-uffs daemon restart
+uffs --daemon restart
 
 # Force re-parse (bypass .iocp cache)
-uffs daemon restart --no-cache
+uffs --daemon restart --no-cache
 ```
 
 ---

--- a/docs/user-manual/getting-started.md
+++ b/docs/user-manual/getting-started.md
@@ -113,7 +113,7 @@ second one was instant.  That is the daemon.
 Check its status:
 
 ```bash
-uffs daemon status
+uffs --daemon status
 ```
 
 

--- a/docs/user-manual/glossary.md
+++ b/docs/user-manual/glossary.md
@@ -25,7 +25,7 @@ Key terms used throughout the UFFS documentation.
 | **MFT** | Master File Table — the central metadata database of an NTFS volume. Contains one record per file/directory with name, size, timestamps, and attributes. |
 | **MFT bitmap** | A bitmap indicating which MFT records are in use. UFFS uses this to skip free records (faster reads). Disabled with `--no-bitmap`. |
 | **NDJSON** | Newline-Delimited JSON — one JSON object per line. UFFS's `--format json` output format. |
-| **Parquet** | Apache Parquet — a columnar file format. `uffs index` can export the MFT to Parquet for external analysis. |
+| **Parquet** | Apache Parquet — a columnar file format. UFFS can export the MFT to Parquet (daemon-managed, or via the `uffs-mft` tool) for external analysis. |
 | **Path resolution** | The process of reconstructing full file paths from MFT data. The MFT stores only filenames and parent FRS numbers, not full paths. UFFS's `FastPathResolver` walks the parent chain. |
 | **Reparse point** | An NTFS feature for symlinks, junctions, and volume mount points. Detected via the reparse attribute flag. |
 | **SoA** | Struct of Arrays — a data layout where each field is stored in a separate contiguous array. UFFS uses SoA for the compact index, enabling SIMD-friendly scans. |

--- a/docs/user-manual/index.md
+++ b/docs/user-manual/index.md
@@ -125,7 +125,7 @@ Start here and follow the arrows.  Each page builds on the previous one.
 | Search with wildcards or regex | [Search Modes](search-modes.md) |
 | Find large / old / hidden files | [Filters](filters.md) |
 | Clean up disk space | [Getting Started](getting-started.md) §5 — Triage recipes |
-| Get a filesystem overview | [Aggregation](aggregation.md) §1 — `uffs agg overview` |
+| Get a filesystem overview | [Aggregation](aggregation.md) §1 — `uffs --agg overview` |
 | Understand why sizes differ from Explorer | [Concepts](concepts.md) §1 |
 | See real-world performance numbers | [Performance](performance.md) |
 | Set up UFFS for AI agents | [MCP Server](mcp.md) |

--- a/docs/user-manual/installation.md
+++ b/docs/user-manual/installation.md
@@ -80,10 +80,10 @@ This downloads the latest release binaries and installs them to `~/bin`.
 5. To start the MCP server for AI agents:
 
    ```powershell
-   uffs mcp start
+   uffs --mcp start
    ```
 
-   Run `uffs mcp --help` for instructions on how to configure
+   Run `uffs --mcp --help` for instructions on how to configure
    Claude, Cursor, Windsurf, and other AI agents to connect to the
    MCP server.
 

--- a/docs/user-manual/mcp.md
+++ b/docs/user-manual/mcp.md
@@ -33,7 +33,7 @@ The daemon must be running (it auto-starts when needed).
 | | HTTP (recommended) | stdio |
 |---|---|---|
 | **Sessions** | Multi-session — many agents share one server | Single-session per AI host |
-| **Lifecycle** | You manage: `uffs mcp start` / `stop` | AI host manages: spawns and kills |
+| **Lifecycle** | You manage: `uffs --mcp start` / `stop` | AI host manages: spawns and kills |
 | **Persistence** | Stays running between agent restarts | Dies when agent disconnects |
 | **Setup** | One `start`, then point hosts at URL | Config per host with `command` + `args` |
 | **Auth** | Optional bearer token | No auth (pipe is private) |
@@ -48,25 +48,25 @@ The daemon must be running (it auto-starts when needed).
 ```bash
 # Start the MCP HTTP server (auto-starts daemon too)
 # Windows — auto-discovers NTFS drives:
-uffs mcp start
+uffs --mcp start
 
 # macOS / Linux — provide MFT data:
-uffs mcp start --data-dir ~/uffs_data
+uffs --mcp start --data-dir ~/uffs_data
 
 # Custom port:
-uffs mcp start --port 9090
+uffs --mcp start --port 9090
 
 # With authentication:
-uffs mcp start --auth-token MY_SECRET_TOKEN
+uffs --mcp start --auth-token MY_SECRET_TOKEN
 
 # Check status:
-uffs mcp status
+uffs --mcp status
 
 # Performance stats:
-uffs mcp stats
+uffs --mcp stats
 
 # Stop:
-uffs mcp stop
+uffs --mcp stop
 ```
 
 ### stdio mode
@@ -74,7 +74,7 @@ uffs mcp stop
 ```bash
 # Typically not run manually — configured in the AI host's MCP settings.
 # The host spawns this process and communicates via stdin/stdout.
-uffs mcp run --data-dir ~/uffs_data
+uffs --mcp run --data-dir ~/uffs_data
 ```
 
 ---
@@ -165,7 +165,7 @@ HTTP mode is auto-detected when the server is running.  Stdio mode:
 
 ### Standalone binary (alternative)
 
-The `uffs-mcp` binary can be used instead of `uffs mcp run`:
+The `uffs-mcp` binary can be used instead of `uffs --mcp run`:
 
 ```json
 {
@@ -308,18 +308,18 @@ then execute the steps using the tools above.
 
 | Command | Description |
 |---------|-------------|
-| `uffs mcp start` | Start the HTTP gateway as a background process |
-| `uffs mcp status` | Show PID, uptime, HTTP health, and load stats |
-| `uffs mcp stats` | Show performance metrics (queries, timing, sessions) |
-| `uffs mcp stop` | Graceful shutdown via HTTP `/shutdown` |
-| `uffs mcp kill` | Hard kill (SIGKILL / taskkill) + PID file cleanup |
-| `uffs mcp restart` | Stop → start with the same configuration |
-| `uffs mcp reload` | SIGHUP all stdio sessions + restart HTTP gateway |
+| `uffs --mcp start` | Start the HTTP gateway as a background process |
+| `uffs --mcp status` | Show PID, uptime, HTTP health, and load stats |
+| `uffs --mcp stats` | Show performance metrics (queries, timing, sessions) |
+| `uffs --mcp stop` | Graceful shutdown via HTTP `/shutdown` |
+| `uffs --mcp kill` | Hard kill (SIGKILL / taskkill) + PID file cleanup |
+| `uffs --mcp restart` | Stop → start with the same configuration |
+| `uffs --mcp reload` | SIGHUP all stdio sessions + restart HTTP gateway |
 
 ### Status
 
 ```
-$ uffs mcp status
+$ uffs --mcp status
 MCP HTTP Server
   PID:         89234
   Transport:   http:127.0.0.1:8080
@@ -331,7 +331,7 @@ MCP HTTP Server
 ### Stats
 
 ```
-$ uffs mcp stats
+$ uffs --mcp stats
 ═══ MCP Server Stats ═══
 Uptime:            15732s
 Tool calls:        847
@@ -365,7 +365,7 @@ When started with `--auth-token`, the HTTP gateway requires a bearer token
 on all `/mcp` requests:
 
 ```bash
-uffs mcp start --auth-token MY_SECRET
+uffs --mcp start --auth-token MY_SECRET
 
 curl -X POST http://127.0.0.1:8080/mcp \
   -H "Authorization: Bearer MY_SECRET" \
@@ -458,7 +458,7 @@ deadline.  A busy agent will never trigger it.
 
 ### HTTP mode
 
-The HTTP gateway runs indefinitely.  Use `uffs mcp stop` to shut it down.
+The HTTP gateway runs indefinitely.  Use `uffs --mcp stop` to shut it down.
 
 ---
 
@@ -469,16 +469,16 @@ or a log file.
 
 ```bash
 # Default: INFO to stderr
-uffs mcp run
+uffs --mcp run
 
 # Verbose: auto-creates log file
-UFFS_LOG=debug uffs mcp run
+UFFS_LOG=debug uffs --mcp run
 
 # Explicit log file
-UFFS_LOG_FILE=/tmp/mcp.log uffs mcp run
+UFFS_LOG_FILE=/tmp/mcp.log uffs --mcp run
 
 # Both
-UFFS_LOG=trace UFFS_LOG_FILE=/tmp/mcp-diag.log uffs mcp run
+UFFS_LOG=trace UFFS_LOG_FILE=/tmp/mcp-diag.log uffs --mcp run
 ```
 
 Default log file location:
@@ -492,12 +492,12 @@ Default log file location:
 
 The MCP server is **not** the daemon.  They are separate processes:
 
-| | Daemon (`uffs-daemon`) | MCP Server (`uffs mcp`) |
+| | Daemon (`uffs-daemon`) | MCP Server (`uffs --mcp`) |
 |---|---|---|
 | **Role** | Holds MFT index in memory, executes queries | Bridges MCP protocol to daemon |
 | **Data** | Yes — full file index | No — stateless bridge |
-| **Started by** | Auto-started by first client | `uffs mcp start` or AI host |
-| **Stopped by** | `uffs daemon stop` or idle timeout | `uffs mcp stop` or AI host disconnect |
+| **Started by** | Auto-started by first client | `uffs --mcp start` or AI host |
+| **Stopped by** | `uffs --daemon stop` or idle timeout | `uffs --mcp stop` or AI host disconnect |
 | **Multiple?** | One daemon per machine | Many MCP servers (one per AI host session) |
 
 When the MCP server connects, it auto-starts the daemon if needed.

--- a/docs/user-manual/troubleshooting.md
+++ b/docs/user-manual/troubleshooting.md
@@ -19,10 +19,10 @@ a crashed daemon.
 uffs '*.txt'
 
 # Or start manually
-uffs daemon start --data-dir ~/uffs_data
+uffs --daemon start --data-dir ~/uffs_data
 
 # If stale files are blocking startup
-uffs daemon kill
+uffs --daemon kill
 uffs '*.txt'
 ```
 
@@ -58,10 +58,10 @@ the daemon may be restarting each time:
 
 ```bash
 # Check if daemon is running
-uffs daemon status
+uffs --daemon status
 
 # Check daemon idle timeout (default: 2 hours)
-uffs daemon stats
+uffs --daemon stats
 ```
 
 ---
@@ -71,7 +71,7 @@ uffs daemon stats
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
 | Zero results for any pattern | Wrong data source | Check `--data-dir` path; verify MFT files exist |
-| Missing files from specific drives | Drive not loaded | Check `uffs daemon status` for loaded drives |
+| Missing files from specific drives | Drive not loaded | Check `uffs --daemon status` for loaded drives |
 | Missing hidden/system files | Filtered by default | Use `--attr hidden` or `--attr system` |
 | Missing `$` files | System files hidden | Use `--hide-system false` or search `$*` |
 | Missing directories | `--files-only` active | Remove `--files-only` or use `--dirs-only` |
@@ -87,10 +87,10 @@ uffs daemon stats
 
 ```bash
 # Force re-parse of raw MFT data (bypass cache)
-uffs daemon restart --no-cache
+uffs --daemon restart --no-cache
 
 # On Windows (re-read live MFT)
-uffs daemon restart
+uffs --daemon restart
 ```
 
 The daemon does not watch the filesystem for changes.  If files have
@@ -157,8 +157,8 @@ NTFS drives and 25 million files uses roughly 4–6 GB of RAM.
 uffs --help
 
 # Show subcommand help
-uffs daemon --help
-uffs agg --help
+uffs --daemon --help
+uffs --agg --help
 
 # Verbose mode for diagnostic output
 uffs '*.txt' -v
@@ -169,6 +169,6 @@ reporting an issue:
 
 ```bash
 uffs --version
-uffs daemon status
-uffs daemon stats
+uffs --daemon status
+uffs --daemon stats
 ```

--- a/packaging/winget/nested-aliases.yaml
+++ b/packaging/winget/nested-aliases.yaml
@@ -36,7 +36,7 @@
 - RelativeFilePath: uffs-windows-x64/uffs-broker.exe
   PortableCommandAlias: uffs-broker
 
-# uffs-update: the self-update helper that `uffs update` / `uffs update
+# uffs-update: the self-update helper that `uffs --update` / `uffs --update
 # doctor` spawn (it finds itself next to uffs.exe). Declaring it as a
 # NestedInstallerFile guarantees winget actually installs it alongside the
 # CLI, so the in-app updater works for winget users too. Bundled into EVERY

--- a/scripts/dev/build-local.rs
+++ b/scripts/dev/build-local.rs
@@ -44,7 +44,7 @@ fn build_profile() -> &'static str {
 /// - uffsd: Background daemon (holds MFT index, serves queries via IPC)
 /// - uffsmcp: MCP HTTP/stdio server (bridges AI agents to daemon)
 /// - uffs_mft: Low-level MFT reading tool
-/// - uffs-update: self-update helper (`uffs update` spawns it as a sibling)
+/// - uffs-update: self-update helper (`uffs --update` spawns it as a sibling)
 /// - uffs-broker: Windows elevated handle broker (real service on Windows;
 ///   a no-op stub off Windows)
 ///

--- a/scripts/dev/daemon-readiness.rs
+++ b/scripts/dev/daemon-readiness.rs
@@ -144,7 +144,7 @@ struct Cli {
     /// ```
     ///
     /// Adds ~`<value>` seconds of wall-clock to the run.  Mirrors
-    /// the Windows-host runbook gate **G6 — `uffs daemon preload` pin
+    /// the Windows-host runbook gate **G6 — `uffs --daemon preload` pin
     /// contract survives idle TTL** (Ctrl-F for `G6 —` in
     /// `docs/architecture/memory-tiering-windows-host-validation.md`).
     /// Reference uses the gate ID, not the section number, so future
@@ -388,12 +388,12 @@ impl Runner {
     // ── Helpers ──────────────────────────────────────────────────────────
 
     fn ensure_stopped(&self) {
-        let _ = self.run_ok(&["daemon", "kill"]);
+        let _ = self.run_ok(&["--daemon", "kill"]);
         // Poll until the daemon is actually gone (up to 10s).
         let deadline = Instant::now() + Duration::from_secs(10);
         while Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(250));
-            if let Ok(out) = self.run_ok(&["daemon", "status"]) {
+            if let Ok(out) = self.run_ok(&["--daemon", "status"]) {
                 if out.contains("not running") { return; }
             }
         }
@@ -403,7 +403,7 @@ impl Runner {
         // Poll for up to 5s — on Windows, process teardown can be slow.
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
-            let out = self.run_ok(&["daemon", "status"])?;
+            let out = self.run_ok(&["--daemon", "status"])?;
             if out.contains("not running") { return Ok(()); }
             if Instant::now() >= deadline {
                 bail!("Expected 'not running', got:\n{out}");
@@ -413,7 +413,7 @@ impl Runner {
     }
 
     fn assert_ready(&self) -> Result<String> {
-        let out = self.run_ok(&["daemon", "status"])?;
+        let out = self.run_ok(&["--daemon", "status"])?;
         if !out.contains("Ready") {
             bail!("Expected 'Ready', got:\n{out}");
         }
@@ -422,7 +422,7 @@ impl Runner {
     }
 
     fn start_daemon(&self) -> Result<String> {
-        let mut args: Vec<&str> = vec!["daemon", "start"];
+        let mut args: Vec<&str> = vec!["--daemon", "start"];
         args.extend(self.source_args());
         self.run_ok(&args)
     }
@@ -443,22 +443,22 @@ impl Runner {
     // hibernate (RAM-only release) vs preload (cold-boot decrypt) vs
     // forget (registry eviction + four-file unlink) costs.
 
-    /// `uffs daemon status_drives` — Phase 8-E table.  Returns the raw
+    /// `uffs --daemon status_drives` — Phase 8-E table.  Returns the raw
     /// stdout; callers parse it with `parse_drive_tier` /
     /// `parse_pin_until` / `parse_promotions_total`.
     fn status_drives(&mut self) -> Result<(String, u128)> {
         let t = Instant::now();
-        let out = self.run_ok(&["daemon", "status_drives"])?;
+        let out = self.run_ok(&["--daemon", "status_drives"])?;
         let ms = t.elapsed().as_millis();
         self.phase8_timings.push(("status_drives".to_owned(), ms));
         Ok((out, ms))
     }
 
-    /// `uffs daemon hibernate [DRIVES...]` — Phase 8-B.  Empty `drives`
+    /// `uffs --daemon hibernate [DRIVES...]` — Phase 8-B.  Empty `drives`
     /// hibernates every loaded drive.
     fn hibernate(&mut self, drives: &[char]) -> Result<(String, u128)> {
         let drive_strs: Vec<String> = drives.iter().map(|c| c.to_string()).collect();
-        let mut args: Vec<&str> = vec!["daemon", "hibernate"];
+        let mut args: Vec<&str> = vec!["--daemon", "hibernate"];
         for s in &drive_strs {
             args.push(s);
         }
@@ -469,7 +469,7 @@ impl Runner {
         Ok((out, ms))
     }
 
-    /// `uffs daemon preload <DRIVE> --pin-minutes N` — Phase 8-C.
+    /// `uffs --daemon preload <DRIVE> --pin-minutes N` — Phase 8-C.
     fn preload(&mut self, drive: char, pin_minutes: u32) -> Result<(String, u128)> {
         let drive_s = drive.to_string();
         let pin_s = pin_minutes.to_string();
@@ -481,11 +481,11 @@ impl Runner {
         Ok((out, ms))
     }
 
-    /// `uffs daemon forget <DRIVE> [--force]` — Phase 8-D.
+    /// `uffs --daemon forget <DRIVE> [--force]` — Phase 8-D.
     /// **Destructive:** deletes every per-drive cache file.
     fn forget(&mut self, drive: char, force: bool) -> Result<(String, u128)> {
         let drive_s = drive.to_string();
-        let mut args: Vec<&str> = vec!["daemon", "forget", &drive_s];
+        let mut args: Vec<&str> = vec!["--daemon", "forget", &drive_s];
         if force {
             args.push("--force");
         }
@@ -753,7 +753,7 @@ fn scenario_a(r: &mut Runner) {
         Ok(format!("[{n} rows]"))
     });
     r.step("A7  Stats show queries", |r| {
-        let out = r.run_ok(&["daemon", "stats"])?;
+        let out = r.run_ok(&["--daemon", "stats"])?;
         if !out.contains("Queries served:") { bail!("Missing stats"); }
         let detail: Vec<&str> = out.lines()
             .map(|l| l.trim())
@@ -763,7 +763,7 @@ fn scenario_a(r: &mut Runner) {
             .collect();
         Ok(detail.join(" | "))
     });
-    r.step("A8  Graceful stop", |r| { r.run_ok(&["daemon", "stop"])?; Ok(String::new()) });
+    r.step("A8  Graceful stop", |r| { r.run_ok(&["--daemon", "stop"])?; Ok(String::new()) });
     r.step("A9  Verify stopped", |r| { r.assert_not_running()?; Ok(String::new()) });
 }
 
@@ -773,24 +773,24 @@ fn scenario_b(r: &mut Runner) {
     r.step("B0  Ensure stopped", |r| { r.ensure_stopped(); Ok(String::new()) });
     r.step("B1  Status when not running", |r| { r.assert_not_running()?; Ok(String::new()) });
     r.step("B2  Stop when not running", |r| {
-        let out = r.run_ok(&["daemon", "stop"])?;
+        let out = r.run_ok(&["--daemon", "stop"])?;
         if !out.contains("not running") { bail!("Expected 'not running', got: {out}"); }
         Ok(String::new())
     });
     r.step("B3  Kill when not running", |r| {
-        let out = r.run_ok(&["daemon", "kill"])?;
+        let out = r.run_ok(&["--daemon", "kill"])?;
         if !out.contains("No daemon found") && !out.contains("not running") {
             bail!("Expected no-daemon message, got: {out}");
         }
         Ok(String::new())
     });
     r.step("B4  Restart when not running", |r| {
-        let out = r.run_ok(&["daemon", "restart"])?;
+        let out = r.run_ok(&["--daemon", "restart"])?;
         if !out.contains("not running") { bail!("Expected 'not running', got: {out}"); }
         Ok(String::new())
     });
     r.step("B5  Stats when not running", |r| {
-        let out = r.run_ok(&["daemon", "stats"])?;
+        let out = r.run_ok(&["--daemon", "stats"])?;
         if !out.contains("not running") { bail!("Expected 'not running', got: {out}"); }
         Ok(String::new())
     });
@@ -807,7 +807,7 @@ fn scenario_c(r: &mut Runner) {
         Ok(String::new())
     });
     r.step("C3  Still Ready", |r| r.assert_ready());
-    r.step("C4  Cleanup: stop", |r| { r.run_ok(&["daemon", "stop"])?; Ok(String::new()) });
+    r.step("C4  Cleanup: stop", |r| { r.run_ok(&["--daemon", "stop"])?; Ok(String::new()) });
 }
 
 fn scenario_d(r: &mut Runner) {
@@ -816,7 +816,7 @@ fn scenario_d(r: &mut Runner) {
     r.step("D0  Ensure stopped", |r| { r.ensure_stopped(); Ok(String::new()) });
     r.step("D1  Start daemon", |r| { r.start_daemon()?; Ok(String::new()) });
     r.step("D2  Verify Ready", |r| r.assert_ready());
-    r.step("D3  Kill -9", |r| { r.run_ok(&["daemon", "kill"])?; Ok(String::new()) });
+    r.step("D3  Kill -9", |r| { r.run_ok(&["--daemon", "kill"])?; Ok(String::new()) });
     r.step("D4  Verify stopped", |r| { r.assert_not_running()?; Ok(String::new()) });
     r.step("D5  Start after kill", |r| { r.start_daemon()?; Ok(String::new()) });
     r.step("D6  Verify Ready after kill→start", |r| r.assert_ready());
@@ -825,7 +825,7 @@ fn scenario_d(r: &mut Runner) {
         if n == 0 { bail!("Zero results after kill→start"); }
         Ok(format!("[{n} rows]"))
     });
-    r.step("D8  Cleanup: stop", |r| { r.run_ok(&["daemon", "stop"])?; Ok(String::new()) });
+    r.step("D8  Cleanup: stop", |r| { r.run_ok(&["--daemon", "stop"])?; Ok(String::new()) });
 }
 
 fn scenario_e(r: &mut Runner) {
@@ -838,7 +838,7 @@ fn scenario_e(r: &mut Runner) {
         if n == 0 { bail!("Zero results"); }
         Ok(format!("[{n} rows]"))
     });
-    r.step("E3  Stop", |r| { r.run_ok(&["daemon", "stop"])?; Ok(String::new()) });
+    r.step("E3  Stop", |r| { r.run_ok(&["--daemon", "stop"])?; Ok(String::new()) });
     r.step("E4  Verify stopped", |r| { r.assert_not_running()?; Ok(String::new()) });
     r.step("E5  Start again", |r| { r.start_daemon()?; Ok(String::new()) });
     r.step("E6  Search after stop→start", |r| {
@@ -846,7 +846,7 @@ fn scenario_e(r: &mut Runner) {
         if n == 0 { bail!("Zero results"); }
         Ok(format!("[{n} rows]"))
     });
-    r.step("E7  Cleanup: stop", |r| { r.run_ok(&["daemon", "stop"])?; Ok(String::new()) });
+    r.step("E7  Cleanup: stop", |r| { r.run_ok(&["--daemon", "stop"])?; Ok(String::new()) });
 }
 
 fn scenario_f(r: &mut Runner) {
@@ -860,14 +860,14 @@ fn scenario_f(r: &mut Runner) {
         if n == 0 { bail!("Zero results"); }
         Ok(format!("[{n} rows]"))
     });
-    r.step("F4  Restart", |r| { r.run_ok(&["daemon", "restart"])?; Ok(String::new()) });
+    r.step("F4  Restart", |r| { r.run_ok(&["--daemon", "restart"])?; Ok(String::new()) });
     r.step("F5  Verify Ready after restart", |r| r.assert_ready());
     r.step("F6  Search after restart", |r| {
         let n = r.search(1000)?;
         if n == 0 { bail!("Zero results after restart"); }
         Ok(format!("[{n} rows]"))
     });
-    r.step("F7  Cleanup: stop", |r| { r.run_ok(&["daemon", "stop"])?; Ok(String::new()) });
+    r.step("F7  Cleanup: stop", |r| { r.run_ok(&["--daemon", "stop"])?; Ok(String::new()) });
 }
 
 fn scenario_g(r: &mut Runner) {
@@ -875,16 +875,16 @@ fn scenario_g(r: &mut Runner) {
 
     r.step("G0  Ensure stopped", |r| { r.ensure_stopped(); Ok(String::new()) });
     r.step("G1  Start", |r| { r.start_daemon()?; Ok(String::new()) });
-    r.step("G2  Restart #1", |r| { r.run_ok(&["daemon", "restart"])?; Ok(String::new()) });
+    r.step("G2  Restart #1", |r| { r.run_ok(&["--daemon", "restart"])?; Ok(String::new()) });
     r.step("G3  Verify Ready", |r| r.assert_ready());
-    r.step("G4  Restart #2", |r| { r.run_ok(&["daemon", "restart"])?; Ok(String::new()) });
+    r.step("G4  Restart #2", |r| { r.run_ok(&["--daemon", "restart"])?; Ok(String::new()) });
     r.step("G5  Verify Ready", |r| r.assert_ready());
     r.step("G6  Search after 2 restarts", |r| {
         let n = r.search(1000)?;
         if n == 0 { bail!("Zero results"); }
         Ok(format!("[{n} rows]"))
     });
-    r.step("G7  Cleanup: stop", |r| { r.run_ok(&["daemon", "stop"])?; Ok(String::new()) });
+    r.step("G7  Cleanup: stop", |r| { r.run_ok(&["--daemon", "stop"])?; Ok(String::new()) });
 }
 
 fn scenario_h(r: &mut Runner) {
@@ -897,7 +897,7 @@ fn scenario_h(r: &mut Runner) {
         Ok(String::new())
     });
     r.step("H3  Stats show ≥3 queries", |r| {
-        let out = r.run_ok(&["daemon", "stats"])?;
+        let out = r.run_ok(&["--daemon", "stats"])?;
         let count_line = out.lines()
             .find(|l| l.contains("Queries served:"))
             .unwrap_or("");
@@ -908,7 +908,7 @@ fn scenario_h(r: &mut Runner) {
         if count < 3 { bail!("Expected ≥3 queries, got {count}"); }
         Ok(format!("[{count} queries]"))
     });
-    r.step("H4  Cleanup: stop", |r| { r.run_ok(&["daemon", "stop"])?; Ok(String::new()) });
+    r.step("H4  Cleanup: stop", |r| { r.run_ok(&["--daemon", "stop"])?; Ok(String::new()) });
 }
 
 fn scenario_i(r: &mut Runner) {
@@ -917,7 +917,7 @@ fn scenario_i(r: &mut Runner) {
     r.step("I0  Ensure stopped", |r| { r.ensure_stopped(); Ok(String::new()) });
     r.step("I1  Start", |r| { r.start_daemon()?; Ok(String::new()) });
     r.step("I2  Verify Ready", |r| r.assert_ready());
-    r.step("I3  Kill", |r| { r.run_ok(&["daemon", "kill"])?; Ok(String::new()) });
+    r.step("I3  Kill", |r| { r.run_ok(&["--daemon", "kill"])?; Ok(String::new()) });
     r.step("I4  Status → not running", |r| { r.assert_not_running()?; Ok(String::new()) });
 }
 
@@ -932,7 +932,7 @@ fn scenario_j(r: &mut Runner) {
         Ok(format!("[{n} rows, daemon auto-started]"))
     });
     r.step("J3  Verify daemon now running", |r| r.assert_ready());
-    r.step("J4  Cleanup: stop", |r| { r.run_ok(&["daemon", "stop"])?; Ok(String::new()) });
+    r.step("J4  Cleanup: stop", |r| { r.run_ok(&["--daemon", "stop"])?; Ok(String::new()) });
 }
 
 // ── Startup Timing (COLD → WARM → HOT) ──────────────────────────────────────
@@ -970,7 +970,7 @@ fn delete_cache() {
 /// Measure daemon start + first-query timing at a given cache level.
 fn measure_startup(r: &Runner, label: &str) -> Result<(u128, u128, usize)> {
     // 1. Start daemon (blocking).
-    let mut start_args: Vec<&str> = vec!["daemon", "start"];
+    let mut start_args: Vec<&str> = vec!["--daemon", "start"];
     let sa = r.source_args();
     start_args.extend(&sa);
     let t0 = Instant::now();
@@ -1109,7 +1109,7 @@ fn scenario_l(r: &mut Runner) {
         // the operator needs to know their mutation didn't run;
         // those error paths are exercised in scenarios M / N / O
         // when the daemon happens to be up and healthy.
-        let out = r.run_ok(&["daemon", "status_drives"])?;
+        let out = r.run_ok(&["--daemon", "status_drives"])?;
         let lower = out.to_lowercase();
         if !lower.contains("not running") {
             bail!(
@@ -1221,7 +1221,7 @@ fn scenario_l(r: &mut Runner) {
     });
 
     r.step("L8  Cleanup: stop", |r| {
-        r.run_ok(&["daemon", "stop"])?;
+        r.run_ok(&["--daemon", "stop"])?;
         Ok(String::new())
     });
 }
@@ -1318,7 +1318,7 @@ fn scenario_m(r: &mut Runner) {
     });
 
     r.step("M9  Cleanup: stop", |r| {
-        r.run_ok(&["daemon", "stop"])?;
+        r.run_ok(&["--daemon", "stop"])?;
         Ok(String::new())
     });
 }
@@ -1443,7 +1443,7 @@ fn scenario_n(r: &mut Runner) {
     }
 
     r.step("N9  Cleanup: stop", |r| {
-        r.run_ok(&["daemon", "stop"])?;
+        r.run_ok(&["--daemon", "stop"])?;
         Ok(String::new())
     });
 }
@@ -1555,7 +1555,7 @@ fn scenario_o(r: &mut Runner) {
     });
 
     r.step("O8  Cleanup: stop", |r| {
-        r.run_ok(&["daemon", "stop"])?;
+        r.run_ok(&["--daemon", "stop"])?;
         Ok(String::new())
     });
 }
@@ -1642,7 +1642,7 @@ fn scenario_p(r: &mut Runner) {
     });
 
     r.step("P10 Cleanup: stop", |r| {
-        r.run_ok(&["daemon", "stop"])?;
+        r.run_ok(&["--daemon", "stop"])?;
         Ok(String::new())
     });
 }
@@ -1828,7 +1828,7 @@ fn scenario_q(r: &mut Runner) {
     });
 
     r.step("Q10 Cleanup: stop", |r| {
-        r.run_ok(&["daemon", "stop"])?;
+        r.run_ok(&["--daemon", "stop"])?;
         Ok(String::new())
     });
 }
@@ -2015,7 +2015,7 @@ fn scenario_r(r: &mut Runner) {
     });
 
     r.step("R13 Cleanup: stop", |r| {
-        r.run_ok(&["daemon", "stop"])?;
+        r.run_ok(&["--daemon", "stop"])?;
         Ok(String::new())
     });
 }
@@ -2228,7 +2228,7 @@ fn scenario_s(r: &mut Runner) {
     });
 
     r.step("S12 Cleanup: stop", |r| {
-        r.run_ok(&["daemon", "stop"])?;
+        r.run_ok(&["--daemon", "stop"])?;
         Ok(String::new())
     });
 }

--- a/scripts/dev/long-soak.rs
+++ b/scripts/dev/long-soak.rs
@@ -50,7 +50,7 @@
 //     ├── daemon.log                  # daemon's own --log-file output
 //     ├── snapshots/
 //     │   ├── 00h-process.json        # Get-Process uffsd (Windows only)
-//     │   ├── 00h-status-drives.txt   # uffs daemon status_drives capture
+//     │   ├── 00h-status-drives.txt   # uffs --daemon status_drives capture
 //     │   ├── 00h-cache-sizes.txt     # encrypted-cache file sizes (Phase 7)
 //     │   ├── ...
 //     │   └── 24h-...
@@ -146,7 +146,7 @@ struct Cli {
 
     /// Offline data dir containing `drive_<L>/<L>_mft.iocp` snapshots
     /// (Mac-only — required because macOS has no live NTFS auto-discovery).
-    /// Forwarded to `uffs daemon start --data-dir <PATH>`.  On Windows the
+    /// Forwarded to `uffs --daemon start --data-dir <PATH>`.  On Windows the
     /// daemon auto-discovers live NTFS volumes; leave this unset.
     #[arg(long, global = true)]
     data_dir: Option<PathBuf>,
@@ -427,10 +427,10 @@ impl Daemon {
     }
 
     fn ensure_stopped(&self) -> Result<()> {
-        let _ = self.run(&["daemon", "kill"]);
+        let _ = self.run(&["--daemon", "kill"]);
         let deadline = Instant::now() + STOP_TIMEOUT;
         while Instant::now() < deadline {
-            if let Ok(out) = self.run(&["daemon", "status"]) {
+            if let Ok(out) = self.run(&["--daemon", "status"]) {
                 if out.contains("not running") {
                     return Ok(());
                 }
@@ -440,10 +440,10 @@ impl Daemon {
         bail!("daemon failed to stop within {}s", STOP_TIMEOUT.as_secs());
     }
 
-    /// True when `uffs daemon status` reports `Ready` — i.e. the
+    /// True when `uffs --daemon status` reports `Ready` — i.e. the
     /// daemon is up AND past the Loading phase.
     fn is_ready(&self) -> bool {
-        matches!(self.run(&["daemon", "status"]), Ok(out) if out.contains("Ready"))
+        matches!(self.run(&["--daemon", "status"]), Ok(out) if out.contains("Ready"))
     }
 
     /// Bring the daemon up to Ready, idempotently.
@@ -485,7 +485,7 @@ impl Daemon {
         //    Windows under elevation.
         let log_arg = self.log_file.to_string_lossy().into_owned();
         let mut cmd = Command::new(&self.binary);
-        cmd.args(["daemon", "start", "--log-file", &log_arg]);
+        cmd.args(["--daemon", "start", "--log-file", &log_arg]);
         // Mac only: forward the offline MFT data dir.  On Windows the
         // daemon auto-discovers live NTFS volumes and this is None.
         if let Some(dir) = data_dir {
@@ -531,7 +531,7 @@ impl Daemon {
     }
 
     fn status_drives(&self) -> Result<String> {
-        self.run(&["daemon", "status_drives"])
+        self.run(&["--daemon", "status_drives"])
     }
 }
 
@@ -1386,15 +1386,15 @@ fn run_ws_trace(
     // capture 24 h of "Get-Process returned nothing".
     if !no_daemon_check {
         let status = daemon
-            .run(&["daemon", "status"])
-            .context("running `uffs daemon status` to check Ready precondition")?;
+            .run(&["--daemon", "status"])
+            .context("running `uffs --daemon status` to check Ready precondition")?;
         if !status.contains("Ready") {
             bail!(
                 "WS-trace requires a Ready daemon — observed status:\n\
                  ───\n{status}───\n\n\
-                 Start the daemon first (e.g. `uffs daemon start \
+                 Start the daemon first (e.g. `uffs --daemon start \
                  --log-file ~/uffs_soak/wstrace.log`) and confirm \
-                 `uffs daemon status` reports Ready before re-running."
+                 `uffs --daemon status` reports Ready before re-running."
             );
         }
         println!("  {}", "Daemon Ready precondition OK".green());
@@ -1755,7 +1755,7 @@ impl Drop for CleanupGuard {
     fn drop(&mut self) {
         // Stop daemon.
         let _ = Command::new(&self.binary)
-            .args(["daemon", "kill"])
+            .args(["--daemon", "kill"])
             .output();
         // Restore daemon.toml.
         if let Some(backup) = &self.cfg_backup {

--- a/scripts/dev/mcp-readiness.rs
+++ b/scripts/dev/mcp-readiness.rs
@@ -94,7 +94,7 @@ fn ensure_fresh_release_build() -> String {
     eprintln!("╚══════════════════════════════════════════════════════════════════╝");
     eprintln!("  Workspace: {}", ws.display());
     let start = Instant::now();
-    // Build both uffs (thin CLI) and uffsmcp (MCP server) — `uffs mcp *`
+    // Build both uffs (thin CLI) and uffsmcp (MCP server) — `uffs --mcp *`
     // delegates to `uffsmcp` so both must be present.
     let status = Command::new("cargo")
         .args(["build", "--release", "-p", "uffs-cli", "-p", "uffs-mcp"])
@@ -465,11 +465,11 @@ impl Runner {
         }
     }
 
-    /// Start the MCP HTTP server via `uffs mcp start`.
+    /// Start the MCP HTTP server via `uffs --mcp start`.
     ///
-    /// `uffs mcp start` already handles:
+    /// `uffs --mcp start` already handles:
     ///   1. Auto-starting the daemon if needed
-    ///   2. Spawning `uffs mcp serve` as a background process
+    ///   2. Spawning `uffs --mcp serve` as a background process
     ///   3. Polling /health until the server is ready
     ///   4. Exiting with code 0 on success, non-zero on failure
     ///
@@ -477,7 +477,7 @@ impl Runner {
     /// pipe handle inheritance issues on Windows) and check the exit code.
     fn mcp_start(&self) -> Result<String> {
         let port_str = self.port.to_string();
-        let mut args: Vec<&str> = vec!["mcp", "start", "--port", &port_str, "--bind", &self.host];
+        let mut args: Vec<&str> = vec!["--mcp", "start", "--port", &port_str, "--bind", &self.host];
         args.extend(self.source_args());
 
         eprintln!("    [mcp_start] {} {}", self.binary, args.join(" "));
@@ -489,7 +489,7 @@ impl Runner {
 
         if !status.success() {
             bail!(
-                "`uffs mcp start` exited with {status}\n\
+                "`uffs --mcp start` exited with {status}\n\
                  Run manually with logging:\n  \
                  UFFS_LOG=debug UFFS_LOG_FILE=/tmp/mcp.log {} {}",
                 self.binary, args.join(" ")
@@ -500,7 +500,7 @@ impl Runner {
         let (ok, detail) = health_check_detail(&self.host, self.port);
         if !ok {
             bail!(
-                "`uffs mcp start` exited OK but /health check failed: {detail}"
+                "`uffs --mcp start` exited OK but /health check failed: {detail}"
             );
         }
 
@@ -547,30 +547,30 @@ impl Runner {
     }
 
     fn ensure_daemon_stopped(&self) {
-        let _ = self.run_ok(&["daemon", "kill"]);
+        let _ = self.run_ok(&["--daemon", "kill"]);
         for _ in 0..20 {
             std::thread::sleep(Duration::from_millis(500));
-            let status = self.run_ok(&["daemon", "status"]).unwrap_or_default().to_lowercase();
+            let status = self.run_ok(&["--daemon", "status"]).unwrap_or_default().to_lowercase();
             if status.contains("not running") { return; }
         }
     }
 
     fn ensure_daemon_running(&self) -> Result<String> {
-        let mut args: Vec<&str> = vec!["daemon", "start"];
+        let mut args: Vec<&str> = vec!["--daemon", "start"];
         args.extend(self.source_args());
         self.run_ok(&args)
     }
 
-    fn mcp_status(&self) -> Result<String> { self.run_ok(&["mcp", "status"]) }
-    fn mcp_stop(&self) -> Result<String> { self.run_ok(&["mcp", "stop"]) }
+    fn mcp_status(&self) -> Result<String> { self.run_ok(&["--mcp", "status"]) }
+    fn mcp_stop(&self) -> Result<String> { self.run_ok(&["--mcp", "stop"]) }
     fn mcp_kill(&self) -> Result<String> {
         let port_str = self.port.to_string();
-        self.run_ok(&["mcp", "kill", "--port", &port_str, "--bind", &self.host])
+        self.run_ok(&["--mcp", "kill", "--port", &port_str, "--bind", &self.host])
     }
-    fn daemon_kill(&self) -> Result<String> { self.run_ok(&["daemon", "kill"]) }
+    fn daemon_kill(&self) -> Result<String> { self.run_ok(&["--daemon", "kill"]) }
 
     fn daemon_status_text(&self) -> String {
-        self.run_ok(&["daemon", "status"]).unwrap_or_default()
+        self.run_ok(&["--daemon", "status"]).unwrap_or_default()
     }
 
     fn is_daemon_running(&self) -> bool {
@@ -581,9 +581,9 @@ impl Runner {
             && !out.contains("not running")
     }
 
-    /// Run `uffs daemon load` with given args, return stdout.
+    /// Run `uffs --daemon load` with given args, return stdout.
     fn daemon_load(&self, extra_args: &[&str]) -> Result<String> {
-        let mut args = vec!["daemon", "load"];
+        let mut args = vec!["--daemon", "load"];
         args.extend_from_slice(extra_args);
         self.run_ok(&args)
     }
@@ -694,7 +694,7 @@ fn scenario_c(r: &mut Runner) {
     });
 
     r.step("C4  Verify daemon now running", |r| {
-        let status = r.run_ok(&["daemon", "status"]).unwrap_or_default();
+        let status = r.run_ok(&["--daemon", "status"]).unwrap_or_default();
         if !status.to_lowercase().contains("ready")
             && !status.to_lowercase().contains("running")
             && !status.to_lowercase().contains("pid") {
@@ -761,7 +761,7 @@ fn scenario_e(r: &mut Runner) {
 
     r.step("E2  Second `mcp start` → already running (gateway ✓, daemon ✓)", |r| {
         let port_str = r.port.to_string();
-        let mut args: Vec<&str> = vec!["mcp", "start", "--port", &port_str, "--bind", &r.host];
+        let mut args: Vec<&str> = vec!["--mcp", "start", "--port", &port_str, "--bind", &r.host];
         args.extend(r.source_args());
         let out = r.run_ok(&args)?;
         let lower = out.to_lowercase();
@@ -835,7 +835,7 @@ fn scenario_g(r: &mut Runner) {
 
     r.step("G3  `mcp start` detects daemon dead → restarts daemon only", |r| {
         let port_str = r.port.to_string();
-        let mut args: Vec<&str> = vec!["mcp", "start", "--port", &port_str, "--bind", &r.host];
+        let mut args: Vec<&str> = vec!["--mcp", "start", "--port", &port_str, "--bind", &r.host];
         args.extend(r.source_args());
         let out = r.run_ok(&args)?;
         let lower = out.to_lowercase();
@@ -950,7 +950,7 @@ fn scenario_j(r: &mut Runner) {
 
     r.step("J3  `mcp start` sees healthy stack → reports already running", |r| {
         let port_str = r.port.to_string();
-        let mut args: Vec<&str> = vec!["mcp", "start", "--port", &port_str, "--bind", &r.host];
+        let mut args: Vec<&str> = vec!["--mcp", "start", "--port", &port_str, "--bind", &r.host];
         args.extend(r.source_args());
         let out = r.run_ok(&args)?;
         // Stack is healthy (gateway ✓ + daemon ✓), even without PID file.
@@ -1053,7 +1053,7 @@ fn scenario_l(r: &mut Runner) {
 
     r.step("L6  `mcp start` sees healthy stack", |r| {
         let port_str = r.port.to_string();
-        let mut args: Vec<&str> = vec!["mcp", "start", "--port", &port_str, "--bind", &r.host];
+        let mut args: Vec<&str> = vec!["--mcp", "start", "--port", &port_str, "--bind", &r.host];
         args.extend(r.source_args());
         let out = r.run_ok(&args)?;
         if !out.to_lowercase().contains("already running") {
@@ -1112,7 +1112,7 @@ fn discover_drive_mft_files(data_dir: &str) -> Vec<(char, String)> {
     results
 }
 
-/// Parse drive count and individual drive letters from `uffs daemon status`.
+/// Parse drive count and individual drive letters from `uffs --daemon status`.
 ///
 /// The status output format (v0.5.95+, Phase 8-E memory-tiering) is:
 /// ```text
@@ -1203,7 +1203,7 @@ fn scenario_m(r: &mut Runner) {
         // M1: Kill everything, start daemon with FIRST drive only (explicit --mft-file).
         r.step("M1  Start daemon with single drive", |r| {
             r.kill_all();
-            let args = vec!["daemon", "start", "--mft-file", &first_mft];
+            let args = vec!["--daemon", "start", "--mft-file", &first_mft];
             r.run_ok(&args)?;
             if !r.is_daemon_running() { bail!("daemon not running"); }
             Ok(format!("started with {first}: via --mft-file"))
@@ -1322,7 +1322,7 @@ fn scenario_m(r: &mut Runner) {
 
     // M7: `daemon load` with no args → informative error.
     r.step("M7  `daemon load` no args → error message", |r| {
-        let (out, success) = r.run_full(&["daemon", "load"])?;
+        let (out, success) = r.run_full(&["--daemon", "load"])?;
         let lower = out.to_lowercase();
         if success {
             bail!("expected non-zero exit, but command succeeded: {out}");
@@ -1336,7 +1336,7 @@ fn scenario_m(r: &mut Runner) {
 
     // M8: `daemon load --mft-file <bogus>` → error reported (not a crash).
     r.step("M8  `daemon load --mft-file /nonexistent` → daemon survives", |r| {
-        let (out, _success) = r.run_full(&["daemon", "load", "--mft-file", "/nonexistent/fake.bin"])?;
+        let (out, _success) = r.run_full(&["--daemon", "load", "--mft-file", "/nonexistent/fake.bin"])?;
         if !r.is_daemon_running() {
             bail!("daemon crashed after bad load: {out}");
         }
@@ -1387,7 +1387,7 @@ fn main() -> Result<()> {
     };
 
     // ── Preflight: verify companion binaries exist ──────────────────
-    // `uffs mcp *` delegates to the standalone `uffsmcp` binary.
+    // `uffs --mcp *` delegates to the standalone `uffsmcp` binary.
     // Fail immediately with a clear message instead of waiting 3.5 min
     // for a health timeout.
     {
@@ -1399,7 +1399,7 @@ fn main() -> Result<()> {
         if !mcp_path.exists() {
             bail!(
                 "Companion binary `{mcp_name}` not found at {}\n\
-                 `uffs mcp *` delegates to `{mcp_name}` which must sit alongside `uffs`.\n\
+                 `uffs --mcp *` delegates to `{mcp_name}` which must sit alongside `uffs`.\n\
                  Rebuild and deploy: just build-local   (or: just use-local)",
                 mcp_path.display(),
             );

--- a/scripts/dev/orphan-cleanup.rs
+++ b/scripts/dev/orphan-cleanup.rs
@@ -159,7 +159,7 @@ fn default_binary() -> String {
 /// pattern as the validation scripts' `capture_daemon_version`,
 /// targeting a different label.
 fn read_daemon_pid_via_status(bin: &str) -> Option<u32> {
-    let out = Command::new(bin).args(["daemon", "status"]).output().ok()?;
+    let out = Command::new(bin).args(["--daemon", "status"]).output().ok()?;
     if !out.status.success() {
         return None;
     }

--- a/scripts/dev/stress-concurrent-queries.rs
+++ b/scripts/dev/stress-concurrent-queries.rs
@@ -105,9 +105,9 @@ fn find_uffs_bin(explicit: &Option<PathBuf>) -> Option<PathBuf> {
     None
 }
 
-/// Check if daemon is running via `uffs daemon status`.
+/// Check if daemon is running via `uffs --daemon status`.
 fn daemon_running_via_cli(bin: &PathBuf) -> bool {
-    if let Ok(out) = std::process::Command::new(bin).args(["daemon", "status"]).output() {
+    if let Ok(out) = std::process::Command::new(bin).args(["--daemon", "status"]).output() {
         let stdout = String::from_utf8_lossy(&out.stdout);
         stdout.contains("Ready") || stdout.contains("Loading")
     } else {
@@ -139,8 +139,8 @@ fn ensure_daemon(sock: &PathBuf, cli: &Cli) -> Result<()> {
     ))?;
     println!("  uffs binary:  {}", bin.display());
 
-    // Build args: `uffs daemon start` blocks until "Daemon started and ready."
-    let mut args = vec!["daemon", "start"];
+    // Build args: `uffs --daemon start` blocks until "Daemon started and ready."
+    let mut args = vec!["--daemon", "start"];
     let data_dir_str;
     if let Some(ref dir) = cli.data_dir {
         args.push("--data-dir");
@@ -154,7 +154,7 @@ fn ensure_daemon(sock: &PathBuf, cli: &Cli) -> Result<()> {
     let output = std::process::Command::new(&bin)
         .args(&args)
         .output()
-        .map_err(|e| anyhow::anyhow!("Failed to run `uffs daemon start`: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("Failed to run `uffs --daemon start`: {e}"))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -162,7 +162,7 @@ fn ensure_daemon(sock: &PathBuf, cli: &Cli) -> Result<()> {
 
     if !output.status.success() {
         bail!(
-            "`uffs daemon start` failed (exit {}):\nstdout: {}\nstderr: {}",
+            "`uffs --daemon start` failed (exit {}):\nstdout: {}\nstderr: {}",
             output.status.code().unwrap_or(-1), stdout.trim(), stderr.trim()
         );
     }

--- a/scripts/dev/tier-load-compare.rs
+++ b/scripts/dev/tier-load-compare.rs
@@ -243,11 +243,11 @@ impl Runner {
     /// Stop the daemon (if running) and wait up to 10 s for it to
     /// actually exit.  Idempotent on a stopped daemon.
     fn ensure_stopped(&self) {
-        let _ = self.run_ok(&["daemon", "kill"]);
+        let _ = self.run_ok(&["--daemon", "kill"]);
         let deadline = Instant::now() + Duration::from_secs(10);
         while Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(250));
-            if let Ok(out) = self.run_ok(&["daemon", "status"]) {
+            if let Ok(out) = self.run_ok(&["--daemon", "status"]) {
                 if out.contains("not running") {
                     return;
                 }
@@ -261,7 +261,7 @@ impl Runner {
     /// `daemon start` blocks until Ready (or errors), so callers
     /// don't need their own poll loop.
     fn start_daemon(&self) -> Result<()> {
-        let mut args: Vec<&str> = vec!["daemon", "start"];
+        let mut args: Vec<&str> = vec!["--daemon", "start"];
         args.extend(self.source_args());
         let out = self.run_raw_with_env(
             &args,
@@ -282,7 +282,7 @@ impl Runner {
 
     /// Sanity-check that the daemon is Ready and report drive count.
     fn assert_ready(&self) -> Result<usize> {
-        let out = self.run_ok(&["daemon", "status"])?;
+        let out = self.run_ok(&["--daemon", "status"])?;
         if !out.contains("Ready") {
             bail!("expected 'Ready' in `daemon status`, got:\n{out}");
         }
@@ -290,12 +290,12 @@ impl Runner {
     }
 
     fn hibernate_all(&self) -> Result<()> {
-        self.run_ok(&["daemon", "hibernate"])?;
+        self.run_ok(&["--daemon", "hibernate"])?;
         Ok(())
     }
 
     fn status_drives_table(&self) -> Result<String> {
-        self.run_ok(&["daemon", "status_drives"])
+        self.run_ok(&["--daemon", "status_drives"])
     }
 
     /// Run the configured search, return wall-clock millis.  Stdout

--- a/scripts/tests/definitions/01-general.toml
+++ b/scripts/tests/definitions/01-general.toml
@@ -2,411 +2,510 @@
 # Auto-split from test-definitions.toml
 
 [[test]]
-id          = "T01"
-group       = "general"
-name        = "--files-only"
-title       = "Filter to files only (exclude directories)"
-short_desc  = "All results must be files, not directories"
-long_desc   = """
+id = "T01"
+group = "general"
+name = "--files-only"
+title = "Filter to files only (exclude directories)"
+short_desc = "All results must be files, not directories"
+long_desc = """
 Searches for *.txt with --files-only and verifies that every row has
 Directory Flag = 0.  This is the fundamental file/dir filter test."""
-cli_args    = ["*.txt", "--files-only", "--limit", "10"]
-cli_format  = "csv"
-rpc_method  = "search"
+cli_args = ["*.txt", "--files-only", "--limit", "10"]
+cli_format = "csv"
+rpc_method = "search"
 expect_min_rows = 1
 expect_max_rows = 10
 expect_columns_all = true
 
 [[test.column_checks]]
 column = "Directory Flag"
-op     = "ne"
-value  = "1"
+op = "ne"
+value = "1"
 
 [[test]]
-id          = "T02"
-group       = "general"
-name        = "--dirs-only"
-title       = "Filter to directories only (exclude files)"
-short_desc  = "All results must be directories"
-cli_args    = ["Windows", "--dirs-only", "--limit", "10"]
-rpc_method  = "search"
+id = "T02"
+group = "general"
+name = "--dirs-only"
+title = "Filter to directories only (exclude files)"
+short_desc = "All results must be directories"
+cli_args = ["Windows", "--dirs-only", "--limit", "10"]
+rpc_method = "search"
 expect_min_rows = 1
 expect_max_rows = 10
 expect_columns_all = true
 
 [[test.column_checks]]
 column = "Directory Flag"
-op     = "eq"
-value  = "1"
+op = "eq"
+value = "1"
 
 [[test]]
-id          = "T03"
-group       = "general"
-name        = "--hide-system"
-title       = "Hide system files (no $-prefixed results)"
-short_desc  = "No result should start with $ when --hide-system is used"
+id = "T03"
+group = "general"
+name = "--hide-system"
+title = "Hide system files (no $-prefixed results)"
+short_desc = "No result should start with $ when --hide-system is used"
 # Pattern must be "*" (all files), NOT "$*" — searching only $-prefixed files
 # with --hide-system is self-contradictory and always returns 0 rows.
-cli_args    = ["*", "--limit", "20", "--hide-system"]
+cli_args = ["*", "--limit", "20", "--hide-system"]
 expect_min_rows = 1
-rpc_method  = "search"
+rpc_method = "search"
 expect_columns_all = true
 
 [[test.column_checks]]
 column = "Name"
-op     = "not_starts_with"
-value  = "$"
+op = "not_starts_with"
+value = "$"
 
 [[test]]
-id          = "T04"
-group       = "general"
-name        = "--ext rs"
-title       = "Filter by single extension"
-short_desc  = "All results must have .rs extension"
-cli_args    = ["*", "--ext", "rs", "--limit", "10"]
-rpc_method  = "search"
+id = "T04"
+group = "general"
+name = "--ext rs"
+title = "Filter by single extension"
+short_desc = "All results must have .rs extension"
+cli_args = ["*", "--ext", "rs", "--limit", "10"]
+rpc_method = "search"
 expect_min_rows = 1
 expect_max_rows = 10
 
 [[test.column_checks]]
 column = "Name"
-op     = "ends_with"
-value  = ".rs"
-case   = "lower"
+op = "ends_with"
+value = ".rs"
+case = "lower"
 
 [[test]]
-id          = "T05"
-group       = "general"
-name        = "--ext jpg,png,gif"
-title       = "Filter by multiple extensions"
-short_desc  = "All results must have one of jpg/png/gif extension"
-cli_args    = ["*", "--ext", "jpg,png,gif", "--limit", "10"]
-rpc_method  = "search"
+id = "T05"
+group = "general"
+name = "--ext jpg,png,gif"
+title = "Filter by multiple extensions"
+short_desc = "All results must have one of jpg/png/gif extension"
+cli_args = ["*", "--ext", "jpg,png,gif", "--limit", "10"]
+rpc_method = "search"
 expect_min_rows = 1
 expect_max_rows = 10
-validator   = "ext_multi_check"
-tags        = ["extensions"]
+validator = "ext_multi_check"
+tags = ["extensions"]
 
 [[test]]
-id          = "T17"
-group       = "general"
-name        = "T17 --name-only"
-title       = "T17 --name-only"
-short_desc  = "T17 --name-only"
-cli_args    = ["readme", "--name-only", "--limit", "10"]
+id = "T17"
+group = "general"
+name = "T17 --name-only"
+title = "T17 --name-only"
+short_desc = "T17 --name-only"
+cli_args = ["readme", "--name-only", "--limit", "10"]
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Name"
-op     = "contains"
-value  = "readme"
-case   = "lower"
+op = "contains"
+value = "readme"
+case = "lower"
 
 [[test]]
-id          = "T18"
-group       = "general"
-name        = "T18 --case sensitive"
-title       = "T18 --case sensitive"
-short_desc  = "T18 --case sensitive"
-cli_args    = ["README", "--case", "--name-only", "--limit", "10"]
+id = "T18"
+group = "general"
+name = "T18 --case sensitive"
+title = "T18 --case sensitive"
+short_desc = "T18 --case sensitive"
+cli_args = ["README", "--case", "--name-only", "--limit", "10"]
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Name"
-op     = "contains"
-value  = "README"
-case   = "lower"
+op = "contains"
+value = "README"
+case = "lower"
 
 [[test]]
-id          = "T19"
-group       = "general"
-name        = "T19 --word"
-title       = "T19 --word"
-short_desc  = "Whole-word match: names must contain 'test' as a word boundary"
-cli_args    = ["test", "--word", "--limit", "10"]
+id = "T19"
+group = "general"
+name = "T19 --word"
+title = "T19 --word"
+short_desc = "Whole-word match: names must contain 'test' as a word boundary"
+cli_args = ["test", "--word", "--limit", "10"]
 expect_min_rows = 1
 expect_max_rows = 10
 
 [[test.column_checks]]
 column = "Name"
-op     = "contains"
-value  = "test"
-case   = "lower"
+op = "contains"
+value = "test"
+case = "lower"
 
 [[test]]
-id          = "T28"
-group       = "general"
-name        = "T28 --drive C"
-title       = "T28 --drive C"
-short_desc  = "T28 --drive C"
-cli_args    = ["*.exe", "--drive", "C", "--limit", "10"]
+id = "T28"
+group = "general"
+name = "T28 --drive C"
+title = "T28 --drive C"
+short_desc = "T28 --drive C"
+cli_args = ["*.exe", "--drive", "C", "--limit", "10"]
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Path Only"
-op     = "starts_with"
-value  = "C:"
-case   = "lower"
+op = "starts_with"
+value = "C:"
+case = "lower"
 
 [[test]]
-id          = "T29"
-group       = "general"
-name        = "T29 --drives C,D"
-title       = "T29 --drives C,D"
-short_desc  = "All results must come from drive C or D"
-cli_args    = ["*.exe", "--drives", "C,D", "--limit", "10"]
+id = "T29"
+group = "general"
+name = "T29 --drives C,D"
+title = "T29 --drives C,D"
+short_desc = "All results must come from drive C or D"
+cli_args = ["*.exe", "--drives", "C,D", "--limit", "10"]
 expect_min_rows = 1
-validator   = "drives_cd"
+validator = "drives_cd"
 
 [[test]]
-id          = "T30"
-group       = "general"
-name        = "T30 --sep | --quotes '"
-title       = "T30 --sep | --quotes '"
-short_desc  = "T30 --sep | --quotes '"
-cli_args    = ["*.txt", "--sep", "|", "--quotes", "'", "--limit", "5"]
-targets     = ["cli"]
+id = "T30"
+group = "general"
+name = "T30 --sep | --quotes '"
+title = "T30 --sep | --quotes '"
+short_desc = "T30 --sep | --quotes '"
+cli_args = ["*.txt", "--sep", "|", "--quotes", "'", "--limit", "5"]
+targets = ["cli"]
 stdout_contains = ["'Path'|'Name'|'Path Only'"]
 expect_min_rows = 1
 
 [[test]]
-id          = "T32"
-group       = "general"
-name        = "T32 --benchmark"
-title       = "T32 --benchmark"
-short_desc  = "T32 --benchmark"
-cli_args    = ["*.rs", "--benchmark"]
-targets     = ["cli"]
-validator   = "T32"
+id = "T32"
+group = "general"
+name = "T32 --benchmark"
+title = "T32 --benchmark"
+short_desc = "T32 --benchmark"
+cli_args = ["*.rs", "--benchmark"]
+targets = ["cli"]
+validator = "T32"
 
 [test.api_checks]
 result_has_key = ["results"]
 total_count_min = 1
 
 [[test]]
-id          = "T33"
-group       = "general"
-name        = "T33 regex >.*\\.config$"
-title       = "T33 regex >.*\\.config$"
-short_desc  = "T33 regex >.*\\.config$"
-cli_args    = [">.*\\.config$", "--limit", "10"]
+id = "T33"
+group = "general"
+name = "T33 regex >.*\\.config$"
+title = "T33 regex >.*\\.config$"
+short_desc = "T33 regex >.*\\.config$"
+cli_args = [">.*\\.config$", "--limit", "10"]
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Name"
-op     = "ends_with"
-value  = ".config"
-case   = "lower"
+op = "ends_with"
+value = ".config"
+case = "lower"
 
 [[test]]
-id          = "T35"
-group       = "general"
-name        = "T35 --limit 0 (unlimited)"
-title       = "T35 --limit 0 (unlimited)"
-short_desc  = "CLI --limit 0 = unlimited — CLI translates to no-limit; API limit=0 = 0 rows"
-cli_args    = ["*.dll", "--limit", "0", "--drive", "C", "--files-only"]
-targets     = ["cli", "api"]
+id = "T35"
+group = "general"
+name = "T35 --limit 0 (unlimited)"
+title = "T35 --limit 0 (unlimited)"
+short_desc = "CLI --limit 0 = unlimited — CLI translates to no-limit; API limit=0 = 0 rows"
+cli_args = ["*.dll", "--limit", "0", "--drive", "C", "--files-only"]
+targets = ["cli", "api"]
 expect_min_rows = 0
 cli_checks.expect_min_rows = 10
-rpc_method  = "search"
-rpc_params  = '{"pattern":"*.dll","drives":["C"],"filter":"files"}'
-api_checks.result_has_key  = ["rows"]
+rpc_method = "search"
+rpc_params = '{"pattern":"*.dll","drives":["C"],"filter":"files"}'
+api_checks.result_has_key = ["rows"]
 api_checks.total_count_min = 10
 
 [[test]]
-id          = "T41"
-group       = "general"
-name        = "T41 --header false"
-title       = "T41 --header false"
-short_desc  = "T41 --header false"
-cli_args    = ["*.exe", "--header", "false", "--limit", "5", "--drive", "C"]
-targets     = ["cli"]
+id = "T41"
+group = "general"
+name = "T41 --header false"
+title = "T41 --header false"
+short_desc = "T41 --header false"
+cli_args = ["*.exe", "--header", "false", "--limit", "5", "--drive", "C"]
+targets = ["cli"]
 stdout_not_contains = ["\"Path\"", "\"Name\""]
 expect_min_rows = 1
 
 [[test]]
-id          = "T42"
-group       = "general"
-name        = "T42 --smart-case (lowercase = insensitive)"
-title       = "T42 --smart-case (lowercase = insensitive)"
-short_desc  = "Lowercase pattern + smart-case = case-insensitive: names contain 'readme'"
-cli_args    = ["readme", "--smart-case", "--name-only", "--limit", "10"]
+id = "T42"
+group = "general"
+name = "T42 --smart-case (lowercase = insensitive)"
+title = "T42 --smart-case (lowercase = insensitive)"
+short_desc = "Lowercase pattern + smart-case = case-insensitive: names contain 'readme'"
+cli_args = ["readme", "--smart-case", "--name-only", "--limit", "10"]
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Name"
-op     = "contains"
-value  = "readme"
-case   = "lower"
+op = "contains"
+value = "readme"
+case = "lower"
 
 [[test]]
-id          = "T88g"
-group       = "general"
-name        = "T88g --not-contains"
-title       = "T88g --not-contains"
-short_desc  = "T88g --not-contains"
-cli_args    = ["*.log", "--not-contains", "debug", "--files-only", "--limit", "10", "--columns", "all"]
+id = "T88g"
+group = "general"
+name = "T88g --not-contains"
+title = "T88g --not-contains"
+short_desc = "T88g --not-contains"
+cli_args = [
+  "*.log",
+  "--not-contains",
+  "debug",
+  "--files-only",
+  "--limit",
+  "10",
+  "--columns",
+  "all",
+]
 expect_min_rows = 1
 expect_columns_all = true
 
 [[test.column_checks]]
 column = "Name"
-op     = "ends_with"
-value  = ".log"
-case   = "lower"
+op = "ends_with"
+value = ".log"
+case = "lower"
 
 [[test]]
-id          = "T89"
-group       = "general"
-name        = "T89 --type code"
-title       = "T89 --type code"
-short_desc  = "All results must have code extensions (rs,py,js,ts,c,cpp,go,java,…)"
-cli_args    = ["*", "--type", "code", "--files-only", "--limit", "10", "--columns", "all"]
+id = "T89"
+group = "general"
+name = "T89 --type code"
+title = "T89 --type code"
+short_desc = "All results must have code extensions (rs,py,js,ts,c,cpp,go,java,…)"
+cli_args = [
+  "*",
+  "--type",
+  "code",
+  "--files-only",
+  "--limit",
+  "10",
+  "--columns",
+  "all",
+]
 expect_columns_all = true
 expect_min_rows = 1
-validator   = "type_code"
+validator = "type_code"
 
 [[test]]
-id          = "T90"
-group       = "general"
-name        = "T90 --type document"
-title       = "T90 --type document"
-short_desc  = "All results must have document extensions (pdf,doc,docx,xls,…)"
-cli_args    = ["*", "--type", "document", "--files-only", "--limit", "10", "--columns", "all"]
+id = "T90"
+group = "general"
+name = "T90 --type document"
+title = "T90 --type document"
+short_desc = "All results must have document extensions (pdf,doc,docx,xls,…)"
+cli_args = [
+  "*",
+  "--type",
+  "document",
+  "--files-only",
+  "--limit",
+  "10",
+  "--columns",
+  "all",
+]
 expect_columns_all = true
 expect_min_rows = 1
-validator   = "type_document"
+validator = "type_document"
 
 [[test]]
-id          = "T91"
-group       = "general"
-name        = "T91 --type executable"
-title       = "T91 --type executable"
-short_desc  = "All results must have executable extensions (exe,msi,bat,cmd,…)"
-cli_args    = ["*", "--type", "executable", "--files-only", "--limit", "10", "--columns", "all"]
+id = "T91"
+group = "general"
+name = "T91 --type executable"
+title = "T91 --type executable"
+short_desc = "All results must have executable extensions (exe,msi,bat,cmd,…)"
+cli_args = [
+  "*",
+  "--type",
+  "executable",
+  "--files-only",
+  "--limit",
+  "10",
+  "--columns",
+  "all",
+]
 expect_columns_all = true
 expect_min_rows = 1
-validator   = "type_executable"
+validator = "type_executable"
 
 [[test]]
-id          = "T92"
-group       = "general"
-name        = "T92 --type picture"
-title       = "T92 --type picture"
-short_desc  = "All results must have picture extensions (jpg,png,gif,bmp,…)"
-cli_args    = ["*", "--type", "picture", "--files-only", "--limit", "10", "--columns", "all"]
+id = "T92"
+group = "general"
+name = "T92 --type picture"
+title = "T92 --type picture"
+short_desc = "All results must have picture extensions (jpg,png,gif,bmp,…)"
+cli_args = [
+  "*",
+  "--type",
+  "picture",
+  "--files-only",
+  "--limit",
+  "10",
+  "--columns",
+  "all",
+]
 expect_columns_all = true
 expect_min_rows = 1
-validator   = "type_picture"
+validator = "type_picture"
 
 [[test]]
-id          = "T93"
-group       = "general"
-name        = "T93 --type system"
-title       = "T93 --type system"
-short_desc  = "All results must have system marker ($-prefix names)"
-cli_args    = ["*", "--type", "system", "--files-only", "--limit", "10", "--columns", "all"]
+id = "T93"
+group = "general"
+name = "T93 --type system"
+title = "T93 --type system"
+short_desc = "All results must have system marker ($-prefix names)"
+cli_args = [
+  "*",
+  "--type",
+  "system",
+  "--files-only",
+  "--limit",
+  "10",
+  "--columns",
+  "all",
+]
 expect_columns_all = true
 expect_min_rows = 1
-validator   = "type_system"
+validator = "type_system"
 
 [[test]]
-id          = "T98"
-group       = "general"
-name        = "T98 --min-bulkiness 200"
-title       = "T98 --min-bulkiness 200"
-short_desc  = "T98 --min-bulkiness 200"
-cli_args    = ["*", "--min-bulkiness", "200", "--files-only", "--limit", "10", "--columns", "all"]
+id = "T98"
+group = "general"
+name = "T98 --min-bulkiness 200"
+title = "T98 --min-bulkiness 200"
+short_desc = "T98 --min-bulkiness 200"
+cli_args = [
+  "*",
+  "--min-bulkiness",
+  "200",
+  "--files-only",
+  "--limit",
+  "10",
+  "--columns",
+  "all",
+]
 expect_columns_all = true
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Bulkiness"
-op     = "gte"
-value  = "200"
+op = "gte"
+value = "200"
 
 [[test]]
-id          = "T103"
-group       = "general"
-name        = "T103 --min-tree-allocated 100MB"
-title       = "T103 --min-tree-allocated 100MB"
-short_desc  = "T103 --min-tree-allocated 100MB"
-cli_args    = ["*", "--dirs-only", "--min-tree-allocated", "104857600", "--limit", "10", "--columns", "all"]
+id = "T103"
+group = "general"
+name = "T103 --min-tree-allocated 100MB"
+title = "T103 --min-tree-allocated 100MB"
+short_desc = "T103 --min-tree-allocated 100MB"
+cli_args = [
+  "*",
+  "--dirs-only",
+  "--min-tree-allocated",
+  "104857600",
+  "--limit",
+  "10",
+  "--columns",
+  "all",
+]
 expect_columns_all = true
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Tree Allocated"
-op     = "gte"
-value  = "104857600"
+op = "gte"
+value = "104857600"
 
 [[test]]
-id          = "T104"
-group       = "general"
-name        = "T104 --min-name-length 50"
-title       = "T104 --min-name-length 50"
-short_desc  = "T104 --min-name-length 50"
-cli_args    = ["*", "--min-name-length", "50", "--files-only", "--limit", "10", "--columns", "all"]
+id = "T104"
+group = "general"
+name = "T104 --min-name-length 50"
+title = "T104 --min-name-length 50"
+short_desc = "T104 --min-name-length 50"
+cli_args = [
+  "*",
+  "--min-name-length",
+  "50",
+  "--files-only",
+  "--limit",
+  "10",
+  "--columns",
+  "all",
+]
 expect_columns_all = true
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Name Length"
-op     = "gte"
-value  = "50"
+op = "gte"
+value = "50"
 
 [[test]]
-id          = "T105"
-group       = "general"
-name        = "T105 --max-name-length 8"
-title       = "T105 --max-name-length 8"
-short_desc  = "T105 --max-name-length 8"
-cli_args    = ["*", "--max-name-length", "8", "--files-only", "--limit", "10", "--columns", "all"]
+id = "T105"
+group = "general"
+name = "T105 --max-name-length 8"
+title = "T105 --max-name-length 8"
+short_desc = "T105 --max-name-length 8"
+cli_args = [
+  "*",
+  "--max-name-length",
+  "8",
+  "--files-only",
+  "--limit",
+  "10",
+  "--columns",
+  "all",
+]
 expect_columns_all = true
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Name Length"
-op     = "lte"
-value  = "8"
+op = "lte"
+value = "8"
 
 [[test]]
-id          = "T106"
-group       = "general"
-name        = "T106 --min-path-length 200"
-title       = "T106 --min-path-length 200"
-short_desc  = "T106 --min-path-length 200"
-cli_args    = ["*", "--min-path-length", "200", "--files-only", "--limit", "10", "--columns", "all"]
+id = "T106"
+group = "general"
+name = "T106 --min-path-length 200"
+title = "T106 --min-path-length 200"
+short_desc = "T106 --min-path-length 200"
+cli_args = [
+  "*",
+  "--min-path-length",
+  "200",
+  "--files-only",
+  "--limit",
+  "10",
+  "--columns",
+  "all",
+]
 expect_columns_all = true
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Path Length"
-op     = "gte"
-value  = "200"
+op = "gte"
+value = "200"
 
 [[test]]
-id          = "T107"
-group       = "general"
-name        = "T107 --max-path-length 30"
-title       = "T107 --max-path-length 30"
-short_desc  = "T107 --max-path-length 30"
-cli_args    = ["*", "--max-path-length", "30", "--files-only", "--limit", "10"]
+id = "T107"
+group = "general"
+name = "T107 --max-path-length 30"
+title = "T107 --max-path-length 30"
+short_desc = "T107 --max-path-length 30"
+cli_args = ["*", "--max-path-length", "30", "--files-only", "--limit", "10"]
 expect_min_rows = 0
 expect_max_rows = 10
 
 [[test.column_checks]]
 column = "Path Length"
-op     = "lte"
-value  = "30"
+op = "lte"
+value = "30"
 
 [[test]]
-id          = "T110"
-group       = "general"
-name        = "T110 --month jan"
-title       = "T110 --month jan"
-short_desc  = "January-modified files — large dataset guarantees matches"
-cli_args    = ["*", "--month", "jan", "--files-only", "--limit", "10"]
+id = "T110"
+group = "general"
+name = "T110 --month jan"
+title = "T110 --month jan"
+short_desc = "January-modified files — large dataset guarantees matches"
+cli_args = ["*", "--month", "jan", "--files-only", "--limit", "10"]
 expect_min_rows = 1
 expect_max_rows = 10
 
@@ -414,12 +513,12 @@ expect_max_rows = 10
 total_count_min = 10
 
 [[test]]
-id          = "T111"
-group       = "general"
-name        = "T111 --month Q4"
-title       = "T111 --month Q4"
-short_desc  = "Q4-modified files (Oct–Dec) — broader range, more results"
-cli_args    = ["*", "--month", "Q4", "--files-only", "--limit", "10"]
+id = "T111"
+group = "general"
+name = "T111 --month Q4"
+title = "T111 --month Q4"
+short_desc = "Q4-modified files (Oct–Dec) — broader range, more results"
+cli_args = ["*", "--month", "Q4", "--files-only", "--limit", "10"]
 expect_min_rows = 1
 expect_max_rows = 10
 
@@ -427,12 +526,12 @@ expect_max_rows = 10
 total_count_min = 10
 
 [[test]]
-id          = "T112"
-group       = "general"
-name        = "T112 --month jan,feb,mar"
-title       = "T112 --month jan,feb,mar"
-short_desc  = "Q1-modified files — must return more than single-month"
-cli_args    = ["*", "--month", "jan,feb,mar", "--files-only", "--limit", "10"]
+id = "T112"
+group = "general"
+name = "T112 --month jan,feb,mar"
+title = "T112 --month jan,feb,mar"
+short_desc = "Q1-modified files — must return more than single-month"
+cli_args = ["*", "--month", "jan,feb,mar", "--files-only", "--limit", "10"]
 expect_min_rows = 1
 expect_max_rows = 10
 
@@ -440,215 +539,233 @@ expect_max_rows = 10
 total_count_min = 10
 
 [[test]]
-id          = "T141"
-group       = "general"
-name        = "T141 --count shorthand"
-title       = "T141 --count shorthand"
-short_desc  = "T141 --count shorthand"
-cli_args    = ["*.exe", "--count"]
-targets     = ["cli"]
+id = "T141"
+group = "general"
+name = "T141 --count shorthand"
+title = "T141 --count shorthand"
+short_desc = "T141 --count shorthand"
+cli_args = ["*.exe", "--count"]
+targets = ["cli"]
 stdout_contains = ["# count", "count"]
 expect_min_rows = 1
 
 [[test]]
-id          = "T142"
-group       = "general"
-name        = "T142 --facet extension"
-title       = "T142 --facet extension"
-short_desc  = "T142 --facet extension"
-cli_args    = ["*", "--facet", "extension"]
-targets     = ["cli"]
+id = "T142"
+group = "general"
+name = "T142 --facet extension"
+title = "T142 --facet extension"
+short_desc = "T142 --facet extension"
+cli_args = ["*", "--facet", "extension"]
+targets = ["cli"]
 stdout_contains = ["# buckets", "key,count,total_bytes"]
 expect_min_rows = 1
 
 [[test]]
-id          = "T143"
-group       = "general"
-name        = "T143 --facet type:10"
-title       = "T143 --facet type:10"
-short_desc  = "T143 --facet type:10"
-cli_args    = ["*", "--facet", "type:10"]
-targets     = ["cli"]
+id = "T143"
+group = "general"
+name = "T143 --facet type:10"
+title = "T143 --facet type:10"
+short_desc = "T143 --facet type:10"
+cli_args = ["*", "--facet", "type:10"]
+targets = ["cli"]
 stdout_contains = ["# buckets", "key,count,total_bytes"]
 expect_min_rows = 1
 
 [[test]]
-id          = "T144"
-group       = "general"
-name        = "T144 --stats size"
-title       = "T144 --stats size"
-short_desc  = "T144 --stats size"
-cli_args    = ["*.exe", "--stats", "size"]
-targets     = ["cli"]
+id = "T144"
+group = "general"
+name = "T144 --stats size"
+title = "T144 --stats size"
+short_desc = "T144 --stats size"
+cli_args = ["*.exe", "--stats", "size"]
+targets = ["cli"]
 stdout_contains = ["# stats", "count,sum,min,max,avg"]
 expect_min_rows = 1
 
 [[test]]
-id          = "T168"
-group       = "general"
-name        = "T168 uffs stats daemon mode"
-title       = "T168 uffs stats daemon mode"
-short_desc  = "T168 uffs stats daemon mode"
-cli_args    = ["stats"]
-targets     = ["cli"]
+id = "T168"
+group = "general"
+name = "T168 uffs --stats daemon mode"
+title = "T168 uffs --stats daemon mode"
+short_desc = "T168 uffs --stats daemon mode"
+cli_args = ["--stats"]
+targets = ["cli"]
 stdout_contains = ["=== total_count ===", "Total:"]
 
 [test.api_checks]
 result_has_key = ["results"]
 
 [[test]]
-id          = "T169"
-group       = "general"
-name        = "T169 uffs daemon stats (perf)"
-title       = "T169 uffs daemon stats (perf)"
-short_desc  = "T169 uffs daemon stats (perf)"
-cli_args    = ["daemon", "stats"]
-targets     = ["cli"]
+id = "T169"
+group = "general"
+name = "T169 uffs --daemon stats (perf)"
+title = "T169 uffs --daemon stats (perf)"
+short_desc = "T169 uffs --daemon stats (perf)"
+cli_args = ["--daemon", "stats"]
+targets = ["cli"]
 stdout_contains = ["Daemon Performance Stats", "Uptime:", "Total records:"]
 
 [test.api_checks]
 result_has_key = ["results"]
 
 [[test]]
-id          = "S3G.2"
-group       = "general"
-name        = "S3G.2 --count shorthand"
-title       = "S3G.2 --count shorthand"
-short_desc  = "S3G.2 --count shorthand"
-cli_args    = ["*.exe", "--count"]
-targets     = ["cli"]
+id = "S3G.2"
+group = "general"
+name = "S3G.2 --count shorthand"
+title = "S3G.2 --count shorthand"
+short_desc = "S3G.2 --count shorthand"
+cli_args = ["*.exe", "--count"]
+targets = ["cli"]
 stdout_contains = ["# count", "count"]
 expect_min_rows = 1
 
 [[test]]
-id          = "S3G.4"
-group       = "general"
-name        = "S3G.4 --facet type:5"
-title       = "S3G.4 --facet type:5"
-short_desc  = "S3G.4 --facet type:5"
-cli_args    = ["*", "--facet", "type:5"]
-targets     = ["cli"]
+id = "S3G.4"
+group = "general"
+name = "S3G.4 --facet type:5"
+title = "S3G.4 --facet type:5"
+short_desc = "S3G.4 --facet type:5"
+cli_args = ["*", "--facet", "type:5"]
+targets = ["cli"]
 stdout_contains = ["# buckets", "key,count,total_bytes"]
 expect_min_rows = 1
 
 [[test]]
-id          = "S3G.5"
-group       = "general"
-name        = "S3G.5 --stats size"
-title       = "S3G.5 --stats size"
-short_desc  = "S3G.5 --stats size"
-cli_args    = ["*.exe", "--stats", "size"]
-targets     = ["cli"]
+id = "S3G.5"
+group = "general"
+name = "S3G.5 --stats size"
+title = "S3G.5 --stats size"
+short_desc = "S3G.5 --stats size"
+cli_args = ["*.exe", "--stats", "size"]
+targets = ["cli"]
 stdout_contains = ["# stats", "count,sum,min,max,avg"]
 expect_min_rows = 1
 
 [[test]]
-id          = "S3G.6"
-group       = "general"
-name        = "S3G.6 --histogram size:1048576"
-title       = "S3G.6 --histogram size:1048576"
-short_desc  = "S3G.6 --histogram size:1048576"
-cli_args    = ["*.exe", "--histogram", "size:1048576"]
-targets     = ["cli"]
+id = "S3G.6"
+group = "general"
+name = "S3G.6 --histogram size:1048576"
+title = "S3G.6 --histogram size:1048576"
+short_desc = "S3G.6 --histogram size:1048576"
+cli_args = ["*.exe", "--histogram", "size:1048576"]
+targets = ["cli"]
 stdout_contains = ["# buckets", "key,count,total_bytes"]
 expect_min_rows = 1
 
 [[test]]
-id          = "T178"
-group       = "general"
-name        = "T178 --case case-sensitive matching"
-title       = "T178 --case case-sensitive matching"
-short_desc  = "Case-sensitive glob returns only exact-case matches"
-cli_args    = ["README*", "--case", "--limit", "20"]
-targets     = ["cli", "api"]
+id = "T178"
+group = "general"
+name = "T178 --case case-sensitive matching"
+title = "T178 --case case-sensitive matching"
+short_desc = "Case-sensitive glob returns only exact-case matches"
+cli_args = ["README*", "--case", "--limit", "20"]
+targets = ["cli", "api"]
 expect_min_rows = 1
-validator   = "T178"
+validator = "T178"
 
 [test.api_checks]
 total_count_min = 1
 
 [[test]]
-id          = "T179"
-group       = "general"
-name        = "T179 --between time range"
-title       = "T179 --between time range"
-short_desc  = "Full-year 2025 range — system has many files from that period"
-cli_args    = ["*", "--between", "2025-01-01,2025-12-31", "--limit", "10"]
-targets     = ["cli", "api"]
+id = "T179"
+group = "general"
+name = "T179 --between time range"
+title = "T179 --between time range"
+short_desc = "Full-year 2025 range — system has many files from that period"
+cli_args = ["*", "--between", "2025-01-01,2025-12-31", "--limit", "10"]
+targets = ["cli", "api"]
 expect_min_rows = 1
 
 [test.api_checks]
 total_count_min = 10
 
 [[test]]
-id          = "T180"
-group       = "general"
-name        = "T180 --exact-size filter"
-title       = "T180 --exact-size filter"
-short_desc  = "Exact file size filter returns only matching sizes"
-cli_args    = ["*", "--exact-size", "0", "--files-only", "--limit", "20"]
-targets     = ["cli", "api"]
+id = "T180"
+group = "general"
+name = "T180 --exact-size filter"
+title = "T180 --exact-size filter"
+short_desc = "Exact file size filter returns only matching sizes"
+cli_args = ["*", "--exact-size", "0", "--files-only", "--limit", "20"]
+targets = ["cli", "api"]
 expect_min_rows = 1
-validator   = "T180"
+validator = "T180"
 
 [test.api_checks]
 total_count_min = 1
 
 [[test]]
-id          = "T181"
-group       = "general"
-name        = "T181 --exact-descendants filter"
-title       = "T181 --exact-descendants filter"
-short_desc  = "Exact descendant count filter (empty directories)"
-cli_args    = ["*", "--exact-descendants", "0", "--dirs-only", "--limit", "20"]
-targets     = ["cli", "api"]
+id = "T181"
+group = "general"
+name = "T181 --exact-descendants filter"
+title = "T181 --exact-descendants filter"
+short_desc = "Exact descendant count filter (empty directories)"
+cli_args = ["*", "--exact-descendants", "0", "--dirs-only", "--limit", "20"]
+targets = ["cli", "api"]
 expect_min_rows = 1
-validator   = "T181"
+validator = "T181"
 
 [test.api_checks]
 total_count_min = 1
 
 [[test]]
-id          = "T182"
-group       = "general"
-name        = "T182 --exact-size-on-disk filter"
-title       = "T182 --exact-size-on-disk filter"
-short_desc  = "All files must have exactly 0 bytes on disk"
-cli_args    = ["*", "--exact-size-on-disk", "0", "--files-only", "--limit", "20", "--columns", "all"]
-targets     = ["cli", "api"]
+id = "T182"
+group = "general"
+name = "T182 --exact-size-on-disk filter"
+title = "T182 --exact-size-on-disk filter"
+short_desc = "All files must have exactly 0 bytes on disk"
+cli_args = [
+  "*",
+  "--exact-size-on-disk",
+  "0",
+  "--files-only",
+  "--limit",
+  "20",
+  "--columns",
+  "all",
+]
+targets = ["cli", "api"]
 expect_columns_all = true
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Size on Disk"
-op     = "eq"
-value  = "0"
+op = "eq"
+value = "0"
 
 [[test]]
-id          = "T183"
-group       = "general"
-name        = "T183 --max-tree-allocated filter"
-title       = "T183 --max-tree-allocated filter"
-short_desc  = "All directories must have tree allocated ≤ 1MB"
-cli_args    = ["*", "--max-tree-allocated", "1048576", "--dirs-only", "--limit", "20", "--columns", "all"]
-targets     = ["cli", "api"]
+id = "T183"
+group = "general"
+name = "T183 --max-tree-allocated filter"
+title = "T183 --max-tree-allocated filter"
+short_desc = "All directories must have tree allocated ≤ 1MB"
+cli_args = [
+  "*",
+  "--max-tree-allocated",
+  "1048576",
+  "--dirs-only",
+  "--limit",
+  "20",
+  "--columns",
+  "all",
+]
+targets = ["cli", "api"]
 expect_columns_all = true
 expect_min_rows = 1
 
 [[test.column_checks]]
 column = "Tree Allocated"
-op     = "lte"
-value  = "1048576"
+op = "lte"
+value = "1048576"
 
 [[test]]
-id          = "T184"
-group       = "general"
-name        = "T184 --case negative (no match)"
-title       = "T184 --case negative (no match)"
-short_desc  = "Case-sensitive search for lowercase 'readme*' returns no README files"
-cli_args    = ["readme*", "--case", "--limit", "20"]
-targets     = ["cli", "api"]
-validator   = "T184"
+id = "T184"
+group = "general"
+name = "T184 --case negative (no match)"
+title = "T184 --case negative (no match)"
+short_desc = "Case-sensitive search for lowercase 'readme*' returns no README files"
+cli_args = ["readme*", "--case", "--limit", "20"]
+targets = ["cli", "api"]
+validator = "T184"
 
 [test.api_checks]
 result_has_key = ["rows"]
@@ -658,4 +775,3 @@ result_has_key = ["rows"]
 # ═══════════════════════════════════════════════════════════════
 
 # ── Daemon / RPC tests (CLI + API) ────────────────────────────────
-

--- a/scripts/tests/definitions/13-help.toml
+++ b/scripts/tests/definitions/13-help.toml
@@ -3,132 +3,126 @@
 # These tests do NOT require a running daemon or data source.
 
 [[test]]
-id          = "H1"
-group       = "help"
-name        = "H1 uffs --help"
-title       = "H1 main help text"
-short_desc  = "Top-level help shows subcommands, options, examples"
-cli_args    = ["--help"]
-targets     = ["cli"]
-validator   = "H1"
+id = "H1"
+group = "help"
+name = "H1 uffs --help"
+title = "H1 main help text"
+short_desc = "Top-level help shows the search-first grammar, commands, options, examples"
+cli_args = ["--help"]
+targets = ["cli"]
+validator = "H1"
 stdout_contains = [
-    "USAGE:",
-    "SUBCOMMANDS:",
-    "daemon",
-    "mcp",
-    "stats",
-    "aggregate",
-    "status",
-    "COMMON OPTIONS:",
-    "--drive",
-    "--mft-file",
-    "--data-dir",
-    "--limit",
-    "--format",
-    "--sort",
-    "--ext",
-    "--columns",
-    "--help",
-    "--version",
-    "EXAMPLES:",
+  "USAGE:",
+  "Search-first",
+  "COMMANDS:",
+  "--search",
+  "--stats",
+  "--agg",
+  "--daemon",
+  "--mcp",
+  "--update",
+  "--status",
+  "COMMON OPTIONS:",
+  "--drive",
+  "--mft-file",
+  "--data-dir",
+  "--limit",
+  "--format",
+  "--sort",
+  "--ext",
+  "--columns",
+  "--help",
+  "--version",
+  "EXAMPLES:",
 ]
 
 [[test]]
-id          = "H2"
-group       = "help"
-name        = "H2 uffs daemon --help"
-title       = "H2 daemon subcommand help"
-short_desc  = "Daemon help shows lifecycle actions"
-cli_args    = ["daemon", "--help"]
-targets     = ["cli"]
-validator   = "H2"
+id = "H2"
+group = "help"
+name = "H2 uffs --daemon --help"
+title = "H2 --daemon command help"
+short_desc = "Daemon help shows lifecycle actions"
+cli_args = ["--daemon", "--help"]
+targets = ["cli"]
+validator = "H2"
 stdout_contains = [
-    "daemon",
-    "ACTIONS:",
-    "start",
-    "status",
-    "stats",
-    "stop",
-    "kill",
-    "restart",
-    "load",
+  "daemon",
+  "ACTIONS:",
+  "start",
+  "status",
+  "stats",
+  "stop",
+  "kill",
+  "restart",
+  "load",
 ]
 
 [[test]]
-id          = "H3"
-group       = "help"
-name        = "H3 uffs mcp --help"
-title       = "H3 MCP subcommand help"
-short_desc  = "MCP help shows server management subcommands"
-cli_args    = ["mcp", "--help"]
-targets     = ["cli"]
-validator   = "H3"
+id = "H3"
+group = "help"
+name = "H3 uffs --mcp --help"
+title = "H3 --mcp command help"
+short_desc = "MCP help shows server management subcommands"
+cli_args = ["--mcp", "--help"]
+targets = ["cli"]
+validator = "H3"
 stdout_contains = [
-    "mcp",
-    "start",
-    "status",
-    "stop",
-    "kill",
-    "restart",
-    "reload",
+  "mcp",
+  "start",
+  "status",
+  "stop",
+  "kill",
+  "restart",
+  "reload",
 ]
 
 [[test]]
-id          = "H4"
-group       = "help"
-name        = "H4 uffs stats --help"
-title       = "H4 stats subcommand help"
-short_desc  = "Stats help shows options"
-cli_args    = ["stats", "--help"]
-targets     = ["cli"]
+id = "H4"
+group = "help"
+name = "H4 uffs --stats --help"
+title = "H4 --stats command help"
+short_desc = "Stats help shows options"
+cli_args = ["--stats", "--help"]
+targets = ["cli"]
+stdout_contains = ["stats", "USAGE:", "--top", "--data-dir", "--mft-file"]
+
+[[test]]
+id = "H5"
+group = "help"
+name = "H5 uffs --agg --help"
+title = "H5 --agg command help"
+short_desc = "Aggregate help shows preset argument and options"
+cli_args = ["--aggregate", "--help"]
+targets = ["cli"]
 stdout_contains = [
-    "stats",
-    "USAGE:",
-    "--top",
-    "--data-dir",
-    "--mft-file",
+  "aggregate",
+  "USAGE:",
+  "PRESET",
+  "overview",
+  "by_type",
+  "by_extension",
+  "--format",
+  "--agg-cursor",
+  "--agg-page-size",
 ]
 
 [[test]]
-id          = "H5"
-group       = "help"
-name        = "H5 uffs aggregate --help"
-title       = "H5 aggregate subcommand help"
-short_desc  = "Aggregate help shows preset argument and options"
-cli_args    = ["aggregate", "--help"]
-targets     = ["cli"]
-stdout_contains = [
-    "aggregate",
-    "USAGE:",
-    "PRESET",
-    "overview",
-    "by_type",
-    "by_extension",
-    "--format",
-    "--agg-cursor",
-    "--agg-page-size",
-]
+id = "H6"
+group = "help"
+name = "H6 uffs --status --help"
+title = "H6 --status command help"
+short_desc = "Status help shows usage"
+cli_args = ["--status", "--help"]
+targets = ["cli"]
+stdout_contains = ["status", "USAGE:"]
 
 [[test]]
-id          = "H6"
-group       = "help"
-name        = "H6 uffs status --help"
-title       = "H6 status subcommand help"
-short_desc  = "Status help shows usage"
-cli_args    = ["status", "--help"]
-targets     = ["cli"]
-stdout_contains = [
-    "status",
-    "USAGE:",
-]
-
-[[test]]
-id          = "H7"
-group       = "help"
-name        = "H7 uffs --version"
-title       = "H7 version output"
-short_desc  = "Version flag prints version string"
-cli_args    = ["--version"]
-targets     = ["cli"]
-validator   = "H7"
+id = "H7"
+group = "help"
+name = "H7 uffs --version"
+title = "H7 version output"
+short_desc = "Version flag prints version string"
+cli_args = ["--version"]
+targets = ["cli"]
+validator = "H7"
 stdout_contains = ["uffs"]

--- a/scripts/verify_parity.rs
+++ b/scripts/verify_parity.rs
@@ -643,7 +643,7 @@ fn run_live_drive_parity(
     print!("  [1/5] Purging daemon + cache for cold Rust run...");
     io::stdout().flush().ok();
     let _ = Command::new(rust_bin)
-        .args(["daemon", "kill"])
+        .args(["--daemon", "kill"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .output();
@@ -670,7 +670,7 @@ fn run_live_drive_parity(
     //    explicitly — matching what C++ (`uffs.com`) does on every run —
     //    so a future regression in `extract_spawn_args` (e.g. a forgotten
     //    flag) can never silently widen the measurement to "all NTFS
-    //    drives".  `uffs daemon start` blocks until the drive's MFT is
+    //    drives".  `uffs --daemon start` blocks until the drive's MFT is
     //    fully indexed (await_ready, 2 min timeout).
     //
     //    We start timing *before* `daemon start` so `rust_elapsed` captures
@@ -680,7 +680,7 @@ fn run_live_drive_parity(
     io::stdout().flush().ok();
     let rust_start = Instant::now();
     let daemon_start_output = Command::new(rust_bin)
-        .args(["daemon", "start", "--drive", &drive_upper, "--no-cache"])
+        .args(["--daemon", "start", "--drive", &drive_upper, "--no-cache"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .output();
@@ -735,7 +735,7 @@ fn run_live_drive_parity(
 
     // Kill daemon after Rust run — next drive must also start cold.
     let _ = Command::new(rust_bin)
-        .args(["daemon", "kill"])
+        .args(["--daemon", "kill"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .output();

--- a/scripts/windows/api-validation.rs
+++ b/scripts/windows/api-validation.rs
@@ -232,14 +232,14 @@ fn default_binary() -> String {
 /// version string for inclusion in the validation-summary block.
 ///
 /// Returns the trimmed value of the `Version:` line printed by
-/// `uffs daemon status` on uffs ≥ 0.5.79.  Pre-0.5.79 daemons emit
+/// `uffs --daemon status` on uffs ≥ 0.5.79.  Pre-0.5.79 daemons emit
 /// `<unknown> (daemon) / X.Y.Z (cli)` via the CLI's back-compat
 /// renderer; pre-this-feature daemons (no `Version:` line at all)
 /// surface as `<line not found>`.  When the daemon is unreachable
 /// the helper reports `<not running>` instead of erroring — the
 /// version line is informational, not load-bearing.
 fn capture_daemon_version(bin: &str) -> String {
-    match Command::new(bin).args(["daemon", "status"]).output() {
+    match Command::new(bin).args(["--daemon", "status"]).output() {
         Ok(out) if out.status.success() => {
             let text = String::from_utf8_lossy(&out.stdout);
             for line in text.lines() {
@@ -754,7 +754,7 @@ fn run_tests(sock: &str, specs: Vec<TestSpec>, args: &ScriptArgs) -> Vec<TestRes
                 };
                 // Build the full CLI command for debugging.
                 // For RPC-only methods (status, drives, etc.) map to
-                // their `uffs daemon <method>` CLI equivalent.
+                // their `uffs --daemon <method>` CLI equivalent.
                 let cli_command = {
                     let mut cli_parts = cli_prefix.as_ref().clone();
                     let bin = cli_parts.remove(0);
@@ -2525,7 +2525,7 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> bool {
     // Step 1: Check status.
     eprintln!("  Checking daemon status...");
     let status = Command::new(bin)
-        .args(["daemon", "status"])
+        .args(["--daemon", "status"])
         .output();
     match status {
         Ok(o) => {
@@ -2564,7 +2564,7 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> bool {
                 // synchronous by design and always leaves a clean slate.
                 eprintln!("  Killing stale daemon...");
                 let _ = Command::new(bin)
-                    .args(["daemon", "kill"])
+                    .args(["--daemon", "kill"])
                     .output();
                 // Brief pause to let the socket slot fully release on macOS
                 // (Darwin retains the inode ~50 ms after the process exits).
@@ -2585,7 +2585,7 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> bool {
     }
 
     // Step 2: Start daemon (blocks until ready).
-    let mut start_args = vec!["daemon".to_string(), "start".to_string()];
+    let mut start_args = vec!["--daemon".to_string(), "start".to_string()];
     if let Some(flag) = args.source_flag {
         start_args.push(flag.to_string());
         start_args.push(args.source_path.clone());
@@ -2740,8 +2740,8 @@ fn main() {
                 eprintln!("  {}", "Tests cannot validate anything without data. Aborting.".red().bold());
                 eprintln!();
                 eprintln!("  Hint: start the daemon with data:");
-                eprintln!("    uffs daemon start --data-dir ~/uffs_data");
-                eprintln!("    uffs daemon start --mft-file /path/to/C_mft.iocp");
+                eprintln!("    uffs --daemon start --data-dir ~/uffs_data");
+                eprintln!("    uffs --daemon start --mft-file /path/to/C_mft.iocp");
                 eprintln!();
                 eprintln!("  Raw response: {}", serde_json::to_string_pretty(&resp).unwrap_or_default());
                 std::process::exit(1);
@@ -2888,8 +2888,8 @@ fn main() {
     // The validation suite is a strict observer: it does not kill orphan
     // processes or mutate the host in any way.  Those concerns live in
     // `scripts/dev/orphan-cleanup.rs` (callable via `just orphan`).
-    print_uffs_command_block(&args.bin, &["daemon", "status"], "═══ Daemon STATUS ═══");
-    print_uffs_command_block(&args.bin, &["daemon", "stats"],  "═══ Daemon STATS ═══");
+    print_uffs_command_block(&args.bin, &["--daemon", "status"], "═══ Daemon STATUS ═══");
+    print_uffs_command_block(&args.bin, &["--daemon", "stats"],  "═══ Daemon STATS ═══");
 
     if failed > 0 {
         // Build retest command with failed test IDs.  Same shape as

--- a/scripts/windows/benchmark.rs
+++ b/scripts/windows/benchmark.rs
@@ -166,12 +166,12 @@ fn flush() { std::io::stderr().flush().ok(); }
 
 /// Kill daemon and **poll until it is confirmed stopped** (up to 10 s).
 fn ensure_stopped(bin: &PathBuf) {
-    let _ = Command::new(bin).args(["daemon", "kill"])
+    let _ = Command::new(bin).args(["--daemon", "kill"])
         .stdout(Stdio::null()).stderr(Stdio::null()).status();
     let deadline = Instant::now() + Duration::from_secs(10);
     while Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(250));
-        if let Ok(out) = Command::new(bin).args(["daemon", "status"])
+        if let Ok(out) = Command::new(bin).args(["--daemon", "status"])
             .stderr(Stdio::null()).output()
         {
             let s = String::from_utf8_lossy(&out.stdout);
@@ -185,7 +185,7 @@ fn ensure_stopped(bin: &PathBuf) {
 /// `source_args` should be e.g. `["--mft-file", "/path/to/C_mft.iocp"]` for a
 /// single drive, or `["--data-dir", "/path"]` for all drives.
 fn start_and_await_ready(bin: &PathBuf, source_args: &[String]) -> bool {
-    let mut args: Vec<String> = vec!["daemon".into(), "start".into()];
+    let mut args: Vec<String> = vec!["--daemon".into(), "start".into()];
     args.extend(source_args.iter().cloned());
     let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let _ = Command::new(bin).args(&str_args)
@@ -193,7 +193,7 @@ fn start_and_await_ready(bin: &PathBuf, source_args: &[String]) -> bool {
 
     let deadline = Instant::now() + Duration::from_secs(120);
     while Instant::now() < deadline {
-        if let Ok(out) = Command::new(bin).args(["daemon", "status"])
+        if let Ok(out) = Command::new(bin).args(["--daemon", "status"])
             .stderr(Stdio::null()).output()
         {
             let s = String::from_utf8_lossy(&out.stdout);
@@ -206,7 +206,7 @@ fn start_and_await_ready(bin: &PathBuf, source_args: &[String]) -> bool {
 
 /// Assert daemon is Ready right now.
 fn assert_ready(bin: &PathBuf) -> bool {
-    if let Ok(out) = Command::new(bin).args(["daemon", "status"])
+    if let Ok(out) = Command::new(bin).args(["--daemon", "status"])
         .stderr(Stdio::null()).output()
     {
         let s = String::from_utf8_lossy(&out.stdout);

--- a/scripts/windows/bulk-retrieval.rs
+++ b/scripts/windows/bulk-retrieval.rs
@@ -106,7 +106,7 @@ impl DataSources {
         DataSources { data_dir: None, drive_files: std::collections::HashMap::new() }
     }
 
-    /// Args for `uffs daemon start` — only --data-dir / --mft-file (NOT --drive).
+    /// Args for `uffs --daemon start` — only --data-dir / --mft-file (NOT --drive).
     fn daemon_start_args(&self) -> Vec<String> {
         match &self.data_dir {
             Some(d) => vec!["--data-dir".into(), d.to_string_lossy().into_owned()],
@@ -163,12 +163,12 @@ struct BulkConfig {
 fn flush() { std::io::stderr().flush().ok(); }
 
 fn ensure_stopped(bin: &PathBuf) {
-    let _ = Command::new(bin).args(["daemon", "kill"])
+    let _ = Command::new(bin).args(["--daemon", "kill"])
         .stdout(Stdio::null()).stderr(Stdio::null()).status();
     let deadline = Instant::now() + Duration::from_secs(10);
     while Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(250));
-        if let Ok(out) = Command::new(bin).args(["daemon", "status"])
+        if let Ok(out) = Command::new(bin).args(["--daemon", "status"])
             .stderr(Stdio::null()).output()
         {
             let s = String::from_utf8_lossy(&out.stdout);
@@ -179,7 +179,7 @@ fn ensure_stopped(bin: &PathBuf) {
 }
 
 fn start_and_await_ready(bin: &PathBuf, source_args: &[String]) -> bool {
-    let mut args: Vec<String> = vec!["daemon".into(), "start".into()];
+    let mut args: Vec<String> = vec!["--daemon".into(), "start".into()];
     args.extend(source_args.iter().cloned());
     let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let _ = Command::new(bin).args(&str_args)
@@ -187,7 +187,7 @@ fn start_and_await_ready(bin: &PathBuf, source_args: &[String]) -> bool {
 
     let deadline = Instant::now() + Duration::from_secs(120);
     while Instant::now() < deadline {
-        if let Ok(out) = Command::new(bin).args(["daemon", "status"])
+        if let Ok(out) = Command::new(bin).args(["--daemon", "status"])
             .stderr(Stdio::null()).output()
         {
             let s = String::from_utf8_lossy(&out.stdout);
@@ -199,7 +199,7 @@ fn start_and_await_ready(bin: &PathBuf, source_args: &[String]) -> bool {
 }
 
 fn assert_ready(bin: &PathBuf) -> bool {
-    if let Ok(out) = Command::new(bin).args(["daemon", "status"])
+    if let Ok(out) = Command::new(bin).args(["--daemon", "status"])
         .stderr(Stdio::null()).output()
     {
         let s = String::from_utf8_lossy(&out.stdout);

--- a/scripts/windows/cli-validation.rs
+++ b/scripts/windows/cli-validation.rs
@@ -278,14 +278,14 @@ fn default_binary() -> String {
 /// version string for inclusion in the validation-summary block.
 ///
 /// Returns the trimmed value of the `Version:` line printed by
-/// `uffs daemon status` on uffs ≥ 0.5.79.  Pre-0.5.79 daemons emit
+/// `uffs --daemon status` on uffs ≥ 0.5.79.  Pre-0.5.79 daemons emit
 /// `<unknown> (daemon) / X.Y.Z (cli)` via the CLI's back-compat
 /// renderer; pre-this-feature daemons (no `Version:` line at all)
 /// surface as `<line not found>`.  When the daemon is unreachable
 /// the helper reports `<not running>` instead of erroring — the
 /// version line is informational, not load-bearing.
 fn capture_daemon_version(bin: &str) -> String {
-    match Command::new(bin).args(["daemon", "status"]).output() {
+    match Command::new(bin).args(["--daemon", "status"]).output() {
         Ok(out) if out.status.success() => {
             let text = String::from_utf8_lossy(&out.stdout);
             for line in text.lines() {
@@ -1430,17 +1430,17 @@ fn run_custom_validator(name: &str, stdout: &str, stderr: &str) -> Result<String
         // ── Help / version validators ────────────────────────────────────
         "H1" => {
             // Main help: verify structure has key sections.
-            let sections = ["SUBCOMMANDS:", "COMMON OPTIONS:", "EXAMPLES:"];
+            let sections = ["COMMANDS:", "COMMON OPTIONS:", "EXAMPLES:"];
             for section in &sections {
                 if !stdout.contains(section) {
                     bail!("Missing section: {section}");
                 }
             }
-            // Verify all expected subcommands are listed.
-            let subcommands = ["daemon", "mcp", "stats", "aggregate", "status"];
+            // Verify all expected `--command`s are listed (search-first grammar).
+            let subcommands = ["--search", "--stats", "--agg", "--daemon", "--mcp", "--update", "--status"];
             for sub in &subcommands {
                 if !stdout.contains(sub) {
-                    bail!("Missing subcommand in help: {sub}");
+                    bail!("Missing command in help: {sub}");
                 }
             }
             // Verify key flags are documented.
@@ -1808,9 +1808,9 @@ fn cli_string(bin: &str, args: &[String]) -> String {
     parts.join(" ")
 }
 
-/// Subcommands that do NOT accept `--data-dir` (they don't connect to the
-/// daemon at all).
-const SUBCOMMANDS_NO_DATA_DIR: &[&str] = &["info", "daemon", "index"];
+/// `--command`s that do NOT accept `--data-dir` (pure management — they
+/// don't read a data source). Search-first grammar: commands are `--<name>`.
+const SUBCOMMANDS_NO_DATA_DIR: &[&str] = &["--daemon", "--status", "--mcp", "--update"];
 
 /// Flags whose presence means we should NOT inject `--columns all`.
 const OUTPUT_SHAPING_FLAGS: &[&str] = &[
@@ -1822,9 +1822,9 @@ fn run_one_test_cli(bin: &str, spec: &TestSpec, source_flag: Option<&str>, sourc
     let mut args = spec.args.clone();
     let first = args.first().map(String::as_str).unwrap_or("");
 
-    // Subcommands (agg, stats, info, etc.) don't accept search flags.
+    // Commands (`--agg`, `--stats`, `--daemon`, …) don't accept search flags.
     let is_subcommand = SUBCOMMANDS_NO_DATA_DIR.iter().any(|s| first.eq_ignore_ascii_case(s))
-        || matches!(first.to_lowercase().as_str(), "agg" | "aggregate" | "stats" | "daemon" | "index");
+        || matches!(first.to_lowercase().as_str(), "--agg" | "--aggregate" | "--stats");
 
     if !is_subcommand {
         if let Some(flag) = source_flag {
@@ -1973,8 +1973,8 @@ fn print_results(results: &[TestResult]) {
 ///
 /// Returns the time spent waiting for the daemon to become ready (ms).
 ///
-/// 1. Run `uffs daemon status` — if "Ready", done.
-/// 2. If "not running", run `uffs daemon start --data-dir ...` (blocks
+/// 1. Run `uffs --daemon status` — if "Ready", done.
+/// 2. If "not running", run `uffs --daemon start --data-dir ...` (blocks
 ///    until "Daemon started and ready." is printed, then returns).
 fn ensure_daemon_ready(args: &ScriptArgs) -> u128 {
     let bin = &args.bin;
@@ -1982,7 +1982,7 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> u128 {
 
     // Step 1: Check status.
     eprintln!("  Checking daemon status...");
-    match run_uffs(bin, &["daemon".to_string(), "status".to_string()]) {
+    match run_uffs(bin, &["--daemon".to_string(), "status".to_string()]) {
         Ok((_code, stdout, stderr)) => {
             let combined = format!("{stdout}{stderr}");
             let lower = combined.to_lowercase();
@@ -2011,7 +2011,7 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> u128 {
                 }
                 // Stop the stale daemon so we can restart with the data source.
                 eprintln!("  Stopping stale daemon...");
-                let _ = run_uffs(bin, &["daemon".to_string(), "stop".to_string()]);
+                let _ = run_uffs(bin, &["--daemon".to_string(), "stop".to_string()]);
                 // Brief pause to let the socket close.
                 std::thread::sleep(std::time::Duration::from_millis(500));
             } else if lower.contains("not running") {
@@ -2030,7 +2030,7 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> u128 {
     }
 
     // Step 2: Start daemon.
-    let mut start_args = vec!["daemon".to_string(), "start".to_string()];
+    let mut start_args = vec!["--daemon".to_string(), "start".to_string()];
     if let Some(flag) = args.source_flag {
         start_args.push(flag.to_string());
         start_args.push(args.source_path.clone());
@@ -2065,7 +2065,7 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> u128 {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(delay_ms));
-        match run_uffs(bin, &["daemon".to_string(), "status".to_string()]) {
+        match run_uffs(bin, &["--daemon".to_string(), "status".to_string()]) {
             Ok((_code, stdout, stderr)) => {
                 let combined = format!("{stdout}{stderr}");
                 let lower = combined.to_lowercase();
@@ -2238,8 +2238,8 @@ fn main() {
     // The validation suite is a strict observer: it does not kill orphan
     // processes or mutate the host in any way.  Those concerns live in
     // `scripts/dev/orphan-cleanup.rs` (callable via `just orphan`).
-    print_uffs_command_block(&args.bin, &["daemon", "status"], "═══ Daemon STATUS ═══");
-    print_uffs_command_block(&args.bin, &["daemon", "stats"],  "═══ Daemon STATS ═══");
+    print_uffs_command_block(&args.bin, &["--daemon", "status"], "═══ Daemon STATUS ═══");
+    print_uffs_command_block(&args.bin, &["--daemon", "stats"],  "═══ Daemon STATS ═══");
 
     if failed > 0 {
         // Build retest command with failed test IDs.  Same shape as

--- a/scripts/windows/cold-parity-per-drive.ps1
+++ b/scripts/windows/cold-parity-per-drive.ps1
@@ -171,7 +171,7 @@ function Remove-DriveCache {
 }
 
 function Get-DaemonTotalRecords {
-    # `uffs daemon stats` prints "Total records: N" with thousands
+    # `uffs --daemon stats` prints "Total records: N" with thousands
     # separators. Returns $null if the daemon isn't running or the line
     # isn't found.
     try {
@@ -296,7 +296,7 @@ function Remove-AllDriveCaches {
 }
 
 function Start-DaemonAllDrives {
-    # Force the daemon to start and load all drives.  `uffs daemon start`
+    # Force the daemon to start and load all drives.  `uffs --daemon start`
     # has no --drive filter (args.rs:109 states daemon auto-discovers
     # all drives on Windows live mode), so a bare daemon start (no -d)
     # gets the right behaviour.  Then we issue a trivial `*` --limit 1

--- a/scripts/windows/cold-parity-per-drive.rs
+++ b/scripts/windows/cold-parity-per-drive.rs
@@ -399,12 +399,12 @@ fn purge_drive_cache(cache_dir: &PathBuf, drive: &str, dump_raw: bool) {
 ///   `UFFS_WARM_TO_PARKED_IDLE_SECS=7200` (2 hr — default 30 min)
 fn kill_and_restart_daemon(uffs_bin: &str, drives: &[String]) {
     let _ = Command::new(uffs_bin)
-        .args(["daemon", "kill"])
+        .args(["--daemon", "kill"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
     std::thread::sleep(std::time::Duration::from_millis(1_200));
-    let mut start_args: Vec<&str> = vec!["daemon", "start"];
+    let mut start_args: Vec<&str> = vec!["--daemon", "start"];
     let drive_flags: Vec<String> = drives
         .iter()
         .flat_map(|d| ["--drive".to_owned(), d.clone()])
@@ -423,7 +423,7 @@ fn kill_and_restart_daemon(uffs_bin: &str, drives: &[String]) {
 
 fn daemon_total_records(uffs_bin: &str) -> Option<u64> {
     let out = Command::new(uffs_bin)
-        .args(["daemon", "stats"])
+        .args(["--daemon", "stats"])
         .output()
         .ok()?;
     let text = String::from_utf8_lossy(&out.stdout);

--- a/scripts/windows/concurrency-sweep.rs
+++ b/scripts/windows/concurrency-sweep.rs
@@ -17,9 +17,9 @@
 //!
 //! 1. `Remove-Item` the on-disk caches (`%LOCALAPPDATA%\uffs\cache` and
 //!    `%TEMP%\uffs_index_cache`) to force a clean start.
-//! 2. `uffs mcp kill`
-//! 3. `uffs daemon kill`
-//! 4. Set `UFFS_SEARCH_MAX_CONCURRENCY=N` and run `uffs daemon start`.
+//! 2. `uffs --mcp kill`
+//! 3. `uffs --daemon kill`
+//! 4. Set `UFFS_SEARCH_MAX_CONCURRENCY=N` and run `uffs --daemon start`.
 //!    On Windows this call blocks until the daemon reports `Ready`
 //!    (typical cold-load time: ~80 s for 26 M records over 7 drives).
 //!    No polling is needed — we just wait for the process to return.
@@ -27,7 +27,7 @@
 //!    verify `source="env"` and `target=N`.
 //! 6. Run one warm-up api-validation (populates the agg cache).
 //! 7. Run one measured api-validation and parse its Timing Breakdown.
-//! 8. Capture `uffs daemon stats` for cache hit-rate and avg query time.
+//! 8. Capture `uffs --daemon stats` for cache hit-rate and avg query time.
 //!
 //! A summary table is printed at the end.
 //!
@@ -115,7 +115,7 @@ fn kill(subcmd: &str) {
         .status();
 }
 
-/// Run `uffs daemon start` with `UFFS_SEARCH_MAX_CONCURRENCY=N` in the
+/// Run `uffs --daemon start` with `UFFS_SEARCH_MAX_CONCURRENCY=N` in the
 /// environment.  This call inherits stdout/stderr and **blocks until
 /// the daemon reports `Ready`** (or the CLI gives up).  No polling —
 /// the child `uffs` process does the wait internally and prints
@@ -128,16 +128,16 @@ fn kill(subcmd: &str) {
 /// nothing ever hits disk).
 ///
 /// # Errors
-/// Returns an error if `uffs daemon start` exits non-zero.
+/// Returns an error if `uffs --daemon start` exits non-zero.
 fn start_daemon(n: usize, log_dir: &PathBuf) -> Result<()> {
     let status = Command::new(uffs_bin())
-        .args(["daemon", "start"])
+        .args(["--daemon", "start"])
         .env("UFFS_SEARCH_MAX_CONCURRENCY", n.to_string())
         .env("UFFS_LOG_DIR", log_dir)
         .status()
-        .context("failed to spawn `uffs daemon start`")?;
+        .context("failed to spawn `uffs --daemon start`")?;
     if !status.success() {
-        bail!("`uffs daemon start` exited with status {status}");
+        bail!("`uffs --daemon start` exited with status {status}");
     }
     Ok(())
 }
@@ -164,7 +164,7 @@ fn status_is_running(value: &str) -> bool {
     !lower.contains("not running") && !lower.contains("not responding") && lower.contains("running")
 }
 
-/// Extract a drive letter from a `uffs status` line like `"[W] G:  … records"`.
+/// Extract a drive letter from a `uffs --status` line like `"[W] G:  … records"`.
 fn status_drive_letter(line: &str) -> Option<String> {
     let after = line.strip_prefix('[')?.split_once(']')?.1.trim_start();
     let mut chars = after.chars();
@@ -173,7 +173,7 @@ fn status_drive_letter(line: &str) -> Option<String> {
         .then(|| letter.to_ascii_uppercase().to_string())
 }
 
-/// Parse `uffs status` stdout into a [`RunState`], scoping `Status:` and the
+/// Parse `uffs --status` stdout into a [`RunState`], scoping `Status:` and the
 /// `[T] L:` drive lines to their section.
 fn parse_run_state(stdout: &str) -> RunState {
     let (mut section, mut daemon_running, mut daemon_seen, mut mcp_running) = (0_u8, false, false, false);
@@ -198,9 +198,9 @@ fn parse_run_state(stdout: &str) -> RunState {
     }
 }
 
-/// Capture the as-found daemon + MCP state via `uffs status`.
+/// Capture the as-found daemon + MCP state via `uffs --status`.
 fn capture_run_state() -> RunState {
-    match Command::new(uffs_bin()).arg("status").output() {
+    match Command::new(uffs_bin()).arg("--status").output() {
         Ok(out) => parse_run_state(&String::from_utf8_lossy(&out.stdout)),
         Err(_) => RunState { daemon_drives: None, mcp_running: false },
     }
@@ -216,14 +216,14 @@ fn restore_run_state(state: &RunState) {
         Some(drives) => {
             let scope = if drives.is_empty() { "(all)".to_string() } else { drives.join(",") };
             println!("  restarting daemon on as-found drives: {scope}");
-            let mut args: Vec<String> = vec!["daemon".into(), "start".into()];
+            let mut args: Vec<String> = vec!["--daemon".into(), "start".into()];
             for d in drives { args.push("--drive".into()); args.push(d.clone()); }
             let _ = Command::new(uffs_bin()).args(&args).status();
         }
     }
     if state.mcp_running {
         println!("  restarting MCP gateway (was up at start)");
-        let _ = Command::new(uffs_bin()).args(["mcp", "start"]).status();
+        let _ = Command::new(uffs_bin()).args(["--mcp", "start"]).status();
     }
 }
 
@@ -272,10 +272,10 @@ fn run_validation(repo_root: &PathBuf) -> Result<String> {
     Ok(text)
 }
 
-/// Capture `uffs daemon stats` as plain text.
+/// Capture `uffs --daemon stats` as plain text.
 fn daemon_stats_text() -> String {
     Command::new(uffs_bin())
-        .args(["daemon", "stats"])
+        .args(["--daemon", "stats"])
         .output()
         .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
         .unwrap_or_default()
@@ -530,7 +530,7 @@ fn main() -> Result<()> {
         thread::sleep(Duration::from_secs(KILL_SETTLE_SECS));
 
         // 3. Start daemon with UFFS_SEARCH_MAX_CONCURRENCY=N.
-        //    `uffs daemon start` blocks until the daemon reports Ready
+        //    `uffs --daemon start` blocks until the daemon reports Ready
         //    (or gives up), so we just wait for the child process to
         //    return — no polling loop required.
         // Truncate the daemon log before each iteration so `last_tune_line`

--- a/scripts/windows/cross-tool-benchmark.rs
+++ b/scripts/windows/cross-tool-benchmark.rs
@@ -380,13 +380,13 @@ fn find_everything() -> Option<PathBuf> {
 fn uffs_stop(bin: &Path) {
     // "daemon kill" is a hard kill; "daemon stop" is a graceful shutdown
     // that may leave shared memory / cache warm.
-    let _ = Command::new(bin).args(["daemon","kill"]).stdout(Stdio::null()).stderr(Stdio::null()).status();
+    let _ = Command::new(bin).args(["--daemon","kill"]).stdout(Stdio::null()).stderr(Stdio::null()).status();
     std::thread::sleep(Duration::from_secs(2));
 }
 /// Start the daemon with bench-safe idle-demote TTLs so it never demotes
 /// Hot→Warm or Warm→Parked mid-run.  These env vars are scoped to the
 /// daemon child process only — the bench script's own env is unchanged,
-/// and teardown's next `uffs daemon start` gets production defaults.
+/// and teardown's next `uffs --daemon start` gets production defaults.
 ///
 /// `drives` scopes which drives the daemon loads on startup.  This is
 /// **essential** for fair timing: without an explicit `--drive` flag the
@@ -395,7 +395,7 @@ fn uffs_stop(bin: &Path) {
 /// under test.  Each letter is forwarded as a separate `--drive <X>`
 /// (`parse_daemon_start` in uffs-cli accumulates them).
 fn uffs_start(bin: &Path, drives: &[String]) {
-    let mut args: Vec<String> = vec!["daemon".into(), "start".into()];
+    let mut args: Vec<String> = vec!["--daemon".into(), "start".into()];
     for d in drives {
         args.push("--drive".into());
         args.push(d.clone());
@@ -430,7 +430,7 @@ fn status_is_running(value: &str) -> bool {
     !lower.contains("not running") && !lower.contains("not responding") && lower.contains("running")
 }
 
-/// Extract a drive letter from a `uffs status` line like `"[W] G:  … records"`.
+/// Extract a drive letter from a `uffs --status` line like `"[W] G:  … records"`.
 fn status_drive_letter(line: &str) -> Option<String> {
     let after = line.strip_prefix('[')?.split_once(']')?.1.trim_start();
     let mut chars = after.chars();
@@ -439,7 +439,7 @@ fn status_drive_letter(line: &str) -> Option<String> {
         .then(|| letter.to_ascii_uppercase().to_string())
 }
 
-/// Parse `uffs status` stdout into a [`RunState`], scoping each `Status:` line
+/// Parse `uffs --status` stdout into a [`RunState`], scoping each `Status:` line
 /// and the `[T] L:` drive lines to their section.
 fn parse_run_state(stdout: &str) -> RunState {
     let (mut section, mut daemon_running, mut daemon_seen, mut mcp_running) = (0_u8, false, false, false);
@@ -466,7 +466,7 @@ fn parse_run_state(stdout: &str) -> RunState {
 
 /// Capture the as-found daemon + MCP state via `<bin> status`.
 fn capture_run_state(bin: &Path) -> RunState {
-    match Command::new(bin).arg("status").output() {
+    match Command::new(bin).arg("--status").output() {
         Ok(out) => parse_run_state(&String::from_utf8_lossy(&out.stdout)),
         Err(_) => RunState { daemon_drives: None, mcp_running: false },
     }
@@ -482,14 +482,14 @@ fn restore_run_state(bin: &Path, state: &RunState) {
         Some(drives) => {
             let scope = if drives.is_empty() { "(all)".to_string() } else { drives.join(",") };
             eprintln!("  restarting daemon on as-found drives: {scope}");
-            let mut args: Vec<String> = vec!["daemon".into(), "start".into()];
+            let mut args: Vec<String> = vec!["--daemon".into(), "start".into()];
             for d in drives { args.push("--drive".into()); args.push(d.clone()); }
             let _ = Command::new(bin).args(&args).stdout(Stdio::null()).stderr(Stdio::null()).status();
         }
     }
     if state.mcp_running {
         eprintln!("  restarting MCP gateway (was up at start)");
-        let _ = Command::new(bin).args(["mcp", "start"]).stdout(Stdio::null()).stderr(Stdio::null()).status();
+        let _ = Command::new(bin).args(["--mcp", "start"]).stdout(Stdio::null()).stderr(Stdio::null()).status();
     }
 }
 
@@ -1963,7 +1963,7 @@ mod tests {
 
     #[test]
     fn parse_run_state_reads_drives_and_mcp() {
-        // The operator's real `uffs status` output: 7 drives loaded, MCP up.
+        // The operator's real `uffs --status` output: 7 drives loaded, MCP up.
         let out = "\
 ── Daemon ──
   Status:      running (PID 62036)

--- a/scripts/windows/interactive-search.rs
+++ b/scripts/windows/interactive-search.rs
@@ -111,7 +111,7 @@ impl DataSources {
     fn empty() -> Self {
         DataSources { data_dir: None, drive_files: std::collections::HashMap::new() }
     }
-    /// Args for `uffs daemon start` — only --data-dir / --mft-file (NOT --drive).
+    /// Args for `uffs --daemon start` — only --data-dir / --mft-file (NOT --drive).
     fn daemon_start_args(&self) -> Vec<String> {
         match &self.data_dir {
             Some(d) => vec!["--data-dir".into(), d.to_string_lossy().into_owned()],
@@ -158,12 +158,12 @@ fn find_best_mft_file(dir: &std::path::Path) -> Option<PathBuf> {
 fn flush() { std::io::stderr().flush().ok(); }
 
 fn ensure_stopped(bin: &PathBuf) {
-    let _ = Command::new(bin).args(["daemon", "kill"])
+    let _ = Command::new(bin).args(["--daemon", "kill"])
         .stdout(Stdio::null()).stderr(Stdio::null()).status();
     let deadline = Instant::now() + Duration::from_secs(10);
     while Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(250));
-        if let Ok(out) = Command::new(bin).args(["daemon", "status"])
+        if let Ok(out) = Command::new(bin).args(["--daemon", "status"])
             .stderr(Stdio::null()).output()
         {
             let s = String::from_utf8_lossy(&out.stdout);
@@ -174,14 +174,14 @@ fn ensure_stopped(bin: &PathBuf) {
 }
 
 fn start_and_await_ready(bin: &PathBuf, source_args: &[String]) -> bool {
-    let mut args: Vec<String> = vec!["daemon".into(), "start".into()];
+    let mut args: Vec<String> = vec!["--daemon".into(), "start".into()];
     args.extend(source_args.iter().cloned());
     let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let _ = Command::new(bin).args(&str_args)
         .stdout(Stdio::null()).stderr(Stdio::null()).status();
     let deadline = Instant::now() + Duration::from_secs(120);
     while Instant::now() < deadline {
-        if let Ok(out) = Command::new(bin).args(["daemon", "status"])
+        if let Ok(out) = Command::new(bin).args(["--daemon", "status"])
             .stderr(Stdio::null()).output()
         {
             let s = String::from_utf8_lossy(&out.stdout);
@@ -193,7 +193,7 @@ fn start_and_await_ready(bin: &PathBuf, source_args: &[String]) -> bool {
 }
 
 fn assert_ready(bin: &PathBuf) -> bool {
-    if let Ok(out) = Command::new(bin).args(["daemon", "status"])
+    if let Ok(out) = Command::new(bin).args(["--daemon", "status"])
         .stderr(Stdio::null()).output()
     {
         let s = String::from_utf8_lossy(&out.stdout);

--- a/scripts/windows/mcp-validation.rs
+++ b/scripts/windows/mcp-validation.rs
@@ -96,14 +96,14 @@ fn default_binary() -> String {
 /// version string for inclusion in the validation-summary block.
 ///
 /// Returns the trimmed value of the `Version:` line printed by
-/// `uffs daemon status` on uffs ≥ 0.5.79.  Pre-0.5.79 daemons emit
+/// `uffs --daemon status` on uffs ≥ 0.5.79.  Pre-0.5.79 daemons emit
 /// `<unknown> (daemon) / X.Y.Z (cli)` via the CLI's back-compat
 /// renderer; pre-this-feature daemons (no `Version:` line at all)
 /// surface as `<line not found>`.  When the daemon is unreachable
 /// the helper reports `<not running>` instead of erroring — the
 /// version line is informational, not load-bearing.
 fn capture_daemon_version(bin: &str) -> String {
-    match Command::new(bin).args(["daemon", "status"]).output() {
+    match Command::new(bin).args(["--daemon", "status"]).output() {
         Ok(out) if out.status.success() => {
             let text = String::from_utf8_lossy(&out.stdout);
             for line in text.lines() {
@@ -230,13 +230,13 @@ struct McpSession {
 }
 
 impl McpSession {
-    /// Spawn a fresh `uffs mcp run` subprocess and attach a background
+    /// Spawn a fresh `uffs --mcp run` subprocess and attach a background
     /// reader thread that routes JSON-RPC responses by id.
     ///
     /// Returns an [`Arc`] because the reader thread holds a clone for
     /// the life of the session.
     fn spawn(binary: &str, source_args: &[&str]) -> Result<Arc<Self>> {
-        let mut args = vec!["mcp", "run"];
+        let mut args = vec!["--mcp", "run"];
         args.extend(source_args);
         let mut child = Command::new(binary)
             .args(&args)
@@ -482,7 +482,7 @@ impl McpSession {
 impl Drop for McpSession {
     fn drop(&mut self) {
         // Best-effort teardown so leaked `Arc<McpSession>`s don't leave
-        // orphan `uffs mcp run` subprocesses.  Mutex::get_mut is
+        // orphan `uffs --mcp run` subprocesses.  Mutex::get_mut is
         // infallible when we hold `&mut self`.
         let _ = self.stdin.get_mut().map(core::mem::take);
         if let Ok(slot) = self.child.get_mut() {
@@ -1668,8 +1668,8 @@ fn run_uffs(bin: &str, args: &[&str]) -> Result<(i32, String, String)> {
 
 /// Ensure the daemon is running and ready with drives loaded.
 ///
-/// 1. `uffs daemon status` — if "Ready" with drives, done.
-/// 2. If not running or stale, `uffs daemon start --data-dir ...`
+/// 1. `uffs --daemon status` — if "Ready" with drives, done.
+/// 2. If not running or stale, `uffs --daemon start --data-dir ...`
 ///    (blocks until daemon is ready, no polling needed).
 ///
 /// Prints the daemon status banner (PID, uptime, drives, records).
@@ -1679,7 +1679,7 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> u128 {
     let t0 = Instant::now();
 
     eprintln!("  Checking daemon status...");
-    match run_uffs(bin, &["daemon", "status"]) {
+    match run_uffs(bin, &["--daemon", "status"]) {
         Ok((_code, stdout, stderr)) => {
             let combined = format!("{stdout}{stderr}");
             let lower = combined.to_lowercase();
@@ -1705,7 +1705,7 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> u128 {
                     eprintln!("    {line}");
                 }
                 eprintln!("  Stopping stale daemon...");
-                let _ = run_uffs(bin, &["daemon", "stop"]);
+                let _ = run_uffs(bin, &["--daemon", "stop"]);
                 std::thread::sleep(Duration::from_millis(500));
             } else if lower.contains("not running") {
                 eprintln!("  Daemon is not running, starting...");
@@ -1724,7 +1724,7 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> u128 {
 
     // Step 2: Start daemon (blocks until ready — `daemon start` waits
     // until all drives are loaded before returning).
-    let mut start_args: Vec<&str> = vec!["daemon", "start"];
+    let mut start_args: Vec<&str> = vec!["--daemon", "start"];
     if let Some(f) = args.source_flag { start_args.push(f); start_args.push(&args.source_path); }
     let cli_str = format!("{bin} {}", start_args.join(" "));
     eprintln!("    ↳ {}", cli_str.dimmed());
@@ -1747,7 +1747,7 @@ fn ensure_daemon_ready(args: &ScriptArgs) -> u128 {
     }
 
     // Verify it's really ready now.
-    match run_uffs(bin, &["daemon", "status"]) {
+    match run_uffs(bin, &["--daemon", "status"]) {
         Ok((_code, stdout, stderr)) => {
             let ms = t0.elapsed().as_millis();
             let combined = format!("{stdout}{stderr}");
@@ -2057,8 +2057,8 @@ fn main() -> Result<()> {
     //                       MCP stdio sessions (this suite specifically
     //                       exercises the MCP surface, so the gateway
     //                       telemetry belongs in the summary).
-    print_uffs_command_block(&args.bin, &["daemon", "status"], "═══ Daemon STATUS ═══");
-    print_uffs_command_block(&args.bin, &["daemon", "stats"],  "═══ Daemon STATS ═══");
+    print_uffs_command_block(&args.bin, &["--daemon", "status"], "═══ Daemon STATUS ═══");
+    print_uffs_command_block(&args.bin, &["--daemon", "stats"],  "═══ Daemon STATS ═══");
     print_uffs_command_block(&args.bin, &["status"],           "═══ MCP STATUS (system-wide) ═══");
 
     if failed > 0 {

--- a/scripts/windows/profile.rs
+++ b/scripts/windows/profile.rs
@@ -56,7 +56,7 @@ struct RunResult {
 fn flush() { std::io::stderr().flush().ok(); }
 
 fn kill_daemon(bin: &PathBuf) {
-    let _ = Command::new(bin).args(["daemon", "kill"])
+    let _ = Command::new(bin).args(["--daemon", "kill"])
         .stdout(Stdio::null()).stderr(Stdio::null()).status();
     std::thread::sleep(Duration::from_secs(2));
 }
@@ -76,7 +76,7 @@ fn discover_drives(bin: &PathBuf) -> Vec<String> {
     let _ = Command::new(bin).args(["*", "--limit", "1"])
         .stdout(Stdio::null()).stderr(Stdio::null()).status();
     std::thread::sleep(Duration::from_secs(1));
-    let output = Command::new(bin).args(["daemon", "status"])
+    let output = Command::new(bin).args(["--daemon", "status"])
         .stderr(Stdio::null()).output().ok();
     let stdout = output.map(|o| String::from_utf8_lossy(&o.stdout).to_string())
         .unwrap_or_default();

--- a/scripts/windows/record-demo-prep.rs
+++ b/scripts/windows/record-demo-prep.rs
@@ -256,13 +256,13 @@ fn run_hot(bin: &str, drives: &[String]) -> Result<()> {
     println!();
     step("Mode=hot — warming the daemon so targeted queries answer from memory.");
     step("Restarting daemon for a clean, known state...");
-    run_show(bin, &["daemon", "restart"])?;
+    run_show(bin, &["--daemon", "restart"])?;
 
     for d in drives {
         step(&format!(
             "Preloading drive {d} and pinning it for the recording window..."
         ));
-        run_show(bin, &["daemon", "preload", d, "--pin-minutes", "60"])?;
+        run_show(bin, &["--daemon", "preload", d, "--pin-minutes", "60"])?;
     }
 
     step("Priming the query path (these warm-up results are NOT part of the clip)...");
@@ -271,7 +271,7 @@ fn run_hot(bin: &str, drives: &[String]) -> Result<()> {
 
     println!();
     step("Current tier / telemetry (this is the table the CLI clip shows):");
-    run_show(bin, &["daemon", "status_drives"])?;
+    run_show(bin, &["--daemon", "status_drives"])?;
 
     println!();
     println!(
@@ -299,7 +299,7 @@ fn run_cold(bin: &str, drives: &[String], confirm: bool) -> Result<()> {
     }
     for d in drives {
         step(&format!("Forgetting drive {d} (evict + delete on-disk caches)..."));
-        run_show(bin, &["daemon", "forget", d, "--force"])?;
+        run_show(bin, &["--daemon", "forget", d, "--force"])?;
     }
     println!();
     println!(

--- a/scripts/windows/scale-ceiling.rs
+++ b/scripts/windows/scale-ceiling.rs
@@ -112,12 +112,12 @@ struct MftSource {
 fn flush() { std::io::stderr().flush().ok(); }
 
 fn ensure_stopped(bin: &PathBuf) {
-    let _ = Command::new(bin).args(["daemon", "kill"])
+    let _ = Command::new(bin).args(["--daemon", "kill"])
         .stdout(Stdio::null()).stderr(Stdio::null()).status();
     let deadline = Instant::now() + Duration::from_secs(10);
     while Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(250));
-        if let Ok(out) = Command::new(bin).args(["daemon", "status"])
+        if let Ok(out) = Command::new(bin).args(["--daemon", "status"])
             .stderr(Stdio::null()).output()
         {
             let s = String::from_utf8_lossy(&out.stdout);
@@ -352,7 +352,7 @@ fn bench_tier(
     // Daemon should still be running from WARM phase.
     if !assert_ready(&cfg.bin) {
         // If warm failed, try to start fresh.
-        let start_args: Vec<String> = vec!["daemon".into(), "start".into(),
+        let start_args: Vec<String> = vec!["--daemon".into(), "start".into(),
             "--data-dir".into(), corpus.to_string_lossy().into_owned()];
         let _ = Command::new(&cfg.bin).args(&start_args)
             .stdout(Stdio::null()).stderr(Stdio::null()).status();

--- a/scripts/windows/startup-profiler.rs
+++ b/scripts/windows/startup-profiler.rs
@@ -403,7 +403,7 @@ fn run_null_matrix(cfg: &Cfg) {
                 size, p50(&times), p95(&times), p_min(&times),
             ));
         }
-        // uffs search (hot, tiny result, to NUL)
+        // uffs --search (hot, tiny result, to NUL)
         let drive_arg = format!("--drive={}", cfg.drive);
         let times = measure_binary(&cfg.uffs_bin,
             &["notepad.exe", &drive_arg, "--columns", "Path"],
@@ -532,24 +532,24 @@ fn run_startup(cfg: &Cfg) {
 
     // 2. Status (connects to daemon, no search)
     let t_status = measure_binary(&cfg.uffs_bin, &["status"], cfg.rounds,
-        "uffs status (+ daemon connect)", || Stdio::null());
+        "uffs --status (+ daemon connect)", || Stdio::null());
 
     // 3. Tiny search → NUL (connect + search + serialize, no output)
     let t_search_nul = measure_binary(&cfg.uffs_bin,
         &["notepad.exe", &drive_arg, "--columns", "Path"],
-        cfg.rounds, "uffs search tiny → NUL", || Stdio::null());
+        cfg.rounds, "uffs --search tiny → NUL", || Stdio::null());
 
     // 4. Tiny search → stdout (adds console output cost)
     let t_search_stdout = measure_binary(&cfg.uffs_bin,
         &["notepad.exe", &drive_arg, "--columns", "Path"],
-        cfg.rounds, "uffs search tiny → stdout", || Stdio::piped());
+        cfg.rounds, "uffs --search tiny → stdout", || Stdio::piped());
 
     // 5. Tiny search → --out file (daemon-direct file write)
     let out_file = cfg.build_dir.join("startup_bench_out.csv");
     let out_arg = format!("--out={}", out_file.display());
     let t_search_file = measure_binary(&cfg.uffs_bin,
         &["notepad.exe", &drive_arg, "--columns", "Path", &out_arg],
-        cfg.rounds, "uffs search tiny → --out file", || Stdio::null());
+        cfg.rounds, "uffs --search tiny → --out file", || Stdio::null());
     let _ = fs::remove_file(&out_file);
 
     // 6. Medium search → NUL (more rows, IPC transfer cost)
@@ -673,7 +673,7 @@ fn run_ipc(cfg: &Cfg) {
 
     let drive_arg = format!("--drive={}", cfg.drive);
 
-    // Current IPC path: uffs search with --profile (shows IPC breakdown)
+    // Current IPC path: uffs --search with --profile (shows IPC breakdown)
     eprintln!("── Current IPC (AF_UNIX socket + JSON-RPC) ──\n");
 
     // Tiny result — IPC overhead dominates

--- a/scripts/windows/stream-stress.rs
+++ b/scripts/windows/stream-stress.rs
@@ -725,11 +725,11 @@ fn wait_with_timeout_partial(mut child: Child, timeout: Duration) -> Result<Wait
 
 // ── Daemon sanity ─────────────────────────────────────────────────────────
 
-/// Emit a one-time `uffs daemon status` summary before the matrix so
+/// Emit a one-time `uffs --daemon status` summary before the matrix so
 /// a zero-rows run is obviously a "daemon has no drives" issue rather
 /// than a streaming regression.
 fn print_daemon_banner(bin: &Path) {
-    let out = Command::new(bin).args(["daemon", "status"]).output();
+    let out = Command::new(bin).args(["--daemon", "status"]).output();
     match out {
         Ok(o) => {
             let combined = format!(


### PR DESCRIPTION
Redesigns the `uffs` CLI grammar to be **search-first**: the first token decides the mode — a known `--command` runs that command, anything else (bare word, glob, single dash, search flag) is a search. So `uffs update` searches for "update" again; management is `uffs --update`, `uffs --daemon start`, etc. Full design + tracking in `docs/architecture/cli-grammar.md`.

## What changed

**Grammar core (P0–P7)**
- First-token dispatcher (`dispatch.rs`): `--search/--stats/--agg/--daemon/--mcp/--update/--status`; bare `--` escape for literal `--`-patterns.
- `--update` normalized to a positional action (`snapshot|acquire|apply|doctor|recover`); wired the foreground `recover`.
- `-h`/`-V` kept as the only two reserved single-dash exceptions (like ripgrep/fd), enumerated + tested.
- **"Did you mean a command?"** hint for a `--`-flag typo (`uffs --updat` → `--update`), done *thinly*: the CLI calls the shared `from_cli_args` parser for flag validation and suggests over its own command set — the daemon never learns CLI commands; the CLI never duplicates the flag registry.

**Repo-wide alignment**
- Swept every CLI-syntax reference (docs, comments, help/errors, CI, scripts, test-defs) to the new grammar.
- Fixed real **functional regressions**: the self-update quiesce (`uffs daemon/mcp stop` would have *searched* instead of stopping services), the bench harness, Windows validation scripts, and the CLI test-definition suite.
- Removed docs for the long-removed `index`/`info`/`save-raw`/`load-raw` ghost commands; redirected to the daemon / `uffs-mft` tool.
- Audited `cli-overview.md` against the real binary and corrected `cli-grammar.md` (the "disjoint sets" claim was false — `--stats`/`--agg` are dual-use; a non-existent `serve` mcp action).

## Verification
- Full pre-push gate green (cargo-check, lint-ci/prod/tests, rustdoc, doc-tests, tests, smoke, deny, windows-lint).
- ~1588 tests pass; host + Windows-MSVC clippy clean; cargo-vet green (`strsim` already audited).
- Every `uffs --<command> --help` body re-checked against the test assertions.

No external API/version promise (pre-1.0; the binaries are the product), so the old bare-word subcommands are removed, not aliased.