### PR TITLE
feat: self-upgrading MCP supervisor, permanent daemon residency, and a repo health pass

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -31,7 +31,24 @@ target-dir = "target"
 # docs/architecture/dev-flow.md § 5.2).  See
 # docs/architecture/dev-flow-implementation-plan.md § 2.1 / 6.4 and
 # https://doc.rust-lang.org/cargo/reference/config.html#build
-rustc-wrapper = "sccache"
+#
+# The wrapper is a SHIM, not `sccache` itself (issue #587): it forwards to
+# sccache when installed and execs rustc directly when it is not.  Naming
+# `sccache` here made the whole repo unbuildable anywhere sccache is
+# absent — every cargo invocation died with
+#   error: could not execute process `sccache .../rustc -vV` (never executed)
+# which is exactly why Dependabot's cargo updater could never open a PR
+# (its container has no sccache), and the same wall a fresh clone hits
+# before `cargo install sccache`.  The Bug B pairing above is unaffected:
+# both keys still live here, in one place; only the wrapper's value moved
+# behind a shim.
+#
+# The path is resolved relative to the WORKSPACE ROOT (the parent of this
+# `.cargo/` directory) — verified empirically; a `../`-prefixed form does
+# NOT resolve.  Windows uses the `.cmd` twin next to it; set
+# `RUSTC_WRAPPER=scripts\dev\rustc-wrapper.cmd` there if you invoke cargo
+# directly rather than through `just`.
+rustc-wrapper = "scripts/dev/rustc-wrapper"
 incremental = false
 
 [net]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4445,6 +4445,7 @@ dependencies = [
  "uffs-client",
  "uffs-format",
  "uffs-mft",
+ "uffs-security",
  "uffs-statusfmt",
  "uffs-time",
  "uffs-version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,7 +2113,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -3051,7 +3051,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -3073,7 +3073,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3395,7 +3395,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4031,11 +4031,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4051,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4302,7 +4302,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -4381,7 +4381,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "toml",
  "uffs-version",
  "winresource",
@@ -4394,7 +4394,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "tracing-subscriber",
  "uffs-broker-protocol",
@@ -4409,7 +4409,7 @@ dependencies = [
 name = "uffs-broker-protocol"
 version = "0.6.30"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4464,7 +4464,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uffs-broker-protocol",
@@ -4493,7 +4493,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uffs-format",
@@ -4521,7 +4521,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "toml",
  "tracing",
@@ -4623,7 +4623,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tower-service",
  "tracing",
@@ -4662,7 +4662,7 @@ dependencies = [
  "sha2 0.11.0",
  "smallvec",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-appender",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -935,9 +935,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -945,26 +945,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -981,9 +981,9 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "devicons"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830e47e2f330cf4fdd5a958dcef921b9523ffc21ab6713aa5e77ba2cce03904b"
+checksum = "777b2f88eb5418ba48f117570ecd0320404da0bdc39c66edf23d4d23550354b7"
 dependencies = [
  "lazy_static",
 ]
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1214,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1224,15 +1224,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1241,38 +1241,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1353,9 +1353,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -3301,9 +3301,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3375,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -3406,15 +3406,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,7 +253,7 @@ smallvec = "1.15.2"
 zerocopy = { version = "0.8", features = ["derive"] }
 
 # ───── Error Handling ─────
-thiserror = "2.0.19"
+thiserror = "2.0.20"
 anyhow = "1.0.104"
 
 # ───── MCP (Model Context Protocol) ─────

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ tokio = { version = "1.53.1", default-features = false, features = [
 # Async combinators (`try_join_all`, `FutureExt`).  Used by the internal
 # `uffs-ci-pipeline` tool to fan out parallel cargo invocations; kept at
 # workspace scope so any future consumer tracks the same version.
-futures = "0.3.33"
+futures = "0.3.34"
 
 # ───── Windows APIs (Windows only) ─────
 windows = { version = "0.62.2", features = [
@@ -257,7 +257,7 @@ thiserror = "2.0.20"
 anyhow = "1.0.104"
 
 # ───── MCP (Model Context Protocol) ─────
-rmcp = { version = "3.1.0", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "3.1.2", features = ["server", "transport-io", "macros"] }
 schemars = "1.2.2"
 
 # ───── HTTP / Tower (for MCP Streamable HTTP gateway) ─────
@@ -274,14 +274,14 @@ tracing-subscriber = { version = "0.3.23", features = [
 tracing-appender = "0.2.5"
 
 # ───── CLI ─────
-clap = { version = "4.6.5", features = [
+clap = { version = "4.6.6", features = [
   "derive",
   "env",
   "unicode",
   "wrap_help",
 ] }
 indicatif = "0.18.6"
-devicons = "0.6.12"
+devicons = "0.6.13"
 # ANSI terminal colouring.  Used by the `uffs-ci-pipeline` tool; kept at
 # workspace scope so a future UI surface that wants colored output inherits
 # the same pin.  Audited and `cargo vet certify`'d at 3.1.1 — see
@@ -292,7 +292,7 @@ colored = "3.1.1"
 regex = "1.13.1"
 memchr = "2.8.3"
 aho-corasick = "1.1.5"
-globset = "0.4.19"
+globset = "0.4.20"
 
 # ───── Time ─────
 chrono = { version = "0.4.45", features = ["serde"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -69,6 +69,45 @@ avoid-breaking-exported-api = false
 # ── Identifier length ────────────────────────────────────────────────────────
 # Default (1) kept — threshold 2 was tested and only flagged idiomatic Rust
 # names (ch, cp, io, fs) with zero real wins.  Removed as pure noise.
+#
+# Single UPPERCASE letters are explicitly allowed (`".."` keeps Clippy's
+# default lowercase list): they are legitimate domain identifiers here —
+# the `DriveLetter` A–Z constants in `uffs-mft::platform::drive_letter`
+# ARE the domain model.  Posture decision from nightly-canary issue #584:
+# the 2026-08-09 floating-nightly clippy briefly extended
+# `min_ident_chars` to macro-generated single-letter constants and broke
+# the canary on exactly those A–Z constants (upstream reverted the next
+# day).  Declaring the intent in config keeps the canary green across
+# such churn without weakening the lint for ordinary identifiers.
+allowed-idents-below-min-chars = [
+  "..",
+  "A",
+  "B",
+  "C",
+  "D",
+  "E",
+  "F",
+  "G",
+  "H",
+  "I",
+  "J",
+  "K",
+  "L",
+  "M",
+  "N",
+  "O",
+  "P",
+  "Q",
+  "R",
+  "S",
+  "T",
+  "U",
+  "V",
+  "W",
+  "X",
+  "Y",
+  "Z",
+]
 
 # ── Thresholds ──────────────────────────────────────────────────────────────
 # All thresholds at Clippy defaults.  Violations are handled with targeted

--- a/crates/uffs-bench/src/matrix.rs
+++ b/crates/uffs-bench/src/matrix.rs
@@ -414,7 +414,11 @@ mod tests {
 
         let matrix = compute_matrix(&spec, &preflight);
 
-        assert!(matrix.cross_cells.is_empty());
+        assert_eq!(
+            matrix.cross_cells,
+            Vec::<super::CrossCell>::new(),
+            "no cross cells expected"
+        );
         assert_eq!(matrix.uffs_only.len(), 1);
         let reason = &matrix.uffs_only.first().expect("one solo cell").reason;
         assert!(reason.contains("es infeasible"));
@@ -476,7 +480,11 @@ mod tests {
 
         assert_eq!(matrix.capable_drives, vec!['C', 'E']);
         assert_eq!(matrix.cross_cells.len(), 2);
-        assert!(matrix.uffs_only.is_empty());
+        assert_eq!(
+            matrix.uffs_only,
+            Vec::<super::SoloCell>::new(),
+            "no solo cells expected"
+        );
     }
 
     #[test]

--- a/crates/uffs-bench/tests/spine.rs
+++ b/crates/uffs-bench/tests/spine.rs
@@ -120,7 +120,11 @@ mod tests {
             confirm(&host, &mut mode, &mut seen, &make_card()),
             Decision::ProceedNoop
         );
-        assert!(!host.output().is_empty());
+        assert_ne!(
+            host.output(),
+            Vec::<String>::new(),
+            "confirm must explain the noop"
+        );
     }
 
     #[test]
@@ -301,7 +305,11 @@ mod tests {
         };
         let before = capture(&host, &spec);
         let after = capture(&host, &spec);
-        assert!(diff(&before, &after).is_empty());
+        assert_eq!(
+            diff(&before, &after),
+            Vec::<String>::new(),
+            "identical captures must not drift"
+        );
     }
 
     #[test]

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -90,6 +90,13 @@ uffs-mft.workspace = true
 # one visual language in exactly one place.
 uffs-statusfmt.workspace = true
 
+# Shared per-platform native log-directory resolution — the resident
+# login item (`--daemon resident on`) must bake an ABSOLUTE --log-file
+# into the launchd plist / Run key / systemd unit (a login-started
+# daemon has no useful cwd).  Direct dep so the CLI resolves the same
+# path uffsd and uffsmcp use, instead of reinventing the logic.
+uffs-security.workspace = true
+
 # Error handling
 anyhow.workspace = true
 

--- a/crates/uffs-cli/src/args.rs
+++ b/crates/uffs-cli/src/args.rs
@@ -198,6 +198,19 @@ pub(crate) enum DaemonAction {
         /// Force-forget non-`Cold` drives by auto-hibernating first.
         force: bool,
     },
+    /// Make the daemon permanently resident: manage the per-user login
+    /// item that starts `uffsd --no-retire` at login (never retires on
+    /// idle; the memory-tiering ladder still parks unused drives).
+    Resident {
+        /// What to do with the login item.
+        mode: ResidentMode,
+        /// Raw MFT file(s) baked into the login item (non-Windows).
+        mft_file: Vec<PathBuf>,
+        /// Data directory baked into the login item (non-Windows).
+        data_dir: Option<PathBuf>,
+        /// Drive letter(s) baked into the login item (Windows).
+        drives: Vec<DriveLetter>,
+    },
     /// Per-drive tier + telemetry table (Phase 8-E).
     ///
     /// Operator-facing companion to `daemon status`: surfaces tier,
@@ -206,6 +219,17 @@ pub(crate) enum DaemonAction {
     /// shards included so `forget` candidates are visible without
     /// cross-referencing tracing logs.
     StatusDrives,
+}
+
+/// Sub-action of `uffs --daemon resident`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResidentMode {
+    /// Install the login item (and start the daemon when none runs).
+    On,
+    /// Remove the login item.
+    Off,
+    /// Report login-item + daemon state.
+    Status,
 }
 
 /// Parse `uffs --daemon <action> [flags...]` from raw args.
@@ -230,10 +254,11 @@ pub(crate) fn parse_daemon_action(args: &[String]) -> Result<DaemonAction, anyho
         "hibernate" => Ok(parse_daemon_hibernate(rest)),
         "preload" => parse_daemon_preload(rest),
         "forget" => parse_daemon_forget(rest),
+        "resident" => parse_daemon_resident(rest),
         "status_drives" | "status-drives" => Ok(DaemonAction::StatusDrives),
         other => anyhow::bail!(
             "Unknown daemon action: '{other}'. Use: start, status, stop, kill, \
-             restart, load, hibernate, preload, forget, status_drives"
+             restart, load, hibernate, preload, forget, resident, status_drives"
         ),
     }
 }
@@ -352,6 +377,58 @@ fn parse_daemon_load(rest: &[String]) -> DaemonAction {
         drives,
         no_cache,
     }
+}
+
+/// Parse `uffs --daemon resident [on|off|status] [data-source flags]`.
+///
+/// The mode defaults to `status`; data-source flags (same shapes as
+/// `start` / `load`) are only meaningful with `on`, where they are
+/// baked into the login item.
+fn parse_daemon_resident(rest: &[String]) -> Result<DaemonAction, anyhow::Error> {
+    let (mode, flags) = match rest.first().map(String::as_str) {
+        None => (ResidentMode::Status, rest),
+        Some("on") => (ResidentMode::On, rest.get(1..).unwrap_or_default()),
+        Some("off") => (ResidentMode::Off, rest.get(1..).unwrap_or_default()),
+        Some("status") => (ResidentMode::Status, rest.get(1..).unwrap_or_default()),
+        Some(other) => {
+            anyhow::bail!("Unknown resident mode: '{other}'. Use: on, off, status")
+        }
+    };
+    let mut mft_file = Vec::new();
+    let mut data_dir = None;
+    let mut drives = Vec::new();
+    let mut iter = flags.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--mft-file" => {
+                if let Some(val) = iter.next() {
+                    for part in val.split(',') {
+                        mft_file.push(PathBuf::from(part.trim()));
+                    }
+                }
+            }
+            "--data-dir" => {
+                if let Some(val) = iter.next() {
+                    data_dir = Some(val.into());
+                }
+            }
+            "--drive" | "-d" | "--drives" => {
+                if let Some(val) = iter.next() {
+                    extend_drives_from_csv(&mut drives, val);
+                }
+            }
+            other => anyhow::bail!(
+                "Unknown resident flag: '{other}'. \
+                 Use: --data-dir <DIR>, --mft-file <PATH>, --drive <LETTER>"
+            ),
+        }
+    }
+    Ok(DaemonAction::Resident {
+        mode,
+        mft_file,
+        data_dir,
+        drives,
+    })
 }
 
 /// Parse `uffs --daemon hibernate [DRIVE...]` / `[--drive D]` /

--- a/crates/uffs-cli/src/args_help.rs
+++ b/crates/uffs-cli/src/args_help.rs
@@ -122,6 +122,13 @@ ACTIONS:
     [DRIVE...]         Drive letter(s); at least one required
     --drives A,B       Drive letter(s) as comma-separated list
     --force            Auto-hibernate non-Cold drives first (default: refuse)
+  resident           Keep UFFS permanently resident (login autostart, no idle retire)
+    on                 Install the per-user login item (uffsd --no-retire) + start now
+      --data-dir PATH    Data directory baked into the login item (non-Windows)
+      --mft-file PATH    Raw MFT file(s) baked into the login item (non-Windows)
+      --drive LETTER     Drive letter(s) baked into the login item (Windows)
+    off                Remove the login item
+    status             Show login-item + daemon state (default)
   status_drives      Per-drive tier + telemetry table (Hot/Warm/Parked/Cold)
 ";
 

--- a/crates/uffs-cli/src/commands.rs
+++ b/crates/uffs-cli/src/commands.rs
@@ -30,6 +30,11 @@ pub(crate) mod deleted;
 /// admin-only work up front and decide once (elevate / continue-without /
 /// abort) instead of failing mid-flow. Keeps both flows' elevation UX aligned.
 pub(crate) mod elevation;
+/// `uffs --daemon resident` — permanent residency: per-user login item
+/// that starts `uffsd --no-retire` at login (Run key / LaunchAgent /
+/// systemd user unit), so the daemon is warm before the first search
+/// and never removes itself from the process list on idle.
+pub(crate) mod resident;
 /// `uffs --snapshot --drive C --out FILE` — capture the live MFT to a baseline.
 pub(crate) mod snapshot;
 // Index and info subcommands were merged into other modules.

--- a/crates/uffs-cli/src/commands/daemon_mgmt.rs
+++ b/crates/uffs-cli/src/commands/daemon_mgmt.rs
@@ -84,10 +84,15 @@ pub(crate) fn daemon(action: &DaemonAction) -> Result<()> {
     // Elevation gate — checked here, once, before any action is dispatched,
     // so no individual subcommand handler can accidentally bypass it.
     {
+        // `Resident` is exempt: it manages a *per-user* login item
+        // (HKCU Run key / LaunchAgent / systemd user unit) and never
+        // touches a running daemon, so it must work without elevation —
+        // that is the whole zero-UAC residency story.
         let is_read_only_or_uac_start = matches!(
             action,
             DaemonAction::Status { .. }
                 | DaemonAction::StatusDrives
+                | DaemonAction::Resident { .. }
                 | DaemonAction::Start { elevate: true, .. }
         );
         if !is_read_only_or_uac_start
@@ -161,6 +166,12 @@ pub(crate) fn daemon(action: &DaemonAction) -> Result<()> {
             pin_minutes,
         } => daemon_tiering::daemon_preload(drives, *pin_minutes),
         DaemonAction::Forget { drives, force } => daemon_tiering::daemon_forget(drives, *force),
+        DaemonAction::Resident {
+            mode,
+            mft_file,
+            data_dir,
+            drives,
+        } => super::resident::resident(*mode, mft_file, data_dir.as_deref(), drives),
         DaemonAction::StatusDrives => daemon_tiering::daemon_status_drives(),
     }
 }

--- a/crates/uffs-cli/src/commands/resident.rs
+++ b/crates/uffs-cli/src/commands/resident.rs
@@ -28,6 +28,14 @@
 //! daemon is already running, `on` leaves it untouched (its idle
 //! timeout keeps ruling until it retires or is stopped) and the
 //! resident configuration takes over from the next start.
+//!
+//! `on` also writes the **auto-spawn marker** (`resident.args`, next
+//! to the daemon PID file). Every implicit daemon auto-spawn merges
+//! the marker's argv (caller flags win — see
+//! `uffs_client::daemon_resident::merge_resident_args`), so the next
+//! search after a crash or a manual stop revives the daemon
+//! *resident* — this is what closes the Windows gap where the Run key
+//! alone cannot restart a crashed daemon mid-session.
 
 use std::path::{Path, PathBuf};
 
@@ -80,12 +88,29 @@ fn resident_on(
     let exe = resolve_daemon_exe()?;
     let argv = daemon_argv(mft_files, data_dir, drives);
     platform::turn_on(&exe, &argv)?;
+    write_marker(&argv)?;
     println!(
         "\nUFFS is now resident: uffsd starts at login with --no-retire\n\
-         (never exits on idle; memory tiering still parks unused drives).\n\
+         (never exits on idle; memory tiering still parks unused drives),\n\
+         and every auto-started daemon inherits the resident lifetime.\n\
          Undo with: uffs --daemon resident off"
     );
     Ok(())
+}
+
+/// Write the resident marker (`resident.args`) so implicit auto-spawns
+/// — the next search after a crash or a manual stop — revive the
+/// daemon with the same resident argv the login item uses (merged in
+/// `uffs_client::daemon_resident`; caller flags win).
+fn write_marker(argv: &[String]) -> Result<()> {
+    let path = uffs_client::daemon_ctl::resident_args_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let mut content = argv.join("\n");
+    content.push('\n');
+    std::fs::write(&path, content).with_context(|| format!("writing {}", path.display()))
 }
 
 /// Resolve the daemon binary to an absolute, existing path — a login
@@ -164,10 +189,12 @@ fn daemon_running() -> bool {
 
 // ── off ─────────────────────────────────────────────────────────────
 
-/// Remove the login item.
+/// Remove the login item and the auto-spawn marker.
 #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
 fn resident_off() -> Result<()> {
     platform::turn_off()?;
+    // Auto-spawns fall back to the default idle-retire lifetime.
+    let _absent = std::fs::remove_file(uffs_client::daemon_ctl::resident_args_path());
     if daemon_running() {
         println!(
             "A daemon is still running; it is unaffected.\n\
@@ -185,6 +212,11 @@ fn resident_status() {
     match platform::installed_at() {
         Some(artifact) => println!("Login item:  installed ({artifact})"),
         None => println!("Login item:  not installed"),
+    }
+    if uffs_client::daemon_ctl::resident_args_path().exists() {
+        println!("Auto-spawn:  resident (revived daemons keep --no-retire)");
+    } else {
+        println!("Auto-spawn:  default (idle retire)");
     }
     if daemon_running() {
         println!("Daemon:      running (details: uffs --daemon status)");

--- a/crates/uffs-cli/src/commands/resident.rs
+++ b/crates/uffs-cli/src/commands/resident.rs
@@ -1,0 +1,654 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! `uffs --daemon resident` — make the daemon permanently resident.
+//!
+//! The daemon's go-to-sleep ladder (Hot → Warm → Parked → Cold) frees
+//! memory beautifully, but its final rung — the idle auto-retire —
+//! removes `uffsd` from the process list entirely, so the next search
+//! pays the full daemon-restart cost. This command flips that trade:
+//! a **resident** daemon runs with `--no-retire` (never exits on
+//! idle; the tiering ladder still shrinks it to a few MB when unused)
+//! and is registered as a **per-user login item** so it is already
+//! warm before the first search of the day.
+//!
+//! Per platform the login item is:
+//!
+//! - **Windows** — an `HKCU\…\Run` registry value (never needs Administrator; a
+//!   non-elevated resident daemon reads the MFT through the Access Broker, so
+//!   the zero-UAC story is preserved).
+//! - **macOS** — a launchd `LaunchAgent` (`launchctl bootstrap`,
+//!   `KeepAlive.SuccessfulExit = false`: crash → relaunch, clean `uffs --daemon
+//!   stop` → stays stopped).
+//! - **Linux** — a systemd *user* unit (`systemctl --user enable`,
+//!   `Restart=on-failure`).
+//!
+//! `on` installs the item and starts the daemon right away when none
+//! is running; `off` removes it; `status` reports both halves. When a
+//! daemon is already running, `on` leaves it untouched (its idle
+//! timeout keeps ruling until it retires or is stopped) and the
+//! resident configuration takes over from the next start.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result};
+use uffs_client::connect_sync::UffsClientSync;
+use uffs_client::daemon_ctl::find_daemon_exe;
+use uffs_mft::platform::DriveLetter;
+
+use crate::args::ResidentMode;
+
+/// `uffs --daemon resident <on|off|status>` entry point.
+///
+/// # Errors
+///
+/// Fails when the daemon binary cannot be located, the platform login
+/// item cannot be written/removed, or the immediate start fails.
+pub(crate) fn resident(
+    mode: ResidentMode,
+    mft_files: &[PathBuf],
+    data_dir: Option<&Path>,
+    drives: &[DriveLetter],
+) -> Result<()> {
+    match mode {
+        ResidentMode::On => resident_on(mft_files, data_dir, drives),
+        ResidentMode::Off => resident_off(),
+        ResidentMode::Status => {
+            resident_status();
+            Ok(())
+        }
+    }
+}
+
+// ── on ──────────────────────────────────────────────────────────────
+
+/// Install the login item and start the resident daemon when possible.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn resident_on(
+    mft_files: &[PathBuf],
+    data_dir: Option<&Path>,
+    drives: &[DriveLetter],
+) -> Result<()> {
+    if !cfg!(windows) && mft_files.is_empty() && data_dir.is_none() {
+        anyhow::bail!(
+            "No MFT data sources specified.\n\
+             The resident daemon needs data to serve at login:\n\
+             \x20 uffs --daemon resident on --data-dir <path>\n\
+             \x20 uffs --daemon resident on --mft-file <path>"
+        );
+    }
+    let exe = resolve_daemon_exe()?;
+    let argv = daemon_argv(mft_files, data_dir, drives);
+    platform::turn_on(&exe, &argv)?;
+    println!(
+        "\nUFFS is now resident: uffsd starts at login with --no-retire\n\
+         (never exits on idle; memory tiering still parks unused drives).\n\
+         Undo with: uffs --daemon resident off"
+    );
+    Ok(())
+}
+
+/// Resolve the daemon binary to an absolute, existing path — a login
+/// item must not depend on the login shell's `PATH`.
+fn resolve_daemon_exe() -> Result<PathBuf> {
+    let exe = find_daemon_exe();
+    if exe.is_absolute() && exe.exists() {
+        return Ok(exe);
+    }
+    // `find_daemon_exe` fell back to a bare name: resolve it on PATH.
+    which::which(&exe).with_context(|| {
+        format!(
+            "Cannot locate the daemon binary ({}).\n\
+             Install uffsd next to uffs, or add it to PATH.",
+            exe.display()
+        )
+    })
+}
+
+/// Build the resident daemon's argv (after the program): `--no-retire`,
+/// the forwarded data sources, and an absolute `--log-file` (a
+/// login-started process has no useful working directory to drop a
+/// relative log into).
+///
+/// Rendered lossily to `String` — the login-item formats (registry
+/// value, plist, unit file) are text, so a non-UTF-8 path cannot be
+/// represented in them anyway.
+fn daemon_argv(
+    mft_files: &[PathBuf],
+    data_dir: Option<&Path>,
+    drives: &[DriveLetter],
+) -> Vec<String> {
+    let mut argv = vec![String::from("--no-retire")];
+    if let Some(dir) = data_dir {
+        argv.push(String::from("--data-dir"));
+        argv.push(dir.to_string_lossy().into_owned());
+    }
+    for mft in mft_files {
+        argv.push(String::from("--mft-file"));
+        argv.push(mft.to_string_lossy().into_owned());
+    }
+    for letter in drives {
+        argv.push(String::from("--drive"));
+        argv.push(letter.to_string());
+    }
+    let log_dir = uffs_security::log_dir::log_dir();
+    // Best effort — uffsd's appender creates the directory again.
+    let _ensure = std::fs::create_dir_all(&log_dir);
+    argv.push(String::from("--log-file"));
+    argv.push(log_dir.join("uffsd.log").to_string_lossy().into_owned());
+    argv
+}
+
+/// Start the daemon through the normal client auto-start path (broker
+/// aware, elevation-refusing) and wait until it is ready. Windows
+/// only — the Run key has no "start now" verb of its own (launchd and
+/// systemd start their job as part of activation).
+#[cfg(windows)]
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn spawn_now(argv: &[String]) -> Result<()> {
+    let spawn_args: Vec<std::ffi::OsString> = argv.iter().map(std::ffi::OsString::from).collect();
+    println!("Starting resident daemon...");
+    let mut client = UffsClientSync::connect_with_args(&spawn_args)
+        .with_context(|| "Failed to start the resident daemon")?;
+    client
+        .await_ready(core::time::Duration::from_mins(2))
+        .with_context(|| "Daemon did not become ready in time")?;
+    println!("Resident daemon started and ready.");
+    Ok(())
+}
+
+/// True when a daemon is already reachable on the per-user endpoint.
+fn daemon_running() -> bool {
+    UffsClientSync::connect_raw().is_ok()
+}
+
+// ── off ─────────────────────────────────────────────────────────────
+
+/// Remove the login item.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn resident_off() -> Result<()> {
+    platform::turn_off()?;
+    if daemon_running() {
+        println!(
+            "A daemon is still running; it is unaffected.\n\
+             Stop it with: uffs --daemon stop"
+        );
+    }
+    Ok(())
+}
+
+// ── status ──────────────────────────────────────────────────────────
+
+/// Report the login-item and daemon state.
+#[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+fn resident_status() {
+    match platform::installed_at() {
+        Some(artifact) => println!("Login item:  installed ({artifact})"),
+        None => println!("Login item:  not installed"),
+    }
+    if daemon_running() {
+        println!("Daemon:      running (details: uffs --daemon status)");
+    } else {
+        println!("Daemon:      not running");
+    }
+}
+
+// ── shared plumbing ─────────────────────────────────────────────────
+
+/// Run one system tool to completion, mapping a non-zero exit into an
+/// error carrying the tool's stderr.
+fn run_tool(program: &str, args: &[&str]) -> Result<std::process::Output> {
+    let output = std::process::Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("running {program}"))?;
+    if output.status.success() {
+        Ok(output)
+    } else {
+        anyhow::bail!(
+            "{program} {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+    }
+}
+
+// ── macOS: launchd LaunchAgent ──────────────────────────────────────
+
+/// macOS backend: launchd `LaunchAgent` in `~/Library/LaunchAgents`.
+#[cfg(target_os = "macos")]
+mod platform {
+    use anyhow::{Context as _, Result};
+
+    use super::{daemon_running, run_tool};
+
+    /// launchd label — also the plist file stem.
+    const LABEL: &str = "com.skyllc.uffs.daemon";
+
+    /// Path of the `LaunchAgent` plist.
+    fn plist_path() -> Result<std::path::PathBuf> {
+        let home = std::env::var_os("HOME").context("HOME is not set")?;
+        Ok(std::path::PathBuf::from(home)
+            .join("Library/LaunchAgents")
+            .join(format!("{LABEL}.plist")))
+    }
+
+    /// The current user's launchd GUI domain (`gui/<uid>`).
+    fn gui_domain() -> Result<String> {
+        let output = run_tool("id", &["-u"])?;
+        Ok(format!(
+            "gui/{}",
+            String::from_utf8_lossy(&output.stdout).trim()
+        ))
+    }
+
+    /// Minimal XML escaping for plist string values.
+    fn xml_escape(raw: &str) -> String {
+        raw.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+    }
+
+    /// Render the `LaunchAgent` plist. `KeepAlive.SuccessfulExit=false`
+    /// relaunches a crashed daemon but honors a clean shutdown;
+    /// `ThrottleInterval` keeps a pathological respawn loop tame.
+    fn launch_agent_plist(exe: &str, argv: &[String], stderr_log: &str) -> String {
+        use core::fmt::Write as _;
+        let mut arguments = String::new();
+        for arg in core::iter::once(exe).chain(argv.iter().map(String::as_str)) {
+            // Writing into a String is infallible.
+            let _infallible = writeln!(arguments, "        <string>{}</string>", xml_escape(arg));
+        }
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+{arguments}    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>StandardErrorPath</key>
+    <string>{}</string>
+</dict>
+</plist>
+"#,
+            xml_escape(stderr_log)
+        )
+    }
+
+    /// Write the plist and bootstrap it (which also starts the daemon)
+    /// unless one is already running.
+    #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+    pub(super) fn turn_on(exe: &std::path::Path, argv: &[String]) -> Result<()> {
+        let plist = plist_path()?;
+        if let Some(parent) = plist.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let stderr_log = uffs_security::log_dir::log_dir().join("uffsd.launchd.err.log");
+        std::fs::write(
+            &plist,
+            launch_agent_plist(&exe.to_string_lossy(), argv, &stderr_log.to_string_lossy()),
+        )
+        .with_context(|| format!("writing {}", plist.display()))?;
+        println!("Login item installed: {}", plist.display());
+
+        if daemon_running() {
+            println!(
+                "A daemon is already running; leaving it untouched.\n\
+                 The resident (launchd-managed) daemon takes over at next login,\n\
+                 or right away after: uffs --daemon stop && uffs --daemon resident on"
+            );
+            return Ok(());
+        }
+        let domain = gui_domain()?;
+        // A previous registration may linger — clear it, then load.
+        let _bootout = std::process::Command::new("launchctl")
+            .args(["bootout", &format!("{domain}/{LABEL}")])
+            .output();
+        run_tool("launchctl", &[
+            "bootstrap",
+            &domain,
+            &plist.to_string_lossy(),
+        ])?;
+        println!("Resident daemon started (launchd-managed).");
+        Ok(())
+    }
+
+    /// Boot the agent out (stops a launchd-managed daemon) and delete
+    /// the plist.
+    #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+    pub(super) fn turn_off() -> Result<()> {
+        let plist = plist_path()?;
+        if let Ok(domain) = gui_domain() {
+            // Ignore failure — the agent may simply not be loaded.
+            let _bootout = std::process::Command::new("launchctl")
+                .args(["bootout", &format!("{domain}/{LABEL}")])
+                .output();
+        }
+        if plist.exists() {
+            std::fs::remove_file(&plist)
+                .with_context(|| format!("removing {}", plist.display()))?;
+            println!("Login item removed: {}", plist.display());
+        } else {
+            println!("No login item installed.");
+        }
+        Ok(())
+    }
+
+    /// The install artifact, when present.
+    pub(super) fn installed_at() -> Option<String> {
+        let plist = plist_path().ok()?;
+        plist.exists().then(|| plist.display().to_string())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{launch_agent_plist, xml_escape};
+
+        /// The plist carries the label, the full argv in order, and the
+        /// crash-only `KeepAlive` policy.
+        #[test]
+        fn plist_renders_label_argv_and_keepalive() {
+            let rendered = launch_agent_plist(
+                "/opt/uffs/uffsd",
+                &[
+                    String::from("--no-retire"),
+                    String::from("--data-dir"),
+                    String::from("/Users/me/uffs data"),
+                ],
+                "/tmp/err.log",
+            );
+            assert!(rendered.contains("<string>com.skyllc.uffs.daemon</string>"));
+            assert!(rendered.contains("<string>/opt/uffs/uffsd</string>"));
+            assert!(rendered.contains("<string>--no-retire</string>"));
+            assert!(rendered.contains("<string>/Users/me/uffs data</string>"));
+            assert!(rendered.contains("<key>SuccessfulExit</key>\n        <false/>"));
+            assert!(rendered.contains("<key>RunAtLoad</key>\n    <true/>"));
+        }
+
+        /// Paths with XML-special characters survive escaping.
+        #[test]
+        fn xml_special_characters_are_escaped() {
+            assert_eq!(xml_escape("a&b<c>d"), "a&amp;b&lt;c&gt;d");
+        }
+    }
+}
+
+// ── Windows: HKCU Run key ───────────────────────────────────────────
+
+/// Windows backend: per-user `HKCU\…\Run` registry value.
+#[cfg(windows)]
+mod platform {
+    use anyhow::Result;
+
+    use super::{daemon_running, run_tool, spawn_now};
+
+    /// Registry path of the per-user Run key.
+    const RUN_KEY: &str = r"HKCU\Software\Microsoft\Windows\CurrentVersion\Run";
+
+    /// Value name of the UFFS login item under [`RUN_KEY`].
+    const RUN_VALUE: &str = "UFFSDaemon";
+
+    /// Render the Run-key command line: the exe always quoted, each
+    /// argument quoted when it contains whitespace.
+    fn run_command_line(exe: &str, argv: &[String]) -> String {
+        let mut parts = vec![format!("\"{exe}\"")];
+        for arg in argv {
+            if arg.contains(char::is_whitespace) {
+                parts.push(format!("\"{arg}\""));
+            } else {
+                parts.push(arg.clone());
+            }
+        }
+        parts.join(" ")
+    }
+
+    /// Write the Run value (no Administrator needed — HKCU is the
+    /// user's own hive; a non-elevated resident daemon reads the MFT
+    /// via the Access Broker) and start the daemon when none runs.
+    #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+    pub(super) fn turn_on(exe: &std::path::Path, argv: &[String]) -> Result<()> {
+        let line = run_command_line(&exe.to_string_lossy(), argv);
+        run_tool("reg", &[
+            "add", RUN_KEY, "/v", RUN_VALUE, "/t", "REG_SZ", "/d", &line, "/f",
+        ])?;
+        println!("Login item installed: {RUN_KEY}\\{RUN_VALUE}");
+        if daemon_running() {
+            println!(
+                "A daemon is already running; leaving it untouched.\n\
+                 The resident configuration takes over at next login,\n\
+                 or right away after: uffs --daemon stop && uffs --daemon resident on"
+            );
+            return Ok(());
+        }
+        spawn_now(argv)
+    }
+
+    /// Delete the Run value (absent value is not an error).
+    #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+    pub(super) fn turn_off() -> Result<()> {
+        if installed_at().is_none() {
+            println!("No login item installed.");
+            return Ok(());
+        }
+        run_tool("reg", &["delete", RUN_KEY, "/v", RUN_VALUE, "/f"])?;
+        println!("Login item removed: {RUN_KEY}\\{RUN_VALUE}");
+        Ok(())
+    }
+
+    /// The install artifact, when present.
+    pub(super) fn installed_at() -> Option<String> {
+        let query = std::process::Command::new("reg")
+            .args(["query", RUN_KEY, "/v", RUN_VALUE])
+            .output()
+            .ok()?;
+        query
+            .status
+            .success()
+            .then(|| format!("{RUN_KEY}\\{RUN_VALUE}"))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::run_command_line;
+
+        /// The exe is always quoted; args are quoted only when they
+        /// contain whitespace (Run-key command-line convention).
+        #[test]
+        fn run_command_line_quotes_exe_and_spaced_args() {
+            let line = run_command_line(r"C:\Program Files\UFFS\uffsd.exe", &[
+                String::from("--no-retire"),
+                String::from("--log-file"),
+                String::from(r"C:\Users\Me\App Data\uffsd.log"),
+            ]);
+            assert_eq!(
+                line,
+                r#""C:\Program Files\UFFS\uffsd.exe" --no-retire --log-file "C:\Users\Me\App Data\uffsd.log""#
+            );
+        }
+    }
+}
+
+// ── Linux (and other unix): systemd user unit ───────────────────────
+
+/// Linux / other-unix backend: systemd user unit.
+#[cfg(all(unix, not(target_os = "macos")))]
+mod platform {
+    use anyhow::{Context as _, Result};
+
+    use super::{daemon_running, run_tool};
+
+    /// systemd user-unit file name.
+    const UNIT: &str = "uffs-daemon.service";
+
+    /// Path of the user unit file.
+    fn unit_path() -> Result<std::path::PathBuf> {
+        let base = std::env::var_os("XDG_CONFIG_HOME").map_or_else(
+            || std::env::var_os("HOME").map(|home| std::path::PathBuf::from(home).join(".config")),
+            |xdg| Some(std::path::PathBuf::from(xdg)),
+        );
+        Ok(base
+            .context("neither XDG_CONFIG_HOME nor HOME is set")?
+            .join("systemd/user")
+            .join(UNIT))
+    }
+
+    /// Render the unit. `Restart=on-failure` relaunches a crashed
+    /// daemon but honors a clean `uffs --daemon stop`.
+    fn systemd_unit(exe: &str, argv: &[String]) -> String {
+        let exec = core::iter::once(exe)
+            .chain(argv.iter().map(String::as_str))
+            .map(|token| format!("\"{token}\""))
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!(
+            "[Unit]\n\
+             Description=UFFS resident search daemon\n\n\
+             [Service]\n\
+             ExecStart={exec}\n\
+             Restart=on-failure\n\
+             RestartSec=10\n\n\
+             [Install]\n\
+             WantedBy=default.target\n"
+        )
+    }
+
+    /// Write + enable the unit; start it when no daemon runs.
+    #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+    pub(super) fn turn_on(exe: &std::path::Path, argv: &[String]) -> Result<()> {
+        let unit = unit_path()?;
+        if let Some(parent) = unit.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        std::fs::write(&unit, systemd_unit(&exe.to_string_lossy(), argv))
+            .with_context(|| format!("writing {}", unit.display()))?;
+        run_tool("systemctl", &["--user", "daemon-reload"])?;
+        run_tool("systemctl", &["--user", "enable", UNIT])?;
+        println!("Login item installed: {}", unit.display());
+        if daemon_running() {
+            println!(
+                "A daemon is already running; leaving it untouched.\n\
+                 The resident (systemd-managed) daemon takes over at next login,\n\
+                 or right away after: uffs --daemon stop && uffs --daemon resident on"
+            );
+            return Ok(());
+        }
+        run_tool("systemctl", &["--user", "start", UNIT])?;
+        println!("Resident daemon started (systemd-managed).");
+        Ok(())
+    }
+
+    /// Disable + delete the unit (a still-running instance is left
+    /// alone; the caller prints the stop hint).
+    #[expect(clippy::print_stdout, reason = "CLI user-facing output")]
+    pub(super) fn turn_off() -> Result<()> {
+        let unit = unit_path()?;
+        if !unit.exists() {
+            println!("No login item installed.");
+            return Ok(());
+        }
+        // Ignore failure — the unit may not be enabled.
+        let _disable = std::process::Command::new("systemctl")
+            .args(["--user", "disable", UNIT])
+            .output();
+        std::fs::remove_file(&unit).with_context(|| format!("removing {}", unit.display()))?;
+        let _reload = std::process::Command::new("systemctl")
+            .args(["--user", "daemon-reload"])
+            .output();
+        println!("Login item removed: {}", unit.display());
+        Ok(())
+    }
+
+    /// The install artifact, when present.
+    pub(super) fn installed_at() -> Option<String> {
+        let unit = unit_path().ok()?;
+        unit.exists().then(|| unit.display().to_string())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::systemd_unit;
+
+        /// The unit quotes every `ExecStart` token and carries the
+        /// crash-only restart policy.
+        #[test]
+        fn unit_renders_execstart_and_restart_policy() {
+            let unit = systemd_unit("/opt/uffs/uffsd", &[
+                String::from("--no-retire"),
+                String::from("--data-dir"),
+                String::from("/data dir"),
+            ]);
+            assert!(unit.contains(
+                "ExecStart=\"/opt/uffs/uffsd\" \"--no-retire\" \"--data-dir\" \"/data dir\""
+            ));
+            assert!(unit.contains("Restart=on-failure"));
+            assert!(unit.contains("WantedBy=default.target"));
+        }
+    }
+}
+
+// ── Fallback: unsupported platforms ─────────────────────────────────
+
+/// Fallback backend: residency is unsupported.
+#[cfg(not(any(windows, unix)))]
+mod platform {
+    use anyhow::Result;
+
+    /// Residency is not supported on this platform.
+    pub(super) fn turn_on(_exe: &std::path::Path, _argv: &[String]) -> Result<()> {
+        anyhow::bail!("resident mode is not supported on this platform")
+    }
+
+    /// Residency is not supported on this platform.
+    pub(super) fn turn_off() -> Result<()> {
+        anyhow::bail!("resident mode is not supported on this platform")
+    }
+
+    /// Residency is not supported on this platform.
+    pub(super) fn installed_at() -> Option<String> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::daemon_argv;
+
+    /// The resident argv always leads with `--no-retire`, forwards the
+    /// data sources, and ends with an absolute `--log-file`.
+    #[test]
+    fn argv_carries_no_retire_sources_and_log_file() {
+        let argv = daemon_argv(
+            &[std::path::PathBuf::from("/mft/c.bin")],
+            Some(std::path::Path::new("/data")),
+            &[],
+        );
+        assert_eq!(argv.first().map(String::as_str), Some("--no-retire"));
+        let joined = argv.join(" ");
+        assert!(joined.contains("--data-dir /data"));
+        assert!(joined.contains("--mft-file /mft/c.bin"));
+        let log_flag = argv
+            .iter()
+            .position(|arg| arg == "--log-file")
+            .expect("--log-file present");
+        let log_path = argv.get(log_flag + 1).expect("log path follows flag");
+        assert!(
+            std::path::Path::new(log_path).is_absolute(),
+            "log path must be absolute for a login-started process: {log_path}"
+        );
+        assert!(log_path.ends_with("uffsd.log"));
+    }
+}

--- a/crates/uffs-cli/src/commands/uninstall/verify.rs
+++ b/crates/uffs-cli/src/commands/uninstall/verify.rs
@@ -37,6 +37,6 @@ mod tests {
 
     #[test]
     fn empty_input_is_clean() {
-        assert!(still_present(&[]).is_empty());
+        assert_eq!(still_present(&[]), Vec::<PathBuf>::new());
     }
 }

--- a/crates/uffs-cli/src/commands/update/winget_discover.rs
+++ b/crates/uffs-cli/src/commands/update/winget_discover.rs
@@ -152,6 +152,6 @@ mod tests {
     #[test]
     fn missing_base_yields_nothing() {
         let roots = roots_under_packages_base(std::path::Path::new("/nonexistent/winget/packages"));
-        assert!(roots.is_empty());
+        assert_eq!(roots, Vec::<std::path::PathBuf>::new());
     }
 }

--- a/crates/uffs-client/src/daemon_ctl.rs
+++ b/crates/uffs-client/src/daemon_ctl.rs
@@ -288,6 +288,21 @@ pub fn pid_file_path() -> PathBuf {
     base.join("uffs").join("daemon.pid")
 }
 
+/// Path of the resident-marker file (`resident.args`), sibling of the
+/// PID file.
+///
+/// Written by `uffs --daemon resident on` with the daemon argv the
+/// login item uses (one argument per line); removed by `resident off`.
+/// Every implicit daemon auto-spawn merges these arguments in — caller
+/// flags win, see `daemon_resident::merge_resident_args` — so a crashed
+/// or stopped resident daemon comes back **resident** on the next
+/// search instead of falling back to the default idle-retire lifetime.
+#[must_use]
+pub fn resident_args_path() -> PathBuf {
+    let base = dirs_next::data_local_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    base.join("uffs").join("resident.args")
+}
+
 /// Parse a daemon PID file. Returns `(pid, timestamp, exe_hash, nonce)`.
 #[must_use]
 pub fn parse_pid_file(path: &std::path::Path) -> Option<(u32, u64, u64, String)> {

--- a/crates/uffs-client/src/daemon_resident.rs
+++ b/crates/uffs-client/src/daemon_resident.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! Resident-marker support for the daemon auto-spawn path.
+//!
+//! `uffs --daemon resident on` writes a marker file (`resident.args`,
+//! next to the daemon PID file — see
+//! [`crate::daemon_ctl::resident_args_path`]) holding the daemon argv
+//! the login item uses, one argument per line. [`spawn_daemon`] merges
+//! that marker into every implicit auto-spawn, so a crashed or
+//! manually stopped resident daemon is revived *resident* by the next
+//! search instead of silently falling back to the default idle-retire
+//! lifetime.
+//!
+//! Extracted from `daemon_spawn.rs` to keep that file under the
+//! workspace 800-LOC policy ceiling.
+//!
+//! [`spawn_daemon`]: crate::daemon_spawn
+
+/// Load the resident marker and merge it into `args` (see
+/// [`merge_resident_args`]). A missing or unreadable marker leaves the
+/// caller's args untouched.
+pub(crate) fn apply_resident_marker(args: &[std::ffi::OsString]) -> Vec<std::ffi::OsString> {
+    let marker =
+        std::fs::read_to_string(crate::daemon_ctl::resident_args_path()).unwrap_or_default();
+    merge_resident_args(args, &marker)
+}
+
+/// Merge the resident-marker argv (one argument per line — what
+/// `uffs --daemon resident on` baked into the login item) into a
+/// caller's spawn args.
+///
+/// Merging is conservative: the caller's flags always win. A marker
+/// flag group (the `--flag` line plus the value lines that follow it)
+/// is appended only when the caller did not pass that flag itself, so
+/// an explicit `--data-dir` from a search command overrides the
+/// resident one while a bare auto-spawn inherits the full resident
+/// configuration — most importantly `--no-retire`.
+///
+/// Ephemeral instances (`--ephemeral-id`) are never made resident:
+/// their args pass through unchanged.
+fn merge_resident_args(caller: &[std::ffi::OsString], marker: &str) -> Vec<std::ffi::OsString> {
+    let mut merged = caller.to_vec();
+    if caller.iter().any(|arg| arg == "--ephemeral-id") {
+        return merged;
+    }
+    let mut lines = marker
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .peekable();
+    while let Some(flag) = lines.next() {
+        let mut group = vec![flag];
+        while lines.peek().is_some_and(|next| !next.starts_with("--")) {
+            if let Some(value) = lines.next() {
+                group.push(value);
+            }
+        }
+        if flag.starts_with("--") && !caller.iter().any(|arg| arg == flag) {
+            merged.extend(group.iter().map(std::ffi::OsString::from));
+        }
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::merge_resident_args;
+
+    /// Shorthand: caller args from strs.
+    fn args(raw: &[&str]) -> Vec<OsString> {
+        raw.iter().map(OsString::from).collect()
+    }
+
+    /// An empty (or missing → read as empty) marker changes nothing.
+    #[test]
+    fn empty_marker_is_a_passthrough() {
+        let caller = args(&["--data-dir", "/data"]);
+        assert_eq!(merge_resident_args(&caller, ""), caller);
+    }
+
+    /// A bare auto-spawn inherits the full resident configuration in
+    /// marker order — most importantly `--no-retire`.
+    #[test]
+    fn bare_spawn_inherits_full_resident_argv() {
+        let merged = merge_resident_args(
+            &[],
+            "--no-retire\n--data-dir\n/Users/me/uffs data\n--log-file\n/logs/uffsd.log\n",
+        );
+        assert_eq!(
+            merged,
+            args(&[
+                "--no-retire",
+                "--data-dir",
+                "/Users/me/uffs data",
+                "--log-file",
+                "/logs/uffsd.log",
+            ])
+        );
+    }
+
+    /// The caller's own flag wins: its `--data-dir` suppresses the
+    /// marker's group, while `--no-retire` is still inherited.
+    #[test]
+    fn caller_flags_override_marker_groups() {
+        let caller = args(&["--data-dir", "/theirs"]);
+        let merged = merge_resident_args(&caller, "--no-retire\n--data-dir\n/resident\n");
+        assert_eq!(merged, args(&["--data-dir", "/theirs", "--no-retire"]));
+    }
+
+    /// Repeatable marker flags (two `--drive` groups) are both
+    /// appended when the caller passed none.
+    #[test]
+    fn repeated_marker_flags_all_append() {
+        let merged = merge_resident_args(&[], "--no-retire\n--drive\nC\n--drive\nD\n");
+        assert_eq!(
+            merged,
+            args(&["--no-retire", "--drive", "C", "--drive", "D"])
+        );
+    }
+
+    /// Ephemeral job-scoped instances must never become resident —
+    /// `--no-retire` on a snapshot daemon would leak it forever.
+    #[test]
+    fn ephemeral_instances_are_exempt() {
+        let caller = args(&["--ephemeral-id", "job-7"]);
+        assert_eq!(
+            merge_resident_args(&caller, "--no-retire\n"),
+            caller,
+            "ephemeral spawn must pass through unchanged"
+        );
+    }
+
+    /// A malformed marker (value lines with no leading flag) appends
+    /// nothing — the merge never invents arguments.
+    #[test]
+    fn stray_value_lines_are_dropped() {
+        let merged = merge_resident_args(&[], "stray\nvalue\n--no-retire\n");
+        assert_eq!(merged, args(&["--no-retire"]));
+    }
+}

--- a/crates/uffs-client/src/daemon_spawn.rs
+++ b/crates/uffs-client/src/daemon_spawn.rs
@@ -120,7 +120,8 @@ pub(crate) fn spawn_daemon(
     // `policy` is Windows-only; the Unix spawn never prompts for
     // elevation.  The parameter stays in the public signature so
     // callers can pass the same value on every platform.
-    spawn_daemon_unix(exe, args)
+    let merged_args = crate::daemon_resident::apply_resident_marker(args);
+    spawn_daemon_unix(exe, &merged_args)
 }
 
 /// Windows implementation of [`spawn_daemon`].
@@ -143,7 +144,8 @@ pub(crate) fn spawn_daemon(
     args: &[std::ffi::OsString],
     policy: ElevationPolicy,
 ) -> Result<DaemonChildHandle, crate::error::ClientError> {
-    spawn_daemon_windows(exe, args, policy)
+    let merged_args = crate::daemon_resident::apply_resident_marker(args);
+    spawn_daemon_windows(exe, &merged_args, policy)
 }
 
 // ── Platform-specific spawn impls ─────────────────────────────────────────

--- a/crates/uffs-client/src/lib.rs
+++ b/crates/uffs-client/src/lib.rs
@@ -172,6 +172,9 @@ pub mod daemon_ctl;
 /// Exposes `spawn_daemon`, `ElevationPolicy`, the MSVCRT-compatible
 /// arg quoter, and the Windows UAC helpers.  Canonical home — no
 /// cascade through `daemon_ctl`.
+/// Resident-marker merge for the auto-spawn path (split off
+/// `daemon_spawn` to stay under the 800-LOC policy ceiling).
+pub(crate) mod daemon_resident;
 pub(crate) mod daemon_spawn;
 pub mod error;
 pub mod format;

--- a/crates/uffs-client/src/protocol/tests.rs
+++ b/crates/uffs-client/src/protocol/tests.rs
@@ -946,8 +946,8 @@ fn aggregate_spec_wire_minimal_json() {
     assert_eq!(parsed.kind, "count");
     assert!(parsed.label.is_none());
     assert!(parsed.field.is_none());
-    assert!(parsed.boundaries.is_empty());
-    assert!(parsed.metrics.is_empty());
+    assert_eq!(parsed.boundaries, Vec::<u64>::new());
+    assert_eq!(parsed.metrics, Vec::<String>::new());
     assert!(parsed.preset.is_none());
 }
 
@@ -1079,8 +1079,8 @@ fn bucket_wire_backward_compat_no_sample_fields() {
     let parsed: BucketWire = serde_json::from_str(json_str).expect("deserialize");
     assert_eq!(parsed.key, "rs");
     assert_eq!(parsed.count, 50);
-    assert!(parsed.sample_rows.is_empty());
-    assert!(parsed.drilldown.is_empty());
+    assert_eq!(parsed.sample_rows, Vec::<SampleRowWire>::new());
+    assert_eq!(parsed.drilldown, Vec::<DrilldownWire>::new());
 }
 
 #[test]
@@ -2214,5 +2214,5 @@ fn from_cli_args_no_drive_path_pattern_unscoped() {
     let args: Vec<String> = vec!["\\rnio\\*".into()];
     let params = SearchParams::from_cli_args(&args).expect("parse");
     assert_eq!(params.pattern, "\\rnio\\*");
-    assert!(params.drives.is_empty());
+    assert_eq!(params.drives, Vec::<uffs_mft::platform::DriveLetter>::new());
 }

--- a/crates/uffs-client/src/stdout_kind.rs
+++ b/crates/uffs-client/src/stdout_kind.rs
@@ -487,7 +487,7 @@ mod shared_tests {
     #[test]
     fn utf8_to_utf16_empty_input_returns_empty() {
         let out = utf8_to_utf16(b"").expect("empty UTF-8 is valid");
-        assert!(out.is_empty());
+        assert_eq!(out, Vec::<u16>::new());
     }
 
     /// Pure ASCII round-trips as zero-extended 16-bit code units —

--- a/crates/uffs-core/src/aggregate/sample_heap.rs
+++ b/crates/uffs-core/src/aggregate/sample_heap.rs
@@ -353,7 +353,7 @@ mod tests {
         let mut heap = SampleHeap::from_spec(&spec);
         assert!(heap.is_empty());
         let entries = heap.drain_sorted();
-        assert!(entries.is_empty());
+        assert_eq!(entries, Vec::<SampleEntry>::new());
     }
 
     #[test]

--- a/crates/uffs-core/src/aggregate/spec.rs
+++ b/crates/uffs-core/src/aggregate/spec.rs
@@ -558,7 +558,7 @@ mod tests {
         assert_eq!(spec.count, 2);
         assert_eq!(spec.sort_field, FieldId::Size);
         assert!(spec.sort_desc);
-        assert!(spec.projection.is_empty());
+        assert_eq!(spec.projection, Vec::<FieldId>::new());
     }
 
     #[test]

--- a/crates/uffs-core/src/bloom.rs
+++ b/crates/uffs-core/src/bloom.rs
@@ -246,9 +246,10 @@ impl Bloom {
         bytes
     }
 
-    /// Number of hash functions per insert / query.
+    /// Number of hash functions per insert / query (the classic
+    /// bloom-filter `k` parameter).
     #[must_use]
-    pub const fn k(&self) -> u8 {
+    pub const fn hash_count(&self) -> u8 {
         self.k_hashes
     }
 
@@ -422,7 +423,7 @@ mod tests {
             bloom.nbits(),
         );
         // k for 1 % FPR rounds to 7.
-        assert_eq!(bloom.k(), 7);
+        assert_eq!(bloom.hash_count(), 7);
         // Size in bytes is ~1.2 MB.
         assert!(bloom.size_bytes() >= 1_180_000 && bloom.size_bytes() <= 1_220_000);
     }
@@ -484,9 +485,9 @@ mod tests {
     #[test]
     fn with_size_and_k_clamps_k_to_valid_range() {
         let too_small = Bloom::with_size_and_k(64, 0);
-        assert_eq!(too_small.k(), 1);
+        assert_eq!(too_small.hash_count(), 1);
         let too_big = Bloom::with_size_and_k(64, 200);
-        assert_eq!(too_big.k(), 32);
+        assert_eq!(too_big.hash_count(), 32);
     }
 
     /// `estimated_fpr` returns 0 for an empty filter and a value in

--- a/crates/uffs-core/src/bloom.rs
+++ b/crates/uffs-core/src/bloom.rs
@@ -75,7 +75,7 @@ const SEED_B: u64 = 0x5A5A_3C3C_0F0F_A5A5;
 /// target.
 ///
 /// Per tiering-plan §6.2 this is fixed at 7.  Exposed via
-/// [`Bloom::k`] so callers can introspect.
+/// [`Bloom::hash_count`] so callers can introspect.
 pub const DEFAULT_K: u8 = 7;
 
 /// Bit-packed bloom filter with double-hashing.

--- a/crates/uffs-core/src/compact_cache/filters_io.rs
+++ b/crates/uffs-core/src/compact_cache/filters_io.rs
@@ -78,7 +78,7 @@ const BLOOM_HEADER_BYTES: usize = 16;
 /// Returns the underlying `io::Error` if any write fails.
 pub(super) fn write_bloom_section<W: io::Write>(writer: &mut W, bloom: &Bloom) -> io::Result<()> {
     writer.write_all(&bloom.nbits().to_le_bytes())?;
-    writer.write_all(&u32::from(bloom.k()).to_le_bytes())?;
+    writer.write_all(&u32::from(bloom.hash_count()).to_le_bytes())?;
     let words = bloom.bits();
     write_u32(writer, words.len())?;
     writer.write_all(bytemuck::cast_slice(words))?;
@@ -90,7 +90,7 @@ pub(super) fn write_bloom_section<W: io::Write>(writer: &mut W, bloom: &Bloom) -
 /// `serialize_compact` path.
 pub(super) fn push_bloom_section(buf: &mut Vec<u8>, bloom: &Bloom) {
     buf.extend_from_slice(&bloom.nbits().to_le_bytes());
-    buf.extend_from_slice(&u32::from(bloom.k()).to_le_bytes());
+    buf.extend_from_slice(&u32::from(bloom.hash_count()).to_le_bytes());
     let words = bloom.bits();
     let words_count: u32 = u32::try_from(words.len()).unwrap_or(u32::MAX);
     buf.extend_from_slice(&words_count.to_le_bytes());
@@ -317,7 +317,7 @@ mod tests {
         let (decoded, end) = read_bloom_section(&buf, 0).expect("bloom round-trip should succeed");
         assert_eq!(end, buf.len(), "decoder should consume the full section");
         assert_eq!(decoded.nbits(), bloom.nbits());
-        assert_eq!(decoded.k(), bloom.k());
+        assert_eq!(decoded.hash_count(), bloom.hash_count());
         assert_eq!(decoded.bits(), bloom.bits());
 
         for input in ["alpha", "beta", "gamma", "delta", "epsilon"] {
@@ -440,7 +440,7 @@ mod tests {
         let (decoded, _) =
             read_bloom_section(&buf, 0).expect("empty-bloom round-trip should succeed");
         assert_eq!(decoded.nbits(), bloom.nbits());
-        assert_eq!(decoded.k(), bloom.k());
+        assert_eq!(decoded.hash_count(), bloom.hash_count());
         assert!(decoded.bits().iter().all(|&w| w == 0));
     }
 
@@ -459,8 +459,8 @@ mod tests {
         assert_eq!(end, buf.len());
         assert!(decoded.is_empty());
         assert!(decoded.nodes().is_empty());
-        assert!(decoded.names().is_empty());
+        assert_eq!(decoded.names(), Vec::<u8>::new());
         assert_eq!(decoded.child_offsets(), &[0_u32]);
-        assert!(decoded.child_indices().is_empty());
+        assert_eq!(decoded.child_indices(), Vec::<u32>::new());
     }
 }

--- a/crates/uffs-core/src/compact_tests.rs
+++ b/crates/uffs-core/src/compact_tests.rs
@@ -698,7 +698,7 @@ fn resolve_ext_ids_handles_full_table_miss_without_overflow() {
     // Absent extension: must scan the entire (full) table and return
     // no matches instead of panicking.
     let ids = drive.resolve_ext_ids(&["nonexistent".to_owned()]);
-    assert!(ids.is_empty());
+    assert_eq!(ids, Vec::<u16>::new());
 }
 
 /// Companion to the miss-case regression above: a real extension at

--- a/crates/uffs-core/src/diff.rs
+++ b/crates/uffs-core/src/diff.rs
@@ -291,8 +291,8 @@ mod tests {
         let current = [rec(10, 1, 100, 5), rec(12, 1, 50, 9)];
         let report = diff_records(&baseline, &current);
         assert_eq!(report.added, vec![1], "the new row (idx 1) is an add");
-        assert!(report.deleted.is_empty());
-        assert!(report.modified.is_empty());
+        assert_eq!(report.deleted, Vec::<u32>::new());
+        assert_eq!(report.modified, Vec::<u32>::new());
     }
 
     #[test]
@@ -301,8 +301,8 @@ mod tests {
         let current = [rec(10, 1, 100, 5)];
         let report = diff_records(&baseline, &current);
         assert_eq!(report.deleted, vec![1], "baseline idx 1 vanished");
-        assert!(report.added.is_empty());
-        assert!(report.modified.is_empty());
+        assert_eq!(report.added, Vec::<u32>::new());
+        assert_eq!(report.modified, Vec::<u32>::new());
     }
 
     #[test]
@@ -311,8 +311,8 @@ mod tests {
         let current = [rec(10, 1, 999, 5)];
         let report = diff_records(&baseline, &current);
         assert_eq!(report.modified, vec![0], "same ref, changed size → modify");
-        assert!(report.added.is_empty());
-        assert!(report.deleted.is_empty());
+        assert_eq!(report.added, Vec::<u32>::new());
+        assert_eq!(report.deleted, Vec::<u32>::new());
     }
 
     #[test]

--- a/crates/uffs-core/src/path_trie.rs
+++ b/crates/uffs-core/src/path_trie.rs
@@ -528,7 +528,7 @@ mod tests {
         assert_eq!(trie.roots(), vec![0_u32]);
         assert_eq!(trie.name_of(0), Some(b"C" as &[u8]));
         assert_eq!(trie.parent_of(0), None);
-        assert!(trie.children_of(0).is_empty());
+        assert_eq!(trie.children_of(0), Vec::<u32>::new());
     }
 
     /// Two-level hierarchy: `C` (root) with two children `Users` and

--- a/crates/uffs-core/src/search/dispatch.rs
+++ b/crates/uffs-core/src/search/dispatch.rs
@@ -617,7 +617,7 @@ mod tests {
         let mut filters = SearchFilters::default();
         let (pat, _) = run_safety_nets(">.*\\.jpg", &mut filters);
         assert_eq!(pat, ">.*\\.jpg", "no $ anchor — pattern must stay");
-        assert!(filters.extensions.is_empty());
+        assert_eq!(filters.extensions, Vec::<String>::new());
     }
 
     #[test]
@@ -625,7 +625,7 @@ mod tests {
         let mut filters = SearchFilters::default();
         let (pat, _) = run_safety_nets(">.*\\.(jp.?|png)$", &mut filters);
         assert_eq!(pat, ">.*\\.(jp.?|png)$");
-        assert!(filters.extensions.is_empty());
+        assert_eq!(filters.extensions, Vec::<String>::new());
     }
 
     #[test]
@@ -706,6 +706,6 @@ mod tests {
         let mut filters = SearchFilters::default();
         let (pat, drives) = run_safety_nets("\\rnio\\*", &mut filters);
         assert_eq!(pat, "\\rnio\\*", "no drive prefix → untouched");
-        assert!(drives.is_empty());
+        assert_eq!(drives, Vec::<uffs_mft::platform::DriveLetter>::new());
     }
 }

--- a/crates/uffs-daemon/src/cache/cache_cleaner.rs
+++ b/crates/uffs-daemon/src/cache/cache_cleaner.rs
@@ -210,7 +210,7 @@ mod tests {
         let (freed, errors) = delete_drive_cache_files(&paths);
 
         assert_eq!(freed, 0);
-        assert!(errors.is_empty());
+        assert_eq!(errors, Vec::<String>::new());
     }
 
     /// `delete_drive_cache_files` sums file sizes correctly across
@@ -249,7 +249,7 @@ mod tests {
         let (freed, errors) = delete_drive_cache_files(core::slice::from_ref(&path_dir));
 
         assert_eq!(freed, 0);
-        assert!(errors.is_empty());
+        assert_eq!(errors, Vec::<String>::new());
         assert!(path_dir.exists(), "non-file entry must be left in place");
     }
 

--- a/crates/uffs-daemon/src/cache/prefetch.rs
+++ b/crates/uffs-daemon/src/cache/prefetch.rs
@@ -284,7 +284,7 @@ pub(crate) mod tests {
     #[test]
     fn recording_prefetch_captures_every_region_in_order() {
         let prefetch = RecordingPrefetch::new();
-        assert!(prefetch.calls().is_empty());
+        assert_eq!(prefetch.calls(), Vec::<Vec<(usize, usize)>>::new());
 
         let buf_a = [0_u8; 16];
         let buf_b = [0_u8; 32];

--- a/crates/uffs-daemon/src/index/tests/forget_status.rs
+++ b/crates/uffs-daemon/src/index/tests/forget_status.rs
@@ -83,9 +83,12 @@ async fn forget_cold_drive_evicts_and_unlinks() {
         panic!("expected Ok outcome on Cold-drive forget; got {outcome:?}");
     };
     assert_eq!(out.forgotten, vec![uffs_mft::platform::DriveLetter::C]);
-    assert!(out.already_absent.is_empty());
+    assert_eq!(
+        out.already_absent,
+        Vec::<uffs_mft::platform::DriveLetter>::new()
+    );
     assert_eq!(out.freed_bytes, 1_024);
-    assert!(out.errors.is_empty());
+    assert_eq!(out.errors, Vec::<String>::new());
 
     assert_eq!(
         cleaner.calls(),
@@ -159,8 +162,11 @@ async fn forget_warm_with_force_auto_hibernates_then_evicts() {
         uffs_mft::platform::DriveLetter::D
     ]);
     assert_eq!(out.freed_bytes, 4_096, "2 drives × 2_048 bytes each");
-    assert!(out.already_absent.is_empty());
-    assert!(out.errors.is_empty());
+    assert_eq!(
+        out.already_absent,
+        Vec::<uffs_mft::platform::DriveLetter>::new()
+    );
+    assert_eq!(out.errors, Vec::<String>::new());
 
     assert_eq!(
         cleaner.calls(),
@@ -191,10 +197,10 @@ async fn forget_unknown_drive_is_idempotent_already_absent() {
     let ForgetOutcomeOrBusy::Ok(out) = outcome else {
         panic!("expected Ok for unknown drive; got {outcome:?}");
     };
-    assert!(out.forgotten.is_empty());
+    assert_eq!(out.forgotten, Vec::<uffs_mft::platform::DriveLetter>::new());
     assert_eq!(out.already_absent, vec![uffs_mft::platform::DriveLetter::Z]);
     assert_eq!(out.freed_bytes, 0);
-    assert!(out.errors.is_empty());
+    assert_eq!(out.errors, Vec::<String>::new());
 
     assert_eq!(
         cleaner.calls(),
@@ -257,7 +263,10 @@ async fn forget_pinned_hot_drive_with_force_clears_pin() {
     assert_eq!(out.freed_bytes, 512);
 
     let post_states = mgr.shard_states_for_test().await;
-    assert!(post_states.is_empty());
+    assert_eq!(
+        post_states,
+        Vec::<(uffs_mft::platform::DriveLetter, ShardState)>::new()
+    );
 }
 
 /// Phase 8-D — multi-drive forget where one drive is busy and
@@ -317,7 +326,10 @@ async fn status_drives_empty_registry_returns_empty_drives() {
 
     let response = mgr.status_drives().await;
 
-    assert!(response.drives.is_empty());
+    assert_eq!(
+        response.drives,
+        Vec::<uffs_client::protocol::response::DriveTierStatus>::new()
+    );
 }
 
 /// Phase 8-E — a single Warm shard surfaces `tier = "warm"`,

--- a/crates/uffs-daemon/src/index/tests/lifecycle_hooks.rs
+++ b/crates/uffs-daemon/src/index/tests/lifecycle_hooks.rs
@@ -271,7 +271,10 @@ async fn ensure_warm_for_dispatch_invokes_prefetch_with_records_and_names_region
     );
 
     // Pre-promote: no prefetch calls.
-    assert!(recording_prefetch.calls().is_empty());
+    assert_eq!(
+        recording_prefetch.calls(),
+        Vec::<Vec<(usize, usize)>>::new()
+    );
 
     mgr.ensure_warm_for_dispatch(&[uffs_mft::platform::DriveLetter::C], &[])
         .await;

--- a/crates/uffs-daemon/src/index/tests/tiering_ops.rs
+++ b/crates/uffs-daemon/src/index/tests/tiering_ops.rs
@@ -63,9 +63,18 @@ async fn hibernate_demotes_all_loaded_drives_to_cold() {
         ],
         "both freshly-loaded Warm drives must be reported as warm-demoted"
     );
-    assert!(outcome.hot_demoted.is_empty());
-    assert!(outcome.parked_demoted.is_empty());
-    assert!(outcome.already_cold.is_empty());
+    assert_eq!(
+        outcome.hot_demoted,
+        Vec::<uffs_mft::platform::DriveLetter>::new()
+    );
+    assert_eq!(
+        outcome.parked_demoted,
+        Vec::<uffs_mft::platform::DriveLetter>::new()
+    );
+    assert_eq!(
+        outcome.already_cold,
+        Vec::<uffs_mft::platform::DriveLetter>::new()
+    );
 
     let states = mgr.shard_states_for_test().await;
     assert_eq!(
@@ -136,8 +145,14 @@ async fn hibernate_reports_already_cold_drives_separately() {
     assert_eq!(outcome.warm_demoted, vec![
         uffs_mft::platform::DriveLetter::D
     ]);
-    assert!(outcome.hot_demoted.is_empty());
-    assert!(outcome.parked_demoted.is_empty());
+    assert_eq!(
+        outcome.hot_demoted,
+        Vec::<uffs_mft::platform::DriveLetter>::new()
+    );
+    assert_eq!(
+        outcome.parked_demoted,
+        Vec::<uffs_mft::platform::DriveLetter>::new()
+    );
 }
 
 /// Phase 8-C contract — `preload C:` against a `Cold` shard goes

--- a/crates/uffs-fetch/src/github.rs
+++ b/crates/uffs-fetch/src/github.rs
@@ -249,7 +249,7 @@ mod tests {
         let mut sink: Vec<u8> = Vec::new();
         let written = copy_capped(&mut reader, &mut sink, 100, no_progress).expect("empty copies");
         assert_eq!(written, 0);
-        assert!(sink.is_empty());
+        assert_eq!(sink, Vec::<u8>::new(), "sink must stay untouched");
     }
 
     #[test]

--- a/crates/uffs-mcp/src/lib_tests.rs
+++ b/crates/uffs-mcp/src/lib_tests.rs
@@ -354,8 +354,8 @@ mod tool_args_tests {
         let args: AggregateArgs = serde_json::from_value(serde_json::json!({})).unwrap();
         assert_eq!(args.pattern, "*");
         assert!(args.preset.is_none());
-        assert!(args.aggregations.is_empty());
-        assert!(args.drives.is_empty());
+        assert_eq!(args.aggregations, Vec::<String>::new());
+        assert_eq!(args.drives, Vec::<String>::new());
     }
 
     #[test]

--- a/crates/uffs-mcp/src/main.rs
+++ b/crates/uffs-mcp/src/main.rs
@@ -29,6 +29,7 @@ use tracing_appender as _;
 use uffs_mft as _;
 
 mod process;
+mod supervisor;
 
 use anyhow::{Context as _, Result};
 use clap::{Parser, Subcommand};
@@ -42,6 +43,11 @@ struct Cli {
     /// runs in stdio mode (for AI host integration).
     #[command(subcommand)]
     action: Option<Action>,
+
+    /// Run as the supervised stdio worker (spawned by the supervisor —
+    /// see `supervisor.rs`; not part of the public CLI surface).
+    #[arg(long, hide = true, global = true)]
+    worker: bool,
 }
 
 /// MCP server lifecycle actions.
@@ -114,11 +120,40 @@ enum Action {
     Reload,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     uffs_version::handle_version!("uffsmcp");
     let cli = Cli::parse();
 
+    // Stdio mode (no subcommand, or `run`) is served through the
+    // self-upgrading supervisor: it owns the client's pipes and pumps
+    // JSON-RPC through a `--worker` child it can hot-swap when the
+    // binary on disk is replaced (see `supervisor.rs`).  The worker
+    // child — and every non-stdio action — takes the async path.
+    let stdio_mode = matches!(cli.action, None | Some(Action::Run { .. }));
+    if stdio_mode && !cli.worker {
+        let _ignore = tracing_subscriber::fmt()
+            .with_writer(std::io::stderr)
+            .with_target(false)
+            .with_max_level(tracing::Level::INFO)
+            .try_init();
+        // Re-issue our own argv verbatim (plus `--worker`) so the child
+        // serves exactly what the client asked the supervisor for.
+        let mut worker_args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+        worker_args.push(std::ffi::OsString::from("--worker"));
+        return supervisor::run(&worker_args);
+    }
+
+    // The supervisor path above is pure std (blocking pipes + threads);
+    // only the server/action paths need the async runtime.
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("building the tokio runtime")?
+        .block_on(async_main(cli))
+}
+
+/// The async half of `main`: the stdio worker and every lifecycle action.
+async fn async_main(cli: Cli) -> Result<()> {
     match cli.action {
         // No subcommand → stdio mode (for AI hosts like Claude Desktop).
         None => {

--- a/crates/uffs-mcp/src/roots.rs
+++ b/crates/uffs-mcp/src/roots.rs
@@ -377,7 +377,7 @@ mod tests {
         let (drives, prefixes, warnings) = roots_scope(&state).unwrap();
         assert_eq!(drives, vec!["C", "D"]);
         assert_eq!(prefixes.len(), 2);
-        assert!(warnings.is_empty());
+        assert_eq!(warnings, Vec::<String>::new());
     }
 
     #[test]
@@ -393,8 +393,8 @@ mod tests {
         update_roots_state(&mut state, &roots);
 
         let (drives, prefixes, warnings) = roots_scope(&state).unwrap();
-        assert!(drives.is_empty());
-        assert!(prefixes.is_empty());
+        assert_eq!(drives, Vec::<String>::new());
+        assert_eq!(prefixes, Vec::<String>::new());
         assert_eq!(warnings.len(), 1);
     }
 
@@ -430,7 +430,7 @@ mod tests {
 
         assert_eq!(params.drives, vec![uffs_mft::platform::DriveLetter::D]);
         // "D:" is only 2 chars — should NOT inject a path predicate.
-        assert!(params.predicates.is_empty());
+        assert_eq!(params.predicates, Vec::<SearchPredicate>::new());
     }
 
     #[test]
@@ -499,8 +499,8 @@ mod tests {
         let mut params = SearchParams::default();
         apply_roots_scope(&state, &mut params);
 
-        assert!(params.drives.is_empty());
-        assert!(params.predicates.is_empty());
+        assert_eq!(params.drives, Vec::<uffs_mft::platform::DriveLetter>::new());
+        assert_eq!(params.predicates, Vec::<SearchPredicate>::new());
     }
 
     // ── longest_common_prefix tests ─────────────────────────────────

--- a/crates/uffs-mcp/src/supervisor.rs
+++ b/crates/uffs-mcp/src/supervisor.rs
@@ -1,0 +1,560 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! The self-upgrading MCP supervisor: zero-downtime binary switches
+//! for `uffsmcp` stdio sessions.
+//!
+//! The problem: `just use-local` (and any installer) atomically
+//! replaces `uffsmcp` on disk, but every RUNNING stdio server keeps
+//! executing its old image until someone kills it — and killing it
+//! breaks the AI-host session that spawned it. The fix is a tiny
+//! supervisor that OWNS the client's stdio pipes for the whole
+//! session and serves through a worker child it can replace:
+//!
+//! - `uffsmcp` (stdio mode) runs the supervisor (the MCP client config never
+//!   changes); the supervisor spawns `<current-exe> … --worker` with piped
+//!   stdio and pumps newline-delimited JSON-RPC between client and child,
+//!   byte-for-byte.
+//! - It remembers the client's `initialize` request and `initialized`
+//!   notification verbatim, and tracks in-flight request ids (client requests
+//!   forwarded minus child responses returned).
+//! - A ticker stats the executable; when the on-disk identity changes (a
+//!   rename-replace install) and NOTHING is in flight, it spawns a fresh child,
+//!   replays the handshake into it (swallowing the duplicate response the
+//!   client must never see), atomically routes traffic to it, kills the old
+//!   child, and nudges the client with `notifications/tools/list_changed` so a
+//!   changed toolset is re-listed. The client's pipes never close: zero visible
+//!   downtime.
+//! - The same replay path restarts a CRASHED child, so the supervisor is also
+//!   the server's crash hatch (rate-limited; a child that dies repeatedly ends
+//!   the session honestly).
+//!
+//! Deliberately a byte pump, not a proxy that re-frames: the
+//! supervisor parses each line only enough to classify it (request id
+//! / response id / the two handshake messages) and always forwards
+//! the ORIGINAL bytes. Cross-platform by construction — plain
+//! `std::process` and threads, no exec(2), identical on Windows.
+//!
+//! # Environment
+//!
+//! | Variable | Effect | Default |
+//! |---|---|---|
+//! | `UFFS_MCP_WORKER_EXE` | Program spawned as the worker | the supervisor's own executable |
+//! | `UFFS_MCP_WATCH_PATH` | File whose identity change triggers a swap | the worker executable |
+//! | `UFFS_MCP_POLL_MS`    | Ticker interval in milliseconds | `5000` |
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::collections::HashSet;
+use std::io::{BufRead as _, BufReader, Write as _};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::Mutex;
+
+use anyhow::{Context as _, Result, anyhow};
+
+/// How often the ticker checks the executable for replacement.
+const POLL_MS_DEFAULT: u64 = 5_000;
+
+/// Child crashes tolerated inside [`CRASH_WINDOW_SECS`] before the
+/// supervisor gives up and ends the session.
+const CRASH_LIMIT: usize = 3;
+
+/// The crash-rate window (see [`CRASH_LIMIT`]).
+const CRASH_WINDOW_SECS: u64 = 60;
+
+/// The on-disk identity of the served binary: replaced-in-place is a
+/// changed (len, mtime) pair — installers replace by rename, so a
+/// swap always changes mtime even when the length matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BinaryIdentity {
+    /// File length in bytes.
+    len: u64,
+    /// Modification time (unix millis; 0 when unavailable).
+    mtime_ms: u128,
+}
+
+impl BinaryIdentity {
+    /// Reads the identity of `path`; `None` when it cannot be stat'ed
+    /// (a transient install window — the ticker just retries).
+    fn of(path: &std::path::Path) -> Option<Self> {
+        let meta = std::fs::metadata(path).ok()?;
+        let mtime_ms = meta
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map_or(0, |elapsed| elapsed.as_millis());
+        Some(Self {
+            len: meta.len(),
+            mtime_ms,
+        })
+    }
+}
+
+/// What one JSON-RPC line means to the pump (classification only; the
+/// original bytes are always what gets forwarded).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LineKind {
+    /// A request carrying an id (the client expects a response).
+    Request(String),
+    /// A response carrying an id (settles an in-flight request).
+    Response(String),
+    /// The `initialize` request (also a [`LineKind::Request`]; carries
+    /// the id the replay must swallow).
+    Initialize(String),
+    /// The `notifications/initialized` notification.
+    Initialized,
+    /// Anything else (notifications, malformed lines): forward as-is.
+    Other,
+}
+
+/// Classifies one JSON-RPC line. A malformed line is [`LineKind::Other`]:
+/// the pump never drops bytes it does not understand.
+fn classify(line: &str) -> LineKind {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+        return LineKind::Other;
+    };
+    let request_id = value.get("id").map(ToString::to_string);
+    let method = value.get("method").and_then(serde_json::Value::as_str);
+    match (method, request_id) {
+        (Some("initialize"), Some(found)) => LineKind::Initialize(found),
+        (Some("notifications/initialized"), None) => LineKind::Initialized,
+        (Some(_), Some(found)) => LineKind::Request(found),
+        (None, Some(found)) => LineKind::Response(found),
+        (Some(_) | None, None) => LineKind::Other,
+    }
+}
+
+/// The captured client handshake, replayed into every fresh child.
+#[derive(Debug, Default, Clone)]
+struct Handshake {
+    /// The verbatim `initialize` request line and its id.
+    initialize: Option<(String, String)>,
+    /// The verbatim `notifications/initialized` line.
+    initialized: Option<String>,
+}
+
+/// The live worker child: process handle plus its stdin (the stdout
+/// pump thread owns the read half).
+struct Worker {
+    /// The child process.
+    child: Child,
+    /// Its stdin, for forwarded client bytes.
+    stdin: ChildStdin,
+    /// Generation counter (stdout pumps of dead generations exit).
+    generation: u64,
+}
+
+/// The shared pump state.
+struct Shared {
+    /// The current worker (swapped under this lock).
+    worker: Mutex<Option<Worker>>,
+    /// Ids of requests forwarded to the child and not yet answered.
+    in_flight: Mutex<HashSet<String>>,
+    /// The captured handshake.
+    handshake: Mutex<Handshake>,
+    /// The client-facing stdout (one writer at a time).
+    client_out: Mutex<std::io::Stdout>,
+    /// Set when the session is over (client EOF or fatal error).
+    done: AtomicBool,
+}
+
+/// Runs the supervisor until the client disconnects.
+///
+/// `worker_args` is the argv (minus the program) the worker child is
+/// spawned with — the caller passes its own arguments plus `--worker`.
+///
+/// # Errors
+///
+/// Returns an error when the executable cannot be resolved or the
+/// first worker fails to spawn; later worker crashes are handled by
+/// the respawn path (rate-limited).
+pub(crate) fn run(worker_args: &[std::ffi::OsString]) -> Result<()> {
+    let exe = std::env::var_os("UFFS_MCP_WORKER_EXE").map_or_else(
+        || std::env::current_exe().context("resolving the uffsmcp executable"),
+        |raw| Ok(std::path::PathBuf::from(raw)),
+    )?;
+    let watch_path = std::env::var_os("UFFS_MCP_WATCH_PATH")
+        .map_or_else(|| exe.clone(), std::path::PathBuf::from);
+    let poll_ms = std::env::var("UFFS_MCP_POLL_MS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .unwrap_or(POLL_MS_DEFAULT);
+    let shared = Arc::new(Shared {
+        worker: Mutex::new(None),
+        in_flight: Mutex::new(HashSet::new()),
+        handshake: Mutex::new(Handshake::default()),
+        client_out: Mutex::new(std::io::stdout()),
+        done: AtomicBool::new(false),
+    });
+    let first = spawn_worker(&exe, worker_args, 0)?;
+    install_worker(&shared, first, None);
+    tracing::info!(exe = %exe.display(), poll_ms, "mcp supervisor armed (self-upgrading)");
+
+    let ticker = {
+        let shared_for_ticker = Arc::clone(&shared);
+        let exe_for_ticker = exe;
+        let args: Vec<std::ffi::OsString> = worker_args.to_vec();
+        std::thread::spawn(move || {
+            ticker_loop(
+                &shared_for_ticker,
+                &exe_for_ticker,
+                &watch_path,
+                &args,
+                poll_ms,
+            );
+        })
+    };
+    pump_client_stdin(&shared);
+    shared.done.store(true, Ordering::SeqCst);
+    if let Ok(mut slot) = shared.worker.lock()
+        && let Some(mut worker) = slot.take()
+    {
+        let _kill = worker.child.kill();
+        let _wait = worker.child.wait();
+    }
+    let _join = ticker.join();
+    Ok(())
+}
+
+/// Reads the client's stdin to EOF, classifying and forwarding each
+/// line to the current worker.
+fn pump_client_stdin(shared: &Arc<Shared>) {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let read = std::io::stdin().lock().read_line(&mut line);
+        match read {
+            Ok(0) | Err(_) => break,
+            Ok(_bytes) => {}
+        }
+        match classify(line.trim_end()) {
+            LineKind::Initialize(id) => {
+                if let Ok(mut handshake) = shared.handshake.lock() {
+                    handshake.initialize = Some((line.clone(), id.clone()));
+                }
+                track(shared, &id);
+            }
+            LineKind::Initialized => {
+                if let Ok(mut handshake) = shared.handshake.lock() {
+                    handshake.initialized = Some(line.clone());
+                }
+            }
+            LineKind::Request(id) => track(shared, &id),
+            LineKind::Response(_) | LineKind::Other => {}
+        }
+        if forward_to_worker(shared, &line).is_err() {
+            // The child is gone mid-write; the respawn path owns
+            // recovery. Dropping a request here would strand the
+            // client, so the session ends honestly instead.
+            tracing::warn!("worker write failed; ending session");
+            break;
+        }
+    }
+}
+
+/// Records one in-flight request id.
+fn track(shared: &Shared, id: &str) {
+    if let Ok(mut in_flight) = shared.in_flight.lock() {
+        in_flight.insert(id.to_owned());
+    }
+}
+
+/// Writes one raw line to the current worker's stdin.
+fn forward_to_worker(shared: &Shared, line: &str) -> Result<()> {
+    let mut slot = shared
+        .worker
+        .lock()
+        .map_err(|_poison| anyhow!("worker slot poisoned"))?;
+    let outcome = match slot.as_mut() {
+        Some(worker) => worker
+            .stdin
+            .write_all(line.as_bytes())
+            .and_then(|()| worker.stdin.flush())
+            .map_err(|error| anyhow!("writing to the worker: {error}")),
+        None => Err(anyhow!("no live worker")),
+    };
+    drop(slot);
+    outcome
+}
+
+/// Spawns one worker child of `exe` with piped stdin/stdout (stderr
+/// passes through to the supervisor's own stderr).
+fn spawn_worker(
+    exe: &std::path::Path,
+    worker_args: &[std::ffi::OsString],
+    generation: u64,
+) -> Result<Worker> {
+    let mut child = Command::new(exe)
+        .args(worker_args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .context("spawning the uffsmcp worker")?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("worker stdin missing"))?;
+    Ok(Worker {
+        child,
+        stdin,
+        generation,
+    })
+}
+
+/// Installs `worker` as current and starts its stdout pump.
+/// `swallow_id` is the replayed-initialize response id the pump must
+/// NOT forward (the client already holds the original response).
+fn install_worker(shared: &Arc<Shared>, mut worker: Worker, swallow_id: Option<String>) {
+    let stdout = worker.child.stdout.take();
+    let generation = worker.generation;
+    if let Ok(mut slot) = shared.worker.lock() {
+        *slot = Some(worker);
+    }
+    if let Some(taken) = stdout {
+        let shared_for_pump = Arc::clone(shared);
+        std::thread::spawn(move || {
+            pump_worker_stdout(&shared_for_pump, taken, generation, swallow_id);
+        });
+    }
+}
+
+/// Reads one worker's stdout to EOF, forwarding to the client and
+/// settling in-flight ids. Exits quietly when its generation was
+/// superseded by a swap.
+fn pump_worker_stdout(
+    shared: &Arc<Shared>,
+    stdout: std::process::ChildStdout,
+    generation: u64,
+    swallow_id: Option<String>,
+) {
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    let mut swallow = swallow_id;
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => break,
+            Ok(_bytes) => {}
+        }
+        if let LineKind::Response(id) = classify(line.trim_end()) {
+            if swallow.as_deref() == Some(id.as_str()) {
+                // The duplicate response to the replayed initialize:
+                // the client must never see it twice.
+                swallow = None;
+                continue;
+            }
+            if let Ok(mut in_flight) = shared.in_flight.lock() {
+                in_flight.remove(&id);
+            }
+        }
+        let forwarded = shared.client_out.lock().ok().and_then(|mut out| {
+            out.write_all(line.as_bytes())
+                .and_then(|()| out.flush())
+                .ok()
+        });
+        if forwarded.is_none() {
+            break;
+        }
+    }
+    let superseded = shared.worker.lock().is_ok_and(|slot| {
+        slot.as_ref()
+            .is_some_and(|live| live.generation != generation)
+    });
+    if !superseded && !shared.done.load(Ordering::SeqCst) {
+        tracing::warn!(generation, "uffsmcp worker exited unexpectedly");
+    }
+}
+
+/// The upgrade/respawn ticker: polls the binary identity and the
+/// worker's liveness, swapping at quiet moments.
+fn ticker_loop(
+    shared: &Arc<Shared>,
+    exe: &std::path::Path,
+    watch_path: &std::path::Path,
+    worker_args: &[std::ffi::OsString],
+    poll_ms: u64,
+) {
+    let mut installed = BinaryIdentity::of(watch_path);
+    let mut generation = 0_u64;
+    let mut crashes: Vec<std::time::Instant> = Vec::new();
+    while !shared.done.load(Ordering::SeqCst) {
+        std::thread::sleep(core::time::Duration::from_millis(poll_ms));
+        let worker_died = worker_exited(shared);
+        let current = BinaryIdentity::of(watch_path);
+        let replaced = current.is_some() && current != installed;
+        if !replaced && !worker_died {
+            continue;
+        }
+        if worker_died && crash_limit_hit(&mut crashes) {
+            tracing::error!("uffsmcp worker crash-looping; ending session");
+            shared.done.store(true, Ordering::SeqCst);
+            return;
+        }
+        let quiet = shared
+            .in_flight
+            .lock()
+            .is_ok_and(|in_flight| in_flight.is_empty());
+        if !quiet && !worker_died {
+            continue; // a request is mid-air; try again next tick
+        }
+        generation += 1;
+        if perform_swap(shared, exe, worker_args, generation, worker_died) {
+            installed = current;
+        } else {
+            return;
+        }
+    }
+}
+
+/// True when the current worker process has exited.
+fn worker_exited(shared: &Shared) -> bool {
+    shared.worker.lock().is_ok_and(|mut slot| {
+        slot.as_mut()
+            .is_some_and(|live| matches!(live.child.try_wait(), Ok(Some(_status))))
+    })
+}
+
+/// One swap attempt with its logging; `false` ends the ticker (the
+/// session is marked done on failure).
+fn perform_swap(
+    shared: &Arc<Shared>,
+    exe: &std::path::Path,
+    worker_args: &[std::ffi::OsString],
+    generation: u64,
+    worker_died: bool,
+) -> bool {
+    match swap_worker(shared, exe, worker_args, generation) {
+        Ok(()) => {
+            tracing::info!(
+                generation,
+                reason = if worker_died {
+                    "crash"
+                } else {
+                    "binary replaced"
+                },
+                "uffsmcp worker swapped in place"
+            );
+            true
+        }
+        Err(error) => {
+            tracing::error!(%error, "worker swap failed; ending session");
+            shared.done.store(true, Ordering::SeqCst);
+            false
+        }
+    }
+}
+
+/// Records one worker crash and prunes the rate window; `true` when
+/// the limit is exceeded and the supervisor should give up.
+fn crash_limit_hit(crashes: &mut Vec<std::time::Instant>) -> bool {
+    let now = std::time::Instant::now();
+    crashes.retain(|at| now.duration_since(*at).as_secs() < CRASH_WINDOW_SECS);
+    crashes.push(now);
+    crashes.len() > CRASH_LIMIT
+}
+
+/// Spawns a fresh worker, replays the captured handshake into it,
+/// installs it (its stdout pump swallows the duplicate initialize
+/// response), and kills the predecessor.
+fn swap_worker(
+    shared: &Arc<Shared>,
+    exe: &std::path::Path,
+    worker_args: &[std::ffi::OsString],
+    generation: u64,
+) -> Result<()> {
+    let handshake = shared
+        .handshake
+        .lock()
+        .map_err(|_poison| anyhow!("handshake poisoned"))?
+        .clone();
+    let mut fresh = spawn_worker(exe, worker_args, generation)?;
+    let swallow_id = if let Some((line, id)) = &handshake.initialize {
+        fresh
+            .stdin
+            .write_all(line.as_bytes())
+            .context("replaying initialize")?;
+        Some(id.clone())
+    } else {
+        None
+    };
+    if let Some(line) = &handshake.initialized {
+        fresh
+            .stdin
+            .write_all(line.as_bytes())
+            .context("replaying initialized")?;
+    }
+    fresh
+        .stdin
+        .flush()
+        .context("flushing the handshake replay")?;
+    let previous = shared
+        .worker
+        .lock()
+        .map_err(|_poison| anyhow!("worker slot poisoned"))?
+        .take();
+    install_worker(shared, fresh, swallow_id);
+    if let Some(mut old) = previous {
+        let _kill = old.child.kill();
+        let _wait = old.child.wait();
+    }
+    // A changed binary may carry a changed toolset: nudge the client
+    // to re-list (spec notification; clients without the capability
+    // ignore it).
+    if handshake.initialize.is_some()
+        && let Ok(mut out) = shared.client_out.lock()
+    {
+        let _nudge = out
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/tools/list_changed\"}\n")
+            .and_then(|()| out.flush());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LineKind, classify};
+
+    /// Requests, responses, and the two handshake messages classify by
+    /// shape; malformed lines are passthrough.
+    #[test]
+    fn lines_classify_by_jsonrpc_shape() {
+        assert_eq!(
+            classify(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#),
+            LineKind::Initialize(String::from("1"))
+        );
+        assert_eq!(
+            classify(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#),
+            LineKind::Initialized
+        );
+        assert_eq!(
+            classify(r#"{"jsonrpc":"2.0","id":"a-7","method":"tools/call","params":{}}"#),
+            LineKind::Request(String::from("\"a-7\""))
+        );
+        assert_eq!(
+            classify(r#"{"jsonrpc":"2.0","id":"a-7","result":{}}"#),
+            LineKind::Response(String::from("\"a-7\""))
+        );
+        assert_eq!(
+            classify(r#"{"jsonrpc":"2.0","method":"notifications/progress"}"#),
+            LineKind::Other
+        );
+        assert_eq!(classify("not json at all"), LineKind::Other);
+    }
+
+    /// A request and its response settle to the same id string, number
+    /// and string ids alike.
+    #[test]
+    fn request_and_response_ids_agree() {
+        let request = classify(r#"{"jsonrpc":"2.0","id":42,"method":"tools/list"}"#);
+        let response = classify(r#"{"jsonrpc":"2.0","id":42,"result":{"tools":[]}}"#);
+        match (request, response) {
+            (LineKind::Request(sent), LineKind::Response(settled)) => {
+                assert_eq!(sent, settled);
+            }
+            other => panic!("unexpected classification: {other:?}"),
+        }
+    }
+}

--- a/crates/uffs-mcp/tests/supervisor.rs
+++ b/crates/uffs-mcp/tests/supervisor.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025-2026 SKY, LLC.
+
+//! End-to-end proof of the self-upgrading stdio supervisor: one client
+//! connection survives a binary "replacement" (the watch file is
+//! touched) with the worker hot-swapped underneath it — the
+//! zero-downtime contract, exercised over real processes and pipes.
+//!
+//! The real worker refuses to serve without a live daemon, so the test
+//! points `UFFS_MCP_WORKER_EXE` at a tiny scripted JSON-RPC responder
+//! that stamps every reply with its own PID — which is exactly what
+//! makes the swap observable: the same session sees two different
+//! worker PIDs across the "install".
+
+#![expect(
+    clippy::tests_outside_test_module,
+    reason = "integration tests are inherently outside cfg(test)"
+)]
+#![expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "integration test — relaxed linting for test clarity"
+)]
+
+// Acknowledge crates used by the lib/bin but not this test target.
+use anyhow as _;
+#[cfg(feature = "streamable-http")]
+use axum as _;
+use clap as _;
+use rmcp as _;
+use schemars as _;
+use serde as _;
+use thiserror as _;
+use tokio as _;
+#[cfg(feature = "streamable-http")]
+use tower_service as _;
+use tracing as _;
+use tracing_appender as _;
+use tracing_subscriber as _;
+use uffs_client as _;
+use uffs_mcp as _;
+use uffs_mft as _;
+use uffs_security as _;
+use uffs_version as _;
+
+#[cfg(unix)]
+mod unix {
+    use std::io::{BufRead, BufReader, Write as _};
+    use std::os::unix::fs::PermissionsExt as _;
+    use std::process::Stdio;
+
+    /// A scripted stand-in for the real worker: answers `initialize`
+    /// and `tools/list` with canned results stamped with its own PID,
+    /// so a hot swap is visible as a PID change on the same session.
+    const FAKE_WORKER: &str = r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      id=`printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p'`
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"serverInfo":{"name":"fake-worker"},"workerPid":%s}}\n' "$id" "$$"
+      ;;
+    *'"method":"tools/list"'*)
+      id=`printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p'`
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"tools":[],"workerPid":%s}}\n' "$id" "$$"
+      ;;
+  esac
+done
+"#;
+
+    /// A scratch dir holding the fake worker script + the watch file,
+    /// removed on drop.
+    struct Scratch {
+        /// The directory itself.
+        dir: std::path::PathBuf,
+    }
+
+    impl Scratch {
+        /// Creates the scratch dir with the executable fake worker and
+        /// an initial watch file inside.
+        fn new() -> Self {
+            let dir = std::env::temp_dir().join(format!("uffs-mcp-sup-{}", std::process::id()));
+            std::fs::create_dir_all(&dir).expect("create scratch dir");
+            let script = dir.join("fake-worker.sh");
+            std::fs::write(&script, FAKE_WORKER).expect("write fake worker");
+            std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod +x fake worker");
+            std::fs::write(dir.join("watch"), b"original-binary-identity").expect("seed watch");
+            Self { dir }
+        }
+
+        /// Path of the fake worker script.
+        fn worker(&self) -> std::path::PathBuf {
+            self.dir.join("fake-worker.sh")
+        }
+
+        /// Path of the watch file.
+        fn watch(&self) -> std::path::PathBuf {
+            self.dir.join("watch")
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _cleanup = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    /// Sends one JSON-RPC line and reads lines until the response with
+    /// `id` arrives (collecting skipped notifications), returning it
+    /// parsed.
+    fn call(
+        stdin: &mut impl std::io::Write,
+        reader: &mut impl BufRead,
+        line: &str,
+        id: u64,
+        skipped: &mut Vec<String>,
+    ) -> serde_json::Value {
+        stdin.write_all(line.as_bytes()).expect("write request");
+        stdin.write_all(b"\n").expect("write newline");
+        stdin.flush().expect("flush request");
+        let mut buffer = String::new();
+        loop {
+            buffer.clear();
+            let bytes = reader.read_line(&mut buffer).expect("read response line");
+            assert!(bytes > 0, "server closed the pipe waiting for id {id}");
+            let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&buffer) else {
+                continue;
+            };
+            if parsed.get("id").and_then(serde_json::Value::as_u64) == Some(id) {
+                return parsed;
+            }
+            skipped.push(buffer.clone());
+        }
+    }
+
+    /// The worker PID a fake-worker response was stamped with.
+    fn worker_pid(response: &serde_json::Value) -> u64 {
+        response["result"]["workerPid"]
+            .as_u64()
+            .expect("workerPid stamp")
+    }
+
+    /// One session: initialize, call, "replace" the binary (touch the
+    /// watch file), wait past the poll interval, call again. The
+    /// connection never breaks, both calls succeed, and the second is
+    /// served by a DIFFERENT worker process on the same pipes.
+    #[test]
+    fn one_session_survives_a_binary_swap() {
+        let scratch = Scratch::new();
+        let mut supervisor = std::process::Command::new(env!("CARGO_BIN_EXE_uffsmcp"))
+            .env("UFFS_MCP_WORKER_EXE", scratch.worker())
+            .env("UFFS_MCP_WATCH_PATH", scratch.watch())
+            .env("UFFS_MCP_POLL_MS", "150")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("supervisor spawns");
+        let mut stdin = supervisor.stdin.take().expect("supervisor stdin");
+        let mut reader = BufReader::new(supervisor.stdout.take().expect("supervisor stdout"));
+
+        let mut skipped: Vec<String> = Vec::new();
+        let initialize = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"swap-test","version":"0"}}}"#;
+        let response = call(&mut stdin, &mut reader, initialize, 1, &mut skipped);
+        assert!(
+            response.get("result").is_some(),
+            "initialize succeeds: {response}"
+        );
+        stdin
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+            .expect("initialized notification");
+        stdin.flush().expect("flush");
+
+        let list = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#;
+        let first = call(&mut stdin, &mut reader, list, 2, &mut skipped);
+        let first_pid = worker_pid(&first);
+
+        // "Replace the binary": touch the watch file, then give the
+        // ticker time to notice and swap at the quiet moment.
+        std::fs::write(scratch.watch(), b"new-binary-identity").expect("touch watch file");
+        std::thread::sleep(core::time::Duration::from_millis(700));
+
+        let list_again = r#"{"jsonrpc":"2.0","id":3,"method":"tools/list"}"#;
+        let second = call(&mut stdin, &mut reader, list_again, 3, &mut skipped);
+        let second_pid = worker_pid(&second);
+
+        assert_ne!(
+            first_pid, second_pid,
+            "the post-swap call is served by a FRESH worker process"
+        );
+        assert!(
+            skipped
+                .iter()
+                .any(|line| line.contains("notifications/tools/list_changed")),
+            "the swap nudged the client to re-list tools: {skipped:?}"
+        );
+
+        drop(stdin);
+        let _status = supervisor.wait();
+    }
+}

--- a/crates/uffs-mcp/tests/supervisor.rs
+++ b/crates/uffs-mcp/tests/supervisor.rs
@@ -12,14 +12,23 @@
 //! makes the swap observable: the same session sees two different
 //! worker PIDs across the "install".
 
-#![expect(
-    clippy::tests_outside_test_module,
-    reason = "integration tests are inherently outside cfg(test)"
+// The expectations only apply on unix — the test module is cfg-gated
+// (the fake worker is a sh script), so on Windows they would be
+// unfulfilled and the lint lane rejects unfulfilled expectations.
+#![cfg_attr(
+    unix,
+    expect(
+        clippy::tests_outside_test_module,
+        reason = "integration tests are inherently outside cfg(test)"
+    )
 )]
-#![expect(
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    reason = "integration test — relaxed linting for test clarity"
+#![cfg_attr(
+    unix,
+    expect(
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        reason = "integration test — relaxed linting for test clarity"
+    )
 )]
 
 // Acknowledge crates used by the lib/bin but not this test target.
@@ -30,6 +39,10 @@ use clap as _;
 use rmcp as _;
 use schemars as _;
 use serde as _;
+// Used by the unix-only test module; without it the Windows lint pass
+// sees an unused crate dependency.
+#[cfg(not(unix))]
+use serde_json as _;
 use thiserror as _;
 use tokio as _;
 #[cfg(feature = "streamable-http")]

--- a/crates/uffs-mft/src/discovery.rs
+++ b/crates/uffs-mft/src/discovery.rs
@@ -150,6 +150,6 @@ mod tests {
         std::fs::write(bad.join("CD.iocp"), b"").unwrap();
 
         let files = discover_mft_files(tmp.path());
-        assert!(files.is_empty());
+        assert_eq!(files, Vec::<PathBuf>::new());
     }
 }

--- a/crates/uffs-mft/src/index/tests_ads.rs
+++ b/crates/uffs-mft/src/index/tests_ads.rs
@@ -104,7 +104,7 @@ fn ads_stream_accessible_via_get_stream_at() {
 
     // Index 0: default $DATA
     let s0 = index.get_stream_at(rec, 0).expect("stream 0 must exist");
-    assert!(index.stream_name(s0).is_empty());
+    assert_eq!(index.stream_name(s0), "", "default $DATA stream is unnamed");
 
     // Index 1: ADS
     let s1 = index.get_stream_at(rec, 1).expect("stream 1 must exist");

--- a/crates/uffs-mft/src/parity_tests.rs
+++ b/crates/uffs-mft/src/parity_tests.rs
@@ -115,7 +115,7 @@ mod tier1_decoder_corpus {
     #[test]
     fn empty_name_is_empty() {
         let (decoded, lossy) = decode_name_u16(&[]);
-        assert!(decoded.is_empty());
+        assert_eq!(decoded, "");
         assert_eq!(lossy, 0);
     }
 }

--- a/crates/uffs-mft/src/parse/tests/mod.rs
+++ b/crates/uffs-mft/src/parse/tests/mod.rs
@@ -398,7 +398,7 @@ fn parsed_record_default() {
     assert_eq!(record.frs, Frs::ZERO);
     assert_eq!(record.sequence_number, 0);
     assert_eq!(record.parent_frs, ParentFrs::ZERO);
-    assert!(record.name.is_empty());
+    assert_eq!(record.name, "");
     assert!(!record.in_use);
     assert!(!record.is_directory);
 }

--- a/crates/uffs-mft/src/platform/extents.rs
+++ b/crates/uffs-mft/src/platform/extents.rs
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn data_runs_empty_yields_no_extents() {
-        assert!(data_runs_to_extents(&[]).is_empty());
+        assert_eq!(data_runs_to_extents(&[]), Vec::<MftExtent>::new());
     }
 
     #[test]

--- a/crates/uffs-mft/src/reader.rs
+++ b/crates/uffs-mft/src/reader.rs
@@ -639,7 +639,7 @@ mod tests {
     #[test]
     fn multi_drive_reader_empty() {
         let reader = MultiDriveMftReader::new(vec![]);
-        assert!(reader.drives().is_empty());
+        assert_eq!(reader.drives(), Vec::<crate::platform::DriveLetter>::new());
     }
 
     #[tokio::test]

--- a/crates/uffs-update/src/restore.rs
+++ b/crates/uffs-update/src/restore.rs
@@ -164,7 +164,7 @@ mod tests {
     fn parses_program_only() {
         let (program, args) = parse_command_line("uffsmcp").expect("parse");
         assert_eq!(program, "uffsmcp");
-        assert!(args.is_empty());
+        assert_eq!(args, Vec::<String>::new(), "program-only line has no args");
     }
 
     #[test]

--- a/crates/uffs-winsvc/src/lib.rs
+++ b/crates/uffs-winsvc/src/lib.rs
@@ -212,7 +212,7 @@ mod tests {
             ServiceState::Stopped,
             ServiceState::Running,
         ] {
-            assert!(!state.label().is_empty());
+            assert_ne!(state.label(), "", "label missing for {state:?}");
         }
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -24,16 +24,23 @@ ignore = [
   # untrusted XML). Transitive-only: polars-io -> object_store 0.13 -> quick-xml ^0.39.
   # NOT reachable in UFFS: the vulnerable path is object_store's cloud-store XML LIST
   # parsing; UFFS only reads the local NTFS MFT and local index files, never a cloud
-  # object path. No upstream fix exists to bump to as of 2026-07-02 — the newest
-  # object_store (0.14.0) still requires quick-xml ^0.40.1 (< the fixed 0.41), and we
-  # are already on the latest polars (0.54.4). Remove this ignore when object_store
-  # ships a quick-xml >=0.41 release AND polars adopts it.
+  # object path.
+  #
+  # Upstream status re-verified 2026-08-11 (half the removal condition is now met):
+  #   * object_store 0.14.1 DOES require quick-xml ^0.41.0 — the fixed line. (The
+  #     0.14.0-requires-^0.40.1 note below this line was true on 2026-07-02 and is
+  #     now superseded.)
+  #   * polars-io still pins object_store ^0.13.1 — and so does the newest polars
+  #     (0.55.2, checked against the crates.io API), so bumping polars off 0.54.4
+  #     would NOT clear these advisories. The remaining blocker is entirely
+  #     upstream: polars-io must adopt object_store 0.14.
+  # Remove this ignore once polars-io ships with object_store >= 0.14.
   # See: https://rustsec.org/advisories/RUSTSEC-2026-0195
   "RUSTSEC-2026-0195",
   # Same crate, same path, same reasoning as RUSTSEC-2026-0195 above: quick-xml <0.41
   # quadratic run time checking a start tag for duplicate attribute names (DoS on
-  # untrusted XML). Unreachable in UFFS (no cloud object paths); no upstream fix
-  # reachable yet. Remove together with the ignore above.
+  # untrusted XML). Unreachable in UFFS (no cloud object paths); still gated on
+  # polars-io adopting object_store 0.14. Remove together with the ignore above.
   # See: https://rustsec.org/advisories/RUSTSEC-2026-0194
   "RUSTSEC-2026-0194",
 ]

--- a/docs/user-manual/daemon.md
+++ b/docs/user-manual/daemon.md
@@ -149,6 +149,14 @@ so residency costs almost nothing.  On macOS and Linux a crashed
 resident daemon is relaunched automatically (a clean
 `uffs --daemon stop` is honored and does not relaunch).
 
+Residency also survives crashes and stops on **every** platform
+through the auto-spawn marker: `resident on` records the resident
+configuration next to the daemon's PID file, and any daemon started
+implicitly (the next search, an MCP tool call) inherits it — most
+importantly `--no-retire`.  Flags you pass explicitly always win over
+the marker.  `resident off` removes the marker along with the login
+item.
+
 ---
 
 ## 5  Management Commands

--- a/docs/user-manual/daemon.md
+++ b/docs/user-manual/daemon.md
@@ -122,6 +122,33 @@ uffs --daemon start --data-dir ~/uffs_data --idle-timeout 0
 uffs --daemon start --data-dir ~/uffs_data --idle-timeout 1800
 ```
 
+### Permanent residency (start at login, never retire)
+
+If UFFS is part of your every-day workflow, make the daemon
+**resident** instead of tuning timeouts:
+
+```bash
+# Windows — auto-discovers NTFS drives, zero UAC (uses the Access Broker):
+uffs --daemon resident on
+
+# macOS / Linux — provide MFT data:
+uffs --daemon resident on --data-dir ~/uffs_data
+
+# Inspect / undo:
+uffs --daemon resident status
+uffs --daemon resident off
+```
+
+`resident on` registers a per-user login item (Windows: `HKCU` Run
+key; macOS: launchd LaunchAgent; Linux: systemd user unit) that
+starts `uffsd --no-retire` at login, and starts the daemon
+immediately when none is running.  The daemon then never removes
+itself from the process list — searches are always instant — while
+the memory-tiering ladder still parks unused drives down to a few MB,
+so residency costs almost nothing.  On macOS and Linux a crashed
+resident daemon is relaunched automatically (a clean
+`uffs --daemon stop` is honored and does not relaunch).
+
 ---
 
 ## 5  Management Commands

--- a/docs/user-manual/mcp.md
+++ b/docs/user-manual/mcp.md
@@ -77,6 +77,28 @@ uffs --mcp stop
 uffs --mcp run --data-dir ~/uffs_data
 ```
 
+### Zero-downtime upgrades (stdio supervisor)
+
+Every stdio session is fronted by a tiny **self-upgrading supervisor**:
+the process the AI host spawns owns the stdio pipes for the whole
+session and serves through a hidden worker child it can replace.  When
+the `uffsmcp` binary on disk is replaced (an installer or `just
+use-local` rename-swap), the supervisor notices, waits for a quiet
+moment (no request in flight), spawns a fresh worker from the new
+binary, replays the MCP handshake into it, and reroutes traffic — then
+notifies the client with `notifications/tools/list_changed` so a
+changed toolset is re-listed.  The host's MCP connection never drops:
+**a new binary is picked up without restarting any AI-host session**.
+The same path transparently restarts a crashed worker (rate-limited).
+
+No configuration is needed.  Tuning knobs (rarely needed):
+
+| Variable | Effect | Default |
+|---|---|---|
+| `UFFS_MCP_WORKER_EXE` | Program spawned as the worker | the supervisor's own executable |
+| `UFFS_MCP_WATCH_PATH` | File whose identity change triggers a swap | the worker executable |
+| `UFFS_MCP_POLL_MS` | How often the binary is checked (ms) | `5000` |
+
 ---
 
 ## 3  Host configuration

--- a/just/shared.just
+++ b/just/shared.just
@@ -32,10 +32,16 @@ export TERM := "xterm-256color"
 export COLORTERM := "truecolor"
 export CARGO_TERM_COLOR := "always"
 # CARGO_INCREMENTAL is deliberately NOT exported here.  `.cargo/config.toml`
-# owns the cache policy: `build.rustc-wrapper = "sccache"` + `build.incremental
-# = false`.  Env var overrides config, so exporting `CARGO_INCREMENTAL=1`
+# owns the cache policy: `build.rustc-wrapper` (the optional-sccache shim at
+# `scripts/dev/rustc-wrapper`, see issue #587) + `build.incremental = false`.
+# Env var overrides config, so exporting `CARGO_INCREMENTAL=1`
 # from just would defeat sccache (incremental artifacts are non-cacheable)
 # and recreate v0.5.71's Bug B.  See docs/architecture/dev-flow-implementation-plan.md § 2.1.
+#
+# NOTE: `RUSTC_WRAPPER := ""` below then disables the wrapper outright for
+# every just-driven build, so sccache is in practice only active for raw
+# `cargo` invocations.  That predates the shim and is left as-is here; it is
+# also why the shim's blast radius is small.
 export CARGO_NET_RETRY := "3"
 export CARGO_HTTP_TIMEOUT := "30"
 export CARGO_HTTP_MULTIPLEXING := "true"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -10,9 +10,12 @@
 # CI must NOT override this with `@nightly`; workflows install via
 # `rustup show` (which reads this file) so the pin is always honored.
 #
-# Current pin: nightly-2026-07-06.  Requires ethnum >= 1.5.3 (the
-# workspace Cargo.lock resolves 1.5.3 transitively via polars-compute +
-# parquet — verify with `grep -A1 'name = "ethnum"' Cargo.lock`).
+# The pin lives in the `channel` key at the bottom of this block — do
+# not restate it in prose here; a duplicated date silently rots (this
+# comment claimed 2026-07-06 while the channel had already moved to
+# 2026-07-23).  Requires ethnum >= 1.5.3 (the workspace Cargo.lock
+# resolves 1.5.3 transitively via polars-compute + parquet — verify
+# with `grep -A1 'name = "ethnum"' Cargo.lock`).
 #
 # Resolved-history note (kept so a future bump does not re-tread this):
 #   * nightly-2026-04-13 broke tokio 1.51.1 (unresolved imports in
@@ -32,7 +35,7 @@
 # Run `just toolchain-sync` to re-attempt a channel bump; the CI
 # pipeline auto-refreshes on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed.
-channel = "nightly-2026-07-23"
+channel = "nightly-2026-08-11"
 
 # Specify components that should always be available
 components = [

--- a/scripts/ci/uffs-gen-workflow/src/workflow.rs
+++ b/scripts/ci/uffs-gen-workflow/src/workflow.rs
@@ -384,7 +384,7 @@ jobs:
       - run: echo
 ";
         let workflow = parse(yaml).unwrap();
-        assert!(workflow.jobs["alone"].needs.is_empty());
+        assert_eq!(workflow.jobs["alone"].needs, Vec::<String>::new());
     }
 
     #[test]

--- a/scripts/ci/uffs-manifest-audit/src/audit.rs
+++ b/scripts/ci/uffs-manifest-audit/src/audit.rs
@@ -734,12 +734,30 @@ workspace = true
         let m = parse_member(MEMBER_CLEAN).unwrap();
         let d = disc("crates/uffs-core/Cargo.toml", &m);
         let exc = KnownExceptions::new();
-        assert!(audit_metadata_fields(&d, "uffs-core", &exc).is_empty());
-        assert!(audit_deps_inherit_workspace(&d, "uffs-core", &exc).is_empty());
-        assert!(audit_lints_inherit_workspace(&d, "uffs-core").is_empty());
-        assert!(audit_no_workspace_policy_blocks(&d, "uffs-core").is_empty());
-        assert!(audit_publish_partition(&d, "uffs-core", &exc).is_empty());
-        assert!(audit_docs_rs_metadata_present(&d, "uffs-core").is_empty());
+        assert_eq!(
+            audit_metadata_fields(&d, "uffs-core", &exc),
+            Vec::<Finding>::new()
+        );
+        assert_eq!(
+            audit_deps_inherit_workspace(&d, "uffs-core", &exc),
+            Vec::<Finding>::new()
+        );
+        assert_eq!(
+            audit_lints_inherit_workspace(&d, "uffs-core"),
+            Vec::<Finding>::new()
+        );
+        assert_eq!(
+            audit_no_workspace_policy_blocks(&d, "uffs-core"),
+            Vec::<Finding>::new()
+        );
+        assert_eq!(
+            audit_publish_partition(&d, "uffs-core", &exc),
+            Vec::<Finding>::new()
+        );
+        assert_eq!(
+            audit_docs_rs_metadata_present(&d, "uffs-core"),
+            Vec::<Finding>::new()
+        );
     }
 
     #[test]
@@ -827,7 +845,7 @@ workspace = true
         // Same shape under uffs-diag — should be suppressed.
         let d_diag = disc("crates/uffs-diag/Cargo.toml", &m);
         let suppressed = audit_lib_bin_name_convention(&d_diag, "uffs-diag", &exc);
-        assert!(suppressed.is_empty());
+        assert_eq!(suppressed, Vec::<Finding>::new());
     }
 
     #[test]

--- a/scripts/dev/rustc-wrapper
+++ b/scripts/dev/rustc-wrapper
@@ -1,0 +1,27 @@
+#!/bin/sh
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025-2026 SKY, LLC.
+#
+# Optional-sccache rustc wrapper (POSIX side; see `rustc-wrapper.cmd` for
+# the Windows twin).
+#
+# Cargo invokes a `build.rustc-wrapper` as `<wrapper> <rustc> <args...>`.
+# This shim forwards to sccache when it is installed and execs rustc
+# directly when it is not, so a missing sccache degrades to an uncached
+# build instead of failing every cargo invocation with:
+#
+#     error: could not execute process `sccache .../rustc -vV` (never executed)
+#     Caused by: No such file or directory (os error 2)
+#
+# That hard failure is why Dependabot's cargo updater could never open a
+# PR against this repo (issue #587) — its container has no sccache — and
+# it is the same wall a fresh clone hits before `cargo install sccache`.
+#
+# `exec` keeps this a single process (no extra shell in the build's hot
+# path); `command -v` is a shell builtin, so the probe costs no fork.
+
+if command -v sccache >/dev/null 2>&1; then
+    exec sccache "$@"
+fi
+
+exec "$@"

--- a/scripts/dev/rustc-wrapper.cmd
+++ b/scripts/dev/rustc-wrapper.cmd
@@ -1,0 +1,25 @@
+@echo off
+:: SPDX-License-Identifier: MPL-2.0
+:: Copyright (c) 2025-2026 SKY, LLC.
+::
+:: Optional-sccache rustc wrapper (Windows twin of the POSIX
+:: `rustc-wrapper` shim in this directory).
+::
+:: Cargo invokes a `build.rustc-wrapper` as `<wrapper> <rustc> <args...>`.
+:: This shim forwards to sccache when it is on PATH and runs rustc
+:: directly when it is not, so a missing sccache degrades to an uncached
+:: build instead of failing every cargo invocation with
+:: "could not execute process `sccache ... rustc -vV`" (issue #587).
+::
+:: `%*` carries cargo's own quoting through untouched; `exit /b`
+:: propagates rustc's exit code, which cargo relies on to detect
+:: compilation failure.
+
+where sccache >nul 2>nul
+if %ERRORLEVEL% equ 0 (
+    sccache %*
+    exit /b %ERRORLEVEL%
+)
+
+%*
+exit /b %ERRORLEVEL%

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -169,6 +169,30 @@ criteria = "safe-to-deploy"
 delta = "0.1.6 -> 0.2.2"
 notes = "Delta audit (cargo vet diff 0.1.6 -> 0.2.2). Files: Cargo.toml/Cargo.toml.orig (version + metadata: autolib/autobins/resolver=2, switch generic-array -> hybrid_array dep), CHANGELOG/README/LICENSE-MIT (text), src/lib.rs, src/hazmat.rs, new src/generate.rs. Net unsafe blocks added: 0 (grep confirms the only 'unsafe' token added is a Clippy lint declaration 'undocumented_unsafe_blocks = warn'). New generate.rs is pure-safe key/IV generation over rand_core CryptoRng/TryCryptoRng traits (hybrid_array Array<ArraySize>), no FFI / I/O / process / network / ambient capability. The 0.2 line is the known RustCrypto API restructuring (generic-array -> hybrid_array); behavior of the trait surface is otherwise preserved. Same publisher (github:RustCrypto/traits) the repo already trusts for 'digest'."
 
+[[audits.darling]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.23.0 -> 0.24.0"
+notes = "Reviewed the full diff; the facade crate changes are version bumps, the syn 2->3 dev-dependency migration, documentation updates, new examples and tests for the new transparent/crate/ident_with features, plus two new hidden re-exports from darling_core (TryFrom, Clone, PhantomData in export; autoref_specialization). No build.rs, no unsafe, no I/O or network access anywhere in the source tree."
+
+[[audits.darling_core]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.23.0 -> 0.24.0"
+notes = "Reviewed the full diff including all six new source files. The release migrates to syn 3 (mechanical renames: TypeBareFn->TypeFnPtr, BareFnArg->NamedArg, TraitBoundModifiers), adds #[darling(transparent)] and #[darling(crate = ...)] support, TryFrom<&syn::Data> for the data magic field via a standard autoref-specialization helper, and a new NestedMeta::NameValueInvalidExpr variant capturing unparseable RHS tokens. The codegen refactor wraps emitted impls in const _: () = { use ::darling as _darling; ... } (the same pattern serde uses) and all emitted paths reference only _darling/std items — no arbitrary token injection, no build.rs, no unsafe, no filesystem/network/process access, no new dependencies beyond the syn major bump."
+
+[[audits.darling_macro]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.23.0 -> 0.24.0"
+notes = "Reviewed the full diff; src/lib.rs is byte-identical to 0.23.0. The only changes are the version bump, the pinned darling_core 0.23.0->0.24.0, and the syn 2->3 dependency bump reflected in the manifest and lockfile. No build.rs and no code changes of any kind."
+
+[[audits.devicons]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.12 -> 0.6.13"
+notes = "Reviewed the full diff; the only functional change moves the points_to_directory() check ahead of the extension lookup in dark_icon_for_file/light_icon_for_file (src/icons.rs), so directories whose names contain dots get the default directory icon, with three new unit tests covering that fix. Remaining hunks are version bumps and the vcs-info sha. No dependency, feature, build-script, or unsafe changes."
+
 [[audits.displaydoc]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -199,11 +223,23 @@ criteria = "safe-to-deploy"
 delta = "0.3.32 -> 0.3.33"
 notes = "Reviewed diff: version-bump-only or test/doc-only changes (part of the same futures-rs 0.3.33 release reviewed in detail for futures-util/futures-task/futures-channel/futures-executor in this same batch). No production source changes in this specific crate."
 
+[[audits.futures]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+notes = "Reviewed the full diff; the facade crate bumps all sub-crate dependency versions to 0.3.34, updates a README CI badge, adds a Miri skip to a compat test, and adds a new regression test asserting a cloned FuturesUnordered child waker satisfies will_wake (matching the #[inline(always)] waker changes in futures-task/futures-util). No src/ changes, no dependency additions."
+
 [[audits.futures-channel]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.32 -> 0.3.33"
 notes = "Reviewed diff (4 files, 11/12 lines): cfg simplification (cfg_attr(target_os=none,...) -> plain cfg, no semantic change on our targets) + a miri test-speed tweak. No capability changes."
+
+[[audits.futures-channel]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+notes = "Reviewed the full diff; only the crate version bump and the futures-core/futures-sink dependency requirements moving to 0.3.34, mirrored in the lockfile. No source changes."
 
 [[audits.futures-core]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -211,13 +247,37 @@ criteria = "safe-to-deploy"
 delta = "0.3.32 -> 0.3.33"
 notes = "Reviewed diff: version-bump-only or test/doc-only changes (part of the same futures-rs 0.3.33 release reviewed in detail for futures-util/futures-task/futures-channel/futures-executor in this same batch). No production source changes in this specific crate."
 
+[[audits.futures-core]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+notes = "Reviewed the full diff; it contains only the version bump in Cargo.toml/Cargo.toml.orig/Cargo.lock and the updated git sha in .cargo_vcs_info.json. Zero source changes, no dependency or feature changes, no build script."
+
 [[audits.futures-executor]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.32 -> 0.3.33"
 notes = "Reviewed diff (5 files, 15/18 lines): doc-link cleanup only (removing redundant explicit link targets now inferred by rustdoc). No logic changes."
 
+[[audits.futures-executor]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+notes = "Reviewed the full diff; only version bumps for the crate and its futures-core/futures-task/futures-util dependencies plus corresponding lockfile churn. No source changes."
+
 [[audits.futures-io]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+notes = "Reviewed diff: version-bump-only or test/doc-only changes (part of the same futures-rs 0.3.33 release reviewed in detail for futures-util/futures-task/futures-channel/futures-executor in this same batch). No production source changes in this specific crate."
+
+[[audits.futures-io]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+notes = "Reviewed the full diff; version-bump-only release (manifest, lockfile, vcs-info sha). No source, dependency, or feature changes."
+
+[[audits.futures-macro]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.32 -> 0.3.33"
@@ -226,8 +286,8 @@ notes = "Reviewed diff: version-bump-only or test/doc-only changes (part of the 
 [[audits.futures-macro]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
-delta = "0.3.32 -> 0.3.33"
-notes = "Reviewed diff: version-bump-only or test/doc-only changes (part of the same futures-rs 0.3.33 release reviewed in detail for futures-util/futures-task/futures-channel/futures-executor in this same batch). No production source changes in this specific crate."
+delta = "0.3.33 -> 0.3.34"
+notes = "Reviewed the full diff; no proc-macro source changes at all. The only substantive change widens the syn dependency from 2.0.52 to 3.0 (resolving to the already-vetted syn 3.x in our tree). Standard proc-macro2/quote/unicode-ident tree, nothing suspicious."
 
 [[audits.futures-sink]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -235,17 +295,35 @@ criteria = "safe-to-deploy"
 delta = "0.3.32 -> 0.3.33"
 notes = "Reviewed diff: version-bump-only or test/doc-only changes (part of the same futures-rs 0.3.33 release reviewed in detail for futures-util/futures-task/futures-channel/futures-executor in this same batch). No production source changes in this specific crate."
 
+[[audits.futures-sink]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+notes = "Reviewed the full diff; version-bump-only release (manifest, lockfile, vcs-info sha). No source, dependency, or feature changes."
+
 [[audits.futures-task]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.32 -> 0.3.33"
 notes = "Reviewed diff (4 files, 14/10 lines): cfg simplification (same as futures-channel) + a new re-export (alloc::task::Wake). No new unsafe or capability surface."
 
+[[audits.futures-task]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+notes = "Reviewed the full diff; besides the version bump, the only code change adds #[inline(always)] to the existing noop_clone waker-vtable function in src/noop_waker.rs — an attribute on an already-existing unsafe fn, no new unsafe code, no behavioral or dependency changes."
+
 [[audits.futures-util]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.32 -> 0.3.33"
 notes = "Reviewed diff (28 files, 266/148 lines) including its unsafe-block changes specifically: (1) NotifyWaker (futures 0.1 compat shim) now wraps its Waker in UnsafeCell and gets a *mut via .get() instead of casting a &self reference to *mut -- fixes real UB flagged by Miri (strict-provenance violation), each call site updated correspondingly with Send/Sync impls added for the new UnsafeCell field; (2) FuturesUnordered: fixed an actual unsound Send impl on IterPinRef (previously bounded on Fut: Send when it must be Fut: Sync, since it yields shared Pin<&Fut> that both sides can read concurrently) plus a related task-release-back-to-pool fix in the iterator's Drop path. Both are genuine upstream soundness fixes, not new risk. No fs/net/process/exec capability anywhere in the diff."
+
+[[audits.futures-util]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+notes = "Reviewed the full diff; manifest changes are strictly sibling-dependency version bumps (including the pinned futures-macro =0.3.34). Code changes: #[inline(always)] added to two existing waker-vtable clone functions (compat03as01.rs, futures_unordered/task.rs) and three doctest guards skipping the futures-0.1 compat examples under Miri. No new unsafe blocks, no dependency additions, no behavioral concerns."
 
 [[audits.hashbrown]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -625,6 +703,12 @@ criteria = "safe-to-deploy"
 delta = "2.2.0 -> 3.1.0"
 notes = "Delta audit (cargo vet diff 2.2.0 -> 3.1.0), ~34k-line major-version diff; all changed src/ files were enumerated and reviewed (transport/auth.rs, service/client.rs and new service/client/cache.rs, transport/streamable_http_client.rs, task_manager.rs, streamable_http_server/tower.rs and session files, service.rs, service/server.rs, client_side_sse.rs, reqwest/unix-socket/child-process/async_rw transports, error.rs, lib.rs, handlers, and the new model/mrtr.rs, model/request_state.rs, transport/common/mcp_headers.rs read in full); model-type files (model.rs, meta.rs, serde_impl.rs, task.rs, capabilities.rs, etc.) were reviewed at item level and are serde/schema type changes only. No unsafe anywhere in the diff, no build.rs, no new URLs or domains outside example.com/localhost test fixtures and spec doc links, and no new filesystem/process/env access; child_process.rs only deletes a deprecated API. New optional deps hmac 0.13 and sha2 0.11 back the new request-state feature, an HMAC-SHA256 integrity codec for SEP-2322 requestState with constant-time verification and a redacted-key Debug impl; base64 bumps to 0.23 and jsonwebtoken to 11. Nature of release: MCP 2026-07-28 protocol work — server/discover lifecycle, SEP-2549 client response cache, SEP-2663 task manager, SEP-2322 MRTR, SEP-2243 standard headers, SEP-2260 request-association enforcement, subscription streams. Security posture improves: OAuth discovery gains RFC 8414 issuer validation, stricter RFC 8707 resource matching, refresh-rejection classification, issuer-change credential invalidation, and removal of the unauthenticated POST probe; DoS hardening adds a 16 MiB SSE event cap and a 4 MiB server request-body cap. Capability surface (HTTP client/server to caller-configured endpoints, stdio child-process transport, Unix sockets) is unchanged in kind and honestly consistent with an MCP protocol SDK; no malicious or obfuscated code observed."
 
+[[audits.rmcp]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "3.1.0 -> 3.1.2"
+notes = "Reviewed the full diff; changes match the 3.1.1/3.1.2 changelog exactly: (1) client_side_sse.rs rewrites the poll_next recursion into a loop so skipping non-message/undecodable SSE frames cannot overflow the stack, with a regression test; (2) streamable_http_client.rs maps 401/403 responses with a WWW-Authenticate header on the SSE GET stream to the existing AuthRequired/InsufficientScope error variants so the auth-refresh path triggers — no new endpoints or request behavior; (3) auth.rs threads an optional expected-issuer string into RFC 8414 issuer validation so a legitimate trailing slash no longer causes a false mismatch — validation is not weakened, only the comparison source is corrected; (4) tool.rs adds RequestState/InputResponses extractors for already-parsed MRTR fields, and model.rs tightens CallToolResult deserialization to reject any non-complete resultType. async-trait became optional behind the features that use it; no new dependencies, no new unsafe, build.rs unchanged, and the two added files are localhost-only integration tests."
+
 [[audits.rmcp-macros]]
 who = "Robert Nio <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -654,6 +738,12 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "2.2.0 -> 3.1.0"
 notes = "Delta audit (cargo vet diff 2.2.0 -> 3.1.0), full diff reviewed (~630 lines). Source changes are removal of the task_handler proc-macro (src/task_handler.rs deleted, references removed from lib.rs and tool_handler.rs), removal of the ToolExecution/task_support attribute machinery from tool.rs, renamed generated result types (GetPromptResult -> GetPromptResponse, CallToolResult -> CallToolResponse), new result_type/ttl_ms/cache_scope fields in generated ListTools/ListPrompts results, and mechanical let-chains refactors in common.rs, prompt.rs, and tool.rs (skimmed as purely mechanical). No unsafe code, no build.rs, no filesystem/network/process/env access; codegen emits only rmcp model-type constructors as before. Cargo.toml changes are the version bump and rust-version = 1.88; no new dependencies (Cargo.lock churn is routine version bumps of proc-macro2/quote/syn/serde). Generated-code diff is honestly consistent with the rmcp 3.x protocol-model changes; nothing obfuscated or suspicious."
+
+[[audits.rmcp-macros]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "3.1.0 -> 3.1.2"
+notes = "Reviewed the full diff; the crate migrated from syn 2 / darling 0.23 to syn 3 / darling 0.24, requiring a mechanical receiver-lifetime pattern update in src/prompt.rs and src/tool.rs (receiver.reference -> syn::ReceiverKind::Reference) with new tests asserting the receiver lifetime is preserved. The only codegen behavior change is in the generated list_tools/list_prompts: for protocol versions >= 2026-07-28 they emit ttl_ms=0 and CacheScope::Public cache hints instead of None — a benign protocol-conformance change with no I/O, no build script, and no new dependencies beyond the darling/syn major bumps."
 
 [[audits.rustc-hash]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -310,15 +310,15 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.thiserror]]
-version = "2.0.19"
-when = "2026-07-18"
+version = "2.0.20"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.thiserror-impl]]
-version = "2.0.19"
-when = "2026-07-18"
+version = "2.0.20"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -57,15 +57,15 @@ when = "2026-05-19"
 trusted-publisher = "github:RustCrypto/traits"
 
 [[publisher.clap]]
-version = "4.6.5"
-when = "2026-07-31"
+version = "4.6.6"
+when = "2026-08-06"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_builder]]
-version = "4.6.5"
-when = "2026-07-31"
+version = "4.6.6"
+when = "2026-08-06"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -114,8 +114,8 @@ user-id = 55123
 user-login = "rust-lang-owner"
 
 [[publisher.globset]]
-version = "0.4.19"
-when = "2026-07-15"
+version = "0.4.20"
+when = "2026-08-04"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
@@ -254,8 +254,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.regex-automata]]
-version = "0.4.16"
-when = "2026-07-15"
+version = "0.4.18"
+when = "2026-08-04"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"


### PR DESCRIPTION
Twelve commits in three themes. Every commit was validated locally before push (strict clippy on the pinned **and** floating-nightly toolchains, cross-target clippy for `x86_64-pc-windows-msvc`, all 2424 tests, and the full `lint-pre-push` gate including cargo-vet and the audit-discipline check).

Closes #584 and #587 via commit trailers.

## 1 — Zero-downtime MCP binary swaps

`uffsmcp` stdio mode is now fronted by a supervisor that owns the client's pipes for the whole session and serves through a hidden `--worker` child it can replace. When the binary on disk is swapped (an installer, `just use-local`), a ticker notices the changed `(len, mtime)` identity, waits for a quiet moment with nothing in flight, spawns a fresh worker, replays the captured `initialize`/`initialized` handshake (swallowing the duplicate response), reroutes traffic, kills the predecessor, and nudges the client with `notifications/tools/list_changed`.

**The AI host's MCP connection never drops** — a new binary can be swapped in without restarting any downstream session. The same replay path restarts a crashed worker, rate-limited to 3 crashes/60s. It is deliberately a byte pump, not a re-framing proxy: each JSON-RPC line is parsed only enough to classify it, and the original bytes are always forwarded. Plain `std::process` + threads, so no async runtime in the supervisor process and identical behavior on Windows.

An end-to-end test drives a real session across a simulated binary replacement over real pipes and asserts two different worker PIDs on the same connection plus the `list_changed` nudge.

Overrides: `UFFS_MCP_WORKER_EXE`, `UFFS_MCP_WATCH_PATH`, `UFFS_MCP_POLL_MS`.

## 2 — Permanent residency (`uffs --daemon resident`)

The tiering ladder's final rung (idle auto-retire) removed `uffsd` from the process list, so the next search paid a full restart. `resident on` registers a per-user login item — Windows `HKCU` Run key, macOS launchd LaunchAgent with `KeepAlive.SuccessfulExit=false`, Linux systemd user unit with `Restart=on-failure` — starting `uffsd --no-retire`, and starts the daemon immediately when none is running.

Windows deliberately uses the Run key rather than a scheduled task or service: it needs no Administrator, so the non-elevated resident daemon keeps reading the MFT through the Access Broker and the **zero-UAC story is preserved end to end**. The elevation gate exempts `resident` explicitly, since it only touches per-user artifacts.

Residency also survives crashes and manual stops on every platform via an auto-spawn marker (`resident.args`, beside the PID file). Every implicit daemon spawn merges it in at the single `spawn_daemon` choke point, so a revived daemon keeps `--no-retire`. Merging is conservative and unit-tested: caller flags always win, marker flag groups append only when absent, and ephemeral `--ephemeral-id` instances pass through untouched so a snapshot daemon can never inherit `--no-retire` and leak.

## 3 — Repo health pass

**Nightly canary (#584).** Two independent regressions on the floating nightly. `min_ident_chars` briefly extended to macro-generated single-letter constants and tripped on the `DriveLetter` A–Z constants — which *are* the domain model; that is now declared posture via `allowed-idents-below-min-chars` so the same churn cannot break the canary again, without weakening the lint elsewhere. It did catch one genuine offender: `BloomFilter::k()` → `hash_count()`. Separately, the new pedantic `assert_is_empty` lint: all 36 `assert!(x.is_empty())` sites across 20 files became typed `assert_eq!`/`assert_ne!` so failures print the offending value — a test-quality upgrade, no suppressions. A `redundant_field_names` firing inside thiserror 2.0.19's generated code was fixed at the dependency level (2.0.20), per the ethnum precedent.

**Dependency refresh.** clap 4.6.6, futures 0.3.34, globset 0.4.20, rmcp 3.1.2, devicons 0.6.13, plus the darling 0.24 train. Every non-trusted delta got a real source-diff review recorded as a cargo-vet delta audit with `Vet-Reviewed-Diff` trailers (15 new audits; exemptions 238 → 234).

**Toolchain pin** 2026-07-23 → 2026-08-11, taken via `just toolchain-sync`, which gates on host clippy plus Windows (cargo-xwin) and Linux (cargo-zigbuild) cross-compiles before writing the pin. The canary's green floating-nightly result is exactly the precondition that made this safe.

**sccache shim (#587).** `.cargo/config.toml` named `sccache` directly as `build.rustc-wrapper`, making the repo unbuildable anywhere sccache is absent — which is why Dependabot's cargo updater has never opened a PR here (four red runs a month) and why fresh clones break before `cargo install sccache`. The wrapper now points at a shim that forwards to sccache when present and execs rustc directly when not. Verified with the real toolchain cargo, a PATH carrying rustc but not sccache, and a fresh target dir: before → `could not execute process 'sccache rustc -vV'` (exit 101); after → clean build and a full workspace `cargo metadata` resolve. With sccache present, `sccache --show-stats` records the compile requests, so caching is genuinely preserved. Bug B (dev-flow.md §5.2) is unaffected — both cache keys still live together in one atomic config; only the wrapper's value moved behind the shim.

**Advisory bookkeeping.** Corrected the standing assumption that a polars bump would clear the two quick-xml advisories: object_store 0.14.1 does now require the fixed quick-xml ^0.41, but polars-io still pins object_store ^0.13.1 even in polars 0.55.2, so the blocker is entirely upstream. Reachability remains nil (cloud-store XML LIST parsing; UFFS never touches a cloud object path).
