### PR TITLE
chore: release v0.6.26 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.26] - 2026-07-12
+
+### Fixed
+
+- daemon: verify PID identity so a recycled PID can't wedge startup (#551)
+
 ## [0.6.25] - 2026-07-08
 
 ### Changed
@@ -2680,7 +2686,8 @@ thin clients over a unified `uffsd` process.
 ### Fixed
 - Various MFT parsing edge cases
 
-[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.25...HEAD
+[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.26...HEAD
+[0.6.26]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.25...v0.6.26
 [0.6.25]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.24...v0.6.25
 [0.6.24]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.23...v0.6.24
 [0.6.23]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.22...v0.6.23

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4379,7 +4379,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uffs-bench"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "chrono",
  "clap",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4411,14 +4411,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4437,7 +4437,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "clap",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "chrono",
  "itoa",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "clap",
@@ -4581,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "clap",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "clap",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "axum",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4671,14 +4671,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4693,22 +4693,22 @@ dependencies = [
 
 [[package]]
 name = "uffs-statusfmt"
-version = "0.6.25"
+version = "0.6.26"
 
 [[package]]
 name = "uffs-text"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.6.25"
+version = "0.6.26"
 
 [[package]]
 name = "uffs-update"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -4727,11 +4727,11 @@ dependencies = [
 
 [[package]]
 name = "uffs-version"
-version = "0.6.25"
+version = "0.6.26"
 
 [[package]]
 name = "uffs-winsvc"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "windows 0.62.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.6.25"
+version = "0.6.26"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -132,30 +132,30 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.6.25" }
-uffs-security = { path = "crates/uffs-security", version = "0.6.25" }
-uffs-text = { path = "crates/uffs-text", version = "0.6.25" }
-uffs-time = { path = "crates/uffs-time", version = "0.6.25" }
-uffs-version = { path = "crates/uffs-version", version = "0.6.25" }
-uffs-statusfmt = { path = "crates/uffs-statusfmt", version = "0.6.25" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.6.25" }
-uffs-format = { path = "crates/uffs-format", version = "0.6.25" }
-uffs-core = { path = "crates/uffs-core", version = "0.6.25" }
-uffs-client = { path = "crates/uffs-client", version = "0.6.25" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.6.26" }
+uffs-security = { path = "crates/uffs-security", version = "0.6.26" }
+uffs-text = { path = "crates/uffs-text", version = "0.6.26" }
+uffs-time = { path = "crates/uffs-time", version = "0.6.26" }
+uffs-version = { path = "crates/uffs-version", version = "0.6.26" }
+uffs-statusfmt = { path = "crates/uffs-statusfmt", version = "0.6.26" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.6.26" }
+uffs-format = { path = "crates/uffs-format", version = "0.6.26" }
+uffs-core = { path = "crates/uffs-core", version = "0.6.26" }
+uffs-client = { path = "crates/uffs-client", version = "0.6.26" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.25" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.26" }
 # `uffs-winsvc` — native Windows service control (SCM query/start/stop) +
 # the non-connecting broker-pipe readiness probe.  Layer-0 leaf: its only
 # dependency is the `windows` crate (windows-target), with non-Windows
 # stubs so cross-platform consumers (uffs-update, uffs-cli) compile.
 # Single source of truth for the `sc`/SCM mechanics previously duplicated
 # across uffs-broker, uffs-update, and uffs-cli.
-uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.25" }
+uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.26" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/main.rs"
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-client = { path = "../uffs-client", version = "0.6.25", default-features = false }
+uffs-client = { path = "../uffs-client", version = "0.6.26", default-features = false }
 
 # Canonical CSV / parity / legacy-footer writer.  Direct dep (not a
 # re-export chain through `uffs-client`) so the CLI and the daemon
@@ -77,7 +77,7 @@ uffs-client = { path = "../uffs-client", version = "0.6.25", default-features = 
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-format = { path = "../uffs-format", version = "0.6.25" }
+uffs-format = { path = "../uffs-format", version = "0.6.26" }
 
 # Typed drive-letter newtype.  Direct dep so the CLI command signatures
 # (`daemon_load`, `daemon_tiering`, etc.) name `DriveLetter` natively


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.6.26** — the `[workspace.package].version` bump in `Cargo.toml`.  This PR routes that commit through branch-protection rules.  Once it merges to `main`, run `just release-tag` to cut the signed `v0.6.26` tag, which fires `release.yml` and builds the cross-platform binaries + GitHub Release v0.6.26.  (No auto-tag on merge — the tag step is manual on-demand, Path B.)

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

The auto-commit lived only on `release/v0.6.26`, so local `main` never drifted — sync it with a plain `git pull --ff-only origin main` (no `reset --hard` needed).