### PR TITLE
test(harness): make daemon-status validators JSON-aware

### DIFF
--- a/scripts/tests/definitions/01-general.toml
+++ b/scripts/tests/definitions/01-general.toml
@@ -598,12 +598,12 @@ result_has_key = ["results"]
 [[test]]
 id = "T169"
 group = "general"
-name = "T169 uffs --daemon status -v (perf)"
-title = "T169 uffs --daemon status -v (perf)"
-short_desc = "T169 uffs --daemon status -v (perf, stats folded in)"
-cli_args = ["--daemon", "status", "-v"]
+name = "T169 uffs --daemon status --json (perf)"
+title = "T169 uffs --daemon status --json (perf)"
+short_desc = "T169 uffs --daemon status --json (perf, stats folded in)"
+cli_args = ["--daemon", "status", "--json"]
 targets = ["cli"]
-stdout_contains = ["UFFS Daemon", "Uptime:", "Total records:"]
+stdout_contains = ['"running"', '"total_records"', '"uptime_secs"']
 
 [test.api_checks]
 result_has_key = ["results"]

--- a/scripts/tests/definitions/11-rpc.toml
+++ b/scripts/tests/definitions/11-rpc.toml
@@ -5,14 +5,14 @@
 id = "RPC.1"
 group = "rpc"
 name = "RPC.1 status method"
-title = "RPC.1 daemon status"
+title = "RPC.1 daemon status --json"
 short_desc = "Daemon status returns pid, uptime, status, and loaded drives"
-cli_args = ["daemon", "status"]
+cli_args = ["daemon", "status", "--json"]
 targets = ["cli", "api"]
 rpc_method = "status"
 rpc_params = "{}"
 validator = "RPC.1"
-stdout_contains = ["Daemon PID:", "Uptime:", "Status:", "Ready", "records"]
+stdout_contains = ['"running"', '"pid"', '"uptime_secs"']
 
 [[test]]
 id = "RPC.2"
@@ -20,12 +20,12 @@ group = "rpc"
 name = "RPC.2 drives method"
 title = "RPC.2 loaded drives"
 short_desc = "Drives method returns loaded drive info with record counts"
-cli_args = ["daemon", "status"]
+cli_args = ["daemon", "status", "--json"]
 targets = ["cli", "api"]
 rpc_method = "drives"
 rpc_params = "{}"
 validator = "RPC.2"
-stdout_contains = ["records"]
+stdout_contains = ['"drives"', '"letter"', '"records"']
 
 [[test]]
 id = "RPC.3"
@@ -43,14 +43,14 @@ validator = "RPC.3"
 id = "RPC.4"
 group = "rpc"
 name = "RPC.4 stats method"
-title = "RPC.4 daemon status -v (stats folded in)"
+title = "RPC.4 daemon status --json (stats folded in)"
 short_desc = "Daemon performance stats: uptime, records, queries"
-cli_args = ["daemon", "status", "-v"]
+cli_args = ["daemon", "status", "--json"]
 targets = ["cli", "api"]
 rpc_method = "stats"
 rpc_params = "{}"
 validator = "RPC.4"
-stdout_contains = ["Uptime:", "Total records:", "Queries served:"]
+stdout_contains = ['"stats"', '"total_records"', '"total_queries"']
 
 # RPC.5 — negative-path test for JSON-RPC unknown-method handling.
 #

--- a/scripts/windows/cli-validation.rs
+++ b/scripts/windows/cli-validation.rs
@@ -1334,36 +1334,74 @@ fn run_custom_validator(name: &str, stdout: &str, stderr: &str) -> Result<String
             Ok(format!("{} rows, none start with uppercase README", rows.len()))
         }
 
-        // ── Daemon subcommand validators ─────────────────────────────────
+        // ── Daemon subcommand validators (JSON-aware) ────────────────────
+        //
+        // These drive `uffs --daemon status --json`, whose payload is the
+        // wrapper `{running, status:{...}, drives:[...], stats:{...}}`.  We
+        // parse structured JSON instead of scraping the (colourised, restyled)
+        // human text so the checks are stable across cosmetic output changes.
         "RPC.1" => {
-            // daemon status: must show PID and Ready
-            if !stdout.contains("Daemon PID:") { bail!("Missing 'Daemon PID:' in output"); }
-            if !stdout.contains("Ready") { bail!("Daemon not Ready"); }
-            // Extract PID
-            let pid = stdout.lines()
-                .find(|l| l.contains("Daemon PID:"))
-                .and_then(|l| l.split(':').nth(1))
-                .map(|s| s.trim().to_string())
-                .unwrap_or_default();
-            Ok(format!("pid={pid}, status=Ready"))
+            // status: daemon running, with a pid, uptime, and lifecycle state.
+            let v: serde_json::Value = serde_json::from_str(stdout.trim())
+                .map_err(|e| anyhow::anyhow!("RPC.1: status output is not JSON: {e}"))?;
+            if v.get("running").and_then(serde_json::Value::as_bool) != Some(true) {
+                bail!("RPC.1: 'running' is not true in status JSON");
+            }
+            let status = v.get("status")
+                .ok_or_else(|| anyhow::anyhow!("RPC.1: missing 'status' object"))?;
+            let pid = status.get("pid").and_then(serde_json::Value::as_u64).unwrap_or(0);
+            if pid == 0 { bail!("RPC.1: missing or zero 'pid'"); }
+            let uptime = status.get("uptime_secs").and_then(serde_json::Value::as_u64);
+            if uptime.is_none() { bail!("RPC.1: missing 'uptime_secs'"); }
+            let state = status.get("status")
+                .and_then(|s| s.get("state"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+            if state.is_empty() { bail!("RPC.1: missing 'status.state'"); }
+            Ok(format!("pid={pid}, uptime={}s, state={state}", uptime.unwrap_or(0)))
         }
         "RPC.2" => {
-            // daemon status shows drives with record counts
-            let drive_count = stdout.lines()
-                .filter(|l| l.contains("records"))
-                .count();
-            if drive_count == 0 { bail!("No drives shown in daemon status"); }
-            Ok(format!("{drive_count} drives loaded"))
+            // status carries the tier-aware `drives` array; Parked/Cold shards
+            // legitimately report 0 records (body released), so only resident
+            // (Warm/Hot) drives must be non-empty.
+            let v: serde_json::Value = serde_json::from_str(stdout.trim())
+                .map_err(|e| anyhow::anyhow!("RPC.2: status output is not JSON: {e}"))?;
+            let drives = v.get("drives").and_then(serde_json::Value::as_array)
+                .ok_or_else(|| anyhow::anyhow!("RPC.2: missing 'drives' array"))?;
+            if drives.is_empty() { bail!("RPC.2: no drives loaded"); }
+            let mut resident = 0_usize;
+            let mut demoted = 0_usize;
+            for (i, d) in drives.iter().enumerate() {
+                let letter = d.get("letter").and_then(serde_json::Value::as_str).unwrap_or("");
+                if letter.is_empty() { bail!("RPC.2: drive {i} missing 'letter'"); }
+                let records = d.get("records").and_then(serde_json::Value::as_u64).unwrap_or(0);
+                let tier = d.get("tier").and_then(serde_json::Value::as_str).unwrap_or("");
+                let source = d.get("source").and_then(serde_json::Value::as_str).unwrap_or("");
+                let body_released = matches!(tier, "parked" | "cold" | "evicting" | "unknown")
+                    || matches!(source, "parked" | "cold");
+                if body_released { demoted += 1; continue; }
+                if records == 0 {
+                    bail!("RPC.2: drive {i} ({letter}, tier={tier:?}) has 0 records but is not Parked/Cold");
+                }
+                resident += 1;
+            }
+            Ok(format!("{} drives loaded ({resident} resident, {demoted} demoted)", drives.len()))
         }
         "RPC.4" => {
-            // daemon stats: must show performance metrics
-            if !stdout.contains("Total records:") { bail!("Missing 'Total records:' in output"); }
-            let records = stdout.lines()
-                .find(|l| l.contains("Total records:"))
-                .and_then(|l| l.split(':').nth(1))
-                .map(|s| s.trim().replace(',', ""))
-                .unwrap_or_default();
-            Ok(format!("total_records={records}"))
+            // Performance counters are folded into `status --json` under the
+            // `stats` key (the standalone `--daemon stats` command was removed).
+            let v: serde_json::Value = serde_json::from_str(stdout.trim())
+                .map_err(|e| anyhow::anyhow!("RPC.4: status output is not JSON: {e}"))?;
+            let stats = v.get("stats")
+                .filter(|s| !s.is_null())
+                .ok_or_else(|| anyhow::anyhow!("RPC.4: missing 'stats' object"))?;
+            let records = stats.get("total_records").and_then(serde_json::Value::as_u64);
+            if records.is_none() { bail!("RPC.4: stats missing 'total_records'"); }
+            let uptime = stats.get("uptime_secs").and_then(serde_json::Value::as_u64);
+            if uptime.is_none() { bail!("RPC.4: stats missing 'uptime_secs'"); }
+            let queries = stats.get("total_queries").and_then(serde_json::Value::as_u64).unwrap_or(0);
+            Ok(format!("total_records={}, uptime={}s, queries={queries}",
+                records.unwrap_or(0), uptime.unwrap_or(0)))
         }
 
         // ── Type validators ───────────────────────────────────────────


### PR DESCRIPTION
## What
The status rewrite (#528/#529) restyled the human `--daemon status` output, so the live-Windows CLI validation harness's **text-scraping** (`Daemon PID:`, `Ready`, `Total records:`) went stale. This points the CLI target at **`--daemon status --json`** and parses structured JSON instead — stable across cosmetic output changes.

- `cli-validation.rs` RPC.1/2/4: parse the `--json` wrapper `{running, status, drives, stats}` — pid + lifecycle state (RPC.1), tier-aware drives array (RPC.2, Parked/Cold may report 0 records), folded-in perf counters under `stats` (RPC.4).
- `11-rpc.toml` RPC.1/2/4 + `01-general.toml` T169: invoke `status --json`, assert JSON keys (`"running"`, `"pid"`, `"drives"`, `"total_records"`, …).

`api-validation.rs` already validates the raw JSON-RPC responses (it never scraped text), so its RPC.1–4 validators are unchanged.

## Verification
`cargo check` on the generated rust-script package is clean (harness compiles). These harnesses **run live-on-Windows only** (need a real daemon + NTFS), so end-to-end execution is unverified from macOS — the JSON shapes are matched against the `--json` output introduced in #528/#529.