### PR TITLE
fix(update): make downloaded binaries executable (self-update apply on Unix)

### DIFF
--- a/crates/uffs-update/src/acquire.rs
+++ b/crates/uffs-update/src/acquire.rs
@@ -16,7 +16,7 @@
 //! Requires the release to publish per-binary assets + `SHA256SUMS` (a
 //! release-pipeline follow-up; the code is ready for it).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result, bail};
 
@@ -82,7 +82,66 @@ pub(crate) fn run(plan: &AcquirePlan) -> Result<Vec<PathBuf>> {
             let _ignore = std::fs::remove_file(&dest);
             bail!("SHA-256 mismatch for {asset} — download rejected, nothing staged");
         }
+        // Downloads land 0644 — not executable. The apply-phase smoke test
+        // runs the swapped-in binary (and it must run once installed), so a
+        // staged binary that isn't +x makes apply fail with "smoke test failed"
+        // on macOS/Linux. (No-op on Windows.)
+        make_executable(&dest)?;
         staged.push(dest);
     }
     Ok(staged)
+}
+
+/// Mark a freshly-downloaded binary executable. Unix only; Windows ignores the
+/// mode bits, so this is a no-op there.
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let mut perms = std::fs::metadata(path)
+        .with_context(|| format!("stat {}", path.display()))?
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).with_context(|| format!("chmod +x {}", path.display()))
+}
+
+/// Non-Unix: executability is not governed by file mode.
+#[cfg(not(unix))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "signature mirrors the Unix path so the `?` call site compiles on every target"
+)]
+const fn make_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    #[test]
+    fn make_executable_sets_the_exec_bits() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        use super::make_executable;
+
+        // A freshly-written download lands 0644 (no exec bit) — the exact
+        // state that made apply fail the smoke test on macOS/Linux.
+        let path = std::env::temp_dir().join(format!("uffs-acq-{}", std::process::id()));
+        std::fs::write(&path, b"#!/bin/sh\n").expect("write temp binary");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).expect("seed 0644");
+        assert_eq!(
+            std::fs::metadata(&path).expect("stat").permissions().mode() & 0o111,
+            0,
+            "precondition: not executable"
+        );
+
+        make_executable(&path).expect("make_executable");
+
+        let mode = std::fs::metadata(&path).expect("stat").permissions().mode();
+        assert_ne!(
+            mode & 0o100,
+            0,
+            "owner-execute bit must be set after the fix"
+        );
+        let _cleanup = std::fs::remove_file(&path);
+    }
 }


### PR DESCRIPTION
`uffs --update apply` fails on **macOS/Linux** with **"smoke test failed for uffs; rolled back"** — and it has *never* worked on Unix.

## Root cause
Apply does `backup → swap → smoke → commit`, where the smoke test runs the just-swapped binary (`<bin> --version`, `SMOKE_ARG`) to prove it works before committing. But acquired binaries are written by the HTTP download (`github::download_to` → `File::create`) at the default **`0644` — not executable**. So `uffs --version` gets *permission denied*, smoke fails, and the whole apply rolls back.

It was masked until now: the earlier quiesce failure (daemon stop) aborted before the smoke phase ever ran. With no daemon to stop, apply reached smoke and exposed it. (`just use` is unaffected — its release **tarball preserves `+x`**.)

## Fix
`chmod 0755` on each staged binary immediately after its SHA-256 verifies, in the acquire loop. Unix-only; Windows ignores file mode (no-op `const fn` stub mirroring the signature so the `?` call site compiles everywhere). Split into a `make_executable` helper with a unit test that seeds a `0644` file and asserts the exec bit is set.

## Verification
- Host + Windows-MSVC clippy clean; full pre-push gate green; uffs-update tests pass (46) incl. the new `make_executable_sets_the_exec_bits`.

Note: because the broken helper ships in every release so far (incl. 0.6.7), Unix users must `just use` (tarball) to update until a release carries this fix — after which `uffs --update` / `apply` work on macOS/Linux too.