### PR TITLE
fix(ci): drop `--squash` from dependabot auto-merge so the queue enrolls it

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -154,13 +154,19 @@ jobs:
 
       - name: Enable auto-merge via gh CLI
         # Only call `gh pr merge --auto` when the gate is green.
-        # `--squash` matches the repo's preferred merge style; flip to
-        # --rebase or --merge if the repo convention changes.
+        #
+        # NO method flag: `main` uses a merge queue, which OWNS the merge
+        # strategy. Passing `--squash`/`--rebase`/`--merge` here is silently
+        # rejected ("the merge strategy for main is set by the merge queue") and
+        # leaves auto-merge armed but NOT enrolled in the queue, so the PR sits
+        # CLEAN-but-stuck (cf. #494). `--auto` alone lets the queue own the
+        # squash and enrolls correctly. This step also fires on `synchronize`,
+        # so it now re-arms (self-heals enrollment) after an Update-branch.
         if: steps.gate.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           echo "Enabling auto-merge on $PR_URL"
-          gh pr merge --auto --squash "$PR_URL"
+          gh pr merge --auto "$PR_URL"
           echo "::notice::Auto-merge enabled \u2014 will merge when all required checks pass and reviews (if any) are satisfied."


### PR DESCRIPTION
## Why

`main` uses a **merge queue**, which owns the merge strategy. `dependabot-auto-merge.yml` ran `gh pr merge --auto --squash`, but passing a method on a queue repo is **silently rejected** ("the merge strategy for main is set by the merge queue") — it arms auto-merge but never **enrolls** the PR in the queue.

Observed on **#494**: green required checks, up-to-date branch, `mergeStateStatus: CLEAN` — yet the merge queue stayed **empty** and the PR sat stuck until auto-merge was re-armed with **no method flag**.

## Fix

`gh pr merge --auto --squash` → `gh pr merge --auto` (no method; the queue owns the squash). The step already fires on `synchronize`, so with the method dropped it now **self-heals enrollment** after an Update-branch instead of needing a manual re-arm. Comment updated to document the merge-queue contract.

> Paired with a ruleset change (applied separately): `main` no longer requires branches to be up-to-date before merging — that flag is redundant with the merge queue (which rebuilds against latest `main` at merge time) and was what made open PRs go stale when `main` moved.