### PR TITLE
feat(mcp): read-only freshness signal + honest stale-session messaging

### DIFF
--- a/crates/uffs-cli/src/commands/system_status.rs
+++ b/crates/uffs-cli/src/commands/system_status.rs
@@ -388,7 +388,14 @@ fn print_mcp_stdio_sessions() {
         );
     }
     if any_stale {
-        println!("  Run `uffs --mcp reload` to restart stale sessions.");
+        // Deliberately NO action hint: these stdio sessions are spawned and
+        // OWNED by their AI host (Claude/Cursor/…), not by the user. A human
+        // running `uffs --mcp reload` would only sever the host's live link —
+        // false hope. The host picks up the new binary when it next relaunches
+        // the session; the agent is told this via the MCP server instructions.
+        println!(
+            "  These run an older binary; the AI host that launched them refreshes on its next start."
+        );
     }
 }
 

--- a/crates/uffs-mcp/src/handler/instructions.rs
+++ b/crates/uffs-mcp/src/handler/instructions.rs
@@ -35,7 +35,8 @@ TOOLS (all read-only):
   what exists.
 • uffs_info     — Full metadata for a single file/directory by path.
 • uffs_drives   — List indexed drives with record counts.
-• uffs_status   — Daemon health, uptime, memory, loading progress.
+• uffs_status   — Daemon health, uptime, memory, loading progress, and the \
+  running UFFS server version (see STAYING CURRENT).
 
 QUERY STRATEGY (minimize round-trips):
 1. Start with uffs_aggregate preset='overview' to get the lay of the land.
@@ -124,4 +125,13 @@ paths, and metadata.  For content search, suggest ripgrep or similar.
 PROMPTS (guided multi-step workflows):
 find_large_files, find_by_extension, disk_usage_report, cleanup_report, \
 recent_changes, duplicate_investigation, subtree_analysis.
+
+STAYING CURRENT:
+uffs_status reports `server_version` — the UFFS build serving you. UFFS ships \
+frequent improvements and can self-update. Treat `uffs --update` as a quick, \
+safe, one-shot refresh the USER runs themselves (it stops/swaps binaries) — so \
+if it's worth staying current, SUGGEST it to the user; never run it yourself \
+(these tools are read-only). Note: an update refreshes the on-disk binaries, \
+but YOUR session keeps its current `server_version` until its host relaunches \
+the MCP server — so a version bump shows up on your next launch, not mid-session.
 ";

--- a/crates/uffs-mcp/src/schemas.rs
+++ b/crates/uffs-mcp/src/schemas.rs
@@ -131,6 +131,11 @@ pub(crate) struct StatusOutput {
     pub connections: usize,
     /// Daemon process ID.
     pub pid: u32,
+    /// Version of the running `uffsmcp` server binary (e.g. `"0.6.10"`). Lets
+    /// an agent see which UFFS build is serving it. UFFS can self-update,
+    /// so an occasional `uffs --update` (run by the user) keeps
+    /// capabilities current — see the server instructions.
+    pub server_version: String,
 }
 
 // ── uffs_aggregate ──────────────────────────────────────────────────

--- a/crates/uffs-mcp/src/tools/status.rs
+++ b/crates/uffs-mcp/src/tools/status.rs
@@ -22,8 +22,12 @@ pub(crate) async fn run(client: &mut UffsClient) -> Result<CallToolResult, Bridg
 
     let status_str = serde_json::to_string_pretty(&response.status)?;
 
+    // The running `uffsmcp` build version — a read-only freshness signal the
+    // agent can surface (UFFS self-updates via `uffs --update`).
+    let server_version = env!("CARGO_PKG_VERSION");
+
     let text = format!(
-        "Daemon Status: {status_str}\nUptime: {}s\nConnections: {}\nPID: {}\n",
+        "Daemon Status: {status_str}\nUptime: {}s\nConnections: {}\nPID: {}\nUFFS server version: {server_version}\n",
         response.uptime_secs, response.connections, response.pid
     );
 
@@ -32,6 +36,7 @@ pub(crate) async fn run(client: &mut UffsClient) -> Result<CallToolResult, Bridg
         uptime_secs: response.uptime_secs,
         connections: response.connections,
         pid: response.pid,
+        server_version: server_version.to_owned(),
     };
 
     let mut result = CallToolResult::success(vec![Content::text(text)]);


### PR DESCRIPTION
## Why

Version-freshness should reach the audience that can actually act on it — the **LLM host** — and not appear as false hope to a human. Two coupled changes.

## 1. `uffs --status`: stop pointing a human at a button that severs a live session

MCP **stdio sessions** are spawned and OWNED by their AI host (Claude/Cursor/…). Telling a human to `uffs --mcp reload` them just kills the host's live link. The line now states the fact, with no action verb:

```
- Run `uffs --mcp reload` to restart stale sessions.
+ These run an older binary; the AI host that launched them refreshes on its next start.
```

(The **managed HTTP gateway** stale hint is unchanged — that one genuinely is user-restartable.)

## 2. MCP surface: a read-only freshness signal for the agent

- `uffs_status` structured output adds **`server_version`** (the running `uffsmcp` build); the text output prints it too.
- `AGENT_INSTRUCTIONS` gain a **STAYING CURRENT** note: UFFS self-updates; `uffs --update` is a quick one-shot the USER runs; if staying current matters, **suggest** it — never run it (tools stay read-only); a version bump shows up on the agent's **next launch**, not mid-session.

## Constraints honored

- **All-read-only tool contract intact** — no new mutating tool.
- **No network calls** — `server_version` is the compiled-in version.

## Tests

Builds clean; all `uffs-mcp` tests pass; clippy clean on both touched crates.