### PR TITLE
fix(self-update): stop a non-elevated repair from fabricating a broker failure

### DIFF
--- a/crates/uffs-update/src/doctor.rs
+++ b/crates/uffs-update/src/doctor.rs
@@ -382,7 +382,18 @@ fn count_stale_backups(dir: &Path) -> usize {
 fn check_services(snapshot: &plan::Snapshot, repair: bool, report: &mut Report) {
     let mut down = Vec::new();
     for running in &snapshot.running {
-        if proc::is_alive(running.pid) {
+        // The broker runs as a LocalSystem service. A non-elevated uffs-update
+        // can't `OpenProcess` a SYSTEM-owned pid, so `proc::is_alive` false-
+        // negatives on it — which would flag a perfectly healthy broker as
+        // "down" and then trigger a doomed (also elevation-gated) restart.
+        // Its authoritative liveness is the serving pipe (what check_broker
+        // probes too), so use that for the broker instead of pid liveness.
+        let alive = if running.component == "broker" {
+            restore::broker_pipe_ready(DOCTOR_PIPE_PROBE_MS)
+        } else {
+            proc::is_alive(running.pid)
+        };
+        if alive {
             report.add(
                 Health::Ok,
                 format!("Service up: {}", running.component),

--- a/crates/uffs-update/src/restore.rs
+++ b/crates/uffs-update/src/restore.rs
@@ -62,7 +62,15 @@ fn start_component(component: &str, running: &SnapRunning) -> bool {
 /// wait until the pipe is actually serving (R10, §19.13). Service-RUNNING
 /// is necessary but not sufficient: the daemon's warm-up hits
 /// `ERROR_PIPE_BUSY` if it connects before the broker's pipe is listening.
+///
+/// Idempotent: if the broker is **already serving**, it's up — and a
+/// non-elevated caller can neither need nor (via SCM) perform a start of a
+/// `LocalSystem` service. Treat that as success so a redundant, elevation-gated
+/// `uffs_winsvc::start` failure can't surface as a fault on a healthy broker.
 fn start_broker() -> bool {
+    if broker_pipe_ready(PIPE_READY_TIMEOUT_MS) {
+        return true;
+    }
     uffs_winsvc::start(SERVICE_NAME).is_ok() && broker_pipe_ready(PIPE_READY_TIMEOUT_MS)
 }
 


### PR DESCRIPTION
## Symptom

`uffs --update repair` (run **non-elevated** — by design; the Access Broker exists precisely so the daemon/updater run without UAC) reports a hard failure for a broker that is perfectly healthy:

```
[FAIL] Service restart failed   broker
[ OK ] Broker pipe serving          ← same report!
summary: 11 ok, 0 warning(s), 1 failure(s)   → exit 1
```

Confirmed healthy out-of-band: `uffs-broker --status` → `State: running, PID 1536, Pipe: serving`.

## Root cause

The broker runs as a **LocalSystem service**. A non-elevated `uffs-update` can't `OpenProcess` a SYSTEM-owned PID, so `proc::is_alive(pid)` false-negatives → the broker is flagged "down" → `restore` tries to `uffs_winsvc::start` it → that **also** needs elevation → fails → hard `[FAIL]`. The broker was up the whole time.

## Fix (two surgical changes)

- **doctor `check_services`:** judge the broker's liveness by its **serving pipe** (the authoritative signal `check_broker` already uses), not by PID `OpenProcess` liveness. A serving broker reads `Service up: broker` and never enters the down/restart path.
- **restore `start_broker`:** make it **idempotent** — already serving ⇒ return success without an elevation-gated `uffs_winsvc::start`. Also hardens the quiesce→restore path.

Net: a non-elevated repair/restore no longer invents a broker failure when the broker is up; it only acts when the pipe is genuinely not serving.

## Verification

Builds + 46 `uffs-update` tests green, clippy clean, `x86_64-pc-windows-msvc` cross-compile OK.