### PR TITLE
feat(status): protocol + styling foundation for a unified --status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4691,6 +4691,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "uffs-statusfmt"
+version = "0.6.23"
+
+[[package]]
 name = "uffs-text"
 version = "0.6.23"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "crates/uffs-text",            # 📝 Unicode text processing, i18n foundation
   "crates/uffs-time",            # ⏱️ NTFS FILETIME arithmetic (pure, zero deps)
   "crates/uffs-version",         # 🏷️ Shared --version strings + build-metadata stamp (leaf)
+  "crates/uffs-statusfmt",       # 🎨 Shared operator-status styling (color, glyphs, fields) (leaf)
   "crates/uffs-broker-protocol", # 📟 Cross-platform broker wire-protocol types (F5)
   "crates/uffs-winsvc",          # 🪟 Native Windows service control + broker-pipe probe (leaf)
   "crates/uffs-mft",             # 📦 MFT reading → Polars DataFrame
@@ -132,6 +133,7 @@ uffs-security = { path = "crates/uffs-security", version = "0.6.23" }
 uffs-text = { path = "crates/uffs-text", version = "0.6.23" }
 uffs-time = { path = "crates/uffs-time", version = "0.6.23" }
 uffs-version = { path = "crates/uffs-version", version = "0.6.23" }
+uffs-statusfmt = { path = "crates/uffs-statusfmt", version = "0.6.23" }
 uffs-mft = { path = "crates/uffs-mft", version = "0.6.23" }
 uffs-format = { path = "crates/uffs-format", version = "0.6.23" }
 uffs-core = { path = "crates/uffs-core", version = "0.6.23" }

--- a/crates/uffs-client/src/protocol/response.rs
+++ b/crates/uffs-client/src/protocol/response.rs
@@ -12,8 +12,8 @@
 use serde::{Deserialize, Serialize};
 
 pub use super::response_status::{
-    DaemonStatus, DriveInfo, DriveMemoryInfo, DrivesResponse, ShardTier, StatsResponse,
-    StatusResponse,
+    DaemonPaths, DaemonStatus, DriveInfo, DriveMemoryInfo, DrivesResponse, LiveUpdateInfo,
+    ShardTier, StatsResponse, StatusResponse,
 };
 pub use super::response_tiering::{
     DEFAULT_PRELOAD_PIN_MINUTES, DriveTierStatus, ForgetParams, ForgetResponse, HibernateParams,

--- a/crates/uffs-client/src/protocol/response_status.rs
+++ b/crates/uffs-client/src/protocol/response_status.rs
@@ -115,6 +115,60 @@ pub struct StatusResponse {
     /// Per-drive memory breakdown (drive letter → heap bytes).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub drive_memory: Vec<DriveMemoryInfo>,
+    /// Short git commit the running daemon was built from (`UFFS_GIT_SHA`,
+    /// `-dirty` for a modified tree). Lets an operator confirm a rebuilt binary
+    /// actually took effect — the semver alone can't distinguish two builds of
+    /// the same version. `""`/`"unknown"` on daemons that predate this field.
+    #[serde(default)]
+    pub git_sha: String,
+    /// Whether the daemon process is elevated (Administrator). When `false` the
+    /// daemon reads the live MFT through the Access Broker's duplicated handle;
+    /// see [`Self::reading_via_broker`].
+    #[serde(default)]
+    pub elevated: bool,
+    /// Whether the daemon is reading the live MFT via **adopted Access Broker
+    /// handles** (the zero-UAC path) rather than its own elevated handles.
+    /// Always `false` off Windows / for offline-MFT sources.
+    #[serde(default)]
+    pub reading_via_broker: bool,
+    /// Live-update (USN journal) state — how many per-shard journal loops are
+    /// running. Absent on daemons that predate this field or platforms without
+    /// live update.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub live_update: Option<LiveUpdateInfo>,
+    /// Filesystem locations the daemon is using (data/cache dir, socket/pipe,
+    /// log dir), so the operator can find the index, connect, and read logs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paths: Option<DaemonPaths>,
+}
+
+/// Live-update (USN journal) liveness, surfaced in [`StatusResponse`].
+///
+/// Deliberately just the loop count: it is set **once when the loops spawn**,
+/// so reporting it costs nothing on the live-indexing hot path (unlike a
+/// per-patch "last applied" timestamp, which would add a store to every USN
+/// apply). "N loops running" answers the operative question — *is live update
+/// actually active?* — which is what an operator needs.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+pub struct LiveUpdateInfo {
+    /// Number of per-shard journal loops currently running (0 = live update
+    /// not active, e.g. offline MFT sources or a non-Windows host).
+    pub active_loops: usize,
+}
+
+/// Filesystem locations the daemon is operating from, surfaced in
+/// [`StatusResponse`] so an operator can locate the index, socket, and logs.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DaemonPaths {
+    /// Index data / cache directory.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub data_dir: String,
+    /// IPC socket (Unix) or named pipe (Windows) clients connect on.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub socket: String,
+    /// Directory the daemon writes its logs to.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub log_dir: String,
 }
 
 /// Per-drive memory breakdown for status reporting.

--- a/crates/uffs-daemon/src/index/stats.rs
+++ b/crates/uffs-daemon/src/index/stats.rs
@@ -131,6 +131,12 @@ impl IndexManager {
                 (Some(mem.rss_bytes), mem.mimalloc_committed_bytes)
             });
 
+        // Broker-adoption mode: reading via adopted broker handles (zero-UAC)
+        // vs the daemon's own elevated handles. `is_elevated()` is `false` off
+        // Windows; the handle count is `0` there, so both read as "direct".
+        let elevated = uffs_mft::is_elevated();
+        let reading_via_broker = uffs_mft::registered_broker_handle_count() > 0;
+
         StatusResponse {
             status: status_snapshot,
             uptime_secs: self.start_time.elapsed().as_secs(),
@@ -141,6 +147,11 @@ impl IndexManager {
             index_heap_bytes: Some(total_index_heap),
             mimalloc_committed_bytes,
             drive_memory,
+            git_sha: option_env!("UFFS_GIT_SHA").unwrap_or("unknown").to_owned(),
+            elevated,
+            reading_via_broker,
+            live_update: crate::live_update::snapshot(),
+            paths: Some(crate::live_update::daemon_paths()),
         }
     }
 

--- a/crates/uffs-daemon/src/lib.rs
+++ b/crates/uffs-daemon/src/lib.rs
@@ -110,6 +110,8 @@ mod index;
 mod ipc;
 /// Lifecycle manager — PID file, idle timer, shutdown coordination.
 mod lifecycle;
+/// `--status` observability signals (live-update loop count, daemon paths).
+mod live_update;
 /// JSON-RPC protocol types.
 mod protocol;
 /// Phase 2b memory-tiering: runtime-tempfile orphan cleanup at boot.
@@ -589,6 +591,7 @@ async fn spawn_journal_loops_for_warm_shards(
         save_threshold_age_secs = config.save_threshold_age.as_secs(),
         "Spawning per-shard journal loops",
     );
+    let loop_count = letters.len();
     for letter in letters {
         let source: Arc<dyn JournalSource> = make_journal_source(letter);
         let handle = spawn_journal_loop(
@@ -600,6 +603,9 @@ async fn spawn_journal_loops_for_warm_shards(
         );
         idx.attach_journal_handle(letter, handle);
     }
+    // Record live-update liveness once, here — so `--status` can report "N
+    // loops running" without any per-patch bookkeeping on the apply hot path.
+    live_update::set_active_loops(loop_count);
 
     applier_handle
 }

--- a/crates/uffs-daemon/src/live_update.rs
+++ b/crates/uffs-daemon/src/live_update.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! `--status` observability signals kept off the live-indexing hot path.
+//!
+//! Live-update liveness is reported as the **number of running per-shard
+//! journal loops**, recorded once when they spawn (`set_active_loops` — a
+//! single relaxed store). It is deliberately *not* a per-patch "last applied"
+//! timestamp: that would add a store to every USN apply on the hot path, and
+//! "N loops running" already answers the operative question — is live update
+//! actually active? The daemon's filesystem locations are gathered on demand
+//! from the shared path helpers. Both are read only when a `status` RPC lands.
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use uffs_client::protocol::response::{DaemonPaths, LiveUpdateInfo};
+
+/// Number of per-shard journal loops currently running. Set once after the
+/// loops spawn; `0` means live update is not active (offline MFT / non-Windows,
+/// or before the loops start).
+static ACTIVE_LOOPS: AtomicUsize = AtomicUsize::new(0);
+
+/// Record how many live journal loops are running — called once, right after
+/// they spawn. A single relaxed store, so it adds nothing to the per-patch
+/// apply path.
+pub(crate) fn set_active_loops(count: usize) {
+    ACTIVE_LOOPS.store(count, Ordering::Relaxed);
+}
+
+/// Snapshot live-update liveness for a `status` RPC. `None` when no loops are
+/// running, so the field is omitted for offline-MFT / non-Windows daemons.
+pub(crate) fn snapshot() -> Option<LiveUpdateInfo> {
+    match ACTIVE_LOOPS.load(Ordering::Relaxed) {
+        0 => None,
+        active_loops => Some(LiveUpdateInfo { active_loops }),
+    }
+}
+
+/// The daemon's filesystem locations for a `status` RPC, gathered on demand
+/// from the shared path helpers (index/cache dir, client socket/pipe, log dir).
+/// Always available, so the caller wraps it in `Some`.
+pub(crate) fn daemon_paths() -> DaemonPaths {
+    DaemonPaths {
+        data_dir: uffs_mft::cache::cache_dir().display().to_string(),
+        socket: uffs_client::daemon_ctl::socket_path().display().to_string(),
+        log_dir: std::env::var("UFFS_LOG_DIR").unwrap_or_default(),
+    }
+}

--- a/crates/uffs-mft/src/lib.rs
+++ b/crates/uffs-mft/src/lib.rs
@@ -313,6 +313,7 @@ pub use platform::current_euid;
 // Unix: geteuid() == 0).  Exported unconditionally so uffs-cli and
 // uffs-daemon can gate mutating daemon commands on all targets.
 pub use platform::is_elevated;
+pub use platform::registered_broker_handle_count;
 // Re-export platform types
 // Core types (DriveType, MftBitmap, MftExtent) are pure data — available on all platforms
 // Windows-specific types and functions (VolumeHandle, detect_ntfs_drives, etc.) only on

--- a/crates/uffs-mft/src/platform.rs
+++ b/crates/uffs-mft/src/platform.rs
@@ -87,6 +87,10 @@ pub use system::{
     detect_boot_drive, detect_drive_type, detect_ntfs_drives, infer_drive_from_path, is_boot_drive,
     volume_root_path,
 };
+// Cross-platform broker-adoption count so `--status` can report the mode on
+// any target: the real registry count on Windows, `0` (no broker) elsewhere.
+#[cfg(windows)]
+pub use volume::registered_broker_handle_count;
 // Crate-internal: the USN journal open (FU-2b) and `$MFT` extent read (FU-3)
 // adopt the same broker volume handle the MFT read uses.
 #[cfg(windows)]
@@ -101,6 +105,13 @@ pub(crate) use volume::{
 // must be at least as public as the former.
 #[cfg(windows)]
 pub use volume::{NtfsVolumeData, VolumeHandle, register_broker_handle};
+
+/// Non-Windows: there is no Access Broker, so no adopted handles.
+#[cfg(not(windows))]
+#[must_use]
+pub const fn registered_broker_handle_count() -> usize {
+    0
+}
 
 #[cfg(test)]
 #[cfg(windows)]

--- a/crates/uffs-mft/src/platform/volume.rs
+++ b/crates/uffs-mft/src/platform/volume.rs
@@ -79,6 +79,20 @@ pub fn register_broker_handle(drive: super::DriveLetter, raw_handle: u64) {
     }
 }
 
+/// Number of Access Broker volume handles currently registered.
+///
+/// The drives the daemon reads through an adopted broker handle (the zero-UAC
+/// path) rather than its own elevated handle — lets `--status` report the
+/// broker-adoption mode. Off Windows there is no broker, so this is always `0`.
+#[cfg(windows)]
+#[must_use]
+pub fn registered_broker_handle_count() -> usize {
+    BROKER_HANDLES
+        .get()
+        .and_then(|map| map.lock().ok())
+        .map_or(0, |guard| guard.len())
+}
+
 /// Read (without removing) the registered broker handle for `drive`, if any.
 ///
 /// The entry is intentionally retained for the daemon's lifetime: every

--- a/crates/uffs-statusfmt/Cargo.toml
+++ b/crates/uffs-statusfmt/Cargo.toml
@@ -1,0 +1,33 @@
+# ============================================================================
+# uffs-statusfmt: shared operator-status styling for UFFS
+# ============================================================================
+# Layer 0 leaf crate. Zero external dependencies.
+#
+# One visual language for every `--status` / status surface (daemon, broker,
+# combined, MCP): TTY- and NO_COLOR-aware color, health glyphs, aligned
+# `key: value` fields, and section headers. Keeps the human output consistent
+# and scannable; the machine-readable `--json` form is modelled by each caller.
+# ============================================================================
+
+[package]
+name = "uffs-statusfmt"
+description = "Shared operator-status styling (color, glyphs, aligned fields) for UFFS --status surfaces"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+# Internal foundation crate — inherits the workspace `publish = false` default.
+publish.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/uffs-statusfmt/src/lib.rs
+++ b/crates/uffs-statusfmt/src/lib.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Shared operator-status styling for UFFS `--status` surfaces.
+//!
+//! One visual language for the daemon, broker, combined-system, and MCP status
+//! output: a health [`Glyph`], aligned `key: value` [`field`]s, and [`section`]
+//! headers, all through a single [`Palette`] that turns color **off**
+//! automatically when stdout is not a terminal or `NO_COLOR` is set.
+//!
+//! Callers build lines with these helpers and print them; the machine-readable
+//! `--json` form is modelled separately by each caller (this crate is purely
+//! the human-facing look).
+
+use std::io::IsTerminal as _;
+
+/// ANSI SGR select codes used by [`Palette`]. Kept together so the escape
+/// sequences live in exactly one place.
+mod sgr {
+    /// Reset all attributes.
+    pub(super) const RESET: &str = "0";
+    /// Bold / bright.
+    pub(super) const BOLD: &str = "1";
+    /// Dim / faint.
+    pub(super) const DIM: &str = "2";
+    /// Foreground green.
+    pub(super) const GREEN: &str = "32";
+    /// Foreground red.
+    pub(super) const RED: &str = "31";
+    /// Foreground yellow.
+    pub(super) const YELLOW: &str = "33";
+    /// Foreground cyan.
+    pub(super) const CYAN: &str = "36";
+}
+
+/// Whether to emit ANSI color, decided once and threaded through the render.
+#[derive(Debug, Clone, Copy)]
+pub struct Palette {
+    /// `true` when color escapes should be emitted.
+    color: bool,
+}
+
+impl Palette {
+    /// Auto-detect: color on only when **stdout is a terminal**, `NO_COLOR` is
+    /// unset, and `TERM` is not `dumb`. This is the constructor operator
+    /// commands should use so piped / redirected output stays plain.
+    #[must_use]
+    pub fn detect() -> Self {
+        let no_color = std::env::var_os("NO_COLOR").is_some();
+        let dumb = std::env::var("TERM").is_ok_and(|term| term == "dumb");
+        Self {
+            color: std::io::stdout().is_terminal() && !no_color && !dumb,
+        }
+    }
+
+    /// A palette that never emits color (for tests, `--json`, or forced-plain).
+    #[must_use]
+    pub const fn plain() -> Self {
+        Self { color: false }
+    }
+
+    /// Whether this palette emits color.
+    #[must_use]
+    pub const fn is_color(self) -> bool {
+        self.color
+    }
+
+    /// Wrap `text` in the SGR `code`, or return it unchanged when color is off.
+    fn wrap(self, code: &str, text: &str) -> String {
+        if self.color {
+            format!("\u{1b}[{code}m{text}\u{1b}[{}m", sgr::RESET)
+        } else {
+            text.to_owned()
+        }
+    }
+
+    /// Bold `text`.
+    #[must_use]
+    pub fn bold(self, text: &str) -> String {
+        self.wrap(sgr::BOLD, text)
+    }
+    /// Dim / de-emphasize `text` (labels, secondary detail).
+    #[must_use]
+    pub fn dim(self, text: &str) -> String {
+        self.wrap(sgr::DIM, text)
+    }
+    /// Green `text` (healthy / running).
+    #[must_use]
+    pub fn green(self, text: &str) -> String {
+        self.wrap(sgr::GREEN, text)
+    }
+    /// Red `text` (error / failed).
+    #[must_use]
+    pub fn red(self, text: &str) -> String {
+        self.wrap(sgr::RED, text)
+    }
+    /// Yellow `text` (warning / transitional).
+    #[must_use]
+    pub fn yellow(self, text: &str) -> String {
+        self.wrap(sgr::YELLOW, text)
+    }
+    /// Cyan `text` (values, identifiers).
+    #[must_use]
+    pub fn cyan(self, text: &str) -> String {
+        self.wrap(sgr::CYAN, text)
+    }
+}
+
+/// A component's health, mapped to a consistent glyph + color across surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Glyph {
+    /// Running / serving / healthy — green `●`.
+    Up,
+    /// Stopped / not running — dim `○`.
+    Down,
+    /// Transitional or degraded (loading, refreshing) — yellow `◐`.
+    Warn,
+    /// Not installed / not applicable — dim `·`.
+    Off,
+}
+
+impl Glyph {
+    /// The colored glyph for this health, per `palette`.
+    #[must_use]
+    pub fn render(self, palette: Palette) -> String {
+        match self {
+            Self::Up => palette.green("\u{25cf}"),    // ●
+            Self::Down => palette.dim("\u{25cb}"),    // ○
+            Self::Warn => palette.yellow("\u{25d0}"), // ◐
+            Self::Off => palette.dim("\u{b7}"),       // ·
+        }
+    }
+}
+
+/// A top-level banner: `═══ title ═══` (bold when colored).
+#[must_use]
+pub fn header(palette: Palette, title: &str) -> String {
+    let bar = "\u{2550}".repeat(3);
+    palette.bold(&format!("{bar} {title} {bar}"))
+}
+
+/// A section header: `── title ──` (cyan when colored). Groups related fields.
+#[must_use]
+pub fn section(palette: Palette, title: &str) -> String {
+    let dash = "\u{2500}".repeat(2);
+    palette.cyan(&format!("{dash} {title} {dash}"))
+}
+
+/// One `  key:<pad> value` line, with the key dimmed and padded to `key_width`
+/// so a block of fields aligns. `key` is given without its trailing colon.
+#[must_use]
+pub fn field(palette: Palette, key: &str, value: &str, key_width: usize) -> String {
+    // Pad on the raw (uncolored) key+colon so alignment is escape-agnostic.
+    let label = format!("{key}:");
+    let pad = key_width.saturating_add(1).saturating_sub(label.len());
+    format!("  {}{} {value}", palette.dim(&label), " ".repeat(pad))
+}
+
+/// A one-line component summary: `<glyph> <name>  <detail>` — the short-view
+/// row (e.g. `● Daemon   running (PID 1234), 7 drives`). `detail` is optional.
+#[must_use]
+pub fn status_row(palette: Palette, glyph: Glyph, name: &str, detail: &str) -> String {
+    let styled = palette.bold(name);
+    if detail.is_empty() {
+        format!("{} {styled}", glyph.render(palette))
+    } else {
+        format!("{} {styled}  {detail}", glyph.render(palette))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Glyph, Palette, field, header, section, status_row};
+
+    #[test]
+    fn plain_palette_emits_no_escapes() {
+        let plain = Palette::plain();
+        assert!(!plain.is_color());
+        assert_eq!(plain.green("ok"), "ok");
+        assert_eq!(plain.bold("x"), "x");
+        assert!(!header(plain, "UFFS").contains('\u{1b}'));
+        assert!(!Glyph::Up.render(plain).contains('\u{1b}'));
+    }
+
+    #[test]
+    fn field_aligns_to_key_width() {
+        let plain = Palette::plain();
+        // key_width 10: "Status" (6) + ':' (1) → 4 pad spaces + 1 gap.
+        assert_eq!(
+            field(plain, "Status", "running", 10),
+            "  Status:     running"
+        );
+        assert_eq!(field(plain, "PID", "42", 10), "  PID:        42");
+    }
+
+    #[test]
+    fn header_and_section_shapes() {
+        let plain = Palette::plain();
+        assert_eq!(
+            header(plain, "UFFS System Status"),
+            "═══ UFFS System Status ═══"
+        );
+        assert_eq!(section(plain, "Daemon"), "── Daemon ──");
+    }
+
+    #[test]
+    fn status_row_with_and_without_detail() {
+        let plain = Palette::plain();
+        assert_eq!(
+            status_row(plain, Glyph::Up, "Daemon", "running"),
+            "● Daemon  running"
+        );
+        assert_eq!(status_row(plain, Glyph::Down, "Daemon", ""), "○ Daemon");
+    }
+}


### PR DESCRIPTION
## What

Checkpoint **(A)** of the `--status` / stats refactor: land the **data + shared styling** foundation now, so the renderer rewrite and `--json` wiring (Phase 2/3) build on a stable base. **No user-visible change yet.**

### `uffs-statusfmt` (new, zero-dep leaf crate)
One visual language for every status surface — daemon, broker, combined-system, MCP:
- `Palette` — TTY/`NO_COLOR`/`TERM=dumb`-aware color detection (`detect()`), plus `plain()` for `--json`/tests.
- `Glyph` — health markers (`●` up / `○` down / `◐` warn / `·` off), colored per palette.
- `header` / `section` / `field` (aligned `key: value`) / `status_row` (short one-line summary).
- Unit-tested in plain mode (no escapes, alignment, shapes).

### Status protocol gains operator-relevant signals it never exposed
On `StatusResponse` (all `#[serde(default)]`, back-compatible):
- `git_sha` — the running build's short SHA (semver alone can't distinguish two builds).
- `elevated` + `reading_via_broker` — is the daemon elevated-direct, or reading the live MFT via the **zero-UAC Access Broker** path? Backed by a new cross-platform `uffs_mft::registered_broker_handle_count` (real count on Windows, `0` elsewhere).
- `live_update: Option<LiveUpdateInfo>` — how many per-shard USN journal loops are running (is live update *actually* active?).
- `paths: Option<DaemonPaths>` — data/cache dir, socket/pipe, log dir, so an operator can find the index, connect, and read logs.

### Hot-path discipline
`live_update` liveness is recorded **once when the loops spawn** (a single relaxed `AtomicUsize` store) and read **on demand** at status time — deliberately *not* a per-patch "last applied" timestamp, which would add a store to every USN apply on the live-indexing hot path.

## Follow-ups (next PRs)
- Phase 2/3: rewrite all 5 renderers on `uffs-statusfmt` (short / `-v` long / color), consolidate `--daemon stats` into `--daemon status -v`, thread `--json`.
- Broker completeness: version / uptime / binary path / handles-vended (protocol additions on `uffs-broker` + `uffs-broker-protocol`).

## Verification
All local gates green before push (host + Windows xwin clippy `-D warnings`, rustdoc `-Dwarnings --document-private-items`, doc-tests, tests, deny, manifest audit) — full 14-gate pre-push passed (109s).