### PR TITLE
fix(ci): gate toolchain bumps on all three shipped targets + deterministic linux CPU baseline

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -78,9 +78,20 @@ rustflags = [
 # =============================================================================
 # Linux x86_64
 # =============================================================================
+# NOTE: Do NOT use target-cpu=native here (same reasoning as the Windows
+# section above) — it breaks cross-compilation from macOS ARM64 (the host CPU
+# "apple-m4" is not valid for x86_64), and worse: release CI builds this leg
+# natively on whatever GitHub runner it lands on, so `native` baked the
+# RUNNER's CPU features into the shipped binaries (an AVX-512 runner emits
+# binaries that crash on older user CPUs). x86-64-v3 pins a deterministic
+# baseline with AVX2 (Intel Haswell 2013+, AMD Zen 2017+) — matching the
+# Windows leg.
+# NOTE: the `linker` below only applies to host-native builds; cross builds
+# from macOS go through cargo-zigbuild, which injects its own zig-cc linker
+# (toolchain-sync Phase 2c).
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "target-cpu=native", "-C", "link-arg=-Wl,--gc-sections"]
+rustflags = ["-C", "target-cpu=x86-64-v3", "-C", "link-arg=-Wl,--gc-sections"]
 
 # =============================================================================
 # Terminal

--- a/just/shared.just
+++ b/just/shared.just
@@ -176,6 +176,15 @@ toolchain-sync:
         printf "\033[0;31m   Install it with: cargo install cargo-xwin\033[0m\n"
         exit 1
     fi
+    # The Linux release leg (x86_64-unknown-linux-gnu on ubuntu-22.04) gets the
+    # same treatment via cargo-zigbuild (zig provides the cross C compiler +
+    # linker) — Phase 2c below. Refuse rather than fall back to a gate that
+    # skips a shipped target.
+    if ! command -v cargo-zigbuild >/dev/null 2>&1 || ! command -v zig >/dev/null 2>&1; then
+        printf "\033[0;31m❌ cargo-zigbuild + zig are required: toolchain-sync validates the Linux target before a bump.\033[0m\n"
+        printf "\033[0;31m   Install them with: cargo install cargo-zigbuild && brew install zig (or cargo install zig-bin)\033[0m\n"
+        exit 1
+    fi
 
     START_DATE=$(date -u +%Y-%m-%d)
     printf "\033[0;34m   Start date:  nightly-%s (today UTC)\033[0m\n\n" "$START_DATE"
@@ -434,6 +443,48 @@ toolchain-sync:
                 printf "\n\033[0;31m❌ Current pin %s no longer compiles for x86_64-pc-windows-msvc.\033[0m\n" "$CURRENT"
                 printf "\033[0;31m   Full log: /tmp/toolchain-sync-xwin.log\033[0m\n"
                 printf "\033[0;31m   Manual intervention required — the merge gate's Windows build will reject this pin.\033[0m\n"
+                exit 1
+            fi
+            CANDIDATE_DATE=$(date_minus_one "$CANDIDATE_DATE")
+            ITER=$((ITER+1))
+            continue
+        fi
+
+        # ── Phase 2c: Linux cross-compile gate ──────────────────
+        # The release also ships x86_64-unknown-linux-gnu (built natively on
+        # the ubuntu-22.04 runner), so a bump must not be accepted on a nightly
+        # that cannot build that leg either — the exact class of the ring
+        # episode, just pointed at Linux. cargo-zigbuild supplies the cross C
+        # compiler + linker (zig), so crates with native code (ring, mimalloc)
+        # compile for the real GNU triple from this host. `zigbuild` performs a
+        # full build (compile + link) — the faithful equivalent of what the
+        # release runner does; lint drift is already covered by the host clippy
+        # leg. Reuses the per-candidate scratch CARGO_TARGET_DIR.
+        printf "\033[0;34m   Adding x86_64-unknown-linux-gnu target to %s...\033[0m\n" "$CANDIDATE"
+        if ! rustup target add x86_64-unknown-linux-gnu --toolchain "$CANDIDATE" \
+                >/tmp/toolchain-sync-linuxtarget.log 2>&1; then
+            printf "\033[0;33m   ⚠️  could not add the linux target to %s — stepping back one day.\033[0m\n" "$CANDIDATE"
+            if [ "$CANDIDATE" = "$CURRENT" ]; then
+                printf "\n\033[0;31m❌ Current pin %s cannot add x86_64-unknown-linux-gnu.\033[0m\n" "$CURRENT"
+                exit 1
+            fi
+            CANDIDATE_DATE=$(date_minus_one "$CANDIDATE_DATE")
+            ITER=$((ITER+1))
+            continue
+        fi
+        printf "\033[0;34m   Running cargo +%s zigbuild --target x86_64-unknown-linux-gnu...\033[0m\n" "$CANDIDATE"
+        if CARGO_TARGET_DIR="$PROBE_ROOT/$CANDIDATE" \
+            cargo "+$CANDIDATE" zigbuild --target x86_64-unknown-linux-gnu --workspace --all-features --locked --quiet \
+            >/tmp/toolchain-sync-zigbuild.log 2>&1; then
+            printf "\033[0;32m   ✅ linux zigbuild ok\033[0m\n"
+        else
+            printf "\033[0;33m   ⚠️  linux zigbuild failed under %s — stepping back one day.\033[0m\n" "$CANDIDATE"
+            printf "\033[0;33m      (last 5 lines from /tmp/toolchain-sync-zigbuild.log:)\033[0m\n"
+            tail -n 5 /tmp/toolchain-sync-zigbuild.log | sed 's/^/        /'
+            if [ "$CANDIDATE" = "$CURRENT" ]; then
+                printf "\n\033[0;31m❌ Current pin %s no longer compiles for x86_64-unknown-linux-gnu.\033[0m\n" "$CURRENT"
+                printf "\033[0;31m   Full log: /tmp/toolchain-sync-zigbuild.log\033[0m\n"
+                printf "\033[0;31m   Manual intervention required — the release build's Linux leg will reject this pin.\033[0m\n"
                 exit 1
             fi
             CANDIDATE_DATE=$(date_minus_one "$CANDIDATE_DATE")


### PR DESCRIPTION
Closes the last hole in the toolchain-bump gate and fixes a latent release-quality bug it immediately exposed.

## Phase 2c: Linux cross-compile gate
`toolchain-sync` gated a candidate nightly on the host (Phase 2 clippy, both feature sets) and Windows (Phase 2b `cargo xwin clippy`) — but not Linux, although the release ships `x86_64-unknown-linux-gnu` (built natively on the ubuntu-22.04 runner). A linux-only nightly regression (the ring episode's class, pointed at Linux) would have been green-lit and only exploded at release-build time.

Phase 2c runs `cargo zigbuild --target x86_64-unknown-linux-gnu --workspace --all-features --locked` per candidate — a full compile+link, the faithful equivalent of the release runner's leg (zig supplies the cross C compiler + linker, so native-code crates like ring compile for the real GNU triple from the macOS host). Hard-requires cargo-zigbuild + zig with the same refusal posture as 2b's cargo-xwin; step-back/abort semantics mirror 2b exactly. **All three shipped targets now gate every pin bump.**

## The bug the gate caught: non-deterministic Linux CPU baseline
The linux rustflags used `target-cpu=native`. The Windows config section documents exactly why that's wrong for cross-compiles — and worse: release CI builds the linux leg natively on whatever GitHub runner it lands on, so `native` baked the **runner's** CPU features into shipped binaries (an AVX-512 runner emits binaries that crash on older user CPUs). Now pinned to the same deterministic `x86-64-v3` baseline (AVX2; Haswell 2013+ / Zen 2017+) as the Windows leg.

## Validation
Full workspace zigbuild for `x86_64-unknown-linux-gnu` passes on the current pin from the macOS host (exit 0, ELF binaries produced) · justfile parses · the stale local duplicate branch of Phase 2b was deleted.
