### PR TITLE
docs: backfill CHANGELOG + document install/update/uninstall lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.22] - 2026-07-03
+
+Consolidated notes for the 0.6.19–0.6.22 development cycle, which reworked the
+full **install / update / uninstall** lifecycle on Windows and made the
+macOS/Linux binaries portable.
+
+### Added — zero-UAC Access Broker service
+
+`uffs-broker --install` (one-time, from an elevated shell) registers a
+`LocalSystem` Windows service that vends the daemon an elevated, duplicated
+NTFS volume handle over a named pipe. After that, **every** later `uffs` search
+runs non-elevated with **no UAC prompt**, surviving reboots — the daemon reads
+the live MFT through the broker's handle. Install narrates each step with a
+spinner; the one slow step (`sc create`, scanned by antivirus) is called out
+honestly instead of looking hung.
+
+### Added — self-update: `uffs --update` (and the `--upgrade` alias)
+
+One command reconciles any starting state to a complete, current install —
+behind, version-skewed, or even missing a binary — and does nothing when
+already current. It downloads, SHA-256-verifies, and atomically swaps every
+core binary (journaled, with auto-rollback). On a WinGet-managed install it
+stops the daemon and package broker up front (one UAC), runs `winget upgrade`
+against the now-unlocked images, and restarts them — so the bare `winget
+upgrade` that fails on locked binaries is no longer the user's problem.
+
+### Changed — `uffs --uninstall` reworked into a full, safe teardown
+
+Uninstall discovers every UFFS copy across the system (PATH + standard bin
+dirs on all platforms; on Windows also a deep, MFT-driven sweep for strays),
+reloads a version-mismatched daemon before sweeping so it reports the truth,
+and removes binaries, data, cache, config, and the broker service under clear
+CORE / ALL confirmations. Elevation is requested once, only when actually
+needed (the broker service), and the flow degrades cleanly if you decline. The
+`uffs` binary removes itself last, on exit.
+
+### Changed — Linux binary is now a static musl build
+
+The Linux release binary links musl statically (built with cargo-zigbuild), so
+it runs on old-glibc hosts and inside WSL without the previous
+`GLIBC_2.xx not found` failure. macOS and Linux remain **offline MFT analysis
+only** — they do not index the host filesystem (see the platform note in the
+README).
+
+### Changed — binaries renamed with a `uffs-` prefix
+
+Every shipped binary now starts with `uffs` (e.g. `uffs-mcp-http`,
+`uffs-bench`). The pre-rename names are recognized as retired stems, so
+upgrades and uninstall still find and clean up older installs.
+
+### Fixed — USN journal phantom root paths
+
+Live index updates from the NTFS USN journal now apply parent-directory changes
+before their children, so newly-created files resolve under their real parent
+path instead of occasionally appearing at a bare drive root (`C:\name`).
+
+### Fixed — honest winget-upgrade narration
+
+Self-update no longer claims the Access Broker was "not updated" when the
+winget package upgrade actually refreshes it; no longer fires a pointless
+update + UAC when the install is already current (the broker is a
+once-installed service, not required in every CLI folder); and no longer
+reports a scary "failed to restart" for components the winget flow relaunches
+itself.
+
+### Fixed — one-line macOS/Linux installer hardening
+
+`install.sh` resolves the latest version without the intermittent broken-pipe
+failure, verifies every download against the release `SHA256SUMS` (exact match,
+tolerating the `./` prefix), and installs transactionally — it downloads and
+verifies the whole set before moving anything into place, so an interrupted run
+never leaves a half-old / half-new install.
+
 ## [0.6.18] - 2026-06-29
 
 ### Changed: `uffs --uninstall` now finds every copy across the system

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Each release ships pre-built binaries, a `CHECKSUMS.txt` (SHA256), per-crate SBO
 | **macOS Apple Silicon** | [`uffs-macos-arm64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | Offline MFT analysis only. Includes `UFFS.app` bundle + `uffs-tui` demo. |
 | **Linux x64** | [`uffs-linux-x64.zip`](https://github.com/skyllc-ai/UltraFastFileSearch/releases/latest) | Offline MFT analysis only. Includes `install.sh` + `uffs-tui` demo. |
 
+> 🧭 **Which platform does what.** UFFS **indexes and searches live filesystems on Windows only** — it reads the NTFS MFT directly. The **macOS and Linux** builds are for **offline MFT analysis**: inspecting `$MFT` captures pulled from NTFS volumes (a disk image, or a drive attached read-only). They do **not** index or search the macOS/Linux host filesystem.
+
 > 📦 **Three tiers per platform** — `…-min.zip` (just `uffs` + `uffsd` + the `uffs-tui` demo, for CI/scripting), the bare `….zip` (**recommended**: adds MCP + MFT tooling + docs), and `…-full.zip` (adds the `uffs-diag` diagnostic tools). Every tier bundles the free `uffs-tui` demo.
 
 > 🖥️ **Fastest way to try it — no CLI required.** Unzip any tier and run **`uffs-tui`**: the daemon auto-starts and you're browsing your own drives in a UI within seconds. The bundled TUI is the free demo (capped result counts, exports disabled — see `DEMO-LICENSE.txt`); full TUI/GUI are commercial.
@@ -134,6 +136,14 @@ winget install SkyLLC.UFFS
 ```
 
 > ⚠️ **Open a new terminal after installing** — WinGet updates `PATH`, but an already-open shell won't see `uffs` until you start a fresh one.
+
+**Get searching in 3 steps (Windows):**
+
+1. **Install** — `winget install SkyLLC.UFFS`, then open a new terminal.
+2. **Remove UAC once** *(recommended)* — from an **elevated** shell, `uffs-broker --install`. This one-time step registers the Access Broker so every later search runs with no UAC prompt. Skip it and the first search just offers a single `--elevate` prompt instead.
+3. **Search** — `uffs "*.rs"`. The daemon auto-starts, indexes your NTFS drives, and answers subsequent queries in milliseconds.
+
+Later: `uffs --update` to upgrade, `uffs --uninstall` to remove everything.
 
 Or grab the ZIP above, extract it anywhere, add the folder to PATH, then (in a new terminal):
 ```powershell
@@ -191,6 +201,29 @@ uffs --update apply --version v0.6.5    # pin / roll back to a specific release
 > `uffs --daemon stop` + `uffs-broker --stop`.)
 
 > 📖 **[Full update guide](docs/user-manual/updating.md)** — every action, version pinning/rollback, the health check, and edge cases.
+
+---
+
+## Uninstalling
+
+One command removes UFFS completely — binaries, data, cache, config, and (on Windows) the Access Broker service:
+
+```bash
+uffs --uninstall
+```
+
+It shows you exactly what will go before removing anything, then asks for a single confirmation:
+
+- **Finds every copy** — scans `PATH` and the standard binary directories, and on Windows runs a deep MFT-driven sweep for stray copies anywhere on your drives. Each is listed with its version and location.
+- **CORE vs ALL** — **CORE** removes the standard install (the running copy, data, cache, config, broker service); **ALL** additionally removes the stray copies the sweep found elsewhere (one of which might be a build you placed yourself — so it's opt-in).
+- **Elevation only when needed** — the only elevated step is removing the `LocalSystem` broker service, so uninstall asks for **one** UAC prompt just for that, and continues cleanly if you decline (leaving the broker in place with a note).
+- **Self-removing** — the `uffs` binary deletes itself last, as the process exits.
+
+```bash
+uffs --uninstall --dry-run   # show the full plan, remove nothing
+```
+
+> **WinGet installs:** run `uffs --uninstall` rather than `winget uninstall SkyLLC.UFFS`. The bare WinGet uninstall can fail with `remove_all: Access is denied` because the running broker service holds its binary open; `uffs --uninstall` stops the service first, then removes it.
 
 ---
 


### PR DESCRIPTION
Closes out the documentation for the whole install/update/uninstall refactor.

### CHANGELOG — un-stale it
The changelog stopped at `[0.6.18]`. The ship pipeline rolls `[Unreleased]` into a dated section at release, but nobody had been *filling* `[Unreleased]`, so every ship logged "nothing to roll" and 0.6.19–0.6.22 (uninstall rewrite, Access Broker, winget-upgrade self-update, USN phantom-path fix, static-musl Linux, binary rename, installer hardening) went unrecorded. Adds a consolidated, dated **`[0.6.22]`** section and leaves `[Unreleased]` empty for the renewed per-PR habit.

### README
- **Uninstalling** section (parallel to Updating): what `uffs --uninstall` finds + removes, CORE vs ALL, one-UAC-only elevation, `--dry-run`, and the `winget uninstall` "Access is denied" caveat.
- **Platform callout** under Download & Install: UFFS indexes/searches live filesystems **on Windows only**; the macOS/Linux builds are **offline `$MFT` analysis only** and do **not** index the host filesystem — closes the wrong impression without underselling offline analysis.
- **"Get searching in 3 steps (Windows)"**: install → one-time broker → search.

Docs-only; no version bump. The `[0.6.22]` notes are dated to today's real release.