### PR TITLE
fix(mft): use bit_width() to satisfy clippy::manual_bit_width on newer nightly

### DIFF
--- a/crates/uffs-mft/src/index/stats.rs
+++ b/crates/uffs-mft/src/index/stats.rs
@@ -155,10 +155,13 @@ impl MftStats {
         if self.dir_count == 0 {
             return 5;
         }
-        // Integer log2: number of bits needed to represent dir_count.
-        // u32::BITS - leading_zeros gives the position of the highest set bit.
-        let log2 = (u32::BITS - self.dir_count.leading_zeros()) as usize;
-        (log2 + 1).clamp(3, 20) // +1 instead of +2 because ilog2 rounds down
+        // Number of bits needed to represent dir_count (position of the
+        // highest set bit). dir_count > 0 here — the zero case returned
+        // above. `bit_width()` == `u32::BITS - leading_zeros()`, spelled the
+        // idiomatic way so clippy's `manual_bit_width` lint stays satisfied
+        // on newer toolchains.
+        let bits = self.dir_count.bit_width() as usize;
+        (bits + 1).clamp(3, 20) // +1 keeps the original depth heuristic
     }
 
     /// Estimate average path length in bytes.


### PR DESCRIPTION
## Summary

The nightly canary (which builds against the **latest floating nightly**, ahead of our pin) went red on a new clippy lint. `clippy::manual_bit_width` now flags the manual highest-set-bit computation in `estimated_avg_depth`:

```rust
let log2 = (u32::BITS - self.dir_count.leading_zeros()) as usize;
```

This fix switches to the dedicated `bit_width()` method (the lint's own suggestion). The value is identical — `bit_width()` == `u32::BITS - leading_zeros()` for the highest-set-bit position — and `bit_width()` already compiles on our **pinned** nightly, so this satisfies the future lint without disturbing the current PR gate.

## Effect on the canary

- Clears the **linux + windows** canary clippy lanes.
- The **macOS** lane fails separately and earlier, in `cargo check`, inside the upstream **`cpufeatures`** crate — a compile-time assertion (`_AARCH64_APPLE_TARGETS_EXPECTED_FEATURES`) that newer nightlies break on Apple Silicon. That is transitive (via `sha2`→polars and `aes`→`aes-gcm`→`uffs-security`), out of our tree, and clears only with an upstream `cpufeatures` release. Tracked with the other pin-bump blockers in #492.

## Validation

`lint-prod`, `lint-prod-windows` (xwin), `rustdoc`, and `fmt-check` all pass locally. Behavior is unchanged (pure refactor of an integer bit-count).
