### PR TITLE
fix(mcp-validation): fold string sort checks UPPERCASE to match NTFS $UpCase

### DIFF
--- a/scripts/windows/mcp-validation.rs
+++ b/scripts/windows/mcp-validation.rs
@@ -1316,8 +1316,18 @@ fn validate_payload(result: &Value, checks: &PayloadChecks) -> Result<()> {
                 let sort_type = sc.sort_type.as_deref().unwrap_or("string");
 
                 if sort_type == "string" || sort_type == "str" {
+                    // Fold to UPPERCASE, not lowercase: UFFS sorts string
+                    // columns (name/path/ext) with the NTFS `$UpCase` table —
+                    // the filesystem-native collation Explorer and the NTFS
+                    // index B-tree use — which folds to uppercase. The ASCII
+                    // gap 0x5B..=0x60 (`[ \ ] ^ _ \``) sits BETWEEN `Z` (0x5A)
+                    // and `a` (0x61), so a char like `_` orders AFTER letters
+                    // under uppercase folding but BEFORE them under lowercase.
+                    // Folding lowercase here mis-flagged correct UFFS output as
+                    // "not asc" (e.g. `…\cli flow.txt` vs `…\_run\baseline.txt`).
+                    // Match UFFS's collation so this check models real ordering.
                     let vals: Vec<String> = rows.iter()
-                        .map(|r| field_str(r, &sc.column).to_lowercase())
+                        .map(|r| field_str(r, &sc.column).to_uppercase())
                         .collect();
                     for w in vals.windows(2) {
                         match order {
@@ -1413,8 +1423,12 @@ fn run_mcp_custom_validator(name: &str, result: &Value) -> Result<String> {
                 let (po1, n1) = &w[1];
                 if po0.eq_ignore_ascii_case(po1) {
                     saw_tiebreaker = true;
-                    let n0_fold = n0.to_lowercase();
-                    let n1_fold = n1.to_lowercase();
+                    // UPPERCASE fold to match UFFS's NTFS `$UpCase` name
+                    // collation (same 0x5B..=0x60 gap rationale as the string
+                    // sort check above): a name like `_foo` orders AFTER
+                    // letters, so lowercase folding would mis-flag it here too.
+                    let n0_fold = n0.to_uppercase();
+                    let n1_fold = n1.to_uppercase();
                     if n0_fold > n1_fold {
                         bail!(
                             "Not asc (name tiebreaker within '{}'): '{}' > '{}'",


### PR DESCRIPTION
## Why

T59 (`*.txt --sort path`) failed on a live C: drive: UFFS returned `…\$RJCH036\cli flow.txt` before `…\$RJCH036\_run\baseline.txt`, and the harness flagged it "not asc". **UFFS is correct; the validator was wrong.**

UFFS sorts string columns (name/path/ext) with the NTFS `$UpCase` table . the filesystem-native collation Explorer and the NTFS index B-tree use . which folds to **uppercase**. The harness folded `.to_lowercase()`. The ASCII gap `0x5B..=0x60` (`[ \ ] ^ _ \``) sits **between `Z` (0x5A) and `a` (0x61)**, so `_` orders **after** letters under uppercase but **before** them under lowercase, flipping the expected order for any path/name with such a char next to a letter.

## What

- **String sort check:** `.to_lowercase()` → `.to_uppercase()` (covers both the `asc` and `desc` branches . they share the folded `vals`).
- **Name-tiebreaker check** (within equal `path_only`): same lowercase → uppercase . it had the identical latent bug.
- Comments on both sites explain the `$UpCase` / `0x5B..=0x60` rationale so it is not "corrected" back to lowercase later.

UFFS itself is unchanged . this only fixes the conformance harness so its ascending/descending assertions model UFFS's real (NTFS-native) collation. `rust-script` compile-check passes.