### PR TITLE
feat(broker): add --version/-V so the self-update probe shows its version

### DIFF
--- a/crates/uffs-broker/src/broker.rs
+++ b/crates/uffs-broker/src/broker.rs
@@ -133,6 +133,7 @@ fn print_usage() {
     eprintln!("  --start       Start the service (waits for RUNNING)");
     eprintln!("  --stop        Stop the service (waits for STOPPED)");
     eprintln!("  --run         Run in foreground (debugging)");
+    eprintln!("  --version     Print version (also -V)");
 }
 
 /// Run the broker in foreground mode.

--- a/crates/uffs-broker/src/main.rs
+++ b/crates/uffs-broker/src/main.rs
@@ -15,9 +15,11 @@
 //! uffs-broker --start       # Start the service
 //! uffs-broker --stop        # Stop the service
 //! uffs-broker --run         # Run in foreground (for debugging)
+//! uffs-broker --version     # Print version (also -V)
 //! ```
 //!
-//! On non-Windows platforms, this binary prints an error and exits.
+//! On non-Windows platforms, every subcommand except `--version` prints an
+//! error and exits.
 
 // `broker` is gated to `#[cfg(windows)]` because the entire module
 // (Win32 named-pipe service, OpenProcess, DuplicateHandle, audit log,
@@ -45,6 +47,19 @@ mod broker;
               `--install` failed with NO output). stderr always reaches the operator."
 )]
 fn main() {
+    // `--version` / `-V` is handled here, before the Windows service dispatch,
+    // so it works on every platform and exits 0. The self-update version probe
+    // runs `<bin> --version` and parses the output; without this arm the broker
+    // fell through to its usage text and the probe reported the broker as `?`
+    // (every other UFFS binary prints a version, so it was the odd one out).
+    if std::env::args()
+        .skip(1)
+        .any(|arg| arg == "--version" || arg == "-V")
+    {
+        print_version();
+        return;
+    }
+
     #[cfg(windows)]
     {
         if let Err(run_err) = broker::run() {
@@ -60,4 +75,11 @@ fn main() {
         eprintln!("uffs-broker is a Windows-only component.");
         std::process::exit(1);
     }
+}
+
+/// Print `uffs-broker <version>` to stdout, matching the `uffs <version>`
+/// shape the other binaries use so the self-update version probe parses it.
+#[expect(clippy::print_stdout, reason = "intentional version output")]
+fn print_version() {
+    println!("uffs-broker {}", env!("CARGO_PKG_VERSION"));
 }

--- a/crates/uffs-cli/src/commands/update/binaries.rs
+++ b/crates/uffs-cli/src/commands/update/binaries.rs
@@ -146,6 +146,9 @@ mod tests {
     fn parses_named_version_line() {
         assert_eq!(parse_version("uffs 0.6.2").as_deref(), Some("0.6.2"));
         assert_eq!(parse_version("uffsd 0.6.10\n").as_deref(), Some("0.6.10"));
+        // The broker prints a hyphenated name; the hyphen must not be mistaken
+        // for part of the version token (else its version probes back as `?`).
+        assert_eq!(parse_version("uffs-broker 0.6.9").as_deref(), Some("0.6.9"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In `uffs --update`, every binary resolves a version except the broker:

```
- uffs-broker  ?
```

`uffs-broker` had no `--version` arm — any unrecognised flag falls through to the SCM service dispatch, which (run interactively) prints usage text. The self-update snapshot probes each binary with `<bin> --version` and parses a semver token from the output, so the broker came back as `?`: the only binary without a resolvable version, leaving version-skew detection blind to it.

## Fix

- Add a cross-platform `--version` / `-V` arm in `main()`, handled **before** the Windows-only service dispatch, printing `uffs-broker <version>` to stdout in the same shape as every other UFFS binary (`uffs <version>`). Works on every platform, exits 0.
- List `--version` in the usage help.
- Add a `parse_version` regression test for the hyphenated `uffs-broker 0.6.9` line (the name's hyphen must not be mistaken for part of the version token).

## Verification

```
$ uffs-broker --version   →  uffs-broker 0.6.9   (exit 0)
$ uffs-broker -V          →  uffs-broker 0.6.9   (exit 0)
```

Parser extracts `0.6.9`; all 7 `binaries::tests` pass. Result: the `uffs-broker  ?` line in `uffs --update` becomes `uffs-broker  0.6.9`.