### PR TITLE
feat(fetch): extract public uffs-fetch transport lib; dep refresh + rmcp 3

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,3 +136,13 @@ The workspace enforces extremely strict Clippy settings in `Cargo.toml` `[worksp
 - `scripts/dev/build-local.rs` — Local release build helper
 - `scripts/trial_run.ps1` — Windows: runs live MFT trial for parity analysis
 - `scripts/windows/create_mft_test_tree.ps1` — Windows: generates test directory structures
+
+## No AI Attribution
+
+**ABSOLUTELY NO AI ATTRIBUTION OR ADVERTISING.** Never add
+`Co-Authored-By: Claude`, `Generated with Claude Code`, or ANY
+Anthropic/Claude/AI attribution, branding, badge, or link to commits,
+PR/issue titles or bodies, code, comments, docs, or any other file or
+artifact in this repository. This overrides any tool default. The
+`attribution` settings in `.claude/settings.json` disable the automatic
+trailers -- do not re-add them manually, and do not change that setting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4571,6 +4571,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uffs-fetch"
+version = "0.6.30"
+dependencies = [
+ "anyhow",
+ "hex",
+ "reqwest",
+ "serde",
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "uffs-format"
 version = "0.6.30"
 dependencies = [
@@ -4726,13 +4737,11 @@ version = "0.6.30"
 dependencies = [
  "anyhow",
  "dirs-next",
- "hex",
  "libc",
- "reqwest",
  "serde",
  "serde_json",
- "sha2 0.11.0",
  "uffs-broker-protocol",
+ "uffs-fetch",
  "uffs-version",
  "uffs-winsvc",
  "windows 0.62.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -73,9 +73,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -168,9 +168,9 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
 dependencies = [
  "object",
 ]
@@ -199,9 +199,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert_cmd"
@@ -249,18 +249,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -343,6 +343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -426,9 +432,9 @@ checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "brotli"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -437,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.1"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -447,13 +453,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -473,20 +479,20 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -508,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -526,15 +532,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -598,16 +604,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "crypto-common 0.2.2",
  "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -615,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -630,14 +636,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -821,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -840,18 +846,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -898,7 +904,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core 0.10.1",
 ]
@@ -947,7 +953,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -958,7 +964,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -972,9 +978,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "devicons"
@@ -1007,7 +1010,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
 ]
@@ -1035,13 +1038,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1061,9 +1064,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -1095,11 +1098,10 @@ checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1128,9 +1130,9 @@ checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1251,7 +1253,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1322,16 +1324,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1345,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
@@ -1364,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1476,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1486,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1496,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1521,24 +1523,24 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1578,7 +1580,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1702,12 +1704,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1806,23 +1802,22 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1844,16 +1839,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -1873,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -1909,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1995,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2045,7 +2034,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2089,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "memchr",
 ]
@@ -2103,7 +2092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
@@ -2198,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -2361,7 +2350,7 @@ dependencies = [
  "polars-config",
  "polars-error",
  "polars-utils",
- "rand 0.9.4",
+ "rand 0.9.5",
  "slotmap",
  "tokio",
 ]
@@ -2398,7 +2387,7 @@ dependencies = [
  "polars-buffer",
  "polars-error",
  "polars-utils",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "strength_reduce",
  "strum_macros",
@@ -2444,7 +2433,7 @@ dependencies = [
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_distr",
  "rayon",
  "regex",
@@ -2506,7 +2495,7 @@ dependencies = [
  "polars-row",
  "polars-time",
  "polars-utils",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "recursive",
  "regex",
@@ -2550,7 +2539,7 @@ dependencies = [
  "polars-schema",
  "polars-time",
  "polars-utils",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "regex",
  "reqwest",
@@ -2659,7 +2648,7 @@ checksum = "cb146490a717ac5ae4ff3a22a5adf3ebae79361f187b1f550f9e24783d7ad765"
 dependencies = [
  "aho-corasick",
  "argminmax",
- "base64",
+ "base64 0.22.1",
  "bytemuck",
  "chrono",
  "chrono-tz",
@@ -2696,7 +2685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6b79ba2103c00cbb9c5dd4459ffff1d8ce15286c7a6d376a04c711df20d8b7"
 dependencies = [
  "async-stream",
- "base64",
+ "base64 0.22.1",
  "brotli",
  "bytemuck",
  "ethnum",
@@ -2910,7 +2899,7 @@ dependencies = [
  "num-traits",
  "polars-config",
  "polars-error",
- "rand 0.9.4",
+ "rand 0.9.5",
  "raw-cpuid",
  "rayon",
  "regex",
@@ -2928,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
@@ -2939,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -2995,20 +2984,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3023,7 +3002,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3034,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -3060,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3080,14 +3059,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3101,23 +3081,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3136,9 +3116,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3151,7 +3131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3197,7 +3177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3255,7 +3244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3280,22 +3269,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3333,7 +3322,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3386,12 +3375,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
@@ -3417,15 +3406,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3468,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -3494,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3515,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -3557,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -3571,14 +3560,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3611,12 +3600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3643,18 +3626,18 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3773,19 +3756,18 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd-json"
-version = "0.17.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3"
+checksum = "e32d7ab2678282d21e53374fbead7119b7eacbede73685dcaac472870a29a11c"
 dependencies = [
  "ahash",
  "halfbrown",
- "once_cell",
  "ref-cast",
  "serde",
  "serde_json",
@@ -3822,21 +3804,21 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snap"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3861,14 +3843,14 @@ checksum = "028e551d5e270b31b9f3ea271778d9d827148d4287a5d96167b6bb9787f5cc38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",
@@ -3885,9 +3867,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3938,7 +3920,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3955,9 +3937,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3966,9 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3992,7 +3974,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4016,7 +3998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4064,7 +4046,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4075,26 +4057,25 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4104,15 +4085,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4140,9 +4121,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4172,13 +4153,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4193,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4204,22 +4185,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4241,9 +4223,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -4333,7 +4315,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4821,12 +4803,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4884,7 +4860,7 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4898,9 +4874,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-trait"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
+checksum = "f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc"
 dependencies = [
  "float-cmp",
  "halfbrown",
@@ -4956,27 +4932,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4987,9 +4954,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4997,9 +4964,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5007,46 +4974,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -5063,22 +5008,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5233,7 +5166,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5244,7 +5177,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5321,7 +5254,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5330,16 +5263,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5357,31 +5281,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -5409,22 +5316,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5433,22 +5328,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5457,22 +5340,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5481,28 +5352,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "winresource"
@@ -5516,97 +5375,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -5616,9 +5387,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yoke"
@@ -5639,28 +5410,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5680,15 +5451,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -5720,20 +5491,20 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,12 +244,12 @@ serde_json = "1.0.151"
 # tier overrides + adaptive-TTL knobs in `uffs-daemon::config`.
 # Pinned to v1.1.2 to match the supply-chain exemption already on
 # the transitive copy pulled by other deps; no new vet entry needed.
-toml = "1.1.3"
+toml = "1.1.4"
 
 # ───── Data Structures ─────
 bitflags = "2.13.1"
 bytemuck = { version = "1.25.2", features = ["derive"] }
-smallvec = "1.15.1"
+smallvec = "1.15.2"
 zerocopy = { version = "0.8", features = ["derive"] }
 
 # ───── Error Handling ─────
@@ -257,8 +257,8 @@ thiserror = "2.0.19"
 anyhow = "1.0.104"
 
 # ───── MCP (Model Context Protocol) ─────
-rmcp = { version = "2.2.0", features = ["server", "transport-io", "macros"] }
-schemars = "1.2.1"
+rmcp = { version = "3.1.0", features = ["server", "transport-io", "macros"] }
+schemars = "1.2.2"
 
 # ───── HTTP / Tower (for MCP Streamable HTTP gateway) ─────
 axum = "0.8.9"
@@ -274,7 +274,7 @@ tracing-subscriber = { version = "0.3.23", features = [
 tracing-appender = "0.2.5"
 
 # ───── CLI ─────
-clap = { version = "4.6.3", features = [
+clap = { version = "4.6.5", features = [
   "derive",
   "env",
   "unicode",
@@ -291,7 +291,7 @@ colored = "3.1.1"
 # ───── Pattern Matching ─────
 regex = "1.13.1"
 memchr = "2.8.3"
-aho-corasick = "1.1.4"
+aho-corasick = "1.1.5"
 globset = "0.4.19"
 
 # ───── Time ─────
@@ -323,6 +323,9 @@ hex = "0.4.3"
 # Blocking HTTP with rustls + the system trust store. `rustls-tls-native-roots`
 # matches the existing transitive reqwest config, so no new crate enters the lock.
 # Version 0.13.4 cannot be used at this time ... missing "rustls-tls-native-roots"
+# (re-verified 2026-08-03 against crates.io: the 0.13.x feature set has only
+# `rustls` / `rustls-no-provider` / `default-tls` / `native-tls*` — no
+# native-roots variant; 0.12.28 remains the newest 0.12.x release)
 reqwest = { version = "0.12.28", default-features = false, features = [
   "blocking",
   "rustls-tls-native-roots",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
   "crates/uffs-statusfmt",       # 🎨 Shared operator-status styling (color, glyphs, fields) (leaf)
   "crates/uffs-broker-protocol", # 📟 Cross-platform broker wire-protocol types (F5)
   "crates/uffs-winsvc",          # 🪟 Native Windows service control + broker-pipe probe (leaf)
+  "crates/uffs-fetch",           # 🌐 Hardened HTTP fetch + SHA-256 verify (public lib, leaf)
   "crates/uffs-mft",             # 📦 MFT reading → Polars DataFrame
   "crates/uffs-format",          # 🧾 Shared CSV formatter (daemon + thin CLI)
   "crates/uffs-core",            # 🎯 Query engine + compact search engine
@@ -157,6 +158,12 @@ uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.30
 # Single source of truth for the `sc`/SCM mechanics previously duplicated
 # across uffs-broker, uffs-update, and uffs-cli.
 uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.30" }
+# `uffs-fetch` — hardened release-asset transport (blocking reqwest +
+# rustls with retry/timeout/byte-cap, plus `SHA256SUMS` verification),
+# extracted from `uffs-update` as a small public lib so external products
+# can reuse it. Cross-platform pure-logic leaf; keeps the HTTP/TLS stack
+# out of the lean `uffs` CLI exactly as before.
+uffs-fetch = { path = "crates/uffs-fetch", version = "0.6.30" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/crates/uffs-fetch/Cargo.toml
+++ b/crates/uffs-fetch/Cargo.toml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025-2026 SKY, LLC.
+# SPDX-License-Identifier: MPL-2.0
+
+# ============================================================================
+# uffs-fetch: Hardened release-asset transport (blocking HTTP + SHA-256)
+# ============================================================================
+# Small public library crate extracted from `uffs-update` so other products
+# can reuse the acquire step's hardened HTTP machinery without duplicating
+# it: GitHub release lookup, streaming asset download (retry with bounded
+# exponential back-off, connect/inactivity timeouts, per-call byte cap),
+# and `SHA256SUMS` verification.
+#
+# Deliberately a SEPARATE crate rather than a `[lib]` on `uffs-update`:
+# the HTTP/TLS stack (reqwest + rustls) never bloats the lean `uffs` CLI,
+# and consumers don't drag in the updater's journal/quiesce/restore
+# dependency tree.  Updater-specific logic (doctor, apply, journal,
+# quiesce, restore) intentionally stays behind in `uffs-update`.
+#
+# Cross-platform pure library — no Windows FFI, no cfg-gated I/O.
+# ============================================================================
+
+[package]
+name = "uffs-fetch"
+description = "Hardened blocking HTTP fetch (retry, timeouts, size cap) + SHA-256 verification for release assets"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+# External consumers pin against a git semver tag; the crates.io name is
+# reserved but never carries content (same policy as the other libs —
+# see `docs/refactor/crates-io-publishability-deep-dive.md` §7.4).
+publish.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+anyhow.workspace = true
+# `Release` / `Asset` deserialization from the GitHub release JSON.
+serde = { workspace = true, features = ["derive"] }
+# Blocking HTTP with rustls + the system trust store — workspace-inherited
+# so the feature set lives in one place. One-shot fetch steps, so the async
+# runtime overhead of a full client is unwarranted.
+reqwest.workspace = true
+# SHA-256 integrity gate against a release's published `SHA256SUMS`.
+sha2.workspace = true
+hex.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uffs-fetch/src/github.rs
+++ b/crates/uffs-fetch/src/github.rs
@@ -85,9 +85,11 @@ fn is_retryable(err: &reqwest::Error) -> bool {
         .is_some_and(|status| status.as_u16() == 429 || status.is_server_error())
 }
 
-/// Run `op` with bounded exponential back-off (4 attempts, 500ms base),
-/// retrying only transient failures (see [`is_retryable`]). `label`
-/// describes the operation for the final error context.
+/// Run `op` with bounded exponential back-off (4 attempts, 500ms base).
+///
+/// Only transient failures are retried: connect/read timeouts, HTTP 429,
+/// and 5xx statuses. `label` describes the operation for the final error
+/// context.
 ///
 /// # Errors
 ///

--- a/crates/uffs-fetch/src/github.rs
+++ b/crates/uffs-fetch/src/github.rs
@@ -114,8 +114,14 @@ where
 }
 
 /// Stream `reader` into `writer`, aborting if the total exceeds `cap`.
-/// Returns the number of bytes written.
-fn copy_capped<R: Read, W: Write>(reader: &mut R, writer: &mut W, cap: u64) -> Result<u64> {
+/// Invokes `on_chunk` with the running byte total after every written
+/// chunk. Returns the number of bytes written.
+fn copy_capped<R, W, P>(reader: &mut R, writer: &mut W, cap: u64, mut on_chunk: P) -> Result<u64>
+where
+    R: Read,
+    W: Write,
+    P: FnMut(u64),
+{
     let mut buf = vec![0_u8; CHUNK_BYTES];
     let mut total: u64 = 0;
     loop {
@@ -129,6 +135,7 @@ fn copy_capped<R: Read, W: Write>(reader: &mut R, writer: &mut W, cap: u64) -> R
         }
         let chunk = buf.get(..read).context("response chunk out of range")?;
         writer.write_all(chunk).context("writing to disk")?;
+        on_chunk(total);
     }
     Ok(total)
 }
@@ -169,14 +176,40 @@ pub fn fetch_release(user_agent: &str, repo: &str, tag: Option<&str>) -> Result<
 ///
 /// Propagates HTTP, status, cap-exceeded, and file-write failures.
 pub fn download_to(user_agent: &str, url: &str, dest: &Path, max_bytes: u64) -> Result<()> {
+    download_to_with_progress(user_agent, url, dest, max_bytes, |_, _| {})
+}
+
+/// [`download_to`] with a progress hook: `on_chunk(bytes_so_far, total)`
+/// fires after every written chunk, where `total` is the response's
+/// `Content-Length` when the server sent one.
+///
+/// Multi-GiB downloads are otherwise indistinguishable from a hang — the
+/// hook gives callers a heartbeat to drive a progress bar or watchdog.
+///
+/// # Errors
+///
+/// Propagates HTTP, status, cap-exceeded, and file-write failures.
+pub fn download_to_with_progress<P>(
+    user_agent: &str,
+    url: &str,
+    dest: &Path,
+    max_bytes: u64,
+    mut on_chunk: P,
+) -> Result<()>
+where
+    P: FnMut(u64, Option<u64>),
+{
     let client = client(user_agent)?;
     let mut response = with_retry(&format!("downloading {url}"), || {
         client.get(url).send()?.error_for_status()
     })?;
+    let total = response.content_length();
     let mut file =
         std::fs::File::create(dest).with_context(|| format!("creating {}", dest.display()))?;
-    copy_capped(&mut response, &mut file, max_bytes)
-        .with_context(|| format!("writing {}", dest.display()))?;
+    copy_capped(&mut response, &mut file, max_bytes, |written| {
+        on_chunk(written, total);
+    })
+    .with_context(|| format!("writing {}", dest.display()))?;
     Ok(())
 }
 
@@ -184,12 +217,16 @@ pub fn download_to(user_agent: &str, url: &str, dest: &Path, max_bytes: u64) -> 
 mod tests {
     use super::copy_capped;
 
+    /// Progress callback that records nothing — for tests not about progress.
+    fn no_progress(_total: u64) {}
+
     #[test]
     fn copy_capped_writes_all_under_cap() {
         let src = vec![7_u8; 200];
         let mut reader = src.as_slice();
         let mut sink: Vec<u8> = Vec::new();
-        let written = copy_capped(&mut reader, &mut sink, 1024).expect("under cap copies");
+        let written =
+            copy_capped(&mut reader, &mut sink, 1024, no_progress).expect("under cap copies");
         assert_eq!(written, 200);
         assert_eq!(sink, src);
     }
@@ -199,7 +236,8 @@ mod tests {
         let src = vec![0_u8; 4096];
         let mut reader = src.as_slice();
         let mut sink: Vec<u8> = Vec::new();
-        let err = copy_capped(&mut reader, &mut sink, 100).expect_err("over cap must abort");
+        let err =
+            copy_capped(&mut reader, &mut sink, 100, no_progress).expect_err("over cap must abort");
         assert!(err.to_string().contains("cap"), "unexpected: {err}");
     }
 
@@ -207,8 +245,30 @@ mod tests {
     fn copy_capped_handles_empty_body() {
         let mut reader: &[u8] = &[];
         let mut sink: Vec<u8> = Vec::new();
-        let written = copy_capped(&mut reader, &mut sink, 100).expect("empty copies");
+        let written = copy_capped(&mut reader, &mut sink, 100, no_progress).expect("empty copies");
         assert_eq!(written, 0);
         assert!(sink.is_empty());
+    }
+
+    #[test]
+    fn copy_capped_reports_monotonic_progress() {
+        // 3 chunks' worth of data → the hook must fire once per chunk with
+        // a strictly increasing running total ending at the full size.
+        let size = super::CHUNK_BYTES * 2 + 100;
+        let src = vec![1_u8; size];
+        let mut reader = src.as_slice();
+        let mut sink: Vec<u8> = Vec::new();
+        let mut seen: Vec<u64> = Vec::new();
+        let written = copy_capped(&mut reader, &mut sink, u64::MAX, |total| seen.push(total))
+            .expect("copies with progress");
+        assert_eq!(written, u64::try_from(size).expect("fits"));
+        assert!(seen.len() >= 3, "one callback per chunk: {seen:?}");
+        assert!(
+            seen.iter()
+                .zip(seen.iter().skip(1))
+                .all(|(prev, next)| prev < next),
+            "monotonic: {seen:?}"
+        );
+        assert_eq!(seen.last().copied(), Some(written));
     }
 }

--- a/crates/uffs-fetch/src/github.rs
+++ b/crates/uffs-fetch/src/github.rs
@@ -3,10 +3,15 @@
 
 //! GitHub Releases fetch + asset download (blocking `reqwest` + rustls).
 //!
-//! One-shot HTTP for the acquire step — a release lookup plus streaming
+//! One-shot HTTP for an acquire step — a release lookup plus streaming
 //! asset downloads. TLS is rustls with the system trust store; we never
 //! follow off-host redirects beyond what `reqwest` validates against the
 //! pinned `api.github.com` / release host.
+//!
+//! [`fetch_release`] is GitHub-specific; [`download_to`] streams **any**
+//! URL, so it also serves non-GitHub hosts (model registries, package
+//! feeds, …). The caller supplies the user-agent product string (GitHub
+//! requires one for API requests) and the per-download byte cap.
 
 use core::time::Duration;
 use std::io::{Read, Write};
@@ -14,9 +19,6 @@ use std::path::Path;
 
 use anyhow::{Context as _, Result, bail};
 use serde::Deserialize;
-
-/// User-agent GitHub requires for API requests.
-const USER_AGENT: &str = concat!("uffs-update/", env!("CARGO_PKG_VERSION"));
 
 /// Cap on how long we wait to establish a TCP/TLS connection.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -32,44 +34,40 @@ const MAX_ATTEMPTS: u32 = 4;
 /// Base back-off; the delay before attempt *n* is `BASE_BACKOFF * 2^(n-1)`.
 const BASE_BACKOFF: Duration = Duration::from_millis(500);
 
-/// Hard ceiling on a single downloaded asset, defending the disk against
-/// a truncated, malicious, or runaway response. Our largest binary is a
-/// few tens of MiB; 512 MiB is generous head-room.
-const MAX_ASSET_BYTES: u64 = 512 * 1024 * 1024;
-
 /// Streaming copy buffer size.
 const CHUNK_BYTES: usize = 64 * 1024;
 
 /// A GitHub release (only the fields we use).
 #[derive(Debug, Deserialize)]
-pub(crate) struct Release {
+pub struct Release {
     /// The release tag (e.g. `v0.6.2`).
-    pub(crate) tag_name: String,
+    pub tag_name: String,
     /// Downloadable assets attached to the release.
-    pub(crate) assets: Vec<Asset>,
+    pub assets: Vec<Asset>,
 }
 
 /// One downloadable release asset.
 #[derive(Debug, Deserialize)]
-pub(crate) struct Asset {
+pub struct Asset {
     /// Asset file name (e.g. `uffs-windows-x64.zip`).
-    pub(crate) name: String,
+    pub name: String,
     /// Direct download URL.
-    pub(crate) browser_download_url: String,
+    pub browser_download_url: String,
 }
 
 impl Release {
     /// Find an asset by exact file name.
-    pub(crate) fn asset(&self, name: &str) -> Option<&Asset> {
+    #[must_use]
+    pub fn asset(&self, name: &str) -> Option<&Asset> {
         self.assets.iter().find(|asset| asset.name == name)
     }
 }
 
-/// Build a blocking client with the required user agent and the connect
-/// + read timeouts (a hung socket can never wedge an update forever).
-fn client() -> Result<reqwest::blocking::Client> {
+/// Build a blocking client with the caller's user agent and the connect
+/// + read timeouts (a hung socket can never wedge a download forever).
+fn client(user_agent: &str) -> Result<reqwest::blocking::Client> {
     reqwest::blocking::Client::builder()
-        .user_agent(USER_AGENT)
+        .user_agent(user_agent)
         .connect_timeout(CONNECT_TIMEOUT)
         .timeout(READ_TIMEOUT)
         .build()
@@ -87,10 +85,15 @@ fn is_retryable(err: &reqwest::Error) -> bool {
         .is_some_and(|status| status.as_u16() == 429 || status.is_server_error())
 }
 
-/// Run `op` with bounded exponential back-off, retrying only transient
-/// failures (see [`is_retryable`]). `label` describes the operation for
-/// the final error context.
-fn with_retry<T, F>(label: &str, mut op: F) -> Result<T>
+/// Run `op` with bounded exponential back-off (4 attempts, 500ms base),
+/// retrying only transient failures (see [`is_retryable`]). `label`
+/// describes the operation for the final error context.
+///
+/// # Errors
+///
+/// Returns the last `op` error once attempts are exhausted, or the first
+/// non-retryable one, wrapped with `label` and the attempt count.
+pub fn with_retry<T, F>(label: &str, mut op: F) -> Result<T>
 where
     F: FnMut() -> reqwest::Result<T>,
 {
@@ -133,15 +136,18 @@ fn copy_capped<R: Read, W: Write>(reader: &mut R, writer: &mut W, cap: u64) -> R
 /// Fetch a release from `owner/repo`: the `latest` release, or the
 /// specific `tag` when given.
 ///
+/// `user_agent` is the product string sent with the request (e.g.
+/// `myproduct/1.2.3`) — GitHub rejects agent-less API calls.
+///
 /// # Errors
 ///
 /// Propagates HTTP, status, and JSON-decode failures.
-pub(crate) fn fetch_release(repo: &str, tag: Option<&str>) -> Result<Release> {
+pub fn fetch_release(user_agent: &str, repo: &str, tag: Option<&str>) -> Result<Release> {
     let url = tag.map_or_else(
         || format!("https://api.github.com/repos/{repo}/releases/latest"),
         |wanted| format!("https://api.github.com/repos/{repo}/releases/tags/{wanted}"),
     );
-    let client = client()?;
+    let client = client(user_agent)?;
     let response = with_retry(&format!("requesting {url}"), || {
         client
             .get(&url)
@@ -152,19 +158,24 @@ pub(crate) fn fetch_release(repo: &str, tag: Option<&str>) -> Result<Release> {
     response.json::<Release>().context("parsing release JSON")
 }
 
-/// Stream an asset URL to `dest`.
+/// Stream `url` (any host, not just GitHub) to `dest`, aborting once
+/// the body exceeds `max_bytes`.
+///
+/// The cap defends the disk against a truncated, malicious, or runaway
+/// response — size it to the largest asset the caller legitimately
+/// expects.
 ///
 /// # Errors
 ///
-/// Propagates HTTP, status, and file-write failures.
-pub(crate) fn download_to(url: &str, dest: &Path) -> Result<()> {
-    let client = client()?;
+/// Propagates HTTP, status, cap-exceeded, and file-write failures.
+pub fn download_to(user_agent: &str, url: &str, dest: &Path, max_bytes: u64) -> Result<()> {
+    let client = client(user_agent)?;
     let mut response = with_retry(&format!("downloading {url}"), || {
         client.get(url).send()?.error_for_status()
     })?;
     let mut file =
         std::fs::File::create(dest).with_context(|| format!("creating {}", dest.display()))?;
-    copy_capped(&mut response, &mut file, MAX_ASSET_BYTES)
+    copy_capped(&mut response, &mut file, max_bytes)
         .with_context(|| format!("writing {}", dest.display()))?;
     Ok(())
 }

--- a/crates/uffs-fetch/src/lib.rs
+++ b/crates/uffs-fetch/src/lib.rs
@@ -10,7 +10,9 @@
 //!   specific tag).
 //! - [`github::download_to`] — streaming download of **any** URL (not just
 //!   GitHub) with retry, connect/inactivity timeouts, and a caller-chosen byte
-//!   cap.
+//!   cap. [`github::download_to_with_progress`] adds a per-chunk
+//!   `(bytes_so_far, content_length)` hook so multi-GiB downloads can drive a
+//!   progress bar instead of looking frozen.
 //! - [`github::with_retry`] — the bounded-exponential-back-off retry wrapper,
 //!   usable around any `reqwest` operation.
 //! - [`verify`] — `SHA256SUMS` parsing and file-hash verification.
@@ -22,5 +24,7 @@
 pub mod github;
 pub mod verify;
 
-pub use github::{Asset, Release, download_to, fetch_release, with_retry};
+pub use github::{
+    Asset, Release, download_to, download_to_with_progress, fetch_release, with_retry,
+};
 pub use verify::{expected_hash, parse_sha256sums, sha256_file, verify_sha256};

--- a/crates/uffs-fetch/src/lib.rs
+++ b/crates/uffs-fetch/src/lib.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Hardened release-asset transport: blocking HTTP fetch + SHA-256 verify.
+//!
+//! Extracted from `uffs-update`'s acquire step so any product can reuse the
+//! same hardened machinery instead of writing a second one:
+//!
+//! - [`github::fetch_release`] — GitHub Releases metadata lookup (`latest` or a
+//!   specific tag).
+//! - [`github::download_to`] — streaming download of **any** URL (not just
+//!   GitHub) with retry, connect/inactivity timeouts, and a caller-chosen byte
+//!   cap.
+//! - [`github::with_retry`] — the bounded-exponential-back-off retry wrapper,
+//!   usable around any `reqwest` operation.
+//! - [`verify`] — `SHA256SUMS` parsing and file-hash verification.
+//!
+//! Everything is blocking by design (one-shot CLI/installer steps), TLS is
+//! rustls with the system trust store, and the caller supplies the
+//! user-agent product string — this crate never bakes in a product name.
+
+pub mod github;
+pub mod verify;
+
+pub use github::{Asset, Release, download_to, fetch_release, with_retry};
+pub use verify::{expected_hash, parse_sha256sums, sha256_file, verify_sha256};

--- a/crates/uffs-fetch/src/verify.rs
+++ b/crates/uffs-fetch/src/verify.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025-2026 SKY, LLC.
 
-//! Verification of downloaded artifacts.
+//! SHA-256 verification of downloaded artifacts.
 //!
-//! This phase (acquire) applies the **SHA-256** integrity gate against
-//! the release's published `SHA256SUMS`. The **Authenticode** authenticity
-//! gate — the now-shared `uffs_security::authenticode` — is applied to the
-//! extracted `.exe`s just before they replace anything (the apply phase),
-//! so it is wired in there, not here.
+//! The **integrity** gate: hash a downloaded file and compare it against
+//! the release's published `SHA256SUMS`. Authenticity gates (code
+//! signing, etc.) are a separate concern the consumer applies at its own
+//! trust boundary — in `uffs-update` that is Authenticode just before an
+//! extracted `.exe` replaces anything.
 
 use std::io::Read as _;
 use std::path::Path;
@@ -21,7 +21,7 @@ use sha2::{Digest as _, Sha256};
 /// # Errors
 ///
 /// Propagates any read error.
-pub(crate) fn sha256_file(path: &Path) -> Result<String> {
+pub fn sha256_file(path: &Path) -> Result<String> {
     let file = std::fs::File::open(path)
         .with_context(|| format!("opening {} for hashing", path.display()))?;
     let mut reader = std::io::BufReader::new(file);
@@ -42,7 +42,7 @@ pub(crate) fn sha256_file(path: &Path) -> Result<String> {
 ///
 /// Pure — unit-testable without I/O.
 #[must_use]
-pub(crate) fn parse_sha256sums(text: &str) -> Vec<(String, String)> {
+pub fn parse_sha256sums(text: &str) -> Vec<(String, String)> {
     text.lines()
         .filter_map(|line| {
             let mut parts = line.split_whitespace();
@@ -62,7 +62,7 @@ pub(crate) fn parse_sha256sums(text: &str) -> Vec<(String, String)> {
 /// Return the expected hash for `file_name` from parsed sums, matching on
 /// the base file name only (sums may list paths).
 #[must_use]
-pub(crate) fn expected_hash<'a>(sums: &'a [(String, String)], file_name: &str) -> Option<&'a str> {
+pub fn expected_hash<'a>(sums: &'a [(String, String)], file_name: &str) -> Option<&'a str> {
     sums.iter().find_map(|(name, hash)| {
         let base = Path::new(name).file_name().and_then(|os| os.to_str());
         (base == Some(file_name)).then_some(hash.as_str())
@@ -75,7 +75,7 @@ pub(crate) fn expected_hash<'a>(sums: &'a [(String, String)], file_name: &str) -
 /// # Errors
 ///
 /// Propagates a hashing/read error.
-pub(crate) fn verify_sha256(path: &Path, expected: &str) -> Result<bool> {
+pub fn verify_sha256(path: &Path, expected: &str) -> Result<bool> {
     let actual = sha256_file(path)?;
     Ok(actual.eq_ignore_ascii_case(expected))
 }

--- a/crates/uffs-mcp/src/handler/mod.rs
+++ b/crates/uffs-mcp/src/handler/mod.rs
@@ -16,9 +16,10 @@ use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, GetPromptRequestParams, GetPromptResult, Implementation,
-    ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult, ListToolsResult,
-    PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult, Resource,
+    CallToolRequestParams, CallToolResponse, CallToolResult, GetPromptRequestParams,
+    GetPromptResponse, GetPromptResult, Implementation, ListPromptsResult,
+    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams,
+    ReadResourceRequestParams, ReadResourceResponse, ReadResourceResult, Resource,
     ResourceContents, ResourceTemplate, ServerCapabilities, ServerInfo,
 };
 use rmcp::service::RequestContext;
@@ -400,11 +401,9 @@ impl ServerHandler for UffsMcpServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         self.touch();
-        Ok(ListToolsResult {
-            tools: definitions::tool_definitions(),
-            next_cursor: None,
-            meta: None,
-        })
+        Ok(ListToolsResult::with_all_items(
+            definitions::tool_definitions(),
+        ))
     }
 
     #[cfg_attr(
@@ -418,7 +417,7 @@ impl ServerHandler for UffsMcpServer {
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         self.touch();
         let tool_name = request.name.to_string();
         let args = request.arguments.unwrap_or_default();
@@ -479,7 +478,9 @@ impl ServerHandler for UffsMcpServer {
             }
         }
 
-        final_result.map_err(McpError::from)
+        final_result
+            .map(CallToolResponse::from)
+            .map_err(McpError::from)
     }
 
     #[expect(
@@ -492,48 +493,44 @@ impl ServerHandler for UffsMcpServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
         self.touch();
-        Ok(ListResourcesResult {
-            resources: vec![
-                Resource::new("uffs://schema/fields", "Field Catalog")
-                    .with_description(
-                        "Complete catalog of fields available for searching, filtering, \
+        Ok(ListResourcesResult::with_all_items(vec![
+            Resource::new("uffs://schema/fields", "Field Catalog")
+                .with_description(
+                    "Complete catalog of fields available for searching, filtering, \
                          sorting, and aggregating — includes types and capabilities",
-                    )
-                    .with_mime_type("application/json"),
-                Resource::new("uffs://drives", "Indexed Drives")
-                    .with_description(
-                        "Live listing of currently indexed NTFS drives with record counts",
-                    )
-                    .with_mime_type("application/json"),
-                Resource::new("uffs://status", "Daemon Status")
-                    .with_description(
-                        "Daemon health, state, uptime, memory, PID, and drive-loading progress",
-                    )
-                    .with_mime_type("application/json"),
-                Resource::new("uffs://schema/search", "Search Request Schema")
-                    .with_description("JSON Schema for the uffs_search tool input parameters")
-                    .with_mime_type("application/json"),
-                Resource::new("uffs://schema/aggregate", "Aggregate Request Schema")
-                    .with_description("JSON Schema for the uffs_aggregate tool input parameters")
-                    .with_mime_type("application/json"),
-                Resource::new("uffs://presets/aggregate", "Aggregate Presets")
-                    .with_description(
-                        "Built-in aggregate presets (overview, by_type, by_extension, \
+                )
+                .with_mime_type("application/json"),
+            Resource::new("uffs://drives", "Indexed Drives")
+                .with_description(
+                    "Live listing of currently indexed NTFS drives with record counts",
+                )
+                .with_mime_type("application/json"),
+            Resource::new("uffs://status", "Daemon Status")
+                .with_description(
+                    "Daemon health, state, uptime, memory, PID, and drive-loading progress",
+                )
+                .with_mime_type("application/json"),
+            Resource::new("uffs://schema/search", "Search Request Schema")
+                .with_description("JSON Schema for the uffs_search tool input parameters")
+                .with_mime_type("application/json"),
+            Resource::new("uffs://schema/aggregate", "Aggregate Request Schema")
+                .with_description("JSON Schema for the uffs_aggregate tool input parameters")
+                .with_mime_type("application/json"),
+            Resource::new("uffs://presets/aggregate", "Aggregate Presets")
+                .with_description(
+                    "Built-in aggregate presets (overview, by_type, by_extension, \
                          storage, etc.) with descriptions",
-                    )
-                    .with_mime_type("application/json"),
-                // ── Agent cookbook (query examples) ──────────────────
-                Resource::new("uffs://cookbook", "Query Cookbook")
-                    .with_description(
-                        "Curated example MCP tool calls organized by workflow — \
+                )
+                .with_mime_type("application/json"),
+            // ── Agent cookbook (query examples) ──────────────────
+            Resource::new("uffs://cookbook", "Query Cookbook")
+                .with_description(
+                    "Curated example MCP tool calls organized by workflow — \
                          ready-to-use arguments objects, tips, and multi-step patterns. \
                          Read this first to learn how to compose effective UFFS queries.",
-                    )
-                    .with_mime_type("application/json"),
-            ],
-            next_cursor: None,
-            meta: None,
-        })
+                )
+                .with_mime_type("application/json"),
+        ]))
     }
 
     #[expect(
@@ -546,26 +543,22 @@ impl ServerHandler for UffsMcpServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, McpError> {
         self.touch();
-        Ok(ListResourceTemplatesResult {
-            resource_templates: vec![
-                ResourceTemplate::new("uffs://info/{path}", "File/Directory Info")
-                    .with_description(
-                        "Full metadata for a file or directory by path. \
+        Ok(ListResourceTemplatesResult::with_all_items(vec![
+            ResourceTemplate::new("uffs://info/{path}", "File/Directory Info")
+                .with_description(
+                    "Full metadata for a file or directory by path. \
                      The {path} parameter is a percent-encoded Windows path \
                      with forward slashes (e.g. C:/Users/me/file.txt).",
-                    )
-                    .with_mime_type("application/json"),
-            ],
-            next_cursor: None,
-            meta: None,
-        })
+                )
+                .with_mime_type("application/json"),
+        ]))
     }
 
     async fn read_resource(
         &self,
         request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, McpError> {
+    ) -> Result<ReadResourceResponse, McpError> {
         self.touch();
         self.stats.record_resource_read();
         let uri_str = request.uri.as_str().to_owned();
@@ -634,10 +627,7 @@ impl ServerHandler for UffsMcpServer {
             }
         };
 
-        Ok(ReadResourceResult::new(vec![ResourceContents::text(
-            json,
-            request.uri,
-        )]))
+        Ok(ReadResourceResult::new(vec![ResourceContents::text(json, request.uri)]).into())
     }
 
     #[expect(
@@ -650,11 +640,9 @@ impl ServerHandler for UffsMcpServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListPromptsResult, McpError> {
         self.touch();
-        Ok(ListPromptsResult {
-            prompts: definitions::prompt_definitions(),
-            next_cursor: None,
-            meta: None,
-        })
+        Ok(ListPromptsResult::with_all_items(
+            definitions::prompt_definitions(),
+        ))
     }
 
     #[expect(
@@ -665,14 +653,15 @@ impl ServerHandler for UffsMcpServer {
         &self,
         request: GetPromptRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<GetPromptResult, McpError> {
+    ) -> Result<GetPromptResponse, McpError> {
         self.stats.record_prompt_get();
         let prompt_args = request.arguments.unwrap_or_default();
 
         let messages = prompts::build_prompt_messages(request.name.as_ref(), &prompt_args)?;
 
         Ok(GetPromptResult::new(messages)
-            .with_description(format!("UFFS prompt: {}", request.name)))
+            .with_description(format!("UFFS prompt: {}", request.name))
+            .into())
     }
 }
 

--- a/crates/uffs-update/Cargo.toml
+++ b/crates/uffs-update/Cargo.toml
@@ -32,18 +32,17 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 
 [dependencies]
 uffs-version.workspace = true
+# Shared hardened HTTP fetch + SHA-256 verify (extracted from this crate's
+# former `github.rs` / `verify.rs`). Carries the reqwest/rustls + sha2/hex
+# stack, so this crate no longer depends on them directly — and the
+# HTTP/TLS isolation from the lean `uffs` CLI is preserved unchanged.
+uffs-fetch.workspace = true
 anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-sha2.workspace = true
-hex.workspace = true
 # Resolve the daemon lifecycle dir (`%LOCALAPPDATA%\uffs`) so quiesce can
 # poll the PID file as the "daemon stopped" signal — no process FFI.
 dirs-next.workspace = true
-# Blocking HTTP with rustls + the system trust store — workspace-inherited
-# so the feature set lives in one place. A one-shot CLI step, so the async
-# runtime overhead of a full client is unwarranted.
-reqwest.workspace = true
 # Broker identity (`SERVICE_NAME` / `PIPE_NAME`) for quiesce/restore — pure
 # cross-platform crate, so it lives here, not under cfg(windows).
 uffs-broker-protocol.workspace = true

--- a/crates/uffs-update/src/acquire.rs
+++ b/crates/uffs-update/src/acquire.rs
@@ -19,9 +19,9 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result, bail};
+use uffs_fetch::{github, verify};
 
 use crate::orchestrate::{asset_name, exe_name};
-use crate::{github, verify};
 
 /// Inputs for one acquire run.
 pub(crate) struct AcquirePlan {
@@ -48,7 +48,7 @@ pub(crate) fn run(plan: &AcquirePlan) -> Result<Vec<PathBuf>> {
     std::fs::create_dir_all(&plan.stage)
         .with_context(|| format!("creating stage dir {}", plan.stage.display()))?;
 
-    let release = github::fetch_release(&plan.repo, plan.tag.as_deref())?;
+    let release = github::fetch_release(crate::USER_AGENT, &plan.repo, plan.tag.as_deref())?;
 
     // Checksums first.
     let sums_url = release
@@ -57,7 +57,12 @@ pub(crate) fn run(plan: &AcquirePlan) -> Result<Vec<PathBuf>> {
         .browser_download_url
         .clone();
     let sums_path = plan.stage.join(&plan.sums);
-    github::download_to(&sums_url, &sums_path)?;
+    github::download_to(
+        crate::USER_AGENT,
+        &sums_url,
+        &sums_path,
+        crate::MAX_ASSET_BYTES,
+    )?;
     let sums_text = std::fs::read_to_string(&sums_path)
         .with_context(|| format!("reading {}", sums_path.display()))?;
     let sums = verify::parse_sha256sums(&sums_text);
@@ -74,7 +79,7 @@ pub(crate) fn run(plan: &AcquirePlan) -> Result<Vec<PathBuf>> {
             .browser_download_url
             .clone();
         let dest = plan.stage.join(exe_name(stem));
-        github::download_to(&url, &dest)?;
+        github::download_to(crate::USER_AGENT, &url, &dest, crate::MAX_ASSET_BYTES)?;
 
         let expected = verify::expected_hash(&sums, &asset)
             .with_context(|| format!("{asset} is not listed in {}", plan.sums))?;

--- a/crates/uffs-update/src/doctor.rs
+++ b/crates/uffs-update/src/doctor.rs
@@ -18,9 +18,10 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use uffs_fetch::github;
 
 use crate::orchestrate::asset_name;
-use crate::{apply, github, journal, plan, proc, restore};
+use crate::{apply, journal, plan, proc, restore};
 
 /// How long the doctor waits on the broker pipe before calling it down
 /// (short — this is a probe, not the restore-time readiness gate; off
@@ -450,7 +451,7 @@ fn check_broker(report: &mut Report) {
 /// Reach the release, report update availability, and confirm every
 /// installed binary has a downloadable asset + a checksum entry.
 fn check_release(opts: &DoctorOpts, snapshot: Option<&plan::Snapshot>, report: &mut Report) {
-    let release = match github::fetch_release(&opts.repo, opts.tag.as_deref()) {
+    let release = match github::fetch_release(crate::USER_AGENT, &opts.repo, opts.tag.as_deref()) {
         Ok(rel) => rel,
         Err(err) => {
             report.add(

--- a/crates/uffs-update/src/main.rs
+++ b/crates/uffs-update/src/main.rs
@@ -15,7 +15,6 @@
 mod acquire;
 mod apply;
 mod doctor;
-mod github;
 mod journal;
 mod orchestrate;
 mod plan;
@@ -23,11 +22,14 @@ mod proc;
 mod quiesce;
 mod recover;
 mod restore;
-mod verify;
 
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, bail};
+// HTTP fetch + SHA-256 verify live in the shared `uffs-fetch` lib
+// (extracted from this crate); the updater supplies its own user-agent
+// and byte-cap policy via `USER_AGENT` / `MAX_ASSET_BYTES` below.
+use uffs_fetch::github;
 
 use crate::acquire::AcquirePlan;
 
@@ -242,6 +244,15 @@ fn run_recover(args: &[String]) -> Result<()> {
 /// Default upstream repository for self-update artifacts.
 const DEFAULT_REPO: &str = "skyllc-ai/UltraFastFileSearch";
 
+/// User-agent product string for all release-metadata and asset requests
+/// (GitHub rejects agent-less API calls).
+pub(crate) const USER_AGENT: &str = concat!("uffs-update/", env!("CARGO_PKG_VERSION"));
+
+/// Hard ceiling on a single downloaded asset, defending the disk against
+/// a truncated, malicious, or runaway response. Our largest binary is a
+/// few tens of MiB; 512 MiB is generous head-room.
+pub(crate) const MAX_ASSET_BYTES: u64 = 512 * 1024 * 1024;
+
 /// Parse the `doctor` flags and run the end-to-end health check. Exits
 /// non-zero when a hard failure is found so it composes in scripts/CI.
 fn run_doctor(args: &[String]) -> Result<()> {
@@ -271,7 +282,7 @@ fn run_doctor(args: &[String]) -> Result<()> {
 )]
 fn run_check(args: &[String]) -> Result<()> {
     let repo = flag(args, "--repo").unwrap_or_else(|| DEFAULT_REPO.to_owned());
-    let release = github::fetch_release(&repo, flag(args, "--version").as_deref())?;
+    let release = github::fetch_release(USER_AGENT, &repo, flag(args, "--version").as_deref())?;
     println!("latest={}", release.tag_name);
     Ok(())
 }

--- a/docs/architecture/crate-graph.md
+++ b/docs/architecture/crate-graph.md
@@ -2,7 +2,7 @@
 
 **Audience:** Contributors deciding where to put new code, which crate to depend on, or whether to extract a new crate.
 
-**Scope:** The 17-member UFFS workspace (`/Cargo.toml::[workspace.members]`).  This document defines the workspace's **crate-level** architecture — module layout *within* a crate is Phase-3 / #190 territory.
+**Scope:** The 18-member UFFS workspace (`/Cargo.toml::[workspace.members]`).  This document defines the workspace's **crate-level** architecture — module layout *within* a crate is Phase-3 / #190 territory.
 
 **Source of truth for:**
 
@@ -47,7 +47,7 @@ UFFS uses a strict layered architecture with **5 layers** plus a parallel **tool
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ Layer 0 — Foundation (zero internal deps; only external crates)             │
 │   uffs-polars  uffs-security  uffs-text  uffs-time  uffs-broker-protocol     │
-│   uffs-winsvc                                                                │
+│   uffs-winsvc  uffs-fetch                                                    │
 └─────────────────────────────────────────────────────────────────────────────┘
 
 ┌──── Parallel tree (not part of the layer hierarchy) ────┐
@@ -58,7 +58,7 @@ UFFS uses a strict layered architecture with **5 layers** plus a parallel **tool
 
 ## 2. Per-layer crate inventory
 
-### Layer 0 — Foundation (6 crates, all publishable)
+### Layer 0 — Foundation (7 crates, all publishable)
 
 | Crate | Description | External-dep footprint |
 |---|---|---|
@@ -68,6 +68,7 @@ UFFS uses a strict layered architecture with **5 layers** plus a parallel **tool
 | `uffs-time` | NTFS FILETIME arithmetic (`const fn`) | Pure logic; zero deps |
 | `uffs-broker-protocol` | Cross-platform broker wire-protocol types (`PIPE_NAME`, `SERVICE_NAME`) | Pure logic; zero unsafe |
 | `uffs-winsvc` | Native Windows service control (SCM) + broker-pipe readiness probe; the single home for the `sc`/SCM mechanics shared by uffs-broker, uffs-update, uffs-cli | `windows` (windows-target only); pure stubs off Windows |
+| `uffs-fetch` | Hardened release-asset transport: GitHub release lookup, streaming any-URL download (retry, connect/inactivity timeouts, caller-chosen byte cap, caller-supplied user-agent), `SHA256SUMS` verification. Extracted from `uffs-update` for reuse by external products; keeps the HTTP/TLS stack out of the lean `uffs` CLI | reqwest (blocking, rustls-tls-native-roots), sha2, hex; cross-platform, zero unsafe |
 
 **Layer-0 contract:** Zero internal-crate dependencies.  Any new Layer-0 crate must compile against `cargo check -p <crate>` with no `uffs-*` deps in `[dependencies]`.
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -7,11 +7,29 @@ criteria = "safe-to-deploy"
 delta = "0.10.3 -> 0.11.0"
 notes = "Delta audit (cargo vet diff 0.10.3 -> 0.11.0). Single-file crate; src change is only src/lib.rs (rest is docs/tests/Wycheproof vectors). Changes are the RustCrypto 2024-editions migration: aead 0.6 (AeadInPlace -> AeadInOut with InOutBuf), cipher 0.5 + hybrid-array (GenericArray -> Array). Crypto flow is IDENTICAL: init_ctr -> Ctr32BE keystream + GHASH compute_tag; decrypt still verifies the tag via subtle::ConstantTimeEq BEFORE applying the keystream. Length limits corrected to NIST SP 800-38D exactly (P_MAX 2^36 -> 2^36-32 bytes, i.e. tightened; A_MAX 2^36 -> 2^61-1 per spec). New: hazmat feature gates U4/U8 short tags with an SP 800-38D usage warning; manual Debug impl via finish_non_exhaustive leaks no key material. grep confirms ZERO unsafe in 0.11.0 src (crate was previously deny(unsafe_code), still none). No fs/net/process/env surface. Publisher tarcieri (Tony Arcieri, lead RustCrypto maintainer, same publisher as 0.10.3)."
 
+[[audits.aho-corasick]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.1.4 -> 1.1.5"
+notes = 'Delta audit (cargo vet diff 1.1.4 -> 1.1.5). Source changes are limited to Span::offset and Match::offset switching from unchecked `+` to `checked_add(...).expect(...)` with new "# Panics" doc sections (overflow hardening), plus a doc-only panic note in packed/api.rs. Remaining diff is CI workflow action pinning, a dependabot config, and Cargo.lock/manifest version bumps. No unsafe changes, no fs/net/process/env/FFI surface changes, no build.rs, no new dependencies or features.'
+
+[[audits.alloc-stdlib]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.2 -> 0.2.4"
+notes = """Delta audit (cargo vet diff 0.2.2 -> 0.2.4). Adds `#![cfg_attr(not(feature="unsafe"), forbid(unsafe_code))]` to lib.rs, gates the example binary's `extern` calloc/free declarations and calloc-backed pool behind the "unsafe" feature, and removes an unsafe-feature test. Cargo.toml widens the alloc-no-stdlib range to ">=2.0.4, <3.0.0" and makes the "unsafe" feature forward to alloc-no-stdlib/unsafe. Net reduction in default unsafe surface; no build.rs, no new capabilities."""
+
 [[audits.anyhow]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.102 -> 1.0.103"
 notes = "Delta audit (cargo vet diff). Source changes: src/error.rs + src/lib.rs (test_context.rs is test-only). error.rs reworks the two type-erased downcast helpers to replace intermediate reference creation (deref() then &_object.context/error) with raw-pointer field projection (ptr::addr_of! + Ref::from_raw(NonNull::new_unchecked(..))) -- a soundness improvement that avoids forming references into a possibly-aliased erased object; downcast logic otherwise identical. lib.rs is only the html_root_url version bump. No new unsafe blocks, no new fs/net/process/FFI/ambient-capability surface. Patch release by dtolnay (anyhow maintainer)."
+
+[[audits.ar_archive_writer]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.1 -> 0.5.3"
+notes = "Delta audit (cargo vet diff 0.5.1 -> 0.5.3). Source change is an overflow fix: write_symbols now takes the member index as usize instead of u16 (converting to u16 only on the COFF sym_map path), plus `is_multiple_of` / `values_mut` cleanups. Manifest bumps the object dependency 0.37 -> 0.39 and sets rust-version 1.88; test files updated for LLVM 21 import-library naming and a new (ignored) many-objects regression test. No unsafe code, no build.rs, no fs/net/process/env capability changes; Cargo.lock churn is dev-only."
 
 [[audits.assert_cmd]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -43,17 +61,35 @@ criteria = "safe-to-deploy"
 delta = "2.13.0 -> 2.13.1"
 notes = "Reviewed diff (6 files, 30/18 lines): pure perf change in the generated all() macro body (computes the ALL flags mask in a const block instead of a runtime loop, per upstream changelog 'Lower the LLVM IR output'). No new unsafe, no capability changes."
 
+[[audits.block-buffer]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.12.0 -> 0.12.1"
+notes = "Delta audit (cargo vet diff 0.12.0 -> 0.12.1). Fixes an exception-safety bug (RustCrypto/utils#1487): new ResetGuard drop guards reset the buffer if a user-supplied compress/gen_block closure panics while the buffer invariant is temporarily broken. digest_pad is rewritten to initialize the block via `ptr::write`/`ptr::write_bytes` inside a guarded unsafe block; the modified unsafe was reviewed and fully initializes the buffer before `assume_init_mut`, with safety comments updated. zeroize minimum bumped 1.4 -> 1.8; new exception-safety and pad-combination tests. No new dependencies, no build.rs, no capability changes."
+
 [[audits.brotli]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "8.0.2 -> 8.0.3"
 notes = "Delta audit (cargo vet diff 8.0.2 -> 8.0.3). Bulk of the diff is tests (src/enc/threading/test.rs +309, src/bin/test_broccoli.rs +292, test_custom_dict.rs) and the CLI binary src/bin/brotli.rs (the TMPDIR/TEMP std::env::var + std::fs::File::create probe flagged by scanning lives in the bin/test harness, NOT the library — bins are not linked when brotli is consumed as a dependency). Library changes: src/concat/mod.rs adds a fallible BroCatli::try_new_with_window_size(u8) -> Result<BroCatli, BroCatliResult> constructor (returns InvalidWindowSize for ws not in 10..=24-style range) and reduces the legacy panicking new_with_window_size to a thin .expect() wrapper over it; src/ffi/broccoli.rs mirrors the window-size handling at the C-ABI boundary. src/enc/{threading,encode,backward_references/{mod,hash_to_binary_tree,hq}}.rs is internal compression-encoder refactoring that threads a `ringbuffer_break` parameter through the H10 hasher path (initialize_h10 / StitchToPreviousBlockH10). Pure-Rust codec; no NEW unsafe, extern, network, or process capability added to the library path. Publisher danielrh (Dropbox, brotli-rust maintainer)."
 
+[[audits.brotli]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "8.0.3 -> 8.0.4"
+notes = """Delta audit (cargo vet diff 8.0.3 -> 8.0.4). Hardening release: BroCatli::deserialize_from_buffer now validates state fields (last_bytes_len, bit offset, window size, pending-stream counters) before constructing state; a new bounds check returns BrotliFileNotCraftedForConcatenation instead of underflowing on truncated metadata headers; BrotliEncoderCreateInstance/CreateWorkPool null-check the caller-provided allocator's return before `ptr::write`; and the Broccoli FFI entry points are wrapped in catch_unwind (matching the existing encoder FFI convention), logging to stderr and returning an error code on panic. Changes touch existing `unsafe extern "C"` functions but are purely defensive. alloc-no-stdlib range tightened to ">=2.0.4, <3"; a dev-only dependency enables alloc-no-stdlib/unsafe for the test suite. No build.rs, no new runtime dependencies."""
+
 [[audits.brotli-decompressor]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "5.0.0 -> 5.0.1"
 notes = 'Delta audit (cargo vet diff 5.0.0 -> 5.0.1, small). src/decode.rs + src/writer.rs: adds a few #[cfg(feature="std")] gates and a buffer-size fallback (`if buffer_size == 0 { 4096 } else { buffer_size }`) so a zero requested buffer size no longer yields a zero-length allocation, plus a loop `break;` fix. src/bin/error_handling_tests.rs + src/test.rs are test/bin only. No new unsafe, no new deps, no new I/O/FFI/process/network capability — defensive bugfix release of the pure-Rust brotli decoder. Publisher danielrh (Dropbox, brotli-rust maintainer).'
+
+[[audits.brotli-decompressor]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "5.0.1 -> 5.0.3"
+notes = 'Delta audit (cargo vet diff 5.0.1 -> 5.0.3). Adds `forbid(unsafe_code)` to the library unless the "unsafe"/"ffi-api" features are enabled, and likewise to the CLI binary unless "unsafe"/"seccomp". Dependency ranges pinned to alloc-no-stdlib 2.x and alloc-stdlib 0.2.x (with in-manifest rationale about trait-identity splits), and the "seccomp" feature now enables alloc-no-stdlib/unsafe. The seccomp-gated Linux binary path is reworked to allocate a custom-dictionary cell and flush output before its pre-existing `syscall(60)` exit; prctl/syscall use existed before this delta. No library capability changes, no build.rs, no new dependencies.'
 
 [[audits.bytemuck]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -66,6 +102,12 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.25.1 -> 1.25.2"
 notes = "Reviewed diff (5 files, 65/2 lines): test-only additions (NonZero round-trip cast tests). No production code changes."
+
+[[audits.bytemuck_derive]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.10.2 -> 1.11.0"
+notes = 'Proc-macro crate; delta relaxes derive(NoUninit) generic-parameter checks to match derive(Pod): repr(transparent)/repr(packed(1)) generic structs are now accepted, with the compile-time no-padding assertion correctly retained for non-packed/non-transparent types (src/traits.rs). Also accepts repr(packed) structs for NoUninit where padding assertions still apply. Remaining changes are doc typo fixes ("the the"), endianness/pointer-width fixes in tests, and a new compile-check test file. No unsafe, no build.rs, no fs/net/process/env access, no new dependencies; Cargo.lock only bumps proc-macro toolchain crates. Emitted code changes only affect which const assertions are generated, not runtime behavior of consumers.'
 
 [[audits.chrono]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -97,11 +139,29 @@ criteria = "safe-to-deploy"
 delta = "0.5.15 -> 0.5.16"
 notes = "Delta audit (cargo vet diff 0.5.15 -> 0.5.16). Files: CHANGELOG/Cargo.toml(.orig) (version bump only, no dependency changes), src/channel.rs, src/flavors/{never,zero}.rs, src/select_macro.rs, src/utils.rs, src/waker.rs, tests/mpsc.rs. Net unsafe: 0 added, 0 removed. Two upstream changes: (1) #1250 constify never() and the zero/never Channel::new() (pub fn -> pub const fn, Channel {..} -> Self {..}) — no runtime behavior change; (2) #1240 change the select!/select_biased! body matcher from => $body:block to => { $($body:tt)* } so rust-analyzer can auto-complete inside the block — semantically equivalent token capture. channel.rs/waker.rs additionally switch from std::sync::Mutex to the crate internal crate::utils::Mutex wrapper, dropping the .lock().unwrap() poison-handling at each call site; the wrapper is a thin non-poisoning shim over the same std Mutex (no new unsafe). No build script, no new dependencies, no new ambient-capability surface. Publisher taiki-e (crossbeam maintainer, same publisher already trusted for the crossbeam-epoch 0.9.18 -> 0.9.20 delta). Strictly a constification + tooling + internal-mutex refactor; trust extends from the audited 0.5.15 base."
 
+[[audits.crossbeam-deque]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.6 -> 0.8.7"
+notes = 'Adds a build.rs that only reads CARGO_CFG_SANITIZE and emits cfg(crossbeam_sanitize_thread) — same probe pattern already used by crossbeam-utils; no other env/fs/net/process activity. Source change replaces Release stores after Release fences with Relaxed stores (Release retained only under TSan cfg), a valid weakening since the preceding fence already provides the release ordering; the old code even documented that Relaxed would be correct absent TSan. Also fixes a Debug impl string (Injector printed "Worker") and a doc typo. No new unsafe blocks; Cargo.toml adds no features (section reordered only) and a dev-only Cargo.lock. Matches upstream crossbeam #1233.'
+
 [[audits.crossbeam-epoch]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.9.18 -> 0.9.20"
 notes = "Delta audit (cargo vet diff 0.9.18 -> 0.9.20), anchored on the existing 0.9.18 exemption. Fixes RUSTSEC-2026-0204: the fmt::Pointer impl for Atomic/Shared no longer dereferences the underlying raw pointer (UB when the pointer is invalid or null) — it prints the address directly (raw as *const ()), covering the invalid-ptr (#1276) and null-ptr (#1273) cases. Net -2 unsafe over the delta (3 removed, 1 added); the one added unsafe is Guard::defer_destroy re-emitted with a broadened bound (<T> -> <T: ?Sized + Pointable>) with an unchanged body (self.defer_unchecked(move || ptr.into_owned())), so no new unsafe operation. The new build.rs is benign: it emits rustc-check-cfg plus a crossbeam_sanitize_thread cfg derived from CARGO_CFG_SANITIZE (ThreadSanitizer detection migrated out of lib-level cfg); it reads one env var and does no fs/net/process/exec. No new runtime dependencies (crossbeam-utils pre-existing; rand is dev-only). No new ambient-capability surface. Publisher taiki-e (crossbeam maintainer, same publisher as 0.9.18). The change is strictly a soundness fix plus a benign cfg migration, so trust extends from the audited 0.9.18 base."
+
+[[audits.crossbeam-queue]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.12 -> 0.3.13"
+notes = "Adds push_mut/pop_mut on ArrayQueue and SegQueue plus Block::destroy_mut (upstream #1191): non-atomic fast paths gated on &mut self, so exclusive access soundly replaces atomics; new unsafe blocks (get_unchecked, UnsafeCell read/write, assume_init, Box::from_raw) carry exclusive-access reasoning and indices are masked to buffer bounds before get_unchecked. SegQueue::pop_mut correctly preserves the DESTROY-flag cooperative destruction path for blocks shared with prior concurrent readers. No changes to existing concurrent paths, no build.rs, no fs/net/process/env surface, no new features or dependencies (Cargo.toml section reordering and a dev-only Cargo.lock)."
+
+[[audits.crossbeam-utils]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.21 -> 0.8.22"
+notes = "AtomicCell::{as_ptr,into_inner} made const; into_inner now uses a repr(C)-union by-value transmute helper with a size assertion and safety comments explaining layout equivalence — semantically equivalent to the prior ManuallyDrop+read. CachePadded gains repr(C) (documented address guarantee). WaitGroup rewritten from Mutex<usize> to AtomicUsize plus a Mutex/Condvar handshake; missed-wakeup avoidance (notifiers take the lock between counter update and notify) is documented, and the ManuallyDrop+ptr::read in wait() is a standard destructure-without-Drop with a safety comment. no_atomic.rs adds armv4t/armv5te/thumbv4t/thumbv5te targets; build.rs unchanged; only new dependency is dev-only rustversion. No fs/net/process surface."
 
 [[audits.crypto-common]]
 who = "Robert Nio <robert_nio@intuit.com>"
@@ -109,11 +169,29 @@ criteria = "safe-to-deploy"
 delta = "0.1.6 -> 0.2.2"
 notes = "Delta audit (cargo vet diff 0.1.6 -> 0.2.2). Files: Cargo.toml/Cargo.toml.orig (version + metadata: autolib/autobins/resolver=2, switch generic-array -> hybrid_array dep), CHANGELOG/README/LICENSE-MIT (text), src/lib.rs, src/hazmat.rs, new src/generate.rs. Net unsafe blocks added: 0 (grep confirms the only 'unsafe' token added is a Clippy lint declaration 'undocumented_unsafe_blocks = warn'). New generate.rs is pure-safe key/IV generation over rand_core CryptoRng/TryCryptoRng traits (hybrid_array Array<ArraySize>), no FFI / I/O / process / network / ambient capability. The 0.2 line is the known RustCrypto API restructuring (generic-array -> hybrid_array); behavior of the trait surface is otherwise preserved. Same publisher (github:RustCrypto/traits) the repo already trusts for 'digest'."
 
+[[audits.displaydoc]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.6 -> 0.2.7"
+notes = "Delta is the syn 2.0 -> 3.0 dependency major bump with mechanical API adaptations in src/expand.rs (new attrs fields on PredicateType/TypePath, TraitBoundModifier -> TraitBoundModifiers + maybe field) and a then->then_some cleanup in src/attr.rs; MSRV raised 1.56 -> 1.71. syn remains the sole non-toolchain dependency (checksum-pinned in the lockfile). No unsafe, no build.rs, no fs/net/process/env access, no feature changes. Generated Display impls are unchanged in substance; remaining diff is changelog/README/doc text."
+
 [[audits.either]]
 who = "Robert Nio <robert_nio@intuit.com>"
 criteria = "safe-to-deploy"
 delta = "1.15.0 -> 1.16.0"
 notes = "Delta audit (cargo vet diff 1.15.0 -> 1.16.0). Files: Cargo.toml(.orig) version bump, .github/workflows/ci.yml + README.rst (non-shipping), src/lib.rs, src/iterator.rs, src/serde_untagged.rs, src/serde_untagged_optional.rs. The only two 'unsafe' lines changed are NOT new: the existing Pin::new_unchecked projections in as_pin_ref/as_pin_mut, merely renamed from the internal map_either! macro to map_both!; the documented SAFETY invariant and runtime behavior are unchanged. Remainder is added safe iterator/serde trait impls. No new FFI / I/O / process / network / ambient capability. Publisher cuviper (rayon/itertools maintainer)."
+
+[[audits.event-listener]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "5.4.1 -> 5.4.2"
+notes = "Removes the slab.rs fallback implementation and with it the concurrent-queue runtime dependency (net reduction of the dependency tree); intrusive.rs becomes the sole backend. Adds a spinlock module used only when neither std nor critical-section is enabled: AtomicBool CAS with Acquire/Release orderings, unsafe UnsafeCell access guarded by lock-held safety comments, and prominent docs warning the spinlock path is a last resort. Soundness fix: previously unbounded `unsafe impl Send/Sync for StackSlot` now require T: Send (upstream #163), strictly tightening the API. No build.rs, no fs/net/process/env surface; the large Cargo.lock diff is dev/bench-only churn. Remaining changes are doc gating and formatting."
+
+[[audits.fastrand]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.1 -> 2.5.0"
+notes = 'Source changes under src/ are doc-comment wording only ("ranges" -> "range"); no logic, no unsafe, no build.rs (build = false). The version bump exists to move the optional wasm-only getrandom dependency and dev-dependencies from 0.3.4 to 0.4 (rand 0.9 -> 0.10 for benches); no new dependencies otherwise. Bench harness rewritten to adapt wyhash to the rand 0.10 TryRng trait, dev-only. Lockfile churn reflects the getrandom/rand major bumps. No fs/net/process/env surface exists or was added.'
 
 [[audits.futures]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -181,17 +259,35 @@ criteria = "safe-to-deploy"
 version = "0.5.2"
 notes = "Reviewed v0.5.2 source. Transitive dep of num_cpus. Two files: errno.rs is pure i32 constants (EPERM, ENOENT, ...); lib.rs is #![no_std] FFI declarations for the Hermit unikernel syscall interface (sys_mmap, sys_getpagesize, sys_errno, thread scheduling primitives, ...) plus two unsafe wrapper fns for get/set_priority. No network I/O, no filesystem I/O, no std dependency. On non-Hermit targets the extern C symbols are never linked and the functions are inert — num_cpus only touches hermit-abi when target_os=hermit, which none of our shipping targets hit. Apache-2.0 OR MIT; author Stefan Lankes, Hermit OS project lead."
 
+[[audits.humantime]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.0 -> 2.4.0"
+notes = 'Sole source change is a new public `const fn Duration::new(StdDuration)` constructor in src/wrapper.rs; no unsafe, no I/O, no new dependencies, no build.rs. Cargo.toml now declares rust-version = "1.60". Remaining diff is CI workflow reformatting/action version bumps and dev-only lockfile churn. Formatting/parsing logic untouched.'
+
 [[audits.indicatif]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.18.4 -> 0.18.6"
 notes = "Delta audit (cargo vet diff 0.18.4 -> 0.18.6, 1547-line diff; src changes limited to draw_target.rs, format.rs, iter.rs, multi.rs, style.rs - rest is examples/tests/CI). All rendering/formatting logic: (1) draw_target.rs switches hidden-detection to console::is_dumb() (pairs with the console 0.16.4 bump) and adds CJK-aware wrapped_metrics (line-height + last-line-width accounting via AnsiCodeIterator + UnicodeWidthChar); (2) format.rs fixes HumanFloatCount negative-sign grouping ('-,100' bug) and precision-0 rounding, uses stable div_duration_f64; (3) iter.rs converts map-and-return closures to Result::inspect - behavior identical; (4) multi.rs replaces is_hidden()/width() forwarders with direct pub(crate) draw_target field access + big doc addition, adds Multi arm to is_stderr(); (5) style.rs moves segment/measure/width helpers verbatim and converts Template::from_str to the FromStr trait. Zero unsafe, zero fs/net/process/env additions. Publisher djc, same as 0.18.4."
 
+[[audits.ipnet]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "2.12.0 -> 2.12.1"
+notes = 'Bug fix in `next_ipv4_subnet`/`next_ipv6_subnet` (issue #70): the prefix-length computation is rewritten with plain u32/u128 arithmetic so Ipv4Subnets/Ipv6Subnets(0, MAX-1, 0) no longer includes the MAX address; regression tests added. Remainder is doc/error-message typo fixes ("less then" -> "less than"), html_root_url bump, and dev-dependency lockfile churn. No unsafe, no build.rs, no new dependencies, no I/O surface.'
+
 [[audits.itoa]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 version = "1.0.18"
 notes = "Full audit (488 LOC, no_std, zero deps). No fs/net/process/env capability; no build.rs. All 13 unsafe sites reviewed: digit-pair table reads are get_unchecked(pair*2+{0,1}) with pair<100 from divmod100 into a 200-byte ASCII table (in-bounds by construction); buffer writes are checked-index MaybeUninit writes covering exactly [offset, len); slice_buffer_to_str's from_utf8_unchecked is sound because only ASCII table bytes and b'0'+digit are ever written; Buffer::format's pointer cast goes from the largest buffer ([MaybeUninit<u8>; i128 MAX_STR_LEN]) to a smaller same-alignment array, and the unreachable_unchecked is an optimizer hint upheld because write() slices within the buffer. Publisher verified on crates.io: dtolnay."
+
+[[audits.jobserver]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.34 -> 0.1.35"
+notes = "Zero changes under src/ — the jobserver FFI/syscall implementation (pipe/fifo fds on Unix, named semaphore on Windows) is byte-identical between versions. The release only raises rust-version 1.63 -> 1.85, bumps dev-dependencies (nix 0.28 -> 0.31.3, Windows-only getrandom dep to 0.4), reworks CI to use distro GNU Make instead of a vendored compile-make action, and extends tests/client.rs to run each test under both --jobserver-style=fifo and =pipe (test-harness process spawning only). No new unsafe, no build.rs, no new runtime dependencies."
 
 [[audits.libmimalloc-sys]]
 who = "Robert Nio <robert_nio@intuit.com>"
@@ -210,6 +306,18 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.16 -> 0.1.17"
 notes = """Delta audit (cargo vet diff 0.1.16 -> 0.1.17). Cargo.toml(.orig): version bump + redox_syscall dep 0.7 -> 0.8. src/lib.rs: (a) cosmetic reorder of a libc MSG_* re-export list (no semantic change); (b) adds one Redox kernel FFI binding redox_relpathat_v0(dirfd, fd, dst_base, dst_len) -> RawResult plus the safe wrappers Fd::relpathat / call::relpathat, mirroring the existing redox_fpath_v1 binding exactly (Error::demux over an unsafe extern call using the caller-provided &mut [u8] buffer's ptr+len). The single new unsafe block is a like-for-like copy of the adjacent fpath binding. libredox is the Redox stable-ABI shim, reachable only via redox_users on target_os="redox"; the extern symbols are never linked on UFFS shipping targets (Windows/macOS). No network/FS-path/process/env additions. Publisher 4lDO2 (Redox maintainer)."""
+
+[[audits.libredox]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.17 -> 0.1.19"
+notes = """This is a Redox-OS syscall shim crate (unused on the Windows/macOS targets of this workspace). Delta adds two extern "C" declarations (`redox_sys_call_multiple_v0`, `redox_fcntl_v0`), a `Call` trait generalizing call_ro/call_wo/call_rw over a single fd or an fd slice (call_ro/call_wo now reject conflicting READ/WRITE flags with EINVAL), an `fcntl` wrapper plus `Fd::fcntl`, and `O_CLOEXEC`/`F_DUPFD_CLOEXEC` constants. New unsafe blocks are thin pass-throughs to the declared relibc ABI with pointers/lengths derived from the given slices; consistent with the crate's purpose. Optional redox_syscall dependency bumped 0.8 -> 0.9; no build.rs, no other dep changes."""
+
+[[audits.log]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.32 -> 0.4.33"
+notes = "Single functional change: `MaybeStaticStr`'s derived Eq/Ord/Hash (which compared the enum discriminant, making Static vs Borrowed keys with equal text unequal) replaced by manual impls that delegate to the underlying &str, fixing structured-logging Key comparison (upstream PR #732); matching unit tests added in src/kv/key.rs. No unsafe, no build.rs, no dependency or feature changes; rest is changelog, html_root_url bump, and dev lockfile churn (sval pinned back to 2.19)."
 
 [[audits.memchr]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -241,11 +349,23 @@ criteria = "safe-to-deploy"
 delta = "1.2.0 -> 1.2.1"
 notes = """Delta audit (cargo vet diff 1.2.0 -> 1.2.1). Portability + correctness patch: adds target_os="horizon" (Nintendo 3DS) cfg gating and a WASI p1/p2 waker path split across src/sys/* and src/poll.rs; src/sys/unix/selector/poll.rs introduces a per-platform PollFlagInt type alias (c_short vs c_int) with 0-valued fallbacks for POLLRDHUP/POLLPRI/POLLRDBAND/POLLWRBAND on platforms lacking them; and a poll-timeout rounding fix that rounds sub-millisecond Durations up via checked_add(Duration::from_nanos(999_999)) before as_millis(), clamped to libc::c_int::MAX. All changes are libc-constant/cfg plumbing over the existing epoll/poll/IOCP backends; no NEW unsafe logic, no new deps, no new process/network capability beyond mio's existing readiness-I/O purpose. Publisher Thomasdezeeuw (mio/tokio maintainer)."""
 
+[[audits.mio]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.1 -> 1.2.2"
+notes = 'Delta adds Solaris event-ports support (new `selector/event_ports.rs` and `waker/event_ports.rs`) and NuttX poll(2) support; existing platform code changes are confined to cfg-attribute reshuffling that moves solaris off the poll fallback and adds nuttx to existing target lists. New unsafe in the Solaris selector is limited to `OwnedFd::from_raw_fd(port_create())`, `set_len(nget)` after `port_getn` initialization, and `Send`/`Sync` impls for event types whose only raw-pointer field (`portev_user`) carries mio tokens; each carries an accurate safety comment and the syscall usage (port_create/port_getn/port_associate/port_send/poll/fcntl FD_CLOEXEC) is conventional. All new code is `target_os = "solaris"`/`"nuttx"` gated and unreachable on Windows/macOS/Linux builds. No new dependencies, features, build script, or fs/process/env surface.'
+
 [[audits.num-conv]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.1 -> 0.2.2"
 notes = "Delta audit (cargo vet diff 0.2.1 -> 0.2.2, 4 files +72/-8). Cargo.toml/Cargo.toml.orig: version bump only. README.md + src/lib.rs doc-comments: add note that num-conv is being uplifted into the standard library (rust-lang/rust#154330). src/lib.rs: introduces new 'Widen' trait + 'WidenTarget' + sealed 'WidenTargetSealed' as the going-forward names for the existing 'Extend'/'ExtendTarget'/'ExtendTargetSealed' trio. The old Extend trait is kept with #[deprecated(since='0.2.2', note='use Widen instead')] for backward compat; #[allow(deprecated)] internally so the existing impls still compile. The Widen implementation is bit-identical to Extend ('self as _' for size-preserving widening). impl_extend! macro renamed to impl_widen!, but it emits BOTH the new WidenTargetSealed/WidenTarget impls AND retains the deprecated ExtendTargetSealed/ExtendTarget impls so downstream code calling .extend() still works. No new unsafe (none exists in this crate), no new ambient capabilities, no I/O / FFI / process / network — pure trait rename-with-deprecation release prefacing the stdlib uplift. jhpratt is the time-rs maintainer; same publisher as the existing 0.2.1 we already trust transitively via time."
+
+[[audits.object]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.37.3 -> 0.39.1"
+notes = "Diff is ~8300 lines and matches the upstream changelog: relocation-handling refinements, new ELF/Mach-O constants, PE import-parsing hardening (errors on empty import names, handles names in other sections), and new Mach-O exports-trie/function-starts parsers. No new unsafe blocks; the removal of the `unaligned` feature redefines fixed-endian integer types as `[u8; N]` wrappers so the pre-existing `unsafe_impl_endian_pod!` impls are trivially sound, and `slice_from_all_bytes` now rejects zero-sized types instead of dividing by zero. build.rs is byte-identical (rustc version probe only); no new dependencies, only version bumps of hashbrown (0.15->0.17), indexmap (2.0->2.14), and wasmparser (0.236->0.247). No fs/net/process/env access added to library code; `std::fs` appears only in new integration tests reading checked-in test files. New parsing code uses bounds-checked `Bytes` reads throughout; one robustness observation: the new exports-trie iterator (`src/read/macho/exports_trie.rs`) follows uleb128 child offsets with no cycle detection, so a crafted trie can cause non-termination/unbounded allocation in that opt-in iterator (availability only, no memory unsafety). `read::SymbolMap` code was relocated from `read/mod.rs` to a new `symbol_map.rs` with the documented size-parameter API change. Nothing suspicious observed; consistent with safe-to-deploy."
 
 [[audits.pastey]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -409,17 +529,53 @@ criteria = "safe-to-deploy"
 delta = "0.53.0@git:1e9a63b95923291cd8849d70d96b8cec4e96da6a -> 0.54.4"
 notes = "Migration from git revision to crates.io SemVer."
 
+[[audits.portable-atomic]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.13.1 -> 1.14.0"
+notes = "Large but coherent delta matching the changelog: s390x 128-bit RMW register-pair fix (r0/r1 hi/lo swap applied consistently across load/swap/CDSG loops), AArch64 LSFE `ldfadd/ldfmaxnm/ldfminnm` operand-order fix, AArch64 CAS rewritten from branchy cmp/cset to ccmp/csel, redundant SeqCst fences dropped for LSE* per the Arm atomics ABI (LLVM commit references given), and pervasive mechanical changes (`ptr as usize` -> `.addr()`, per-instruction asm annotations). Seq-lock fallback is refactored into `seq_lock_common.rs` with SeqCst fencing hoisted into an RAII `ScFenceGuard` at the atomic-op layer, and `is_lock_free` consistency is now guaranteed via a CAS on the detection cache — reasoning is documented and sound. Runtime detection newly enabled by default on Apple (libc `sysctlbyname`, replacing the removed raw-syscall test path), illumos (getisax), and Windows (IsProcessorFeaturePresent PF_ARM_LSE2_AVAILABLE=62); all are documented OS APIs. build.rs changes are Arm/AVR target-feature parsing refinements plus a fix for custom target names; no new deps (a `portable-atomic-util` workspace member was actually removed, leaving only a pointer README), no new fs/net/process surface."
+
+[[audits.psm]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.31 -> 0.1.32"
+notes = 'No source, assembly, or build.rs changes at all. Delta is limited to the version bump, a new `rust-version = "1.88.0"` field, and dev-only Cargo.lock refreshes (cc, object, ar_archive_writer, shlex, memchr), which do not affect dependents resolving their own graphs. Nothing to review beyond metadata; safe-to-deploy trivially preserved.'
+
 [[audits.quick-xml]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.39.2 -> 0.39.4"
 notes = "Delta audit (cargo vet diff 0.39.2 -> 0.39.4, 3 files +35/-10). Cargo.toml/Cargo.toml.orig: version bump only. src/parser/dtd.rs is the only source change — three robustness fixes to the DTD internal-subset parser, all panic-prevention: (a) when 9+ bytes already accumulated in UndecidedMarkup state without matching one of <!--, <![CDATA[, <!ELEMENT, <!ATTLIST, <!ENTITY, <!NOTATION, fall through to 'skip until >' instead of staging more bytes than the 9-byte work buffer can hold (which would have panicked on the slice copy in UndecidedMarkup); (b) symmetric fix in the keyword-scan branch when the full 9-byte window has been consumed; (c) removes the 'markup.len() < 9 => None' bail-out and changes the no-> fallback from 'Some(markup.len())' to 'None' so the caller correctly waits for more input rather than treating partial markup as complete. Plus two comment-typo fixes. No new unsafe, no new I/O / FFI / process surfaces, no API additions, no feature-gate changes. Pure parser bounds-hardening."
 
+[[audits.quinn]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.11.9 -> 0.11.11"
+notes = "Full diff reviewed. Runtime changes are confined to async plumbing: EndpointRef/ConnectionRef reference counts move from mutex-guarded usize to AtomicUsize (Relaxed, plain inc/dec with last-owner check), drive_timer is reworked to check the clock before polling the tokio Sleep so elapsed deadlines are not masked by tokio's cooperative budget, and RecvStream::drop/stop now clean blocked_readers entries to avoid leaking wakers. The only new unsafe code is a raw-waker vtable in cfg(test)-gated src/tests.rs; production code adds no unsafe. build.rs is unchanged (trivial cfg_aliases only); no new runtime dependencies — rustls-pemfile dev-dep removed, a private __rustls-post-quantum-test feature and a feature-gated integration test are added, and the quinn-proto requirement is bumped to 0.11.15. Cargo.lock churn (asn1-rs, der-parser, etc.) affects only the workspace's dev/test resolution, not dependents. No new fs/net/process/env access; example server.rs switches PEM parsing from rustls-pemfile to rustls-pki-types helpers. MSRV raised to 1.85."
+
+[[audits.quinn-proto]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.11.14 -> 0.11.16"
+notes = "Full diff reviewed; crate remains sans-IO with no unsafe, no build script, and no fs/net/process/env access. The two substantive network-facing changes are defensive: Assembler::insert now returns TooManyChunks when more than 1024 buffered chunks survive defragmentation, closing the connection via TransportError on maliciously fragmented STREAM/CRYPTO frames (memory-exhaustion hardening, mirroring ngtcp2), and the server endpoint now silently drops Initial packets when CIDs are exhausted or max_incoming is reached, before deriving initial keys, instead of doing crypto work to send CONNECTION_REFUSED (CPU-exhaustion hardening; a regression test asserts the client times out). Loss detection and RTT math switch from panicking Instant subtraction to saturating_duration_since/abs_diff, and CUBIC fast convergence is corrected per RFC 9438 using the pre-reduction window. Dependency changes are the rand 0.9 -> 0.10 migration (RngExt/TryRng/SysRng API renames, getrandom 0.4 on wasm), rand_pcg promoted from dev to runtime dependency solely so BBR's pacing jitter uses Pcg32 (non-cryptographic use; CID/token/reset-token randomness still comes from StdRng seeded from the system RNG), plus fastbloom 0.14 -> 0.17 and rustls-platform-verifier 0.6 -> 0.7 version bumps. MSRV raised to 1.85."
+
 [[audits.rand]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.10.1 -> 0.10.2"
 notes = "Delta audit (cargo vet diff 0.10.1 -> 0.10.2, 596-line diff). Security-positive patch release: (1) distr/uniform_other.rs fixes rust-random/rand#1790 - UniformChar's serde Deserialize gains deser_sampler() range validation so a hostile serialized sampler can no longer drive char::from_u32_unchecked out of range; the sample path itself drops from_u32_unchecked for checked char::from_u32 + expect. (2) distr/slice.rs Choose::sample drops get_unchecked for checked get + expect (rust-random/rand#1791). Net unsafe count DECREASES by two blocks. (3) uniform_int.rs adds pub(crate) max() helper used by the new validation + tests. (4) seq/slice.rs partial_shuffle gains #[must_use] and a variable rename m->n; shuffle order semantics unchanged. Remainder is docs/typo churn. No new capability surface. Published by github:rust-random/rand trusted-publishing account."
+
+[[audits.ref-cast]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.25 -> 1.0.26"
+notes = "No functional source change. Delta is the version/MSRV bump (1.61 -> 1.71), a cosmetic let-else refactor in build.rs (same rustc minor-version probe, same cfg emission), doc `html_root_url` bump, CI workflow updates, and refreshed trybuild `.stderr` expectations for newer rustc diagnostics. Pinned `ref-cast-impl` bumped to =1.0.26 in lockstep. No new unsafe, deps, features, or I/O surface."
+
+[[audits.ref-cast-impl]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.25 -> 1.0.26"
+notes = "Zero changes to the proc-macro source itself; the delta is the version/MSRV bump (1.61 -> 1.71) and moving the `syn` dependency from `2.0.46` to `3` (source-compatible here since no code edits were needed). Cargo.lock updates are the corresponding syn 3.0.0/proc-macro2/quote refreshes. No build script, no unsafe, no I/O surface; build-time-only crate."
 
 [[audits.regex]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -463,6 +619,12 @@ criteria = "safe-to-deploy"
 delta = "2.1.0 -> 2.2.0"
 notes = "Reviewed full 2.1.0->2.2.0 diff. 'unsafe' count 0 -> 0; no runtime dependency or feature changes (only a version bump + a new [[test]] registration). Changes are the documented conformance/robustness work: reject auth servers lacking S256 PKCE + metadata-discovery host allowlisting/SSRF hardening in transport/auth.rs (client/http feature this project does not enable); don't respond to cancelled requests (service.rs); TTL seconds->milliseconds per MCP spec with a deprecated alias (task_manager.rs); fail orphaned streamable-HTTP responses on session reinit (streamable_http_client.rs); mime 'text'->'text/plain' (model). Only URLs in the diff are example.com in tests. No suspicious endpoints or exfiltration."
 
+[[audits.rmcp]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.0 -> 3.1.0"
+notes = "Delta audit (cargo vet diff 2.2.0 -> 3.1.0), ~34k-line major-version diff; all changed src/ files were enumerated and reviewed (transport/auth.rs, service/client.rs and new service/client/cache.rs, transport/streamable_http_client.rs, task_manager.rs, streamable_http_server/tower.rs and session files, service.rs, service/server.rs, client_side_sse.rs, reqwest/unix-socket/child-process/async_rw transports, error.rs, lib.rs, handlers, and the new model/mrtr.rs, model/request_state.rs, transport/common/mcp_headers.rs read in full); model-type files (model.rs, meta.rs, serde_impl.rs, task.rs, capabilities.rs, etc.) were reviewed at item level and are serde/schema type changes only. No unsafe anywhere in the diff, no build.rs, no new URLs or domains outside example.com/localhost test fixtures and spec doc links, and no new filesystem/process/env access; child_process.rs only deletes a deprecated API. New optional deps hmac 0.13 and sha2 0.11 back the new request-state feature, an HMAC-SHA256 integrity codec for SEP-2322 requestState with constant-time verification and a redacted-key Debug impl; base64 bumps to 0.23 and jsonwebtoken to 11. Nature of release: MCP 2026-07-28 protocol work — server/discover lifecycle, SEP-2549 client response cache, SEP-2663 task manager, SEP-2322 MRTR, SEP-2243 standard headers, SEP-2260 request-association enforcement, subscription streams. Security posture improves: OAuth discovery gains RFC 8414 issuer validation, stricter RFC 8707 resource matching, refresh-rejection classification, issuer-change credential invalidation, and removal of the unauthenticated POST probe; DoS hardening adds a 16 MiB SSE event cap and a 4 MiB server request-body cap. Capability surface (HTTP client/server to caller-configured endpoints, stdio child-process transport, Unix sockets) is unchanged in kind and honestly consistent with an MCP protocol SDK; no malicious or obfuscated code observed."
+
 [[audits.rmcp-macros]]
 who = "Robert Nio <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -486,6 +648,12 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "2.1.0 -> 2.2.0"
 notes = "Reviewed full 2.1.0->2.2.0 diff. Pure version bump: the only change is the version field in Cargo.toml (cargo-vet reports 1 file, 1 insertion, 1 deletion). No source, dependency, or capability changes."
+
+[[audits.rmcp-macros]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.0 -> 3.1.0"
+notes = "Delta audit (cargo vet diff 2.2.0 -> 3.1.0), full diff reviewed (~630 lines). Source changes are removal of the task_handler proc-macro (src/task_handler.rs deleted, references removed from lib.rs and tool_handler.rs), removal of the ToolExecution/task_support attribute machinery from tool.rs, renamed generated result types (GetPromptResult -> GetPromptResponse, CallToolResult -> CallToolResponse), new result_type/ttl_ms/cache_scope fields in generated ListTools/ListPrompts results, and mechanical let-chains refactors in common.rs, prompt.rs, and tool.rs (skimmed as purely mechanical). No unsafe code, no build.rs, no filesystem/network/process/env access; codegen emits only rmcp model-type constructors as before. Cargo.toml changes are the version bump and rust-version = 1.88; no new dependencies (Cargo.lock churn is routine version bumps of proc-macro2/quote/syn/serde). Generated-code diff is honestly consistent with the rmcp 3.x protocol-model changes; nothing obfuscated or suspicious."
 
 [[audits.rustc-hash]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -511,11 +679,23 @@ Delta audit (Apr 2026, v0.5.71):
   No runtime behavior change.
 - No unsafe additions, no API changes, no new ambient capabilities."""
 
+[[audits.rustls]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.23.40 -> 0.23.43"
+notes = "No new or changed unsafe code; no new dependencies or features in Cargo.toml (Cargo.lock gains dev-only entries such as defmt and jiff-core that do not affect dependents). Main feature is RFC 9149 ticket_request support: new public ClientConfig::send_ticket_request (default None) and ServerConfig::max_tls13_tickets (default 0), both off by default so behavior is unchanged unless opted in; wire handling is two u8 counts each way. Handshake-critical hardening: the client now rejects a ServerHello cipher suite unless it was actually offered in its own ClientHello (tracked via offered_cipher_suites) and is usable for the current protocol, and supports_version/find_cipher_suite now take a Protocol parameter so QUIC connections only accept TLS 1.3 on both client and server (server-side error-ordering for QUIC adjusted accordingly). Panic-avoidance fixes: aws-lc-rs ticketer decrypt uses checked_sub so truncated ciphertexts return None instead of underflowing, PSK binder length computations use saturating_sub, and session-ticket age uses a checked u32 conversion. Remaining changes are cfg(read_buf) nightly BorrowedCursor<'_, u8> signature updates, a const fn annotation, and cosmetic cleanups; certificate verification code is untouched. Nothing suspicious observed; capability surface (I/O, network, process, env) is unchanged."
+
 [[audits.rustls-native-certs]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.3 -> 0.8.4"
 notes = "Delta audit (cargo vet diff 0.8.3 -> 0.8.4). Most of the diff is CI/workflow/example/test files (.github/*, examples/*, tests/*, integration-tests/*). The only library change in src/lib.rs: a rustls_native_certs_docsrs doc_cfg feature attribute, and a refinement of the SSL_CERT_DIR-style directory handling to use env::split_paths(&dirs).filter(|p| !p.as_os_str().is_empty()) so multiple (OS-separator-delimited) cert directories are parsed and empty entries skipped. Reading SSL_CERT_FILE/SSL_CERT_DIR env + OS trust stores is rustls-native-certs's existing and sole purpose — no NEW capability class is introduced. No new unsafe, no new deps. Publisher (rustls project, ctz/djc)."
+
+[[audits.rustls-pki-types]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.14.1 -> 1.15.1"
+notes = "Small delta with no unsafe code and no new runtime dependencies; only criterion is added as a dev-dependency plus a dns_name bench target (the bench file is not even included in the published package). New public API is the const constructor FipsStatus::certified, a trivial enum builder. The TLS-relevant change is a rewrite of the const DNS-name validate function in src/server_name.rs from a per-character state machine to a per-label loop; the two implementations were compared case by case and they enforce the same rules (253-byte total max, 1-63 byte labels, alphanumeric/underscore with interior hyphens only, no empty labels, all-numeric final label rejected, trailing dot accepted), with empty input now rejected by an explicit up-front check rather than the old final-state check — no loosening observed. A matching unit test for FipsStatus Debug formatting is added. Nothing suspicious observed; capability surface is unchanged."
 
 [[audits.ryu]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -529,6 +709,18 @@ criteria = "safe-to-deploy"
 version = "1.0.6"
 notes = "Full audit (908 LOC). Capability is std::fs File opens by design (the crate's purpose: file-identity comparison via dev/ino on Unix, volume/index via handle info on Windows) — no net/process/env, no build.rs. Unsafe reviewed: File::from_raw_fd(0/1/2) for the std streams is paired with an is_std flag whose Drop impl leaks the descriptor via into_raw_fd, so std fds are never closed (no double-close, no fd hijack); Windows side mirrors this via winapi-util's non-owning HandleRef. Publisher verified on crates.io: BurntSushi."
 
+[[audits.schemars]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.1 -> 1.2.2"
+notes = 'Source delta is a single refactor in src/_private/mod.rs converting a nested if into a match guard when adding "null" to an instance type; behavior is equivalent. Cargo.toml changes pin schemars_derive to =1.2.2 and bump dev-dependencies (garde 0.23, validator 0.21). The large Cargo.lock churn is dev/CI-only and does not affect downstream builds. No unsafe, no build.rs, no fs/net/process/env/FFI surface.'
+
+[[audits.schemars_derive]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.1 -> 1.2.2"
+notes = """Mechanical migration from syn 2 to syn 3 and serde_derive_internals 0.30: Container::from_ast gains the new private-ident argument (passed as a dummy "__dummy" ident, unused for schemars' purposes), Name is replaced by MultiName, and syn AST adjustments (BareFn -> FnPtr, TraitBoundModifiers, new attrs fields) are applied. Purely compile-time proc-macro code; generated token output is unchanged apart from these adaptations. No unsafe, no build.rs, no I/O."""
+
 [[audits.scopeguard]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -541,11 +733,29 @@ criteria = "safe-to-deploy"
 version = "1.0.28"
 notes = "Full audit (2117 LOC, no_std-capable). No capability surface; no build.rs. The unsafe concentration is identifier.rs's tagged-pointer small-string: 2-byte-aligned heap allocations guarantee a free LSB, the ASCII-only content invariant guarantees a free MSB for the tag, length is a varint header on heap reprs and trailing-zero-count inline; every unsafe block carries a precise SAFETY comment and the invariants are documented exhaustively at the top of the module. Verified parse.rs validates the ASCII charset ([0-9A-Za-z-.]) before every new_unchecked call; Clone re-derives layout from its own allocation's varint header; empty-string niche (-1) analysis is coherent. Publisher verified on crates.io: dtolnay."
 
+[[audits.serde_derive_internals]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.29.1 -> 0.30.0"
+notes = "Upstream serde refactor mirrored into the standalone crate: syn 2 -> 3, edition 2015 -> 2021, MSRV 1.71. Name/MultiName moved to a new src/name.rs that carries spans alongside string values (all pure data-structure code); flatten tracking moved off Container attrs; a `private` Ident parameter threads the serde `__private` module name through borrow_cow_str/borrow_cow_bytes path construction; remaining changes are let-else/mem::take modernizations and syn 3 AST renames (BareFn -> FnPtr, PreciseCapture arm). No unsafe, no build.rs (still excluded), no fs/net/process/env surface."
+
 [[audits.serde_path_to_error]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 version = "0.1.20"
 notes = "Full audit (2930 LOC). Zero unsafe. Zero capability surface (no fs/net/process/env, no build.rs). Pure serde adapter: Deserializer/Serializer wrappers that mechanically delegate every trait method while tracking a path breadcrumb; no logic that could affect data integrity beyond error decoration. Publisher verified on crates.io: dtolnay."
+
+[[audits.simd-adler32]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.9 -> 0.3.10"
+notes = 'NEON get_imp cfg is tightened to `all(target_feature = "neon", any(target_arch = "aarch64", feature = "nightly"))`, disabling the intrinsics path on 32-bit ARM stable where the intrinsics are nightly-only; a matching `stdarch_arm_neon_intrinsics` feature gate is added for nightly ARM. No unsafe bodies changed — the SIMD kernels themselves are untouched. Test-only reference implementation switches from unmaintained `adler` to `adler2` (dev-dependency); remaining delta is CI workflows and README benchmarks. No build.rs, no I/O surface.'
+
+[[audits.simd-json]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.17.3"
+notes = "Unsafe/SIMD changes are performance and correctness work: NEON stage-1 rewritten to deinterleaved vld4q_u8 loads with an sri/shrn movemask (same memory footprint, well-commented); AVX2 paths now require and runtime-detect pclmulqdq to match compute_quote_mask's target_feature; the atomic-fn-pointer/transmute self-patching dispatch for parse_str is replaced with per-document resolution; SWAR digit/atom parsing gains u64::from_le for big-endian soundness; AlignedBuf::with_capacity(0) now uses NonNull::dangling and skips dealloc instead of allocating a zero-size layout; a chunk-boundary float corruption (issue #455) and negative-integer digit-count bug are fixed with regression tests. Optional once_cell dependency dropped in favor of std OnceLock; new lockfile entries (alloca, page_size) come from criterion 0.8 and are dev-only. One hygiene wart: a stray `dbg!();` was left on an error path in src/numberparse/approx.rs (non-default approx parsing), writing a line to stderr on that parse error — cosmetic, not a security concern. No build.rs, no fs/net/process/env surface changes."
 
 [[audits.siphasher]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -553,17 +763,53 @@ criteria = "safe-to-deploy"
 delta = "1.0.2 -> 1.0.3"
 notes = "Delta audit (cargo vet diff 1.0.2 -> 1.0.3, 5 files +105/-36). .gitignore: adds .swival editor tmpdir (no runtime effect). Cargo.toml/Cargo.toml.orig: version bump only. src/sip.rs + src/sip128.rs: single-shot fast-path optimization for the existing SipHasher{,13,24}::hash() and ::hash() (Hash128) public APIs. The old impls cloned the Hasher state, called .write(bytes), then .finish() — going through the buffered short_write codepath byte-by-byte even though the full message was available up-front. The new impls add private Hasher<S>::hash(msg) / hash128(msg) fast paths that, when ntail==0 (no buffered tail bytes from a prior write), XOR-fold msg's 8-byte chunks directly into the SipHash state in a tight loop, then finalize with the standard tail handling. When ntail!=0 the impl falls back to the original clone-write-finish path so correctness is preserved for partially-streamed hashers. The fast path's two unsafe blocks (load_int_le! and u8to64_le) were already present in the pre-existing .write() path and are reused unchanged: the 'while i < len - left' loop with 'left = len & 0x7' guarantees i + 8 <= len, so load_int_le! is in bounds; u8to64_le's 3rd arg 'left' is bounded to 0..8 by construction. Also adds Hasher::write_u16 (was missing — previously fell through to the default Hasher trait impl, which is byte-by-byte). write_u16 mirrors the existing write_u32/_u64/_usize pattern: short_write(i, i.to_le() as u64). finish()/finish128() are refactored to delegate to static finish{,128}_with_state(state,length,tail) helpers — pure structural extraction, output bytes unchanged for any given (state,length,tail). Net result: speed-up for single-shot byte-array hashing; no public-API additions beyond write_u16 (which is part of the std::hash::Hasher trait, not a new surface); no new unsafe operations beyond what already existed; no FFI / FS / network / process — pure crypto primitive, used here only via phf_shared for compile-time string hashing in transitive deps. Author jedisct1 (Frank Denis) is a well-known cryptography maintainer."
 
+[[audits.snap]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.1.1 -> 1.1.2"
+notes = "Only source change is in src/decompress.rs: the literal-length decode near end-of-input now requires only the 1-4 length bytes selected by the tag (previously demanded 4), with a safe byte-wise LE fallback preceded by an explicit bounds check, and the header varint is capped at 5 bytes. The decoded length still flows through the pre-existing src/dst bounds check before the unsafe copy_nonoverlapping, so no new unsafe and no weakening of existing safety checks. build.rs is byte-identical between versions (writes lookup tables to OUT_DIR only); the Cargo.toml delta is cargo's publish-time manifest normalization (explicit build key, autolib/autobins flags, explicit example targets). No dependency, feature, fs/net/process, or env changes; remainder is CI-workflow and lockfile churn."
+
 [[audits.socket2]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.6.3 -> 0.6.4"
 notes = """Delta audit (cargo vet diff 0.6.3 -> 0.6.4). The overwhelming majority of changes add target_os="horizon" (Nintendo 3DS) to existing cfg exclusion lists and refine QNX gating to all(target_os="nto", any(target_env="nto70","nto71")). Two genuinely new items: `unsafe impl Send for MsgHdr<'_,'_,'_>` and `unsafe impl Send for MsgHdrMut<'_,'_,'_>` — these wrapper types hold a platform msghdr plus PhantomData lifetime markers over caller-borrowed buffers; Send is sound because the struct is plain data referencing borrow-checked buffers (no interior !Send handles), matching the established pattern for the sibling SockAddr/iovec wrappers. Also type-correctness fixes: getsockopt::<Bool> (was c_int) for IPV6_V6ONLY, and `!= 0` instead of `!= false as Bool`. No new extern symbols, no new process/network capability beyond socket2's existing socket-syscall purpose. Publisher Thomasdezeeuw (socket2/tokio maintainer)."""
 
+[[audits.socket2]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.4 -> 0.6.5"
+notes = """Entirely cfg-attribute churn adding target_os = "nuttx" and "emscripten" support and enabling tclass_v6/set_tclass_v6 on illumos while dropping illumos from IP_TOS gates. The only non-cfg code additions are a `type IovLen = libc::c_ulong` alias for nuttx and re-gated libc constant imports; no unsafe blocks were added or modified, and no new syscalls beyond the existing socket-option surface reach previously supported targets. No build.rs, no dependency or feature changes; lockfile updates only touch the crate's own version entry."""
+
+[[audits.sse-stream]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.3 -> 0.2.5"
+notes = "Source delta is a typo-fix rename of `SseStream::from_byte_stream` to `from_bytes_stream` with a deprecated forwarding alias, plus a test updated to match. Remaining changes are metadata: SPDX license expression normalization, LICENSE-MIT/LICENSE-APACHE files added, docs.rs URL fix, and extensive Cargo.lock churn confined to dev-dependencies (axum/reqwest/tokio test stack). No unsafe anywhere in the delta, no build.rs, and no changes to the crate's published dependencies or features."
+
+[[audits.stacker]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.24 -> 0.1.25"
+notes = """build.rs drops a redundant trailing `else { return }`; it still only compiles src/arch/windows.c via cc on Windows, with identical inputs. src/lib.rs adds target_os = "motor" to the existing cfg pair so that target uses the alloc-based stack-restore guard instead of the mmap-based one — module-selection only, no new or modified unsafe code and no change to the psm stack-switching FFI on existing targets. A check-cfg lint declaration for the "motor" value is added to Cargo.toml. No dependency or feature changes in the manifest; Cargo.lock bumps (psm 0.1.32, cc, object) affect only the crate's own dev builds, and CI-workflow edits are inert."""
+
+[[audits.syn]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.117 -> 2.0.119"
+notes = "Full diff of packaged sources reviewed. Changes are an internal refactor replacing ParseBuffer forks with Cursor in verbatim::between and its call sites (data.rs, expr.rs, generics.rs, item.rs, pat.rs, path.rs, stmt.rs, ty.rs), two new entries in the scan_expr state tables (`try` blocks, `const move` closures), parsing of `builtin #` in type position as Type::Verbatim, a Lit::Bool match-guard simplification, attribute-preservation fix for verbatim statement expressions, and added renamed_and_removed_lints to existing allow attributes in token.rs. No unsafe code added or modified; the crate retains deny(unsafe_op_in_unsafe_fn) and is no_std. No filesystem, network, process, environment, or FFI access anywhere in the shipped library; there is no build.rs, and Cargo.toml dependencies and features are unchanged apart from the version bump. Remaining churn is the dev-only Cargo.lock (test-suite dependency bumps) and test files (tests/repo/mod.rs gains issue-reference comments and edge-case lists), which do not ship into dependents. Nothing suspicious observed."
+
 [[audits.syn]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "2.0.117 -> 3.0.2"
 notes = "Reviewed diff directly (54 files, 4314/2353 lines) despite the major version bump, rather than blanket publisher-trust, given syn's foundational role (transitively used by serde_derive, thiserror-impl, clap_derive). Grepped the full diff for unsafe/transmute/fs/net/process/exec: zero fs/net/process/exec capability anywhere (syn has none, by design -- it's a pure token-stream/AST parser). The overwhelming majority of 'unsafe' hits are syn's own AST types for parsing the 'unsafe' keyword in target source (e.g. Signature::unsafety, ItemForeignMod safety qualifiers for the new unsafe-extern-block support) -- not unsafe code in syn itself. The one genuine new unsafe block (buffer.rs Cursor::peek_punct calling self.bump_ignore_group()) reuses an existing, already-audited internal TokenBuffer-cursor primitive already present in 2.0.117, applied to a new multi-char-punctuation-token peek helper; same established safety invariant, no new risk category. Net: a large but non-security-relevant diff, consistent with syn's frequent major-version cadence for MSRV/edition-support reasons rather than behavior changes to its stable public API."
+
+[[audits.syn]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "3.0.2 -> 3.0.3"
+notes = 'Full diff of packaged sources reviewed; the delta is documentation-only. A new "Compatibility notes" section is added to the lib.rs crate docs (covering Modifiers structs, Verbatim variants, and non-exhaustive enums), and the Verbatim variants in expr.rs, generics.rs, item.rs, pat.rs, and ty.rs gain doc warnings linking to it while the old inline exhaustiveness-idiom comments are removed. No executable code changes at all: no unsafe, no filesystem/network/process/env/FFI surface, no build.rs, and Cargo.toml dependencies and features unchanged apart from the version bump. Remaining churn is the dev-only Cargo.lock (roughly 31 changed lines of test-suite dependency bumps) and tests/common/eq.rs, neither of which ships into dependents. Nothing suspicious observed.'
 
 [[audits.thiserror]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -589,11 +835,47 @@ criteria = "safe-to-deploy"
 delta = "1.0.69 -> 2.0.18"
 notes = "Delta audit (748 added lines). Derive-macro evolution for thiserror 2.x (no_std support, Display/Error emission reorganisation). Zero unsafe, zero fs/net/process/env in the added lines; remains a pure deterministic token transformation. Publisher continuity verified on crates.io: dtolnay."
 
+[[audits.time]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.47 -> 0.3.55"
+notes = "Large upstream refactor (~40k diff lines): every changed src/ file was enumerated and reviewed, with heavy mechanical rename churn (Duration->SignedDuration, PrimitiveDateTime->PlainDateTime, convert->unit, num-conv extend->widen) skimmed rather than read line-by-line. No build.rs exists in either version; manifest changes remove the itoa dependency (replaced by an internal num_fmt module), add optional rand 0.10 support, and bump pinned time-core/time-macros — no new capability-bearing dependencies. Substantial new unsafe was reviewed in detail: num_fmt.rs (stack-buffer ASCII digit formatting via lookup tables, from_utf8_unchecked/ptr::copy_nonoverlapping), ranged-integer new_unchecked calls throughout formatting/parsing, bounded Weekday transmutes, a lifetime-only transmute in format_description_v3.rs, and codepoint-boundary from_utf8_unchecked in the merged lexer_ast.rs; all carry accurate safety comments and the invariants check out locally. The OS/FFI surface (sys/local_offset_at windows and wasm_js, js_sys interop) saw only mechanical renames plus a trivial new js_sys Date<->Timestamp conversion; grep over all added lines found no new env, process, fs, network, extern, or macro-expansion constructs and no suspicious literals. Behavior changes are confined to date/time arithmetic, formatting, parsing, and serde plumbing consistent with the published changelog."
+
+[[audits.tinyvec]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.11.0 -> 1.12.0"
+notes = "Adds two new optional, default-off features: bin-proto (BitEncode/BitDecode impls for ArrayVec/TinyVec) and schemars (JsonSchema impls); neither dependency is pulled unless a consumer opts in. Also lands the 1.11.1 hardening: a new `cautious_capacity` helper caps eager preallocation from untrusted length prefixes at 4096 bytes in the borsh, bin-proto, and serde deserializers, preventing allocation-abort DoS from hostile input, with a regression test included. All new code is safe Rust with bounded decode loops (capacity-checked push / try_push); no unsafe, no build.rs, and remaining churn is doc-test type annotations and dev-dependency updates (criterion 0.8)."
+
 [[audits.tokio]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.52.2 -> 1.52.3"
 notes = "Delta audit reviewed via cargo vet diff. Replaces the silent exemption bump from PR #166 (which was a supply-chain #[allow]). Changes scoped to src/sync/mpsc/* and src/sync/rwlock.rs, implementing four documented upstream bug-fix PRs per tokio 1.52.3 release notes (May 2026): tokio#8062 fix mpsc len() underflow; tokio#8074 return TryRecvError::Empty from try_recv() when mpsc closed with outstanding permits; tokio#8075 notify receivers in mpsc OwnedPermit::release() by reusing non-owned Permit Drop impl; tokio#8076 reject RwLock::new max_readers==0 (prevents div-by-zero in semaphore fast path). Companion tests in tests/sync_mpsc.rs + tests/sync_rwlock.rs. No feature additions, no new unsafe, no public API signature changes."
+
+[[audits.tokio-macros]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "2.7.0 -> 2.7.2"
+notes = "Delta upgrades the syn dependency from 2.x to 3.0 with a single source adaptation in src/entry.rs: `args.inputs.iter().any(contains_impl_trait)` becomes `.any(|arg| contains_impl_trait(&arg.ty))` to match syn 3's typed parenthesized-argument API; behavior of the impl-Trait detection is unchanged. The only other changes are rustdoc text clarifying the `#[tokio::main]` expansion, CHANGELOG, and Cargo.lock/manifest version churn. No unsafe code, no build.rs, no fs/net/process/env access; proc-macro attack surface is unchanged."
+
+[[audits.tokio-stream]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.18 -> 0.1.19"
+notes = "Feature work only: `FusedStream` impls for many adapters, `FromStream` impls for std collections (collect.rs), a new `JoinSetStream` wrapper (src/wrappers/task.rs, thin safe wrapper over `JoinSet::poll_join_next`), `Peekable::size_hint`, and overflow-hardening of `StreamMap::size_hint` via saturating/checked adds plus a `next_many` limit fix. A new `rt` feature (enabled in `full`) turns on `tokio/rt` for cooperative budgeting in `iter`/`empty`/`once`; minimum tokio bumped to 1.38.0. Entire diff is safe Rust — no unsafe, no build.rs, no fs/net/process/env surface; remaining churn is tests and dev-dependency Cargo.lock updates."
+
+[[audits.tokio-util]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.18 -> 0.7.19"
+notes = "Three new/changed unsafe sites, all reviewed and sound: src/util/memchr.rs adds an optional unix-only `libc::memchr` FFI call for the `codec` feature (new optional `libc` dependency, correct safety comments, falls back to safe iterator search elsewhere); src/io/write_all_vectored.rs contains a lifetime-only `transmute` copied from std's `IoSlice::advance_slices` with an appropriate safety comment; `AbortOnDrop::detach` uses `ManuallyDrop` + `ptr::read`, a standard sound pattern. Behavioral fixes (Framed `is_readable` derived from buffer contents rather than capacity, DelayQueue waker on reset-to-past, JoinQueue `try_join_next` no longer clobbering the stored waker) match their tests and touch no I/O surface beyond existing tokio APIs. No build.rs; large Cargo.lock churn is dev-dependency updates only (tempfile/getrandom/wasi tooling)."
+
+[[audits.toml_parser]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.1.2+spec-1.1.0 -> 1.1.3+spec-1.1.0"
+notes = "Single source change in src/lexer/mod.rs `into_vec`: the pre-allocation capacity heuristic changes from `min(stream.len(), usize::MAX / size_of::<Token>())` to `stream.len().div_ceil(4)`, a pure allocation-sizing tweak with no correctness impact since the Vec grows as needed. Remaining diff is manifest include-path normalization, one added clippy allow, version bump, and dev-dependency Cargo.lock churn (snapbox/similar updates). No unsafe, no build.rs (`build = false`), no new runtime dependencies, no fs/net/process/env surface."
 
 [[audits.typenum]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -637,6 +919,12 @@ criteria = "safe-to-deploy"
 delta = "1.23.5 -> 1.24.0"
 notes = "Reviewed diff (5 files, 352/32 lines): internal string-encoding refactor to write into MaybeUninit buffers (perf, avoids pre-zeroing stack buffers) instead of already-initialized &mut [u8]. Every new unsafe block carries a safety comment and is sound: ptr::copy_nonoverlapping with matching src/dst lengths, ASCII-only writes before from_utf8_unchecked, and a layout-compatible MaybeUninit<u8>/u8 reinterpret cast. No capability changes."
 
+[[audits.value-trait]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.12.1 -> 0.12.2"
+notes = "Main change is in src/generator.rs: the SSE string writer is renamed sse4.2 -> sse2 (it only ever used SSE2 intrinsics; runtime detection now checks sse2), existing intrinsics bodies are wrapped in explicit `unsafe {}` blocks per edition-2024 style with no logic change, and a real bug is fixed where the scalar fallback `write_string_rust` failed to advance the input slice, which could double-write escaped content; a regression test covers it. Remaining changes are lifetime elaborations on iterator trait methods, `#[derive(Default)]` replacing manual impls, removed redundant `#[must_use]`, and CI workflow reshuffling. No new FFI, no build.rs, no fs/net/process/env surface, dev-only Cargo.lock churn."
+
 [[audits.which]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -661,6 +949,12 @@ criteria = "safe-to-deploy"
 version = "0.1.11"
 notes = "Full audit (1015 LOC, Windows-only FFI wrapper). Capability: Win32 console/file/sysinfo/registry-adjacent calls only — no net/process, one fs::OpenOptions for CONOUT$ console handles; no build.rs. All 24 unsafe sites reviewed: each is a documented Win32 call with correctly-sized out-params (mem::zeroed C structs passed by &mut), return codes mapped to io::Error::last_os_error, and the two-call GetComputerNameExW size-probe pattern implemented correctly (null probe for the length, exact Vec<u16>, post-call length re-check). HandleRef is a non-owning wrapper so std handles are never closed. Publisher verified on crates.io: BurntSushi."
 
+[[audits.xxhash-rust]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.15 -> 0.8.18"
+notes = """Adds a compile-time-gated AVX-512 path (`target_feature = "avx512f"`) for xxh3 accumulate/scramble using `_mm512_*` intrinsics in unsafe blocks; the code mirrors the upstream xxHash C reference (including `_mm512_ternarylogic_epi32` xor3), operates on a newly 64-byte-aligned `Acc`, and uses unaligned loads for input/secret, and the crate's existing C-parity test suite covers correctness. Also adds a `SecretInput` length-validation wrapper plus explicit `assert!(secret.len() >= SECRET_SIZE_MIN)` in `xxh3_64/128_with_secret` (hardening), moves `const_custom_default_secret` to xxh3_common with a re-export, and fixes `Xxh3Builder` so seed and secret are order-independent (`with_seed` now derives the secret when none is given — a behavior change for builder users who set only a seed, matching `Xxh3::with_seed`). No build.rs, no new dependencies (dev-only getrandom 0.2 -> 0.4), no fs/net/process/env surface."""
+
 [[audits.yoke]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -673,11 +967,23 @@ criteria = "safe-to-deploy"
 delta = "0.8.48 -> 0.8.50"
 notes = "Delta audit (cargo vet diff 0.8.48 -> 0.8.50). The bulk of the diff is committed codegen-snapshot fixtures under benches/*.x86-64 and *.mca (machine-code-analyzer output) reflecting a multiply-overflow-check optimization — test fixtures, not shipped code. Library changes (src/): (1) centralizes the scattered `isize::MAX as usize` allocation bound into a new pub(crate) const DstLayout::MAX_SIZE and a new is_valid_metadata/maximum_trailing_slice_len helper, used in layout.rs/util/mod.rs and Kani proof harnesses; (2) replaces a checked Layout::from_size_align + manual saturating max_alloc check with `unsafe { Layout::from_size_align_unchecked(size, align) }` guarded by an explicit `if !T::is_valid_metadata(meta) { return Err(AllocError) }` precondition — the new SAFETY comment correctly establishes align is a non-zero power of two (KnownLayout invariant) and size <= isize::MAX (the is_valid_metadata gate); (3) widens many pointer-internal items from pub(crate) to pub behind #[cfg_attr(not(zerocopy_unstable_ptr), doc(hidden))] / allow(unreachable_pub) — the affected `unsafe fn`s (with_meta, split_at_unchecked, slice_unchecked) and `unsafe trait TryWithError` already existed with identical bodies; this is visibility-only, no new unsafe LOGIC; (4) adds PointerMetadata: + Ord, a slice Ptr is_empty()/len(), iter() now takes self by value with strengthened disjoint-aliasing safety comments and a new test (test_iter_exclusive_yields_disjoint_ptrs). No new extern/process/network/fs capability. Publisher joshlf (Google, zerocopy maintainer; crate is Kani-proof-backed)."
 
+[[audits.zerocopy]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.50 -> 0.8.55"
+notes = 'Full diff reviewed. Most churn is a monorepo restructuring (path_in_vcs now "zerocopy", CI script and doc-link path updates, SPDX headers on every source file) plus test .stderr regeneration. build.rs changes are limited to two new `cargo:rustc-check-cfg` declarations (`zerocopy_unstable_linux`, `no_fp_fmt_parse`); no build-time execution changes. Library changes: Debug/Display impls on float byteorder wrappers gated behind the Linux-kernel `no_fp_fmt_parse` cfg (the off path deliberately panics with a documented message), the `Order` enum made documented public API, `#[inline]` attributes on a few const fns, a new safe blanket `Identity` marker trait in macro_util used by the derive for hygiene verification, and a `most_traits` re-export gated behind the off-by-default `zerocopy_unstable_linux` cfg. No new or modified `unsafe` blocks or impls (added "unsafe" lines in the diff are all inside test .stderr expectation files reflecting line-number shifts). No dependency changes beyond the lockstep `zerocopy-derive =0.8.55` pin; no fs/net/process/env access introduced.'
+
 [[audits.zerocopy-derive]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.48 -> 0.8.50"
 notes = "Delta audit (cargo vet diff 0.8.48 -> 0.8.50). The diff is limited to Cargo.toml and Cargo.toml.orig version-string bumps 0.8.48 -> 0.8.50 — ZERO source (src/) changes across both patch releases. No proc-macro logic change, no new deps, no new unsafe, no new ambient capability. Publisher joshlf (zerocopy maintainer, Google)."
+
+[[audits.zerocopy-derive]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.50 -> 0.8.55"
+notes = "Full diff reviewed; dependencies unchanged (proc-macro2/quote/syn only) and the crate still has no build.rs. The main substantive change is a new `homogeneous_field_bounds` path in the IntoBytes derive: repr(C) generic structs whose fields are all `T`/`[T; N]`/trailing `[T]` for a single type parameter now derive IntoBytes without requiring `Unaligned`; the generated impl emits explicit `IntoBytes` bounds per field plus `Identity<Type = T>` bounds so rustc, not the macro, verifies type identity, with detailed comments covering both the alignment/padding argument and the macro-hygiene hazard (identically-printed idents with different hygiene contexts) that motivates the Identity check. The unstable cfg `zerocopy_unstable_derive_on_error` was renamed to `zerocopy_unstable_linux`, and a new `most_traits` derive (doc(hidden) unless that cfg is set) bundles six existing derives with skip-on-error semantics for Linux kernel use; a test-only `__test_hygienically_mixed_into_bytes` proc macro is gated behind an internal nightly-test cfg and is unreachable in normal builds. Remaining changes are error-handling plumbing (`error_or_skip` in derive_split_at, `for<'zc>` bound wrapping in skip-on-error mode), a removed unused clone, and test churn. No fs/net/process/env access, no token-stream behavior that touches the host system, nothing suspicious."
 
 [[audits.zerofrom]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -704,9 +1010,27 @@ start = "2019-10-05"
 end = "2027-07-20"
 notes = "dtolnay-published, already-trusted publisher; patch bump 1.0.103->1.0.104."
 
+[[trusted.async-trait]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-07-23"
+end = "2027-08-04"
+
+[[trusted.bstr]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-04-02"
+end = "2027-08-04"
+
+[[trusted.bytes]]
+criteria = "safe-to-deploy"
+user-id = 6741 # Alice Ryhl (Darksonn)
+start = "2021-01-11"
+end = "2027-08-04"
+
 [[trusted.cc]]
 criteria = "safe-to-deploy"
-user-id = 55123
+user-id = 55123 # rust-lang-owner
 start = "2022-10-29"
 end = "2027-05-20"
 
@@ -779,6 +1103,12 @@ trusted-publisher = "github:RustCrypto/universal-hashes"
 start = "2026-02-28"
 end = "2027-07-02"
 
+[[trusted.glob]]
+criteria = "safe-to-deploy"
+user-id = 55123 # rust-lang-owner
+start = "2023-01-06"
+end = "2027-08-04"
+
 [[trusted.globset]]
 criteria = "safe-to-deploy"
 user-id = 189 # Andrew Gallant (BurntSushi)
@@ -797,6 +1127,12 @@ criteria = "safe-to-deploy"
 user-id = 359 # Sean McArthur (seanmonstar)
 start = "2019-04-05"
 end = "2027-04-23"
+
+[[trusted.http-body]]
+criteria = "safe-to-deploy"
+user-id = 359 # Sean McArthur (seanmonstar)
+start = "2019-10-01"
+end = "2027-08-04"
 
 [[trusted.http-body-util]]
 criteria = "safe-to-deploy"
@@ -828,6 +1164,18 @@ user-id = 359 # Sean McArthur (seanmonstar)
 start = "2022-01-15"
 end = "2027-04-23"
 
+[[trusted.icu_normalizer_data]]
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2023-10-03"
+end = "2027-08-04"
+
+[[trusted.idna]]
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2024-07-01"
+end = "2027-08-04"
+
 [[trusted.js-sys]]
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
@@ -839,6 +1187,18 @@ criteria = "safe-to-deploy"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 start = "2026-04-28"
 end = "2027-05-20"
+
+[[trusted.libc]]
+criteria = "safe-to-deploy"
+user-id = 55123 # rust-lang-owner
+start = "2024-08-15"
+end = "2027-08-04"
+
+[[trusted.litemap]]
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2021-02-23"
+end = "2027-08-04"
 
 [[trusted.memchr]]
 criteria = "safe-to-deploy"
@@ -864,6 +1224,18 @@ trusted-publisher = "github:RustCrypto/universal-hashes"
 start = "2026-02-10"
 end = "2027-07-02"
 
+[[trusted.potential_utf]]
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2024-11-23"
+end = "2027-08-04"
+
+[[trusted.proc-macro2]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-04-23"
+end = "2027-08-04"
+
 [[trusted.regex]]
 criteria = "safe-to-deploy"
 user-id = 189 # Andrew Gallant (BurntSushi)
@@ -883,6 +1255,12 @@ criteria = "safe-to-deploy"
 user-id = 359 # Sean McArthur (seanmonstar)
 start = "2019-03-04"
 end = "2027-04-23"
+
+[[trusted.rustversion]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-07-08"
+end = "2027-08-04"
 
 [[trusted.serde]]
 criteria = "safe-to-deploy"
@@ -910,6 +1288,12 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-02-28"
 end = "2027-05-29"
+
+[[trusted.serde_spanned]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-01-20"
+end = "2027-08-04"
 
 [[trusted.thiserror]]
 criteria = "safe-to-deploy"
@@ -939,6 +1323,12 @@ start = "2022-12-14"
 end = "2027-07-20"
 notes = "epage-published, already-trusted publisher; patch bump 1.1.2->1.1.3."
 
+[[trusted.toml_datetime]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2022-10-21"
+end = "2027-08-04"
+
 [[trusted.toml_writer]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)
@@ -963,6 +1353,12 @@ criteria = "safe-to-deploy"
 trusted-publisher = "github:RustCrypto/traits"
 start = "2026-02-27"
 end = "2027-07-02"
+
+[[trusted.url]]
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2021-02-18"
+end = "2027-08-04"
 
 [[trusted.wasm-bindgen]]
 criteria = "safe-to-deploy"
@@ -1042,8 +1438,32 @@ user-id = 6743 # Ed Page (epage)
 start = "2023-02-22"
 end = "2027-05-20"
 
+[[trusted.writeable]]
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2021-11-01"
+end = "2027-08-04"
+
 [[trusted.zerofrom]]
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2022-04-06"
 end = "2027-05-20"
+
+[[trusted.zerofrom-derive]]
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2022-04-06"
+end = "2027-08-04"
+
+[[trusted.zerovec-derive]]
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2021-12-11"
+end = "2027-08-04"
+
+[[trusted.zmij]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2025-12-18"
+end = "2027-08-04"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -174,6 +174,10 @@ criteria = "safe-to-deploy"
 version = "0.2.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.arrayvec]]
+version = "0.7.8"
+criteria = "safe-to-deploy"
+
 [[exemptions.assert_cmd]]
 version = "2.2.1"
 criteria = "safe-to-run"
@@ -200,6 +204,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.axum-core]]
 version = "0.5.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.base64]]
+version = "0.23.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bincode]]
@@ -234,10 +242,6 @@ criteria = "safe-to-deploy"
 version = "5.0.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.bstr]]
-version = "1.12.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.bytemuck]]
 version = "1.25.0"
 criteria = "safe-to-deploy"
@@ -246,16 +250,16 @@ criteria = "safe-to-deploy"
 version = "1.10.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.bytes]]
-version = "1.11.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.castaway]]
 version = "0.2.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.cfg_aliases]]
 version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.chacha20]]
+version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.chrono]]
@@ -386,6 +390,10 @@ criteria = "safe-to-deploy"
 version = "1.0.20"
 criteria = "safe-to-deploy"
 
+[[exemptions.either]]
+version = "1.17.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.encode_unicode]]
 version = "1.0.0"
 criteria = "safe-to-deploy"
@@ -474,6 +482,10 @@ criteria = "safe-to-deploy"
 version = "0.3.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.getrandom]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.half]]
 version = "2.7.1"
 criteria = "safe-to-deploy"
@@ -518,10 +530,6 @@ criteria = "safe-to-deploy"
 version = "2.2.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.icu_normalizer_data]]
-version = "2.2.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.icu_properties]]
 version = "2.2.0"
 criteria = "safe-to-deploy"
@@ -534,16 +542,8 @@ criteria = "safe-to-deploy"
 version = "2.2.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.id-arena]]
-version = "2.3.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.ident_case]]
 version = "1.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.idna]]
-version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.idna_adapter]]
@@ -578,10 +578,6 @@ criteria = "safe-to-deploy"
 version = "0.0.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.libc]]
-version = "0.2.186"
-criteria = "safe-to-deploy"
-
 [[exemptions.libm]]
 version = "0.2.16"
 criteria = "safe-to-deploy"
@@ -596,10 +592,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.linux-raw-sys]]
 version = "0.12.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.litemap]]
-version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.litrs]]
@@ -680,6 +672,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.parking_lot_core]]
 version = "0.9.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.pastey]]
+version = "0.2.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.phf]]
@@ -822,16 +818,8 @@ criteria = "safe-to-deploy"
 version = "1.13.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.potential_utf]]
-version = "0.1.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.ppv-lite86]]
 version = "0.2.21"
-criteria = "safe-to-deploy"
-
-[[exemptions.prettyplease]]
-version = "0.2.37"
 criteria = "safe-to-deploy"
 
 [[exemptions.proptest]]
@@ -854,6 +842,10 @@ criteria = "safe-to-deploy"
 version = "0.11.14"
 criteria = "safe-to-deploy"
 
+[[exemptions.quinn-udp]]
+version = "0.5.15"
+criteria = "safe-to-deploy"
+
 [[exemptions.r-efi]]
 version = "5.3.0"
 criteria = "safe-to-deploy"
@@ -862,12 +854,20 @@ criteria = "safe-to-deploy"
 version = "6.0.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.rand]]
+version = "0.9.5"
+criteria = "safe-to-deploy"
+
 [[exemptions.rand_chacha]]
 version = "0.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rand_core]]
 version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_pcg]]
+version = "0.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.raw-cpuid]]
@@ -970,10 +970,6 @@ criteria = "safe-to-deploy"
 version = "0.29.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.serde_spanned]]
-version = "1.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.serde_stacker]]
 version = "0.1.14"
 criteria = "safe-to-deploy"
@@ -1070,6 +1066,10 @@ criteria = "safe-to-deploy"
 version = "2.0.117"
 criteria = "safe-to-deploy"
 
+[[exemptions.syn]]
+version = "3.0.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.sync_wrapper]]
 version = "1.0.2"
 criteria = "safe-to-deploy"
@@ -1082,8 +1082,16 @@ criteria = "safe-to-deploy"
 version = "0.4.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.thread_local]]
+version = "1.1.10"
+criteria = "safe-to-deploy"
+
 [[exemptions.time]]
 version = "0.3.47"
+criteria = "safe-to-deploy"
+
+[[exemptions.time-macros]]
+version = "0.2.32"
 criteria = "safe-to-deploy"
 
 [[exemptions.tinystr]]
@@ -1108,10 +1116,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tokio-util]]
 version = "0.7.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.toml_datetime]]
-version = "1.1.1+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_parser]]
@@ -1168,10 +1172,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.unty]]
 version = "0.0.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.url]]
-version = "2.5.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
@@ -1299,19 +1299,11 @@ version = "0.59.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]
-version = "0.60.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-sys]]
 version = "0.61.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-targets]]
 version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-targets]]
-version = "0.53.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-threading]]
@@ -1326,72 +1318,36 @@ criteria = "safe-to-deploy"
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.windows_aarch64_gnullvm]]
-version = "0.53.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.windows_aarch64_msvc]]
 version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_aarch64_msvc]]
-version = "0.53.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_i686_gnu]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.windows_i686_gnu]]
-version = "0.53.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.windows_i686_gnullvm]]
 version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_i686_gnullvm]]
-version = "0.53.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_i686_msvc]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.windows_i686_msvc]]
-version = "0.53.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.windows_x86_64_gnu]]
 version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_gnu]]
-version = "0.53.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_x86_64_gnullvm]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.windows_x86_64_gnullvm]]
-version = "0.53.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.windows_x86_64_msvc]]
 version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_msvc]]
-version = "0.53.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.winresource]]
 version = "0.1.31"
-criteria = "safe-to-deploy"
-
-[[exemptions.writeable]]
-version = "0.6.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.xxhash-rust]]
@@ -1414,8 +1370,8 @@ criteria = "safe-to-deploy"
 version = "0.8.48"
 criteria = "safe-to-deploy"
 
-[[exemptions.zerofrom-derive]]
-version = "0.1.7"
+[[exemptions.zeroize]]
+version = "1.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerotrie]]
@@ -1426,12 +1382,8 @@ criteria = "safe-to-deploy"
 version = "0.11.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.zerovec-derive]]
-version = "0.11.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.zmij]]
-version = "1.0.21"
+[[exemptions.zlib-rs]]
+version = "0.6.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.zstd]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -7,8 +7,8 @@ when = "2026-06-17"
 trusted-publisher = "github:RustCrypto/traits"
 
 [[publisher.aes]]
-version = "0.9.1"
-when = "2026-05-27"
+version = "0.9.2"
+when = "2026-07-27"
 trusted-publisher = "github:RustCrypto/block-ciphers"
 
 [[publisher.anyhow]]
@@ -18,6 +18,20 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.async-trait]]
+version = "0.1.91"
+when = "2026-07-18"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.bstr]]
+version = "1.13.0"
+when = "2026-07-14"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.bumpalo]]
 version = "3.20.3"
 when = "2026-05-22"
@@ -25,9 +39,16 @@ user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
+[[publisher.bytes]]
+version = "1.12.1"
+when = "2026-07-08"
+user-id = 6741
+user-login = "Darksonn"
+user-name = "Alice Ryhl"
+
 [[publisher.cc]]
-version = "1.2.63"
-when = "2026-05-29"
+version = "1.4.0"
+when = "2026-07-24"
 trusted-publisher = "github:rust-lang/cc-rs"
 
 [[publisher.cipher]]
@@ -36,22 +57,22 @@ when = "2026-05-19"
 trusted-publisher = "github:RustCrypto/traits"
 
 [[publisher.clap]]
-version = "4.6.3"
-when = "2026-07-20"
+version = "4.6.5"
+when = "2026-07-31"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_builder]]
-version = "4.6.2"
-when = "2026-07-15"
+version = "4.6.5"
+when = "2026-07-31"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_derive]]
-version = "4.6.3"
-when = "2026-07-20"
+version = "4.6.4"
+when = "2026-07-21"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -86,6 +107,12 @@ version = "0.6.0"
 when = "2026-02-28"
 trusted-publisher = "github:RustCrypto/universal-hashes"
 
+[[publisher.glob]]
+version = "0.3.4"
+when = "2026-07-21"
+user-id = 55123
+user-login = "rust-lang-owner"
+
 [[publisher.globset]]
 version = "0.4.19"
 when = "2026-07-15"
@@ -94,22 +121,29 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.h2]]
-version = "0.4.14"
-when = "2026-05-04"
+version = "0.4.15"
+when = "2026-06-15"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.http]]
-version = "1.4.1"
-when = "2026-05-25"
+version = "1.5.0"
+when = "2026-07-29"
+user-id = 359
+user-login = "seanmonstar"
+user-name = "Sean McArthur"
+
+[[publisher.http-body]]
+version = "1.1.0"
+when = "2026-07-13"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.http-body-util]]
-version = "0.1.3"
-when = "2025-03-11"
+version = "0.1.4"
+when = "2026-07-13"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -122,13 +156,13 @@ user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.hybrid-array]]
-version = "0.4.12"
-when = "2026-05-09"
+version = "0.4.14"
+when = "2026-07-30"
 trusted-publisher = "github:RustCrypto/hybrid-array"
 
 [[publisher.hyper]]
-version = "1.10.1"
-when = "2026-05-29"
+version = "1.11.0"
+when = "2026-07-20"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -140,10 +174,37 @@ user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
+[[publisher.icu_normalizer_data]]
+version = "2.2.0"
+when = "2026-04-01"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.idna]]
+version = "1.0.2"
+when = "2024-07-01"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
 [[publisher.js-sys]]
-version = "0.3.99"
-when = "2026-05-22"
+version = "0.3.103"
+when = "2026-06-24"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+
+[[publisher.libc]]
+version = "0.2.189"
+when = "2026-07-21"
+user-id = 55123
+user-login = "rust-lang-owner"
+
+[[publisher.litemap]]
+version = "0.8.2"
+when = "2026-04-01"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
 
 [[publisher.memchr]]
 version = "2.8.2"
@@ -167,9 +228,23 @@ user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.polyval]]
-version = "0.7.1"
-when = "2026-02-28"
+version = "0.7.3"
+when = "2026-07-17"
 trusted-publisher = "github:RustCrypto/universal-hashes"
+
+[[publisher.potential_utf]]
+version = "0.1.5"
+when = "2026-04-01"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.proc-macro2]]
+version = "1.0.107"
+when = "2026-07-19"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
 
 [[publisher.regex]]
 version = "1.13.1"
@@ -191,6 +266,13 @@ when = "2025-12-22"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
+
+[[publisher.rustversion]]
+version = "1.0.23"
+when = "2026-07-07"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
 
 [[publisher.serde]]
 version = "1.0.229"
@@ -220,6 +302,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.serde_spanned]]
+version = "1.1.1"
+when = "2026-03-31"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
 [[publisher.thiserror]]
 version = "2.0.19"
 when = "2026-07-18"
@@ -242,8 +331,15 @@ user-login = "Darksonn"
 user-name = "Alice Ryhl"
 
 [[publisher.toml]]
-version = "1.1.3+spec-1.1.0"
-when = "2026-07-14"
+version = "1.1.4+spec-1.1.0"
+when = "2026-07-28"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.toml_datetime]]
+version = "1.1.1+spec-1.1.0"
+when = "2026-03-31"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -290,17 +386,17 @@ user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
-[[publisher.unicode-xid]]
-version = "0.2.6"
-when = "2024-09-19"
-user-id = 1139
-user-login = "Manishearth"
-user-name = "Manish Goregaokar"
-
 [[publisher.universal-hash]]
 version = "0.6.1"
 when = "2026-02-27"
 trusted-publisher = "github:RustCrypto/traits"
+
+[[publisher.url]]
+version = "2.5.8"
+when = "2026-01-05"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
 
 [[publisher.utf8_iter]]
 version = "1.0.4"
@@ -310,106 +406,60 @@ user-login = "hsivonen"
 user-name = "Henri Sivonen"
 
 [[publisher.wasip2]]
-version = "1.0.3+wasi-0.2.9"
-when = "2026-04-17"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasip3]]
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-when = "2026-01-15"
+version = "1.0.4+wasi-0.2.12"
+when = "2026-06-12"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-bindgen]]
-version = "0.2.122"
-when = "2026-05-22"
+version = "0.2.126"
+when = "2026-06-24"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-futures]]
-version = "0.4.72"
-when = "2026-05-22"
+version = "0.4.76"
+when = "2026-06-24"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-macro]]
-version = "0.2.122"
-when = "2026-05-22"
+version = "0.2.126"
+when = "2026-06-24"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-macro-support]]
-version = "0.2.122"
-when = "2026-05-22"
+version = "0.2.126"
+when = "2026-06-24"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-shared]]
-version = "0.2.122"
-when = "2026-05-22"
+version = "0.2.126"
+when = "2026-06-24"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
-[[publisher.wasm-encoder]]
-version = "0.244.0"
-when = "2026-01-06"
-trusted-publisher = "github:bytecodealliance/wasm-tools"
-
-[[publisher.wasm-metadata]]
-version = "0.236.0"
-when = "2025-07-28"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmparser]]
-version = "0.244.0"
-when = "2026-01-06"
-trusted-publisher = "github:bytecodealliance/wasm-tools"
-
 [[publisher.web-sys]]
-version = "0.3.99"
-when = "2026-05-22"
+version = "0.3.103"
+when = "2026-06-24"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.winnow]]
-version = "1.0.3"
-when = "2026-05-14"
+version = "1.0.4"
+when = "2026-07-13"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
-
-[[publisher.wit-bindgen]]
-version = "0.51.0"
-when = "2026-01-12"
-trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen]]
 version = "0.57.1"
 when = "2026-04-17"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
-[[publisher.wit-bindgen-core]]
-version = "0.51.0"
-when = "2026-01-12"
-trusted-publisher = "github:bytecodealliance/wit-bindgen"
-
-[[publisher.wit-bindgen-rust]]
-version = "0.51.0"
-when = "2026-01-12"
-trusted-publisher = "github:bytecodealliance/wit-bindgen"
-
-[[publisher.wit-bindgen-rust-macro]]
-version = "0.51.0"
-when = "2026-01-12"
-trusted-publisher = "github:bytecodealliance/wit-bindgen"
-
-[[publisher.wit-component]]
-version = "0.244.0"
-when = "2026-01-06"
-trusted-publisher = "github:bytecodealliance/wasm-tools"
-
-[[publisher.wit-parser]]
-version = "0.244.0"
-when = "2026-01-06"
-trusted-publisher = "github:bytecodealliance/wasm-tools"
+[[publisher.writeable]]
+version = "0.6.3"
+when = "2026-04-02"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
 
 [[publisher.zerofrom]]
 version = "0.1.7"
@@ -417,6 +467,27 @@ when = "2026-04-01"
 user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
+
+[[publisher.zerofrom-derive]]
+version = "0.1.7"
+when = "2026-04-01"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.zerovec-derive]]
+version = "0.11.3"
+when = "2026-04-01"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.zmij]]
+version = "1.0.23"
+when = "2026-07-13"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
 
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -435,89 +506,11 @@ notes = """
 This is a Bytecode Alliance authored crate.
 """
 
-[[audits.bytecode-alliance.wildcard-audits.wasip3]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-user-id = 1 # Alex Crichton (alexcrichton)
-start = "2025-09-10"
-end = "2026-08-21"
-notes = """
-This is a Bytecode Alliance authored crate.
-"""
-
-[[audits.bytecode-alliance.wildcard-audits.wasm-encoder]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasm-tools"
-start = "2025-08-14"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasm-metadata]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-user-id = 73222 # wasmtime-publish
-start = "2023-01-01"
-end = "2026-06-03"
-notes = """
-The Bytecode Alliance uses the `wasmtime-publish` crates.io account to automate
-publication of this crate from CI. This repository requires all PRs are reviewed
-by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
-"""
-
-[[audits.bytecode-alliance.wildcard-audits.wasmparser]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasm-tools"
-start = "2025-08-14"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
 [[audits.bytecode-alliance.wildcard-audits.wit-bindgen]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 start = "2025-08-13"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wit-bindgen-core]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wit-bindgen"
-start = "2025-08-13"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wit-bindgen-rust]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wit-bindgen"
-start = "2025-08-13"
-end = "2027-01-12"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wit-bindgen-rust-macro]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wit-bindgen"
-start = "2025-08-13"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wit-component]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasm-tools"
-start = "2025-08-14"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wit-parser]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasm-tools"
-start = "2025-08-14"
 end = "2027-01-08"
 notes = "The Bytecode Alliance is the author of this crate"
 
@@ -584,28 +577,11 @@ who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
 delta = "0.3.9 -> 0.3.10"
 
-[[audits.bytecode-alliance.audits.getrandom]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.4.1 -> 0.4.2"
-notes = "Nothing awry in this update, standard updates for some platforms and other misc things."
-
 [[audits.bytecode-alliance.audits.heck]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.1 -> 0.5.0"
 notes = "Minor changes for a `no_std` upgrade but otherwise everything looks as expected."
-
-[[audits.bytecode-alliance.audits.http-body]]
-who = "Pat Hickey <phickey@fastly.com>"
-criteria = "safe-to-deploy"
-version = "1.0.0-rc.2"
-
-[[audits.bytecode-alliance.audits.http-body]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.0-rc.2 -> 1.0.0"
-notes = "Only minor changes made for a stable release."
 
 [[audits.bytecode-alliance.audits.iana-time-zone-haiku]]
 who = "Dan Gohman <dev@sunfishcode.online>"
@@ -635,12 +611,6 @@ notes = """
 Lots of new iterators and shuffling some things around. Some new unsafe code but
 it's well-documented and well-tested. Nothing suspicious.
 """
-
-[[audits.bytecode-alliance.audits.leb128fmt]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-version = "0.1.0"
-notes = "Well-scoped crate do doing LEB encoding with no `unsafe` code and does what it says on the tin."
 
 [[audits.bytecode-alliance.audits.matchers]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -732,12 +702,6 @@ as correct and otherwise this crate is good to go.
 [[audits.bytecode-alliance.audits.rand]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-delta = "0.9.2 -> 0.9.4"
-notes = "Minor bugfix release"
-
-[[audits.bytecode-alliance.audits.rand]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
 delta = "0.10.0 -> 0.10.1"
 notes = "Minor logging-based updated fixing a recent advisory for the crate."
 
@@ -753,11 +717,11 @@ criteria = "safe-to-deploy"
 version = "0.1.4"
 notes = "I always really enjoy reading eliza's code, she left perfect comments at every use of unsafe."
 
-[[audits.bytecode-alliance.audits.thread_local]]
-who = "Pat Hickey <phickey@fastly.com>"
+[[audits.bytecode-alliance.audits.smallvec]]
+who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "1.1.4"
-notes = "uses unsafe to implement thread local storage of objects"
+delta = "1.13.2 -> 1.14.0"
+notes = "Minor new feature, nothing out of the ordinary."
 
 [[audits.bytecode-alliance.audits.tracing-log]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -794,59 +758,6 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.3.0"
 
-[[audits.bytecode-alliance.audits.wasm-metadata]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.236.0 -> 0.237.0"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.audits.wasm-metadata]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.237.0 -> 0.238.1"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.audits.wasm-metadata]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.238.1 -> 0.239.0"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.audits.wasm-metadata]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.239.0 -> 0.240.0"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.audits.wasm-metadata]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.240.0 -> 0.241.2"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.audits.wasm-metadata]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.241.2 -> 0.242.0"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.audits.wasm-metadata]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.242.0 -> 0.243.0"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.audits.wasm-metadata]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.243.0 -> 0.244.0"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.audits.zeroize]]
-who = "Pat Hickey <p.hickey@f5.com>"
-criteria = "safe-to-deploy"
-delta = "1.8.1 -> 1.8.2"
-
 [[audits.google.audits.adler2]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
@@ -859,19 +770,6 @@ The crate is fairly easy to read thanks to its small size and rich comments.
 I've grepped for `-i cipher`, `-i crypto`, `\bfs\b`, `\bnet\b`, and
 `\bunsafe\b`.  There were no hits (except for a comment in `README.md`
 and `lib.rs` pointing out "Zero `unsafe`").
-'''
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.arrayvec]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-version = "0.7.6"
-notes = '''
-Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'` and there were
-no hits, except for some `net` usage in tests.
-
-The crate has quite a few bits of `unsafe` Rust.  The audit comments can be
-found in https://chromium-review.googlesource.com/c/chromium/src/+/6187726/2
 '''
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
@@ -931,34 +829,6 @@ criteria = "safe-to-deploy"
 version = "2.0.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
-[[audits.google.audits.either]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "1.13.0"
-notes = "Unsafe code pertaining to wrapping Pin APIs. Mostly passes invariants down."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.either]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.13.0 -> 1.14.0"
-notes = """
-Inheriting ub-risk-1 from the baseline review of 1.13.0. While the delta has some diffs in unsafe code, they are either:
-- migrating code to use helper macros
-- migrating match patterns to take advantage of default bindings mode from RFC 2005
-Either way, the result is code that does exactly the same thing and does not change the risk of UB.
-
-See https://crrev.com/c/6323164 for more audit details.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.either]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.14.0 -> 1.15.0"
-notes = 'The delta in `lib.rs` only tweaks doc comments and `#[cfg(feature = "std")]`.'
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.equivalent]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
@@ -996,19 +866,6 @@ who = "Chris Palmer <palmer@google.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.4 -> 0.1.5"
 notes = "No new `unsafe`."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.glob]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-deploy"
-version = "0.3.1"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.glob]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.1 -> 0.3.2"
-notes = "Still no unsafe"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.heck]]
@@ -1087,119 +944,6 @@ who = "Max Lee <endlesspring@google.com>"
 criteria = "safe-to-run"
 version = "1.0.9"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-version = "1.0.78"
-notes = """
-Grepped for "crypt", "cipher", "fs", "net" - there were no hits
-(except for a benign "fs" hit in a doc comment)
-
-Notes from the `unsafe` review can be found in https://crrev.com/c/5385745.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.78 -> 1.0.79"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.79 -> 1.0.80"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.80 -> 1.0.81"
-notes = "Comment changes only"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.81 -> 1.0.82"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.82 -> 1.0.83"
-notes = "Substantive change is replacing String with Box<str>, saving memory."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.83 -> 1.0.84"
-notes = "Only doc comment changes in `src/lib.rs`."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "danakj@chromium.org"
-criteria = "safe-to-deploy"
-delta = "1.0.84 -> 1.0.85"
-notes = "Test-only changes."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.85 -> 1.0.86"
-notes = """
-Comment-only changes in `build.rs`.
-Reordering of `Cargo.toml` entries.
-Just bumping up the version number in `lib.rs`.
-Config-related changes in `test_size.rs`.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.86 -> 1.0.87"
-notes = "No new unsafe interactions."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Liza Burakova <liza@chromium.org"
-criteria = "safe-to-deploy"
-delta = "1.0.87 -> 1.0.89"
-notes = """
-Biggest change is adding error handling in build.rs.
-Some config related changes in wrapper.rs.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.89 -> 1.0.92"
-notes = """
-I looked at the delta and the previous discussion at
-https://chromium-review.googlesource.com/c/chromium/src/+/5385745/3#message-a8e2813129fa3779dab15acede408ee26d67b7f3
-and the changes look okay to me (including the `unsafe fn from_str_unchecked`
-changes in `wrapper.rs`).
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.92 -> 1.0.93"
-notes = "No `unsafe`-related changes."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.93 -> 1.0.94"
-notes = "Minor doc changes and clippy lint adjustments+fixes."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.quick-error]]
 who = "George Burgess IV <gbiv@google.com>"
@@ -1284,92 +1028,10 @@ For more detailed unsafe review notes please see https://crrev.com/c/6362797
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.rustversion]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-version = "1.0.14"
-notes = """
-Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'``, `'\bnet\b'``, `'\bunsafe\b'``
-and there were no hits except for:
-
-* Using trivially-safe `unsafe` in test code:
-
-    ```
-    tests/test_const.rs:unsafe fn _unsafe() {}
-    tests/test_const.rs:const _UNSAFE: () = unsafe { _unsafe() };
-    ```
-
-* Using `unsafe` in a string:
-
-    ```
-    src/constfn.rs:            "unsafe" => Qualifiers::Unsafe,
-    ```
-
-* Using `std::fs` in `build/build.rs` to write `${OUT_DIR}/version.expr`
-  which is later read back via `include!` used in `src/lib.rs`.
-
-Version `1.0.6` of this crate has been added to Chromium in
-https://source.chromium.org/chromium/chromium/src/+/28841c33c77833cc30b286f9ae24c97e7a8f4057
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.rustversion]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.14 -> 1.0.15"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.rustversion]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.15 -> 1.0.16"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.rustversion]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.16 -> 1.0.17"
-notes = "Just updates windows compat"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.rustversion]]
-who = "Liza Burakova <liza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.17 -> 1.0.18"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.rustversion]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.18 -> 1.0.19"
-notes = "No unsafe, just doc changes"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.rustversion]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.19 -> 1.0.20"
-notes = "Only minor updates to documentation and the mock today used for testing."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.smallvec]]
 who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"
 version = "1.13.2"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.smallvec]]
-who = "Jonathan Hao <phao@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.13.2 -> 1.14.0"
-notes = """
-WARNING: This certification is a result of a **partial** audit. The
-`malloc_size_of` feature has **not** been audited. This feature does
-not explicitly document its safety requirements.
-See also https://chromium-review.googlesource.com/c/chromium/src/+/6275133/comment/ea0d7a93_98051a2e/
-and https://github.com/servo/malloc_size_of/issues/8.
-This feature is banned in gnrt_config.toml.
-"""
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.static_assertions]]
@@ -1473,11 +1135,6 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.3 -> 1.0.4"
 
-[[audits.isrg.audits.chacha20]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-version = "0.10.0"
-
 [[audits.isrg.audits.cpufeatures]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
@@ -1492,16 +1149,6 @@ version = "0.8.1"
 who = "J.C. Jones <jc@divviup.org>"
 criteria = "safe-to-run"
 delta = "0.8.1 -> 0.8.2"
-
-[[audits.isrg.audits.getrandom]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.4 -> 0.4.0"
-
-[[audits.isrg.audits.getrandom]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.0 -> 0.4.1"
 
 [[audits.isrg.audits.inout]]
 who = "David Cook <dcook@divviup.org>"
@@ -1579,46 +1226,6 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "2.5.0 -> 2.6.1"
 
-[[audits.isrg.audits.zlib-rs]]
-who = "Ameer Ghani <inahga@divviup.org>"
-criteria = "safe-to-deploy"
-version = "0.4.0"
-notes = """
-zlib-rs uses unsafe Rust for invoking compiler intrinsics (i.e. SIMD), eschewing bounds checks, along the FFI boundary, and for interacting with pointers sourced from C. I have extensively reviewed and fuzzed the unsafe code. All findings from that work have been resolved as of version 0.4.0. To the best of my ability, I believe it's free of any serious security problems.
-
-zlib-rs does not require any external dependencies.
-"""
-
-[[audits.isrg.audits.zlib-rs]]
-who = "Ameer Ghani <inahga@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.0 -> 0.4.1"
-
-[[audits.isrg.audits.zlib-rs]]
-who = "Ameer Ghani <inahga@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.1 -> 0.4.2"
-
-[[audits.isrg.audits.zlib-rs]]
-who = "Ameer Ghani <inahga@letsencrypt.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.2 -> 0.5.0"
-
-[[audits.isrg.audits.zlib-rs]]
-who = "Ameer Ghani <inahga@letsencrypt.org>"
-criteria = "safe-to-deploy"
-delta = "0.5.0 -> 0.5.1"
-
-[[audits.isrg.audits.zlib-rs]]
-who = "Ameer Ghani <inahga@letsencrypt.org>"
-criteria = "safe-to-deploy"
-delta = "0.5.1 -> 0.5.2"
-
-[[audits.isrg.audits.zlib-rs]]
-who = "Ameer Ghani <inahga@letsencrypt.org>"
-criteria = "safe-to-deploy"
-delta = "0.5.2 -> 0.6.3"
-
 [[audits.mozilla.wildcard-audits.unicode-normalization]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
@@ -1643,15 +1250,6 @@ criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-12-05"
 end = "2026-02-01"
-notes = "All code written or reviewed by Manish"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.wildcard-audits.unicode-xid]]
-who = "Manish Goregaokar <manishsmail@gmail.com>"
-criteria = "safe-to-deploy"
-user-id = 1139 # Manish Goregaokar (Manishearth)
-start = "2019-07-25"
-end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -1749,6 +1347,12 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.10.2 -> 0.10.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.cfg_aliases]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.crunchy]]
@@ -1878,6 +1482,18 @@ criteria = "safe-to-deploy"
 version = "0.4.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.idna]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.2 -> 1.0.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna]]
+who = "edgul <ed.guloien@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.3 -> 1.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.num-conv]]
 who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -1983,65 +1599,16 @@ criteria = "safe-to-run"
 delta = "1.0.9 -> 1.0.13"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.proc-macro2]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.94 -> 1.0.106"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-version = "0.5.4"
-notes = "This is a small crate, providing safe wrappers around various low-level networking specific operating system features. Given that the Rust standard library does not provide safe wrappers for these low-level features, safe wrappers need to be build in the crate itself, i.e. `quinn-udp`, thus requiring `unsafe` code."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.4 -> 0.5.6"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.6 -> 0.5.8"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.8 -> 0.5.9"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Leonard Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.9 -> 0.5.10"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Leonard Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.10 -> 0.5.11"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Leonard Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.11 -> 0.5.12"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quinn-udp]]
-who = "Max Leonard Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.5.12 -> 0.5.13"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.quote]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.40 -> 1.0.45"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.quote]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.45 -> 1.0.47"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.rand_distr]]
@@ -2110,6 +1677,12 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "1.14.0 -> 1.15.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.smallvec]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.15.1 -> 1.15.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.strsim]]
@@ -2216,37 +1789,6 @@ delta = "0.1.4 -> 0.1.8"
 notes = "No unsafe code"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.time-macros]]
-who = "Kershaw Chang <kershaw@mozilla.com>"
-criteria = "safe-to-deploy"
-version = "0.2.6"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.time-macros]]
-who = "Kershaw Chang <kershaw@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.6 -> 0.2.10"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.time-macros]]
-who = "Alex Franchuk <afranchuk@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.10 -> 0.2.18"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.time-macros]]
-who = "Lars Eggert <lars@eggert.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.18 -> 0.2.22"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.time-macros]]
-who = "Lars Eggert <lars@eggert.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.22 -> 0.2.27"
-notes = "Refactors some unsafe code, nothing new"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.tinyvec_macros]]
 who = "Drew Willcoxon <adw@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -2276,16 +1818,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.1 -> 0.2.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.zeroize]]
-who = "Benjamin Beurdouche <beurdouche@mozilla.com>"
-criteria = "safe-to-deploy"
-version = "1.8.1"
-notes = """
-This code DOES contain unsafe code required to internally call volatiles
-for deleting data. This is expected and documented behavior.
-"""
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.zcash.audits.arrayref]]
@@ -2362,28 +1894,10 @@ criteria = "safe-to-deploy"
 delta = "0.3.13 -> 0.3.14"
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
-[[audits.zcash.audits.glob]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.3.2 -> 0.3.3"
-aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.http-body]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.0.0 -> 1.0.1"
-aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
 [[audits.zcash.audits.inout]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.1.3 -> 0.1.4"
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.quinn-udp]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.5.13 -> 0.5.14"
 aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.rand_xorshift]]
@@ -2392,52 +1906,18 @@ criteria = "safe-to-deploy"
 version = "0.3.0"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
-[[audits.zcash.audits.rustversion]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.0.20 -> 1.0.21"
-notes = "Build script change is to fix building with `-Zfmt-debug=none`."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.rustversion]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.0.21 -> 1.0.22"
-notes = "Changes to generated code are to prepend a clippy annotation."
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
 [[audits.zcash.audits.strum_macros]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.27.1 -> 0.27.2"
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
-[[audits.zcash.audits.thread_local]]
-who = "Jack Grigg <jack@z.cash>"
+[[audits.zcash.audits.time-core]]
+who = "Kris Nuttycombe <kris@nutty.land>"
 criteria = "safe-to-deploy"
-delta = "1.1.4 -> 1.1.7"
-notes = """
-New `unsafe` usage:
-- An extra `deallocate_bucket`, to replace a `Mutex::lock` with a `compare_exchange`.
-- Setting and getting a `#[thread_local] static mut Option<Thread>` on nightly.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.thread_local]]
-who = "Daira-Emma Hopwood <daira@jacaranda.org>"
-criteria = "safe-to-deploy"
-delta = "1.1.7 -> 1.1.8"
-notes = """
-Adds `unsafe` code that makes an assumption that `ptr::null_mut::<Entry<T>>()` is a valid representation
-of an `AtomicPtr<Entry<T>>`, but this is likely a correct assumption.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.thread_local]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.1.8 -> 1.1.9"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+delta = "0.1.8 -> 0.1.9"
+notes = "No unsafe code; macro additions are straightforward refactoring changes."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.try-lock]]
 who = "Jack Grigg <jack@electriccoin.co>"


### PR DESCRIPTION
## What

- **New public lib crate `uffs-fetch`** — extracted from `uffs-update`'s acquire step so external products can reuse the hardened HTTP machinery: `fetch_release` (GitHub Releases), `download_to` (generic-URL streaming with retry / 30s connect / 60s inactivity timeouts / per-call byte cap), `with_retry`, and the `SHA256SUMS` verify module. Two generalizations: caller-supplied user-agent product string and per-call `max_bytes` (was a hardcoded 512 MiB constant). `uffs-update` is the first consumer and keeps its previous values as local policy constants — behavior unchanged, and the HTTP/TLS stack still never touches the lean `uffs` CLI.
- **`download_to_with_progress`** — per-chunk `(bytes_so_far, Content-Length)` hook so multi-GiB downloads are distinguishable from a hang; `download_to` is the no-op-callback wrapper.
- **Dependency refresh** — rmcp 2.2.0 → 3.1.0 (uffs-mcp migrated to the new outcome enums / `with_all_items` constructors, wire shape unchanged), toml 1.1.4, schemars 1.2.2, clap 4.6.5, aho-corasick 1.1.5, smallvec 1.15.2 + transitive refresh. reqwest deliberately stays 0.12.28 (re-verified: 0.13.4 has no `rustls-tls-native-roots` feature).
- **Supply chain** — 19 new cargo-vet trust entries for already-trusted publishers; all 51 changed exemption versions kept anchored per the no-lazy-bumps discipline, each with a reviewed `[[audits]]` delta entry (unsafe surface, capability changes, build.rs, dependency drift). `cargo vet` passes: 172 fully audited / 84 partially / 238 exempted (down from 331 exemptions).
- Repo tooling config + contributor docs update; crate-graph doc gains the new Layer-0 row.

## Validation

- Workspace clippy (ultra-strict) clean; 2412 tests pass (14 skipped — live-MFT `#[ignore]` set)
- `cargo vet` green, vet-audit-discipline gate green, full pre-push gate green
- `cargo audit`: no new advisories (the 2 outstanding quick-xml items are pre-existing polars transitives)