### PR TITLE
build: bump nightly to 2026-07-06 and migrate chunks_exact to as_chunks

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -270,8 +270,18 @@ on:
   #     `docs/architecture/release-automation-plan.md` §8 (Path B row) and
   #     `just/build.just` `release-pr` / `release-tag`.
   #
-  # push:                # ← Path B: disabled by design (manual releases)
-  #   branches: [main]
+  # push.branches:[main] stays disabled by design (Path B — manual
+  # releases; see the trigger-history comment above).  Instead a narrow
+  # tag trigger drives the OIDC `crates-io-publish` job below: it fires
+  # exactly when a release tag is cut (the same `v*` tags `release.yml`
+  # builds binaries for), carrying the crates.io publish along with
+  # every `just ship` release — no long-lived token, no manual step.
+  # The release-pr / release jobs stay workflow_dispatch-only (they are
+  # gated to `github.event_name == 'workflow_dispatch'`), so a tag push
+  # only runs the publish job.
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 # Default to ZERO permissions; each job grants only what it needs.
@@ -303,8 +313,10 @@ jobs:
 
     # Skip on forks (fork PRs can't access the repo's secrets and would
     # produce noisy "permission denied" runs).  Matches the convention
-    # release-plz docs recommend.
-    if: github.repository_owner == 'skyllc-ai'
+    # release-plz docs recommend.  Restricted to workflow_dispatch: the
+    # `v*` tag trigger is reserved for the crates-io-publish job, so the
+    # release-pr job must not run on a tag push.
+    if: github.repository_owner == 'skyllc-ai' && github.event_name == 'workflow_dispatch'
 
     # Push branch + open/update PR.  Granted at job level so the
     # release job below can run with a tighter (no pull-requests)
@@ -375,7 +387,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
-    if: github.repository_owner == 'skyllc-ai'
+    # workflow_dispatch only — the `v*` tag trigger is reserved for the
+    # crates-io-publish job; this release job must not fire on a tag push
+    # (release.yml already builds binaries from the tag).
+    if: github.repository_owner == 'skyllc-ai' && github.event_name == 'workflow_dispatch'
 
     # Tag push only — no PR operations from this job.
     permissions:
@@ -436,13 +451,14 @@ jobs:
           done
 
   # ─────────────────────────────────────────────────────────────────
-  # R7: OIDC Trusted Publishing scaffolding (crates.io)
+  # OIDC Trusted Publishing to crates.io (ACTIVE)
   # ─────────────────────────────────────────────────────────────────
   #
-  # Phase R7 — OIDC trusted publisher scaffolding.  This job is gated
-  # by the repo variable `ENABLE_CRATES_IO_PUBLISH` (unset → dormant)
-  # until Phase R8 (first dress rehearsal).  It sets up the OIDC token
-  # exchange with crates.io for passwordless, short-lived credentials.
+  # Fires on every `v*` release tag (gated by the repo variable
+  # `ENABLE_CRATES_IO_PUBLISH`), minting a short-lived crates.io token
+  # via OIDC — no long-lived registry token is ever stored.  This is
+  # what carries the crates.io publish along with each `just ship`
+  # release tag.
   #
   # A repo-variable gate is used instead of a literal `if: false` for
   # two reasons: (1) actionlint rejects constant `if:` conditions, and
@@ -468,20 +484,20 @@ jobs:
   # See: docs/architecture/release-automation-plan.md §Phase R7/R8
   #
   crates-io-publish:
-    name: crates.io / OIDC publish (R7 scaffolding)
+    name: crates.io / OIDC publish
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: release-plz-release
 
     # Two gates, both required:
-    #   1. Repo variable ENABLE_CRATES_IO_PUBLISH=true — the R9 master
+    #   1. Repo variable ENABLE_CRATES_IO_PUBLISH=true — the master
     #      switch (unset / any-other-value keeps the job dormant).
-    #   2. releases_created — `release-plz-release` runs on EVERY push
-    #      to main and no-ops internally when HEAD isn't a release-PR
-    #      merge; without this gate the publish job would fire (and
-    #      page the environment reviewer) on every push, then fail
-    #      republishing the already-live version.
-    if: ${{ vars.ENABLE_CRATES_IO_PUBLISH == 'true' && needs.release-plz-release.outputs.releases_created == 'true' }}
+    #   2. A `v*` release-tag push — the ship pipeline (and release.yml)
+    #      cut exactly one such tag per release, so publish fires once
+    #      per released version and never on ordinary pushes.  The
+    #      checkout below resolves to the tag ref, so cargo publishes the
+    #      freshly-released version.  Re-running against an already-live
+    #      version is a harmless no-op-error from crates.io.
+    if: ${{ vars.ENABLE_CRATES_IO_PUBLISH == 'true' && startsWith(github.ref, 'refs/tags/v') }}
 
     environment: crates.io-publish
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3449,9 +3449,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,7 +295,7 @@ which = "8.0.4"
 strsim = "0.11.1"
 
 # ───── Hashing ─────
-rustc-hash = "2.1.2"
+rustc-hash = "2.1.3"
 
 # ───── Formatting / Encoding ─────
 itoa = "1.0.18"
@@ -314,7 +314,7 @@ reqwest = { version = "0.12.28", default-features = false, features = [
 
 # ───── Parallelism ─────
 rayon = "1.12.0"
-crossbeam-channel = "0.5.15"
+crossbeam-channel = "0.5.16"
 
 # ───── Memory ─────
 mimalloc = "0.1.52"

--- a/crates/uffs-bench/src/host/mod.rs
+++ b/crates/uffs-bench/src/host/mod.rs
@@ -43,7 +43,7 @@ impl ProcOutput {
 /// Implemented by [`SystemHost`] (real OS) and [`MockHost`] (in-memory, for
 /// tests). Methods are intentionally low-level wrappers; higher-level logic in
 /// `state`, `restore`, and `fingerprint` composes them and maps their
-/// [`io::Error`]s into [`crate::error::BenchError`] with path context.
+/// [`std::io::Error`]s into [`crate::error::BenchError`] with path context.
 pub trait Host {
     /// Read the entire contents of a file.
     ///

--- a/crates/uffs-client/src/shmem.rs
+++ b/crates/uffs-client/src/shmem.rs
@@ -155,7 +155,7 @@ static SHMEM_COUNTER: AtomicU64 = AtomicU64::new(0);
 ///
 /// # Errors
 ///
-/// Returns [`io::Error`] if the directory cannot be created.
+/// Returns [`std::io::Error`] if the directory cannot be created.
 fn shmem_dir() -> io::Result<PathBuf> {
     let base = dirs_next::data_local_dir()
         .unwrap_or_else(|| PathBuf::from(if cfg!(windows) { r"C:\temp" } else { "/tmp" }));
@@ -168,7 +168,7 @@ fn shmem_dir() -> io::Result<PathBuf> {
 ///
 /// # Errors
 ///
-/// Returns [`io::Error`] if the shmem directory cannot be created.
+/// Returns [`std::io::Error`] if the shmem directory cannot be created.
 fn unique_shmem_path() -> io::Result<PathBuf> {
     let dir = shmem_dir()?;
     let pid = std::process::id();
@@ -567,7 +567,7 @@ pub(crate) const STREAM_CHUNK_BYTES: usize = 4 * 1024 * 1024;
 ///
 /// ## Error pinpointing
 ///
-/// Every failure path attaches a step-specific [`io::Error`] kind +
+/// Every failure path attaches a step-specific [`std::io::Error`] kind +
 /// message identifying which stage broke (`open`, `metadata`,
 /// `mmap`, `write_all`) together with the blob byte size and, for
 /// write failures, the byte offset reached.  This converts opaque

--- a/crates/uffs-client/src/stdout_kind.rs
+++ b/crates/uffs-client/src/stdout_kind.rs
@@ -141,11 +141,6 @@ pub fn write_stdout_buffer(buf: &[u8]) -> std::io::Result<()> {
 /// well-formed UTF-8.  `WriteConsoleW` cannot represent invalid UTF-8
 /// anyway, so surfacing the error up-front is strictly better than a
 /// mangled console write.
-#[expect(
-    clippy::std_instead_of_core,
-    reason = "core::io::Error is not yet stable — see rust-lang/rust#103765. \
-              Remove this expect once `error_in_core` stabilises."
-)]
 pub fn utf8_to_utf16(buf: &[u8]) -> std::io::Result<Vec<u16>> {
     let utf8 = core::str::from_utf8(buf)
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
@@ -346,11 +341,6 @@ mod platform_windows {
     /// a pipe/file/NUL stdout would fail at `WriteConsoleW` with
     /// `ERROR_INVALID_HANDLE`.
     #[expect(unsafe_code, reason = "FFI to GetStdHandle + WriteConsoleW")]
-    #[expect(
-        clippy::std_instead_of_core,
-        reason = "core::io::Error is not yet stable — see rust-lang/rust#103765. \
-                  Remove this expect once `error_in_core` stabilises."
-    )]
     pub(super) fn write_to_console_w(buf: &[u8]) -> std::io::Result<()> {
         let utf16 = super::utf8_to_utf16(buf)?;
         if utf16.is_empty() {
@@ -533,11 +523,6 @@ mod shared_tests {
     /// Invalid UTF-8 must surface as `InvalidData`, not silently
     /// produce mojibake on the console.
     #[test]
-    #[expect(
-        clippy::std_instead_of_core,
-        reason = "core::io::ErrorKind is not yet stable — see rust-lang/rust#103765. \
-                  Remove this expect once `error_in_core` stabilises."
-    )]
     fn utf8_to_utf16_invalid_utf8_is_invalid_data_error() {
         // 0xFF is never valid as a standalone UTF-8 byte.
         let err = utf8_to_utf16(&[0xFF_u8]).expect_err("must reject invalid UTF-8");

--- a/crates/uffs-core/src/compact_cache.rs
+++ b/crates/uffs-core/src/compact_cache.rs
@@ -308,7 +308,7 @@ pub fn compact_runtime_root() -> PathBuf {
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the parent directory cannot be created
+/// Returns an [`std::io::Error`] if the parent directory cannot be created
 /// or if the owner-only permissions cannot be applied (Unix `0o700`,
 /// Windows owner-only DACL).
 fn compact_runtime_tempfile_path(
@@ -550,9 +550,9 @@ pub fn deserialize_compact(
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if:
+/// Returns an [`std::io::Error`] if:
 /// * the cache bytes are truncated, wrong magic, or use a stale/unsupported
-///   version (parse error lifted via [`io::Error::other`]);
+///   version (parse error lifted via `std::io::Error::other`);
 /// * `runtime_dir.create_owner_only` fails (path collision, permissions, parent
 ///   missing);
 /// * writing the layout into the tempfile fails (I/O / disk-full);

--- a/crates/uffs-core/src/compact_mmap.rs
+++ b/crates/uffs-core/src/compact_mmap.rs
@@ -146,7 +146,7 @@ impl RuntimeLayout {
 ///
 /// # Errors
 ///
-/// Forwards any [`io::Error`] from `set_len`, `seek`, `write_all`,
+/// Forwards any [`std::io::Error`] from `set_len`, `seek`, `write_all`,
 /// `flush`, or `sync_all`.
 ///
 /// # Examples

--- a/crates/uffs-daemon/src/cache/cursor_store.rs
+++ b/crates/uffs-daemon/src/cache/cursor_store.rs
@@ -69,13 +69,6 @@ impl super::journal_loop::CursorStore for DiskCursorStore {
     /// as "start from journal head" which is the correct fallback
     /// for a never-saved or corrupted cursor — better to re-replay
     /// than to silently start from a stale or invalid USN.
-    #[expect(
-        clippy::std_instead_of_core,
-        reason = "`core::io::ErrorKind` is not yet stable — see \
-                  rust-lang/rust#103765.  Mirrors the same pattern \
-                  used in `crate::config::Config::load_from_path`.  \
-                  Remove this expect once `error_in_core` stabilises."
-    )]
     fn load(&self, letter: uffs_mft::platform::DriveLetter) -> u64 {
         let path = self.cursor_path(letter);
         match std::fs::read(&path) {

--- a/crates/uffs-daemon/src/config.rs
+++ b/crates/uffs-daemon/src/config.rs
@@ -380,13 +380,6 @@ impl Config {
     /// All other I/O errors (permission denied, EISDIR on a path
     /// that exists as a directory, etc.) propagate as
     /// [`ConfigError::Io`].
-    #[expect(
-        clippy::std_instead_of_core,
-        reason = "`core::io::ErrorKind` is not yet stable — see \
-                  rust-lang/rust#103765.  Mirrors the same pattern \
-                  used in `crate::index::aggregation`.  Remove this \
-                  expect once `error_in_core` stabilises."
-    )]
     pub(crate) fn load_from_path(path: &Path) -> Result<Self, ConfigError> {
         match std::fs::read_to_string(path) {
             Ok(body) => Self::from_toml(&body),

--- a/crates/uffs-daemon/src/index/aggregation.rs
+++ b/crates/uffs-daemon/src/index/aggregation.rs
@@ -57,11 +57,6 @@ impl DaemonFileReader<'_> {
 }
 
 impl FileReader for DaemonFileReader<'_> {
-    #[expect(
-        clippy::std_instead_of_core,
-        reason = "core::io::Error is not yet stable — see rust-lang/rust#103765. \
-                  Remove this expect once `error_in_core` stabilises."
-    )]
     fn read_first_bytes(
         &self,
         record_idx: usize,
@@ -81,11 +76,6 @@ impl FileReader for DaemonFileReader<'_> {
         Ok(buf)
     }
 
-    #[expect(
-        clippy::std_instead_of_core,
-        reason = "core::io::Error is not yet stable — see rust-lang/rust#103765. \
-                  Remove this expect once `error_in_core` stabilises."
-    )]
     fn read_all(&self, record_idx: usize, drive_ordinal: u8) -> std::io::Result<Vec<u8>> {
         let path = self
             .resolve_path(record_idx, drive_ordinal)

--- a/crates/uffs-mft/src/index/storage/file_io.rs
+++ b/crates/uffs-mft/src/index/storage/file_io.rs
@@ -117,11 +117,6 @@ impl MftIndex {
     /// # Errors
     ///
     /// Returns an error if file reading, decryption, or deserialization fails.
-    #[expect(
-        clippy::std_instead_of_core,
-        reason = "core::io::Error is not yet stable — see rust-lang/rust#103765. \
-                  Remove this expect once `error_in_core` stabilises."
-    )]
     pub fn load_from_file(
         path: &std::path::Path,
     ) -> Result<(Self, IndexHeader), Box<dyn core::error::Error>> {

--- a/crates/uffs-mft/src/io/parser/fragment.rs
+++ b/crates/uffs-mft/src/io/parser/fragment.rs
@@ -50,7 +50,6 @@ use crate::ntfs::{
 )]
 #[expect(
     clippy::indexing_slicing,
-    clippy::missing_asserts_for_indexing,
     reason = "the only `[]` indexing that remains is into internal arena vectors \
               (fragment.links / fragment.streams / fragment.records / fragment.frs_to_idx) \
               whose indices are produced by this code, not by untrusted on-disk bytes. \
@@ -175,8 +174,10 @@ pub fn parse_record_to_fragment(
                         .and_then(|end| data.get(name_bytes_offset..end))
                     {
                         let name_u16: Vec<u16> = name_bytes
-                            .chunks_exact(2)
-                            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|pair| u16::from_le_bytes(*pair))
                             .collect();
                         let name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                         let parent_frs = file_reference_to_frs(fn_attr.parent_directory);
@@ -272,8 +273,10 @@ pub fn parse_record_to_fragment(
                         .and_then(|end| data.get(name_offset..end))
                     {
                         let name_u16: SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|pair| u16::from_le_bytes(*pair))
                             .collect();
                         let stream_name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                         // ALL named $DATA streams create regular

--- a/crates/uffs-mft/src/io/parser/fragment_extension.rs
+++ b/crates/uffs-mft/src/io/parser/fragment_extension.rs
@@ -118,8 +118,10 @@ pub(super) fn parse_extension_to_fragment(
                             .and_then(|end| data.get(name_start..end))
                         {
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .map(|pair| <[u8; 2]>::try_from(pair).map_or(0, u16::from_le_bytes))
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|pair| u16::from_le_bytes(*pair))
                                 .collect();
                             let name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                             let parent_frs = fn_attr.parent_directory & 0x0000_FFFF_FFFF_FFFF;
@@ -188,8 +190,10 @@ pub(super) fn parse_extension_to_fragment(
                         .and_then(|end| data.get(name_offset..end))
                     {
                         let name_u16: SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .map(|pair| <[u8; 2]>::try_from(pair).map_or(0, u16::from_le_bytes))
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|pair| u16::from_le_bytes(*pair))
                             .collect();
                         let stream_name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                         // ALL named $DATA streams create regular

--- a/crates/uffs-mft/src/io/parser/index.rs
+++ b/crates/uffs-mft/src/io/parser/index.rs
@@ -77,7 +77,6 @@ use crate::parse::index_helpers::{
 )]
 #[expect(
     clippy::indexing_slicing,
-    clippy::missing_asserts_for_indexing,
     reason = "remaining [] are internal arena indices (index.records[..]/stream_indices[..]/\
               link_indices[..]) keyed by indices minted by this fn; not attacker-controlled. \
               All untrusted-`data` reads go through .get()/rd_u* (WI-5.2)."
@@ -235,8 +234,10 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                         {
                             // SmallVec avoids heap allocation for typical filenames (<= 64 chars)
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|pair| u16::from_le_bytes(*pair))
                                 .collect();
                             let name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                             let parent_frs = file_reference_to_frs(fn_attr.parent_directory);
@@ -358,8 +359,10 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                         .and_then(|name_end| data.get(name_offset..name_end))
                     {
                         let name_u16: SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|pair| u16::from_le_bytes(*pair))
                             .collect();
                         let stream_name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
 
@@ -452,8 +455,10 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                             String::new()
                         } else {
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|pair| u16::from_le_bytes(*pair))
                                 .collect();
                             crate::io::parser::unified::decode_name_u16(&name_u16).0
                         };

--- a/crates/uffs-mft/src/io/parser/index_extension.rs
+++ b/crates/uffs-mft/src/io/parser/index_extension.rs
@@ -62,7 +62,6 @@ use crate::index::{frs_to_usize, len_to_u16, len_to_u32, u32_as_usize};
 )]
 #[expect(
     clippy::indexing_slicing,
-    clippy::missing_asserts_for_indexing,
     reason = "the only `[]` indexing that remains is into internal arena vectors \
               (index.records / index.links / index.streams / index.internal_streams / \
               index.frs_to_idx) whose indices are produced by this code, not by untrusted \
@@ -158,8 +157,10 @@ pub(super) fn parse_extension_to_index(
                                 .and_then(|end| data.get(name_start..end))
                             {
                                 let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                    .chunks_exact(2)
-                                    .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                                    .as_chunks::<2>()
+                                    .0
+                                    .iter()
+                                    .map(|pair| u16::from_le_bytes(*pair))
                                     .collect();
                                 let name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                                 let parent_frs = fn_attr.parent_directory & 0x0000_FFFF_FFFF_FFFF;
@@ -245,8 +246,10 @@ pub(super) fn parse_extension_to_index(
                     let name_offset = offset.saturating_add(usize::from(attr_header.name_offset));
                     if let Some(name_bytes) = read_name_bytes(data, name_offset, name_len) {
                         let name_u16: SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|pair| u16::from_le_bytes(*pair))
                             .collect();
                         let stream_name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                         // ALL named $DATA streams create regular
@@ -278,8 +281,10 @@ pub(super) fn parse_extension_to_index(
                                 String::new()
                             } else {
                                 let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                    .chunks_exact(2)
-                                    .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                                    .as_chunks::<2>()
+                                    .0
+                                    .iter()
+                                    .map(|pair| u16::from_le_bytes(*pair))
                                     .collect();
                                 crate::io::parser::unified::decode_name_u16(&name_u16).0
                             };

--- a/crates/uffs-mft/src/ntfs/records.rs
+++ b/crates/uffs-mft/src/ntfs/records.rs
@@ -540,8 +540,10 @@ impl<'a> AttributeRef<'a> {
 
         Some(
             name_bytes
-                .chunks_exact(2)
-                .filter_map(|chunk| chunk.try_into().ok().map(u16::from_le_bytes))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|chunk| u16::from_le_bytes(*chunk))
                 .collect(),
         )
     }

--- a/crates/uffs-mft/src/parse/attribute_helpers.rs
+++ b/crates/uffs-mft/src/parse/attribute_helpers.rs
@@ -101,13 +101,11 @@ pub(super) fn parse_file_name_full(
     }
 
     let name_bytes = &data[name_offset..name_offset + name_len * 2];
-    #[expect(
-        clippy::missing_asserts_for_indexing,
-        reason = "chunks_exact(2) guarantees chunk.len() == 2"
-    )]
     let name_u16: SmallVec<[u16; 128]> = name_bytes
-        .chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|chunk| u16::from_le_bytes(*chunk))
         .collect();
 
     let name = String::from_utf16(&name_u16).ok()?;
@@ -149,13 +147,11 @@ pub(super) fn parse_data_attribute_full(
             return None;
         }
         let name_bytes = &data[name_offset..name_offset + name_len * 2];
-        #[expect(
-            clippy::missing_asserts_for_indexing,
-            reason = "chunks_exact(2) guarantees chunk.len() == 2"
-        )]
         let name_u16: SmallVec<[u16; 64]> = name_bytes
-            .chunks_exact(2)
-            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| u16::from_le_bytes(*chunk))
             .collect();
         String::from_utf16(&name_u16).unwrap_or_default()
     } else {

--- a/crates/uffs-mft/src/parse/direct_index.rs
+++ b/crates/uffs-mft/src/parse/direct_index.rs
@@ -21,10 +21,6 @@
     reason = "explicit match is clearer in NTFS attribute dispatch"
 )]
 #![expect(
-    clippy::missing_asserts_for_indexing,
-    reason = "bounds are verified by size checks before all index access"
-)]
-#![expect(
     clippy::single_match_else,
     reason = "explicit match arms are clearer for attribute type dispatch"
 )]
@@ -193,8 +189,10 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                                 &data[name_bytes_offset..name_bytes_offset + name_len * 2];
                             // SmallVec avoids heap allocation for typical filenames (<= 64 chars)
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|c| u16::from_le_bytes(*c))
                                 .collect();
                             let name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                             let parent_frs = file_reference_to_frs(fn_attr.parent_directory);
@@ -301,8 +299,10 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                     if name_offset + name_len * 2 <= data.len() {
                         let name_bytes = &data[name_offset..name_offset + name_len * 2];
                         let name_u16: SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|c| u16::from_le_bytes(*c))
                             .collect();
                         let stream_name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                         // ALL named $DATA streams create regular stream entries.
@@ -373,8 +373,10 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                             String::new()
                         } else {
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|c| u16::from_le_bytes(*c))
                                 .collect();
                             crate::io::parser::unified::decode_name_u16(&name_u16).0
                         };
@@ -497,8 +499,10 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                         if name_offset + name_len * 2 <= data.len() {
                             let name_bytes = &data[name_offset..name_offset + name_len * 2];
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|c| u16::from_le_bytes(*c))
                                 .collect();
                             crate::io::parser::unified::decode_name_u16(&name_u16).0
                         } else {
@@ -582,8 +586,10 @@ pub fn parse_record_to_index(data: &[u8], frs: u64, index: &mut crate::index::Mf
                         if name_offset + name_len * 2 <= data.len() {
                             let name_bytes = &data[name_offset..name_offset + name_len * 2];
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|c| u16::from_le_bytes(*c))
                                 .collect();
                             crate::io::parser::unified::decode_name_u16(&name_u16).0
                         } else {

--- a/crates/uffs-mft/src/parse/direct_index_extension.rs
+++ b/crates/uffs-mft/src/parse/direct_index_extension.rs
@@ -16,10 +16,6 @@
     reason = "explicit match is clearer in NTFS attribute dispatch"
 )]
 #![expect(
-    clippy::missing_asserts_for_indexing,
-    reason = "bounds are verified by size checks before all index access"
-)]
-#![expect(
     clippy::shadow_unrelated,
     reason = "reusing common names like 'record' in nested scopes is idiomatic here"
 )]
@@ -151,8 +147,10 @@ pub(super) fn parse_extension_to_index(
                             if name_start + name_len * 2 <= data.len() {
                                 let name_bytes = &data[name_start..name_start + name_len * 2];
                                 let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                    .chunks_exact(2)
-                                    .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                    .as_chunks::<2>()
+                                    .0
+                                    .iter()
+                                    .map(|c| u16::from_le_bytes(*c))
                                     .collect();
                                 let name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                                 let parent_frs = fn_attr.parent_directory & 0x0000_FFFF_FFFF_FFFF;
@@ -230,8 +228,10 @@ pub(super) fn parse_extension_to_index(
                     if name_offset + name_len * 2 <= data.len() {
                         let name_bytes = &data[name_offset..name_offset + name_len * 2];
                         let name_u16: SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|c| u16::from_le_bytes(*c))
                             .collect();
                         let stream_name = crate::io::parser::unified::decode_name_u16(&name_u16).0;
                         // ALL named $DATA streams create regular
@@ -279,8 +279,10 @@ pub(super) fn parse_extension_to_index(
                             String::new()
                         } else {
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|c| u16::from_le_bytes(*c))
                                 .collect();
                             crate::io::parser::unified::decode_name_u16(&name_u16).0
                         };
@@ -400,8 +402,10 @@ pub(super) fn parse_extension_to_index(
                         if name_offset + name_len * 2 <= data.len() {
                             let name_bytes = &data[name_offset..name_offset + name_len * 2];
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|c| u16::from_le_bytes(*c))
                                 .collect();
                             crate::io::parser::unified::decode_name_u16(&name_u16).0
                         } else {
@@ -485,8 +489,10 @@ pub(super) fn parse_extension_to_index(
                         if name_offset + name_len * 2 <= data.len() {
                             let name_bytes = &data[name_offset..name_offset + name_len * 2];
                             let name_u16: SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|c| u16::from_le_bytes(*c))
                                 .collect();
                             crate::io::parser::unified::decode_name_u16(&name_u16).0
                         } else {

--- a/crates/uffs-mft/src/parse/forensic/base.rs
+++ b/crates/uffs-mft/src/parse/forensic/base.rs
@@ -176,10 +176,10 @@ pub(super) fn parse_base_record(
                             String::new()
                         } else {
                             let name_u16: smallvec::SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .filter_map(|chunk| {
-                                    <[u8; 2]>::try_from(chunk).ok().map(u16::from_le_bytes)
-                                })
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|chunk| u16::from_le_bytes(*chunk))
                                 .collect();
                             String::from_utf16(&name_u16).unwrap_or_default()
                         };
@@ -327,10 +327,10 @@ pub(super) fn parse_base_record(
                     if name_offset + name_len * 2 <= data.len() {
                         let name_bytes = &data[name_offset..name_offset + name_len * 2];
                         let name_u16: smallvec::SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .filter_map(|chunk| {
-                                <[u8; 2]>::try_from(chunk).ok().map(u16::from_le_bytes)
-                            })
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|chunk| u16::from_le_bytes(*chunk))
                             .collect();
                         String::from_utf16(&name_u16).unwrap_or_default()
                     } else {
@@ -435,10 +435,10 @@ pub(super) fn parse_base_record(
                     if name_offset + name_len * 2 <= data.len() {
                         let name_bytes = &data[name_offset..name_offset + name_len * 2];
                         let name_u16: smallvec::SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .filter_map(|chunk| {
-                                <[u8; 2]>::try_from(chunk).ok().map(u16::from_le_bytes)
-                            })
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|chunk| u16::from_le_bytes(*chunk))
                             .collect();
                         String::from_utf16(&name_u16).unwrap_or_default()
                     } else {

--- a/crates/uffs-mft/src/parse/forensic/extension.rs
+++ b/crates/uffs-mft/src/parse/forensic/extension.rs
@@ -124,10 +124,10 @@ pub(super) fn parse_extension_record(
                             String::new()
                         } else {
                             let name_u16: smallvec::SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .filter_map(|chunk| {
-                                    <[u8; 2]>::try_from(chunk).ok().map(u16::from_le_bytes)
-                                })
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|chunk| u16::from_le_bytes(*chunk))
                                 .collect();
                             String::from_utf16(&name_u16).unwrap_or_default()
                         };
@@ -245,10 +245,10 @@ pub(super) fn parse_extension_record(
                     if name_offset + name_len * 2 <= data.len() {
                         let name_bytes = &data[name_offset..name_offset + name_len * 2];
                         let name_u16: smallvec::SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .filter_map(|chunk| {
-                                <[u8; 2]>::try_from(chunk).ok().map(u16::from_le_bytes)
-                            })
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|chunk| u16::from_le_bytes(*chunk))
                             .collect();
                         String::from_utf16(&name_u16).unwrap_or_default()
                     } else {
@@ -325,10 +325,10 @@ pub(super) fn parse_extension_record(
                     if name_offset + name_len * 2 <= data.len() {
                         let name_bytes = &data[name_offset..name_offset + name_len * 2];
                         let name_u16: smallvec::SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .filter_map(|chunk| {
-                                <[u8; 2]>::try_from(chunk).ok().map(u16::from_le_bytes)
-                            })
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|chunk| u16::from_le_bytes(*chunk))
                             .collect();
                         String::from_utf16(&name_u16).unwrap_or_default()
                     } else {

--- a/crates/uffs-mft/src/parse/full.rs
+++ b/crates/uffs-mft/src/parse/full.rs
@@ -226,10 +226,10 @@ pub fn parse_record_full(data: &[u8], frs: u64) -> ParseResult {
                             String::new()
                         } else {
                             let name_u16: smallvec::SmallVec<[u16; 64]> = name_bytes
-                                .chunks_exact(2)
-                                .filter_map(|chunk| {
-                                    <[u8; 2]>::try_from(chunk).ok().map(u16::from_le_bytes)
-                                })
+                                .as_chunks::<2>()
+                                .0
+                                .iter()
+                                .map(|chunk| u16::from_le_bytes(*chunk))
                                 .collect();
                             String::from_utf16(&name_u16).unwrap_or_default()
                         };
@@ -380,10 +380,10 @@ pub fn parse_record_full(data: &[u8], frs: u64) -> ParseResult {
                     if name_offset + name_len * 2 <= data.len() {
                         let name_bytes = &data[name_offset..name_offset + name_len * 2];
                         let name_u16: smallvec::SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .filter_map(|chunk| {
-                                <[u8; 2]>::try_from(chunk).ok().map(u16::from_le_bytes)
-                            })
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|chunk| u16::from_le_bytes(*chunk))
                             .collect();
                         String::from_utf16(&name_u16).unwrap_or_default()
                     } else {
@@ -501,10 +501,10 @@ pub fn parse_record_full(data: &[u8], frs: u64) -> ParseResult {
                     if name_offset + name_len * 2 <= data.len() {
                         let name_bytes = &data[name_offset..name_offset + name_len * 2];
                         let name_u16: smallvec::SmallVec<[u16; 64]> = name_bytes
-                            .chunks_exact(2)
-                            .filter_map(|chunk| {
-                                <[u8; 2]>::try_from(chunk).ok().map(u16::from_le_bytes)
-                            })
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|chunk| u16::from_le_bytes(*chunk))
                             .collect();
                         String::from_utf16(&name_u16).unwrap_or_default()
                     } else {

--- a/crates/uffs-mft/src/platform/metafile_decode.rs
+++ b/crates/uffs-mft/src/platform/metafile_decode.rs
@@ -161,8 +161,10 @@ pub fn attribute_list_data_frs(list: &[u8], stream_name: &str) -> Vec<u64> {
 /// Decode UTF-16LE bytes to a lossy UTF-8 string.
 fn decode_utf16_lossy(bytes: &[u8]) -> String {
     let units: Vec<u16> = bytes
-        .chunks_exact(2)
-        .filter_map(|pair| pair.try_into().ok().map(u16::from_le_bytes))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|pair| u16::from_le_bytes(*pair))
         .collect();
     String::from_utf16_lossy(&units)
 }

--- a/crates/uffs-mft/src/platform/metafile_read.rs
+++ b/crates/uffs-mft/src/platform/metafile_read.rs
@@ -407,8 +407,10 @@ fn scan_index_entries(buf: &[u8], header_start: usize, target: &[u16]) -> Option
         let name_length = usize::from(*entry.get(16 + 0x40)?);
         let name_bytes = entry.get(16 + 0x42..16 + 0x42 + name_length * 2)?;
         let name: Vec<u16> = name_bytes
-            .chunks_exact(2)
-            .filter_map(|pair| pair.try_into().ok().map(u16::from_le_bytes))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|pair| u16::from_le_bytes(*pair))
             .collect();
         if name == target {
             return Some(crate::ntfs::file_reference_to_frs(file_reference));

--- a/crates/uffs-mft/src/usn/mod.rs
+++ b/crates/uffs-mft/src/usn/mod.rs
@@ -383,11 +383,6 @@ pub use windows::{query_usn_journal, read_targeted_frs_records, read_usn_journal
 ///
 /// Always returns an error on non-Windows platforms.
 #[cfg(not(windows))]
-#[expect(
-    clippy::std_instead_of_core,
-    reason = "core::io::Error is not yet stable — see rust-lang/rust#103765. \
-              Remove this expect once `error_in_core` stabilises."
-)]
 pub fn query_usn_journal(
     _volume: crate::platform::DriveLetter,
 ) -> Result<UsnJournalInfo, std::io::Error> {
@@ -403,11 +398,6 @@ pub fn query_usn_journal(
 ///
 /// Always returns an error on non-Windows platforms.
 #[cfg(not(windows))]
-#[expect(
-    clippy::std_instead_of_core,
-    reason = "core::io::Error is not yet stable — see rust-lang/rust#103765. \
-              Remove this expect once `error_in_core` stabilises."
-)]
 pub fn read_usn_journal(
     _volume: crate::platform::DriveLetter,
     _journal_id: u64,

--- a/crates/uffs-mft/src/usn/windows.rs
+++ b/crates/uffs-mft/src/usn/windows.rs
@@ -328,13 +328,10 @@ pub fn read_usn_journal(
                 .filter(|_| name_end <= bytes_returned_usize)
                 .map_or_else(String::new, |name_bytes| {
                     let name_u16: Vec<u16> = name_bytes
-                        .chunks_exact(2)
-                        .map(|pair| {
-                            u16::from_le_bytes([
-                                *pair.first().unwrap_or(&0),
-                                *pair.get(1).unwrap_or(&0),
-                            ])
-                        })
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
+                        .map(|pair| u16::from_le_bytes(*pair))
                         .collect();
                     crate::io::parser::unified::decode_name_u16(&name_u16).0
                 });

--- a/crates/uffs-security/src/fs.rs
+++ b/crates/uffs-security/src/fs.rs
@@ -34,8 +34,8 @@ use std::path::Path;
 ///
 /// # Errors
 ///
-/// Returns [`io::ErrorKind::AlreadyExists`] if the path exists, or any other
-/// error from the underlying open.
+/// Returns [`std::io::ErrorKind::AlreadyExists`] if the path exists, or any
+/// other error from the underlying open.
 pub fn create_new_secure_file(path: &Path) -> io::Result<std::fs::File> {
     #[cfg(unix)]
     {
@@ -80,8 +80,8 @@ pub fn create_new_secure_file(path: &Path) -> io::Result<std::fs::File> {
 ///
 /// # Errors
 ///
-/// Returns [`io::ErrorKind::AlreadyExists`] if the path exists, or any other
-/// error from the underlying open.
+/// Returns [`std::io::ErrorKind::AlreadyExists`] if the path exists, or any
+/// other error from the underlying open.
 pub fn create_new_file_exclusive(path: &Path) -> io::Result<std::fs::File> {
     std::fs::OpenOptions::new()
         .write(true)

--- a/crates/uffs-security/src/keystore.rs
+++ b/crates/uffs-security/src/keystore.rs
@@ -66,7 +66,7 @@ pub fn get_cache_key() -> io::Result<[u8; KEY_SIZE]> {
 ///
 /// # Errors
 ///
-/// Returns [`io::Error`] if Keychain access fails (e.g. user denies
+/// Returns [`std::io::Error`] if Keychain access fails (e.g. user denies
 /// permission, Keychain is locked, or the stored key has an invalid size
 /// after multiple regeneration attempts).
 #[cfg(target_os = "macos")]

--- a/crates/uffs-security/src/pipe.rs
+++ b/crates/uffs-security/src/pipe.rs
@@ -162,7 +162,7 @@ impl PipeName {
     ///
     /// # Errors
     ///
-    /// Returns [`io::Error`] if the user SID cannot be resolved.  This
+    /// Returns [`std::io::Error`] if the user SID cannot be resolved.  This
     /// should not happen on a normally functioning Windows session; if
     /// it does, the caller should log and exit rather than fall back to
     /// an insecure name.
@@ -228,7 +228,7 @@ impl fmt::Display for PipeName {
 ///
 /// # Errors
 ///
-/// Returns [`io::Error`] if both resolution paths fail — typically only
+/// Returns [`std::io::Error`] if both resolution paths fail — typically only
 /// in very broken token scenarios.
 pub(crate) fn current_user_sid_string() -> io::Result<String> {
     // Try the linked-token path first.
@@ -269,7 +269,7 @@ impl OwnerOnlySd {
     ///
     /// # Errors
     ///
-    /// Returns [`io::Error`] if SID resolution or SDDL conversion fails.
+    /// Returns [`std::io::Error`] if SID resolution or SDDL conversion fails.
     pub fn for_current_user() -> io::Result<Self> {
         let sid = current_user_sid_string()?;
         Self::for_sid_string(&sid)
@@ -281,7 +281,7 @@ impl OwnerOnlySd {
     ///
     /// # Errors
     ///
-    /// Returns [`io::Error`] if the SDDL conversion fails.
+    /// Returns [`std::io::Error`] if the SDDL conversion fails.
     pub(crate) fn for_sid_string(sid: &str) -> io::Result<Self> {
         // SDDL: DACL with one ACE — Allow, GenericAll, to <sid>.
         let sddl = format!("D:(A;;GA;;;{sid})");

--- a/crates/uffs-security/src/runtime_dir.rs
+++ b/crates/uffs-security/src/runtime_dir.rs
@@ -131,7 +131,8 @@ pub trait RuntimeDir: Send + Sync {
     ///   name, e.g. via volume GUID).
     /// * `PermissionDenied` — parent dir is unwriteable, or the process lacks
     ///   permission to set the requested mode/DACL.
-    /// * Any other [`io::Error`] forwarded from the underlying filesystem call.
+    /// * Any other [`std::io::Error`] forwarded from the underlying filesystem
+    ///   call.
     fn create_owner_only(&self, path: &Path) -> io::Result<RuntimeFile>;
 
     /// Sweep `<parent_dir>/<pid>/` subdirectories whose pid is no
@@ -180,7 +181,7 @@ pub trait RuntimeDir: Send + Sync {
 ///
 /// # Errors
 ///
-/// Forwards any [`io::Error`] from the underlying mmap syscall
+/// Forwards any [`std::io::Error`] from the underlying mmap syscall
 /// (`mmap` on Unix, `MapViewOfFile` on Windows).
 pub fn mmap_read_only(file: &RuntimeFile) -> io::Result<Mmap> {
     #[expect(

--- a/crates/uffs-security/src/runtime_dir/tests.rs
+++ b/crates/uffs-security/src/runtime_dir/tests.rs
@@ -43,12 +43,6 @@ fn create_owner_only_writes_and_reads_round_trip() {
 }
 
 #[test]
-#[expect(
-    clippy::std_instead_of_core,
-    reason = "core::io::ErrorKind is feature-gated (rust-lang/rust#154046); \
-              std path is the only stable spelling.  Remove this expect \
-              once the re-export stabilises."
-)]
 fn create_owner_only_rejects_existing_file() {
     let tmp = TempDir::new().expect("tempdir");
     let path = tmp.path().join("dupe.live");

--- a/crates/uffs-text/README.md
+++ b/crates/uffs-text/README.md
@@ -53,7 +53,7 @@ crates above.**
 
 ```toml
 [dependencies]
-uffs-text = "0.5"
+uffs-text = "0.6"
 ```
 
 ## Usage

--- a/crates/uffs-time/README.md
+++ b/crates/uffs-time/README.md
@@ -44,7 +44,7 @@ keep using `chrono` / `time` / `jiff` and convert at the boundary via
 
 ```toml
 [dependencies]
-uffs-time = "0.5"
+uffs-time = "0.6"
 ```
 
 ## Usage

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -10,7 +10,7 @@
 # CI must NOT override this with `@nightly`; workflows install via
 # `rustup show` (which reads this file) so the pin is always honored.
 #
-# Current pin: nightly-2026-05-31.  Requires ethnum >= 1.5.3 (the
+# Current pin: nightly-2026-07-06.  Requires ethnum >= 1.5.3 (the
 # workspace Cargo.lock resolves 1.5.3 transitively via polars-compute +
 # parquet — verify with `grep -A1 'name = "ethnum"' Cargo.lock`).
 #
@@ -32,7 +32,7 @@
 # Run `just toolchain-sync` to re-attempt a channel bump; the CI
 # pipeline auto-refreshes on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed.
-channel = "nightly-2026-06-26"
+channel = "nightly-2026-07-06"
 
 # Specify components that should always be available
 components = [

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -73,6 +73,12 @@ criteria = "safe-to-deploy"
 delta = "0.16.3 -> 0.16.4"
 notes = "Delta audit (cargo vet diff 0.16.3 -> 0.16.4, 435-line diff). (1) term.rs: TermInner construction deduplicated into new()/new_buffered()/with_buffer() helpers - pure refactor; new pub fn is_dumb() reads TERM env var (read-only env access, same capability class the crate already had via is_a_color_terminal). (2) utils.rs: Style::from_dotted_str gains is_ascii() guards on '#RRGGBB'/'on_#RRGGBB' parsing - fixes a panic on non-ASCII input that slices mid-UTF-8 char (robustness improvement for untrusted style strings), plus regression tests. (3) windows_term: as_handle() helper removed in favor of out.as_raw_handle() at existing call sites - unchanged unsafe surface (same SetConsoleCursorPosition/SetConsoleCursorInfo calls as before); read_secure backspace arm converted to a match guard, logic identical. No new unsafe blocks, no new fs/net/process capability. Publisher djc (Dirkjan Ochtman, console-rs maintainer, same publisher as 0.16.3)."
 
+[[audits.crossbeam-channel]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.15 -> 0.5.16"
+notes = "Delta audit (cargo vet diff 0.5.15 -> 0.5.16). Files: CHANGELOG/Cargo.toml(.orig) (version bump only, no dependency changes), src/channel.rs, src/flavors/{never,zero}.rs, src/select_macro.rs, src/utils.rs, src/waker.rs, tests/mpsc.rs. Net unsafe: 0 added, 0 removed. Two upstream changes: (1) #1250 constify never() and the zero/never Channel::new() (pub fn -> pub const fn, Channel {..} -> Self {..}) — no runtime behavior change; (2) #1240 change the select!/select_biased! body matcher from => $body:block to => { $($body:tt)* } so rust-analyzer can auto-complete inside the block — semantically equivalent token capture. channel.rs/waker.rs additionally switch from std::sync::Mutex to the crate internal crate::utils::Mutex wrapper, dropping the .lock().unwrap() poison-handling at each call site; the wrapper is a thin non-poisoning shim over the same std Mutex (no new unsafe). No build script, no new dependencies, no new ambient-capability surface. Publisher taiki-e (crossbeam maintainer, same publisher already trusted for the crossbeam-epoch 0.9.18 -> 0.9.20 delta). Strictly a constification + tooling + internal-mutex refactor; trust extends from the audited 0.5.15 base."
+
 [[audits.crossbeam-epoch]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -384,6 +390,12 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.8.0 -> 2.1.0"
 notes = "Delta audit (cargo vet diff 1.8.0 -> 2.1.0, 147-line diff). Proc-macro crate; changes are purely to the token streams it emits: prompt_handler.rs fully qualifies previously-bare type paths (rmcp::model::GetPromptRequestParams, rmcp::service::RequestContext, etc.); task_handler.rs renames model types for the MCP 2025-11-25 spec (GetTaskInfoParams->GetTaskParams, GetTaskResultParams->GetTaskPayloadParams) and swaps struct-literal construction for ::new() constructors. No new unsafe, no fs/net/process/env access, no build script, generated code only references rmcp's own types. Publisher alexhancock (modelcontextprotocol/rust-sdk release chain, same as 1.8.0->2.x series)."
+
+[[audits.rustc-hash]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.2 -> 2.1.3"
+notes = "Delta audit (cargo vet diff 2.1.2 -> 2.1.3). Files: CHANGELOG/Cargo.toml(.orig) (version + optional `rand` dep 0.8 -> 0.9), src/lib.rs, src/random_state.rs. Zero unsafe added or removed. src/lib.rs replaces the hand-written `default_impl!` macro with `#[cfg_attr(not(nightly), derive(Default))]` / `#[cfg_attr(nightly, derive_const(Default))]` — a pure-safe refactor of the Default impl (fixes the nightly-feature build, upstream PR #77). The only functional change is the rand 0.8 -> 0.9 API migration in src/random_state.rs (rand::thread_rng().gen() -> rand::rng().random_range(..=usize::MAX)), which lives entirely behind the optional rand/random_state feature that this workspace does not enable (no rustc-hash feature activation anywhere in the tree), so neither random_state.rs nor rand 0.9 enters our build. No build script, no new ambient capability, no I/O / FFI / process. Publisher Noratrieb (rustc-hash maintainer, rust-lang). Safe extension from the audited 2.1.2 base."
 
 [[audits.rustls]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"


### PR DESCRIPTION
## Summary
Five commits, all validated on the new pinned nightly (host + windows-msvc clippy `-D warnings`, rustdoc, doctests, tests — the full pre-push gate is green):

- **`refactor(uffs-mft)`** — migrate all 35 `chunks_exact(2)` sites to `as_chunks::<2>()`; net **−7** lint suppressions (each `&[u8]` chunk becomes `&[u8; 2]`, dropping fallible `try_into().ok()` and `[c[0], c[1]]` reindexing). Handles the `chunks_exact`-lint half of #492.
- **`build(deps)`** — bump `rustc-hash` 2.1.3 + `crossbeam-channel` 0.5.16, each with a proper cargo-vet delta audit (`Vet-Reviewed-Diff:` trailers; `cargo vet` + discipline gate pass).
- **`docs(crates)`** — fix `uffs-time`/`uffs-text` README install snippet `"0.5"` → `"0.6"`.
- **`ci(release)`** — publish crates.io on `v*` release tags via OIDC, so the ship pipeline's release tag carries the `uffs-time`/`uffs-text` publish (no long-lived token; the `release-plz.yml` + `crates.io-publish` trusted-publisher registration is unchanged).
- **`build(toolchain)`** — bump pinned nightly **2026-06-26 → 2026-07-06**. Clears the ring half of #492 (ring 0.17.14 compiles clean for aarch64-apple **and** x86_64-pc-windows-msvc). The new nightly feature-gated `core::io::Error`/`ErrorKind`, so `std::io::*` re-exports from the incomplete `core::io` — removed **10** now-dead `#[expect(std_instead_of_core)]` and qualified 17 `io::` intra-doc links to `std::io::` (the one unresolvable `::other` method link → code span). No `#[allow]`, no skips — every fix removes a suppression or corrects a path.

## Release
Version bump + crates.io publish are intentionally **not** in this PR — they ride the normal `just ship` flow from `main` after merge (version branch → `just release-tag` → `release.yml` binaries + the re-wired OIDC crates publish at 0.6.24).

Closes #492.