### PR TITLE
fix(update): journal to_version, stdio-mcp restore, repair verb

### DIFF
--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -66,11 +66,11 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
     if let Some(act) = action
         && !matches!(
             act,
-            "check" | "snapshot" | "acquire" | "apply" | "doctor" | "recover"
+            "check" | "snapshot" | "acquire" | "apply" | "doctor" | "repair" | "recover"
         )
     {
         bail!(
-            "unknown `--update` action `{act}` — expected: check | snapshot | acquire | apply | doctor | recover"
+            "unknown `--update` action `{act}` — expected: check | snapshot | acquire | apply | doctor | repair | recover"
         );
     }
 
@@ -85,12 +85,23 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
         return self_heal::run_foreground();
     }
 
-    // `doctor` runs its own flow: detect → freeze a snapshot → hand off to the
-    // helper's health check (which prints its own report).
-    if action == Some("doctor") {
+    // `repair` is the first-class verb for `doctor --repair`; a bare `--repair`
+    // flag (with no action) means the same. Both route to the doctor health
+    // check with self-heal on — so the user never has to remember whether
+    // repair is a verb or a flag.
+    let repair = action == Some("repair") || args.iter().any(|arg| arg == "--repair");
+
+    // `doctor` (diagnose) and `repair` (diagnose + self-heal) share one flow:
+    // detect → freeze a snapshot → hand off to the helper's health check
+    // (which prints its own report). A health-check snapshot has no target.
+    if action == Some("doctor") || repair {
         let report = detect();
-        let snapshot_path = snapshot::write_snapshot(&report)?;
-        return doctor::spawn(&snapshot_path, args);
+        let snapshot_path = snapshot::write_snapshot(&report, None)?;
+        let mut forwarded: Vec<String> = args.to_vec();
+        if repair && !forwarded.iter().any(|arg| arg == "--repair") {
+            forwarded.push("--repair".to_owned());
+        }
+        return doctor::spawn(&snapshot_path, &forwarded);
     }
 
     let report = detect();
@@ -115,12 +126,12 @@ pub(crate) fn run_update(args: &[String]) -> Result<()> {
         }
         // `acquire` only stages + verifies; `apply` implies acquire then swaps.
         Some("acquire" | "apply") => {
-            let snapshot_path = snapshot::write_snapshot(&report)?;
-            acquire::spawn(
-                &snapshot_path,
-                flag_value(args, "--version").as_deref(),
-                verbose,
-            )?;
+            // The target this snapshot is for: an explicit `--version`, else
+            // the resolved latest — so the journal stamps `to_version`
+            // faithfully instead of "unknown".
+            let target = flag_value(args, "--version").or_else(acquire::latest_version);
+            let snapshot_path = snapshot::write_snapshot(&report, target.as_deref())?;
+            acquire::spawn(&snapshot_path, target.as_deref(), verbose)?;
             if action == Some("apply") {
                 apply::spawn(&snapshot_path, verbose)?;
             }
@@ -183,7 +194,7 @@ fn run_automatic_update(report: &DetectionReport, verbose: bool) -> Result<()> {
         }
         UpdatePlan::Available { latest } => {
             print_updating(&latest);
-            let snapshot_path = snapshot::write_snapshot(report)?;
+            let snapshot_path = snapshot::write_snapshot(report, Some(&latest))?;
             acquire::spawn(&snapshot_path, None, verbose)?;
             apply::spawn(&snapshot_path, verbose)?;
             print_updated(&latest);
@@ -254,7 +265,7 @@ fn flag_value(args: &[String], name: &str) -> Option<String> {
 /// Write a Phase-B snapshot and report where it landed.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
 fn write_and_report_snapshot(report: &DetectionReport) {
-    match snapshot::write_snapshot(report) {
+    match snapshot::write_snapshot(report, None) {
         Ok(path) => println!("\nSnapshot written: {}", path.display()),
         Err(err) => {
             #[expect(clippy::print_stderr, reason = "CLI user-facing error")]
@@ -424,18 +435,23 @@ fn print_help() {
          \x20                     Journaled + auto-rollback on failure.\n\
          \x20 doctor              End-to-end health check (versions, dirs, journal,\n\
          \x20                     backups, services, broker pipe, release reach).\n\
+         \x20 repair              Diagnose + self-heal (= doctor --repair):\n\
+         \x20                     resume/roll back an interrupted update, sweep\n\
+         \x20                     stale backups, restart stopped services.\n\
          \x20 recover             Finish or roll back an interrupted update now\n\
          \x20                     (foreground; the on-demand self-heal).\n\n\
          OPTIONS:\n\
          \x20 -v, --verbose       Show the full breakdown — per-binary versions,\n\
          \x20                     PIDs, launch commands, every doctor check.\n\
          \x20 --version <tag>     Acquire/apply a specific release tag (default: latest).\n\
-         \x20 --repair            (doctor) self-heal what can be fixed.\n\
+         \x20 --repair            (doctor) self-heal what can be fixed (or use the\n\
+         \x20                     `repair` action above).\n\
          \x20 --offline           (doctor) skip the network checks.\n\n\
          EXAMPLES:\n\
          \x20 uffs --update                 update now (if needed)\n\
          \x20 uffs --update check           is a new release available?\n\
          \x20 uffs --update doctor          health-check the update flow\n\
+         \x20 uffs --update repair          self-heal the update flow\n\
          \x20 uffs --update apply --version v0.6.3   pin a specific release\n"
     );
 }

--- a/crates/uffs-cli/src/commands/update/snapshot.rs
+++ b/crates/uffs-cli/src/commands/update/snapshot.rs
@@ -27,11 +27,14 @@ pub(crate) fn update_dir() -> PathBuf {
 /// # Errors
 ///
 /// Propagates any directory-create or file-write failure.
-pub(crate) fn write_snapshot(report: &DetectionReport) -> std::io::Result<PathBuf> {
+pub(crate) fn write_snapshot(
+    report: &DetectionReport,
+    to_version: Option<&str>,
+) -> std::io::Result<PathBuf> {
     let dir = update_dir();
     std::fs::create_dir_all(&dir)?;
     let captured_unix = unix_now();
-    let value = build_snapshot_value(report, &daemon_drive_state(), captured_unix);
+    let value = build_snapshot_value(report, &daemon_drive_state(), captured_unix, to_version);
     let path = dir.join(format!("snapshot-{captured_unix}.json"));
     let body = serde_json::to_string_pretty(&value)
         .unwrap_or_else(|_| "{\"schema\":2,\"error\":\"serialize\"}".to_owned());
@@ -74,6 +77,7 @@ fn build_snapshot_value(
     report: &DetectionReport,
     daemon_drives: &[Value],
     captured_unix: u64,
+    to_version: Option<&str>,
 ) -> Value {
     let targets: Vec<Value> = report
         .roots
@@ -109,6 +113,9 @@ fn build_snapshot_value(
     json!({
         "schema": 2,
         "captured_unix": captured_unix,
+        // The release the apply is moving *to* (so the journal records it
+        // and `Applied + committed → <tag>` is faithful, not "unknown").
+        "to_version": to_version,
         "targets": targets,
         "running": running,
         "daemon": { "drives": daemon_drives },
@@ -149,7 +156,8 @@ mod tests {
     #[test]
     fn snapshot_shape_is_stable() {
         let drives = vec![json!({"letter": "C", "tier": "warm"})];
-        let value = build_snapshot_value(&sample_report(), &drives, 1_700_000_000_u64);
+        let value =
+            build_snapshot_value(&sample_report(), &drives, 1_700_000_000_u64, Some("0.6.3"));
         // `pointer` avoids panicking index ops; `json!(typed)` pins the
         // expected literal type (no default numeric fallback).
         let probe = |path: &str, expected: serde_json::Value| {
@@ -157,6 +165,7 @@ mod tests {
         };
         probe("/schema", json!(2_u64));
         probe("/captured_unix", json!(1_700_000_000_u64));
+        probe("/to_version", json!("0.6.3"));
         probe("/targets/0/channel", json!("unmanaged"));
         probe("/targets/0/anchored_by/1", json!("daemon"));
         probe("/targets/0/binaries/0/on_disk_version", json!("0.6.2"));

--- a/crates/uffs-update/src/doctor.rs
+++ b/crates/uffs-update/src/doctor.rs
@@ -146,7 +146,9 @@ impl Report {
             }
         }
         if !repair && (warn > 0 || fail > 0) {
-            println!("hint: re-run with `--repair` to self-heal what can be fixed automatically.");
+            println!(
+                "hint: run `uffs --update repair` to self-heal what can be fixed automatically."
+            );
         }
     }
 }
@@ -317,7 +319,7 @@ fn check_journal(update_dir: Option<&Path>, repair: bool, report: &mut Report) {
         report.add(
             Health::Warn,
             "Interrupted update found",
-            Some("owner gone — re-run with `--repair` to resume or roll back".to_owned()),
+            Some("owner gone — run `uffs --update repair` to resume or roll back".to_owned()),
         );
         return;
     }

--- a/crates/uffs-update/src/restore.rs
+++ b/crates/uffs-update/src/restore.rs
@@ -45,7 +45,15 @@ fn start_component(component: &str, running: &SnapRunning) -> bool {
     match component {
         "broker" => start_broker(),
         "daemon" => start_from_command_line(running, || daemon_pid_file().exists()),
-        "mcp" => start_from_command_line(running, || true),
+        // The stdio MCP server (`uffsmcp`) is spawned and OWNED by its LLM host
+        // (Claude Desktop / Cursor / Windsurf) over stdio — relaunching it
+        // detached has no client to serve. Quiesce stopped it only to free the
+        // `uffsmcp.exe` file lock for the swap; the host respawns it on the next
+        // tool call. So restoring mcp is a deliberate no-op (and a success, not
+        // a "failed to restart"). The HTTP gateway is a separate binary
+        // (`uffs-mcp-http`), never captured here — detection scans only for
+        // `uffsmcp`.
+        "mcp" => true,
         _ => false,
     }
 }
@@ -91,7 +99,22 @@ pub(crate) fn parse_command_line(cmd: &str) -> Option<(String, Vec<String>)> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_command_line;
+    use super::{parse_command_line, start_component};
+    use crate::plan::SnapRunning;
+
+    #[test]
+    fn mcp_restore_is_noop_success() {
+        // A stdio `uffsmcp` is client-owned: restore must not relaunch it,
+        // and must report success (not a "failed to restart") so the commit
+        // path doesn't warn about a component it deliberately leaves alone.
+        let running = SnapRunning {
+            component: "mcp".to_owned(),
+            pid: 1,
+            image_path: None,
+            command_line: Some("uffsmcp".to_owned()),
+        };
+        assert!(start_component("mcp", &running));
+    }
 
     #[test]
     fn parses_switch_style_command_line() {


### PR DESCRIPTION
Three rough edges surfaced while exercising upgrade → downgrade → realign on a
live Windows install (the mechanism itself is sound; these are polish).

### 1. `Applied + committed → unknown` (real)
The CLI never wrote `to_version` into the snapshot, so `journal.to_version`
always fell back to `"unknown"` — on **both** the bare auto-apply and explicit
`--version` paths. The journal's record of what an apply committed to was wrong,
which matters for `recover`/rollback and audit. `write_snapshot` now takes the
target tag (explicit `--version`, else resolved latest) and emits it (the schema
already modelled the field).

### 2. Spurious `components failed to restart: [mcp]` (real, minor)
The stdio MCP server (`uffsmcp`) is spawned and **owned by its LLM host** (Claude
Desktop / Cursor / Windsurf) over stdio. Quiesce rightly stops it to free the file
lock; `restore` then tried to relaunch it detached — no client to serve, so it
warned. Now a deliberate no-op success; the host respawns it on next use. (The HTTP
gateway is a separate binary, `uffs-mcp-http`, never captured here — detection
scans only for `uffsmcp`.)

### 3. `--repair` UX (minor)
The doctor hint said *"re-run with `--repair`"*, but `uffs --update repair` errored
and bare `uffs --update --repair` silently no-op'd; the only working form was the
non-obvious `doctor --repair`. Added **`repair` as a first-class verb** (= `doctor
--repair`), routed a bare `--repair` flag to it, and fixed the hints to name
`uffs --update repair`.

**Best-practice note:** verbs stay bare (`doctor`, `repair`), options stay dashed
(`--repair`, `--version`) — git/cargo convention. `repair` becomes a verb so users
never have to guess whether it's a verb or a flag.

### Validation
Host clippy (strict workspace lints) clean; `uffs-cli` + `uffs-update` tests pass,
incl. new coverage: snapshot `to_version` probe + `mcp_restore_is_noop_success`.