### PR TITLE
chore: migrate contact emails from @nios.net to @uffs.io

### DIFF
--- a/.github/workflows/ci-failure-notify.yml
+++ b/.github/workflows/ci-failure-notify.yml
@@ -208,7 +208,7 @@ jobs:
               title = `🔴 CI Failure: Tier 2 Nightly CI — ${shortSha}`;
               extraBody = [
                 '',
-                '📧 Notification sent to: githubrobbi@nios.net',
+                '📧 Notification sent to: cifail@uffs.io',
               ];
             } else if (wf === '🐤 Nightly Canary') {
               // Early-warning probe against the LATEST floating nightly
@@ -228,7 +228,7 @@ jobs:
                 'regression, the fix is usually a dependency bump (cf. the ethnum ' +
                 '1.5.2→1.5.3 episode), not a toolchain downgrade.',
                 '',
-                '📧 Notification sent to: githubrobbi@nios.net',
+                '📧 Notification sent to: cifail@uffs.io',
               ];
             } else {
               core.warning(`Unknown workflow name: ${wf}; not notifying.`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1229,7 +1229,7 @@ jobs:
               ``,
               `⚠️ **This is a release pipeline failure — immediate attention required.**`,
               ``,
-              `📧 Notification sent to: githubrobbi@nios.net`,
+              `📧 Notification sent to: releasefail@uffs.io`,
             ].join('\n');
 
             const existing = await github.rest.issues.listForRepo({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ Thanks for helping improve UFFS.
 ## Contact
 
 - **Bug reports, feature requests, questions:** open a GitHub issue on [skyllc-ai/UltraFastFileSearch](https://github.com/skyllc-ai/UltraFastFileSearch/issues).
-- **Brand / trademark questions:** open an issue tagged `brand`, or email [`uffs@nios.net`](mailto:uffs@nios.net).
-- **Commercial / partnership inquiries:** [`uffs@nios.net`](mailto:uffs@nios.net), or a [discussion](https://github.com/skyllc-ai/UltraFastFileSearch/discussions) with the `commercial-interest` label.
+- **Brand / trademark questions:** open an issue tagged `brand`, or email [`trademark@uffs.io`](mailto:trademark@uffs.io).
+- **Commercial / partnership inquiries:** [`partnerships@uffs.io`](mailto:partnerships@uffs.io), or a [discussion](https://github.com/skyllc-ai/UltraFastFileSearch/discussions) with the `commercial-interest` label.
 - **Organization:** [Sky, LLC](https://github.com/skyllc-ai).
 
 ## Platform and privilege model

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ UFFS is free, MPL-2.0, and stays that way — **no telemetry, no accounts, no pa
 | 🏢 **Companies** (invoice / receipt via Sky, LLC) | [Open Collective](https://opencollective.com/uffs-search) | expensing it as a tool |
 | 🔁 **Recurring (individuals)** | GitHub Sponsors — *enrolling* | following the roadmap |
 
-The **"Sponsor"** button at the top of this repo lists every live channel. For custom arrangements, enterprise pilots, or partnership inquiries: [`uffs@nios.net`](mailto:uffs@nios.net).
+The **"Sponsor"** button at the top of this repo lists every live channel. For custom arrangements, enterprise pilots, or partnership inquiries: [`partnerships@uffs.io`](mailto:partnerships@uffs.io).
 
 ---
 
@@ -346,7 +346,7 @@ See [LICENSES/MPL-2.0.txt](LICENSES/MPL-2.0.txt) for the full license text and [
 
 UFFS is developed and maintained by **[Sky, LLC](https://github.com/skyllc-ai)** — a systems-engineering shop focused on high-performance Rust tooling.
 
-- **Commercial UFFS frontends** (polished GUI / premium TUI) are in development on top of this open-source engine. For waitlist or partnership inquiries: [`uffs@nios.net`](mailto:uffs@nios.net) or open a [discussion](https://github.com/skyllc-ai/UltraFastFileSearch/discussions) with the `commercial-interest` label.
+- **Commercial UFFS frontends** (polished GUI / premium TUI) are in development on top of this open-source engine. For waitlist or partnership inquiries: [`partnerships@uffs.io`](mailto:partnerships@uffs.io) or open a [discussion](https://github.com/skyllc-ai/UltraFastFileSearch/discussions) with the `commercial-interest` label.
 - **Hiring / collaboration.** This repository is also the public engineering portfolio of its maintainer; see the [Sky, LLC org page](https://github.com/skyllc-ai) for the full pitch and contact details.
 - **Sponsorship.** UFFS is free and MPL-2.0 forever; sponsorships fund Windows code-signing, benchmark hardware, and release engineering — see [**Support UFFS**](#support-uffs) for the channels and what they fund.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,11 +18,10 @@ If you discover a security vulnerability in UFFS, please report it responsibly
 through one of these channels:
 
 1. **GitHub Security Advisories (preferred)**
-   → [Report a vulnerability](https://github.com/githubrobbi/Ultra-Fast-File-Search/security/advisories/new)
+   → [Report a vulnerability](https://github.com/skyllc-ai/UltraFastFileSearch/security/advisories/new)
 
 2. **Email**
-   → Send details to the email address listed in the repository's `Cargo.toml`
-   under `[workspace.package]`.
+   → [`security@uffs.io`](mailto:security@uffs.io)
 
 ### What to include
 

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -129,7 +129,7 @@ that's cool — call it something else.
 
 For anything in the "ask first" list: open a GitHub issue on the
 repository with the label `brand`, or email
-[`uffs@nios.net`](mailto:uffs@nios.net).
+[`trademark@uffs.io`](mailto:trademark@uffs.io).
 
 Tell us:
 
@@ -173,7 +173,7 @@ the repository's `HEAD`.
 
 - **Project:** <https://github.com/skyllc-ai/UltraFastFileSearch>
 - **Maintainer:** Robert Nio · [Sky, LLC](https://github.com/skyllc-ai)
-- **Email:** [`uffs@nios.net`](mailto:uffs@nios.net)
+- **Email:** [`trademark@uffs.io`](mailto:trademark@uffs.io)
 
 ---
 

--- a/just/bench_uffs.just
+++ b/just/bench_uffs.just
@@ -170,7 +170,7 @@ ship-crt-static:
 
     # Use a sibling target directory so the main release build cache
     # is not invalidated by the rustflags change.  Honors any active
-    # CARGO_TARGET_DIR (e.g. C:\rust-target\ttapi).
+    # CARGO_TARGET_DIR (e.g. C:\rust-target\uffs).
     if ($env:CARGO_TARGET_DIR) {
         $targetDir = "$env:CARGO_TARGET_DIR-crt-static"
     } else {


### PR DESCRIPTION
Migrates every `@nios.net` contact reference to a purpose-specific `@uffs.io`
address now that the domain + catch-all mail are live. One address per
function, per the `EMAIL_ADDRESSES.md` convention (in `uffs-products`).

## Changes
- `README.md` → `partnerships@uffs.io` (commercial/partnership)
- `TRADEMARK.md` → `trademark@uffs.io`
- `CONTRIBUTING.md` → `trademark@uffs.io` (brand) + `partnerships@uffs.io` (commercial)
- `.github/workflows/ci-failure-notify.yml` → `cifail@uffs.io`
- `.github/workflows/release.yml` → `releasefail@uffs.io`
- `SECURITY.md` → `security@uffs.io` + advisory URL fixed to `skyllc-ai/UltraFastFileSearch`
- `just/bench_uffs.just` → drop the last stale `ttapi` example path

No code/behavior change — contact strings + a comment only.