### PR TITLE
fix: correct Ko-fi sponsor handle to uffssearch

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -25,9 +25,9 @@ open_collective: uffs-search
 
 # ── Ko-fi ───────────────────────────────────────────────────────────────────
 # Low-friction one-time tips.  Takes ~20 min to set up.
-# Create at: https://ko-fi.com  — use handle "uffs" if available.
-# Uncomment once the Ko-fi page is live:
-ko_fi: ufffssearch
+# Create at: https://ko-fi.com  (handle: uffssearch — 4-char "uffs" is paywalled).
+# Live:
+ko_fi: uffssearch
 
 # ── Patreon ─────────────────────────────────────────────────────────────────
 # Not used — Patreon is optimised for creative content, not developer tooling.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg" alt="License: MPL 2.0"></a>
   <a href="https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest"><img src="https://img.shields.io/badge/platform-Windows-blue.svg" alt="Platform: Windows"></a>
   <a href="https://opencollective.com/uffs-search"><img src="https://img.shields.io/badge/Sponsor-Open%20Collective-3385FF?logo=opencollective&logoColor=white" alt="Sponsor on Open Collective"></a>
-  <a href="https://ko-fi.com/ufffssearch"><img src="https://img.shields.io/badge/Tip-Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Tip on Ko-fi"></a>
+  <a href="https://ko-fi.com/uffssearch"><img src="https://img.shields.io/badge/Tip-Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Tip on Ko-fi"></a>
 </p>
 
 **A benchmark-driven NTFS search engine for Windows.** UFFS reads the Master File Table directly, builds a compact persisted index, and keeps large NTFS estates searchable through a background daemon.
@@ -217,7 +217,7 @@ Operator commands let you tune this manually for known workload shapes — `prel
 ## Support UFFS
 
 <p align="center">
-  <a href="https://ko-fi.com/ufffssearch"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Tip on Ko-fi" height="38"></a>
+  <a href="https://ko-fi.com/uffssearch"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Tip on Ko-fi" height="38"></a>
   &nbsp;&nbsp;
   <a href="https://opencollective.com/uffs-search"><img src="https://opencollective.com/uffs-search/donate/button@2x.png?color=blue" alt="Donate on Open Collective" height="38"></a>
 </p>
@@ -230,7 +230,7 @@ UFFS is free, MPL-2.0, and stays that way — **no telemetry, no accounts, no pa
 
 | Supporter | Where | Best for |
 |---|---|---|
-| 💛 **One-time tip** | [Ko-fi](https://ko-fi.com/ufffssearch) | "this saved me an afternoon" |
+| 💛 **One-time tip** | [Ko-fi](https://ko-fi.com/uffssearch) | "this saved me an afternoon" |
 | 🏢 **Companies** (invoice / receipt via Sky, LLC) | [Open Collective](https://opencollective.com/uffs-search) | expensing it as a tool |
 | 🔁 **Recurring (individuals)** | GitHub Sponsors — *enrolling* | following the roadmap |
 


### PR DESCRIPTION
`ko_fi: ufffssearch` had a stray third `f` — a dead handle, so the
"Sponsor this project" Ko-fi link 404'd. The account is now live at
**ko-fi.com/uffssearch**.

Once merged to `main`, GitHub re-renders the sponsor button (repo sidebar
+ org profile) with the corrected link automatically — no deploy needed.