### PR TITLE
fix(mft): demote IOCP-fallback chain messages from WARN to INFO

### DIFF
--- a/crates/uffs-mft/src/reader/index_read.rs
+++ b/crates/uffs-mft/src/reader/index_read.rs
@@ -803,7 +803,13 @@ impl MftReader {
                         // 1. Open `X:\$MFT` as a file (filesystem-mediated)
                         // 2. Re-open volume with FILE_FLAG_NO_BUFFERING (bypasses cache manager,
                         //    direct device I/O)
-                        warn!(
+                        // INFO, not WARN: the cascade below is designed,
+                        // automatically-handled resilience — a normal run
+                        // stays quiet (WARN-default subscribers show
+                        // nothing) and `-v`/verbose reveals the chain when
+                        // debugging. If every fallback fails too, the `?`
+                        // propagates a real error.
+                        info!(
                             volume = %self.volume,
                             error = %iocp_err,
                             "⚠️  IOCP inline read failed — trying fallback strategies"
@@ -920,7 +926,10 @@ impl MftReader {
                 return result;
             }
             Err(err) => {
-                warn!(
+                // INFO for the same reason as the IOCP-failure line: an
+                // intermediate rung of the handled fallback chain, not an
+                // operator-actionable warning.
+                info!(
                     volume = %self.volume,
                     error = %err,
                     "⚠️  Fallback 1 ($MFT file) failed — trying unbuffered volume I/O"


### PR DESCRIPTION
Flagged by the content-service team: the two intermediate messages of the MFT read fallback cascade (`IOCP inline read failed — trying fallback strategies` and `Fallback 1 ($MFT file) failed — trying unbuffered volume I/O`) fired at WARN, piercing quiet WARN-default subscribers on every run that walked the chain.

The cascade is designed, automatically-handled resilience — a normal run should stay silent, and `-v`/verbose reveals the chain when debugging. Both messages are now INFO with **byte-identical text** so existing log greps keep matching. A chain that exhausts every fallback still propagates a real `Err` to the caller — that remains the operator-actionable signal. `Failed to get MFT extents, using fallback` stays WARN deliberately: an extent-query failure on an open volume is genuinely unusual, unlike the (pre-#578) every-run snapshot chain.

Cherry-picked from the tail of #578's branch — the original commit missed that PR's merge window.