### PR TITLE
fix(self-update): remove '--' from manifest XML comment — the real SxS 14001 cause

### DIFF
--- a/crates/uffs-update/app.manifest
+++ b/crates/uffs-update/app.manifest
@@ -10,8 +10,14 @@
   heuristic from force-elevating this binary purely because its NAME contains
   "update" — without it, `uffs.exe` (non-elevated) cannot spawn
   `uffs-update.exe`; it fails with ERROR_ELEVATION_REQUIRED (os error 740),
-  breaking every `uffs --update` operation. The self-update helper only
-  rewrites files in the user's own install dir; it never needs Administrator.
+  breaking every `uffs` self-update operation. The helper only rewrites
+  files in the user's own install dir; it never needs Administrator.
+
+  DO NOT write a double hyphen anywhere inside this comment block. XML
+  forbids "- -" (no space) in a comment body, and Windows' side-by-side
+  manifest parser rejects the whole manifest as "Invalid Xml syntax" if it
+  finds one — which is exactly the os error 14001 crash this file once had
+  (the old comment contained the literal CLI flag with two leading dashes).
 
   WHY MINIMAL — nothing but `trustInfo`: an earlier, richer version of this
   manifest (with `<assemblyIdentity>`, a `<compatibility>` supportedOS block,


### PR DESCRIPTION
## The actual root cause

`uffs-update.exe` failed to start on Windows with `ERROR_SXS_CANT_GEN_ACTCTX` (os error 14001). Three independent diagnostics all point to the same line:

- **Error text:** *"...side-by-side configuration is incorrect... os error 14001"*
- **Application event log** (`SideBySide`, id 59): *"Error in manifest or policy file ... on line 1. Invalid Xml syntax."*
- **sxstrace:** *"INFO: Parsing Manifest File ... ERROR: Line 1: XML Syntax error. ERROR: Activation Context generation failed."*

The embedded manifest's XML comment contained the literal example invocation **`uffs --update`** — and **XML forbids `--` (double hyphen) inside a `<!-- -->` comment**. Windows' strict side-by-side manifest parser rejects the whole manifest.

## Why the earlier fixes missed it

That `uffs --update` line was in the comment of **both** the original #454 manifest **and** the #456 "minimal" rewrite. So #456 (which removed `<assemblyIdentity>`) never touched the real fault — the binary kept crashing identically. The breakthrough was the event log / sxstrace pinpointing *line 1 / Invalid Xml*, not the elements.

## Fix

Reword the comment so no `--` appears in the body, plus an explicit DO-NOT-USE-double-hyphen warning to prevent regression. `asInvoker` is unchanged, so the #454 Installer-Detection / os error 740 fix still holds.

## Verification

Extracted the embedded `RT_MANIFEST` from a freshly cross-compiled `uffs-update.exe` and validated it:

```
xmllint --noout <embedded-manifest>   →  well-formed   (was: malformed)
```