### PR TITLE
fix(update): honest winget-upgrade narration + unblock the musl release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -502,7 +502,11 @@ jobs:
           sudo chmod +x /usr/local/bin/zig
           zig version
           cargo install --locked cargo-zigbuild@0.22.3
-          cargo zigbuild --version
+          # No `cargo zigbuild --version` smoke here: `cargo zigbuild <args>`
+          # forwards to the `zigbuild` subcommand, which has no `--version`
+          # (it errors "unexpected argument '--version'"). The real proof is
+          # the `cargo zigbuild --release` build step below; installing at the
+          # pinned @0.22.3 already fixes the version.
 
       - name: Build optimized release binaries
         shell: bash

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -232,16 +232,34 @@ fn assess(report: &DetectionReport) -> UpdatePlan {
 /// the install is incomplete relative to the canonical set
 /// (`binaries::KNOWN_BINARIES`, the single source of truth). `WinGet` roots are
 /// delegated to `winget upgrade`, so they are not reconciled here.
+///
+/// `uffs-broker` is **excluded** from the required set: it is a Windows
+/// `LocalSystem` service installed *once* (via the winget package or
+/// `uffs-broker --install`), so it legitimately does not live in every
+/// hand-placed CLI root. Requiring it would mark a perfectly current install
+/// "incomplete" and trigger a pointless update + UAC prompt every time the
+/// broker sits in a different (e.g. winget) root than the CLI.
 fn has_missing_core(report: &DetectionReport) -> bool {
     report
         .roots
         .iter()
         .filter(|root| root.channel.label() == "unmanaged")
-        .any(|root| {
-            binaries::KNOWN_BINARIES
-                .iter()
-                .any(|stem| !root.binaries.iter().any(|bin| bin.name == *stem))
-        })
+        .any(|root| root_missing_core(root, &binaries::KNOWN_BINARIES))
+}
+
+/// Binary stem of the Access Broker — excluded from [`root_missing_core`]
+/// because it is a once-installed Windows service, not a per-root binary.
+const BROKER_STEM: &str = "uffs-broker";
+
+/// Whether `root` lacks any *required* core binary, treating the broker as
+/// optional (see [`has_missing_core`]). Split out as a pure function so the
+/// broker-exclusion is testable off Windows, where `KNOWN_BINARIES` omits the
+/// broker anyway.
+fn root_missing_core(root: &InstallRoot, required: &[&str]) -> bool {
+    required
+        .iter()
+        .filter(|stem| **stem != BROKER_STEM)
+        .any(|stem| !root.binaries.iter().any(|bin| bin.name == *stem))
 }
 
 /// Point the user at the update flow — the fix for an out-of-date, skewed, or
@@ -597,8 +615,56 @@ fn print_phase_a_footer() {
 
 #[cfg(test)]
 mod tests {
-    use super::model::{Anchor, InstallRoot};
-    use super::{normalize_tag, strip_verbatim_str, upsert_root};
+    use super::model::{Anchor, BinaryInfo, Channel, InstallRoot, Scope};
+    use super::{normalize_tag, root_missing_core, strip_verbatim_str, upsert_root};
+
+    /// An unmanaged root holding exactly the given binary stems.
+    fn unmanaged_root(stems: &[&str]) -> InstallRoot {
+        InstallRoot {
+            dir: "/nonexistent/bin".into(),
+            channel: Channel::Unmanaged,
+            scope: Scope::Unknown,
+            anchored_by: vec![Anchor::Cli],
+            binaries: stems
+                .iter()
+                .map(|name| BinaryInfo {
+                    name: (*name).to_owned(),
+                    version: Some("0.6.20".to_owned()),
+                })
+                .collect(),
+        }
+    }
+
+    // The Windows core set (broker included) — the case the exclusion fixes.
+    const CORE_WITH_BROKER: [&str; 6] = [
+        "uffs",
+        "uffsd",
+        "uffsmcp",
+        "uffs-update",
+        "uffs-mft",
+        "uffs-broker",
+    ];
+
+    #[test]
+    fn absent_broker_does_not_mark_root_incomplete() {
+        // Every non-broker core binary present, broker absent (it lives in the
+        // winget root / as the service) → NOT incomplete, so no pointless update.
+        let root = unmanaged_root(&["uffs", "uffsd", "uffsmcp", "uffs-update", "uffs-mft"]);
+        assert!(
+            !root_missing_core(&root, &CORE_WITH_BROKER),
+            "a missing broker must not count as an incomplete install"
+        );
+    }
+
+    #[test]
+    fn absent_non_broker_core_marks_root_incomplete() {
+        // A genuine gap (no uffsd) is still incomplete, broker present or not.
+        let root = unmanaged_root(&["uffs", "uffsmcp", "uffs-update", "uffs-mft", "uffs-broker"]);
+        assert!(
+            root_missing_core(&root, &CORE_WITH_BROKER),
+            "a missing non-broker core binary must count as incomplete"
+        );
+    }
 
     #[test]
     fn strip_verbatim_str_handles_drive_unc_and_plain() {

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -113,6 +113,14 @@ fn run_apply(args: &[String]) -> Result<()> {
     // (its wire protocol is back-compatible) and catches up on the next elevated
     // update. `is_elevated()` is `false` off Windows, but the snapshot has no
     // broker there, so this is a no-op away from Windows.
+    // Read this BEFORE drop_broker strips the broker entries: when the broker
+    // lives in a WinGet-delegated root, the caller's `winget upgrade` refreshes
+    // its `.exe` and cycles the service, so it is not left at the old version.
+    let broker_delegated = snapshot.broker_in_winget_root();
+    // Components whose image is in a WinGet-delegated root: the caller
+    // (uffs-cli) stops them up front and its `resume` relaunches them on the
+    // new binary, so if restore can't restart them here it is NOT a fault.
+    let winget_delegated = snapshot.winget_delegated_components();
     let skipped_broker = if uffs_winsvc::is_elevated() {
         None
     } else {
@@ -166,21 +174,39 @@ fn run_apply(args: &[String]) -> Result<()> {
     // Committed: relaunch services into the new binaries.
     let failed = restore::restore(&snapshot);
     journal.transition(journal::UpdateState::Restored, "restore.done")?;
-    if !failed.is_empty() {
+    // Split the failures: a component in a WinGet-delegated root was stopped by
+    // the caller and is relaunched by its `resume` on the new binary, so it is
+    // not a fault here — only genuinely-ours components warrant the warning.
+    let (delegated_down, genuine_failed): (Vec<String>, Vec<String>) = failed
+        .into_iter()
+        .partition(|component| winget_delegated.contains(component));
+    if !genuine_failed.is_empty() {
         #[expect(clippy::print_stderr, reason = "CLI user-facing warning")]
         {
             eprintln!(
                 "warning: components failed to restart: [{}]",
-                failed.join(", ")
+                genuine_failed.join(", ")
             );
         }
+    }
+    if !delegated_down.is_empty() {
+        println!(
+            "note: {} left stopped here — the winget package update relaunches \
+             it on the new binary.",
+            delegated_down.join(", ")
+        );
     }
 
     orchestrate::prune_all(&journal);
     journal.transition(journal::UpdateState::Done, "apply.done")?;
     journal.archive();
     println!("Applied + committed → {}", journal.to_version);
-    if let Some(broker_version) = skipped_broker {
+    // Only warn when nothing else will refresh the broker. If it lives in a
+    // WinGet-delegated root, the caller's `winget upgrade` + service cycle
+    // brings it to the new version, so this hint would contradict reality.
+    if let Some(broker_version) = skipped_broker
+        && !broker_delegated
+    {
         println!(
             "note: the Access Broker (uffs-broker {broker_version}) was left running \
              and NOT updated — refreshing the LocalSystem broker service needs \

--- a/crates/uffs-update/src/plan.rs
+++ b/crates/uffs-update/src/plan.rs
@@ -9,7 +9,7 @@
 //! phases need are modelled; unknown fields are ignored so the schema can
 //! grow without breaking older helpers.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result};
 use serde::Deserialize;
@@ -78,7 +78,7 @@ impl Snapshot {
     /// # Errors
     ///
     /// Fails if the file is missing or not valid snapshot JSON.
-    pub(crate) fn load(path: &std::path::Path) -> Result<Self> {
+    pub(crate) fn load(path: &Path) -> Result<Self> {
         let text = std::fs::read_to_string(path)
             .with_context(|| format!("reading snapshot {}", path.display()))?;
         serde_json::from_str(&text).with_context(|| format!("parsing snapshot {}", path.display()))
@@ -122,6 +122,43 @@ impl Snapshot {
             target.binaries.retain(|bin| bin.name != BROKER_STEM);
         }
         Some(version)
+    }
+
+    /// Whether the Access Broker binary lives under a `WinGet`-delegated root.
+    /// When it does, a non-elevated apply skips the broker here, but the
+    /// caller's `winget upgrade` refreshes `uffs-broker.exe` and cycles the
+    /// service — so the broker is NOT left at the old version and the
+    /// "left running and NOT updated" hint would be wrong. Must be read
+    /// **before** [`Self::drop_broker`], which strips the broker entries.
+    pub(crate) fn broker_in_winget_root(&self) -> bool {
+        self.targets.iter().any(|target| {
+            target.channel == "winget" && target.binaries.iter().any(|bin| bin.name == BROKER_STEM)
+        })
+    }
+
+    /// Names of running components whose image lives under a `WinGet`-delegated
+    /// root. Their lifecycle is owned by the caller's `winget upgrade` + resume
+    /// (in `uffs-cli`), so a non-elevated apply that could not restart them
+    /// here has not actually left anything broken — the caller relaunches
+    /// them on the new binary. Used to keep these out of the alarming
+    /// "failed to restart" warning (they are stopped-on-purpose, not a
+    /// fault).
+    pub(crate) fn winget_delegated_components(&self) -> Vec<String> {
+        let winget_roots: Vec<&Path> = self
+            .targets
+            .iter()
+            .filter(|target| target.channel == "winget")
+            .map(|target| target.root.as_path())
+            .collect();
+        self.running
+            .iter()
+            .filter(|run| {
+                run.image_path
+                    .as_deref()
+                    .is_some_and(|img| winget_roots.iter().any(|root| img.starts_with(root)))
+            })
+            .map(|run| run.component.clone())
+            .collect()
     }
 
     /// Roots the **updater** owns: `unmanaged` only. `WinGet` roots are
@@ -261,5 +298,75 @@ mod tests {
     fn drop_broker_is_none_when_absent() {
         let mut snap: Snapshot = serde_json::from_str(SNAP).expect("parse");
         assert_eq!(snap.drop_broker(), None, "snapshot has no broker");
+    }
+
+    #[test]
+    fn broker_in_winget_root_detects_delegated_broker() {
+        // Broker binary sits in the winget root → delegated `winget upgrade`
+        // will refresh it, so the "left NOT updated" note must be suppressed.
+        const WINGET_BROKER: &str = r#"{
+          "to_version": "0.6.21",
+          "targets": [
+            { "root": "C:\\bin", "channel": "unmanaged", "binaries": [
+              { "name": "uffs", "on_disk_version": "0.6.21" }
+            ] },
+            { "root": "C:\\wg", "channel": "winget", "binaries": [
+              { "name": "uffsd", "on_disk_version": "0.6.18" },
+              { "name": "uffs-broker", "on_disk_version": "0.6.18" }
+            ] }
+          ]
+        }"#;
+        let snap: Snapshot = serde_json::from_str(WINGET_BROKER).expect("parse");
+        assert!(
+            snap.broker_in_winget_root(),
+            "broker under a winget root is delegated"
+        );
+    }
+
+    #[test]
+    fn winget_delegated_components_matches_images_under_winget_root() {
+        // Forward slashes so the path component-split works on Unix CI too;
+        // on Windows the real backslash paths split the same way.
+        const SNAP_RUN: &str = r#"{
+          "to_version": "0.6.21",
+          "targets": [
+            { "root": "/bin", "channel": "unmanaged", "binaries": [] },
+            { "root": "/wg",  "channel": "winget",    "binaries": [] }
+          ],
+          "running": [
+            { "component": "daemon", "pid": 1, "image_path": "/wg/uffsd.exe" },
+            { "component": "mcp",    "pid": 2, "image_path": "/bin/uffsmcp.exe" }
+          ]
+        }"#;
+        let snap: Snapshot = serde_json::from_str(SNAP_RUN).expect("parse");
+        assert_eq!(
+            snap.winget_delegated_components(),
+            vec!["daemon".to_owned()],
+            "only the component whose image is under the winget root is delegated"
+        );
+    }
+
+    #[test]
+    fn broker_in_winget_root_false_for_unmanaged_broker() {
+        // Broker in an unmanaged root: nothing else refreshes it, so the
+        // note stays. (Also false when there is no broker at all.)
+        const UNMANAGED_BROKER: &str = r#"{
+          "to_version": "0.6.21",
+          "targets": [
+            { "root": "C:\\bin", "channel": "unmanaged", "binaries": [
+              { "name": "uffs-broker", "on_disk_version": "0.6.20" }
+            ] }
+          ]
+        }"#;
+        let snap: Snapshot = serde_json::from_str(UNMANAGED_BROKER).expect("parse");
+        assert!(
+            !snap.broker_in_winget_root(),
+            "broker in an unmanaged root is not delegated"
+        );
+        let no_broker: Snapshot = serde_json::from_str(SNAP).expect("parse");
+        assert!(
+            !no_broker.broker_in_winget_root(),
+            "no broker at all is not delegated"
+        );
     }
 }


### PR DESCRIPTION
Folds four fixes from live-Windows testing of the winget upgrade flow so manual + winget **install / uninstall / upgrade** all narrate what actually happened. Precursor to shipping **0.6.22** (0.6.21's release build failed on the musl leg below and published nothing — latest stayed 0.6.20).

### `ci(release)` — unblock the static-musl Linux build
`cargo zigbuild <args>` forwards to the `zigbuild` subcommand, which rejects `--version` (`unexpected argument`). The smoke line failed the musl matrix leg before the real build ran, so `create-github-release` (needs the whole build matrix) was skipped — no Linux asset. Removed the line; the real `cargo zigbuild --release` step is the proof and `@0.22.3` is pinned.

### `fix(update)` — three narration/behaviour fixes
- **Broker "NOT updated" note** suppressed when the broker lives in a WinGet-delegated root: there `winget upgrade` swaps `uffs-broker.exe` and cycles the service, so it *does* reach the new version. The note contradicted the very next `Restarting the broker service` line. Gated on `broker_in_winget_root()`.
- **Pointless update + UAC** when already current: `has_missing_core` counted `uffs-broker` as required in every unmanaged root, but it is a once-installed Windows service, legitimately absent from a hand-placed CLI root — so a fully-current install looked "incomplete". Broker excluded from the required set.
- **"failed to restart: [daemon]"** demoted to a note in the delegated path: the caller stops those components and its `resume` relaunches them on the new binary, so a non-elevated apply that can't restart them here left nothing broken.

### Tests
`root_missing_core` broker-exclusion, `broker_in_winget_root`, `winget_delegated_components` (forward-slash paths so the component split runs cross-platform). Clippy clean on both crates.