### PR TITLE
ci(windows): native workspace tests in merge queue + fix the 3 Windows-only failures + delete-visibility note

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -640,11 +640,13 @@ jobs:
         run: cargo-machete --skip-target-dir
 
   # ─────────────────────────────────────────────────────────────────────
-  # windows-lint — native Windows clippy gate on `windows-latest`.
+  # windows-lint — native Windows clippy + test gate on `windows-latest`.
   # Authoritative cross-target lint gate (local xwin is advisory — see
   # dev-flow-implementation-plan.md § 1.3.3).  Replaces the weekly
   # Tier 2 Windows job; Tier 2 drops that job in the same PR as Phase
-  # 4b housekeeping.
+  # 4b housekeeping. Also runs the workspace test suite natively on
+  # Windows (2026-07-13) so cross-platform-logic bugs that only bite on
+  # Windows are caught in the merge queue, not the nightly Tier 2 run.
   #
   # Phase W5.5 of windows-clippy-and-linux-cross-plan.md flipped this
   # job from `cargo check` → `cargo clippy -- -D warnings`.  The
@@ -653,11 +655,11 @@ jobs:
   # strict flag stack now passes natively on `windows-latest`.
   # ─────────────────────────────────────────────────────────────────────
   windows-lint:
-    name: Windows clippy
+    name: Windows clippy + tests
     runs-on: windows-latest
     needs: [classify, sanity]
     if: needs.classify.outputs.code == 'true' && github.event_name != 'pull_request'
-    timeout-minutes: 25
+    timeout-minutes: 40
     env:
       # Windows-appropriate target-cpu baseline (same as release.yml's
       # Windows matrix rows).  DO NOT use target-cpu=native here — it
@@ -678,6 +680,19 @@ jobs:
       # locally (cargo-xwin variant).  Native Windows runs natively here;
       # local xwin remains the developer-loop equivalent.
       - run: cargo clippy --workspace --all-targets --all-features --locked --no-deps -- -D warnings
+
+      # Windows test run (added 2026-07-13). The workspace is full of
+      # cross-platform pure-logic tests that had only ever run on ubuntu, so a
+      # bug that manifests only on Windows — an absent-path `secure_remove`, a
+      # verbatim `\\?\` path assumption, a `#[cfg(windows)]` test that never ran
+      # in CI — slipped through to the nightly Tier 2 run (or not at all).
+      # Exercise the same suite natively on Windows in the merge queue so the
+      # class is caught before merge. Mirrors the ubuntu `tests` job's
+      # invocation; `#[ignore]`d live-MFT tests still skip.
+      - uses: taiki-e/install-action@dfc84ffb7254b048a0a843316ff5a2714dcdc7bd # v2
+        with:
+          tool: nextest
+      - run: cargo nextest run --workspace --all-features --lib --tests --profile ci --locked
 
   # ─────────────────────────────────────────────────────────────────────
   # required — sole branch-protection target (post-2026-04-23 cutover).

--- a/crates/uffs-cli/src/commands/uninstall/analyze.rs
+++ b/crates/uffs-cli/src/commands/uninstall/analyze.rs
@@ -377,7 +377,12 @@ mod tests {
         // Pass the dir twice: it must still be added exactly once (deduped).
         super::add_roots_for_dirs(&mut report, &[dir.clone(), dir.clone()]);
 
-        let key = std::fs::canonicalize(&dir).unwrap();
+        // `add_roots_for_dirs` stores the verbatim-stripped canonical path
+        // (`C:\…`), so the expected key must strip too — on Windows
+        // `canonicalize` yields the `\\?\C:\…` verbatim form, which would never
+        // match the stored key. `strip_verbatim_prefix` is a no-op off Windows.
+        let key =
+            crate::commands::update::strip_verbatim_prefix(std::fs::canonicalize(&dir).unwrap());
         let matching: Vec<_> = report.roots.iter().filter(|root| root.dir == key).collect();
         assert_eq!(
             matching.len(),

--- a/crates/uffs-cli/src/commands/uninstall/plan/tests.rs
+++ b/crates/uffs-cli/src/commands/uninstall/plan/tests.rs
@@ -330,10 +330,21 @@ fn size_binaries_fills_only_binary_delete_items_from_the_sizer() {
 #[test]
 fn ensure_daemon_shutdown_injects_a_stop_before_the_runtime_binaries() {
     // No daemon was running when the plan was built (the deep sweep starts one
-    // afterwards), so the plan has no daemon stop — but it does have runtime
-    // binaries whose image the sweep-started daemon would lock.
+    // afterwards), so the plan has no daemon stop — but the root holds a
+    // RUNTIME binary (uffsd, the daemon image the sweep-started daemon would
+    // lock), so a "Runtime binaries (after shutdown)" group forms and the
+    // shutdown-before-runtime ordering is actually exercised. The shared
+    // `root()` helper's default `uffs` is a *tool* stem that lands in the
+    // "Binaries" group and forms no runtime group — the pre-existing bug this
+    // `#[cfg(windows)]`, never-run-in-CI test hid until the workspace was first
+    // tested natively on Windows.
+    let mut install_root = root(Channel::Unmanaged, Scope::User, r"C:\Users\me\bin");
+    install_root.binaries.push(BinaryInfo {
+        name: "uffsd".to_owned(),
+        version: Some("0.6.16".to_owned()),
+    });
     let report = DetectionReport {
-        roots: vec![root(Channel::Unmanaged, Scope::User, r"C:\Users\me\bin")],
+        roots: vec![install_root],
         running: Vec::new(),
     };
     let mut plan = built(

--- a/crates/uffs-client/src/windows_deadline.rs
+++ b/crates/uffs-client/src/windows_deadline.rs
@@ -407,17 +407,28 @@ mod tests {
     /// without masking a genuine regression.
     #[test]
     fn drop_is_prompt_when_guard_is_disarmed() {
-        let guard = WindowsDeadlineGuard::new(Duration::from_mins(1))
-            .expect("guard construction must succeed on a healthy Windows box");
-        let start = std::time::Instant::now();
-        drop(guard);
-        let elapsed = start.elapsed();
+        // A single wall-clock sample is flaky on a loaded CI Windows runner
+        // (AV / scheduler jitter can push one drop past 10 ms). Take the
+        // *minimum* across several iterations instead: the instant-wake floor
+        // is < 1 ms, while a regression to the old `thread::sleep(50 ms)` poll
+        // would put even the fastest drop near 48 ms — so the min cleanly
+        // separates healthy from regressed regardless of per-sample jitter.
+        let min_drop = (0..8_u32)
+            .map(|_| {
+                let guard = WindowsDeadlineGuard::new(Duration::from_mins(1))
+                    .expect("guard construction must succeed on a healthy Windows box");
+                let start = std::time::Instant::now();
+                drop(guard);
+                start.elapsed()
+            })
+            .min()
+            .expect("at least one sample");
         assert!(
-            elapsed < Duration::from_millis(10),
-            "drop took {elapsed:?}; regression beyond 10 ms means the mpsc-channel \
-             shutdown wake is gone. Run 11 bisect: before the channel fix the \
-             watchdog used `thread::sleep(50 ms)` and the CLI hot path paid \
-             48 ms median on every invocation.",
+            min_drop < Duration::from_millis(10),
+            "fastest drop over 8 iters was {min_drop:?}; a floor beyond 10 ms means \
+             the mpsc-channel shutdown wake is gone. Run 11 bisect: before the \
+             channel fix the watchdog used `thread::sleep(50 ms)` and the CLI hot \
+             path paid 48 ms median on every invocation.",
         );
     }
 

--- a/docs/architecture/delete-visibility-snapshot-diff.md
+++ b/docs/architecture/delete-visibility-snapshot-diff.md
@@ -1,0 +1,160 @@
+<!--
+SPDX-License-Identifier: MPL-2.0
+Copyright (c) 2025-2026 SKY, LLC.
+-->
+
+# Delete visibility for the `--newer` fallback (snapshot diff + tombstone read)
+
+**Status:** design sketch / proposed slice
+**Motivating gap:** the `--newer` (timestamp) delta path can report files
+*created or modified* after a date, but it is structurally blind to
+*deletions*. A deleted file simply stops appearing; a timestamp cannot express
+"this is gone." The native USN path does not have this problem because
+`FILE_DELETE` is an explicit journal reason. Slice 8.6 (delete reconciliation)
+exists today purely to paper over this with a periodic full walk. This note
+proposes turning that blind spot into a first-class, deterministic capability.
+
+## Why timestamps cannot do it
+
+Timestamps are append-only facts about a file that *exists*. Deletion removes
+the file, taking its timestamp with it, so there is no value left to compare
+against a `--newer <date>` threshold. To recover delete visibility without the
+USN journal you need one of two things UFFS can already produce from the MFT:
+
+1. **Two states to compare** (a prior full read vs the current one), or
+2. **The corpse of the record itself** (NTFS leaves deleted records behind
+   until their slot is reused).
+
+## Background: FRS vs sequence number (the File Reference)
+
+These are two different fields, and the distinction is the crux of reliable
+delete detection.
+
+- **FRS** (File Record Segment number) — *which slot* in the MFT the record
+  occupies (the record index). When a file is deleted, its slot is later
+  recycled and the new file gets the **same FRS**.
+- **sequence_number** — a `u16` in the record header (offset `0x10`) that NTFS
+  **increments every time it reallocates that slot**. It identifies *which
+  generation* of the slot you are looking at.
+- Together they form the 64-bit **File Reference**:
+  `(sequence_number << 48) | FRS`. This is how directory entries point at their
+  children, and why a stale reference to a recycled slot is detectable — the
+  sequence number will not match.
+
+`ParsedRecord` (`crates/uffs-mft/src/parse/types.rs`) already carries both
+`frs` and `sequence_number` (documented there as "incremented when FRS is
+reused"). FRS alone cannot tell "same file" from "slot reused by a different
+file"; **`(FRS, sequence_number)` can**, and that is what makes delete-vs-reuse
+unambiguous.
+
+## Mechanism 1 — Snapshot diff (primary, deterministic)
+
+UFFS already reads the *entire* MFT into a persisted compact index
+(`crates/uffs-core/src/compact_cache.rs`). Retain the prior index as a baseline
+and set-difference the next full read by stable identity:
+
+| Class | Predicate |
+|-------|-----------|
+| **Deleted** | key in baseline, absent in current |
+| **Added** | key in current, absent in baseline |
+| **Modified** | same key, changed `size` / `written` timestamp |
+
+**Key = File Reference `(frs, sequence_number)`.** Keying on FRS alone would
+misclassify a delete-then-reuse of the same slot as a "modify." The sequence
+number makes it exact: if `(frs=N, seq=3)` is in the baseline and the current
+read has `(frs=N, seq=4)`, that is a **delete of seq 3 plus an add of seq 4**,
+not a modification.
+
+### The one real gap
+
+The compact index parses `sequence_number` but does not appear to **persist**
+it (the cache keys on frs / name / parent). Persisting it is a cheap ~2
+bytes/record and is the only prerequisite that makes the diff reuse-safe.
+Without it, a fallback diff can still key on `(frs, name, parent)` — correct
+for the common case, but unable to distinguish slot reuse cleanly.
+
+### It reuses the existing tombstone model
+
+`crates/uffs-mft/src/flags.rs` already defines
+`FileFlags::DELETED = 0x8000` ("UFFS internal flag for USN tracking; bit 15
+reserved in NTFS"). The index *already models* a deleted tombstone, and the USN
+path already sets it. The snapshot diff would set the **same** flag on the
+fallback path, so the query surface (`--deleted`, projections) is largely
+pre-built — the fallback simply is not feeding it yet. This is slice 8.6's
+periodic reconciliation promoted from an internal daemon-consistency chore into
+a user-facing "what was deleted since snapshot N" answer.
+
+## Mechanism 2 — Tombstone read (forensic bonus, single scan)
+
+When NTFS deletes a file it clears the record's in-use flag and the `$MFT`
+allocation bitmap bit, but the record's bytes (name, parent, timestamps)
+survive until the slot is reallocated. UFFS already reads that bitmap
+(`bitmap.count_in_use()` throughout `crates/uffs-mft/src/reader/`), so it can
+surface the **allocated-in-MFT-but-marked-not-in-use** records as
+recently-deleted tombstones from a single scan, with no baseline required. This
+is the forensic-flow direction.
+
+Honest limits (why this complements, and does not replace, Mechanism 1):
+
+- **Best-effort.** Slots recycle non-deterministically, so you see only
+  *recent* deletes, not a complete set.
+- **No true deletion time.** The timestamps are the file's own (last written,
+  etc.), not when it was deleted.
+- **Paths may be unresolvable** if the parent directory was itself deleted or
+  its slot reused.
+
+Great as "recently deleted, possibly recoverable"; not a reliable delete-delta.
+
+## Tradeoff vs USN
+
+Snapshot diff is **coarser** than USN: it reports the *net* delete between two
+scans, not every intermediate delete the way USN's continuous log does, and it
+costs a full read plus a retained baseline. But it is **reliable and
+journal-free**, which is exactly what the `--newer` fallback needs (offline
+captures, non-Windows, wrapped/disabled journal). USN stays the gold path where
+available; this is the fallback's missing half.
+
+## Proposed slice (phased, minimal-viable first)
+
+**Phase 1 — persist identity.** Add `sequence_number: u16` to the compact
+record and its serialization (`compact_cache.rs` + the column layout in
+`uffs-polars::columns`). Pure data-plumbing; no behavior change yet.
+
+**Phase 2 — the diff engine.** A pure function
+`fn diff_indexes(baseline, current) -> DeltaReport { added, modified, deleted }`
+keyed on `(frs, sequence_number)`. Deterministic, unit-testable against
+synthetic index pairs. Deleted entries carry the baseline's path + metadata and
+set `FileFlags::DELETED`.
+
+**Phase 3 — surface it.** A CLI entry point (`uffs diff <baseline>` or a
+`--deleted-since` flag on the existing search) that runs a full read, diffs
+against the retained baseline, and emits the delta (reusing the existing
+`--deleted` projection path). The daemon's slice-8.6 reconciliation becomes a
+consumer of the same engine.
+
+**Phase 4 (optional) — tombstone view.** A `--recently-deleted` / forensic flag
+that surfaces not-in-use records from a single scan, clearly labelled
+best-effort, tying into the forensic-flow feature.
+
+## Testing
+
+- **Phase 2** is the high-value, fully-deterministic target: build two
+  synthetic compact indexes (a baseline and a mutated current) covering pure
+  add, pure delete, in-place modify, and the tricky **delete-then-reuse of the
+  same FRS** (same `frs`, bumped `seq`), and assert the `DeltaReport`
+  classifies each correctly. This is exactly the case FRS-only keying gets
+  wrong, so it is the anchor test.
+- Golden round-trip: persist a baseline, reload, diff against an unchanged
+  current → empty delta (no false deletes from serialization drift).
+- Tombstone read: fixture MFT with a not-in-use record whose parent is intact
+  (resolvable) and one whose parent is also freed (unresolvable path) → assert
+  both are surfaced with the right resolvability.
+
+## Open questions
+
+- **Baseline retention policy** — reuse the existing on-disk compact cache as
+  the baseline, or keep a dedicated "last reconciled" snapshot per drive?
+- **Whether Phase 1 (persisting `sequence_number`) belongs to this slice or a
+  prior index-format bump**, given it touches the cache format.
+- **Surface naming** — `--deleted-since <snapshot>` vs a standalone `uffs diff`
+  subcommand; the latter reads more naturally for the "two states" model.


### PR DESCRIPTION
Consolidated follow-up to #556: adds native Windows test coverage to the merge queue, fixes the 3 pre-existing Windows-only failures that coverage surfaced (all validated on a real Windows box), and lands the delete-visibility design note.

## Why
Before this, the full workspace had **only ever been tested on Ubuntu** — the sole Windows test execution in CI was `uffs-security` via the Tier-2 cargo-mutants baseline. A whole class of Windows-only failures had no way to be caught (an absent-path `secure_remove`, verbatim `\\?\` path assumptions, and even a `#[cfg(windows)]` test that had **never run anywhere**).

## Windows test gate
`windows-lint` (already on `windows-latest` in the merge queue) now also runs `cargo nextest run --workspace` after clippy, mirroring the ubuntu `tests` job. Only the `required` aggregator is branch-protection gated, so extending/renaming this job is safe; the workflow-drift gate (job-id + `if:` unchanged) still passes.

The first native run found exactly **3 failures out of 2347 tests** — all fixed here, so the gate is green from day one.

## The 3 fixes (test-side Windows assumptions, not product bugs)
- **`analyze` dedup**: compared against a raw `canonicalize()` (`\\?\C:\…` on Windows) while the product stores the verbatim-stripped path — keys never matched. Strip in the test (`strip_verbatim_prefix`, a no-op off Windows).
- **`windows_deadline` drop-promptness**: a single wall-clock sample flaked on a loaded CI runner. Take the minimum drop over 8 iters — jitter-immune, still catches a regression to the old 50 ms poll (~48 ms floor).
- **`plan` runtime-group** (`#[cfg(windows)]`, never ran in CI): asserted a "Runtime binaries (after shutdown)" group but its root held only `uffs` (a tool stem → "Binaries" group, no runtime group). Confirmed on Windows (`actual groups = ["Binaries", "Shutdown (stopped last)", "Data / cache / config"]`); give the root an actual runtime binary (`uffsd`) so the group forms and the ordering is genuinely exercised.

All three now **pass on a real Windows box** (validated interactively), and the two cross-platform ones still pass on host.

## Design note
`docs/architecture/delete-visibility-snapshot-diff.md` — how to give the timestamp-based `--newer` fallback the delete visibility it structurally lacks: snapshot-diff keyed on the File Reference `(frs, sequence_number)`, plus a forensic tombstone read of not-in-use MFT records. Docs only.
