### PR TITLE
fix(update): embed asInvoker manifest in uffs-update.exe (Windows elevation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4688,6 +4688,7 @@ dependencies = [
  "uffs-broker-protocol",
  "uffs-winsvc",
  "windows 0.62.2",
+ "winresource",
 ]
 
 [[package]]

--- a/crates/uffs-update/Cargo.toml
+++ b/crates/uffs-update/Cargo.toml
@@ -59,5 +59,10 @@ windows.workspace = true
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+# Embed `app.manifest` (asInvoker) into uffs-update.exe on Windows MSVC so the
+# "update" name doesn't trip Installer Detection → forced UAC (os error 740).
+[build-dependencies]
+winresource.workspace = true
+
 [lints]
 workspace = true

--- a/crates/uffs-update/app.manifest
+++ b/crates/uffs-update/app.manifest
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  SPDX-FileCopyrightText: 2025-2026 SKY, LLC.
+  SPDX-License-Identifier: MPL-2.0
+
+  uffs-update application manifest.
+
+  CRITICAL: the `asInvoker` requestedExecutionLevel below is what stops
+  Windows' "Installer Detection" heuristic from force-elevating this binary.
+  That heuristic auto-flags executables whose NAME contains update/setup/
+  install/patch as installers needing UAC — so `uffs-update.exe` would
+  otherwise fail to launch from the non-elevated `uffs.exe` with
+  ERROR_ELEVATION_REQUIRED (os error 740), breaking every `uffs --update`
+  operation. The self-update helper only rewrites files in the user's own
+  install dir; it never needs Administrator.
+-->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity type="win32" name="UFFS.Update" version="0.0.0.0"/>
+
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Long-path support for deep install/staging paths (> 260 chars). -->
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 / 11 (shared supportedOS GUID per MS docs). -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/crates/uffs-update/build.rs
+++ b/crates/uffs-update/build.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+// Build scripts run on the build host, not the shipping binary; the workspace
+// deny-expect lint exists for runtime code. `expect` with a readable message is
+// the idiomatic shape for build-script error reporting.
+#![allow(
+    clippy::expect_used,
+    reason = "build scripts may panic on build-host failure; workspace deny-expect exists for runtime code"
+)]
+
+//! Build script: embed `app.manifest` into `uffs-update.exe` on Windows MSVC.
+//!
+//! The manifest declares `asInvoker`, which is **required** to stop Windows'
+//! Installer Detection heuristic from force-elevating this binary purely
+//! because its name contains "update". Without it, `uffs.exe` (non-elevated)
+//! cannot spawn `uffs-update.exe` — it fails with `ERROR_ELEVATION_REQUIRED`
+//! (os error 740) — breaking every `uffs --update` operation on Windows. The
+//! helper only rewrites files in the user's install dir; it never needs admin.
+//!
+//! Inert on non-Windows / non-MSVC targets (the helper ships windows-msvc).
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=app.manifest");
+    println!("cargo:rerun-if-changed=../../assets/brand/icons/uffs.ico");
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+
+    if target_os == "windows" && target_env == "msvc" {
+        let mut res = winresource::WindowsResource::new();
+        res.set_icon("../../assets/brand/icons/uffs.ico")
+            .set("ProductName", "UltraFastFileSearch")
+            .set("FileDescription", "UFFS self-update helper")
+            .set("CompanyName", "SKY, LLC.")
+            .set("LegalCopyright", "(c) 2025-2026 SKY, LLC. MPL-2.0.")
+            .set("OriginalFilename", "uffs-update.exe")
+            .set_manifest_file("app.manifest");
+
+        // Panic on failure is fine in a build script (host-only; the
+        // workspace deny-unwrap lint targets runtime code).
+        res.compile()
+            .expect("winresource: failed to embed uffs-update manifest");
+    }
+}


### PR DESCRIPTION
On Windows, **every** `uffs --update` operation (doctor/acquire/apply) fails immediately:

```
Error: spawning C:\Users\…\bin\uffs-update.exe
  Caused by: The requested operation requires elevation. (os error 740)
```

## Cause
`os error 740` = `ERROR_ELEVATION_REQUIRED`. Windows' **Installer Detection** heuristic auto-flags executables whose *name* contains `update`/`setup`/`install`/`patch` as installers that require UAC — **unless** the binary carries an application manifest opting out. `uffs.exe` already ships an `asInvoker` manifest (so it's exempt); `uffs-update.exe` had **no manifest at all**, so the heuristic force-elevated it, and the non-elevated `uffs.exe` couldn't `CreateProcess` it.

## Fix
Mirror what `uffs.exe` already does:
- `crates/uffs-update/app.manifest` — `requestedExecutionLevel level="asInvoker"` (+ `longPathAware`).
- `crates/uffs-update/build.rs` — embeds it into the PE on `windows-msvc` via `winresource` (inert on other targets).
- `winresource` added to `[build-dependencies]`.

`asInvoker` is correct: the helper only rewrites files in the user's own install dir; it never needs Administrator.

## Verification
- Built `x86_64-pc-windows-msvc/uffs-update.exe` now contains `requestedExecutionLevel level="asInvoker"` (grepped the PE).
- Host + Windows-MSVC clippy clean; uffs-update tests pass (46).

Together with #452 (Unix exec-bit), this makes `uffs --update` work on **all three platforms**.