### PR TITLE
fix(ci): don't let a transient GitHub API error fail the commitlint gate

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -196,11 +196,24 @@ jobs:
           # comments endpoint (PR comments live there) and jq-filter
           # by marker presence.  `head -1` defends against the
           # (impossible-but-cheap-to-guard) double-managed-comment case.
+          #
+          # A transient GitHub API error (e.g. a 503) makes `gh api`
+          # print its JSON error body to stdout while still exiting
+          # non-zero; the `|| true` swallows the exit code but not
+          # that body, so EXISTING_ID could otherwise become garbage
+          # text instead of a real comment id — which then crashes the
+          # DELETE/PATCH call below and fails this *required* gate for
+          # a reason unrelated to title conformance. Validate the
+          # result is purely numeric (a real id always is) and treat
+          # anything else as "no existing comment found".
           EXISTING_ID=$(
             gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
               --jq ".[] | select(.body | contains(\"${COMMENT_MARKER}\")) | .id" \
               | head -1 || true
           )
+          if ! [[ "${EXISTING_ID}" =~ ^[0-9]+$ ]]; then
+            EXISTING_ID=""
+          fi
 
           if echo "$TITLE" | grep -qE "$PATTERN"; then
             # ── Conforming title ───────────────────────────────────


### PR DESCRIPTION
## Summary
The commitlint gate's stale-advisory-comment cleanup looked up an
existing comment id via \`gh api\`. On a transient 5xx, \`gh api\` prints
its JSON error body to stdout while still exiting non-zero; the
existing \`|| true\` swallowed the exit code but not that body, so
\`EXISTING_ID\` could become garbage text instead of a real id. The
subsequent DELETE/PATCH then crashed on the malformed URL
(\`net/url: invalid control character in URL\`), failing this
*required* gate for a reason unrelated to title conformance.

Hit for real on release PR #564: the title conformed
(\`"PR title matches Conventional Commits"\` fired), but the lookup
503'd and the whole job died anyway.

## Fix
Validate \`EXISTING_ID\` is purely numeric before trusting it; anything
else (including a JSON error blob) is treated as "no existing comment".

## Test plan
- [x] \`just workflow-drift\` — structural validator still passes
- [x] \`just gates-drift\` — manifest/consumers still agree
- [x] \`actionlint .github/workflows/commitlint.yml\` — clean