### PR TITLE
fix(release): ship the Linux binary as static musl (runs on old glibc / WSL)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,8 +313,10 @@ jobs:
   # Three targets, each earning its slot:
   #   - x86_64-pc-windows-msvc   — primary product: live NTFS MFT indexing
   #   - aarch64-apple-darwin     — offline MFT analysis on Apple Silicon
-  #   - x86_64-unknown-linux-gnu — offline MFT analysis on Linux (servers,
-  #                                forensics VMs, Docker, CI harnesses)
+  #   - x86_64-unknown-linux-musl — offline MFT analysis on Linux (servers,
+  #                                 forensics VMs, Docker, CI harnesses).
+  #                                 STATIC (no glibc floor) → runs on every
+  #                                 Linux incl. old LTS / WSL / Alpine.
   #
   # Dropped vs previous iterations:
   #   - x86_64-apple-darwin (Intel Mac) — Apple deprecated the platform;
@@ -359,7 +361,14 @@ jobs:
             binary-suffix: ""
             rustflags: "-C target-cpu=apple-m1 -C link-arg=-Wl,-dead_strip"
             timeout: 45
-          - target: x86_64-unknown-linux-gnu
+          # musl = fully STATIC binary, zero glibc dependency: the gnu build on
+          # ubuntu-22.04 (glibc 2.35) baked a glibc floor that broke Ubuntu
+          # 20.04 / WSL (glibc 2.31: "GLIBC_2.33 not found"). The static musl
+          # binary runs on every Linux (20.04, Alpine, old servers) forever. No
+          # perf cost here — the daemon uses mimalloc globally, so libc's
+          # allocator is irrelevant. Built via cargo-zigbuild (zig supplies the
+          # C cross-toolchain + static link cleanly, incl. the mimalloc C dep).
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
             artifact-name: uffs-linux-x64
             binary-suffix: ""
@@ -474,6 +483,25 @@ jobs:
           rustup default "$(rustup show active-toolchain | awk '{print $1}')"
           cargo --version
 
+      - name: Set up cargo-zigbuild for static musl (Linux only)
+        if: contains(matrix.target, 'musl')
+        shell: bash
+        run: |
+          # musl static Linux is built with cargo-zigbuild: zig provides the C
+          # cross-toolchain (mimalloc's C compiles cleanly) and a static musl
+          # link, without the musl-gcc / CC_* env fiddling plain cargo needs.
+          # Pinned zig via the `ziglang` PyPI wheel (no marketplace action).
+          rustup target add ${{ matrix.target }}
+          python3 -m pip install --user "ziglang==0.13.0"
+          # cargo-zigbuild finds zig via `python3 -m ziglang`; expose it on PATH
+          # as `zig` for good measure.
+          ZIG_DIR="$(python3 -c 'import ziglang, os; print(os.path.dirname(ziglang.__file__))')"
+          printf 'exec python3 -m ziglang "$@"\n' | sudo tee /usr/local/bin/zig >/dev/null
+          sudo chmod +x /usr/local/bin/zig
+          zig version
+          cargo install --locked cargo-zigbuild@0.19.8
+          cargo zigbuild --version
+
       - name: Build optimized release binaries
         shell: bash
         run: |
@@ -492,7 +520,13 @@ jobs:
           # may differ from what the tests validated — worst-case a
           # silent dep drift ships to end-users.  CI fails loudly
           # instead.
-          cargo build --locked --release --target ${{ matrix.target }} --workspace --bins
+          # musl → cargo-zigbuild (static C toolchain via zig); everything else
+          # → the native cargo build. Same flags/profile either way.
+          if [[ "${{ matrix.target }}" == *musl* ]]; then
+            cargo zigbuild --locked --release --target ${{ matrix.target }} --workspace --bins
+          else
+            cargo build --locked --release --target ${{ matrix.target }} --workspace --bins
+          fi
 
           echo "✅ Build completed for ${{ matrix.target }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,15 +491,17 @@ jobs:
           # cross-toolchain (mimalloc's C compiles cleanly) and a static musl
           # link, without the musl-gcc / CC_* env fiddling plain cargo needs.
           # Pinned zig via the `ziglang` PyPI wheel (no marketplace action).
+          # Pinned to the exact zig + cargo-zigbuild the maintainer validated
+          # the static-musl build with locally (this workflow leg only runs at
+          # release time, so it cannot drift-test itself — pin what is proven).
           rustup target add ${{ matrix.target }}
-          python3 -m pip install --user "ziglang==0.13.0"
+          python3 -m pip install --user "ziglang==0.14.1"
           # cargo-zigbuild finds zig via `python3 -m ziglang`; expose it on PATH
           # as `zig` for good measure.
-          ZIG_DIR="$(python3 -c 'import ziglang, os; print(os.path.dirname(ziglang.__file__))')"
           printf 'exec python3 -m ziglang "$@"\n' | sudo tee /usr/local/bin/zig >/dev/null
           sudo chmod +x /usr/local/bin/zig
           zig version
-          cargo install --locked cargo-zigbuild@0.19.8
+          cargo install --locked cargo-zigbuild@0.22.3
           cargo zigbuild --version
 
       - name: Build optimized release binaries


### PR DESCRIPTION
The released Linux binary fails on **Ubuntu 20.04 / WSL**: `libc.so.6: version 'GLIBC_2.33' not found` (also 2.32 / 2.34). We built `x86_64-unknown-linux-gnu` on **ubuntu-22.04 (glibc 2.35)**, and glibc symbol versioning is forward-only — so the binary demanded a glibc floor that 20.04 (2.31, an LTS into 2025) and every older distro can't meet.

## Fix: ship static musl
Switch the Linux release target to **`x86_64-unknown-linux-musl`** — a fully static binary, **zero glibc dependency**, runs on every Linux (20.04, WSL, Alpine, old servers) forever. The standard portable-Rust-CLI approach (ripgrep / fd). **No perf cost**: the daemon uses mimalloc as its global allocator (libc's allocator is irrelevant) and the CLI is a thin IPC client.

- Built via **cargo-zigbuild** (zig supplies the C cross-toolchain so mimalloc's C compiles, plus the static musl link), set up on the Linux leg only via the pinned `ziglang` wheel. Build step branches musl→zigbuild, everything else→`cargo build`.
- Pinned to the **exact zig 0.14.1 + cargo-zigbuild 0.22.3** the build was validated with locally — this workflow leg only runs at release time, so it can't drift-test itself.
- **`artifact-name: uffs-linux-x64` unchanged** → install.sh and every consumer untouched.

## Validation
Locally: full workspace `--bins` builds for `x86_64-unknown-linux-musl`, and all five shipped binaries (uffs/uffsd/uffsmcp/uffs-update/uffs-mft) report `file` = **"statically linked"**. release.yml is valid YAML.

⚠ **The workflow change itself is only exercised by a real release run** (fail-safe: a broken build fails the release, no bad artifact ships). The next `ship-fresh` → 0.6.21 is the true test — and the WSL re-test then confirms it end-to-end.
