### PR TITLE
chore: release v0.6.27 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.27] - 2026-07-14
+
+### Added
+
+- status: physical drive view + nightly-run fixes (fuzz, secure_remove, udeps) (#556)
+- delete-visibility: --diff / --deleted / --snapshot — deleted-file search + forensic tombstone read (#559)
+
+### Fixed
+
+- mft: use bit_width() to satisfy clippy::manual_bit_width on newer nightly (#554)
+
 ## [0.6.26] - 2026-07-12
 
 ### Fixed
@@ -2686,7 +2697,8 @@ thin clients over a unified `uffsd` process.
 ### Fixed
 - Various MFT parsing edge cases
 
-[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.26...HEAD
+[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.27...HEAD
+[0.6.27]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.26...v0.6.27
 [0.6.26]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.25...v0.6.26
 [0.6.25]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.24...v0.6.25
 [0.6.24]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.23...v0.6.24

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -464,9 +464,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -664,7 +664,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1607,7 +1607,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1955,9 +1955,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -2028,7 +2028,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3300,9 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3386,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64",
@@ -3417,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3463,7 +3463,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3839,7 +3839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3893,7 +3893,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4008,7 +4008,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4018,7 +4018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4379,7 +4379,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uffs-bench"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "chrono",
  "clap",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "tracing",
@@ -4411,14 +4411,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4437,7 +4437,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "clap",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "chrono",
  "itoa",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "clap",
@@ -4581,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "clap",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "clap",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "axum",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4671,14 +4671,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4693,22 +4693,22 @@ dependencies = [
 
 [[package]]
 name = "uffs-statusfmt"
-version = "0.6.26"
+version = "0.6.27"
 
 [[package]]
 name = "uffs-text"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.6.26"
+version = "0.6.27"
 
 [[package]]
 name = "uffs-update"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -4727,11 +4727,11 @@ dependencies = [
 
 [[package]]
 name = "uffs-version"
-version = "0.6.26"
+version = "0.6.27"
 
 [[package]]
 name = "uffs-winsvc"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "windows 0.62.2",
@@ -4845,9 +4845,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5090,7 +5090,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.6.26"
+version = "0.6.27"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -132,30 +132,30 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.6.26" }
-uffs-security = { path = "crates/uffs-security", version = "0.6.26" }
-uffs-text = { path = "crates/uffs-text", version = "0.6.26" }
-uffs-time = { path = "crates/uffs-time", version = "0.6.26" }
-uffs-version = { path = "crates/uffs-version", version = "0.6.26" }
-uffs-statusfmt = { path = "crates/uffs-statusfmt", version = "0.6.26" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.6.26" }
-uffs-format = { path = "crates/uffs-format", version = "0.6.26" }
-uffs-core = { path = "crates/uffs-core", version = "0.6.26" }
-uffs-client = { path = "crates/uffs-client", version = "0.6.26" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.6.27" }
+uffs-security = { path = "crates/uffs-security", version = "0.6.27" }
+uffs-text = { path = "crates/uffs-text", version = "0.6.27" }
+uffs-time = { path = "crates/uffs-time", version = "0.6.27" }
+uffs-version = { path = "crates/uffs-version", version = "0.6.27" }
+uffs-statusfmt = { path = "crates/uffs-statusfmt", version = "0.6.27" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.6.27" }
+uffs-format = { path = "crates/uffs-format", version = "0.6.27" }
+uffs-core = { path = "crates/uffs-core", version = "0.6.27" }
+uffs-client = { path = "crates/uffs-client", version = "0.6.27" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.26" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.27" }
 # `uffs-winsvc` — native Windows service control (SCM query/start/stop) +
 # the non-connecting broker-pipe readiness probe.  Layer-0 leaf: its only
 # dependency is the `windows` crate (windows-target), with non-Windows
 # stubs so cross-platform consumers (uffs-update, uffs-cli) compile.
 # Single source of truth for the `sc`/SCM mechanics previously duplicated
 # across uffs-broker, uffs-update, and uffs-cli.
-uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.26" }
+uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.27" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace
@@ -235,7 +235,7 @@ toml = "1.1.2"
 
 # ───── Data Structures ─────
 bitflags = "2.13.0"
-bytemuck = { version = "1.25.0", features = ["derive"] }
+bytemuck = { version = "1.25.1", features = ["derive"] }
 smallvec = "1.15.1"
 zerocopy = { version = "0.8", features = ["derive"] }
 
@@ -244,7 +244,7 @@ thiserror = "2.0.18"
 anyhow = "1.0.103"
 
 # ───── MCP (Model Context Protocol) ─────
-rmcp = { version = "2.1.0", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "2.2.0", features = ["server", "transport-io", "macros"] }
 schemars = "1.2.1"
 
 # ───── HTTP / Tower (for MCP Streamable HTTP gateway) ─────
@@ -276,8 +276,8 @@ devicons = "0.6.12"
 colored = "3.1.1"
 
 # ───── Pattern Matching ─────
-regex = "1.12.4"
-memchr = "2.8.2"
+regex = "1.13.0"
+memchr = "2.8.3"
 aho-corasick = "1.1.4"
 globset = "0.4.18"
 
@@ -334,7 +334,7 @@ hostname = "0.4.2"
 num_cpus = "1.17.0"
 # Random unique identifiers.  Only the `v4` (random) feature is enabled
 # workspace-wide; consumers that need v1/v5/v7 etc. re-add the feature.
-uuid = { version = "1.23.4", features = ["v4"] }
+uuid = { version = "1.23.5", features = ["v4"] }
 
 # ───── Security / Crypto ─────
 aes-gcm = "0.11.0"

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/main.rs"
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-client = { path = "../uffs-client", version = "0.6.26", default-features = false }
+uffs-client = { path = "../uffs-client", version = "0.6.27", default-features = false }
 
 # Canonical CSV / parity / legacy-footer writer.  Direct dep (not a
 # re-export chain through `uffs-client`) so the CLI and the daemon
@@ -77,7 +77,7 @@ uffs-client = { path = "../uffs-client", version = "0.6.26", default-features = 
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-format = { path = "../uffs-format", version = "0.6.26" }
+uffs-format = { path = "../uffs-format", version = "0.6.27" }
 
 # Typed drive-letter newtype.  Direct dep so the CLI command signatures
 # (`daemon_load`, `daemon_tiering`, etc.) name `DriveLetter` natively

--- a/crates/uffs-core/src/diff.rs
+++ b/crates/uffs-core/src/diff.rs
@@ -26,6 +26,18 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::compact::{CompactRecord, DriveCompactIndex, MalformedRender};
 use crate::search::tree::resolve_path;
 
+/// UFFS-internal marker bit set on a baseline [`CompactRecord`]'s `flags` to
+/// tag it as a snapshot-diff **delete** (present in the baseline, absent from
+/// the current index).
+///
+/// Bit 31 of the `u32` attribute word — deliberately **above** every NTFS
+/// `FILE_ATTRIBUTE_*` bit (which top out at
+/// `FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS = 0x0040_0000`), so it never collides
+/// with a real attribute and never renders in an attribute column. The daemon
+/// sets it in `IndexManager::diff_search`;
+/// [`crate::search::filters::SearchFilters::deleted`] filters on it.
+pub const DELETED_TOMBSTONE_FLAG: u32 = 0x8000_0000;
+
 /// The classified delta between a baseline and a current compact index.
 ///
 /// Every entry is a **row index** into the corresponding index's record array,

--- a/crates/uffs-core/src/search/filters/mod.rs
+++ b/crates/uffs-core/src/search/filters/mod.rs
@@ -151,9 +151,8 @@ pub struct SearchFilters {
     pub malformed: Option<bool>,
 
     /// Filter on whether the record is a **deleted tombstone** — its
-    /// `FileFlags::DELETED` bit (`0x8000`, bit 15, UFFS-internal) is set.
-    /// `Some(true)` keeps only deleted records;
-    /// `Some(false)` only live ones; `None` = no filter.
+    /// [`crate::diff::DELETED_TOMBSTONE_FLAG`] bit is set. `Some(true)` keeps
+    /// only deleted records; `Some(false)` only live ones; `None` = no filter.
     ///
     /// Populated by the snapshot-diff path, which marks the baseline rows that
     /// vanished from the current index before running the normal search over
@@ -852,11 +851,7 @@ impl SearchFilters {
     }
 }
 
-/// UFFS-internal "deleted tombstone" bit — mirrors
-/// `uffs_mft::flags::FileFlags::DELETED` (0x8000, bit 15, reserved in NTFS).
-/// The snapshot-diff path sets it on a baseline record whose File Reference
-/// vanished from the current index; `SearchFilters::deleted` filters on it.
-const DELETED_TOMBSTONE_FLAG: u32 = 0x8000;
+use crate::diff::DELETED_TOMBSTONE_FLAG;
 
 #[cfg(test)]
 mod tests;

--- a/crates/uffs-core/src/search/filters/tests.rs
+++ b/crates/uffs-core/src/search/filters/tests.rs
@@ -1225,7 +1225,12 @@ fn deleted_filter_selects_only_tombstoned_records() {
     let mut names = Vec::new();
     let live = test_record("live.txt", &mut names); // flags = 0x20 (ARCHIVE)
     let mut gone = test_record("gone.txt", &mut names);
-    gone.flags |= 0x8000; // FileFlags::DELETED tombstone bit
+    gone.flags |= DELETED_TOMBSTONE_FLAG; // diff-marked deleted (bit 31)
+    // Collision guard: a record with the real NTFS Integrity attribute
+    // (FILE_ATTRIBUTE_INTEGRITY_STREAM = 0x8000) must NOT read as a diff delete
+    // — the marker is bit 31, deliberately clear of every NTFS attribute bit.
+    let mut integrity = test_record("integrity.dat", &mut names);
+    integrity.flags |= 0x8000;
 
     let fold = CaseFold::default_table();
 
@@ -1240,6 +1245,10 @@ fn deleted_filter_selects_only_tombstoned_records() {
     );
     assert!(only_deleted.matches_record(&gone, &names, &mut Vec::new(), fold));
     assert!(!only_deleted.matches_record(&live, &names, &mut Vec::new(), fold));
+    assert!(
+        !only_deleted.matches_record(&integrity, &names, &mut Vec::new(), fold),
+        "the NTFS Integrity attribute (0x8000) must not be read as a diff delete",
+    );
 
     // Some(false) keeps only live records.
     let only_live = SearchFilters {

--- a/crates/uffs-daemon/src/index/diff.rs
+++ b/crates/uffs-daemon/src/index/diff.rs
@@ -24,16 +24,11 @@ use std::path::PathBuf;
 use uffs_client::protocol::SearchParams;
 use uffs_client::protocol::response::SearchResponse;
 use uffs_core::compact::MftSource;
+use uffs_core::diff::DELETED_TOMBSTONE_FLAG;
 use uffs_core::search::backend::DriveIndex;
 use uffs_mft::platform::DriveLetter;
 
 use super::IndexManager;
-
-/// UFFS-internal "deleted tombstone" bit — mirrors
-/// `uffs_mft::flags::FileFlags::DELETED` (0x8000, bit 15, reserved in NTFS) and
-/// `uffs_core::search::filters`'s `DELETED_TOMBSTONE_FLAG`. Set on a baseline
-/// record whose File Reference vanished from the current index.
-const DELETED_FLAG: u32 = 0x8000;
 
 /// Why a `diff` request could not be served. Mapped to a JSON-RPC error by the
 /// handler; kept data-only here so this module stays free of wire concerns.
@@ -91,7 +86,7 @@ impl IndexManager {
             let records = baseline.records.as_mut_slice();
             for &idx in &report.deleted {
                 if let Some(record) = records.get_mut(idx as usize) {
-                    record.flags |= DELETED_FLAG;
+                    record.flags |= DELETED_TOMBSTONE_FLAG;
                 }
             }
             anyhow::Ok(baseline)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -32,7 +32,7 @@
 # Run `just toolchain-sync` to re-attempt a channel bump; the CI
 # pipeline auto-refreshes on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed.
-channel = "nightly-2026-07-09"
+channel = "nightly-2026-07-14"
 
 # Specify components that should always be available
 components = [

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -49,6 +49,12 @@ criteria = "safe-to-deploy"
 delta = "5.0.0 -> 5.0.1"
 notes = 'Delta audit (cargo vet diff 5.0.0 -> 5.0.1, small). src/decode.rs + src/writer.rs: adds a few #[cfg(feature="std")] gates and a buffer-size fallback (`if buffer_size == 0 { 4096 } else { buffer_size }`) so a zero requested buffer size no longer yields a zero-length allocation, plus a loop `break;` fix. src/bin/error_handling_tests.rs + src/test.rs are test/bin only. No new unsafe, no new deps, no new I/O/FFI/process/network capability — defensive bugfix release of the pure-Rust brotli decoder. Publisher danielrh (Dropbox, brotli-rust maintainer).'
 
+[[audits.bytemuck]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.25.0 -> 1.25.1"
+notes = "Reviewed full 1.25.0->1.25.1 diff. Only substantive changes: (1) add not(target_arch = 'spirv') to the cfg gate on two 'impl core::error::Error' blocks (PodCastError, CheckedCastError) to fix a spirv build error (upstream PR #348); (2) a doc note on try_cast_slice about empty-slice alignment; (3) one new regression test. No new unsafe, no new deps, no fs/net/process/FFI/crypto surface. Cargo.lock churn is bytemuck's own dev lockfile only. Matches changelog. Publisher Lokathor (bytemuck maintainer)."
+
 [[audits.chrono]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -138,6 +144,12 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.16 -> 0.1.17"
 notes = """Delta audit (cargo vet diff 0.1.16 -> 0.1.17). Cargo.toml(.orig): version bump + redox_syscall dep 0.7 -> 0.8. src/lib.rs: (a) cosmetic reorder of a libc MSG_* re-export list (no semantic change); (b) adds one Redox kernel FFI binding redox_relpathat_v0(dirfd, fd, dst_base, dst_len) -> RawResult plus the safe wrappers Fd::relpathat / call::relpathat, mirroring the existing redox_fpath_v1 binding exactly (Error::demux over an unsafe extern call using the caller-provided &mut [u8] buffer's ptr+len). The single new unsafe block is a like-for-like copy of the adjacent fpath binding. libredox is the Redox stable-ABI shim, reachable only via redox_users on target_os="redox"; the extern symbols are never linked on UFFS shipping targets (Windows/macOS). No network/FS-path/process/env additions. Publisher 4lDO2 (Redox maintainer)."""
+
+[[audits.memchr]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "2.8.2 -> 2.8.3"
+notes = "Reviewed full 2.8.2->2.8.3 diff. Two source files change (unsafe count 342->349): (1) src/arch/x86_64/memchr.rs marks the pub(crate) raw-pointer functions (memchr_raw/memrchr_raw/memchr2_raw/memrchr2_raw/memchr3_raw/memrchr3_raw/count_raw, all taking *const u8) as 'unsafe fn' with no body changes -- an explicit-safety-contract hardening; internal callers updated (crate compiles). (2) src/arch/generic/memchr.rs adds a guarded core::hint::unreachable_unchecked() perf hint asserting the found index is in-bounds (sound: a matched byte's distance from start is always < haystack.len()). No new deps, no fs/net/process/FFI surface. Authored by BurntSushi (memchr maintainer), whom this project already trusts."
 
 [[audits.memmap2]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -349,6 +361,12 @@ criteria = "safe-to-deploy"
 delta = "1.12.3 -> 1.12.4"
 notes = "Reviewed full diff (3 files): changelog + version metadata + regex-syntax dependency requirement 0.8.5 -> 0.8.11 and a benches/ include glob. No source code changes in the regex crate itself; the substantive change ships in regex-syntax 0.8.11 (audited separately)."
 
+[[audits.regex]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.12.4 -> 1.13.0"
+notes = "Reviewed full 1.12.4->1.13.0 diff. Sole substantive change is the new 'regex!' / 'bytes::regex!' declarative macro (CHANGELOG #709): a 'static Lazy<Regex>' wrapper (regex_automata::util::lazy::Lazy, re-exported via a #[doc(hidden)] __private module) for one-time compilation of literal patterns; panics via .expect on an invalid literal at first use (documented, opt-in). No unsafe, no new deps, no new capabilities; existing regex usage unchanged. Authored by BurntSushi, whom this project already trusts."
+
 [[audits.regex-syntax]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -373,6 +391,12 @@ criteria = "safe-to-deploy"
 delta = "1.8.0 -> 2.1.0"
 notes = "Delta audit (cargo vet diff 1.8.0 -> 2.1.0, ~10k-line diff; bulk is the MCP 2025-11-25 spec migration in src/model/* - mechanical serde type renames (GetTaskInfoParams->GetTaskParams, CreateElicitationRequest->ElicitRequest, request_id becomes Option, etc.) plus matching handler/service plumbing and large test additions). Capability grep of ALL added lines found net/process usage ONLY inside #[cfg(test)] blocks and tests/ (loopback axum test servers, test child-process spawn); zero new unsafe. Security-relevant runtime changes are all HARDENING: (1) transport/auth.rs adds SSRF protections to OAuth discovery - redirects now manually followed with same-origin enforcement + 10-redirect cap, authorization-server metadata URLs rejected for private/loopback/link-local/CGNAT/benchmark ranges, IPv4-mapped IPv6, localhost and cloud metadata hosts (metadata.google.internal etc.); RFC 9728 resource field now required and must match base_url; resource_metadata URLs from WWW-Authenticate must be same-origin; RFC 6749 s6 fix retains the old refresh token when a refresh response omits one. (2) reqwest default client sets redirect::Policy::none so custom headers cannot replay to redirect targets. (3) streamable_http_server/tower.rs validates the MCP-Protocol-Version header before creating a session. (4) transport/async_rw.rs fixes read_until cancellation safety (partial line kept across select! polls) and stops replying to syntactically-invalid JSON (error-storm prevention, matches other official SDKs; well-formed-but-wrong JSON still gets Invalid Request). Publisher alexhancock (Alex Hancock) - crates.io shows the SAME publisher for 1.7.0/1.8.0/2.0.0/2.1.0, i.e. continuity with our accepted baseline; repo is the official modelcontextprotocol/rust-sdk."
 
+[[audits.rmcp]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.0 -> 2.2.0"
+notes = "Reviewed full 2.1.0->2.2.0 diff. 'unsafe' count 0 -> 0; no runtime dependency or feature changes (only a version bump + a new [[test]] registration). Changes are the documented conformance/robustness work: reject auth servers lacking S256 PKCE + metadata-discovery host allowlisting/SSRF hardening in transport/auth.rs (client/http feature this project does not enable); don't respond to cancelled requests (service.rs); TTL seconds->milliseconds per MCP spec with a deprecated alias (task_manager.rs); fail orphaned streamable-HTTP responses on session reinit (streamable_http_client.rs); mime 'text'->'text/plain' (model). Only URLs in the diff are example.com in tests. No suspicious endpoints or exfiltration."
+
 [[audits.rmcp-macros]]
 who = "Robert Nio <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -390,6 +414,12 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.8.0 -> 2.1.0"
 notes = "Delta audit (cargo vet diff 1.8.0 -> 2.1.0, 147-line diff). Proc-macro crate; changes are purely to the token streams it emits: prompt_handler.rs fully qualifies previously-bare type paths (rmcp::model::GetPromptRequestParams, rmcp::service::RequestContext, etc.); task_handler.rs renames model types for the MCP 2025-11-25 spec (GetTaskInfoParams->GetTaskParams, GetTaskResultParams->GetTaskPayloadParams) and swaps struct-literal construction for ::new() constructors. No new unsafe, no fs/net/process/env access, no build script, generated code only references rmcp's own types. Publisher alexhancock (modelcontextprotocol/rust-sdk release chain, same as 1.8.0->2.x series)."
+
+[[audits.rmcp-macros]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.0 -> 2.2.0"
+notes = "Reviewed full 2.1.0->2.2.0 diff. Pure version bump: the only change is the version field in Cargo.toml (cargo-vet reports 1 file, 1 insertion, 1 deletion). No source, dependency, or capability changes."
 
 [[audits.rustc-hash]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -522,6 +552,12 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.23.3 -> 1.23.4"
 notes = "Delta audit (cargo vet diff). Source changes: src/lib.rs adds a docsrs-gated #![cfg_attr(docsrs, feature(doc_cfg))] (affects only docs.rs builds) plus version/html_root_url string bumps; src/external/serde_support.rs is intra-doc-link doc-comment fixes only. No runtime/logic change, no new unsafe, network, fs, process, or FFI surface. Patch release by KodrAus (uuid maintainer)."
+
+[[audits.uuid]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.23.4 -> 1.23.5"
+notes = "Reviewed full 1.23.4->1.23.5 diff. Hex encode/decode refactored to const-fn helpers (nibble_to_hex arithmetic replacing the UPPER/LOWER LUTs in fmt.rs; decode_hex32 using fixed [u8;32] buffers with preserved bad-nibble rejection in parser.rs) plus one serde doc-link fix. 'unsafe' count unchanged (19 -> 19). No runtime dep or feature changes; the added gungraun dependency is dev-only (benchmarks, non-wasm target). Authored by KodrAus (uuid maintainer)."
 
 [[audits.which]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.6.27** — the `[workspace.package].version` bump in `Cargo.toml`.  This PR routes that commit through branch-protection rules.  Once it merges to `main`, run `just release-tag` to cut the signed `v0.6.27` tag, which fires `release.yml` and builds the cross-platform binaries + GitHub Release v0.6.27.  (No auto-tag on merge — the tag step is manual on-demand, Path B.)

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

The auto-commit lived only on `release/v0.6.27`, so local `main` never drifted — sync it with a plain `git pull --ff-only origin main` (no `reset --hard` needed).