### PR TITLE
chore: release v0.6.30 — ship pipeline auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.30] - 2026-07-23
+
+### Added
+
+- mft: for_each_record — streaming fixed-up targeted record reads (#577)
+
+### Fixed
+
+- mft: real overlapped re-open for snapshot devices + snapshot-correct $MFT fallback (#578)
+- mft: demote IOCP-fallback chain messages from WARN to INFO (#579)
+- version: re-stamp build info on every HEAD movement via the reflog
+
 ## [0.6.29] - 2026-07-22
 
 ### Added
@@ -2721,7 +2733,8 @@ thin clients over a unified `uffsd` process.
 ### Fixed
 - Various MFT parsing edge cases
 
-[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.29...HEAD
+[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.30...HEAD
+[0.6.30]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.29...v0.6.30
 [0.6.29]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.28...v0.6.29
 [0.6.28]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.27...v0.6.28
 [0.6.27]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.26...v0.6.27

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,7 +4390,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uffs-bench"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "chrono",
  "clap",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "serde",
@@ -4425,14 +4425,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4493,7 +4493,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -4557,7 +4557,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "chrono",
  "itoa",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "axum",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4685,14 +4685,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4707,22 +4707,22 @@ dependencies = [
 
 [[package]]
 name = "uffs-statusfmt"
-version = "0.6.29"
+version = "0.6.30"
 
 [[package]]
 name = "uffs-text"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.6.29"
+version = "0.6.30"
 
 [[package]]
 name = "uffs-update"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -4741,11 +4741,11 @@ dependencies = [
 
 [[package]]
 name = "uffs-version"
-version = "0.6.29"
+version = "0.6.30"
 
 [[package]]
 name = "uffs-vss-requestor"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "cc",
@@ -4757,7 +4757,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-winsvc"
-version = "0.6.29"
+version = "0.6.30"
 dependencies = [
  "anyhow",
  "windows 0.62.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.6.29"
+version = "0.6.30"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -133,30 +133,30 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.6.29" }
-uffs-security = { path = "crates/uffs-security", version = "0.6.29" }
-uffs-text = { path = "crates/uffs-text", version = "0.6.29" }
-uffs-time = { path = "crates/uffs-time", version = "0.6.29" }
-uffs-version = { path = "crates/uffs-version", version = "0.6.29" }
-uffs-statusfmt = { path = "crates/uffs-statusfmt", version = "0.6.29" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.6.29" }
-uffs-format = { path = "crates/uffs-format", version = "0.6.29" }
-uffs-core = { path = "crates/uffs-core", version = "0.6.29" }
-uffs-client = { path = "crates/uffs-client", version = "0.6.29" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.6.30" }
+uffs-security = { path = "crates/uffs-security", version = "0.6.30" }
+uffs-text = { path = "crates/uffs-text", version = "0.6.30" }
+uffs-time = { path = "crates/uffs-time", version = "0.6.30" }
+uffs-version = { path = "crates/uffs-version", version = "0.6.30" }
+uffs-statusfmt = { path = "crates/uffs-statusfmt", version = "0.6.30" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.6.30" }
+uffs-format = { path = "crates/uffs-format", version = "0.6.30" }
+uffs-core = { path = "crates/uffs-core", version = "0.6.30" }
+uffs-client = { path = "crates/uffs-client", version = "0.6.30" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.29" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.30" }
 # `uffs-winsvc` — native Windows service control (SCM query/start/stop) +
 # the non-connecting broker-pipe readiness probe.  Layer-0 leaf: its only
 # dependency is the `windows` crate (windows-target), with non-Windows
 # stubs so cross-platform consumers (uffs-update, uffs-cli) compile.
 # Single source of truth for the `sc`/SCM mechanics previously duplicated
 # across uffs-broker, uffs-update, and uffs-cli.
-uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.29" }
+uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.30" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/main.rs"
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-client = { path = "../uffs-client", version = "0.6.29", default-features = false }
+uffs-client = { path = "../uffs-client", version = "0.6.30", default-features = false }
 
 # Canonical CSV / parity / legacy-footer writer.  Direct dep (not a
 # re-export chain through `uffs-client`) so the CLI and the daemon
@@ -77,7 +77,7 @@ uffs-client = { path = "../uffs-client", version = "0.6.29", default-features = 
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-format = { path = "../uffs-format", version = "0.6.29" }
+uffs-format = { path = "../uffs-format", version = "0.6.30" }
 
 # Typed drive-letter newtype.  Direct dep so the CLI command signatures
 # (`daemon_load`, `daemon_tiering`, etc.) name `DriveLetter` natively

--- a/crates/uffs-version/src/lib.rs
+++ b/crates/uffs-version/src/lib.rs
@@ -152,7 +152,15 @@ pub fn emit_build_env() {
     println!("cargo:rustc-env=UFFS_TARGET={}", env_or_unknown("TARGET"));
     println!("cargo:rustc-env=UFFS_PROFILE={}", env_or_unknown("PROFILE"));
     // Re-stamp when the checked-out commit or the compiler changes.
+    //
+    // `.git/HEAD` alone is not enough: a pull, commit, or reset onto the
+    // *current* branch leaves HEAD's symref unchanged (`ref: refs/heads/...`),
+    // so the SHA would go stale and `--version` would report the previous
+    // build's commit — exactly the "am I running the fix?" trap this stamp
+    // exists to prevent. `.git/logs/HEAD` (the reflog) appends on every HEAD
+    // movement, so it is the reliable trigger.
     println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/logs/HEAD");
     println!("cargo:rerun-if-env-changed=RUSTC");
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -32,7 +32,7 @@
 # Run `just toolchain-sync` to re-attempt a channel bump; the CI
 # pipeline auto-refreshes on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed.
-channel = "nightly-2026-07-22"
+channel = "nightly-2026-07-23"
 
 # Specify components that should always be available
 components = [


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.6.30** — the `[workspace.package].version` bump in `Cargo.toml`.  This PR routes that commit through branch-protection rules.  Once it merges to `main`, run `just release-tag` to cut the signed `v0.6.30` tag, which fires `release.yml` and builds the cross-platform binaries + GitHub Release v0.6.30.  (No auto-tag on merge — the tag step is manual on-demand, Path B.)

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

The auto-commit lived only on `release/v0.6.30`, so local `main` never drifted — sync it with a plain `git pull --ff-only origin main` (no `reset --hard` needed).