### PR TITLE
ci(deps): bump codeql-action to 4.36.3 and group action bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,3 +65,15 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    # Group ALL github-actions bumps into a single PR. Multi-step actions
+    # (notably github/codeql-action's `init` + `analyze`, which MUST share
+    # the same version or CodeQL fails "Not all steps use the same version"
+    # and the SARIF upload errors out) were previously split into separate
+    # per-step PRs that each carried a version mismatch and could never go
+    # green. Grouping everything keeps such steps in lockstep. Actions are
+    # SHA-pinned and gated by the Dependabot Actions Review check, so a
+    # single combined PR is safe to review as one unit.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -138,7 +138,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           # Rust support (public preview) currently only accepts
@@ -153,6 +153,6 @@ jobs:
           # queries: security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Why

CodeQL requires every `github/codeql-action` step (`init`, `analyze`) to use the **same version**. Dependabot opened the 4.36.2 → 4.36.3 bump as two separate PRs:

- #534 — `analyze` → 4.36.3 (but `init` still 4.36.2)
- #533 — `init` → 4.36.3 (but `analyze` still 4.36.2)

Each branch therefore carried a version mismatch. The CodeQL run warned *"Not all workflow steps that use github/codeql-action actions use the same version"* and the SARIF upload errored, so **neither PR could ever go green** — they were stuck in the merge queue indefinitely.

## Fix

1. Bump **both** `init` and `analyze` to 4.36.3 (SHA `54f647b…`) in one commit → versions match → CodeQL passes.
2. Add a `groups:` to the `github-actions` Dependabot block so all action bumps arrive as **one PR** going forward, keeping multi-step actions in lockstep. Prevents recurrence.

Supersedes #533 and #534 (both will be closed).