### PR TITLE
docs(readme): canonicalize benchmark blog link to uffs.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Every clip runs the **real binary** against real NTFS data with unedited timings
 
 ## Benchmark snapshot (v0.5.120 · June 2026)
 
-📖 **The story behind these numbers:** [*I benchmarked my Rust file search engine against Everything until I ran out of excuses*](https://skyllc-ai.github.io/blog/benchmarking-against-everything/) — the methodology I had to fix first, the bulk-export workload Everything's CLI can't run, and the two regressions published anyway.
+📖 **The story behind these numbers:** [*I benchmarked my Rust file search engine against Everything until I ran out of excuses*](https://uffs.io/blog/benchmarking-against-everything/) — the methodology I had to fix first, the bulk-export workload Everything's CLI can't run, and the two regressions published anyway.
 
 Measured 2026-06-11 on AMD Ryzen 9 3900XT, 64 GB RAM, Windows 11 Pro 24H2 — cross-tool on four NTFS volumes (C/D/F/G, 12.8 M records, the Everything-RAM-budget-negotiated set), full-scan on all seven (25.9 M records; that workload is UFFS-only, so the negotiation doesn't constrain it). Raw data: [`cross-tool-summary.csv`](docs/benchmarks/raw/2026-06-v0.5.120_cross-tool-summary.csv) · [`full-scan-all-drives.csv`](docs/benchmarks/raw/2026-06-v0.5.120_full-scan-all-drives.csv). Publication-grade report: [**docs/benchmarks/**](docs/benchmarks/).
 


### PR DESCRIPTION
Repoint the README benchmark blog link from `skyllc-ai.github.io` to the
canonical `uffs.io` domain (the old URL now 301-redirects).

Supersedes #482, whose branch was a stale fork that also carried an old,
unsigned snapshot of the incremental-index-maintenance work (now landed,
signed, via #483). This PR is just the 1-line link change, signed, off
current `main`.