### PR TITLE
fix(install): installer broken-pipe + winget uninstall sequencing for pure-winget installs

### DIFF
--- a/crates/uffs-cli/src/commands/uninstall/effects.rs
+++ b/crates/uffs-cli/src/commands/uninstall/effects.rs
@@ -411,6 +411,15 @@ fn remove_service_via_uac(service: &str) -> Result<()> {
 
 /// Delegate removal of a `WinGet`-managed root to `winget uninstall`.
 fn winget_uninstall(package_id: &str, scope: Scope) -> Result<()> {
+    // Winget refuses to uninstall a USER-scope package from an elevated
+    // session (deliberate scope-safety on their side). Detect it up front and
+    // return the typed marker so the executor records a clean LEFT with the
+    // "run it from a normal terminal" instruction — the elevated re-run we
+    // advertise for the broker service must not report this as a raw failure.
+    #[cfg(windows)]
+    if matches!(scope, Scope::User) && uffs_mft::is_elevated() {
+        return Err(super::remove::WingetNeedsNonElevated.into());
+    }
     let mut command = Command::new("winget");
     command.args([
         "uninstall",

--- a/crates/uffs-cli/src/commands/uninstall/effects.rs
+++ b/crates/uffs-cli/src/commands/uninstall/effects.rs
@@ -22,6 +22,11 @@ use crate::commands::update::model::Scope;
 /// directly fails; [`schedule_self_delete`] removes them after this process
 /// exits instead.
 pub(crate) struct SystemEffects {
+    /// Whether the Access Broker service stays installed after this run (the
+    /// non-elevated "continue without" path, or a declined UAC). A kept
+    /// broker running FROM the winget package locks its files, so the winget
+    /// delegation must be left, not attempted.
+    broker_remains: bool,
     /// Set when `delegate_winget` scheduled a post-exit `winget uninstall`
     /// (the running uffs.exe is inside the winget package). The orchestrator
     /// must then SKIP the plain self-delete script — winget owns deleting the
@@ -48,8 +53,13 @@ impl SystemEffects {
     /// skip in-place (they are deferred to [`schedule_self_delete`]) and
     /// whether admin-only service removal goes through the Windows UAC helper
     /// (`elevate_via_uac`; meaningless off Windows).
-    pub(crate) const fn new(self_paths: Vec<PathBuf>, elevate_via_uac: bool) -> Self {
+    pub(crate) const fn new(
+        self_paths: Vec<PathBuf>,
+        elevate_via_uac: bool,
+        broker_remains: bool,
+    ) -> Self {
         Self {
+            broker_remains,
             winget_deferred: false,
             self_paths,
             elevate_via_uac,
@@ -147,11 +157,18 @@ impl Effects for SystemEffects {
 
     fn delegate_winget(&mut self, package_id: &str, scope: Scope, dir: &Path) -> Result<()> {
         // Running FROM the winget package (a pure-winget install): winget
-        // cannot delete the locked running image, so defer the whole
-        // uninstall to right after this process exits — the same detached
-        // script mechanism as the self-delete. Winget then deletes every
-        // package file (nothing is locked any more) AND cleans its metadata.
+        // cannot delete the locked running image. If the broker service is
+        // ALSO staying (it runs from the same package), even a post-exit
+        // attempt hits the service's locked uffs-broker.exe (`remove_all:
+        // Access is denied` live) — leave the delegation with the two-step
+        // instruction. Otherwise defer the whole uninstall to right after
+        // this process exits (same detached-script mechanism as the
+        // self-delete): winget then deletes every package file (nothing is
+        // locked any more) AND cleans its metadata.
         if self.self_paths.iter().any(|path| path.starts_with(dir)) {
+            if self.broker_remains {
+                return Err(super::remove::WingetBlockedByBroker.into());
+            }
             schedule_deferred_winget(package_id, scope)?;
             self.winget_deferred = true;
             return Err(super::remove::WingetDeferred.into());
@@ -525,7 +542,7 @@ mod tests {
         // The second stem is treated as the running self-binary — it must be
         // skipped (left for the deferred self-delete), not removed in place.
         let self_path = base.join(exe_file_name("uffsd"));
-        let mut effects = SystemEffects::new(vec![self_path.clone()], false);
+        let mut effects = SystemEffects::new(vec![self_path.clone()], false, false);
         effects.delete_binaries(&base, &stems).unwrap();
         assert!(
             !base.join(exe_file_name("uffs")).exists(),

--- a/crates/uffs-cli/src/commands/uninstall/effects.rs
+++ b/crates/uffs-cli/src/commands/uninstall/effects.rs
@@ -22,6 +22,11 @@ use crate::commands::update::model::Scope;
 /// directly fails; [`schedule_self_delete`] removes them after this process
 /// exits instead.
 pub(crate) struct SystemEffects {
+    /// Set when `delegate_winget` scheduled a post-exit `winget uninstall`
+    /// (the running uffs.exe is inside the winget package). The orchestrator
+    /// must then SKIP the plain self-delete script — winget owns deleting the
+    /// package dir, including the running image.
+    winget_deferred: bool,
     /// Absolute paths of the running self-binaries to skip in-place deletes.
     self_paths: Vec<PathBuf>,
     /// Windows: the user chose "elevate at removal time" at the elevation gate,
@@ -45,9 +50,18 @@ impl SystemEffects {
     /// (`elevate_via_uac`; meaningless off Windows).
     pub(crate) const fn new(self_paths: Vec<PathBuf>, elevate_via_uac: bool) -> Self {
         Self {
+            winget_deferred: false,
             self_paths,
             elevate_via_uac,
         }
+    }
+
+    /// Whether `delegate_winget` scheduled a post-exit `winget uninstall`
+    /// that will delete the package dir — including the running uffs.exe —
+    /// so the plain self-delete script must NOT run (both would race over
+    /// the same files, and winget also cleans its metadata).
+    pub(crate) const fn winget_deferred(&self) -> bool {
+        self.winget_deferred
     }
 
     /// Whether `path` is one of the running self-binaries (case-insensitive,
@@ -131,7 +145,17 @@ impl Effects for SystemEffects {
         }
     }
 
-    fn delegate_winget(&mut self, package_id: &str, scope: Scope) -> Result<()> {
+    fn delegate_winget(&mut self, package_id: &str, scope: Scope, dir: &Path) -> Result<()> {
+        // Running FROM the winget package (a pure-winget install): winget
+        // cannot delete the locked running image, so defer the whole
+        // uninstall to right after this process exits — the same detached
+        // script mechanism as the self-delete. Winget then deletes every
+        // package file (nothing is locked any more) AND cleans its metadata.
+        if self.self_paths.iter().any(|path| path.starts_with(dir)) {
+            schedule_deferred_winget(package_id, scope)?;
+            self.winget_deferred = true;
+            return Err(super::remove::WingetDeferred.into());
+        }
         winget_uninstall(package_id, scope)
     }
 
@@ -188,6 +212,45 @@ fn remove_path_entry_impl(dir: &Path) -> Result<()> {
         dir.display()
     )
     .context("writing PATH cleanup hint")
+}
+
+/// Schedule `winget uninstall` to run right after this process exits, for the
+/// pure-winget install where the running uffs.exe is part of the package and
+/// a synchronous uninstall would hit its own locked image. Same detached-`cmd`
+/// pattern as [`schedule_self_delete`]; winget removes the package files AND
+/// its metadata in one owner-driven pass.
+#[cfg(windows)]
+fn schedule_deferred_winget(package_id: &str, scope: Scope) -> Result<()> {
+    use std::os::windows::process::CommandExt as _;
+
+    let scope_arg = match scope {
+        Scope::Machine => " --scope machine",
+        Scope::User => " --scope user",
+        Scope::Unknown => "",
+    };
+    // `ping` is a portable ~2s sleep; by then this process has exited and the
+    // package images are unlocked.
+    let script = format!(
+        "ping 127.0.0.1 -n 3 >nul & winget uninstall --id {package_id} --silent          --accept-source-agreements{scope_arg} & rem deferred winget uninstall"
+    );
+    // `raw_arg`, NOT `args`: see `schedule_self_delete` — std's default
+    // quoting mangles the `/c` payload for cmd.exe.
+    Command::new("cmd")
+        .raw_arg("/c")
+        .raw_arg(&script)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("scheduling the deferred winget uninstall")?;
+    Ok(())
+}
+
+/// Non-Windows: winget does not exist, so a deferred winget uninstall can
+/// never be scheduled (the plan never produces a `DelegateWinget` off
+/// Windows); erroring is the honest outcome if it somehow were.
+#[cfg(not(windows))]
+fn schedule_deferred_winget(package_id: &str, _scope: Scope) -> Result<()> {
+    bail!("cannot defer winget uninstall of {package_id}: winget is Windows-only")
 }
 
 /// Delete the running self-binaries (`uffs.exe` + `uffs-update.exe`) that

--- a/crates/uffs-cli/src/commands/uninstall/mod.rs
+++ b/crates/uffs-cli/src/commands/uninstall/mod.rs
@@ -195,7 +195,8 @@ fn execute_all(
 
     // M4 execute (U-40..42): run the plan(s) once against the live effects sink,
     // accumulating a single outcome so the summary + retry hint print once.
-    let mut effects = effects::SystemEffects::new(self_paths.clone(), elevate_via_uac);
+    let mut effects =
+        effects::SystemEffects::new(self_paths.clone(), elevate_via_uac, broker_remains);
     let mut outcome = remove::RemovalOutcome::default();
     if !removal_plan.is_empty() {
         outcome.absorb(remove::execute(removal_plan, &mut effects, broker_remains));

--- a/crates/uffs-cli/src/commands/uninstall/mod.rs
+++ b/crates/uffs-cli/src/commands/uninstall/mod.rs
@@ -213,7 +213,13 @@ fn execute_all(
 
     // M8 self-delete (U-80): finish the deferred delete of the running
     // self-binaries the executor skipped. If even scheduling fails, say so.
-    if !self_paths.is_empty() {
+    // When the running uffs.exe is INSIDE the winget package, the deferred
+    // `winget uninstall` owns deleting the whole package dir (self included)
+    // — running the plain del script too would race winget over the same
+    // files, so it is skipped in favour of the owner-driven cleanup.
+    if effects.winget_deferred() {
+        render::print_winget_deferred();
+    } else if !self_paths.is_empty() {
         render::print_self_delete_scheduled();
         if let Err(err) = effects::schedule_self_delete(&self_paths) {
             render::print_self_delete_warning(&err);

--- a/crates/uffs-cli/src/commands/uninstall/mod.rs
+++ b/crates/uffs-cli/src/commands/uninstall/mod.rs
@@ -485,6 +485,10 @@ fn sweep_decision(parsed: &UninstallArgs) -> Result<SweepDecision> {
          Choice [d/S]: ",
     )?;
     if matches!(choice.as_str(), "d" | "deep" | "deep sweep") {
+        // Breathing room between the answered prompt and the gather spinner
+        // (emitted here, not in the spinner, so the silent no-question paths
+        // do not accumulate stray blank lines under the run header).
+        println!();
         Ok(SweepDecision::Proceed {
             elevate_daemon: true,
         })
@@ -616,9 +620,6 @@ fn spinner_wait<T>(handle: &std::thread::JoinHandle<T>) {
     use std::io::Write as _;
 
     const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-    // One blank line between the sweep-decision prompt and the spinner, so the
-    // gather does not butt right up against "Choice [d/S]: d".
-    println!();
     let mut frame = 0_usize;
     while !handle.is_finished() {
         let label = if GATHER_PHASE.load(core::sync::atomic::Ordering::Relaxed) == 0 {

--- a/crates/uffs-cli/src/commands/uninstall/plan.rs
+++ b/crates/uffs-cli/src/commands/uninstall/plan.rs
@@ -308,9 +308,10 @@ pub(crate) fn build_plan(
     // running uffs.exe / uffs-update.exe are deferred past process exit
     // (self-delete) by the executor.
 
-    // 1. Tool binaries — per root: unmanaged/dev delete, winget delegate. The
-    // runtime binaries (daemon, broker, MCP servers) are split into the final
-    // group below: their images are locked while those processes/services run.
+    // 1. Tool binaries — per root (unmanaged/dev roots only). The runtime
+    // binaries (daemon, broker, MCP servers) AND the winget delegation are
+    // deferred to the final group below: their images are locked while those
+    // processes/services run, and winget cannot delete locked files either.
     let binaries: Vec<PlanItem> = report
         .roots
         .iter()
@@ -478,8 +479,9 @@ fn is_runtime_stem(stem: &str) -> bool {
 
 /// Build the per-root binary plan item for the requested stem set, or `None`
 /// when the root has no matching binaries. A `WinGet` root delegates whole to
-/// `winget uninstall` in the Tools pass (winget owns the stop/delete order for
-/// its own package), so its Runtime pass is empty.
+/// `winget uninstall` in the RUNTIME (post-shutdown) pass — winget cannot
+/// delete the locked images of a daemon/broker still running from its package
+/// dir — so its Tools pass is empty.
 fn binary_item(root: &InstallRoot, set: StemSet) -> Option<PlanItem> {
     if root.binaries.is_empty() {
         return None;
@@ -492,7 +494,12 @@ fn binary_item(root: &InstallRoot, set: StemSet) -> Option<PlanItem> {
     };
     let target = match root.channel {
         Channel::WinGet => {
-            if set == StemSet::Runtime {
+            // The delegation runs AFTER the shutdown group: a pure-winget
+            // install has uffsd (and possibly the running uffs.exe) inside the
+            // winget package dir, and `winget uninstall` cannot delete locked
+            // images. Delegating before the daemon/broker stop made winget
+            // fail on its own still-running files.
+            if set == StemSet::Tools {
                 return None;
             }
             PlanTarget::DelegateWinget {

--- a/crates/uffs-cli/src/commands/uninstall/plan/tests.rs
+++ b/crates/uffs-cli/src/commands/uninstall/plan/tests.rs
@@ -61,6 +61,44 @@ fn built(report: &DetectionReport, inventory: &Inventory, args: &UninstallArgs) 
 }
 
 #[test]
+fn winget_delegation_runs_after_the_shutdown_group() {
+    // A pure-winget install: uffsd runs FROM the winget package dir, and
+    // winget cannot delete locked images — so the delegation must execute
+    // after the daemon/broker shutdown, never before.
+    let report = DetectionReport {
+        roots: vec![root(Channel::WinGet, Scope::User, r"C:\winget\uffs")],
+        running: vec![RunningProcess {
+            component: Component::Daemon,
+            pid: 4242,
+            image_path: None,
+            command_line: None,
+            version: None,
+        }],
+    };
+    let plan = built(
+        &report,
+        &inventory(BrokerServiceState::Absent, 1024),
+        &UninstallArgs::default(),
+    );
+    let order: Vec<&'static str> = plan
+        .items()
+        .map(|item| item.target.action_label())
+        .collect();
+    let stop = order
+        .iter()
+        .position(|label| *label == "stop-process")
+        .expect("daemon stop present");
+    let winget = order
+        .iter()
+        .position(|label| *label == "delegate-winget")
+        .expect("winget delegation present");
+    assert!(
+        stop < winget,
+        "shutdown must precede the winget delegation: {order:?}"
+    );
+}
+
+#[test]
 fn winget_root_is_delegated_not_deleted() {
     let report = DetectionReport {
         roots: vec![root(Channel::WinGet, Scope::User, r"C:\winget\uffs")],

--- a/crates/uffs-cli/src/commands/uninstall/remove.rs
+++ b/crates/uffs-cli/src/commands/uninstall/remove.rs
@@ -34,6 +34,26 @@ impl core::fmt::Display for ElevationDeclined {
 
 impl core::error::Error for ElevationDeclined {}
 
+/// Marker error: winget refuses to uninstall a USER-scope package from an
+/// elevated session ("The package installed for user scope cannot be
+/// uninstalled when running with administrator privileges") — winget's
+/// deliberate scope-safety, not a failure to force through. The executor
+/// records the delegation as LEFT with the exact non-admin instruction.
+#[derive(Debug)]
+pub(crate) struct WingetNeedsNonElevated;
+
+impl core::fmt::Display for WingetNeedsNonElevated {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("winget cannot uninstall a user-scope package from an elevated session")
+    }
+}
+
+impl core::error::Error for WingetNeedsNonElevated {}
+
+/// Reason recorded when the winget package is left because this run is
+/// elevated: the user needs one command in a normal terminal.
+const WINGET_LEFT: &str = "user-scope winget packages cannot be uninstalled from an admin session; run      `winget uninstall SkyLLC.UFFS` in a normal (non-admin) terminal";
+
 /// Reason recorded when the broker service is left because elevation was
 /// declined at the UAC prompt.
 const BROKER_SERVICE_LEFT: &str = "the Access Broker (a LocalSystem service) needs Administrator";
@@ -185,6 +205,20 @@ fn run_item(
         }
         return;
     }
+    // Winget refuses user-scope uninstalls from an elevated session — record
+    // the delegation as deliberately LEFT with the exact next step, instead of
+    // a raw failure.
+    if let PlanTarget::DelegateWinget { .. } = &item.target {
+        let status = match dispatch(&item.target, effects) {
+            Ok(()) => ItemStatus::Done,
+            Err(err) if err.downcast_ref::<WingetNeedsNonElevated>().is_some() => {
+                ItemStatus::Skipped(WINGET_LEFT.to_owned())
+            }
+            Err(err) => ItemStatus::Failed(format!("{err:#}")),
+        };
+        outcome.record(description, status);
+        return;
+    }
     // The broker service is staying (declined, or the non-elevated run left it),
     // so it still runs and locks uffs-broker.exe: delete the other runtime
     // binaries, leave the broker's alongside its service.
@@ -275,6 +309,9 @@ mod tests {
         /// When set, `remove_service` returns [`super::ElevationDeclined`], as
         /// a declined UAC prompt does.
         decline_service: bool,
+        /// When set, `delegate_winget` returns
+        /// [`super::WingetNeedsNonElevated`], as an elevated session does.
+        winget_elevated: bool,
     }
 
     impl Effects for RecordingEffects {
@@ -301,6 +338,9 @@ mod tests {
         }
         fn delegate_winget(&mut self, package_id: &str, _scope: Scope) -> Result<()> {
             self.calls.push(format!("delegate_winget:{package_id}"));
+            if self.winget_elevated {
+                return Err(super::WingetNeedsNonElevated.into());
+            }
             Ok(())
         }
         fn remove_dir(&mut self, path: &Path) -> Result<()> {
@@ -484,6 +524,69 @@ mod tests {
                 .iter()
                 .any(|call| call == "delete_binaries:/opt/uffs:1"),
             "the non-broker runtime binary is still removed: {:?}",
+            effects.calls
+        );
+    }
+
+    #[test]
+    fn elevated_winget_refusal_is_left_with_the_non_admin_instruction() {
+        // An elevated run delegating to winget: winget refuses user-scope
+        // uninstalls from an admin session — the item must be LEFT (with the
+        // run-it-non-admin reason), never a raw failure, and the rest of the
+        // plan still executes.
+        let report = DetectionReport {
+            roots: vec![InstallRoot {
+                dir: PathBuf::from(r"C:\winget\uffs"),
+                channel: Channel::WinGet,
+                scope: Scope::User,
+                anchored_by: Vec::new(),
+                binaries: vec![BinaryInfo {
+                    name: "uffs".to_owned(),
+                    version: None,
+                }],
+            }],
+            running: Vec::new(),
+        };
+        let inventory = Inventory {
+            dirs: vec![ArtifactDir {
+                kind: ArtifactKind::Cache,
+                path: PathBuf::from("/x/cache"),
+                exists: true,
+                size_bytes: 1,
+            }],
+            broker_service: BrokerServiceState::Absent,
+        };
+        let plan = build_plan(&report, &inventory, &UninstallArgs::default(), &[]);
+        let mut effects = RecordingEffects {
+            winget_elevated: true,
+            ..RecordingEffects::default()
+        };
+        let outcome = execute(&plan, &mut effects, false);
+
+        assert_eq!(outcome.failed_count(), 0, "no raw failure");
+        assert_eq!(outcome.skipped_count(), 1, "the delegation is LEFT");
+        let left = outcome
+            .results
+            .iter()
+            .find_map(|(_, status)| {
+                if let ItemStatus::Skipped(reason) = status {
+                    Some(reason.clone())
+                } else {
+                    None
+                }
+            })
+            .expect("a LEFT item");
+        assert!(
+            left.contains("non-admin"),
+            "the reason carries the non-admin instruction: {left}"
+        );
+        // The cache dir still got removed (best-effort continues).
+        assert!(
+            effects
+                .calls
+                .iter()
+                .any(|call| call == "remove_dir:/x/cache"),
+            "rest of the plan still ran: {:?}",
             effects.calls
         );
     }

--- a/crates/uffs-cli/src/commands/uninstall/remove.rs
+++ b/crates/uffs-cli/src/commands/uninstall/remove.rs
@@ -66,6 +66,25 @@ impl core::fmt::Display for WingetDeferred {
 
 impl core::error::Error for WingetDeferred {}
 
+/// Marker error: the Access Broker service is staying (elevation declined or
+/// deliberately kept) and it runs FROM the winget package dir, so even a
+/// deferred `winget uninstall` would hit the service's locked image — the
+/// exact `remove_all: Access is denied` failure seen live. The delegation is
+/// left with the two-step instruction instead of a doomed attempt.
+#[derive(Debug)]
+pub(crate) struct WingetBlockedByBroker;
+
+impl core::fmt::Display for WingetBlockedByBroker {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("the broker service still runs from the winget package")
+    }
+}
+
+impl core::error::Error for WingetBlockedByBroker {}
+
+/// Reason recorded when the winget uninstall is blocked by the kept broker.
+const WINGET_BLOCKED_BY_BROKER: &str = "the Access Broker service still runs from this winget package and locks its      files; remove the service from an Administrator terminal (`uffs --uninstall`),      then run `winget uninstall SkyLLC.UFFS`";
+
 /// Reason recorded when the winget uninstall is deferred past process exit.
 const WINGET_DEFERRED: &str = "winget uninstall runs right after this process exits (the running      uffs.exe is part of the winget package)";
 
@@ -236,6 +255,9 @@ fn run_item(
             }
             Err(err) if err.downcast_ref::<WingetDeferred>().is_some() => {
                 ItemStatus::Skipped(WINGET_DEFERRED.to_owned())
+            }
+            Err(err) if err.downcast_ref::<WingetBlockedByBroker>().is_some() => {
+                ItemStatus::Skipped(WINGET_BLOCKED_BY_BROKER.to_owned())
             }
             Err(err) => ItemStatus::Failed(format!("{err:#}")),
         };

--- a/crates/uffs-cli/src/commands/uninstall/remove.rs
+++ b/crates/uffs-cli/src/commands/uninstall/remove.rs
@@ -50,6 +50,25 @@ impl core::fmt::Display for WingetNeedsNonElevated {
 
 impl core::error::Error for WingetNeedsNonElevated {}
 
+/// Marker error: the running uffs.exe lives INSIDE the winget package dir, so
+/// a synchronous `winget uninstall` would hit its own locked image. The
+/// effects layer schedules the uninstall to run right after this process
+/// exits (same detached-script mechanism as the self-delete) and returns this
+/// marker; the executor records the item as deliberately deferred.
+#[derive(Debug)]
+pub(crate) struct WingetDeferred;
+
+impl core::fmt::Display for WingetDeferred {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("winget uninstall deferred until this process exits")
+    }
+}
+
+impl core::error::Error for WingetDeferred {}
+
+/// Reason recorded when the winget uninstall is deferred past process exit.
+const WINGET_DEFERRED: &str = "winget uninstall runs right after this process exits (the running      uffs.exe is part of the winget package)";
+
 /// Reason recorded when the winget package is left because this run is
 /// elevated: the user needs one command in a normal terminal.
 const WINGET_LEFT: &str = "user-scope winget packages cannot be uninstalled from an admin session; run      `winget uninstall SkyLLC.UFFS` in a normal (non-admin) terminal";
@@ -80,8 +99,9 @@ pub(crate) trait Effects {
     /// Windows deep-sweep hits found outside the known roots.
     #[cfg(windows)]
     fn delete_file(&mut self, path: &Path) -> Result<()>;
-    /// Hand a `WinGet`-managed root to `winget uninstall`.
-    fn delegate_winget(&mut self, package_id: &str, scope: Scope) -> Result<()>;
+    /// Hand a `WinGet`-managed root to `winget uninstall`. `dir` is the
+    /// package root (used to detect the running-self-inside-the-package case).
+    fn delegate_winget(&mut self, package_id: &str, scope: Scope, dir: &Path) -> Result<()>;
     /// Recursively delete a directory (absent is a no-op).
     fn remove_dir(&mut self, path: &Path) -> Result<()>;
     /// Remove `dir` from the user's PATH (Windows: the registry; Unix: print a
@@ -214,6 +234,9 @@ fn run_item(
             Err(err) if err.downcast_ref::<WingetNeedsNonElevated>().is_some() => {
                 ItemStatus::Skipped(WINGET_LEFT.to_owned())
             }
+            Err(err) if err.downcast_ref::<WingetDeferred>().is_some() => {
+                ItemStatus::Skipped(WINGET_DEFERRED.to_owned())
+            }
             Err(err) => ItemStatus::Failed(format!("{err:#}")),
         };
         outcome.record(description, status);
@@ -276,8 +299,10 @@ fn dispatch(target: &PlanTarget, effects: &mut dyn Effects) -> Result<()> {
         #[cfg(windows)]
         PlanTarget::DeleteFile { path, .. } => effects.delete_file(path),
         PlanTarget::DelegateWinget {
-            package_id, scope, ..
-        } => effects.delegate_winget(package_id, *scope),
+            package_id,
+            scope,
+            dir,
+        } => effects.delegate_winget(package_id, *scope, dir),
         PlanTarget::DeleteDir { path, .. } => effects.remove_dir(path),
         PlanTarget::RemovePathEntry { dir } => effects.remove_path_entry(dir),
     }
@@ -336,7 +361,7 @@ mod tests {
             self.calls.push(format!("delete_file:{}", path.display()));
             Ok(())
         }
-        fn delegate_winget(&mut self, package_id: &str, _scope: Scope) -> Result<()> {
+        fn delegate_winget(&mut self, package_id: &str, _scope: Scope, _dir: &Path) -> Result<()> {
             self.calls.push(format!("delegate_winget:{package_id}"));
             if self.winget_elevated {
                 return Err(super::WingetNeedsNonElevated.into());

--- a/crates/uffs-cli/src/commands/uninstall/render.rs
+++ b/crates/uffs-cli/src/commands/uninstall/render.rs
@@ -385,6 +385,17 @@ pub(crate) fn print_self_delete_scheduled() {
     println!("\nThe uffs command removes itself once this process exits.");
 }
 
+/// Note that the deferred `winget uninstall` finishes the job after the
+/// process exits: it removes the whole winget package (including this running
+/// uffs.exe) and cleans winget's own metadata.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+pub(crate) fn print_winget_deferred() {
+    println!(
+        "\nwinget finishes the removal once this process exits (the running uffs.exe\n\
+         is part of the winget package; winget deletes it and cleans its metadata)."
+    );
+}
+
 /// Warn that the running self-binary could not be scheduled for deletion.
 #[expect(clippy::print_stderr, reason = "CLI user-facing error")]
 pub(crate) fn print_self_delete_warning(error: &anyhow::Error) {

--- a/crates/uffs-cli/src/commands/uninstall/render.rs
+++ b/crates/uffs-cli/src/commands/uninstall/render.rs
@@ -442,7 +442,14 @@ pub(crate) fn print_outcome(outcome: &RemovalOutcome) {
 
     // Left items are always the broker after a declined elevation (Windows-only):
     // one clear next step, not the generic file-in-use hint.
-    if skipped > 0 {
+    // The broker-specific hint only applies to broker LEFT items — a LEFT
+    // winget delegation carries the OPPOSITE instruction (non-admin terminal)
+    // in its own reason line, so a blanket "re-run as Administrator" here
+    // would be misleading.
+    let broker_left = outcome.results.iter().any(|(_, status)| {
+        matches!(status, ItemStatus::Skipped(reason) if reason.contains("Access Broker"))
+    });
+    if broker_left {
         println!(
             "\nThe Access Broker was left because elevation was declined. Re-run\n\
              `uffs --uninstall` from an Administrator terminal to remove it."

--- a/install.sh
+++ b/install.sh
@@ -82,15 +82,37 @@ detect_platform() {
 # ── resolve the version to install (latest, or pinned via UFFS_VERSION) ──────
 resolve_version() {
   if [ -n "${UFFS_VERSION:-}" ]; then
-    VERSION="$UFFS_VERSION"
+    # Accept both `v0.6.18` and `0.6.18` — release tags carry the `v`.
+    case "$UFFS_VERSION" in
+      v*) VERSION="$UFFS_VERSION" ;;
+      *) VERSION="v$UFFS_VERSION" ;;
+    esac
     return
   fi
   info "Resolving the latest release..."
-  # Parse tag_name out of the releases API (no jq dependency).
-  VERSION="$(download - "https://api.github.com/repos/$REPO/releases/latest" \
-    | grep -m1 '"tag_name"' \
-    | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
-  [ -n "$VERSION" ] || err "could not resolve the latest release version"
+  # Fetch the WHOLE response first, then parse WITHOUT pipes. The old
+  # `curl | grep -m1 | sed` died intermittently: grep -m1 closes the pipe as
+  # soon as it sees tag_name (near the top of a large JSON body), the writer
+  # takes SIGPIPE, and `pipefail` fails the install even though the parse
+  # succeeded (curl exit 23 in the wild). Any early-exiting reader — grep -m1,
+  # head, sed q — recreates it, so the parse below is pure parameter
+  # expansion: zero subprocesses, zero pipes, zero SIGPIPE (and no jq).
+  local body
+  body="$(download - "https://api.github.com/repos/$REPO/releases/latest")" \
+    || err "could not reach the GitHub releases API"
+  case "$body" in
+    *'"tag_name"'*) ;;
+    *) err "could not resolve the latest release version \
+(GitHub API rate limit? Pin one instead: UFFS_VERSION=v0.6.18)" ;;
+  esac
+  # `"tag_name": "vX.Y.Z"` -> cut everything through the value's opening
+  # quote, then keep up to the closing quote.
+  VERSION="${body#*\"tag_name\"}"
+  VERSION="${VERSION#*:}"
+  VERSION="${VERSION#*\"}"
+  VERSION="${VERSION%%\"*}"
+  [ -n "$VERSION" ] || err "could not resolve the latest release version \
+(GitHub API rate limit? Pin one instead: UFFS_VERSION=v0.6.18)"
 }
 
 # ── verify one downloaded file against SHA256SUMS ────────────────────────────
@@ -117,6 +139,10 @@ main() {
   download "$tmp/SHA256SUMS" "$base/SHA256SUMS"
   mkdir -p "$INSTALL_DIR"
 
+  # Two-phase install: download + verify EVERYTHING into the temp dir first,
+  # then move the whole set into place. A failed download or checksum aborts
+  # before a single file is touched, so ~/.local/bin is never left half old /
+  # half new (a partial upgrade can pair an old daemon with a new CLI).
   local bin asset
   for bin in "${BINARIES[@]}"; do
     asset="$bin-$PLATFORM"
@@ -124,6 +150,8 @@ main() {
     download "$tmp/$bin" "$base/$asset"
     verify_asset "$tmp/$bin" "$asset" "$tmp/SHA256SUMS"
     chmod +x "$tmp/$bin"
+  done
+  for bin in "${BINARIES[@]}"; do
     mv "$tmp/$bin" "$INSTALL_DIR/$bin"
   done
 


### PR DESCRIPTION
Installer + winget-flow hardening, driven by live pure-winget testing on Windows.

## install.sh (the public one-line installer)
- **Broken-pipe fix at the root**: `curl | grep -m1 | sed` let grep close the pipe early → curl exit 23 → `pipefail` failed the install even when the parse succeeded. The parse is now pure parameter expansion on a buffered body — zero pipes, zero SIGPIPE. (First fix attempt moved the race one layer down and was caught by a 10× live-API test; shipped version passes 10/10 where the old code exits 141.)
- **Transactional install**: download + verify ALL binaries first, then move the set into place — a mid-loop failure can no longer leave `~/.local/bin` half old / half new.
- `UFFS_VERSION=0.6.17` and `v0.6.17` both accepted; resolve-failure message names the rate-limit cause + the pin escape hatch.

## winget uninstall flow (from live pure-winget logs)
- **Delegation moved after shutdown**: `winget uninstall` cannot delete locked images; with uffsd running from the package dir the old order made winget fail on its own files (`remove_all: Access is denied`, reproduced live).
- **Running-self-in-package**: launching `uffs --uninstall` from the winget copy now defers the winget uninstall to right after process exit (same detached-script mechanism as the self-delete) — winget then removes the whole unlocked package and cleans its own metadata.
- **Kept-broker guard**: if the broker service stays (continue-without / declined UAC) it keeps the package locked past our exit — the delegation is LEFT with the honest two-step instruction instead of a doomed deferred attempt.
- **Elevated sessions**: winget refuses user-scope uninstalls from admin sessions (their scope-safety) — now a clean LEFT with the "run it from a normal terminal" instruction, never a raw FAILED; the "re-run as Administrator" hint is scoped to broker items only (for winget that advice is precisely backwards).
- Cosmetic: silent sweep paths no longer stack blank lines under the run header.

## Validation
131 uffs-cli tests (3 new regression tests: plan ordering, elevated-winget LEFT, broker-blocks-winget) · host + Windows clippy clean · rustdoc clean · shellcheck clean · resolve_version verified 10× against the live GitHub API.
