### PR TITLE
feat(status): unify `--daemon status` (short/-v/--json), fold in stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4449,6 +4449,7 @@ dependencies = [
  "uffs-client",
  "uffs-format",
  "uffs-mft",
+ "uffs-statusfmt",
  "uffs-time",
  "uffs-version",
  "uffs-winsvc",

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -85,6 +85,11 @@ uffs-format = { path = "../uffs-format", version = "0.6.23" }
 # unchanged — the (de)serialise impl emits a single ASCII char.
 uffs-mft.workspace = true
 
+# Shared operator-status styling (color, glyphs, aligned fields) for the
+# `--status` / `--daemon status` surfaces.  Zero-dep leaf crate; keeps the
+# one visual language in exactly one place.
+uffs-statusfmt.workspace = true
+
 # Error handling
 anyhow.workspace = true
 

--- a/crates/uffs-cli/src/args.rs
+++ b/crates/uffs-cli/src/args.rs
@@ -141,10 +141,16 @@ pub(crate) enum DaemonAction {
         /// effect for every auto-spawn.
         elevate: bool,
     },
-    /// Show daemon status.
-    Status,
-    /// Show performance statistics.
-    Stats,
+    /// Show daemon status. `verbose` (`-v`) adds the build fingerprint,
+    /// elevation / broker mode, live-update loops, memory tiers, paths, the
+    /// full per-drive breakdown, and performance counters (the former
+    /// `stats`). `json` emits the machine-readable superset.
+    Status {
+        /// Long view: everything, including the folded-in performance counters.
+        verbose: bool,
+        /// Emit JSON (status + drives + stats) instead of the human view.
+        json: bool,
+    },
     /// Gracefully stop.
     Stop,
     /// Hard kill.
@@ -212,8 +218,11 @@ pub(crate) fn parse_daemon_action(args: &[String]) -> Result<DaemonAction, anyho
     let rest = args.get(1..).unwrap_or_default();
     match action {
         "start" => Ok(parse_daemon_start(rest)),
-        "status" => Ok(DaemonAction::Status),
-        "stats" => Ok(DaemonAction::Stats),
+        "status" => Ok(parse_daemon_status(rest)),
+        "stats" => anyhow::bail!(
+            "`--daemon stats` has been folded into `--daemon status -v` \
+             (or `--daemon status --json` for the machine-readable form)."
+        ),
         "stop" => Ok(DaemonAction::Stop),
         "kill" => Ok(DaemonAction::Kill),
         "restart" => Ok(DaemonAction::Restart),
@@ -223,10 +232,24 @@ pub(crate) fn parse_daemon_action(args: &[String]) -> Result<DaemonAction, anyho
         "forget" => parse_daemon_forget(rest),
         "status_drives" | "status-drives" => Ok(DaemonAction::StatusDrives),
         other => anyhow::bail!(
-            "Unknown daemon action: '{other}'. Use: start, status, stats, stop, kill, \
+            "Unknown daemon action: '{other}'. Use: start, status, stop, kill, \
              restart, load, hibernate, preload, forget, status_drives"
         ),
     }
+}
+
+/// Parse `uffs --daemon status [-v|--verbose] [--json]`.
+fn parse_daemon_status(rest: &[String]) -> DaemonAction {
+    let mut verbose = false;
+    let mut json = false;
+    for arg in rest {
+        match arg.as_str() {
+            "-v" | "--verbose" => verbose = true,
+            "--json" => json = true,
+            _ => {}
+        }
+    }
+    DaemonAction::Status { verbose, json }
 }
 
 /// Parse `uffs --daemon start [flags...]`.
@@ -547,7 +570,8 @@ ACTIONS:
     --elevate          Request a UAC prompt (Windows) if not elevated
                        [env: UFFS_ELEVATE=1]
   status             Show daemon status (running, drives, PID)
-  stats              Show performance statistics
+    -v, --verbose      Long view: build, broker mode, memory, paths, perf stats
+    --json             Machine-readable status + drives + stats
   stop               Gracefully stop the daemon
   kill               Hard kill + remove PID/socket files
   restart            Stop then restart (re-loads all indices)

--- a/crates/uffs-cli/src/commands.rs
+++ b/crates/uffs-cli/src/commands.rs
@@ -40,8 +40,8 @@ pub(crate) mod uninstall;
 /// `uffs --update` — self-update detection (Phase A of the self-update design).
 pub(crate) mod update;
 
-/// Render a one-line version summary suitable for `daemon status`,
-/// `daemon stats`, and `uffs --status` output.
+/// Render a one-line version summary suitable for `daemon status`
+/// and `uffs --status` output.
 ///
 /// `daemon_version` is the daemon-reported `env!("CARGO_PKG_VERSION")`
 /// from [`uffs_client::protocol::response::StatusResponse::version`]

--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -86,8 +86,7 @@ pub(crate) fn daemon(action: &DaemonAction) -> Result<()> {
     {
         let is_read_only_or_uac_start = matches!(
             action,
-            DaemonAction::Status
-                | DaemonAction::Stats
+            DaemonAction::Status { .. }
                 | DaemonAction::StatusDrives
                 | DaemonAction::Start { elevate: true, .. }
         );
@@ -146,8 +145,7 @@ pub(crate) fn daemon(action: &DaemonAction) -> Result<()> {
             log_file.as_deref(),
             *elevate,
         ),
-        DaemonAction::Status => daemon_status::daemon_status(),
-        DaemonAction::Stats => daemon_status::daemon_stats(),
+        DaemonAction::Status { verbose, json } => daemon_status::daemon_status(*verbose, *json),
         DaemonAction::Stop => daemon_stop(),
         DaemonAction::Kill => {
             daemon_kill();

--- a/crates/uffs-cli/src/commands/daemon_status.rs
+++ b/crates/uffs-cli/src/commands/daemon_status.rs
@@ -1,8 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! `uffs --daemon status` / `uffs --daemon stats` — the read-only daemon
-//! status and performance displays.
+//! `uffs --daemon status` — the read-only daemon status display.
+//!
+//! One unified view with three levels of detail:
+//! * **short** (default) — health glyph, version, uptime, drives, query rate.
+//! * **long** (`-v` / `--verbose`) — adds build fingerprint, elevation / broker
+//!   mode, live-update loops, memory tiers, filesystem paths, the full
+//!   per-drive memory breakdown, and performance counters (the former `--daemon
+//!   stats`, now folded in here).
+//! * **`--json`** — the machine-readable superset (status + drives + stats),
+//!   for scripts and dashboards.
 //!
 //! Split out of `daemon_mgmt.rs` (which keeps the dispatch, elevation gate,
 //! and the mutating start/stop/kill/restart handlers) so the pure rendering
@@ -11,242 +19,476 @@
 use anyhow::{Context as _, Result};
 use uffs_client::connect_sync::UffsClientSync;
 use uffs_client::daemon_ctl::pid_file_path;
-use uffs_client::protocol::response::{DaemonStatus, DriveInfo, ShardTier};
+use uffs_client::protocol::response::{
+    DaemonStatus, DriveInfo, DriveMemoryInfo, ShardTier, StatsResponse, StatusResponse,
+};
+use uffs_statusfmt::{Glyph, Palette, field, header, section, status_row};
 
-/// `uffs --daemon status` — show daemon status, PID, loaded drives.
-#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
-pub(crate) fn daemon_status() -> Result<()> {
+/// One mebibyte, for the `bytes → MB` display conversions.
+const MIB: u64 = 1024 * 1024;
+
+/// `uffs --daemon status [-v] [--json]` — show daemon status, PID, drives, and
+/// (in long / JSON form) performance counters.
+///
+/// # Errors
+///
+/// Returns an error only if the daemon is reachable but a follow-up RPC
+/// (`drives`) fails; a daemon that is simply not running renders the graceful
+/// "not running" view and returns `Ok`.
+pub(crate) fn daemon_status(verbose: bool, json: bool) -> Result<()> {
     let Ok(mut client) = UffsClientSync::connect_raw() else {
-        print_not_running();
-        return Ok(());
+        return render_not_running(json);
     };
-
     let Ok(status) = client.status() else {
-        print_not_running();
-        return Ok(());
+        return render_not_running(json);
     };
+    let drives = client.drives().with_context(|| "Failed to query drives")?;
+    // Performance counters are best-effort: an older daemon or a transient
+    // error should not sink the whole status view.
+    let perf = client.stats().ok();
 
-    let uptime = core::time::Duration::from_secs(status.uptime_secs);
-    println!(
-        "Version:       {}",
-        crate::commands::version_summary(&status.version)
+    if json {
+        return render_json(&status, &drives.drives, perf.as_ref());
+    }
+    render_human(
+        Palette::detect(),
+        verbose,
+        &status,
+        &drives.drives,
+        perf.as_ref(),
     );
-    println!("Daemon PID:    {}", status.pid);
+    Ok(())
+}
+
+/// Emit the machine-readable superset: daemon status + loaded drives + (when
+/// available) performance counters, all under stable top-level keys.
+#[expect(clippy::print_stdout, reason = "CLI --json output")]
+fn render_json(
+    status: &StatusResponse,
+    drives: &[DriveInfo],
+    perf: Option<&StatsResponse>,
+) -> Result<()> {
+    let doc = serde_json::json!({
+        "running": true,
+        "status": status,
+        "drives": drives,
+        "stats": perf,
+    });
+    println!("{}", serde_json::to_string_pretty(&doc)?);
+    Ok(())
+}
+
+/// Render the human-facing daemon status (short or long) with `palette` colour.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn render_human(
+    palette: Palette,
+    verbose: bool,
+    status: &StatusResponse,
+    drives: &[DriveInfo],
+    perf: Option<&StatsResponse>,
+) {
+    println!("{}", header(palette, "UFFS Daemon"));
+    let (glyph, state) = health(&status.status);
+    let stale_tag = if binary_is_newer_than(status.uptime_secs) {
+        format!("  {}", palette.yellow("\u{26a0} stale binary"))
+    } else {
+        String::new()
+    };
     println!(
-        "Uptime:        {}",
-        uffs_client::format::format_duration(uptime)
+        "{}",
+        status_row(
+            palette,
+            glyph,
+            &state,
+            &format!("PID {}{stale_tag}", status.pid),
+        )
     );
-    match &status.status {
+
+    // Core block — always shown.
+    let width = 11;
+    println!(
+        "{}",
+        field(
+            palette,
+            "Version",
+            &crate::commands::version_summary(&status.version),
+            width
+        )
+    );
+    println!(
+        "{}",
+        field(palette, "Uptime", &fmt_secs(status.uptime_secs), width)
+    );
+    print_drive_headline(palette, drives, width);
+    if let Some(counters) = perf {
+        print_query_headline(palette, counters, width);
+    }
+
+    if verbose {
+        print_build_block(palette, status);
+        print_live_update_block(palette, status);
+        print_memory_block(palette, status);
+        print_paths_block(palette, status);
+        if let Some(counters) = perf {
+            print_performance_block(palette, counters);
+        }
+        print_drive_detail_block(palette, drives, &status.drive_memory);
+    }
+}
+
+/// Map the daemon's lifecycle phase to a health [`Glyph`] and a display label.
+fn health(status: &DaemonStatus) -> (Glyph, String) {
+    match status {
+        DaemonStatus::Ready => (Glyph::Up, "running".to_owned()),
         DaemonStatus::Loading {
             drives_loaded,
             drives_total,
-        } => {
-            println!("Status:        Loading ({drives_loaded}/{drives_total} drives)");
-        }
-        DaemonStatus::Ready => {
-            println!("Status:        Ready");
-        }
+        } => (
+            Glyph::Warn,
+            format!("loading ({drives_loaded}/{drives_total} drives)"),
+        ),
         DaemonStatus::Refreshing { drives } => {
-            let drive_list: String = drives
+            let list: String = drives
                 .iter()
                 .map(|letter| format!("{letter}:"))
                 .collect::<Vec<_>>()
                 .join(", ");
-            println!("Status:        Refreshing ({drive_list})");
+            (Glyph::Warn, format!("refreshing ({list})"))
         }
     }
-    println!("Connections:   {}", status.connections);
+}
 
-    // Memory info.  Three numbers, in increasing order of "what the OS
-    // sees": logical heap (sum of per-drive `heap_size_bytes`), then
-    // mimalloc's committed pages, then the OS-reported RSS.  All three
-    // come from the same `status` payload so they are consistent.
+/// One-line drive summary for the core block.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_drive_headline(palette: Palette, drives: &[DriveInfo], width: usize) {
+    if drives.is_empty() {
+        println!("{}", field(palette, "Drives", "(none loaded)", width));
+        return;
+    }
+    let records: usize = drives.iter().map(|dr| dr.records).sum();
+    let value = format!(
+        "{} loaded \u{b7} {} records",
+        drives.len(),
+        uffs_client::format::format_number_commas(records as u64)
+    );
+    println!("{}", field(palette, "Drives", &value, width));
+}
+
+/// One-line query-rate summary for the core block.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_query_headline(palette: Palette, perf: &StatsResponse, width: usize) {
+    if perf.total_queries == 0 {
+        println!("{}", field(palette, "Queries", "0", width));
+        return;
+    }
+    let avg =
+        core::time::Duration::from_micros(uffs_client::format::f64_to_u64(perf.avg_query_time_us));
+    let value = format!(
+        "{} (avg {}, {:.1}/s)",
+        perf.total_queries,
+        uffs_client::format::format_duration(avg),
+        perf.queries_per_second,
+    );
+    println!("{}", field(palette, "Queries", &value, width));
+}
+
+/// Verbose `── Build ──` section: commit + elevation / broker mode.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_build_block(palette: Palette, status: &StatusResponse) {
+    let width = 9;
+    println!("{}", section(palette, "Build"));
+    let commit = if status.git_sha.is_empty() {
+        "unknown"
+    } else {
+        status.git_sha.as_str()
+    };
+    println!("{}", field(palette, "Commit", commit, width));
+    let mode = if status.elevated {
+        "yes (direct elevated reads)".to_owned()
+    } else if status.reading_via_broker {
+        "no (reading via Access Broker, zero-UAC)".to_owned()
+    } else {
+        "no".to_owned()
+    };
+    println!("{}", field(palette, "Elevated", &mode, width));
+}
+
+/// Verbose `── Live update ──` section: USN journal loop liveness.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_live_update_block(palette: Palette, status: &StatusResponse) {
+    println!("{}", section(palette, "Live update"));
+    let value = match status.live_update {
+        Some(info) if info.active_loops > 0 => {
+            format!("{} journal loop(s) running", info.active_loops)
+        }
+        _ => "inactive (offline source or non-Windows)".to_owned(),
+    };
+    println!("{}", field(palette, "Journal", &value, 9));
+}
+
+/// Verbose `── Memory ──` section: logical heap, allocator-committed, RSS.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_memory_block(palette: Palette, status: &StatusResponse) {
+    if status.index_heap_bytes.is_none()
+        && status.mimalloc_committed_bytes.is_none()
+        && status.rss_bytes.is_none()
+    {
+        return;
+    }
+    let width = 11;
+    println!("{}", section(palette, "Memory"));
     if let Some(heap) = status.index_heap_bytes {
-        println!("Index heap:    {} MB", heap / (1024 * 1024));
+        println!(
+            "{}",
+            field(palette, "Index heap", &format!("{} MB", heap / MIB), width)
+        );
     }
     if let Some(committed) = status.mimalloc_committed_bytes {
         println!(
-            "Mimalloc:      {} MB (committed)",
-            committed / (1024 * 1024)
+            "{}",
+            field(
+                palette,
+                "Mimalloc",
+                &format!("{} MB committed", committed / MIB),
+                width
+            )
         );
     }
     if let Some(rss) = status.rss_bytes {
-        println!("RSS:           {} MB", rss / (1024 * 1024));
+        println!(
+            "{}",
+            field(palette, "RSS", &format!("{} MB", rss / MIB), width)
+        );
     }
-
-    // Also show loaded drives.  The `drives` RPC returns every shard
-    // in the registry — Warm/Hot with their full memory breakdown,
-    // Parked/Cold with just the tier marker (no body in RAM).  Empty
-    // registry still renders `(none loaded)` so cold-boot detection in
-    // external scripts (api-validation, mcp-validation) keeps working.
-    let drives = client.drives().with_context(|| "Failed to query drives")?;
-    if drives.drives.is_empty() {
-        println!("Drives:        (none loaded)");
-    } else {
-        println!("Drives:");
-        for dr in &drives.drives {
-            print_drive_line(dr, &status.drive_memory);
-        }
-    }
-    Ok(())
 }
 
-/// Render one row of the `Drives:` block in `daemon status`.
-///
-/// Format depends on the shard's tier (per Phase 5 task 5.11):
-/// * Warm/Hot — full breakdown (records count, source, memory rec= / names= /
-///   tri= / ch= / ext=).
-/// * Parked  — `[Parked]` marker + bloom + trie kept resident note.
-/// * Cold    — `[Cold]` marker only (no body, no filters).
-/// * Other   — fall back to the legacy single-line format so the formatter
-///   never panics on a state we haven't taught it about.
+/// Verbose `── Paths ──` section: where the daemon keeps data, socket, logs.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
-fn print_drive_line(
-    dr: &DriveInfo,
-    drive_memory: &[uffs_client::protocol::response::DriveMemoryInfo],
-) {
-    let tier_marker = tier_marker(dr.tier);
+fn print_paths_block(palette: Palette, status: &StatusResponse) {
+    let Some(paths) = status.paths.as_ref() else {
+        return;
+    };
+    let width = 8;
+    println!("{}", section(palette, "Paths"));
+    if !paths.data_dir.is_empty() {
+        println!("{}", field(palette, "Data", &paths.data_dir, width));
+    }
+    if !paths.socket.is_empty() {
+        println!("{}", field(palette, "Socket", &paths.socket, width));
+    }
+    if !paths.log_dir.is_empty() {
+        println!("{}", field(palette, "Logs", &paths.log_dir, width));
+    }
+}
+
+/// Verbose `── Performance ──` section: the former `--daemon stats`, folded in.
+///
+/// Field labels are kept stable (`Total records:`, `Queries served:`,
+/// `Avg query time:`, `Agg cache:`, …) because the live-Windows benchmark /
+/// validation harnesses scrape them by name.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_performance_block(palette: Palette, perf: &StatsResponse) {
+    let width = 17;
+    let fmt = uffs_client::format::format_duration;
+    println!("{}", section(palette, "Performance"));
+    println!(
+        "{}",
+        field(
+            palette,
+            "Startup duration",
+            &fmt(core::time::Duration::from_millis(perf.startup_duration_ms)),
+            width
+        )
+    );
+    println!(
+        "{}",
+        field(
+            palette,
+            "Total records",
+            &uffs_client::format::format_number_commas(perf.total_records as u64),
+            width
+        )
+    );
+    println!(
+        "{}",
+        field(
+            palette,
+            "Queries served",
+            &perf.total_queries.to_string(),
+            width
+        )
+    );
+    if perf.total_queries > 0 {
+        let avg = core::time::Duration::from_micros(uffs_client::format::f64_to_u64(
+            perf.avg_query_time_us,
+        ));
+        println!("{}", field(palette, "Avg query time", &fmt(avg), width));
+        println!(
+            "{}",
+            field(
+                palette,
+                "Total query time",
+                &fmt(core::time::Duration::from_micros(perf.total_query_time_us)),
+                width
+            )
+        );
+    }
+    println!(
+        "{}",
+        field(
+            palette,
+            "Queries/second",
+            &format!("{:.2}", perf.queries_per_second),
+            width
+        )
+    );
+    let lookups = perf.agg_cache_hits.saturating_add(perf.agg_cache_misses);
+    let hit_rate = hit_rate_percent(perf.agg_cache_hits, lookups);
+    println!(
+        "{}",
+        field(
+            palette,
+            "Agg cache",
+            &format!(
+                "{} hits / {} misses ({hit_rate:.1}% hit-rate, {} entries)",
+                perf.agg_cache_hits, perf.agg_cache_misses, perf.agg_cache_entries
+            ),
+            width
+        )
+    );
+}
+
+/// Verbose `── Drives ──` section: full per-drive tier + memory breakdown.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_drive_detail_block(palette: Palette, drives: &[DriveInfo], memory: &[DriveMemoryInfo]) {
+    println!("{}", section(palette, "Drives"));
+    if drives.is_empty() {
+        println!("  {}", palette.dim("(none loaded)"));
+        return;
+    }
+    for dr in drives {
+        print_drive_line(palette, dr, memory);
+    }
+}
+
+/// Render one detailed drive row, tier-aware, with a colour-coded glyph.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn print_drive_line(palette: Palette, dr: &DriveInfo, memory: &[DriveMemoryInfo]) {
+    let glyph = tier_glyph(dr.tier).render(palette);
+    let letter = palette.bold(&format!("{}:", dr.letter));
     match dr.tier {
         Some(ShardTier::Warm | ShardTier::Hot) | None => {
-            let mem = drive_memory.iter().find(|dm| dm.drive == dr.letter);
-            if let Some(dm) = mem {
-                let mb = |bytes: u64| bytes / (1024 * 1024);
-                println!(
-                    "  {} {}: — {:>10} records ({}) — {} MB  [rec={} names={} tri={} ch={} ext={}]",
-                    tier_marker,
-                    dr.letter,
-                    uffs_client::format::format_number_commas(dr.records as u64),
-                    dr.source,
-                    mb(dm.heap_bytes),
-                    mb(dm.records_bytes),
-                    mb(dm.names_bytes),
-                    mb(dm.trigram_bytes),
-                    mb(dm.children_bytes),
-                    mb(dm.ext_index_bytes),
-                );
-            } else {
-                println!(
-                    "  {} {}: — {:>10} records ({})",
-                    tier_marker,
-                    dr.letter,
-                    uffs_client::format::format_number_commas(dr.records as u64),
-                    dr.source
-                );
+            let records = uffs_client::format::format_number_commas(dr.records as u64);
+            match memory.iter().find(|dm| dm.drive == dr.letter) {
+                Some(dm) => {
+                    let mb = |bytes: u64| bytes / MIB;
+                    println!(
+                        "  {glyph} {letter} {records:>12} records ({}) \u{b7} {} MB  [rec={} names={} tri={} ch={} ext={}]",
+                        dr.source,
+                        mb(dm.heap_bytes),
+                        mb(dm.records_bytes),
+                        mb(dm.names_bytes),
+                        mb(dm.trigram_bytes),
+                        mb(dm.children_bytes),
+                        mb(dm.ext_index_bytes),
+                    );
+                }
+                None => {
+                    println!("  {glyph} {letter} {records:>12} records ({})", dr.source);
+                }
             }
         }
         Some(ShardTier::Parked) => {
             println!(
-                "  {} {}: — bloom + trie kept resident; body released",
-                tier_marker, dr.letter
+                "  {glyph} {letter} {}",
+                palette.dim("bloom + trie resident; body released")
             );
         }
         Some(ShardTier::Cold) => {
             println!(
-                "  {} {}: — encrypted cache only; nothing in RAM",
-                tier_marker, dr.letter
+                "  {glyph} {letter} {}",
+                palette.dim("encrypted cache only; nothing in RAM")
             );
         }
         Some(ShardTier::Evicting | ShardTier::Unknown) => {
-            println!("  {} {}: — ({})", tier_marker, dr.letter, dr.source);
+            println!("  {glyph} {letter} ({})", dr.source);
         }
     }
 }
 
-/// Format the bracket-style tier marker for `daemon status`'s drive
-/// list.  An 8-character right-padded label so the per-drive lines
-/// align in the operator's terminal.
-const fn tier_marker(tier: Option<ShardTier>) -> &'static str {
+/// Map a shard tier to the shared health glyph: Hot/Warm are up, Parked is
+/// transitional, Cold/Evicting/Unknown are down/off.
+const fn tier_glyph(tier: Option<ShardTier>) -> Glyph {
     match tier {
-        Some(ShardTier::Hot) => "[Hot]   ",
-        Some(ShardTier::Warm) => "[Warm]  ",
-        Some(ShardTier::Parked) => "[Parked]",
-        Some(ShardTier::Cold) => "[Cold]  ",
-        Some(ShardTier::Evicting) => "[Evict] ",
-        Some(ShardTier::Unknown) => "[?]     ",
-        None => "        ",
+        Some(ShardTier::Hot | ShardTier::Warm) | None => Glyph::Up,
+        Some(ShardTier::Parked) => Glyph::Warn,
+        Some(ShardTier::Cold | ShardTier::Evicting) => Glyph::Down,
+        Some(ShardTier::Unknown) => Glyph::Off,
     }
 }
 
-/// Print the "not running" message with optional stale-PID hint.
-///
-/// Visible to sibling command modules (`daemon_tiering.rs`) so the
-/// graceful "daemon down" rendering stays consistent across every
-/// read-only daemon command — the operator sees the **same** stdout
-/// shape from `uffs --daemon status` and `uffs --daemon status_drives`
-/// when the daemon happens to be down.  Mutating commands
-/// (`hibernate` / `preload` / `forget`) deliberately stay on the
-/// bail-with-error path because the operator should know their
-/// requested mutation didn't run.
+/// Render the graceful "daemon not running" view (human or JSON).
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
-pub(crate) fn print_not_running() {
-    println!("Daemon is not running.");
+fn render_not_running(json: bool) -> Result<()> {
+    if json {
+        let doc = serde_json::json!({ "running": false });
+        println!("{}", serde_json::to_string_pretty(&doc)?);
+        return Ok(());
+    }
+    let palette = Palette::detect();
+    println!(
+        "{}",
+        status_row(palette, Glyph::Down, "Daemon", "not running")
+    );
     let pid_path = pid_file_path();
     if pid_path.exists() {
-        println!("  (stale PID file exists at {})", pid_path.display());
-    }
-}
-
-/// `uffs --daemon stats` — show performance metrics.
-#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
-pub(crate) fn daemon_stats() -> Result<()> {
-    if let Ok(mut client) = UffsClientSync::connect_raw() {
-        let stats = client
-            .stats()
-            .with_context(|| "Failed to query daemon stats")?;
-
-        let fmt = uffs_client::format::format_duration;
-        let uptime = core::time::Duration::from_secs(stats.uptime_secs);
-        let startup = core::time::Duration::from_millis(stats.startup_duration_ms);
-        let avg_query = core::time::Duration::from_micros(uffs_client::format::f64_to_u64(
-            stats.avg_query_time_us,
-        ));
-        let total_query = core::time::Duration::from_micros(stats.total_query_time_us);
-
-        println!("═══ Daemon Performance Stats ═══");
         println!(
-            "Version:           {}",
-            crate::commands::version_summary(&stats.version)
+            "  {}",
+            palette.dim(&format!("(stale PID file at {})", pid_path.display()))
         );
-        println!("Uptime:            {}", fmt(uptime));
-        println!("Startup duration:  {}", fmt(startup));
-        println!(
-            "Total records:     {}",
-            uffs_client::format::format_number_commas(stats.total_records as u64)
-        );
-        println!("Queries served:    {}", stats.total_queries);
-        if stats.total_queries > 0 {
-            println!("Avg query time:    {}", fmt(avg_query));
-            println!("Total query time:  {}", fmt(total_query));
-        }
-        println!("Queries/second:    {:.2}", stats.queries_per_second);
-
-        // Aggregate cache observability.  Hit-rate is computed on
-        // demand to avoid a division-by-zero for cold daemons.
-        let lookups = stats.agg_cache_hits.saturating_add(stats.agg_cache_misses);
-        let hit_rate = compute_hit_rate_percent(stats.agg_cache_hits, lookups);
-        println!(
-            "Agg cache:         {} hits / {} misses ({:.1}% hit-rate, {} entries)",
-            stats.agg_cache_hits, stats.agg_cache_misses, hit_rate, stats.agg_cache_entries,
-        );
-    } else {
-        println!("Daemon is not running.");
     }
     Ok(())
 }
 
-/// Compute aggregate-cache hit-rate as a percentage for daemon status display.
+/// Print the "not running" message for sibling read-only commands.
 ///
-/// Returns `0.0` when no lookups have occurred, avoiding a division by
-/// zero on cold daemons.  The `cast_precision_loss` expect is justified
-/// for telemetry display: well over `2^53` cache lookups would be
-/// required to lose a single bit of precision, and the output is
-/// rendered with `{:.1}` so single-bit differences are invisible.
+/// Visible to `daemon_tiering.rs` so the graceful "daemon down" rendering
+/// stays consistent across every read-only daemon command. Mutating commands
+/// (`hibernate` / `preload` / `forget`) deliberately stay on the bail-with-
+/// error path because the operator should know their mutation didn't run.
+pub(crate) fn print_not_running() {
+    // Human view only; callers that want JSON go through `daemon_status`.
+    let _ignored = render_not_running(false);
+}
+
+/// Format a whole-second duration for display.
+fn fmt_secs(secs: u64) -> String {
+    uffs_client::format::format_duration(core::time::Duration::from_secs(secs))
+}
+
+/// Was the on-disk CLI binary modified *after* the daemon started? A `true`
+/// means the running daemon is older than the installed binary (stale).
+fn binary_is_newer_than(uptime_secs: u64) -> bool {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| std::fs::metadata(path).ok())
+        .and_then(|meta| meta.modified().ok())
+        .is_some_and(|bin_mtime| {
+            let started =
+                std::time::SystemTime::now() - core::time::Duration::from_secs(uptime_secs);
+            started < bin_mtime
+        })
+}
+
+/// Aggregate-cache hit-rate as a percentage; `0.0` when there were no lookups
+/// (avoids a divide-by-zero on cold daemons). Rendered with `{:.1}` so the
+/// cast's precision loss is invisible.
 #[expect(
     clippy::float_arithmetic,
     clippy::cast_precision_loss,
     reason = "telemetry hit-rate percent; rendered with `{:.1}` so precision loss is invisible"
 )]
-fn compute_hit_rate_percent(hits: u64, lookups: u64) -> f64 {
+fn hit_rate_percent(hits: u64, lookups: u64) -> f64 {
     if lookups == 0 {
         return 0.0_f64;
     }

--- a/scripts/tests/definitions/01-general.toml
+++ b/scripts/tests/definitions/01-general.toml
@@ -598,12 +598,12 @@ result_has_key = ["results"]
 [[test]]
 id = "T169"
 group = "general"
-name = "T169 uffs --daemon stats (perf)"
-title = "T169 uffs --daemon stats (perf)"
-short_desc = "T169 uffs --daemon stats (perf)"
-cli_args = ["--daemon", "stats"]
+name = "T169 uffs --daemon status -v (perf)"
+title = "T169 uffs --daemon status -v (perf)"
+short_desc = "T169 uffs --daemon status -v (perf, stats folded in)"
+cli_args = ["--daemon", "status", "-v"]
 targets = ["cli"]
-stdout_contains = ["Daemon Performance Stats", "Uptime:", "Total records:"]
+stdout_contains = ["UFFS Daemon", "Uptime:", "Total records:"]
 
 [test.api_checks]
 result_has_key = ["results"]

--- a/scripts/tests/definitions/11-rpc.toml
+++ b/scripts/tests/definitions/11-rpc.toml
@@ -2,54 +2,54 @@
 # Auto-split from test-definitions.toml
 
 [[test]]
-id          = "RPC.1"
-group       = "rpc"
-name        = "RPC.1 status method"
-title       = "RPC.1 daemon status"
-short_desc  = "Daemon status returns pid, uptime, status, and loaded drives"
-cli_args    = ["daemon", "status"]
-targets     = ["cli", "api"]
-rpc_method  = "status"
-rpc_params  = "{}"
-validator   = "RPC.1"
+id = "RPC.1"
+group = "rpc"
+name = "RPC.1 status method"
+title = "RPC.1 daemon status"
+short_desc = "Daemon status returns pid, uptime, status, and loaded drives"
+cli_args = ["daemon", "status"]
+targets = ["cli", "api"]
+rpc_method = "status"
+rpc_params = "{}"
+validator = "RPC.1"
 stdout_contains = ["Daemon PID:", "Uptime:", "Status:", "Ready", "records"]
 
 [[test]]
-id          = "RPC.2"
-group       = "rpc"
-name        = "RPC.2 drives method"
-title       = "RPC.2 loaded drives"
-short_desc  = "Drives method returns loaded drive info with record counts"
-cli_args    = ["daemon", "status"]
-targets     = ["cli", "api"]
-rpc_method  = "drives"
-rpc_params  = "{}"
-validator   = "RPC.2"
+id = "RPC.2"
+group = "rpc"
+name = "RPC.2 drives method"
+title = "RPC.2 loaded drives"
+short_desc = "Drives method returns loaded drive info with record counts"
+cli_args = ["daemon", "status"]
+targets = ["cli", "api"]
+rpc_method = "drives"
+rpc_params = "{}"
+validator = "RPC.2"
 stdout_contains = ["records"]
 
 [[test]]
-id          = "RPC.3"
-group       = "rpc"
-name        = "RPC.3 info method"
-title       = "RPC.3 info method"
-short_desc  = "Info method looks up a file by path"
-cli_args    = []
-targets     = ["api"]
-rpc_method  = "info"
-rpc_params  = "{\"path\": \"C:\\\\Windows\\\\System32\\\\notepad.exe\"}"
-validator   = "RPC.3"
+id = "RPC.3"
+group = "rpc"
+name = "RPC.3 info method"
+title = "RPC.3 info method"
+short_desc = "Info method looks up a file by path"
+cli_args = []
+targets = ["api"]
+rpc_method = "info"
+rpc_params = "{\"path\": \"C:\\\\Windows\\\\System32\\\\notepad.exe\"}"
+validator = "RPC.3"
 
 [[test]]
-id          = "RPC.4"
-group       = "rpc"
-name        = "RPC.4 stats method"
-title       = "RPC.4 daemon stats"
-short_desc  = "Daemon performance stats: uptime, records, queries"
-cli_args    = ["daemon", "stats"]
-targets     = ["cli", "api"]
-rpc_method  = "stats"
-rpc_params  = "{}"
-validator   = "RPC.4"
+id = "RPC.4"
+group = "rpc"
+name = "RPC.4 stats method"
+title = "RPC.4 daemon status -v (stats folded in)"
+short_desc = "Daemon performance stats: uptime, records, queries"
+cli_args = ["daemon", "status", "-v"]
+targets = ["cli", "api"]
+rpc_method = "stats"
+rpc_params = "{}"
+validator = "RPC.4"
 stdout_contains = ["Uptime:", "Total records:", "Queries served:"]
 
 # RPC.5 — negative-path test for JSON-RPC unknown-method handling.
@@ -72,14 +72,13 @@ stdout_contains = ["Uptime:", "Total records:", "Queries served:"]
 # methods — only specific subcommands (daemon status, stats, etc.) —
 # so there's no surface to test "unknown method" at the CLI layer.
 [[test]]
-id          = "RPC.5"
-group       = "rpc"
-name        = "RPC.5 unknown method"
-title       = "RPC.5 unknown method returns JSON-RPC error"
-short_desc  = "Calling a nonexistent RPC method returns -32601 (MethodNotFound)"
-targets     = ["api"]
-rpc_method  = "this_method_does_not_exist"
-rpc_params  = "{}"
+id = "RPC.5"
+group = "rpc"
+name = "RPC.5 unknown method"
+title = "RPC.5 unknown method returns JSON-RPC error"
+short_desc = "Calling a nonexistent RPC method returns -32601 (MethodNotFound)"
+targets = ["api"]
+rpc_method = "this_method_does_not_exist"
+rpc_params = "{}"
 expect_error = true
-validator   = "RPC.5"
-
+validator = "RPC.5"

--- a/scripts/windows/api-validation.rs
+++ b/scripts/windows/api-validation.rs
@@ -2889,7 +2889,7 @@ fn main() {
     // processes or mutate the host in any way.  Those concerns live in
     // `scripts/dev/orphan-cleanup.rs` (callable via `just orphan`).
     print_uffs_command_block(&args.bin, &["--daemon", "status"], "═══ Daemon STATUS ═══");
-    print_uffs_command_block(&args.bin, &["--daemon", "stats"],  "═══ Daemon STATS ═══");
+    print_uffs_command_block(&args.bin, &["--daemon", "status", "-v"],  "═══ Daemon STATUS -v (perf) ═══");
 
     if failed > 0 {
         // Build retest command with failed test IDs.  Same shape as

--- a/scripts/windows/cli-validation.rs
+++ b/scripts/windows/cli-validation.rs
@@ -2239,7 +2239,7 @@ fn main() {
     // processes or mutate the host in any way.  Those concerns live in
     // `scripts/dev/orphan-cleanup.rs` (callable via `just orphan`).
     print_uffs_command_block(&args.bin, &["--daemon", "status"], "═══ Daemon STATUS ═══");
-    print_uffs_command_block(&args.bin, &["--daemon", "stats"],  "═══ Daemon STATS ═══");
+    print_uffs_command_block(&args.bin, &["--daemon", "status", "-v"],  "═══ Daemon STATUS -v (perf) ═══");
 
     if failed > 0 {
         // Build retest command with failed test IDs.  Same shape as

--- a/scripts/windows/cold-parity-per-drive.ps1
+++ b/scripts/windows/cold-parity-per-drive.ps1
@@ -171,11 +171,11 @@ function Remove-DriveCache {
 }
 
 function Get-DaemonTotalRecords {
-    # `uffs --daemon stats` prints "Total records: N" with thousands
+    # `uffs --daemon status -v` prints "Total records: N" with thousands
     # separators. Returns $null if the daemon isn't running or the line
     # isn't found.
     try {
-        $statsOut = & $UffsBin daemon stats 2>&1 | Out-String
+        $statsOut = & $UffsBin daemon status -v 2>&1 | Out-String
         if ($statsOut -match 'Total records:\s+([0-9,]+)') {
             return [int64]($matches[1] -replace ',', '')
         }

--- a/scripts/windows/concurrency-sweep.rs
+++ b/scripts/windows/concurrency-sweep.rs
@@ -27,7 +27,7 @@
 //!    verify `source="env"` and `target=N`.
 //! 6. Run one warm-up api-validation (populates the agg cache).
 //! 7. Run one measured api-validation and parse its Timing Breakdown.
-//! 8. Capture `uffs --daemon stats` for cache hit-rate and avg query time.
+//! 8. Capture `uffs --daemon status -v` for cache hit-rate and avg query time.
 //!
 //! A summary table is printed at the end.
 //!
@@ -272,10 +272,10 @@ fn run_validation(repo_root: &PathBuf) -> Result<String> {
     Ok(text)
 }
 
-/// Capture `uffs --daemon stats` as plain text.
+/// Capture `uffs --daemon status -v` as plain text (perf stats folded in).
 fn daemon_stats_text() -> String {
     Command::new(uffs_bin())
-        .args(["--daemon", "stats"])
+        .args(["--daemon", "status", "-v"])
         .output()
         .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
         .unwrap_or_default()

--- a/scripts/windows/mcp-validation.rs
+++ b/scripts/windows/mcp-validation.rs
@@ -2072,7 +2072,7 @@ fn main() -> Result<()> {
     //                       exercises the MCP surface, so the gateway
     //                       telemetry belongs in the summary).
     print_uffs_command_block(&args.bin, &["--daemon", "status"], "═══ Daemon STATUS ═══");
-    print_uffs_command_block(&args.bin, &["--daemon", "stats"],  "═══ Daemon STATS ═══");
+    print_uffs_command_block(&args.bin, &["--daemon", "status", "-v"],  "═══ Daemon STATUS -v (perf) ═══");
     print_uffs_command_block(&args.bin, &["status"],           "═══ MCP STATUS (system-wide) ═══");
 
     if failed > 0 {


### PR DESCRIPTION
## What

Phase (B) of the `--status` refactor. Consolidates the daemon read-only surfaces onto the new `uffs-statusfmt` styling (from #527) and **folds `--daemon stats` into `--daemon status -v`**.

### `--daemon status` — one command, three detail levels
- **short** (default): health glyph, version, uptime, drives, query rate.
- **`-v` / `--verbose`** (long): adds
  - **Build** — commit SHA + elevation / Access-Broker mode (`elevated`, `reading_via_broker`)
  - **Live update** — USN journal loop liveness (`live_update.active_loops`)
  - **Memory** — index heap / mimalloc-committed / RSS
  - **Paths** — data-dir / socket / logs (`paths`)
  - **Performance** — the folded-in `stats` (startup, records, queries, agg-cache)
  - **Drives** — full per-drive tier + memory breakdown
- **`--json`**: machine-readable superset (`status` + `drives` + `stats`) for scripts/dashboards.

Surfaces the operator fields added to `StatusResponse` in #527 (`git_sha`, `elevated`, `reading_via_broker`, `live_update`, `paths`).

### `--daemon stats` removed
The parser now returns a one-line redirect to `status -v` / `status --json` (chosen over a silent alias per "no history to worry about"). Elevation gate + dispatch updated.

### Colour
TTY/`NO_COLOR`-aware via `uffs-statusfmt::Palette`. Piped/redirected output stays plain — so the live-Windows benchmark/validation harnesses keep scraping the same field labels (`Total records:`, `Queries served:`, `Avg query time:`, `Agg cache:`). Those harnesses + the two CLI test definitions are updated to invoke `status -v` (`11-rpc.toml` also picks up taplo's no-align normalization).

## Verification
All local gates green before push (host + **xwin Windows** clippy `--all-targets -D warnings`, rustdoc `-Dwarnings --document-private-items`, fmt, taplo) — full 14-gate pre-push passed (147s).

## Follow-ups
- Phase C: rewrite combined `uffs --status` on `uffs-statusfmt` (+ `-v` / `--json`).
- Phase D: broker protocol completeness (version / uptime / binary path / handles vended).