### PR TITLE
feat(version): consistent --version across every UFFS binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — consistent `--version` across every UFFS binary
+
+All 22 shipped and dev binaries now print the same `--version`: a short line
+`<name>[.exe] <semver> (<sha>)` (with `-dirty` on an uncommitted tree), and a
+multi-line build fingerprint with `--version --verbose` / `-v` (commit + date,
+rustc, target triple, release profile) for bug reports. On Windows the name
+carries its real `.exe` suffix (`uffsd.exe 0.6.23 (…)`). Previously only `uffs`
+showed the build sha; the others were plainer and slightly inconsistent (e.g.
+`uffsmcp` printed `uffs-mcp v…`). Backed by a new zero-dependency `uffs-version`
+leaf crate (macros + a `build.rs` metadata stamp), so it can never drift again.
+
 ## [0.6.23] - 2026-07-04
 
 ### Fixed — calmer message when WinGet doesn't have the new version yet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,6 +4390,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "uffs-version",
  "winresource",
 ]
 
@@ -4402,6 +4403,7 @@ dependencies = [
  "tracing-subscriber",
  "uffs-broker-protocol",
  "uffs-security",
+ "uffs-version",
  "uffs-winsvc",
  "windows 0.62.2",
  "winresource",
@@ -4428,6 +4430,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "uffs-version",
  "uuid",
  "winresource",
 ]
@@ -4447,6 +4450,7 @@ dependencies = [
  "uffs-format",
  "uffs-mft",
  "uffs-time",
+ "uffs-version",
  "uffs-winsvc",
  "which",
  "winresource",
@@ -4531,6 +4535,7 @@ dependencies = [
  "uffs-format",
  "uffs-mft",
  "uffs-security",
+ "uffs-version",
  "windows 0.62.2",
  "winresource",
 ]
@@ -4546,6 +4551,7 @@ dependencies = [
  "sha2 0.11.0",
  "uffs-mft",
  "uffs-polars",
+ "uffs-version",
  "winresource",
 ]
 
@@ -4568,6 +4574,7 @@ dependencies = [
  "clap",
  "serde",
  "toml",
+ "uffs-version",
  "winresource",
 ]
 
@@ -4580,6 +4587,7 @@ dependencies = [
  "regex",
  "serde",
  "toml",
+ "uffs-version",
  "winresource",
 ]
 
@@ -4591,6 +4599,7 @@ dependencies = [
  "clap",
  "serde",
  "toml",
+ "uffs-version",
  "winresource",
 ]
 
@@ -4614,6 +4623,7 @@ dependencies = [
  "uffs-client",
  "uffs-mft",
  "uffs-security",
+ "uffs-version",
  "winresource",
 ]
 
@@ -4651,6 +4661,7 @@ dependencies = [
  "uffs-polars",
  "uffs-security",
  "uffs-text",
+ "uffs-version",
  "windows 0.62.2",
  "winresource",
  "zerocopy",
@@ -4703,10 +4714,15 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "uffs-broker-protocol",
+ "uffs-version",
  "uffs-winsvc",
  "windows 0.62.2",
  "winresource",
 ]
+
+[[package]]
+name = "uffs-version"
+version = "0.6.23"
 
 [[package]]
 name = "uffs-winsvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "crates/uffs-security",        # 🔒 Crypto, key storage, secure FS ops
   "crates/uffs-text",            # 📝 Unicode text processing, i18n foundation
   "crates/uffs-time",            # ⏱️ NTFS FILETIME arithmetic (pure, zero deps)
+  "crates/uffs-version",         # 🏷️ Shared --version strings + build-metadata stamp (leaf)
   "crates/uffs-broker-protocol", # 📟 Cross-platform broker wire-protocol types (F5)
   "crates/uffs-winsvc",          # 🪟 Native Windows service control + broker-pipe probe (leaf)
   "crates/uffs-mft",             # 📦 MFT reading → Polars DataFrame
@@ -130,6 +131,7 @@ uffs-polars = { path = "crates/uffs-polars", version = "0.6.23" }
 uffs-security = { path = "crates/uffs-security", version = "0.6.23" }
 uffs-text = { path = "crates/uffs-text", version = "0.6.23" }
 uffs-time = { path = "crates/uffs-time", version = "0.6.23" }
+uffs-version = { path = "crates/uffs-version", version = "0.6.23" }
 uffs-mft = { path = "crates/uffs-mft", version = "0.6.23" }
 uffs-format = { path = "crates/uffs-format", version = "0.6.23" }
 uffs-core = { path = "crates/uffs-core", version = "0.6.23" }

--- a/crates/uffs-bench/Cargo.toml
+++ b/crates/uffs-bench/Cargo.toml
@@ -47,6 +47,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 
 [dependencies]
+uffs-version.workspace = true
 # Error handling for the crate-level error type.
 thiserror.workspace = true
 
@@ -77,6 +78,7 @@ tempfile.workspace = true
 # Embeds the UFFS icon + version info + shared app.manifest into `uffs-bench.exe`
 # (see build.rs) for branding consistency.
 [build-dependencies]
+uffs-version = { workspace = true, features = ["build"] }
 winresource.workspace = true
 
 [lints]

--- a/crates/uffs-bench/build.rs
+++ b/crates/uffs-bench/build.rs
@@ -18,6 +18,7 @@
 //! MSVC-Windows only; a no-op on every other build target.
 
 fn main() {
+    uffs_version::emit_build_env();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../../assets/brand/icons/uffs.ico");
     println!("cargo:rerun-if-changed=../../assets/brand/app.manifest");

--- a/crates/uffs-bench/src/lib.rs
+++ b/crates/uffs-bench/src/lib.rs
@@ -52,6 +52,11 @@
 // paths.
 extern crate alloc;
 
+// Linked for this crate's `uffs-bench` binary, which calls
+// `uffs_version::handle_version!` in `main`; the library itself does not
+// reference it (sanctioned unused-crate-dependencies marker).
+use uffs_version as _;
+
 pub mod baseline;
 pub mod bundle;
 pub mod cards;

--- a/crates/uffs-bench/src/main.rs
+++ b/crates/uffs-bench/src/main.rs
@@ -33,6 +33,7 @@ use uffs_bench::{Cli, Result, run};
 /// load/save, or a Stage 0 artifact write. An operator abort/back is a graceful
 /// stop, not an error.
 fn main() -> Result<()> {
+    uffs_version::handle_version!("uffs-bench");
     let cli = Cli::parse();
     let host = SystemHost::new();
     run(&host, &cli)

--- a/crates/uffs-broker/Cargo.toml
+++ b/crates/uffs-broker/Cargo.toml
@@ -41,6 +41,12 @@ default-target = "x86_64-pc-windows-msvc"
 name = "uffs-broker"
 path = "src/main.rs"
 
+# Cross-platform deps: `main.rs` calls `uffs_version::handle_version!` on every
+# platform (so `uffs-broker --version` works and the self-update probe parses
+# it), so this is used on Linux/macOS too — not a visible-but-unused marker.
+[dependencies]
+uffs-version.workspace = true
+
 # Windows-only deps: the elevated handle-broker logic in `broker.rs` is
 # fully `#[cfg(windows)]`, so its supporting crates compile only on the
 # Windows target.  Scoped to `[target.'cfg(windows)'.dependencies]` so
@@ -74,6 +80,7 @@ uffs-winsvc.workspace = true
 # `uffs-broker.exe` (see build.rs). A metadata-less binary is both unbranded
 # and a mild antivirus false-positive signal.
 [build-dependencies]
+uffs-version = { workspace = true, features = ["build"] }
 winresource.workspace = true
 
 [lints]

--- a/crates/uffs-broker/build.rs
+++ b/crates/uffs-broker/build.rs
@@ -20,6 +20,7 @@
 //! no-op on every other build target.
 
 fn main() {
+    uffs_version::emit_build_env();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../../assets/brand/icons/uffs.ico");
     println!("cargo:rerun-if-changed=../../assets/brand/app.manifest");

--- a/crates/uffs-broker/src/main.rs
+++ b/crates/uffs-broker/src/main.rs
@@ -49,16 +49,9 @@ mod broker;
 fn main() {
     // `--version` / `-V` is handled here, before the Windows service dispatch,
     // so it works on every platform and exits 0. The self-update version probe
-    // runs `<bin> --version` and parses the output; without this arm the broker
-    // fell through to its usage text and the probe reported the broker as `?`
-    // (every other UFFS binary prints a version, so it was the odd one out).
-    if std::env::args()
-        .skip(1)
-        .any(|arg| arg == "--version" || arg == "-V")
-    {
-        print_version();
-        return;
-    }
+    // runs `<bin> --version` and parses the output; without this the broker
+    // fell through to its usage text and the probe reported the broker as `?`.
+    uffs_version::handle_version!("uffs-broker");
 
     #[cfg(windows)]
     {
@@ -75,11 +68,4 @@ fn main() {
         eprintln!("uffs-broker is a Windows-only component.");
         std::process::exit(1);
     }
-}
-
-/// Print `uffs-broker <version>` to stdout, matching the `uffs <version>`
-/// shape the other binaries use so the self-update version probe parses it.
-#[expect(clippy::print_stdout, reason = "intentional version output")]
-fn print_version() {
-    println!("uffs-broker {}", env!("CARGO_PKG_VERSION"));
 }

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -110,6 +110,9 @@ dirs-next.workspace = true
 # filetime_with_tz_bias}` for timestamp formatting.
 uffs-time.workspace = true
 
+# Shared `--version` strings (short + long build fingerprint). Zero-dep leaf.
+uffs-version.workspace = true
+
 # Broker identity (`SERVICE_NAME` / `PIPE_NAME`) + native SCM status so
 # `uffs --status` can report the Access Broker. Both Layer-0 leaves:
 # broker-protocol is pure; uffs-winsvc stubs to "not installed" off Windows.
@@ -154,6 +157,8 @@ workspace = true
 # Version is pinned at workspace scope — see root Cargo.toml.
 [build-dependencies]
 winresource.workspace = true
+# Stamps UFFS_GIT_SHA + build metadata for the version macros (build side only).
+uffs-version = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/crates/uffs-cli/build.rs
+++ b/crates/uffs-cli/build.rs
@@ -99,12 +99,11 @@ fn main() {
     println!("cargo:rerun-if-changed=app.manifest");
     println!("cargo:rerun-if-changed=../../assets/brand/icons/uffs.ico");
 
-    // Stamp the short git commit (+ `-dirty`) into `UFFS_GIT_SHA` so
-    // `uffs --version` can tie a running binary back to the exact build —
-    // closing the "ran a stale binary" trap. The daemon already does this in its
-    // startup log; the CLI surfaced no commit, so a rebuilt-but-not-deployed
-    // uffs.exe was indistinguishable from the old one.
-    emit_git_sha();
+    // Stamp UFFS_GIT_SHA + build metadata (commit date, rustc, target, profile)
+    // that the shared `uffs-version` macros read, so `uffs --version` ties a
+    // running binary to its exact build and `--version -v` prints the full
+    // fingerprint. Same stamp across every UFFS binary.
+    uffs_version::emit_build_env();
 
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
@@ -137,34 +136,4 @@ fn main() {
         res.compile()
             .expect("winresource: failed to embed icon + manifest");
     }
-}
-
-/// Emit `UFFS_GIT_SHA` = the short `HEAD` commit, with a `-dirty` suffix when
-/// the working tree has uncommitted changes (so a hand-tweaked local build is
-/// never mistaken for the clean commit). Best-effort: `unknown` when git is
-/// absent. Mirrors `uffs-daemon`'s build stamp; `../../.git/HEAD` is watched so
-/// the stamp tracks the checked-out commit.
-fn emit_git_sha() {
-    use std::process::Command;
-
-    let sha = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()
-        .filter(|out| out.status.success())
-        .and_then(|out| String::from_utf8(out.stdout).ok())
-        .map(|raw| raw.trim().to_owned())
-        .filter(|trimmed| !trimmed.is_empty())
-        .unwrap_or_else(|| "unknown".to_owned());
-
-    let dirty = Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .ok()
-        .filter(|out| out.status.success())
-        .is_some_and(|out| !out.stdout.is_empty());
-
-    let stamp = if dirty { format!("{sha}-dirty") } else { sha };
-    println!("cargo:rustc-env=UFFS_GIT_SHA={stamp}");
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
 }

--- a/crates/uffs-cli/src/args.rs
+++ b/crates/uffs-cli/src/args.rs
@@ -518,18 +518,17 @@ pub(crate) fn print_help() {
     print!("{HELP}");
 }
 
-/// Print version and exit. Includes the build's short git commit (stamped by
-/// `build.rs` into `UFFS_GIT_SHA`, with `-dirty` for an uncommitted tree) so a
-/// running binary can be tied to the exact source it was built from — match it
-/// against `git rev-parse --short HEAD` to confirm you are not on a stale
-/// build.
+/// Print version and exit. The short line ties a running binary to the exact
+/// source (`<name>[.exe] <semver> (<sha>)`, `-dirty` for an uncommitted tree);
+/// `verbose` adds the multi-line build fingerprint (commit date, rustc, target,
+/// profile) for bug reports. Shared with every UFFS binary via `uffs-version`.
 #[expect(clippy::print_stdout, reason = "intentional version output")]
-pub(crate) fn print_version() {
-    println!(
-        "uffs {} ({})",
-        env!("CARGO_PKG_VERSION"),
-        option_env!("UFFS_GIT_SHA").unwrap_or("unknown")
-    );
+pub(crate) fn print_version(verbose: bool) {
+    if verbose {
+        println!("{}", uffs_version::version_long!("uffs"));
+    } else {
+        println!("{}", uffs_version::version_short!("uffs"));
+    }
 }
 
 // ── Subcommand help texts ─────────────────────────────────────────────

--- a/crates/uffs-cli/src/main.rs
+++ b/crates/uffs-cli/src/main.rs
@@ -69,7 +69,11 @@ fn run() -> Result<()> {
             return Ok(());
         }
         Some("--version" | "-V") => {
-            args::print_version();
+            let verbose = raw_args
+                .iter()
+                .skip(2)
+                .any(|arg| arg == "--verbose" || arg == "-v");
+            args::print_version(verbose);
             return Ok(());
         }
         _ => {}

--- a/crates/uffs-cli/tests/cli_integration.rs
+++ b/crates/uffs-cli/tests/cli_integration.rs
@@ -119,6 +119,21 @@ mod tests {
     }
 
     #[test]
+    fn version_short_form_carries_the_build_sha() {
+        // `uffs[.exe] <semver> (<sha>)` — the parenthesised build sha ties a
+        // running binary to its exact source (shared shape across all binaries).
+        assert_success("version_sha", &["--version"], &["uffs", "("]);
+    }
+
+    #[test]
+    fn version_verbose_prints_the_build_fingerprint() {
+        // `--version -v` → the multi-line build fingerprint for bug reports.
+        assert_success("version_verbose", &["--version", "-v"], &[
+            "commit:", "rustc:", "target:", "profile:",
+        ]);
+    }
+
+    #[test]
     fn other_single_dash_token_is_a_pattern_not_help() {
         // `-x` must NOT print help/version — it is a search pattern, so with
         // no daemon it fails trying to connect (it never exits 0 with help).

--- a/crates/uffs-daemon/Cargo.toml
+++ b/crates/uffs-daemon/Cargo.toml
@@ -46,6 +46,7 @@ name = "uffs_daemon"
 path = "src/lib.rs"
 
 [dependencies]
+uffs-version.workspace = true
 # Internal
 uffs-security.workspace = true
 uffs-mft.workspace = true
@@ -127,6 +128,7 @@ tokio = { workspace = true, features = ["test-util", "macros"] }
 # (see build.rs, alongside the UFFS_GIT_SHA stamp). A metadata-less binary is
 # both unbranded and a mild antivirus false-positive signal.
 [build-dependencies]
+uffs-version = { workspace = true, features = ["build"] }
 winresource.workspace = true
 
 [lints]

--- a/crates/uffs-daemon/build.rs
+++ b/crates/uffs-daemon/build.rs
@@ -26,38 +26,14 @@
 //!    binary carries proper metadata instead of shipping bare — a bare binary
 //!    is both unbranded and a mild antivirus false-positive signal.
 
-use std::process::Command;
-
 fn main() {
     embed_windows_resources();
 
-    let sha = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()
-        .filter(|out| out.status.success())
-        .and_then(|out| String::from_utf8(out.stdout).ok())
-        .map(|raw| raw.trim().to_owned())
-        .filter(|trimmed| !trimmed.is_empty())
-        .unwrap_or_else(|| "unknown".to_owned());
-
-    // Append `-dirty` when the working tree has uncommitted changes, so a
-    // hand-tweaked local build is never mistaken for the clean commit.
-    let dirty = Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .ok()
-        .filter(|out| out.status.success())
-        .is_some_and(|out| !out.stdout.is_empty());
-
-    let stamp = if dirty { format!("{sha}-dirty") } else { sha };
-    println!("cargo:rustc-env=UFFS_GIT_SHA={stamp}");
-
-    // Re-run when HEAD moves so the stamp tracks the checked-out commit.
-    // Best-effort relative path from the crate dir to the repo `.git`; a wrong
-    // path just means the stamp can lag one commit on an exotic layout, which
-    // is acceptable for a dev-only marker.
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    // Stamp UFFS_GIT_SHA + build metadata (commit date, rustc, target, profile)
+    // for the shared `uffs-version` macros — the same stamp every UFFS binary
+    // uses. `startup.rs` still reads `option_env!("UFFS_GIT_SHA")` for its log
+    // prelude; `--version` / `--version -v` read the full set.
+    uffs_version::emit_build_env();
     println!("cargo:rerun-if-changed=build.rs");
 }
 

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -65,6 +65,9 @@
 
 extern crate alloc;
 
+// Linked for this crate's binary target(s), which call
+// `uffs_version::handle_version!` in `main`; the library itself does not
+// reference it (sanctioned unused-crate-dependencies marker).
 use alloc::sync::Arc;
 use std::path::PathBuf;
 
@@ -78,6 +81,7 @@ use thiserror as _;
 use tracing_appender as _;
 use tracing_subscriber as _;
 use uffs_mft as _;
+use uffs_version as _;
 
 /// Broker client — volume handle requests (Windows) / stubs (other).
 mod broker_client;

--- a/crates/uffs-daemon/src/main.rs
+++ b/crates/uffs-daemon/src/main.rs
@@ -118,6 +118,7 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    uffs_version::handle_version!("uffsd");
     let cli = Cli::parse();
 
     // Initialize tracing (standalone binary owns the subscriber).

--- a/crates/uffs-daemon/tests/ipc_integration.rs
+++ b/crates/uffs-daemon/tests/ipc_integration.rs
@@ -21,6 +21,8 @@
 // dependencies` quiet on Windows, where the inner `unix_tests` module
 // is compiled out entirely.
 // ─────────────────────────────────────────────────────────────────────
+// Linked via the crate's `[dependencies]` (its binaries call
+// `uffs_version::handle_version!`); this target does not reference it.
 use anyhow as _;
 use clap as _;
 use dirs_next as _;
@@ -54,6 +56,7 @@ use uffs_daemon as _;
 use uffs_format as _;
 use uffs_mft as _;
 use uffs_security as _;
+use uffs_version as _;
 #[cfg(windows)]
 use windows as _;
 

--- a/crates/uffs-diag/Cargo.toml
+++ b/crates/uffs-diag/Cargo.toml
@@ -124,6 +124,7 @@ path = "src/bin/verify_iocp_capture.rs"
 # Dependencies (minimal set for diagnostic tools)
 # ─────────────────────────────────────────────────────────────────────────────
 [dependencies]
+uffs-version.workspace = true
 # Error handling (used by all binaries)
 anyhow.workspace = true
 
@@ -147,6 +148,7 @@ uffs-polars.workspace = true
 # Embeds the UFFS icon + version info + shared app.manifest into the diagnostic
 # binaries (see build.rs) for branding consistency.
 [build-dependencies]
+uffs-version = { workspace = true, features = ["build"] }
 winresource.workspace = true
 
 [lints]

--- a/crates/uffs-diag/build.rs
+++ b/crates/uffs-diag/build.rs
@@ -19,6 +19,7 @@
 //! build target.
 
 fn main() {
+    uffs_version::emit_build_env();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../../assets/brand/icons/uffs.ico");
     println!("cargo:rerun-if-changed=../../assets/brand/app.manifest");

--- a/crates/uffs-diag/src/bin/analyze_diff.rs
+++ b/crates/uffs-diag/src/bin/analyze_diff.rs
@@ -166,6 +166,7 @@ fn extract_ads_name(path: &str) -> Option<&str> {
 ///
 /// Returns an error if input files cannot be read or parsed.
 fn main() -> Result<()> {
+    uffs_version::handle_version!("uffs-analyze-diff");
     let args: Vec<String> = env::args().collect();
     if args.len() < 3 {
         eprintln!("Usage: uffs-analyze-diff <reference.txt> <rust.txt>");

--- a/crates/uffs-diag/src/bin/analyze_mft_parents.rs
+++ b/crates/uffs-diag/src/bin/analyze_mft_parents.rs
@@ -44,6 +44,7 @@ use anyhow::{Context as _, Result};
 use uffs_polars::{BooleanChunked, DataFrame, SerReader as _, UInt64Chunked};
 
 fn main() -> Result<()> {
+    uffs_version::handle_version!("uffs-analyze-mft-parents");
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         eprintln!("Usage: uffs-analyze-mft-parents <mft.parquet>");

--- a/crates/uffs-diag/src/bin/compare_raw_mft.rs
+++ b/crates/uffs-diag/src/bin/compare_raw_mft.rs
@@ -120,6 +120,7 @@ fn read_header<P: AsRef<Path>>(path: P) -> Result<(RawMftHeader, BufReader<File>
               compare-loop → report pipeline; splitting would scatter the linear flow"
 )]
 fn main() -> Result<()> {
+    uffs_version::handle_version!("uffs-compare-raw-mft");
     let args: Vec<String> = env::args().collect();
     if args.len() != 3 {
         eprintln!("Usage: uffs-compare-raw-mft <file_a> <file_b>");

--- a/crates/uffs-diag/src/bin/compare_scan_parity.rs
+++ b/crates/uffs-diag/src/bin/compare_scan_parity.rs
@@ -543,6 +543,7 @@ fn compare_dataframes(
 // ============================================================================
 
 fn main() -> Result<()> {
+    uffs_version::handle_version!("uffs-compare-scan-parity");
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 3 {

--- a/crates/uffs-diag/src/bin/cross_check_mft_reference.rs
+++ b/crates/uffs-diag/src/bin/cross_check_mft_reference.rs
@@ -42,6 +42,7 @@ use uffs_polars::{
 };
 
 fn main() -> Result<()> {
+    uffs_version::handle_version!("uffs-cross-check-mft-reference");
     let args: Vec<String> = env::args().collect();
     if args.len() != 3 {
         let program = args

--- a/crates/uffs-diag/src/bin/dump_mft_extents.rs
+++ b/crates/uffs-diag/src/bin/dump_mft_extents.rs
@@ -44,6 +44,7 @@ use anyhow::{Context as _, Result};
 use uffs_mft::{MftExtent, VolumeHandle};
 
 fn main() -> std::process::ExitCode {
+    uffs_version::handle_version!("uffs-dump-mft-extents");
     #[cfg(windows)]
     {
         if let Err(error) = real_main() {

--- a/crates/uffs-diag/src/bin/dump_mft_records.rs
+++ b/crates/uffs-diag/src/bin/dump_mft_records.rs
@@ -149,6 +149,7 @@ fn parse_file_record_segment_header(data: &[u8]) -> Option<FileRecordSegmentHead
 }
 
 fn main() -> Result<()> {
+    uffs_version::handle_version!("uffs-dump-mft-records");
     let args: Vec<String> = env::args().collect();
     if args.len() < 3 {
         eprintln!(

--- a/crates/uffs-diag/src/bin/inspect_mft_record_flow.rs
+++ b/crates/uffs-diag/src/bin/inspect_mft_record_flow.rs
@@ -151,6 +151,7 @@ fn parse_file_record_segment_header(data: &[u8]) -> Option<FileRecordSegmentHead
 }
 
 fn main() -> Result<()> {
+    uffs_version::handle_version!("uffs-inspect-mft-record-flow");
     let args: Vec<String> = env::args().collect();
     if args.len() < 3 {
         eprintln!("Usage: uffs-inspect-mft-record-flow <mft.raw> <frs1> [frs2 frs3 ...]");

--- a/crates/uffs-diag/src/bin/scan_mft_magic.rs
+++ b/crates/uffs-diag/src/bin/scan_mft_magic.rs
@@ -94,6 +94,7 @@ struct BucketCounts {
 }
 
 fn main() -> Result<()> {
+    uffs_version::handle_version!("uffs-scan-mft-magic");
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         eprintln!("Usage: uffs-scan-mft-magic <mft.raw> [bucket_size]");

--- a/crates/uffs-diag/src/bin/verify_iocp_capture.rs
+++ b/crates/uffs-diag/src/bin/verify_iocp_capture.rs
@@ -60,6 +60,7 @@ const HASH_CHUNK_SIZE: usize = 256 * 1024 * 1024;
 const BYTES_TO_GIB: f64 = 1024.0 * 1024.0 * 1024.0;
 
 fn main() -> Result<()> {
+    uffs_version::handle_version!("uffs-verify-iocp-capture");
     let args: Vec<String> = env::args().collect();
     if args.len() != 3 {
         eprintln!("Usage: {} <iocp_file.iocp> <reference.raw|.bin>", args[0]);

--- a/crates/uffs-diag/src/lib.rs
+++ b/crates/uffs-diag/src/lib.rs
@@ -8,6 +8,8 @@
 
 // Keep dependencies wired in for version-locking, even though the library
 // portion does not use them directly (the binaries do).
+// Linked for this crate's diagnostic binaries, which call
+// `uffs_version::handle_version!` in `main`; the library does not use it.
 use anyhow as _;
 use chrono as _;
 use hex as _;
@@ -15,6 +17,7 @@ use rayon as _;
 use sha2 as _;
 use uffs_mft as _;
 use uffs_polars as _;
+use uffs_version as _;
 
 /// Parity comparison helpers for validating scan output between reference and
 /// Rust implementations.

--- a/crates/uffs-mcp/Cargo.toml
+++ b/crates/uffs-mcp/Cargo.toml
@@ -93,6 +93,7 @@ streamable-http = [
 ]
 
 [dependencies]
+uffs-version.workspace = true
 # Internal
 uffs-client.workspace = true
 # Typed drive-letter newtype.  Direct dep so the MCP roots / schema
@@ -139,6 +140,7 @@ tokio = { workspace = true, features = ["test-util"] }
 # (see build.rs). A metadata-less binary is both unbranded and a mild antivirus
 # false-positive signal.
 [build-dependencies]
+uffs-version = { workspace = true, features = ["build"] }
 winresource.workspace = true
 
 [lints]

--- a/crates/uffs-mcp/build.rs
+++ b/crates/uffs-mcp/build.rs
@@ -20,6 +20,7 @@
 //! no-op on every other build target.
 
 fn main() {
+    uffs_version::emit_build_env();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../../assets/brand/icons/uffs.ico");
     println!("cargo:rerun-if-changed=../../assets/brand/app.manifest");

--- a/crates/uffs-mcp/src/bin/http_gateway.rs
+++ b/crates/uffs-mcp/src/bin/http_gateway.rs
@@ -117,6 +117,7 @@ impl Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    uffs_version::handle_version!("uffs-mcp-http");
     // Initialise tracing to stderr (stdout is NOT used by HTTP mode,
     // but keeping the convention consistent with the stdio binary).
     tracing_subscriber::fmt()

--- a/crates/uffs-mcp/src/lib.rs
+++ b/crates/uffs-mcp/src/lib.rs
@@ -79,7 +79,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // `clap` is used by the `uffsmcp` binary, not this library crate.
+// Linked for this crate's binary target(s), which call
+// `uffs_version::handle_version!` in `main`; the library itself does not
+// reference it (sanctioned unused-crate-dependencies marker).
 use clap as _;
+use uffs_version as _;
 
 // ── MCP tracing initialisation ────────────────────────────────────────
 

--- a/crates/uffs-mcp/src/main.rs
+++ b/crates/uffs-mcp/src/main.rs
@@ -116,6 +116,7 @@ enum Action {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    uffs_version::handle_version!("uffsmcp");
     let cli = Cli::parse();
 
     match cli.action {

--- a/crates/uffs-mcp/tests/mcp_protocol.rs
+++ b/crates/uffs-mcp/tests/mcp_protocol.rs
@@ -22,6 +22,8 @@
 )]
 
 // Acknowledge crates used by the lib/bin but not this test target.
+// Linked via the crate's `[dependencies]` (its binaries call
+// `uffs_version::handle_version!`); this target does not reference it.
 use anyhow as _;
 #[cfg(feature = "streamable-http")]
 use axum as _;
@@ -39,6 +41,7 @@ use uffs_client as _;
 use uffs_mcp::handler::UffsMcpServer;
 use uffs_mft as _;
 use uffs_security as _;
+use uffs_version as _;
 
 /// Spin up an in-process MCP server + client pair over a duplex channel.
 ///

--- a/crates/uffs-mft/Cargo.toml
+++ b/crates/uffs-mft/Cargo.toml
@@ -62,6 +62,7 @@ name = "uffs-mft"
 path = "src/main.rs"
 
 [dependencies]
+uffs-version.workspace = true
 # Internal
 uffs-polars.workspace = true
 uffs-text.workspace = true
@@ -135,6 +136,7 @@ harness = false
 # (see build.rs). A metadata-less binary is both unbranded and a mild antivirus
 # false-positive signal. Only affects the bin target; the library is unchanged.
 [build-dependencies]
+uffs-version = { workspace = true, features = ["build"] }
 winresource.workspace = true
 
 [lints]

--- a/crates/uffs-mft/benches/mft_read.rs
+++ b/crates/uffs-mft/benches/mft_read.rs
@@ -16,6 +16,8 @@
 
 // Suppress unused crate warnings for dependencies used by the main crate
 // but not directly by the benchmark binary.
+// Linked via the crate's `[dependencies]` (its binaries call
+// `uffs_version::handle_version!`); this target does not reference it.
 use anyhow as _;
 use bitflags as _;
 use bytemuck as _;
@@ -54,6 +56,7 @@ use uffs_mft as _;
 use uffs_polars as _;
 use uffs_security as _;
 use uffs_text as _;
+use uffs_version as _;
 // `windows` is linked via the `[target.'cfg(windows)'.dependencies]` section
 // of `uffs-mft`'s Cargo.toml.  The benchmark's Windows body only reaches the
 // crate transitively (through `uffs_mft::AlignedBuffer` / `ParsedColumns`),

--- a/crates/uffs-mft/build.rs
+++ b/crates/uffs-mft/build.rs
@@ -21,6 +21,7 @@
 //! unaffected either way).
 
 fn main() {
+    uffs_version::emit_build_env();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../../assets/brand/icons/uffs.ico");
     println!("cargo:rerun-if-changed=../../assets/brand/app.manifest");

--- a/crates/uffs-mft/src/lib.rs
+++ b/crates/uffs-mft/src/lib.rs
@@ -155,6 +155,9 @@ extern crate alloc;
 // Binary dependencies (used by src/main.rs only, or by #[cfg(windows)]
 // modules). Listed here to prevent unused_crate_dependencies false positives on
 // non-Windows.
+// Linked for this crate's binary target(s), which call
+// `uffs_version::handle_version!` in `main`; the library itself does not
+// reference it (sanctioned unused-crate-dependencies marker).
 use anyhow as _;
 // ============================================================================
 // Suppress unused crate warnings
@@ -205,6 +208,7 @@ use tracing_subscriber as _;
 #[cfg(not(windows))]
 use uffs_polars as _;
 use uffs_text as _;
+use uffs_version as _;
 #[cfg(windows)]
 use windows as _;
 

--- a/crates/uffs-mft/src/main.rs
+++ b/crates/uffs-mft/src/main.rs
@@ -151,6 +151,7 @@ fn ctrl_c_listener_error(operation: &'static str, error: &std::io::Error) -> uff
     reason = "intentional user-facing error output in main"
 )]
 async fn main() {
+    uffs_version::handle_version!("uffs-mft");
     let verbose = std::env::args().any(|arg| arg == "-v" || arg == "--verbose");
     let _guard = logging::init_logging(verbose);
 

--- a/crates/uffs-update/Cargo.toml
+++ b/crates/uffs-update/Cargo.toml
@@ -31,6 +31,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 
 [dependencies]
+uffs-version.workspace = true
 anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
@@ -62,6 +63,7 @@ libc = "0.2"
 # Embed `app.manifest` (asInvoker) into uffs-update.exe on Windows MSVC so the
 # "update" name doesn't trip Installer Detection → forced UAC (os error 740).
 [build-dependencies]
+uffs-version = { workspace = true, features = ["build"] }
 winresource.workspace = true
 
 [lints]

--- a/crates/uffs-update/build.rs
+++ b/crates/uffs-update/build.rs
@@ -25,6 +25,7 @@
 //! Inert on non-Windows / non-MSVC targets (the helper ships windows-msvc).
 
 fn main() {
+    uffs_version::emit_build_env();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=app.manifest");
     println!("cargo:rerun-if-changed=../../assets/brand/icons/uffs.ico");

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -58,7 +58,11 @@ fn run() -> Result<()> {
         Some("doctor") => run_doctor(args.get(1..).unwrap_or_default()),
         Some("check") => run_check(args.get(1..).unwrap_or_default()),
         Some("--version" | "-V") => {
-            print_version();
+            let verbose = args
+                .iter()
+                .skip(1)
+                .any(|arg| arg == "--verbose" || arg == "-v");
+            print_version(verbose);
             Ok(())
         }
         Some("--help" | "-h") | None => {
@@ -274,8 +278,12 @@ fn run_check(args: &[String]) -> Result<()> {
 
 /// Print the helper version.
 #[expect(clippy::print_stdout, reason = "intentional version output")]
-fn print_version() {
-    println!("uffs-update {}", env!("CARGO_PKG_VERSION"));
+fn print_version(verbose: bool) {
+    if verbose {
+        println!("{}", uffs_version::version_long!("uffs-update"));
+    } else {
+        println!("{}", uffs_version::version_short!("uffs-update"));
+    }
 }
 
 /// Parse the `acquire` flags and download + verify the installed-subset

--- a/crates/uffs-version/Cargo.toml
+++ b/crates/uffs-version/Cargo.toml
@@ -1,0 +1,41 @@
+# ============================================================================
+# uffs-version: shared `--version` strings for every UFFS binary
+# ============================================================================
+# Layer 0 leaf crate. Zero external dependencies.
+#
+# Gives every UFFS executable an identical `--version`: a short one-liner by
+# default (`<name>[.exe] <semver> (<sha>)`) and a multi-line build fingerprint
+# with `--version --verbose` / `-v`. The strings are produced by the
+# `version_short!` / `version_long!` macros (they expand in the calling crate,
+# so each binary reports its own version + build sha). The `build` feature
+# exposes `emit_build_env`, called from each binary's `build.rs` to stamp the
+# git sha + build metadata the macros read.
+# ============================================================================
+
+[package]
+name = "uffs-version"
+description = "Consistent short/long --version strings + build-metadata stamping for UFFS binaries"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+# Internal foundation crate — inherits the workspace `publish = false` default.
+publish.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+# Enables `emit_build_env` (git/rustc/target/profile stamping). Binaries turn
+# it on only in `[build-dependencies]`, so the shipped binary never compiles it.
+build = []
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/uffs-version/src/lib.rs
+++ b/crates/uffs-version/src/lib.rs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Consistent `--version` output for every UFFS binary.
+//!
+//! Every UFFS executable prints the same shape: a short one-liner by default
+//! and a multi-line build fingerprint with `--version --verbose` / `-v`.
+//!
+//! - [`version_short!`] → `"<name>[.exe] <semver> (<sha>)"`
+//! - [`version_long!`] → the short line plus commit date, rustc, target,
+//!   profile
+//!
+//! The macros expand **in the calling crate**, so `CARGO_PKG_VERSION` resolves
+//! to that binary's version and `option_env!("UFFS_GIT_SHA")` (and the other
+//! `UFFS_*` build vars) resolve to what its `build.rs` stamped via
+//! [`emit_build_env`]. On Windows the name carries the real `.exe` suffix so
+//! `--version` matches the on-disk filename.
+
+/// Executable-name suffix for the compiled target.
+///
+/// `.exe` on Windows, empty elsewhere — so the version macros print a name that
+/// matches the actual on-disk filename.
+#[must_use]
+pub const fn exe_suffix() -> &'static str {
+    if cfg!(windows) { ".exe" } else { "" }
+}
+
+/// Short one-line version: `"<name>[.exe] <semver> (<sha>)"`.
+///
+/// Expands in the caller, so `CARGO_PKG_VERSION` and `UFFS_GIT_SHA` are that
+/// binary's. `$name` is the bare binary stem (e.g. `"uffsd"`); the `.exe`
+/// suffix is appended automatically on Windows.
+#[macro_export]
+macro_rules! version_short {
+    ($name:literal) => {
+        format!(
+            "{}{} {} ({})",
+            $name,
+            $crate::exe_suffix(),
+            env!("CARGO_PKG_VERSION"),
+            option_env!("UFFS_GIT_SHA").unwrap_or("unknown"),
+        )
+    };
+}
+
+/// Multi-line build fingerprint for bug reports (`--version --verbose` / `-v`).
+///
+/// The short line followed by `commit` (sha + date), `rustc`, `target`, and
+/// `profile`, each read from the `UFFS_*` env this crate's [`emit_build_env`]
+/// stamps at build time (`"unknown"` when a field could not be resolved).
+#[macro_export]
+macro_rules! version_long {
+    ($name:literal) => {
+        format!(
+            "{}{} {}\n\
+             commit:   {} ({})\n\
+             rustc:    {}\n\
+             target:   {}\n\
+             profile:  {}",
+            $name,
+            $crate::exe_suffix(),
+            env!("CARGO_PKG_VERSION"),
+            option_env!("UFFS_GIT_SHA").unwrap_or("unknown"),
+            option_env!("UFFS_COMMIT_DATE").unwrap_or("unknown"),
+            option_env!("UFFS_RUSTC").unwrap_or("unknown"),
+            option_env!("UFFS_TARGET").unwrap_or("unknown"),
+            option_env!("UFFS_PROFILE").unwrap_or("unknown"),
+        )
+    };
+}
+
+/// Intercept `--version` / `-V` at the top of `main` and exit.
+///
+/// Prints the short line, or the multi-line fingerprint when `--verbose` / `-v`
+/// follows. `$name` is the bare binary stem (`"uffsd"`). Only fires when the
+/// version flag is the **first** argument (matching the search-first CLI
+/// grammar, where a later `--version` is a search term). Writes straight to
+/// stdout (not `println!`) so callers need no `print_stdout` allow. Put it as
+/// the very first statement in `main`.
+#[macro_export]
+macro_rules! handle_version {
+    ($name:literal) => {
+        // A single call, so `main` gains ~no cognitive complexity (some UFFS
+        // mains sit right at the `cognitive_complexity` ceiling). The closures
+        // defer the (caller-expanded) version macros so each reads the caller's
+        // own `CARGO_PKG_VERSION` + `UFFS_GIT_SHA`; only the requested form is
+        // built. On `--version` the helper prints and exits.
+        $crate::print_version_if_requested(
+            || $crate::version_short!($name),
+            || $crate::version_long!($name),
+        );
+    };
+}
+
+/// When `--version` / `-V` is the first argument, print the version and **exit
+/// the process**; otherwise return so the caller proceeds.
+///
+/// Prints the `long` form when `--verbose` / `-v` follows, else `short`. The
+/// caller passes closures so the version strings expand in *its* crate (its own
+/// `CARGO_PKG_VERSION` + `UFFS_GIT_SHA`). Writes straight to stdout (not
+/// `println!`). See [`handle_version!`].
+// Exiting is this function's contract (a `--version` handler); there is no
+// resource cleanup to skip at version-print time, and doing the exit here (not
+// in the macro) keeps callers' `main` free of an extra branch.
+#[expect(
+    clippy::exit,
+    reason = "version handler exits by contract after printing; no cleanup to skip"
+)]
+pub fn print_version_if_requested<Short, Long>(short: Short, long: Long)
+where
+    Short: FnOnce() -> String,
+    Long: FnOnce() -> String,
+{
+    use std::io::Write as _;
+
+    let args: Vec<String> = std::env::args().collect();
+    if !matches!(args.get(1).map(String::as_str), Some("--version" | "-V")) {
+        return;
+    }
+    let verbose = args
+        .iter()
+        .skip(2)
+        .any(|arg| arg == "--verbose" || arg == "-v");
+    let line = if verbose { long() } else { short() };
+    let mut out = std::io::stdout();
+    let _written = out
+        .write_all(line.as_bytes())
+        .and_then(|()| out.write_all(b"\n"))
+        .and_then(|()| out.flush());
+    std::process::exit(0);
+}
+
+/// Stamp the build metadata the version macros read into `cargo:rustc-env`.
+///
+/// Call once from a binary crate's `build.rs` (with the `build` feature on).
+/// Emits `UFFS_GIT_SHA` (short HEAD sha, `-dirty` when the tree is modified),
+/// `UFFS_COMMIT_DATE`, `UFFS_RUSTC`, `UFFS_TARGET`, and `UFFS_PROFILE`.
+/// Best-effort: any field that cannot be resolved is stamped `unknown`, so a
+/// build with no git available still succeeds.
+#[cfg(feature = "build")]
+#[expect(
+    clippy::print_stdout,
+    reason = "build-script API: values are passed to cargo via stdout directives"
+)]
+pub fn emit_build_env() {
+    println!("cargo:rustc-env=UFFS_GIT_SHA={}", git_sha());
+    println!(
+        "cargo:rustc-env=UFFS_COMMIT_DATE={}",
+        git_output(&["show", "-s", "--format=%cs", "HEAD"])
+    );
+    println!("cargo:rustc-env=UFFS_RUSTC={}", rustc_version());
+    println!("cargo:rustc-env=UFFS_TARGET={}", env_or_unknown("TARGET"));
+    println!("cargo:rustc-env=UFFS_PROFILE={}", env_or_unknown("PROFILE"));
+    // Re-stamp when the checked-out commit or the compiler changes.
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-env-changed=RUSTC");
+}
+
+/// Run `git <args>`, returning trimmed stdout or `"unknown"`.
+#[cfg(feature = "build")]
+fn git_output(args: &[&str]) -> String {
+    std::process::Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|raw| raw.trim().to_owned())
+        .filter(|trimmed| !trimmed.is_empty())
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
+/// Short HEAD sha with a `-dirty` suffix when the working tree has uncommitted
+/// changes (so a hand-tweaked local build is never mistaken for the commit).
+#[cfg(feature = "build")]
+fn git_sha() -> String {
+    let sha = git_output(&["rev-parse", "--short", "HEAD"]);
+    let dirty = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .is_some_and(|out| !out.stdout.is_empty());
+    if dirty && sha != "unknown" {
+        format!("{sha}-dirty")
+    } else {
+        sha
+    }
+}
+
+/// The building compiler's `rustc --version` line (via the `RUSTC` cargo sets).
+#[cfg(feature = "build")]
+fn rustc_version() -> String {
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_owned());
+    std::process::Command::new(rustc)
+        .arg("--version")
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|raw| raw.trim().to_owned())
+        .filter(|trimmed| !trimmed.is_empty())
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
+/// A cargo-provided build env var (e.g. `TARGET`, `PROFILE`) or `"unknown"`.
+#[cfg(feature = "build")]
+fn env_or_unknown(key: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| "unknown".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::exe_suffix;
+
+    #[test]
+    fn exe_suffix_matches_target() {
+        if cfg!(windows) {
+            assert_eq!(exe_suffix(), ".exe");
+        } else {
+            assert_eq!(exe_suffix(), "");
+        }
+    }
+
+    #[test]
+    fn version_short_has_name_semver_and_sha_shape() {
+        // Expands in this (test) crate: CARGO_PKG_VERSION is uffs-version's.
+        let line = version_short!("uffs-version");
+        assert!(line.starts_with("uffs-version"));
+        assert!(line.contains(env!("CARGO_PKG_VERSION")));
+        assert!(line.contains('(') && line.ends_with(')'));
+        #[cfg(windows)]
+        assert!(line.starts_with("uffs-version.exe "));
+    }
+
+    #[test]
+    fn version_long_is_multiline_with_fields() {
+        let text = version_long!("uffs-version");
+        assert!(text.lines().count() >= 5, "short line + 4 metadata lines");
+        assert!(text.contains("commit:"));
+        assert!(text.contains("rustc:"));
+        assert!(text.contains("target:"));
+        assert!(text.contains("profile:"));
+    }
+}

--- a/scripts/ci-pipeline/Cargo.toml
+++ b/scripts/ci-pipeline/Cargo.toml
@@ -61,6 +61,7 @@ path = "src/main.rs"
 # different major versions of the same crate.
 
 [dependencies]
+uffs-version.workspace = true
 anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
@@ -88,6 +89,7 @@ tokio = { workspace = true, features = ["process"] }
 # Embeds the UFFS icon + version info + shared app.manifest into
 # `uffs-ci-pipeline.exe` (see build.rs) for branding consistency.
 [build-dependencies]
+uffs-version = { workspace = true, features = ["build"] }
 winresource.workspace = true
 
 [lints]

--- a/scripts/ci-pipeline/build.rs
+++ b/scripts/ci-pipeline/build.rs
@@ -18,6 +18,7 @@
 //! MSVC-Windows only; a no-op on every other build target.
 
 fn main() {
+    uffs_version::emit_build_env();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../../assets/brand/icons/uffs.ico");
     println!("cargo:rerun-if-changed=../../assets/brand/app.manifest");

--- a/scripts/ci-pipeline/src/main.rs
+++ b/scripts/ci-pipeline/src/main.rs
@@ -215,6 +215,7 @@ fn handle_workflow_resume() -> Result<()> {
 /// match.
 #[tokio::main]
 async fn main() -> Result<()> {
+    uffs_version::handle_version!("uffs-ci-pipeline");
     let cli = Cli::parse();
     let validation_command = matches!(
         cli.command,

--- a/scripts/ci/uffs-gen-hooks/Cargo.toml
+++ b/scripts/ci/uffs-gen-hooks/Cargo.toml
@@ -52,6 +52,7 @@ path = "src/main.rs"
 # Cargo.toml so a single Cargo.lock entry serves this tool and every other
 # crate.  See `scripts/ci-pipeline/Cargo.toml` for the rationale.
 [dependencies]
+uffs-version.workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
@@ -75,6 +76,7 @@ toml = { workspace = true }
 # Embeds the UFFS icon + version info + shared app.manifest into `uffs-gen-hooks.exe`
 # (see build.rs) for branding consistency.
 [build-dependencies]
+uffs-version = { workspace = true, features = ["build"] }
 winresource.workspace = true
 
 [lints]

--- a/scripts/ci/uffs-gen-hooks/build.rs
+++ b/scripts/ci/uffs-gen-hooks/build.rs
@@ -18,6 +18,7 @@
 //! MSVC-Windows only; a no-op on every other build target.
 
 fn main() {
+    uffs_version::emit_build_env();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../../../assets/brand/icons/uffs.ico");
     println!("cargo:rerun-if-changed=../../../assets/brand/app.manifest");

--- a/scripts/ci/uffs-gen-hooks/src/main.rs
+++ b/scripts/ci/uffs-gen-hooks/src/main.rs
@@ -108,6 +108,7 @@ struct Args {
 /// emit failure surfaces as exit code `2` (schema error class)
 /// with the underlying error chain on stderr.
 fn main() -> ExitCode {
+    uffs_version::handle_version!("uffs-gen-hooks");
     let args = Args::parse();
     match run(&args) {
         Ok(code) => code,

--- a/scripts/ci/uffs-gen-workflow/Cargo.toml
+++ b/scripts/ci/uffs-gen-workflow/Cargo.toml
@@ -46,6 +46,7 @@ path = "src/main.rs"
 # Cargo.toml so a single Cargo.lock entry serves this tool and every
 # other crate.  See `scripts/ci/uffs-gen-hooks/Cargo.toml` for the rationale.
 [dependencies]
+uffs-version.workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true }
 regex = { workspace = true }
@@ -67,6 +68,7 @@ toml = { workspace = true }
 # Embeds the UFFS icon + version info + shared app.manifest into
 # `uffs-gen-workflow.exe` (see build.rs) for branding consistency.
 [build-dependencies]
+uffs-version = { workspace = true, features = ["build"] }
 winresource.workspace = true
 
 [lints]

--- a/scripts/ci/uffs-gen-workflow/build.rs
+++ b/scripts/ci/uffs-gen-workflow/build.rs
@@ -18,6 +18,7 @@
 //! MSVC-Windows only; a no-op on every other build target.
 
 fn main() {
+    uffs_version::emit_build_env();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../../../assets/brand/icons/uffs.ico");
     println!("cargo:rerun-if-changed=../../../assets/brand/app.manifest");

--- a/scripts/ci/uffs-gen-workflow/src/main.rs
+++ b/scripts/ci/uffs-gen-workflow/src/main.rs
@@ -118,6 +118,7 @@ struct Args {
 }
 
 fn main() -> ExitCode {
+    uffs_version::handle_version!("uffs-gen-workflow");
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {

--- a/scripts/ci/uffs-manifest-audit/Cargo.toml
+++ b/scripts/ci/uffs-manifest-audit/Cargo.toml
@@ -54,6 +54,7 @@ path = "src/main.rs"
 # Cargo.toml so a single Cargo.lock entry serves this tool and every
 # other crate.  See `scripts/ci/uffs-gen-hooks/Cargo.toml` for the rationale.
 [dependencies]
+uffs-version.workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
@@ -71,6 +72,7 @@ toml = { workspace = true }
 # Embeds the UFFS icon + version info + shared app.manifest into
 # `uffs-manifest-audit.exe` (see build.rs) for branding consistency.
 [build-dependencies]
+uffs-version = { workspace = true, features = ["build"] }
 winresource.workspace = true
 
 [lints]

--- a/scripts/ci/uffs-manifest-audit/build.rs
+++ b/scripts/ci/uffs-manifest-audit/build.rs
@@ -18,6 +18,7 @@
 //! MSVC-Windows only; a no-op on every other build target.
 
 fn main() {
+    uffs_version::emit_build_env();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../../../assets/brand/icons/uffs.ico");
     println!("cargo:rerun-if-changed=../../../assets/brand/app.manifest");

--- a/scripts/ci/uffs-manifest-audit/src/main.rs
+++ b/scripts/ci/uffs-manifest-audit/src/main.rs
@@ -80,6 +80,7 @@ struct Args {
 }
 
 fn main() -> ExitCode {
+    uffs_version::handle_version!("uffs-manifest-audit");
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {


### PR DESCRIPTION
Makes **all 22 binaries** print an identical, informative `--version` — short by default, a full build fingerprint on demand — and factors the logic into a new zero-dep leaf crate so it can't drift again.

### Before → after
Only `uffs` showed the build sha; the rest were plainer/inconsistent (`uffsmcp` even printed `uffs-mcp v…`). Now:

```
# short (default)                # long (`--version -v`)
uffs.exe 0.6.23 (2ce30ee)        uffs.exe 0.6.23
uffsd.exe 0.6.23 (2ce30ee)       commit:   2ce30ee (2026-07-04)
uffsmcp.exe 0.6.23 (2ce30ee)     rustc:    rustc 1.98.0-nightly (…)
uffs-broker.exe 0.6.23 (…)       target:   x86_64-pc-windows-msvc
…all 22…                         profile:  release
```
- `<name>[.exe] <semver> (<sha>)`, `-dirty` on a modified tree.
- **`.exe` on Windows only** (via `cfg!(windows)`), so the name matches the on-disk filename.
- `-v` / `--verbose` after `--version` → the multi-line fingerprint for bug reports.

### New `uffs-version` crate (zero deps, `publish = false`)
- `version_short!` / `version_long!` — expand **in each caller**, so every binary reports its own `CARGO_PKG_VERSION` + stamped `UFFS_GIT_SHA`.
- `handle_version!` — one-call `--version` interceptor for `main`; the `exit` lives in the helper (its contract) so callers gain ~no cognitive complexity.
- `emit_build_env` (`feature = "build"`) — stamps sha + commit date + rustc + target + profile from each `build.rs`. Replaces the old per-crate git-sha logic in uffs-cli/uffs-daemon.

### Scope
Wired into every binary crate (cli, daemon, mcp+http, broker, update, mft, bench, the 10 diag tools, and the ci-pipeline/gen-hooks/gen-workflow/manifest-audit tools). lib+bin crates carry the compiler-suggested `use uffs_version as _;` marker in their lib root.

### Verified
`clippy --workspace --all-targets -D warnings` green on **host and `x86_64-pc-windows-msvc` (xwin)**; unit + integration tests (short/long shape, `.exe`, sha, verbose fingerprint); manifest-inheritance audit. No `#[allow]` hiding — the only exceptions are the two sanctioned idioms (`use … as _;` and one `#[expect(clippy::exit)]` on the exit-by-contract helper), each with a documented reason.

### Not published
`uffs-version` stays internal — it's UFFS-branded glue (name + `UFFS_*` env), and the general-purpose space is already served by `vergen`/`shadow-rs`/`built`.