### PR TITLE
chore: release v0.6.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.18] - 2026-06-29
+
 ### Added — one-line macOS/Linux installer (`install.sh`)
 
 `curl -fsSL https://raw.githubusercontent.com/skyllc-ai/UltraFastFileSearch/main/install.sh | bash`
@@ -2532,7 +2534,8 @@ thin clients over a unified `uffsd` process.
 ### Fixed
 - Various MFT parsing edge cases
 
-[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.17...HEAD
+[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.18...HEAD
+[0.6.18]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.17...v0.6.18
 [0.6.17]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.15...v0.6.17
 [0.6.15]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.14...v0.6.15
 [0.6.14]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.13...v0.6.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.18] - 2026-06-29
 
+### Changed: `uffs --uninstall` now finds every copy across the system
+
+Uninstall discovers UFFS wherever it actually lives, not just the running copy.
+It scans `PATH` and the standard binary directories (`~/bin`, `~/.local/bin`,
+`~/.cargo/bin`, `/usr/local/bin`, `/opt/homebrew/bin`) with a stat-only,
+which-style lookup (never a filesystem walk), reusing the real channel/scope
+classifier so a WinGet copy is still delegated to `winget` and a root-owned
+location is still flagged for elevation. Retired and optional binary names
+(`uffs-daemon`, `uffs-mcp`, the legacy `uffs_*` names) are swept too. PATH
+cleanup now only touches a directory that is exclusively UFFS, so a shared
+`~/bin` full of your other tools is left untouched.
+
+On Windows, where UFFS indexes the live drives, uninstall also offers to start
+the daemon and index any missing NTFS drives, then asks UFFS itself for stray
+copies anywhere on the system, versions them, and removes them under a separate
+confirmation (a copy you placed yourself might be among them). The coverage
+offer runs under `--dry-run` too, since starting and indexing are
+non-destructive; only the deletions are withheld.
+
 ### Added — one-line macOS/Linux installer (`install.sh`)
 
 `curl -fsSL https://raw.githubusercontent.com/skyllc-ai/UltraFastFileSearch/main/install.sh | bash`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4373,7 +4373,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uffs-bench"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "chrono",
  "clap",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4401,14 +4401,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "chrono",
  "itoa",
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -4571,7 +4571,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -4581,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4642,14 +4642,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4664,18 +4664,18 @@ dependencies = [
 
 [[package]]
 name = "uffs-text"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.6.17"
+version = "0.6.18"
 
 [[package]]
 name = "uffs-update"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -4693,7 +4693,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-winsvc"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "windows 0.62.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.6.17"
+version = "0.6.18"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -126,28 +126,28 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.6.17" }
-uffs-security = { path = "crates/uffs-security", version = "0.6.17" }
-uffs-text = { path = "crates/uffs-text", version = "0.6.17" }
-uffs-time = { path = "crates/uffs-time", version = "0.6.17" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.6.17" }
-uffs-format = { path = "crates/uffs-format", version = "0.6.17" }
-uffs-core = { path = "crates/uffs-core", version = "0.6.17" }
-uffs-client = { path = "crates/uffs-client", version = "0.6.17" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.6.18" }
+uffs-security = { path = "crates/uffs-security", version = "0.6.18" }
+uffs-text = { path = "crates/uffs-text", version = "0.6.18" }
+uffs-time = { path = "crates/uffs-time", version = "0.6.18" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.6.18" }
+uffs-format = { path = "crates/uffs-format", version = "0.6.18" }
+uffs-core = { path = "crates/uffs-core", version = "0.6.18" }
+uffs-client = { path = "crates/uffs-client", version = "0.6.18" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.17" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.18" }
 # `uffs-winsvc` — native Windows service control (SCM query/start/stop) +
 # the non-connecting broker-pipe readiness probe.  Layer-0 leaf: its only
 # dependency is the `windows` crate (windows-target), with non-Windows
 # stubs so cross-platform consumers (uffs-update, uffs-cli) compile.
 # Single source of truth for the `sc`/SCM mechanics previously duplicated
 # across uffs-broker, uffs-update, and uffs-cli.
-uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.17" }
+uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.18" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/main.rs"
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-client = { path = "../uffs-client", version = "0.6.17", default-features = false }
+uffs-client = { path = "../uffs-client", version = "0.6.18", default-features = false }
 
 # Canonical CSV / parity / legacy-footer writer.  Direct dep (not a
 # re-export chain through `uffs-client`) so the CLI and the daemon
@@ -77,7 +77,7 @@ uffs-client = { path = "../uffs-client", version = "0.6.17", default-features = 
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-format = { path = "../uffs-format", version = "0.6.17" }
+uffs-format = { path = "../uffs-format", version = "0.6.18" }
 
 # Typed drive-letter newtype.  Direct dep so the CLI command signatures
 # (`daemon_load`, `daemon_tiering`, etc.) name `DriveLetter` natively


### PR DESCRIPTION
## Release v0.6.18

Cuts the v0.6.18 release (version bump + changelog roll). On the pinned `nightly-2026-06-26` (the `ship --fresh` toolchain auto-bump to `06-30` was reverted — it tripped the #492 `ring` regression at the Windows xwin step; tracked for a flow fix).

### Headline
- **`uffs --uninstall` finds every copy** — cross-platform PATH/standard-dir scan (no walk), retired-name sweep, PATH safety gate (shared `~/bin` left alone), and on Windows the live-drive deep sweep + drive-coverage offer. (#499)
- **One-line macOS/Linux installer** (`install.sh`). (#498)

Changelog updated so the release notes match the shipped binary (the uninstall feature had no `[Unreleased]` entry).