### PR TITLE
docs(crates): "Part of UFFS" callout on uffs-text / uffs-time READMEs

### DIFF
--- a/crates/uffs-text/README.md
+++ b/crates/uffs-text/README.md
@@ -7,6 +7,12 @@
 [![License: MPL-2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](../../LICENSE)
 [![Repository](https://img.shields.io/badge/repo-skyllc--ai%2FUltraFastFileSearch-blue)](https://github.com/skyllc-ai/UltraFastFileSearch)
 
+> **Part of [Ultra Fast File Search](https://github.com/skyllc-ai/UltraFastFileSearch).**
+> UFFS is a Windows-first, high-performance file-search engine that reads the
+> NTFS Master File Table directly. `uffs-text` is its case-folding component,
+> published standalone because bit-exact NTFS filename comparison is useful
+> well beyond UFFS.
+
 NTFS performs every case-insensitive filename operation — directory
 lookup, attribute matching, indexed binary-tree comparisons — against
 its on-disk **`$UpCase`** table.  That table is a 128 KB flat array

--- a/crates/uffs-time/README.md
+++ b/crates/uffs-time/README.md
@@ -7,6 +7,12 @@
 [![License: MPL-2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](../../LICENSE)
 [![Repository](https://img.shields.io/badge/repo-skyllc--ai%2FUltraFastFileSearch-blue)](https://github.com/skyllc-ai/UltraFastFileSearch)
 
+> **Part of [Ultra Fast File Search](https://github.com/skyllc-ai/UltraFastFileSearch).**
+> UFFS is a Windows-first, high-performance file-search engine that reads the
+> NTFS Master File Table directly. `uffs-time` provides its FILETIME conversion
+> primitives, published standalone because any tool decoding raw NTFS
+> timestamps can reuse them.
+
 Windows stores timestamps as **FILETIME**: a 64-bit signed count of
 100-nanosecond ticks since `1601-01-01 00:00:00 UTC`.  Every NTFS MFT
 record carries four of them (created / modified / MFT-modified /


### PR DESCRIPTION
## What
Adds a short, tasteful **"Part of Ultra Fast File Search"** callout right under the badges on both crates-io-published crates (`uffs-text`, `uffs-time`). They previously only linked back to UFFS at the very bottom.

The callout gives someone discovering the crate on crates.io immediate context — credibility for the crate, a little exposure for UFFS — with a link to the parent project.

**Docs-only.** No change to either crate's API, behaviour, or output. Reaches crates.io only on the next deliberate `cargo publish` of those crates.