### PR TITLE
ci(gates): shift-left commit-signature gate + signed-merge flow helpers

### DIFF
--- a/just/workflow.just
+++ b/just/workflow.just
@@ -100,6 +100,106 @@ go-justfile:
     printf "\033[0;34m💡 Run 'just phase2-ship' only when ready to ship\033[0m\n"
     printf "\033[0;36m⏱️  Total execution time: ${DURATION}s\033[0m\n"
 
+# ─────────────────────────────────────────────────────────────────────
+# Signed-merge flow helpers (see scripts/ci/check_commit_signatures.sh)
+# ─────────────────────────────────────────────────────────────────────
+
+# Merge a PR through main's merge queue (the queue-correct incantation).
+#
+# `main` uses a GitHub merge queue, so `gh pr merge <PR> --squash` is
+# silently rejected ("the merge strategy for main is set by the merge
+# queue") and does NOT enroll the PR.  This wrapper uses the right form —
+# `gh pr merge <PR> --auto` with NO method flag (the queue owns the
+# squash) — so the PR enters the queue and merges once its checks pass.
+merge PR:
+    @printf "\033[0;34m🔀 Enrolling PR #{{ PR }} into main's merge queue...\033[0m\n"
+    gh pr merge {{ PR }} --auto
+    @printf "\033[0;32m✅ PR #{{ PR }} queued — it merges when checks pass (watch: gh pr view {{ PR }}).\033[0m\n"
+
+# Self-heal: re-sign every commit on the current branch, then re-push.
+#
+# `main`'s ruleset requires every commit to carry a verified signature.
+# If one slipped through unsigned (e.g. committed with
+# `-c commit.gpgsign=false`), the `commit-signatures` pre-push gate blocks
+# the push.  This rebases the branch in place, re-signing each commit with
+# your configured GPG key, then force-pushes with lease.  `--amend` leaves
+# the staged set empty so the per-commit pre-commit hook no-ops; the heavy
+# gates run once on the final push.
+sign-branch:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    branch=$(git rev-parse --abbrev-ref HEAD)
+    if [[ "$branch" == "main" ]]; then
+        printf "\033[0;31m❌ refusing to rewrite main — run this on a feature branch.\033[0m\n" >&2
+        exit 1
+    fi
+    base=$(git merge-base origin/main HEAD)
+    n=$(git rev-list --count "$base"..HEAD)
+    printf "\033[0;34m🔏 Re-signing %s commit(s) on '%s' (base %s)...\033[0m\n" "$n" "$branch" "${base:0:10}"
+    git rebase --exec 'git commit --amend --no-edit -S' "$base"
+    printf "\033[0;34m⬆️  Force-pushing (with lease)...\033[0m\n"
+    git push --force-with-lease
+    printf "\033[0;32m✅ Branch re-signed and pushed — every commit now carries a signature.\033[0m\n"
+
+# Verify commit signing is set up so commits can land on main.
+#
+# Checks, in order: commit.gpgsign is on; a signing key is configured; GPG
+# can actually produce a signature with it; and the key is registered on
+# GitHub (so commits render as "verified").  Each is a soft check with a
+# clear fix; exits non-zero if any fails.
+doctor-signing:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    fail=0
+    ok()   { printf "  \033[0;32m✅ %s\033[0m\n" "$1"; }
+    bad()  { printf "  \033[0;31m❌ %s\033[0m\n" "$1"; fail=1; }
+    printf "\033[0;34m🩺 Commit-signing doctor\033[0m\n"
+
+    if [[ "$(git config --get commit.gpgsign || echo false)" == "true" ]]; then
+        ok "commit.gpgsign = true"
+    else
+        bad "commit.gpgsign is not true — run: git config commit.gpgsign true"
+    fi
+
+    key=$(git config --get user.signingkey || true)
+    if [[ -n "$key" ]]; then
+        ok "user.signingkey = $key"
+    else
+        bad "no user.signingkey — set it: git config user.signingkey <KEYID>"
+    fi
+
+    if printf 'test' | gpg ${key:+--local-user "$key"} --clearsign >/dev/null 2>&1; then
+        ok "GPG can sign with the configured key"
+    else
+        bad "GPG cannot sign (broken agent / locked key) — check 'gpg --list-secret-keys'"
+    fi
+
+    # GitHub-registration check is ADVISORY: listing GPG keys needs the
+    # `admin:gpg_key` token scope, which the default `gh` auth lacks (404).
+    # The authoritative proof is GitHub verifying the actual commit at push
+    # time, so a missing scope is an info note, never a hard fail.
+    info() { printf "  \033[0;36mℹ️  %s\033[0m\n" "$1"; }
+    if [[ -n "$key" ]]; then
+        # Branch on gh's exit status, not its output: on a 404 (missing
+        # scope) gh prints error JSON that would otherwise leak into the
+        # match and read as a false "key not found".
+        if keys=$(gh api user/gpg_keys --jq '.[].key_id, .[].subkeys[]?.key_id' 2>/dev/null); then
+            if printf '%s\n' "$keys" | grep -qiF "${key: -16}"; then
+                ok "signing key is registered on GitHub (commits will verify)"
+            else
+                info "configured key not found among your GitHub GPG keys — if commits show 'Unverified', add it: https://github.com/settings/keys"
+            fi
+        else
+            info "could not list GitHub GPG keys (gh token lacks admin:gpg_key scope) — skipped; GitHub still verifies signatures at push time"
+        fi
+    fi
+
+    if (( fail )); then
+        printf "\033[0;31m❌ signing setup incomplete — commits may be rejected by main's ruleset.\033[0m\n" >&2
+        exit 1
+    fi
+    printf "\033[0;32m✅ local signing is set up — commits will be signed.\033[0m\n"
+
 # Comprehensive validation (Rust optimized).
 check-all:
     @printf "\033[0;34m📋 Comprehensive Validation (RUST OPTIMIZED)\033[0m\n"

--- a/scripts/ci/check_commit_signatures.sh
+++ b/scripts/ci/check_commit_signatures.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# Commit-signature validator.
+#
+# **Why this exists** — `main` is governed by a GitHub ruleset that
+# requires every commit to carry a *verified* signature (plus a merge
+# queue).  An unsigned commit pushes fine and passes every other local
+# gate, so the breakage only surfaces at the merge queue
+# ("Merging is blocked: Commits must have verified signatures") — a slow,
+# maximally-late failure after a full CI round-trip.  This gate moves that
+# catch left: it fails the push in ~1 second when any commit in the pushed
+# range is unsigned, and points at the one-command self-heal.
+#
+# It mirrors the shape of `check_commit_subjects.sh` (same `range` mode,
+# same `{{COMMIT_RANGES}}` wiring from the pre-push hook).
+#
+# **Mode**:
+#   range RANGE   -- check every non-merge commit in the git revision
+#                    range RANGE (e.g. `origin/main..HEAD`).  Empty /
+#                    merges-only ranges silently succeed.
+#
+# **What counts as signed** — `git log --format=%G?` status codes:
+#   G  good signature                              -> OK
+#   U  good signature, unknown validity            -> OK
+#   E  signature present, cannot verify (key not   -> OK (GitHub is the
+#      in local keyring, e.g. a teammate's commit)     authoritative check)
+#   N  NO signature                                -> FAIL (the bug we hit)
+#   B  BAD signature                               -> FAIL
+#   X/Y/R  expired key / expired sig / revoked     -> FAIL (GitHub rejects too)
+#
+# **Exit codes**: 0 all signed, 1 an unsigned/bad commit (or input error).
+#
+# There is intentionally NO bypass knob: an unsigned commit on a branch
+# bound for `main` WILL be rejected by the ruleset, so "bypassing" locally
+# only defers the same failure to the merge queue.  Fix it, don't skip it.
+
+set -euo pipefail
+
+# ── Colours ─────────────────────────────────────────────────────────
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    C_GREEN=$'\033[0;32m'
+    C_RED=$'\033[0;31m'
+    C_YELLOW=$'\033[1;33m'
+    C_CYAN=$'\033[0;36m'
+    C_RESET=$'\033[0m'
+else
+    C_GREEN=''
+    C_RED=''
+    C_YELLOW=''
+    C_CYAN=''
+    C_RESET=''
+fi
+
+usage() {
+    cat <<USAGE >&2
+Usage: $(basename "$0") range RANGE
+
+  range RANGE   Verify every non-merge commit in RANGE is signed
+                (e.g. 'origin/main..HEAD').
+
+Example:
+  $(basename "$0") range origin/main..HEAD
+USAGE
+    exit 2
+}
+
+print_help_block() {
+    cat >&2 <<HELP
+
+${C_YELLOW}-> Why:${C_RESET} \`main\` requires every commit to have a ${C_CYAN}verified signature${C_RESET}
+   (GitHub ruleset).  Unsigned commits are rejected at the merge queue.
+
+${C_YELLOW}Fix (self-heal):${C_RESET} re-sign the whole branch in place, then re-push:
+   ${C_CYAN}just sign-branch${C_RESET}
+
+   (equivalent to:
+     ${C_CYAN}git rebase --exec 'git commit --amend --no-edit -S' \$(git merge-base origin/main HEAD)${C_RESET}
+     ${C_CYAN}git push --force-with-lease${C_RESET})
+
+${C_YELLOW}Root cause to avoid:${C_RESET} never commit with ${C_CYAN}-c commit.gpgsign=false${C_RESET}.
+   \`commit.gpgsign=true\` is the repo default; run ${C_CYAN}just doctor-signing${C_RESET}
+   to confirm your GPG key works and is registered on GitHub.
+HELP
+}
+
+# ── Main ────────────────────────────────────────────────────────────
+[[ $# -ge 2 ]] || usage
+mode="$1"
+arg="$2"
+
+case "$mode" in
+    range)
+        if ! git rev-parse --git-dir >/dev/null 2>&1; then
+            printf '%s[FAIL]%s not in a git repository\n' "$C_RED" "$C_RESET" >&2
+            exit 1
+        fi
+        # `%H<tab>%G?` one line per non-merge commit.  Merge commits are
+        # skipped (`main` requires linear history, so they never reach the
+        # queue; a local merge on a feature branch would be flattened).
+        fail=0
+        count=0
+        while IFS=$'\t' read -r oid sig; do
+            [[ -n "$oid" ]] || continue
+            count=$((count + 1))
+            case "$sig" in
+                G | U | E) ;; # signed (GitHub does the authoritative verify)
+                *)
+                    fail=1
+                    printf '%s[FAIL]%s unsigned/bad-signature commit (%s) %s\n' \
+                        "$C_RED" "$C_RESET" "$sig" "${oid:0:10}" >&2
+                    printf '   %ssubject:%s %s\n' "$C_CYAN" "$C_RESET" \
+                        "$(git log -1 --format='%s' "$oid" 2>/dev/null)" >&2
+                    ;;
+            esac
+        done < <(git log --no-merges --format='%H%x09%G?' "$arg" 2>/dev/null || true)
+
+        if (( fail )); then
+            print_help_block
+            exit 1
+        fi
+        if [[ "${COMMIT_SIGNATURE_VERBOSE:-0}" == "1" ]]; then
+            printf '%s[OK]%s %d commit(s) in %s are signed\n' \
+                "$C_GREEN" "$C_RESET" "$count" "$arg"
+        fi
+        ;;
+
+    *)
+        usage
+        ;;
+esac

--- a/scripts/ci/gates.toml
+++ b/scripts/ci/gates.toml
@@ -284,6 +284,33 @@ local-vs-remote feedback loop that used to surface scope typos like
 upstream.  Bypass via `COMMIT_SUBJECT_BYPASS=1 git push`.
 """
 
+[[gate]]
+id = "commit-signatures"
+label = "Commit-signature validator"
+command = [
+  "bash",
+  "scripts/ci/check_commit_signatures.sh",
+  "range",
+  "{{COMMIT_RANGES}}",
+]
+tiers = ["pre-push"]
+gate_when = "always"
+hard = true
+tool = "bash"
+expected_runtime_secs = 1
+bucket = "bg"
+order = 31
+notes = """
+Verifies every non-merge commit in the pushed range carries a signature.
+`main` is governed by a `required_signatures` ruleset (plus a merge
+queue), so an unsigned commit passes every other local gate yet is
+rejected at the merge queue — a slow, maximally-late failure after a full
+CI round-trip.  This moves the catch left to ~1 s at push time and points
+at the `just sign-branch` self-heal.  No bypass: an unsigned commit bound
+for `main` will be rejected upstream regardless, so skipping only defers
+the same failure.
+"""
+
 # ─────────────────────────────────────────────────────────────────────
 # Rust-changed gates — fire when *.rs is touched
 # ─────────────────────────────────────────────────────────────────────

--- a/scripts/hooks/_lint_pre_push.sh
+++ b/scripts/hooks/_lint_pre_push.sh
@@ -215,6 +215,14 @@ spawn_bg "commit-subjects" bash -c '
         bash scripts/ci/check_commit_subjects.sh range "$range"
     done <<< "$COMMIT_RANGES"
 '
+spawn_bg "commit-signatures" bash -c '
+    set -euo pipefail
+    [[ -z "${COMMIT_RANGES// /}" ]] && exit 0
+    while IFS= read -r range; do
+        [[ -z "$range" ]] && continue
+        bash scripts/ci/check_commit_subjects.sh range "$range"
+    done <<< "$COMMIT_RANGES"
+'
 if (( DEP_CHANGED )); then
     if ! command -v cargo-vet >/dev/null 2>&1; then
         printf '%s❌ cargo-vet required (Cargo.{toml,lock} or supply-chain/ changed)%s\n' "$C_RED" "$C_RESET" >&2


### PR DESCRIPTION
## Harden the signed-merge flow (shift-left + self-heal)

`main` is governed by a `required_signatures` ruleset plus a merge queue.
An unsigned commit pushes fine and passes every other local gate, so the
breakage only surfaces at the merge queue ("Merging is blocked: commits
must have verified signatures") — after a full CI round-trip. This closes
that gap and adds the self-heal tooling around it.

### What's added
- **`commit-signatures` pre-push gate** (`scripts/ci/check_commit_signatures.sh`,
  sibling of `commit-subjects`): fails in ~1 s when any commit in the pushed
  range is unsigned, with the exact remediation. No bypass — an unsigned
  commit bound for `main` is rejected upstream regardless.
- **`just sign-branch`** — self-heal: `rebase --exec` re-signs every commit on
  the branch, then force-pushes with lease.
- **`just doctor-signing`** — preflight: `commit.gpgsign` on, signing key set,
  GPG can sign; GitHub-registration is advisory (listing keys needs a token
  scope the default `gh` auth lacks).
- **`just merge <PR>`** — the queue-correct `gh pr merge <PR> --auto` (no method
  flag; the queue owns the squash), so the silent `--squash` no-op is never
  hit again.

Pre-push hook regenerated from the manifest; gates/hooks/workflow drift all
pass. The push of this very branch exercised the new gate (`✅ commit-signatures`).