### PR TITLE
chore: release v0.6.14 — ship pipeline auto-commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"
@@ -3380,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64",
@@ -3411,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4373,7 +4373,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uffs-bench"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "chrono",
  "clap",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4401,14 +4401,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "chrono",
  "itoa",
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -4571,7 +4571,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -4581,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "axum",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4642,14 +4642,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4664,18 +4664,18 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.6.13"
+version = "0.6.14"
 
 [[package]]
 name = "uffs-update"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -4693,7 +4693,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-winsvc"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "windows 0.62.2",
@@ -4807,9 +4807,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5023,9 +5023,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.6.13"
+version = "0.6.14"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -126,28 +126,28 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.6.13" }
-uffs-security = { path = "crates/uffs-security", version = "0.6.13" }
-uffs-text = { path = "crates/uffs-text", version = "0.6.13" }
-uffs-time = { path = "crates/uffs-time", version = "0.6.13" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.6.13" }
-uffs-format = { path = "crates/uffs-format", version = "0.6.13" }
-uffs-core = { path = "crates/uffs-core", version = "0.6.13" }
-uffs-client = { path = "crates/uffs-client", version = "0.6.13" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.6.14" }
+uffs-security = { path = "crates/uffs-security", version = "0.6.14" }
+uffs-text = { path = "crates/uffs-text", version = "0.6.14" }
+uffs-time = { path = "crates/uffs-time", version = "0.6.14" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.6.14" }
+uffs-format = { path = "crates/uffs-format", version = "0.6.14" }
+uffs-core = { path = "crates/uffs-core", version = "0.6.14" }
+uffs-client = { path = "crates/uffs-client", version = "0.6.14" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.13" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.14" }
 # `uffs-winsvc` — native Windows service control (SCM query/start/stop) +
 # the non-connecting broker-pipe readiness probe.  Layer-0 leaf: its only
 # dependency is the `windows` crate (windows-target), with non-Windows
 # stubs so cross-platform consumers (uffs-update, uffs-cli) compile.
 # Single source of truth for the `sc`/SCM mechanics previously duplicated
 # across uffs-broker, uffs-update, and uffs-cli.
-uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.13" }
+uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.14" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace
@@ -232,10 +232,10 @@ zerocopy = { version = "0.8", features = ["derive"] }
 
 # ───── Error Handling ─────
 thiserror = "2.0.18"
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 
 # ───── MCP (Model Context Protocol) ─────
-rmcp = { version = "1.7.0", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "1.8.0", features = ["server", "transport-io", "macros"] }
 schemars = "1.2.1"
 
 # ───── HTTP / Tower (for MCP Streamable HTTP gateway) ─────
@@ -281,7 +281,7 @@ dirs-next = "2.0.0"
 # daemon binary when the client auto-spawns it.  Workspace-scoped for
 # version consistency across any future consumers (e.g. `uffs-client`
 # when async spawn lands).
-which = "8.0.3"
+which = "8.0.4"
 
 # `strsim` — small, zero-dep Levenshtein impl (already in the tree +
 # audited by Google/Mozilla).  Used by `uffs-cli` to suggest the nearest
@@ -299,8 +299,9 @@ hex = "0.4.3"
 
 # ───── Network (self-update acquire helper only) ─────
 # Blocking HTTP with rustls + the system trust store. `rustls-tls-native-roots`
-# matches the existing transitive reqwest config so no new crate enters the lock.
-reqwest = { version = "0.12", default-features = false, features = [
+# matches the existing transitive reqwest config, so no new crate enters the lock.
+# Version 0.13.4 cannot be used at this time ... missing "rustls-tls-native-roots"
+reqwest = { version = "0.12.28", default-features = false, features = [
   "blocking",
   "rustls-tls-native-roots",
   "json",
@@ -312,7 +313,7 @@ crossbeam-channel = "0.5.15"
 
 # ───── Memory ─────
 mimalloc = "0.1.52"
-memmap2 = "0.9.10"
+memmap2 = "0.9.11"
 
 # ───── System ─────
 libc = "0.2"
@@ -324,7 +325,7 @@ hostname = "0.4.2"
 num_cpus = "1.17.0"
 # Random unique identifiers.  Only the `v4` (random) feature is enabled
 # workspace-wide; consumers that need v1/v5/v7 etc. re-add the feature.
-uuid = { version = "1.23.3", features = ["v4"] }
+uuid = { version = "1.23.4", features = ["v4"] }
 
 # ───── Security / Crypto ─────
 aes-gcm = "0.10"

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/main.rs"
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-client = { path = "../uffs-client", version = "0.6.13", default-features = false }
+uffs-client = { path = "../uffs-client", version = "0.6.14", default-features = false }
 
 # Canonical CSV / parity / legacy-footer writer.  Direct dep (not a
 # re-export chain through `uffs-client`) so the CLI and the daemon
@@ -77,7 +77,7 @@ uffs-client = { path = "../uffs-client", version = "0.6.13", default-features = 
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-format = { path = "../uffs-format", version = "0.6.13" }
+uffs-format = { path = "../uffs-format", version = "0.6.14" }
 
 # Typed drive-letter newtype.  Direct dep so the CLI command signatures
 # (`daemon_load`, `daemon_tiering`, etc.) name `DriveLetter` natively

--- a/crates/uffs-mcp/src/handler/mod.rs
+++ b/crates/uffs-mcp/src/handler/mod.rs
@@ -350,6 +350,14 @@ impl ServerHandler for UffsMcpServer {
     )]
     async fn on_roots_list_changed(&self, context: rmcp::service::NotificationContext<RoleServer>) {
         // Ask the client for the current list of roots.
+        #[expect(
+            deprecated,
+            reason = "rmcp 1.8.0 deprecated Peer::list_roots per MCP SEP-2577 (the Roots \
+                      capability is being phased out). It still functions, and uffs-mcp's \
+                      roots -> NTFS-prefix mapping depends on it; there is no replacement API \
+                      yet. Migrate or drop the roots feature when rmcp removes the method (at \
+                      which point this becomes a hard error, not a silenced warning)."
+        )]
         match context.peer.list_roots().await {
             Ok(result) => {
                 let mut state = self.roots.write().await;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -32,7 +32,7 @@
 # Run `just toolchain-sync` to re-attempt a channel bump; the CI
 # pipeline auto-refreshes on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed.
-channel = "nightly-2026-06-20"
+channel = "nightly-2026-06-26"
 
 # Specify components that should always be available
 components = [

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,6 +1,12 @@
 
 # cargo-vet audits file
 
+[[audits.anyhow]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.102 -> 1.0.103"
+notes = "Delta audit (cargo vet diff). Source changes: src/error.rs + src/lib.rs (test_context.rs is test-only). error.rs reworks the two type-erased downcast helpers to replace intermediate reference creation (deref() then &_object.context/error) with raw-pointer field projection (ptr::addr_of! + Ref::from_raw(NonNull::new_unchecked(..))) -- a soundness improvement that avoids forming references into a possibly-aliased erased object; downcast logic otherwise identical. lib.rs is only the html_root_url version bump. No new unsafe blocks, no new fs/net/process/FFI/ambient-capability surface. Patch release by dtolnay (anyhow maintainer)."
+
 [[audits.assert_cmd]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-run"
@@ -307,11 +313,23 @@ criteria = "safe-to-deploy"
 delta = "1.6.0 -> 1.7.0"
 notes = "Inspected 1.6.0->1.7.0 source diff (8 .rs files, ~50 lines of net change). No new unsafe blocks, no new fs/net/process/FFI surface, no crypto/auth/permission changes. Notable shifts: (a) JsonRpcError.id widened to Option<RequestId> per MCP 2025-11-25 error-response spec; (b) PromptMessageContent::Resource flattened to fix a JSON shape bug (with regression test); (c) async_rw transport switched from FramedRead to BufReader + manual line decode, adding parse-error recovery (sends JSON-RPC -32700 and continues instead of terminating) AND UTF-8 BOM stripping (RFC 8259 §8.1); (d) Cargo.toml narrows chrono to default-features=false + only the 'now' feature (surface reduction). All changes match the published CHANGELOG and are robustness improvements."
 
+[[audits.rmcp]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.7.0 -> 1.8.0"
+notes = 'Delta audit (cargo vet diff, 17 src files). Verified zero `unsafe` in src/ in BOTH versions, build.rs byte-identical, and every powerful-import count unchanged (std::process=1, Command::new=5, std::net=0, std::fs=0, from_raw=3, include_str=1, include_bytes=0) -- no new ambient authority. Changes: (a) new handler/server/common.rs::schema_for_input which generates a JSON schema, validates the root is type "object" per MCP spec and strips top-level title/description, caches per-TypeId and returns Result (the error rmcp-macros now unwraps); (b) MCP protocol/model refinements (model/capabilities, elicitation_schema, tool; service client/server); (c) transport/auth.rs (OAuth2 client) refactor that ADDS hardening -- a 30s request timeout, a 1 MiB cap on OAuth HTTP response bodies, and an explicit OAuthHttpRedirectPolicy; reqwest was already a 1.7.0 dependency; (d) streamable-http and unix-socket client transports treat an empty 2xx success as 202 Accepted for notification/response/error messages (spec compatibility). New regression tests added. No new unsafe, fs, process, or net capability. Minor release by alexhancock (rmcp maintainer).'
+
 [[audits.rmcp-macros]]
 who = "Robert Nio <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.6.0 -> 1.7.0"
 notes = "Pure version-sync release: zero source code changes between 1.6.0 and 1.7.0 (verified via 'diff -qr' over the src/ trees). Only .cargo_vcs_info.json, CHANGELOG.md, Cargo.lock, and the version string in Cargo.toml differ. rmcp-macros is bumped in lockstep with the parent rmcp crate's 1.7.0 release."
+
+[[audits.rmcp-macros]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.7.0 -> 1.8.0"
+notes = "Delta audit (cargo vet diff). Single source change: src/tool.rs -- the tool proc-macro now emits rmcp::handler::server::common::schema_for_input::<T>().unwrap_or_else(|e| panic!(..)) in place of schema_for_type::<T>(), so the generated tool-registration code fails fast with a clear message when an input schema is invalid. Generated code adds no unsafe/fs/net/process surface (a schema lookup plus a dev-facing panic at registration time). Lockstep release with rmcp 1.8.0 by alexhancock (rmcp maintainer)."
 
 [[audits.rustls]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -373,11 +391,23 @@ criteria = "safe-to-deploy"
 delta = "1.23.2 -> 1.23.3"
 notes = "Patch bump reviewed: src/error.rs REMOVES an unsafe std::str::from_utf8_unchecked in the parse-error formatter (uses the already-safe &str input instead) — a net safety improvement; equivalent slice-pattern refactor; parser.rs adds parse-error tests; remainder is version/doc/WASM-dev-fixture bumps. No new unsafe, network, fs, or process surface."
 
+[[audits.uuid]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.23.3 -> 1.23.4"
+notes = "Delta audit (cargo vet diff). Source changes: src/lib.rs adds a docsrs-gated #![cfg_attr(docsrs, feature(doc_cfg))] (affects only docs.rs builds) plus version/html_root_url string bumps; src/external/serde_support.rs is intra-doc-link doc-comment fixes only. No runtime/logic change, no new unsafe, network, fs, process, or FFI surface. Patch release by KodrAus (uuid maintainer)."
+
 [[audits.which]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "8.0.2 -> 8.0.3"
 notes = "Reviewed full diff (4 files). Only code change: cfg-gated fallback is_valid_executable returning Ok(false) on targets that are not unix/windows/wasi/redox, enabling compilation there; conservative default, no unsafe, no new I/O or capabilities. Rest is changelog + version metadata."
+
+[[audits.which]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "8.0.3 -> 8.0.4"
+notes = "Delta audit (cargo vet diff). Source changes: src/error.rs adds a new NonFatalError::PathExtNotPopulated variant (the enum is #[non_exhaustive]) plus its Display arm; src/finder.rs reports it via the non-fatal error handler when, on Windows, PATHEXT is empty AND the queried name has no extension. Reuses already-available inputs (Sys::env_windows_path_ext, PathBuf::extension); purely additive diagnostic. No new unsafe, I/O, process, or ambient-capability surface. Patch release by Xaeroxe (which maintainer)."
 
 [[audits.yoke]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.6.14** — the `[workspace.package].version` bump in `Cargo.toml`.  This PR routes that commit through branch-protection rules.  Once it merges to `main`, run `just release-tag` to cut the signed `v0.6.14` tag, which fires `release.yml` and builds the cross-platform binaries + GitHub Release v0.6.14.  (No auto-tag on merge — the tag step is manual on-demand, Path B.)

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

The auto-commit lived only on `release/v0.6.14`, so local `main` never drifted — sync it with a plain `git pull --ff-only origin main` (no `reset --hard` needed).