### PR TITLE
fix(install): match SHA256SUMS entries with their ./ prefix (installer was dead on arrival)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -118,8 +118,12 @@ resolve_version() {
 # ── verify one downloaded file against SHA256SUMS ────────────────────────────
 verify_asset() {
   # $1 = local file, $2 = asset name (the SHA256SUMS entry), $3 = SHA256SUMS path
+  # The release generates entries as `<hash>  ./<asset>` (note the ./ prefix);
+  # accept the bare name, ./-prefixed, and sha256sum's `*` binary marker.
+  # Exact string comparison in awk — no regex escaping, no pipes.
   local want got
-  want="$(grep -E "[[:space:]][*]?$2\$" "$3" | awk '{print $1}' | head -1)"
+  want="$(awk -v name="$2" \
+    '$2 == name || $2 == "./" name || $2 == "*" name { print $1; exit }' "$3")"
   [ -n "$want" ] || err "no checksum for '$2' in SHA256SUMS"
   got="$(sha256_of "$1")"
   [ "$want" = "$got" ] || err "checksum mismatch for '$2' (expected $want, got $got)"


### PR DESCRIPTION
The Linux/macOS one-line installer downloaded the first binary and silently died — nothing was installed (live report from WSL2).

**Root cause**: the release generates SHA256SUMS entries as `<hash>  ./<asset>` and `verify_asset`'s grep pattern (`[[:space:]][*]?<name>$`) can't match through the `./` prefix — the very first verification failed with "no checksum" and exited. Every release has this format (checked back to v0.6.18): the installer's verify leg was **broken since birth**, previously masked by the broken-pipe bug fixed in #506.

**Fix**: exact string comparison in awk over the bare name, the `./`-prefixed form, and sha256sum's `*` binary marker — no regex escaping, and no pipes (the SIGPIPE class #506 killed can't regrow here).

**Validated end-to-end on macOS against the live v0.6.20 release**: all five binaries download, checksum-verify, install; `uffs --version` → `uffs 0.6.20 (0dec130)`. bash -n + shellcheck clean.

Users fetch install.sh from `main`, so this fix is live for everyone the moment it merges — no release needed.
