### PR TITLE
ci(pr-fast): run heavy jobs only in the merge queue, not on every PR

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -336,12 +336,25 @@ jobs:
   # sanity — `cargo check` + `cargo-vet`.  The fastest compile gate;
   # downstream heavy jobs `needs: sanity` so a type error aborts before
   # paying for clippy / tests / Windows.
+  #
+  # Heavy jobs (sanity / clippy{,-no-default} / docs / test-build / tests /
+  # security / windows-lint) carry `&& github.event_name != 'pull_request'`
+  # so they run ONLY on `merge_group` (the merge queue) and `push` (main),
+  # not on the PR itself.  Rationale: the merge queue revalidates every PR
+  # against current `main` before merging, so a `pull_request` run is a
+  # redundant second pass — the contributor's local `lint-pre-push` gate
+  # already ran the same full suite before the push.  Running heavy CI once,
+  # in the queue, halves Rust-PR CI without losing safety.  The `required`
+  # aggregator below treats these jobs' `skipped` (on PRs) as a pass, so a
+  # PR still goes green and can enter the queue; on `merge_group` they run
+  # for real and gate the merge.  Cheap checks (fmt / file-size / drift /
+  # classify) stay on `pull_request` for fast author feedback.
   # ─────────────────────────────────────────────────────────────────────
   sanity:
     name: Sanity (cargo check + vet)
     runs-on: ubuntu-22.04
     needs: classify
-    if: needs.classify.outputs.code == 'true'
+    if: needs.classify.outputs.code == 'true' && github.event_name != 'pull_request'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -383,7 +396,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-22.04
     needs: [classify, sanity]
-    if: needs.classify.outputs.code == 'true'
+    if: needs.classify.outputs.code == 'true' && github.event_name != 'pull_request'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -415,7 +428,7 @@ jobs:
     name: Clippy (--no-default-features)
     runs-on: ubuntu-22.04
     needs: [classify, sanity]
-    if: needs.classify.outputs.code == 'true'
+    if: needs.classify.outputs.code == 'true' && github.event_name != 'pull_request'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -445,7 +458,7 @@ jobs:
     name: Rustdoc + doctests
     runs-on: ubuntu-22.04
     needs: [classify, sanity]
-    if: needs.classify.outputs.code == 'true'
+    if: needs.classify.outputs.code == 'true' && github.event_name != 'pull_request'
     timeout-minutes: 30
     env:
       RUSTDOCFLAGS: "-Dwarnings"
@@ -478,7 +491,7 @@ jobs:
     name: Test build
     runs-on: ubuntu-22.04
     needs: [classify, sanity]
-    if: needs.classify.outputs.code == 'true'
+    if: needs.classify.outputs.code == 'true' && github.event_name != 'pull_request'
     timeout-minutes: 30
     env:
       # `debuginfo=1` for useful backtraces without paying the full
@@ -517,7 +530,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-22.04
     needs: [classify, test-build]
-    if: needs.classify.outputs.code == 'true'
+    if: needs.classify.outputs.code == 'true' && github.event_name != 'pull_request'
     timeout-minutes: 30
     env:
       # Must match test-build exactly so the cargo fingerprint lines up
@@ -561,7 +574,7 @@ jobs:
     name: Security (deny + vet)
     runs-on: ubuntu-22.04
     needs: classify
-    if: needs.classify.outputs.code == 'true'
+    if: needs.classify.outputs.code == 'true' && github.event_name != 'pull_request'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -643,7 +656,7 @@ jobs:
     name: Windows clippy
     runs-on: windows-latest
     needs: [classify, sanity]
-    if: needs.classify.outputs.code == 'true'
+    if: needs.classify.outputs.code == 'true' && github.event_name != 'pull_request'
     timeout-minutes: 25
     env:
       # Windows-appropriate target-cpu baseline (same as release.yml's


### PR DESCRIPTION
## Why

With the merge queue live, the heavy `pr-fast.yml` jobs (`sanity`, `clippy` ×2, `rustdoc`, `test-build`, `tests`, `security`, `windows-lint`) ran the **full Rust suite twice per PR**: once on `pull_request` (branch in isolation) and again on `merge_group` (against current main). The `pull_request` pass is redundant — the queue revalidates against main before merging, and the contributor's local `lint-pre-push` gate already ran the same suite before the push.

## What

Gate the 8 heavy jobs with `&& github.event_name != 'pull_request'` so they run only on `merge_group` (queue) and `push` (main). Cheap checks (`fmt` / `file-size` / drift / `classify`) stay on `pull_request` for fast author feedback.

The `required` aggregator already treats `skipped` as a pass (`case "$r" in success|skipped) ✅`), so on a PR the heavy jobs skip → `required` is green → the PR enters the queue; on `merge_group` they run for real and gate the merge.

**Effect:** Rust-PR CI runs the heavy suite **once** instead of twice — no loss of safety (the queue is the authoritative validation against current main).

> This PR is workflow-only (no `code` change), so its own heavy jobs skip on both events regardless; the dedup is observable on the next Rust PR.