### PR TITLE
perf(build): Windows ship binaries strip the panic backtrace (build-std)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,6 +530,26 @@ jobs:
           # → the native cargo build. Same flags/profile either way.
           if [[ "${{ matrix.target }}" == *musl* ]]; then
             cargo zigbuild --locked --release --target ${{ matrix.target }} --workspace --bins
+          elif [[ "${{ matrix.target }}" == *windows* ]]; then
+            # Windows-ONLY size strip: rebuild std with panic=immediate-abort +
+            # size-optimized std, so a field panic is a bare, process-local
+            # abort() with no backtrace. The gimli/addr2line DWARF machinery is
+            # ~10% of the CLI and useless on a stripped binary; a panic is a
+            # should-never-happen bug (the workspace lints forbid unwrap/panic
+            # in prod), so dropping the diagnostic is the right trade for ship.
+            # Needs nightly + rust-src (both from rust-toolchain.toml). Linux and
+            # macOS deliberately stay on the plain release profile. Measured:
+            # uffs.exe 1,292,800 -> 1,167,872 (-9.7%). See [profile.ship] in
+            # Cargo.toml.
+            cargo build --locked --profile ship \
+              -Z build-std=std,panic_abort \
+              -Z build-std-features=optimize_for_size \
+              --target ${{ matrix.target }} --workspace --bins
+            # The `ship` profile outputs to target/<triple>/ship/, but every
+            # packaging step below reads target/<triple>/release/ — mirror the
+            # built .exe files across so none of those paths need to change.
+            mkdir -p "target/${{ matrix.target }}/release"
+            cp "target/${{ matrix.target }}/ship/"*.exe "target/${{ matrix.target }}/release/"
           else
             cargo build --locked --release --target ${{ matrix.target }} --workspace --bins
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+cargo-features = [
+  "panic-immediate-abort",
+] # ship profile only (needs -Z build-std)
+
 # =============================================================================
 # Cargo.toml - UFFS (Ultra Fast File Search) Workspace
 # =============================================================================
@@ -761,6 +765,34 @@ opt-level = 0
 # The workspace-level `release` profile keeps `opt-level = 3` for
 # daemon/mcp where steady-state perf dominates.
 [profile.release.package.uffs-cli]
+opt-level = "z"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ship profile — minimal panic (removes the field-useless backtrace machinery)
+# ─────────────────────────────────────────────────────────────────────────────
+# Field binaries are stripped, so a *symbolized* backtrace is dead weight — the
+# `gimli`/`addr2line` DWARF machinery inside std is ~10% of the CLI. This profile
+# rebuilds std with `panic = "immediate-abort"`, so a field panic is a bare,
+# process-local `abort()` (no message, no backtrace) — which matches the
+# workspace no-panic lint policy (panics are forbidden in prod anyway). Dev + CI
+# keep normal panics + full backtraces.
+#
+# Built ONLY with build-std (needs nightly + the `rust-src` component):
+#   cargo [xwin] build --profile ship -Z build-std=std,panic_abort --target <T>
+#
+# Measured (x86_64-pc-windows-msvc, uffs.exe): 1,292,800 → 1,167,872  (−9.7%).
+#
+# CAVEAT: `panic_immediate_abort` became a first-class panic strategy in recent
+# nightlies (it was a `-Z build-std-features` flag before), so this is unstable
+# and may need re-touching on a toolchain bump. Deliberately NOT wired into the
+# default release — opt in from the ship build when ready to own that.
+[profile.ship]
+inherits = "release"
+panic = "immediate-abort"
+
+# Per-package overrides do not inherit into a derived profile, so keep the CLI
+# size-first here too.
+[profile.ship.package.uffs-cli]
 opt-level = "z"
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Shrinks the **shipped Windows** binaries by rebuilding std with `panic="immediate-abort"` in the release flow — a field panic becomes a bare, process-local `abort()` with no backtrace. The `gimli`/`addr2line` DWARF symbolization is ~10% of the CLI and is dead weight on a stripped binary; a panic is a should-never-happen bug anyway (the workspace lints forbid unwrap/panic in prod).

## Commits
- **`[profile.ship]`** (Cargo.toml): inherits `release`, `panic = "immediate-abort"`, plus the `cargo-features` opt-in. Only ever built with `-Z build-std`; dev/normal-release/clippy are unaffected (verified).
- **`release.yml`**: the **Windows matrix row only** builds `--profile ship -Z build-std=std,panic_abort -Z build-std-features=optimize_for_size`, then mirrors the `.exe`s from `ship/` → `release/` so no packaging path changes. Linux/macOS stay on `--release`.

## Measured
`x86_64-pc-windows-msvc`, `uffs.exe`: **1,292,800 → 1,167,872 (−9.7%)** for `build-std=std,panic_abort` (validated locally). `optimize_for_size` is included but not separately measured — the release run confirms it.

## Validation plan
Merge → `just ship` from clean main → watch the Windows leg of `release.yml`: it must build green, finish under the 75-min timeout, and the zip's `uffs.exe` should be ~1.17 MB. A build failure fails the whole release safely (nothing ships); the winget PR is a slow, cancellable downstream. Windows-only, so any revert leaves Linux/macOS untouched.