### PR TITLE
fix(self-update): minimal asInvoker manifest — stop uffs-update.exe SxS crash (os error 14001)

### DIFF
--- a/crates/uffs-update/app.manifest
+++ b/crates/uffs-update/app.manifest
@@ -3,20 +3,26 @@
   SPDX-FileCopyrightText: 2025-2026 SKY, LLC.
   SPDX-License-Identifier: MPL-2.0
 
-  uffs-update application manifest.
+  uffs-update application manifest — deliberately MINIMAL.
 
-  CRITICAL: the `asInvoker` requestedExecutionLevel below is what stops
-  Windows' "Installer Detection" heuristic from force-elevating this binary.
-  That heuristic auto-flags executables whose NAME contains update/setup/
-  install/patch as installers needing UAC — so `uffs-update.exe` would
-  otherwise fail to launch from the non-elevated `uffs.exe` with
-  ERROR_ELEVATION_REQUIRED (os error 740), breaking every `uffs --update`
-  operation. The self-update helper only rewrites files in the user's own
-  install dir; it never needs Administrator.
+  CRITICAL: the `asInvoker` requestedExecutionLevel below is the *one* thing
+  this manifest exists to declare. It stops Windows' "Installer Detection"
+  heuristic from force-elevating this binary purely because its NAME contains
+  "update" — without it, `uffs.exe` (non-elevated) cannot spawn
+  `uffs-update.exe`; it fails with ERROR_ELEVATION_REQUIRED (os error 740),
+  breaking every `uffs --update` operation. The self-update helper only
+  rewrites files in the user's own install dir; it never needs Administrator.
+
+  WHY MINIMAL — nothing but `trustInfo`: an earlier, richer version of this
+  manifest (with `<assemblyIdentity>`, a `<compatibility>` supportedOS block,
+  and `<windowsSettings>`) made the cross-compiled `uffs-update.exe` fail to
+  start at all with ERROR_SXS_CANT_GEN_ACTCTX (os error 14001, "side-by-side
+  configuration is incorrect"). `<assemblyIdentity>` in an application manifest
+  makes the loader attempt a side-by-side assembly resolution that can fail;
+  this helper is a plain console binary that needs none of those settings. Keep
+  this file to `trustInfo`-only so there is zero SxS activation-context surface.
 -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <assemblyIdentity type="win32" name="UFFS.Update" version="0.0.0.0"/>
-
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>
@@ -24,18 +30,4 @@
       </requestedPrivileges>
     </security>
   </trustInfo>
-
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings>
-      <!-- Long-path support for deep install/staging paths (> 260 chars). -->
-      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
-    </windowsSettings>
-  </application>
-
-  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-    <application>
-      <!-- Windows 10 / 11 (shared supportedOS GUID per MS docs). -->
-      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-    </application>
-  </compatibility>
 </assembly>

--- a/crates/uffs-update/build.rs
+++ b/crates/uffs-update/build.rs
@@ -18,6 +18,10 @@
 //! (os error 740) — breaking every `uffs --update` operation on Windows. The
 //! helper only rewrites files in the user's install dir; it never needs admin.
 //!
+//! The manifest is intentionally minimal (`trustInfo`-only): a richer earlier
+//! version tripped `ERROR_SXS_CANT_GEN_ACTCTX` (os error 14001) so the binary
+//! would not start at all. See `app.manifest` for the full rationale.
+//!
 //! Inert on non-Windows / non-MSVC targets (the helper ships windows-msvc).
 
 fn main() {


### PR DESCRIPTION
## Problem

After #454 shipped (v0.6.9), `uffs-update.exe` **fails to start at all** on Windows:

```
The application has failed to start because its side-by-side configuration is
incorrect. ... (os error 14001)   # ERROR_SXS_CANT_GEN_ACTCTX
```

Every invocation dies — including the apply-phase smoke test (`uffs-update --version`) — so `uffs --update` rolls back with *"smoke test failed for uffs-update"*. The self-updater can't even update itself.

## Root cause

The asInvoker manifest added in #454 (to defeat Installer Detection / `os error 740`) also carried `<assemblyIdentity>`, a `<compatibility>` supportedOS block, and `<windowsSettings>`. **`<assemblyIdentity>` in an application manifest makes the loader attempt a side-by-side assembly resolution** that fails for a plain console binary → `ERROR_SXS_CANT_GEN_ACTCTX` (14001).

`uffs.exe` happened to survive the same elements, but `uffs-update.exe` did not — so rather than chase the exact divergence, strip the manifest to only what this helper needs.

## Fix

Reduce `app.manifest` to a single `trustInfo`/`asInvoker` block — removing every SxS activation-context surface (`assemblyIdentity`, `compatibility`, `windowsSettings`). This:

- **keeps** the #454 fix — `asInvoker` still defeats Installer Detection (no more `os error 740`), and
- **eliminates** the 14001 crash.

## Verification

Cross-compiled with `cargo xwin` and inspected the embedded PE manifest:

- `requestedExecutionLevel level="asInvoker"` — **present** (1)
- real `<assemblyIdentity type=>` — **0**
- real `<supportedOS Id=>` — **0**