### PR TITLE
docs: steer Windows/WinGet users to `uffs --update` over `winget upgrade`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,12 @@ uffs --update repair                    # diagnose + self-heal
 uffs --update apply --version v0.6.5    # pin / roll back to a specific release
 ```
 
-> **WinGet installs** update with `winget upgrade SkyLLC.UFFS` instead — UFFS
-> defers to WinGet for WinGet-managed installs.
+> **WinGet installs:** prefer `uffs --update` here too. `winget upgrade
+> SkyLLC.UFFS` can fail with `remove_all: Access is denied` — the running
+> daemon and broker hold open the very binaries WinGet tries to replace.
+> `uffs --update` stops those services first, then swaps, so it's the reliable
+> path. (If you do run `winget upgrade`, stop UFFS first — elevated
+> `uffs --daemon stop` + `uffs-broker --stop`.)
 
 > 📖 **[Full update guide](docs/user-manual/updating.md)** — every action, version pinning/rollback, the health check, and edge cases.
 

--- a/docs/user-manual/updating.md
+++ b/docs/user-manual/updating.md
@@ -11,9 +11,14 @@ inconsistent — it downloads, SHA-256-verifies, and atomically swaps every core
 binary in place (journaled, with automatic rollback on failure). If you're
 already current, it does nothing and touches no services.
 
-> **WinGet installs:** if you installed via `winget install SkyLLC.UFFS`, update
-> with `winget upgrade SkyLLC.UFFS` instead — UFFS detects a WinGet-managed
-> install and defers to WinGet rather than swapping those files itself.
+> **WinGet installs:** use `uffs --update` here too — it updates the WinGet
+> install in place (the binaries live in a per-user `…\WinGet\Links` location
+> UFFS treats as an ordinary unmanaged install). Prefer it over `winget upgrade
+> SkyLLC.UFFS`, which can fail with `remove_all: Access is denied` because the
+> running daemon and broker hold the binaries open while WinGet tries to replace
+> them. `uffs --update` stops those services first, then swaps. If you do want
+> `winget upgrade`, stop UFFS first: elevated `uffs --daemon stop` +
+> `uffs-broker --stop`.
 
 ---
 


### PR DESCRIPTION
## Why

Real-device Windows testing showed `winget upgrade SkyLLC.UFFS` fails:

```
remove_all: Access is denied … \WinGet\Packages\…\uffs-windows-x64
Installer failed with exit code: 0x8a150003
```

The running daemon/broker hold the binaries open, so WinGet can't replace in-use files. Worse, the old docs *steered WinGet users to that failing path* and claimed UFFS "defers to WinGet for WinGet-managed installs" — which is inaccurate: the WinGet binaries live in a per-user `…\WinGet\Links` path UFFS treats as an ordinary **unmanaged** install, and `uffs --update` swaps them directly (stopping services first).

## Change

Update the README's Updating section and `docs/user-manual/updating.md` to:
- recommend `uffs --update` for WinGet installs (it works in place),
- document the `winget upgrade` lock failure, and
- give the stop-services-first workaround for anyone who insists on `winget upgrade`.

Docs-only.