### PR TITLE
fix(update): discover dormant winget installs + don't skip a non-running broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — self-update now sees a dormant WinGet install
+
+`uffs --update` finds a WinGet-managed install even when nothing is running from
+it. Root discovery used to rely only on live anchors (the invoking `uffs.exe`
+plus any running daemon / broker / MCP), so with the daemon and broker stopped
+and `--update` run from a hand-placed copy, the winget install had no anchor and
+was invisible — never seen, never reconciled. Detection now also scans WinGet's
+well-known package location, so the winget copy is found and updated regardless
+of what is running.
+
+### Fixed — the Access Broker note no longer fires when no broker is running
+
+A non-elevated update skips (and warns about) the Access Broker only when it is
+a *running* `LocalSystem` service — the case that genuinely needs elevation to
+cycle. A plain `uffs-broker.exe` file with no running service is now updated in
+place like any other binary, without the misleading "left running and NOT
+updated" note.
+
 ## [0.6.22] - 2026-07-03
 
 Consolidated notes for the 0.6.19–0.6.22 development cycle, which reworked the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4441,6 +4441,7 @@ dependencies = [
  "dirs-next",
  "serde_json",
  "strsim",
+ "tempfile",
  "uffs-broker-protocol",
  "uffs-client",
  "uffs-format",

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -157,3 +157,4 @@ winresource.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true
+tempfile.workspace = true

--- a/crates/uffs-cli/src/commands/update/mod.rs
+++ b/crates/uffs-cli/src/commands/update/mod.rs
@@ -31,6 +31,7 @@ mod report;
 mod self_heal;
 mod snapshot;
 mod winget;
+mod winget_discover;
 
 use std::path::{Path, PathBuf};
 
@@ -414,6 +415,10 @@ pub(crate) fn detect() -> DetectionReport {
     }
     // A.1 anchor #4 — the broker service (Windows-only).
     capture_broker(&mut roots, &mut running);
+    // A.1b — a dormant WinGet install has no live anchor (nothing running from
+    // it, not the invoking exe), so find it at its well-known package location
+    // too; otherwise `uffs --update` can neither see nor reconcile it.
+    winget_discover::discover(&mut roots);
 
     // A.2 + A.3 + A.4 — per root: enumerate binaries, classify, version.
     for root in &mut roots {

--- a/crates/uffs-cli/src/commands/update/model.rs
+++ b/crates/uffs-cli/src/commands/update/model.rs
@@ -73,6 +73,9 @@ pub(crate) enum Anchor {
     Mcp,
     /// The registered broker-service `binPath` directory.
     Broker,
+    /// Found by scanning the well-known `WinGet\Packages` location — a
+    /// winget-managed install with nothing currently running from it.
+    Winget,
 }
 
 impl Anchor {
@@ -83,6 +86,7 @@ impl Anchor {
             Self::Daemon => "daemon",
             Self::Mcp => "mcp",
             Self::Broker => "broker",
+            Self::Winget => "winget",
         }
     }
 }

--- a/crates/uffs-cli/src/commands/update/winget.rs
+++ b/crates/uffs-cli/src/commands/update/winget.rs
@@ -32,8 +32,9 @@ use anyhow::Result;
 
 use super::model::DetectionReport;
 
-/// The `WinGet` package id UFFS publishes under.
-#[cfg(windows)]
+/// The `WinGet` package id UFFS publishes under. Cross-platform: the Windows
+/// upgrade path uses it, and [`super::winget_discover`] matches the winget
+/// package folder against it on every target.
 pub(crate) const WINGET_PACKAGE_ID: &str = "SkyLLC.UFFS";
 
 /// What [`quiesce`] stopped, so [`resume`] can restore exactly that. Opaque +

--- a/crates/uffs-cli/src/commands/update/winget_discover.rs
+++ b/crates/uffs-cli/src/commands/update/winget_discover.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Discover a **dormant** WinGet-managed UFFS install (design: Phase A).
+//!
+//! The ordinary anchor scan (invoking exe + running daemon / broker / MCP)
+//! only surfaces a winget root when something is *running* from it. With the
+//! daemon and broker both stopped, and `uffs --update` invoked from a different
+//! (e.g. hand-placed `~\bin`) copy, the winget install has no live anchor and
+//! goes invisible — so the updater can neither see nor reconcile it.
+//!
+//! `WinGet` does not expose a portable package's install directory (`winget
+//! list` prints the version, not the path), but the location is deterministic:
+//! portable packages always land under
+//! `…\Microsoft\WinGet\Packages\<Id>_<hash>\`. [`discover`] scans that
+//! well-known location so a dormant winget install is found regardless of what
+//! is running. Windows-only; a no-op elsewhere.
+
+use std::path::{Path, PathBuf};
+
+use super::model::{Anchor, InstallRoot};
+use super::winget::WINGET_PACKAGE_ID;
+
+/// Add any WinGet-managed UFFS install root(s) found at the well-known
+/// `WinGet\Packages` location to `roots` (deduplicated by
+/// [`super::upsert_root`]). No-op off Windows and when winget has no UFFS
+/// package folder.
+pub(crate) fn discover(roots: &mut Vec<InstallRoot>) {
+    for base in winget_packages_bases() {
+        for dir in roots_under_packages_base(&base) {
+            super::upsert_root(roots, dir, Anchor::Winget);
+        }
+    }
+}
+
+/// Whether `folder_name` is UFFS's winget portable-package folder — i.e.
+/// `<WINGET_PACKAGE_ID>_<source-hash>` (case-insensitive). The trailing `_`
+/// keeps `SkyLLC.UFFS_…` from matching a hypothetical `SkyLLC.UFFSomething`.
+fn is_uffs_package_folder(folder_name: &str) -> bool {
+    let prefix = format!("{WINGET_PACKAGE_ID}_").to_ascii_lowercase();
+    folder_name.to_ascii_lowercase().starts_with(&prefix)
+}
+
+/// Every UFFS install root directly under a `WinGet\Packages` `base`: for each
+/// `<Id>_<hash>` package folder, the subdirectory that actually holds the UFFS
+/// binaries. Cross-platform filesystem logic (the Windows-only part is which
+/// `base` paths are supplied); a missing/unreadable `base` yields nothing.
+fn roots_under_packages_base(base: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return found;
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            continue;
+        }
+        let name_os = entry.file_name();
+        let Some(name) = name_os.to_str() else {
+            continue;
+        };
+        if is_uffs_package_folder(name)
+            && let Some(dir) = find_dir_with_uffs(&entry.path())
+        {
+            found.push(dir);
+        }
+    }
+    found
+}
+
+/// The directory holding `uffs` within a package folder: the folder itself, or
+/// one of its immediate subdirectories (the extracted zip's single top folder,
+/// e.g. `uffs-windows-x64`). Descends at most one level — enough for the winget
+/// layout, and bounded so a stray package folder can't trigger a deep walk.
+fn find_dir_with_uffs(pkg: &Path) -> Option<PathBuf> {
+    if dir_has_uffs(pkg) {
+        return Some(pkg.to_path_buf());
+    }
+    for entry in std::fs::read_dir(pkg).ok()?.flatten() {
+        let sub = entry.path();
+        if sub.is_dir() && dir_has_uffs(&sub) {
+            return Some(sub);
+        }
+    }
+    None
+}
+
+/// Whether `dir` contains the UFFS CLI binary (`uffs.exe` on Windows; the bare
+/// `uffs` name is accepted too so the logic is unit-testable off Windows).
+fn dir_has_uffs(dir: &Path) -> bool {
+    dir.join("uffs.exe").exists() || dir.join("uffs").exists()
+}
+
+/// The `WinGet\Packages` base directories to scan (user- and machine-scope).
+/// Windows-only; empty elsewhere so [`discover`] is a no-op off Windows.
+#[cfg(windows)]
+fn winget_packages_bases() -> Vec<PathBuf> {
+    let mut bases = Vec::new();
+    if let Ok(local) = std::env::var("LOCALAPPDATA") {
+        bases.push(PathBuf::from(local).join(r"Microsoft\WinGet\Packages"));
+    }
+    if let Ok(program_files) = std::env::var("ProgramFiles") {
+        bases.push(PathBuf::from(program_files).join(r"WinGet\Packages"));
+    }
+    bases
+}
+
+/// Off Windows there is no `WinGet`, so there is nothing to scan.
+#[cfg(not(windows))]
+const fn winget_packages_bases() -> Vec<PathBuf> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        dir_has_uffs, find_dir_with_uffs, is_uffs_package_folder, roots_under_packages_base,
+    };
+
+    #[test]
+    fn recognizes_the_uffs_package_folder() {
+        assert!(is_uffs_package_folder(
+            "SkyLLC.UFFS_Microsoft.Winget.Source_8wekyb3d8bbwe"
+        ));
+        assert!(
+            is_uffs_package_folder("skyllc.uffs_abc"),
+            "case-insensitive"
+        );
+        // No trailing underscore → a different package with a shared prefix.
+        assert!(!is_uffs_package_folder("SkyLLC.UFFSomething"));
+        assert!(!is_uffs_package_folder("Other.Package_hash"));
+        assert!(!is_uffs_package_folder("SkyLLC.UFFS"));
+    }
+
+    #[test]
+    fn finds_the_root_holding_uffs_one_level_down() {
+        // Mimic …\Packages\SkyLLC.UFFS_hash\uffs-windows-x64\uffs(.exe).
+        let base = tempfile::tempdir().expect("tempdir");
+        let pkg = base.path().join("SkyLLC.UFFS_hash");
+        let inner = pkg.join("uffs-windows-x64");
+        std::fs::create_dir_all(&inner).expect("mkdirs");
+        std::fs::write(inner.join("uffs"), b"bin").expect("write uffs");
+        // A sibling non-UFFS package folder must be ignored.
+        std::fs::create_dir_all(base.path().join("Other.Pkg_x")).expect("mkdir other");
+
+        assert!(dir_has_uffs(&inner));
+        assert_eq!(find_dir_with_uffs(&pkg).as_deref(), Some(inner.as_path()));
+
+        let roots = roots_under_packages_base(base.path());
+        assert_eq!(roots, vec![inner], "only the UFFS package's inner root");
+    }
+
+    #[test]
+    fn missing_base_yields_nothing() {
+        let roots = roots_under_packages_base(std::path::Path::new("/nonexistent/winget/packages"));
+        assert!(roots.is_empty());
+    }
+}

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -107,12 +107,16 @@ fn run_apply(args: &[String]) -> Result<()> {
 
     let mut snapshot = plan::Snapshot::load(&snapshot_path)?;
 
-    // Non-elevated apply skips the Access Broker: it is a LocalSystem service we
-    // can neither stop (to unlock its `.exe`) nor restart without admin. Drop it
-    // from this run — update everything else; the running broker keeps serving
-    // (its wire protocol is back-compatible) and catches up on the next elevated
-    // update. `is_elevated()` is `false` off Windows, but the snapshot has no
-    // broker there, so this is a no-op away from Windows.
+    // A non-elevated apply skips the Access Broker ONLY when it is a *running*
+    // LocalSystem service: we can neither stop (to unlock its `.exe`) nor
+    // restart it without admin. Drop it from this run — update everything else;
+    // the running broker keeps serving (its wire protocol is back-compatible)
+    // and catches up on the next elevated update. When the broker is NOT running
+    // (not installed, or just a hand-placed `uffs-broker.exe` file), there is no
+    // service to stop and the binary is swapped in place like any other — so do
+    // not skip it and do not print the "left running" note. `is_elevated()` is
+    // `false` off Windows, but the snapshot has no broker there, so this is a
+    // no-op away from Windows.
     // Read this BEFORE drop_broker strips the broker entries: when the broker
     // lives in a WinGet-delegated root, the caller's `winget upgrade` refreshes
     // its `.exe` and cycles the service, so it is not left at the old version.
@@ -121,10 +125,10 @@ fn run_apply(args: &[String]) -> Result<()> {
     // (uffs-cli) stops them up front and its `resume` relaunches them on the
     // new binary, so if restore can't restart them here it is NOT a fault.
     let winget_delegated = snapshot.winget_delegated_components();
-    let skipped_broker = if uffs_winsvc::is_elevated() {
-        None
-    } else {
+    let skipped_broker = if !uffs_winsvc::is_elevated() && snapshot.broker_is_running() {
         snapshot.drop_broker()
+    } else {
+        None
     };
 
     let backup_dir = update_dir.join(format!("backup-{}", std::process::id()));

--- a/crates/uffs-update/src/plan.rs
+++ b/crates/uffs-update/src/plan.rs
@@ -124,6 +124,17 @@ impl Snapshot {
         Some(version)
     }
 
+    /// Whether a broker service is actually **running** in this snapshot (a
+    /// `broker` entry in `running`). Only then does updating `uffs-broker.exe`
+    /// require elevation (to stop/restart the `LocalSystem` service). A plain
+    /// `uffs-broker.exe` file with no running service is just another binary
+    /// and can be swapped in place like the rest.
+    pub(crate) fn broker_is_running(&self) -> bool {
+        self.running
+            .iter()
+            .any(|run| run.component == BROKER_COMPONENT)
+    }
+
     /// Whether the Access Broker binary lives under a `WinGet`-delegated root.
     /// When it does, a non-elevated apply skips the broker here, but the
     /// caller's `winget upgrade` refreshes `uffs-broker.exe` and cycles the
@@ -320,6 +331,31 @@ mod tests {
         assert!(
             snap.broker_in_winget_root(),
             "broker under a winget root is delegated"
+        );
+    }
+
+    #[test]
+    fn broker_is_running_needs_a_running_entry_not_just_a_binary() {
+        // A uffs-broker.exe file present, but no running broker service.
+        const BINARY_ONLY: &str = r#"{
+          "targets": [ { "root": "C:\\bin", "channel": "unmanaged", "binaries": [
+            { "name": "uffs-broker", "on_disk_version": "0.6.22" }
+          ] } ]
+        }"#;
+        // A running broker service (a `broker` entry in `running`).
+        const RUNNING: &str = r#"{
+          "targets": [],
+          "running": [ { "component": "broker", "pid": 7 } ]
+        }"#;
+        let snap: Snapshot = serde_json::from_str(BINARY_ONLY).expect("parse");
+        assert!(
+            !snap.broker_is_running(),
+            "a broker binary with no running service is not running"
+        );
+        let running: Snapshot = serde_json::from_str(RUNNING).expect("parse");
+        assert!(
+            running.broker_is_running(),
+            "a running broker entry means the service is running"
         );
     }
 


### PR DESCRIPTION
Two self-update fixes from live-Windows testing (issues #1 and #2 from the dual-install `uffs --update` run).

### #1 — a dormant WinGet install was invisible to `uffs --update`
Root discovery was **anchor-only** (invoking exe + running daemon/broker/MCP). With nothing running from the winget copy and `--update` invoked from a hand-placed `~\bin` copy, the winget root had no anchor → never found, never reconciled. WinGet doesn't expose a portable package's path (`winget list` prints the version, not the folder), but the location is deterministic, so `detect()` now also scans `…\Microsoft\WinGet\Packages\SkyLLC.UFFS_*` (user + machine scope) and adds any root holding `uffs.exe`. Windows-only; a no-op elsewhere. New `winget_discover` module + `Anchor::Winget`.

### #2 — broker note fired when no broker was running
The "Access Broker was left running and NOT updated" note fired even for a plain hand-placed `uffs-broker.exe` with no service — and the binary was needlessly skipped. The broker is only un-swappable when it's a **running** `LocalSystem` service. Now gated on `Snapshot::broker_is_running()`; otherwise `uffs-broker.exe` is swapped in place like any binary, no note.

(#3 from that session was the user's own `del` of the other binaries — the "missing core → restore" behavior was correct; no change.)

### Tests
winget package-folder matching + one-level root scan (tempdir, cross-platform); `broker_is_running` needs a running entry not just a binary. Clippy clean on both crates.

### Changelog
Adds an `[Unreleased]` entry (renewing the per-PR habit that had gone stale).