### PR TITLE
fix(update): self-update flow polish — Unix apply, clean errors, complete install gate, quiet output

### DIFF
--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -41,7 +41,10 @@ pub(crate) fn daemon(action: &DaemonAction) -> Result<()> {
                 | DaemonAction::StatusDrives
                 | DaemonAction::Start { elevate: true, .. }
         );
-        if !is_read_only_or_uac_start && !uffs_mft::is_elevated() {
+        if !is_read_only_or_uac_start
+            && !uffs_mft::is_elevated()
+            && mutating_management_needs_elevation()
+        {
             #[cfg(windows)]
             anyhow::bail!(
                 "Daemon management commands require an elevated (Administrator) shell.\n\n\
@@ -115,6 +118,44 @@ pub(crate) fn daemon(action: &DaemonAction) -> Result<()> {
         DaemonAction::Forget { drives, force } => daemon_tiering::daemon_forget(drives, *force),
         DaemonAction::StatusDrives => daemon_tiering::daemon_status_drives(),
     }
+}
+
+/// Whether a *mutating* daemon-management action (stop/kill/restart/load/…)
+/// needs elevation, **given the running daemon's actual owner**.
+///
+/// The gate exists so a non-privileged caller cannot stop or restart a daemon
+/// it could not bring back. On **Unix** that is only true when the running
+/// daemon is owned by a *different* (typically root) user: a daemon we own —
+/// same effective uid — is ours to stop and restart, so no `sudo` is needed
+/// (the common macOS/Linux offline-capture workflow, and what `uffs --update
+/// apply` relies on). The daemon writes its PID file, so the file's owner is
+/// the daemon's uid; an unreadable/absent PID file means there is no daemon to
+/// protect → no elevation required.
+///
+/// On **Windows** (and any non-Unix target) `uffsd` runs elevated to read the
+/// live MFT, so managing it always needs an elevated token — behaviour is
+/// unchanged.
+#[cfg(unix)]
+fn mutating_management_needs_elevation() -> bool {
+    daemon_owner_needs_elevation(&pid_file_path(), uffs_mft::current_euid())
+}
+
+/// Pure core of [`mutating_management_needs_elevation`] (Unix): elevation is
+/// required iff the daemon's PID file exists and is owned by a uid other than
+/// `caller_euid`. An absent/unreadable PID file → no daemon to protect → no
+/// elevation. Split out so the owner comparison is unit-testable without a
+/// live daemon.
+#[cfg(unix)]
+fn daemon_owner_needs_elevation(pid_file: &std::path::Path, caller_euid: u32) -> bool {
+    use std::os::unix::fs::MetadataExt as _;
+
+    std::fs::metadata(pid_file).is_ok_and(|meta| meta.uid() != caller_euid)
+}
+
+/// Non-Unix: managing the (elevated) daemon always needs an elevated token.
+#[cfg(not(unix))]
+const fn mutating_management_needs_elevation() -> bool {
+    true
 }
 
 /// `uffs --daemon start` — start the daemon, forwarding data-source flags
@@ -693,5 +734,52 @@ mod tests {
     #[test]
     fn non_empty_env_keeps_whitespace_only_values() {
         assert_eq!(non_empty_env(Some(" ".to_owned())), Some(" ".to_owned()));
+    }
+
+    // ── Privilege-aware daemon-management gate (Unix) ────────────────
+    //
+    // A daemon we own (same uid) is ours to stop/restart, so no `sudo` is
+    // needed — this is what unblocks `uffs --update apply` against a
+    // user-owned offline daemon on macOS/Linux.
+
+    #[cfg(unix)]
+    #[test]
+    fn own_daemon_pid_file_needs_no_elevation() {
+        use std::os::unix::fs::MetadataExt as _;
+
+        // A file this test created is owned by the test's own euid; managing a
+        // daemon we own must NOT require elevation.
+        let dir = std::env::temp_dir().join(format!("uffs-gate-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let pid_file = dir.join("daemon.pid");
+        std::fs::write(&pid_file, "1234\n").expect("write pid file");
+
+        let our_uid = std::fs::metadata(&pid_file).expect("stat").uid();
+        assert!(
+            !super::daemon_owner_needs_elevation(&pid_file, our_uid),
+            "a daemon owned by the caller must be manageable without sudo"
+        );
+
+        // A PID file owned by *root* (uid 0) while we run as non-root DOES
+        // require elevation — the daemon is not ours to restart.
+        if our_uid != 0 {
+            assert!(
+                super::daemon_owner_needs_elevation(&pid_file, 0),
+                "a root-owned daemon must require elevation for a non-root caller"
+            );
+        }
+
+        // Best-effort cleanup; bound (not a non-binding `let _`) so the
+        // must-use Result is consumed without tripping clippy either way.
+        let _cleanup = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn absent_pid_file_needs_no_elevation() {
+        // No PID file → no daemon to protect → no elevation required (so
+        // `stop`/`start` against a stopped daemon never demands sudo).
+        let missing = std::env::temp_dir().join("uffs-gate-does-not-exist-xyz.pid");
+        assert!(!super::daemon_owner_needs_elevation(&missing, 4242));
     }
 }

--- a/crates/uffs-cli/src/commands/update/acquire.rs
+++ b/crates/uffs-cli/src/commands/update/acquire.rs
@@ -44,12 +44,17 @@ pub(super) fn find_helper() -> Result<PathBuf> {
 
 /// Spawn the acquire helper against a written snapshot, for an optional
 /// target version tag. The helper reads the snapshot to know the
-/// installed subset and downloads each binary individually.
+/// installed subset and downloads each binary individually. `verbose`
+/// forwards `--verbose` so the helper can show per-binary detail.
 ///
 /// # Errors
 ///
 /// Fails if the helper cannot be located or it exits non-zero.
-pub(crate) fn spawn(snapshot_path: &std::path::Path, version: Option<&str>) -> Result<()> {
+pub(crate) fn spawn(
+    snapshot_path: &std::path::Path,
+    version: Option<&str>,
+    verbose: bool,
+) -> Result<()> {
     let helper = find_helper()?;
     let stage = snapshot::update_dir().join("stage");
     let mut command = Command::new(&helper);
@@ -60,6 +65,9 @@ pub(crate) fn spawn(snapshot_path: &std::path::Path, version: Option<&str>) -> R
         .arg(&stage);
     if let Some(tag) = version {
         command.args(["--version", tag]);
+    }
+    if verbose {
+        command.arg("--verbose");
     }
     let status = command
         .status()

--- a/crates/uffs-cli/src/commands/update/apply.rs
+++ b/crates/uffs-cli/src/commands/update/apply.rs
@@ -18,20 +18,26 @@ use super::acquire::find_helper;
 use super::snapshot;
 
 /// Spawn `uffs-update apply` against a written snapshot, streaming its
-/// output. The staging dir is the one acquire filled.
+/// output. The staging dir is the one acquire filled. `verbose` forwards
+/// `--verbose` so the helper can show the full step-by-step detail.
 ///
 /// # Errors
 ///
 /// Fails if the helper cannot be located or the apply exits non-zero (in
 /// which case the helper has already rolled back + restored services).
-pub(crate) fn spawn(snapshot_path: &Path) -> Result<()> {
+pub(crate) fn spawn(snapshot_path: &Path, verbose: bool) -> Result<()> {
     let helper = find_helper()?;
     let stage = snapshot::update_dir().join("stage");
-    let status = Command::new(&helper)
+    let mut command = Command::new(&helper);
+    command
         .args(["apply", "--snapshot"])
         .arg(snapshot_path)
         .arg("--stage")
-        .arg(&stage)
+        .arg(&stage);
+    if verbose {
+        command.arg("--verbose");
+    }
+    let status = command
         .status()
         .with_context(|| format!("spawning {}", helper.display()))?;
     if !status.success() {

--- a/crates/uffs-cli/src/commands/update/doctor.rs
+++ b/crates/uffs-cli/src/commands/update/doctor.rs
@@ -18,7 +18,8 @@ use super::acquire::{DEFAULT_REPO, find_helper};
 use super::snapshot;
 
 /// Spawn `uffs-update doctor` against a written snapshot, forwarding the
-/// pass-through flags (`--repair`, `--offline`, `--version <tag>`).
+/// pass-through flags (`--repair`, `--offline`, `--version <tag>`, `-v` /
+/// `--verbose`).
 ///
 /// # Errors
 ///
@@ -38,6 +39,9 @@ pub(crate) fn spawn(snapshot_path: &Path, args: &[String]) -> Result<()> {
     }
     if args.iter().any(|arg| arg == "--offline") {
         command.arg("--offline");
+    }
+    if args.iter().any(|arg| arg == "-v" || arg == "--verbose") {
+        command.arg("--verbose");
     }
     if let Some(tag) = flag_value(args, "--version") {
         command.args(["--version", &tag]);

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -63,6 +63,11 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
         );
     }
 
+    // `-v` / `--verbose`: show the full per-binary + per-process breakdown
+    // (and forward verbosity to the spawned `uffs-update` helper). Default is
+    // a few plain-language lines for someone who just wants the gist.
+    let verbose = args.iter().any(|arg| arg == "-v" || arg == "--verbose");
+
     // `recover` finishes (or rolls back) an interrupted update in the
     // foreground — the on-demand twin of the startup best-effort self-heal.
     if action == Some("recover") {
@@ -78,19 +83,25 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
     }
 
     let report = detect();
-    report::print_human(&report);
+    report::print_human(&report, verbose);
     if action == Some("snapshot") {
         write_and_report_snapshot(&report);
     }
-    print_phase_a_footer();
+    if verbose {
+        print_phase_a_footer();
+    }
 
     // `apply` runs the full mutating update (acquire → apply); `acquire` only
     // stages + verifies. `apply` implies the acquire step.
     if matches!(action, Some("acquire" | "apply")) {
         let snapshot_path = snapshot::write_snapshot(&report)?;
-        acquire::spawn(&snapshot_path, flag_value(args, "--version").as_deref())?;
+        acquire::spawn(
+            &snapshot_path,
+            flag_value(args, "--version").as_deref(),
+            verbose,
+        )?;
         if action == Some("apply") {
-            apply::spawn(&snapshot_path)?;
+            apply::spawn(&snapshot_path, verbose)?;
         }
     }
     Ok(())
@@ -282,6 +293,8 @@ fn print_help() {
          \x20 recover             Finish or roll back an interrupted update now\n\
          \x20                     (foreground; the on-demand self-heal).\n\n\
          OPTIONS:\n\
+         \x20 -v, --verbose       Show the full breakdown — per-binary versions,\n\
+         \x20                     PIDs, launch commands, every doctor check.\n\
          \x20 --version <tag>     Acquire/apply a specific release tag (default: latest).\n\
          \x20 --repair            (doctor) self-heal what can be fixed.\n\
          \x20 --offline           (doctor) skip the network checks.\n\n\

--- a/crates/uffs-cli/src/commands/update/report.rs
+++ b/crates/uffs-cli/src/commands/update/report.rs
@@ -5,12 +5,65 @@
 //!
 //! Pure formatting: it never mutates the system, it only prints what
 //! detection found (the `--check` view of the self-update flow).
+//!
+//! Two views — chosen by the caller's `verbose` flag:
+//! - **default**: a few plain-language lines (where, which version, what's
+//!   running) for someone who just wants to know if they're up to date;
+//! - **`-v`**: the full breakdown — every binary's version, every running
+//!   process's PID / image path / launch command.
 
 use super::model::{DetectionReport, RunningProcess};
 
-/// Print the detection report to stdout.
+/// Print the detection report. `verbose` selects the full breakdown over the
+/// concise default.
+pub(crate) fn print_human(report: &DetectionReport, verbose: bool) {
+    if verbose {
+        print_full(report);
+    } else {
+        print_concise(report);
+    }
+}
+
+/// Concise, non-technical summary: where UFFS is, which version, and what is
+/// running — with a pointer to `-v` for the details.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
-pub(crate) fn print_human(report: &DetectionReport) {
+fn print_concise(report: &DetectionReport) {
+    println!("UFFS self-update");
+
+    match report.roots.as_slice() {
+        [] => {
+            println!("  Install:  (none found — is UFFS on your PATH?)");
+            return;
+        }
+        [only] => println!("  Install:  {}", only.dir.display()),
+        [first, rest @ ..] => println!(
+            "  Install:  {}  (and {} more)",
+            first.dir.display(),
+            rest.len()
+        ),
+    }
+
+    match distinct_versions(report).as_slice() {
+        [] => println!("  Version:  (could not be read)"),
+        [only] => println!("  Version:  {only}"),
+        many => println!(
+            "  Version:  \u{26a0} mixed ({}) — applying an update will realign them",
+            many.join(", ")
+        ),
+    }
+
+    let running = running_summary(report);
+    if !running.is_empty() {
+        println!("  Running:  {running}");
+    }
+
+    println!("  (run with -v for per-binary versions, PIDs, and launch commands)");
+}
+
+/// Full breakdown: every root, every binary version, every running process'
+/// image + launch recipe, and the version-skew line.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_full(report: &DetectionReport) {
     println!("UFFS self-update — Phase A (detect & capture)\n");
 
     println!("Install roots / update targets ({}):", report.roots.len());
@@ -67,30 +120,122 @@ fn print_running(proc: &RunningProcess) {
     }
 }
 
-/// Print a one-line version-skew summary: the distinct versions seen
-/// across every discovered binary. More than one ⇒ the install is
-/// skewed and an update would realign it.
-#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
-fn print_skew(report: &DetectionReport) {
-    let mut versions: Vec<&str> = Vec::new();
+/// The distinct binary/process versions seen across the whole report, sorted.
+fn distinct_versions(report: &DetectionReport) -> Vec<String> {
+    let mut versions: Vec<String> = Vec::new();
     for root in &report.roots {
         for binary in &root.binaries {
-            versions.extend(binary.version.as_deref());
+            versions.extend(binary.version.clone());
         }
     }
     for proc in &report.running {
-        versions.extend(proc.version.as_deref());
+        versions.extend(proc.version.clone());
     }
     versions.sort_unstable();
     versions.dedup();
+    versions
+}
 
+/// A short list of running components with multiplicity, e.g. `daemon, mcp ×3`.
+fn running_summary(report: &DetectionReport) -> String {
+    // Preserve first-seen order while counting duplicates (3 `mcp` processes
+    // collapse to `mcp ×3` instead of three identical entries).
+    let mut order: Vec<&str> = Vec::new();
+    let mut counts: Vec<(&str, usize)> = Vec::new();
+    for proc in &report.running {
+        let label = proc.component.label();
+        if let Some(entry) = counts.iter_mut().find(|(name, _)| *name == label) {
+            entry.1 += 1;
+        } else {
+            order.push(label);
+            counts.push((label, 1));
+        }
+    }
+    order
+        .iter()
+        .filter_map(|label| counts.iter().find(|(name, _)| name == label))
+        .map(|(name, count)| {
+            if *count > 1 {
+                format!("{name} \u{d7}{count}")
+            } else {
+                (*name).to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Print a one-line version-skew summary (full view only): the distinct
+/// versions seen across every discovered binary. More than one ⇒ the install
+/// is skewed and an update would realign it.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_skew(report: &DetectionReport) {
     println!();
-    match versions.as_slice() {
+    match distinct_versions(report).as_slice() {
         [] => println!("Version skew: (no versions could be read)"),
         [only] => println!("Version skew: none — all components at {only}"),
         many => println!(
-            "Version skew: ⚠ multiple versions present: {}",
+            "Version skew: \u{26a0} multiple versions present: {}",
             many.join(", ")
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::model::{Component, DetectionReport, RunningProcess};
+    use super::{distinct_versions, running_summary};
+
+    fn proc(component: Component, version: &str) -> RunningProcess {
+        RunningProcess {
+            component,
+            pid: 1,
+            image_path: None,
+            command_line: None,
+            version: Some(version.to_owned()),
+        }
+    }
+
+    #[test]
+    fn running_summary_collapses_duplicates_with_counts() {
+        let report = DetectionReport {
+            roots: Vec::new(),
+            running: vec![
+                proc(Component::Daemon, "0.6.4"),
+                proc(Component::Mcp, "0.6.4"),
+                proc(Component::Mcp, "0.6.4"),
+                proc(Component::Mcp, "0.6.4"),
+            ],
+        };
+        // First-seen order preserved; 3 `mcp` processes collapse to `mcp ×3`
+        // instead of three identical lines (the user-reported noise).
+        assert_eq!(running_summary(&report), "daemon, mcp \u{d7}3");
+    }
+
+    #[test]
+    fn running_summary_is_empty_when_nothing_runs() {
+        let report = DetectionReport {
+            roots: Vec::new(),
+            running: Vec::new(),
+        };
+        assert_eq!(running_summary(&report), "");
+    }
+
+    #[test]
+    fn distinct_versions_dedups_and_sorts() {
+        let report = DetectionReport {
+            roots: Vec::new(),
+            running: vec![
+                proc(Component::Daemon, "0.6.4"),
+                proc(Component::Mcp, "0.6.2"),
+                proc(Component::Broker, "0.6.4"),
+            ],
+        };
+        // Two 0.6.4 collapse to one; sorted ascending → drives the "mixed"
+        // skew warning in the concise view.
+        assert_eq!(distinct_versions(&report), vec![
+            "0.6.2".to_owned(),
+            "0.6.4".to_owned()
+        ]);
     }
 }

--- a/crates/uffs-mft/src/lib.rs
+++ b/crates/uffs-mft/src/lib.rs
@@ -301,6 +301,10 @@ pub use ntfs::{
     StandardInformation, StreamInfo, apply_usa_fixup, extract_data_runs_from_attribute,
     fixup_file_record, parse_data_runs,
 };
+// Caller's effective uid (Unix-only) — daemon-management uses it to decide
+// whether managing the *running* daemon needs elevation (owner comparison).
+#[cfg(unix)]
+pub use platform::current_euid;
 // Elevation check — cross-platform public API (Windows: UAC token check;
 // Unix: geteuid() == 0).  Exported unconditionally so uffs-cli and
 // uffs-daemon can gate mutating daemon commands on all targets.

--- a/crates/uffs-mft/src/platform.rs
+++ b/crates/uffs-mft/src/platform.rs
@@ -56,6 +56,10 @@ pub use lcn::Lcn;
 // Export DriveType unconditionally (needed for tests), but Windows-specific functions only on
 // Windows
 pub use system::DriveType;
+// Caller's effective uid — Unix-only; lets daemon-management compare the
+// caller against the running daemon's owner (its PID-file uid).
+#[cfg(unix)]
+pub use system::current_euid;
 // Elevation check — available on all platforms (Windows: UAC token check;
 // Unix: geteuid() == 0).  Both the daemon CLI gate and uffs-daemon use this.
 pub use system::is_elevated;

--- a/crates/uffs-mft/src/platform/system.rs
+++ b/crates/uffs-mft/src/platform/system.rs
@@ -120,6 +120,24 @@ pub fn is_elevated() -> bool {
     unsafe { libc::geteuid() == 0 }
 }
 
+/// Unix: the caller's effective user ID.
+///
+/// Used by daemon-management to decide whether a *mutating* action needs
+/// elevation: a daemon owned by the **same** uid as the caller is theirs to
+/// stop/restart, whereas a daemon owned by a different (typically root) user
+/// is not (see `uffs-cli::commands::daemon_mgmt`).
+#[cfg(unix)]
+#[must_use]
+#[expect(
+    unsafe_code,
+    reason = "FFI: POSIX geteuid() — defined to be safe but the libc binding is unsafe"
+)]
+pub fn current_euid() -> u32 {
+    // SAFETY: `geteuid()` has no preconditions, never fails, and is
+    // signal-safe per POSIX.
+    unsafe { libc::geteuid() }
+}
+
 /// Returns the path to the volume root (e.g., "C:\").
 #[cfg(windows)]
 #[must_use]

--- a/crates/uffs-update/src/doctor.rs
+++ b/crates/uffs-update/src/doctor.rs
@@ -42,6 +42,9 @@ pub(crate) struct DoctorOpts {
     pub(crate) repair: bool,
     /// Skip the network checks entirely.
     pub(crate) offline: bool,
+    /// Print every check (`-v`); default shows only problems + a one-line
+    /// healthy summary.
+    pub(crate) verbose: bool,
 }
 
 /// Severity of a single finding.
@@ -113,21 +116,35 @@ impl Report {
             })
     }
 
-    /// Print the report.
+    /// Print the report. Default shows only the findings that need attention
+    /// (`[WARN]`/`[FAIL]`) plus a one-line health summary; `verbose` lists
+    /// every check (including the `[ OK ]`s).
     #[expect(clippy::print_stdout, reason = "doctor user-facing report")]
-    fn render(&self, repair: bool) {
+    fn render(&self, repair: bool, verbose: bool) {
         println!(
             "UFFS update doctor (uffs-update {})\n",
             env!("CARGO_PKG_VERSION")
         );
+        let (ok, warn, fail) = self.tally();
         for item in &self.findings {
+            // Default view: skip the passing checks — surface only problems.
+            if !verbose && item.health == Health::Ok {
+                continue;
+            }
             println!("{} {}", item.health.tag(), item.title);
             if let Some(detail) = &item.detail {
                 println!("        {detail}");
             }
         }
-        let (ok, warn, fail) = self.tally();
-        println!("\nsummary: {ok} ok, {warn} warning(s), {fail} failure(s)");
+        if !verbose && warn == 0 && fail == 0 {
+            // Brew-doctor style: nothing wrong → one reassuring line.
+            println!("\u{2713} Healthy — all {ok} checks passed.");
+        } else {
+            println!("\nsummary: {ok} ok, {warn} warning(s), {fail} failure(s)");
+            if !verbose {
+                println!("(run with -v to see every check)");
+            }
+        }
         if !repair && (warn > 0 || fail > 0) {
             println!("hint: re-run with `--repair` to self-heal what can be fixed automatically.");
         }
@@ -162,7 +179,7 @@ pub(crate) fn run(opts: &DoctorOpts) -> bool {
         check_release(opts, snapshot.as_ref(), &mut report);
     }
 
-    report.render(opts.repair);
+    report.render(opts.repair, opts.verbose);
     report.healthy()
 }
 

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -31,8 +31,25 @@ use anyhow::{Result, bail};
 
 use crate::acquire::AcquirePlan;
 
-/// Entry point. Returns a non-zero exit on any failure.
-fn main() -> Result<()> {
+/// Entry point. Prints a clean `Error: …` chain (no Rust backtrace) and exits
+/// non-zero on any failure — a usage slip like `uffs-update --doctor` should
+/// read like advice, not a crash. Mirrors `uffs`'s `main` error rendering.
+#[expect(clippy::print_stderr, reason = "top-level CLI error output")]
+fn main() {
+    if let Err(err) = run() {
+        for (idx, cause) in err.chain().enumerate() {
+            if idx == 0 {
+                eprintln!("Error: {cause}");
+            } else {
+                eprintln!("  Caused by: {cause}");
+            }
+        }
+        std::process::exit(1);
+    }
+}
+
+/// Dispatch the subcommand. Returns a non-zero exit (via [`main`]) on failure.
+fn run() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     match args.first().map(String::as_str) {
         Some("acquire") => run_acquire(args.get(1..).unwrap_or_default()),

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -194,6 +194,7 @@ fn run_doctor(args: &[String]) -> Result<()> {
         tag: flag(args, "--version"),
         repair: has_flag(args, "--repair"),
         offline: has_flag(args, "--offline"),
+        verbose: has_flag(args, "--verbose") || has_flag(args, "-v"),
     };
     if doctor::run(&opts) {
         Ok(())
@@ -275,7 +276,8 @@ fn print_usage() {
          \x20 uffs-update apply   --snapshot <path> --stage <dir>\n\
          \x20 uffs-update recover --journal <path>\n\
          \x20 uffs-update doctor  [--snapshot <path>] [--stage <dir>] \\\n\
-         \x20                     [--repo <owner/name>] [--version <tag>] [--repair] [--offline]\n\n\
+         \x20                     [--repo <owner/name>] [--version <tag>] [--repair]\n\
+         \x20                     [--offline] [--verbose]\n\n\
          acquire: per the snapshot's installed subset, downloads each binary\n\
          as an individual release asset + SHA256SUMS, SHA-256-verifies each,\n\
          and leaves them staged. It does not replace anything (apply phase).\n\

--- a/just/build.just
+++ b/just/build.just
@@ -311,16 +311,27 @@ use:
     fi
 
     # ── No-op: already on target with a complete install ─────────────
+    # Gate on EVERY binary, not just `uffs`: each must be present AND at the
+    # target version.  Otherwise a stale sibling (e.g. a `uffs-update` left at
+    # an older version by a prior run) is silently kept while `uffs` reports
+    # current — the bug that left uffs-update at 0.6.2 on a 0.6.4 install.
     if [[ -n "$INSTALLED_VER" ]] && [[ -n "$CARGO_VER" ]] && [[ "$INSTALLED_VER" == "$CARGO_VER" ]]; then
-        ALL_PRESENT=1
+        ALL_CURRENT=1
+        STALE_NOTE=""
         for DEST_NAME in "${BINARIES[@]}"; do
-            [[ -x "$BIN_DIR/$DEST_NAME" ]] || { ALL_PRESENT=0; break; }
+            if [[ ! -x "$BIN_DIR/$DEST_NAME" ]]; then
+                ALL_CURRENT=0; STALE_NOTE="$DEST_NAME missing"; break
+            fi
+            BV=$("$BIN_DIR/$DEST_NAME" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+            if [[ -n "$BV" ]] && [[ "v$BV" != "$CARGO_VER" ]]; then
+                ALL_CURRENT=0; STALE_NOTE="$DEST_NAME is v$BV (want $CARGO_VER)"; break
+            fi
         done
-        if [[ "$ALL_PRESENT" -eq 1 ]]; then
+        if [[ "$ALL_CURRENT" -eq 1 ]]; then
             printf "\033[0;32m  ✅ Already up to date: %s installed in ~/bin — nothing to do.\033[0m\n" "$INSTALLED_VER"
             exit 0
         fi
-        printf "\033[1;33m  ⚠️  %s installed but some binaries are missing — reinstalling.\033[0m\n" "$INSTALLED_VER"
+        printf "\033[1;33m  ⚠️  Stale install (%s) — reinstalling all binaries.\033[0m\n" "$STALE_NOTE"
     fi
 
     DIST_DIR=""
@@ -567,16 +578,24 @@ use:
     }
 
     # ── No-op: already on target with a complete install ─────────────
+    # Gate on EVERY binary, not just uffs.exe: each must be present AND at the
+    # target version. Otherwise a stale sibling (e.g. uffs-update.exe left at an
+    # older version by a prior run / file lock) is silently kept while uffs.exe
+    # reports current — the bug that left uffs-update at 0.6.2 on a 0.6.4 install.
     if ($installedVer -and $cargoVer -and ($installedVer -eq $cargoVer)) {
-        $allPresent = $true
+        $allCurrent = $true
+        $staleNote2 = ""
         foreach ($d in $binaries.Values) {
-            if (-not (Test-Path (Join-Path $binDir $d))) { $allPresent = $false; break }
+            $p = Join-Path $binDir $d
+            if (-not (Test-Path $p)) { $allCurrent = $false; $staleNote2 = "$d missing"; break }
+            $bv = Get-SemVer (& $p --version 2>$null)
+            if ($bv -and ($bv -ne $cargoVer)) { $allCurrent = $false; $staleNote2 = "$d is $bv (want $cargoVer)"; break }
         }
-        if ($allPresent) {
+        if ($allCurrent) {
             Write-Host "  OK: Already up to date: $installedVer installed in ~/bin - nothing to do." -ForegroundColor Green
             exit 0
         }
-        Write-Host "  WARNING: $installedVer installed but some binaries are missing - reinstalling." -ForegroundColor Yellow
+        Write-Host "  WARNING: Stale install ($staleNote2) - reinstalling all binaries." -ForegroundColor Yellow
     }
 
     $distDir = $null


### PR DESCRIPTION
Polish for the self-update flow, driven by end-to-end testing on **macOS and Windows**. Four independent fixes:

## 1. Privilege-aware daemon-management gate (unblocks `uffs --update apply` on Unix)
`uffs --daemon stop/kill/restart/…` demanded root on Unix unconditionally (`geteuid()==0`), assuming the Windows/live-MFT model. On macOS/Linux the daemon is usually a **user-owned** process reading offline captures — so the gate blocked a user from stopping their own daemon, and `uffs --update apply` (whose quiesce shells out to `uffs --daemon stop`) failed without `sudo`. Now the gate consults the **running daemon's actual owner** (its PID-file uid): your own daemon → no sudo; a root/other-user daemon → still gated. Windows unchanged.

## 2. Clean `uffs-update` errors (no backtrace on usage slips)
`fn main() -> Result<()>` let anyhow dump a symbol-less stack trace on a harmless slip like `uffs-update --doctor`. Now renders a clean `Error: …` / `Caused by: …` chain (mirroring `uffs`), no backtrace even with `RUST_BACKTRACE=1`.

## 3. `just use` version-checks **every** binary, not just `uffs`
The "already up to date" gate compared only `uffs --version` and otherwise checked mere file presence — so a stale sibling (e.g. `uffs-update` left at 0.6.2 on a 0.6.4 install) was kept silently. Now each binary must be present **and** at the target version, or the full set reinstalls. Fixed in both the bash and PowerShell recipes.

## 4. Quiet-by-default self-update output; full detail behind `-v`
The flow overwhelmed non-technical users (install roots, per-binary versions, every PID + launch command, all 14 doctor checks). Now:
- `--update`/`snapshot`/`acquire`/`apply`: a few plain lines (Install, Version or "⚠ mixed", Running with `mcp ×3` de-dup). `-v` restores the full breakdown.
- `doctor`: brew-style — problems only + `✓ Healthy — all N checks passed`; `-v` lists every check.

## Verification
- Full pre-push gate green (cargo-check, lint-ci/prod/tests, rustdoc, doc-tests, tests, smoke, windows-lint).
- Host + Windows-MSVC clippy clean; uffs-cli/uffs-mft/uffs-update tests pass; unit tests added for the owner-gate, the `×N` de-dup, and version dedup/sort.