### PR TITLE
fix(core): apply USN batches parents-first (fixes #510 phantom root-level paths)

### DIFF
--- a/crates/uffs-core/src/compact_loader.rs
+++ b/crates/uffs-core/src/compact_loader.rs
@@ -454,6 +454,84 @@ pub fn load_mft_file(
     load_drive(&MftSource::File(mft_path.to_path_buf(), drive), no_cache)
 }
 
+/// Order a USN batch so that a created/renamed record is applied AFTER the
+/// change that creates its parent directory, whenever that parent is itself
+/// created in the same batch. The journal delivers records in time order
+/// (a directory exists before anything appears inside it), but
+/// [`uffs_mft::usn::aggregate_changes`] folds them into a `HashMap`, so the
+/// batch arrives in arbitrary order at every consumer (the live journal loop
+/// AND the cold-start cache replay) — fixing it here covers both.
+///
+/// A fixpoint pass handles arbitrarily deep same-batch trees (an unzip
+/// creates `dir/sub/file` in one poll window). Changes whose parent is
+/// genuinely absent from the batch are emitted as-is: the unknown-parent
+/// fallback still applies, but is now reached only for truly missing parents
+/// (lost/overflowed journal events), and is logged.
+fn order_parent_first(changes: &[uffs_mft::usn::FileChange]) -> Vec<&uffs_mft::usn::FileChange> {
+    use std::collections::HashSet;
+
+    // Only a parent that is CREATED in this batch can become resolvable by
+    // reordering; everything else keeps its relative order.
+    let batch_creates: HashSet<u64> = changes
+        .iter()
+        .filter(|change| change.created)
+        .map(|change| change.frs.raw())
+        .collect();
+    let mut applied_creates: HashSet<u64> = HashSet::new();
+    let mut out: Vec<&uffs_mft::usn::FileChange> = Vec::with_capacity(changes.len());
+    let mut deferred: Vec<&uffs_mft::usn::FileChange> = Vec::new();
+
+    for change in changes {
+        let parent = change.parent_frs.raw();
+        let waits_for_parent = (change.created || change.renamed)
+            && parent != change.frs.raw()
+            && batch_creates.contains(&parent)
+            && !applied_creates.contains(&parent);
+        if waits_for_parent {
+            deferred.push(change);
+        } else {
+            if change.created {
+                applied_creates.insert(change.frs.raw());
+            }
+            out.push(change);
+        }
+    }
+
+    // Fixpoint: each pass releases the changes whose parent has now been
+    // emitted; depth-N same-batch trees settle in N passes.
+    while !deferred.is_empty() {
+        let before = deferred.len();
+        deferred.retain(|change| {
+            if applied_creates.contains(&change.parent_frs.raw()) {
+                if change.created {
+                    applied_creates.insert(change.frs.raw());
+                }
+                out.push(change);
+                false
+            } else {
+                true
+            }
+        });
+        if deferred.len() == before {
+            // No progress: a dependency cycle (corrupt journal) or parents
+            // whose own creates never surfaced. Emit as-is — the
+            // unknown-parent fallback handles them — but say so.
+            for change in &deferred {
+                tracing::warn!(
+                    frs = change.frs.raw(),
+                    parent_frs = change.parent_frs.raw(),
+                    name = %change.filename,
+                    "usn apply: parent create not resolvable within the batch; \
+                     falling back to unknown-parent"
+                );
+                out.push(change);
+            }
+            break;
+        }
+    }
+    out
+}
+
 /// Apply USN changes in-place to the compact index.
 ///
 /// Mutates records (`parent_idx`, names, flags) and the
@@ -508,7 +586,15 @@ pub fn apply_usn_patch(
     // Wall-clock the whole apply (O(changed) mutation loop + the post-loop
     // overlay/path refresh) for the DEBUG batch summary.
     let t_apply = Instant::now();
-    for change in changes {
+    // Parents before children: `aggregate_changes` hands the batch over in
+    // HashMap (arbitrary) order, so without reordering a file's create could
+    // apply before its parent directory's create — the parent lookup then
+    // misses and bakes the unknown-parent sentinel (`u32::MAX`), which the
+    // path machinery legitimately renders as a ROOT-LEVEL entry. That is the
+    // #510 bug: freshly-unzipped files reported at `C:\<name>` and an
+    // uninstall "removing" phantom paths while the real files survived.
+    let ordered = order_parent_first(changes);
+    for change in ordered {
         // Typed `Frs` → raw `u64` lift at the frs_to_compact CSR lookup
         // boundary.  The mapping table is `Vec<u32>` indexed by `usize`,
         // so demoting once per change keeps the inner index arithmetic on
@@ -584,6 +670,10 @@ pub fn apply_usn_patch(
 #[cfg(test)]
 #[path = "compact_loader_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "compact_loader_usn_order_tests.rs"]
+mod usn_order_tests;
 
 #[cfg(test)]
 #[path = "compact_loader_path_oracle_tests.rs"]

--- a/crates/uffs-core/src/compact_loader_tests.rs
+++ b/crates/uffs-core/src/compact_loader_tests.rs
@@ -40,7 +40,7 @@ use crate::trigram::TrigramIndex;
 /// `u32::MAX` sentinels for FRS 13 (newly-created in the create
 /// test) and FRS 99 (unmapped / skipped) so tests can patch the
 /// drive in place without touching a separate slice.
-fn make_synthetic_drive() -> DriveCompactIndex {
+pub(super) fn make_synthetic_drive() -> DriveCompactIndex {
     // Names blob layout:
     //   "C"       [0..1]
     //   "foo.txt" [1..8]

--- a/crates/uffs-core/src/compact_loader_usn_order_tests.rs
+++ b/crates/uffs-core/src/compact_loader_usn_order_tests.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Regression tests for issue #510 — USN batches must apply parents before
+//! children ([`super::order_parent_first`] wired into
+//! [`super::apply_usn_patch`]), or a same-batch child bakes the
+//! unknown-parent sentinel and renders as a phantom root-level path.
+//!
+//! Sibling file (the `compact_loader_tests.rs` pattern) so both stay under
+//! the workspace file-size policy. Reuses that sibling's synthetic-drive
+//! fixture via `super::tests::make_synthetic_drive`.
+
+use uffs_mft::usn::FileChange;
+
+use super::apply_usn_patch;
+use super::tests::make_synthetic_drive;
+
+/// Regression for issue #510: `aggregate_changes` hands the batch over in
+/// arbitrary (`HashMap`) order, so a file's create could be applied BEFORE its
+/// parent directory's create — the parent lookup missed and baked the
+/// unknown-parent sentinel, which the path machinery renders as a ROOT-LEVEL
+/// entry (`C:\<name>`). Live symptom: freshly-unzipped files listed at the
+/// drive root, and an uninstall "removing" phantom paths.
+#[test]
+fn scrambled_child_before_parent_resolves_to_the_new_dir() {
+    let mut drive = make_synthetic_drive();
+    // Deliberately WORST-CASE order: grandchild first, then child, then the
+    // directory that parents them both (FRS 20 dir → FRS 21 subdir → FRS 22
+    // file). A single-pass apply would bake u32::MAX for 22 and 21.
+    let changes = vec![
+        FileChange {
+            frs: 22_u64.into(),
+            parent_frs: 21_u64.into(),
+            filename: "leaf.txt".to_owned(),
+            created: true,
+            ..FileChange::default()
+        },
+        FileChange {
+            frs: 21_u64.into(),
+            parent_frs: 20_u64.into(),
+            filename: "sub".to_owned(),
+            created: true,
+            ..FileChange::default()
+        },
+        FileChange {
+            frs: 20_u64.into(),
+            parent_frs: 5_u64.into(),
+            filename: "unzipped".to_owned(),
+            created: true,
+            ..FileChange::default()
+        },
+    ];
+
+    let stats = apply_usn_patch(&mut drive, &changes);
+    assert_eq!(stats.created, 3);
+
+    let idx_of = |frs: usize| drive.frs_to_compact.get(frs).copied().unwrap();
+    let (dir_idx, sub_idx, leaf_idx) = (idx_of(20), idx_of(21), idx_of(22));
+    assert_ne!(dir_idx, u32::MAX, "dir registered");
+    assert_ne!(sub_idx, u32::MAX, "subdir registered");
+    assert_ne!(leaf_idx, u32::MAX, "leaf registered");
+
+    let rec = |idx: u32| drive.records.as_slice().get(idx as usize).copied().unwrap();
+    // The dir hangs off the root (compact_idx 0 — FRS 5 pre-mapped).
+    assert_eq!(rec(dir_idx).parent_idx, 0, "dir parents to root");
+    // The chain resolves through the SAME-BATCH creates, not to u32::MAX
+    // (which would render as a phantom root-level path — the #510 bake).
+    assert_eq!(
+        rec(sub_idx).parent_idx,
+        dir_idx,
+        "subdir must parent to the same-batch dir, not the root sentinel"
+    );
+    assert_eq!(
+        rec(leaf_idx).parent_idx,
+        sub_idx,
+        "leaf must parent to the same-batch subdir, not the root sentinel"
+    );
+}
+
+/// A same-batch RENAME into a just-created directory must also wait for the
+/// directory's create (renames re-resolve `parent_idx` too).
+#[test]
+fn scrambled_rename_into_new_dir_resolves() {
+    let mut drive = make_synthetic_drive();
+    let changes = vec![
+        // Move existing FRS 10 ("foo.txt") into the new dir — listed FIRST.
+        FileChange {
+            frs: 10_u64.into(),
+            parent_frs: 30_u64.into(),
+            filename: "foo.txt".to_owned(),
+            renamed: true,
+            ..FileChange::default()
+        },
+        // The directory it moves into — listed SECOND.
+        FileChange {
+            frs: 30_u64.into(),
+            parent_frs: 5_u64.into(),
+            filename: "newdir".to_owned(),
+            created: true,
+            ..FileChange::default()
+        },
+    ];
+
+    apply_usn_patch(&mut drive, &changes);
+
+    let dir_idx = drive.frs_to_compact.get(30).copied().unwrap();
+    assert_ne!(dir_idx, u32::MAX);
+    let moved = drive.records.as_slice().get(1).copied().unwrap(); // FRS 10 @ idx 1
+    assert_eq!(
+        moved.parent_idx, dir_idx,
+        "renamed-into-new-dir must parent to the same-batch dir"
+    );
+}
+
+/// A parent that is genuinely absent from the batch (its create event was
+/// never seen — lost/overflowed journal) keeps today's unknown-parent
+/// fallback: the child is still applied, with the sentinel parent.
+#[test]
+fn genuinely_missing_parent_still_applies_with_sentinel() {
+    let mut drive = make_synthetic_drive();
+    let changes = vec![FileChange {
+        frs: 40_u64.into(),
+        parent_frs: 39_u64.into(), // never created anywhere
+        filename: "orphan.txt".to_owned(),
+        created: true,
+        ..FileChange::default()
+    }];
+
+    let stats = apply_usn_patch(&mut drive, &changes);
+    assert_eq!(stats.created, 1, "the orphan is still applied");
+    let idx = drive.frs_to_compact.get(40).copied().unwrap();
+    let rec = drive.records.as_slice().get(idx as usize).copied().unwrap();
+    assert_eq!(
+        rec.parent_idx,
+        u32::MAX,
+        "unknown parent keeps the sentinel (fallback preserved)"
+    );
+}


### PR DESCRIPTION
Closes #510.

## Root cause (three layers)
1. `aggregate_changes` folds the **time-ordered** USN journal into a `HashMap` → every consumer receives the batch in **arbitrary order** (the live journal loop AND the cold-start cache replay).
2. When a file's create is applied before its same-batch parent-directory create (hash luck), the parent lookup misses and `stage_create` bakes the unknown-parent sentinel (`u32::MAX`).
3. That sentinel **legitimately means "root level"** everywhere else (the builder maps real root children to it) — so the file renders as `C:\<name>`. Live symptom: searches returning phantom root paths, and the uninstall deep sweep "removing" nonexistent `C:\` files while the real ones survived (2 of 17 freshly-unzipped files, v0.6.20 report).

## Fix
`order_parent_first` at the **apply layer** (covers both consumers): each batch is reordered so a created/renamed record applies after the same-batch create of its parent, with a fixpoint pass for arbitrarily deep same-batch trees (an unzip creates `dir/sub/file` in one poll window). Changes whose parent is genuinely absent from the batch keep today's sentinel fallback — now reached only for truly lost journal events — and are warn-logged.

## Proof
- Worst-case regression test (grandchild → child → dir, exactly backwards) **verified to FAIL against the unfixed code** and passes with the fix.
- Same-batch rename into a just-created dir resolves; genuinely-missing parent keeps the fallback.
- Tests live in a sibling file (`compact_loader_usn_order_tests.rs`, file-size policy pattern).
- Full uffs-core suite: 876 tests pass · host + Windows clippy clean · rustdoc clean.
