### PR TITLE
chore: release v0.6.31 — ship pipeline auto-commit

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -118,3 +118,23 @@ threads-required = 'num-cpus'
 [[profile.ci.overrides]]
 filter = 'package(uffs-client) & test(shmem::)'
 threads-required = 'num-cpus'
+
+# The `tests_perf` suite asserts WALL-CLOCK budgets (e.g. tree metrics
+# under 100 ms for 100 K files).  Run under the normal fan-out — 2 400+
+# tests saturating every core — those numbers measure scheduler
+# contention, not the code: the same test that takes ~88 ms alone was
+# observed at 118 ms and 436 ms while the rest of the suite ran, i.e. a
+# false failure on an unchanged code path (verified by measuring the
+# identical test before and after the polars 0.54→0.55 bump: 86-93 ms vs
+# 88 ms).
+#
+# Give them the whole machine so the measurement means something.  The
+# budgets themselves are deliberately UNCHANGED — the fix is to measure
+# honestly, never to widen the threshold until it stops failing.
+[[profile.default.overrides]]
+filter = 'package(uffs-mft) & test(tests_perf::)'
+threads-required = 'num-cpus'
+
+[[profile.ci.overrides]]
+filter = 'package(uffs-mft) & test(tests_perf::)'
+threads-required = 'num-cpus'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.31] - 2026-08-11
+
+### Added
+
+- fetch: extract public uffs-fetch transport lib; dep refresh + rmcp 3 (#583)
+- self-upgrading MCP supervisor, permanent daemon residency, and a repo health pass (#588)
+
 ## [0.6.30] - 2026-07-23
 
 ### Added
@@ -2733,7 +2740,8 @@ thin clients over a unified `uffsd` process.
 ### Fixed
 - Various MFT parsing edge cases
 
-[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.30...HEAD
+[Unreleased]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.31...HEAD
+[0.6.31]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.30...v0.6.31
 [0.6.30]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.29...v0.6.30
 [0.6.29]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.28...v0.6.29
 [0.6.28]: https://github.com/skyllc-ai/UltraFastFileSearch/compare/v0.6.27...v0.6.28

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "inout",
 ]
 
@@ -26,7 +26,7 @@ checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -97,9 +97,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -265,11 +265,12 @@ dependencies = [
 
 [[package]]
 name = "atoi_simd"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
 dependencies = [
  "debug_unsafe",
+ "rustversion",
 ]
 
 [[package]]
@@ -344,9 +345,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bincode"
@@ -394,25 +395,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -453,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -479,13 +471,13 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -514,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -543,7 +535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -558,7 +550,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -604,8 +596,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "crypto-common",
  "inout",
 ]
 
@@ -756,15 +748,6 @@ checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -890,16 +873,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -996,23 +969,22 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
+]
+
+[[package]]
+name = "digest-io"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de63d600bc7fab91180bc17385f29b342468dc8ef2af09dceba450a293de3da"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1136,9 +1108,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"
@@ -1189,12 +1161,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.13.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1286,16 +1258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,11 +1277,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1427,9 +1387,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "rayon",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1437,6 +1394,14 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "rayon",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -1473,7 +1438,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1609,7 +1574,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1812,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2182,7 +2147,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2267,12 +2232,12 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f1f122456ec136102033b13f71905b7c3f01e526642679c86aace9f9cdefde"
+checksum = "d52d3ed4e6b3917427f6d3c43edbd2740babe228bb4ccfa3431eac105844045d"
 dependencies = [
  "getrandom 0.2.17",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "polars-arrow",
  "polars-buffer",
  "polars-compute",
@@ -2292,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d4892d5cc6461bb4a184d18e6fa03a5d316ee1d6de06a33dfa08d479fbc2db"
+checksum = "c5ab55460ca2553d1a2bbaf2046998cfbbb685bc18d1e168b4367b63301eb271"
 dependencies = [
  "atoi_simd",
  "bitflags",
@@ -2306,9 +2271,9 @@ dependencies = [
  "either",
  "ethnum",
  "getrandom 0.2.17",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itoa",
  "lz4",
  "num-traits",
@@ -2337,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "polars-async"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e87f836190486f500b28347436985cc0af29b7a514e53f98840d396ce4d5f5"
+checksum = "e8f484cb2db25ff605107a9f8dca8d5a47d25770cf5e04ceb75c0ef4d6bc2418"
 dependencies = [
  "atomic-waker",
  "crossbeam-channel",
@@ -2350,16 +2315,16 @@ dependencies = [
  "polars-config",
  "polars-error",
  "polars-utils",
- "rand 0.9.5",
+ "rand 0.10.2",
  "slotmap",
  "tokio",
 ]
 
 [[package]]
 name = "polars-buffer"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e481eeaf33c544ac0dd71a2e375553ca2fdae47b3472a96eaccb6eb43218783d"
+checksum = "485320cdb93ad4b4725fea30e5d4e59c32c8ad62420dbda7830eb96080e47363"
 dependencies = [
  "bytemuck",
  "either",
@@ -2370,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "polars-compute"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55d41642a9ee887ac394c5a310af3256fa8340a86cde2cb624c515aa963461c"
+checksum = "0b54be44ceacf1028fd8219b34c791ed4e1db852950f3eb7e10ba9bf63bbdb50"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -2380,14 +2345,14 @@ dependencies = [
  "either",
  "fast-float2",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itoa",
  "num-traits",
  "polars-arrow",
  "polars-buffer",
  "polars-error",
  "polars-utils",
- "rand 0.9.5",
+ "rand 0.10.2",
  "serde",
  "strength_reduce",
  "strum_macros",
@@ -2397,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "polars-config"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65af861341b00eac73bcb65423fb5cc3d2322526d6b7561a0ddf094947c38033"
+checksum = "13dcd35a686654570d9642ed4f3c55eccad75911024c95d6b1459663cfb83bc1"
 dependencies = [
  "polars-error",
  "serde",
@@ -2407,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5924fc46306054bae78f9d35ea5e404cf185baa7f170eb55a16ff95191069c"
+checksum = "ac24a25f4c2696089bb9059e4b45338ea74833a79b9552fef066d6f2cfb3aaed"
 dependencies = [
  "bitflags",
  "boxcar",
@@ -2418,8 +2383,8 @@ dependencies = [
  "chrono-tz",
  "comfy-table",
  "either",
- "getrandom 0.3.4",
- "hashbrown 0.16.1",
+ "getrandom 0.4.3",
+ "hashbrown 0.17.1",
  "indexmap",
  "itoa",
  "num-traits",
@@ -2433,7 +2398,7 @@ dependencies = [
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rand_distr",
  "rayon",
  "regex",
@@ -2448,12 +2413,12 @@ dependencies = [
 
 [[package]]
 name = "polars-dtype"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b65a750bb99ea66be90c8a7e336f6f3a87427a0f7f89d2a40adae98314e9b27"
+checksum = "768f9d1f996eebc7f9b0d7686d9147cf4b4f217fd907c4b90f4448dcee01ea05"
 dependencies = [
  "boxcar",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "polars-arrow",
  "polars-error",
  "polars-utils",
@@ -2463,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49a75e3406b9b5b4e5ff177877fe0de766e9688fbdb263a7b25f293dc47d61a"
+checksum = "8f6995c2121c31687704fae5281517e29bbd34838fcf8dd15c8e8ae526bb6624"
 dependencies = [
  "object_store",
  "parking_lot",
@@ -2477,12 +2442,12 @@ dependencies = [
 
 [[package]]
 name = "polars-expr"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21fdd37e8d9ef109f13d3454baffa0a57041cf60069123b8a2bd846c8ad0205"
+checksum = "b59262210ac41f3b30f49f46855501206eba27baaa6bd919545703bc706dd617"
 dependencies = [
  "bitflags",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-traits",
  "polars-arrow",
  "polars-buffer",
@@ -2495,7 +2460,7 @@ dependencies = [
  "polars-row",
  "polars-time",
  "polars-utils",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rayon",
  "recursive",
  "regex",
@@ -2504,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6363a1c44a65fe8d73cce7fe4d77c9b6fea3a0da44007012e755e5b4e65aa078"
+checksum = "3ba705af75665c6c6f6822bdc20a0b162846dd9d23573221096945b45210c2db"
 dependencies = [
  "async-trait",
  "atoi_simd",
@@ -2514,12 +2479,13 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
+ "crossbeam-queue",
  "fast-float2",
  "fastrand",
  "fs4",
  "futures",
  "glob",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "home",
  "itoa",
  "memchr",
@@ -2539,7 +2505,7 @@ dependencies = [
  "polars-schema",
  "polars-time",
  "polars-utils",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rayon",
  "regex",
  "reqwest",
@@ -2553,14 +2519,14 @@ dependencies = [
 
 [[package]]
 name = "polars-json"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dca6cd170370ef7e189a4c362846c57553843653c3fe65aafe12ca77599987c"
+checksum = "495117c99362a05d4ea744c21f54d570991fd8ae3ec9dfb1f0e01f055747553f"
 dependencies = [
  "chrono",
  "chrono-tz",
  "fallible-streaming-iterator",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "itoa",
  "num-traits",
@@ -2575,9 +2541,9 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809d9590232a37d638337629c18279af97bdb0d17c3d8b2b6bb186e903e8bd5e"
+checksum = "79654a98520b5df9be08ce5004be90a5c8004d0f73d54500c1aa923874ec84f3"
 dependencies = [
  "bitflags",
  "chrono",
@@ -2603,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "polars-mem-engine"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c6b7d162c506bc8eee82b065fa0399ebcd20b8f08675a534f3d360904ba38"
+checksum = "843e77a0987bea00063c227cbb889f30e754942b42851043cd9f90403e516ca2"
 dependencies = [
  "memmap2",
  "polars-arrow",
@@ -2624,9 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "polars-ooc"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3eea0b386837b760a97ec9c92df99cbc10f94885cae060fd7100f9b794163"
+checksum = "265c422c52d04c876a07cd688fe0da2c43c6597cdaff36e34746c443ec2e9fdb"
 dependencies = [
  "async-trait",
  "boxcar",
@@ -2634,17 +2600,21 @@ dependencies = [
  "polars-async",
  "polars-config",
  "polars-core",
+ "polars-error",
  "polars-io",
  "polars-utils",
+ "rand 0.10.2",
+ "rand_distr",
  "thread_local",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
 name = "polars-ops"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb146490a717ac5ae4ff3a22a5adf3ebae79361f187b1f550f9e24783d7ad765"
+checksum = "a3eeac77f1380bc8ba40ae9a9512911697952dfd3cfa48013f98a477e7ec6771"
 dependencies = [
  "aho-corasick",
  "argminmax",
@@ -2653,7 +2623,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "either",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "hex",
  "indexmap",
  "jsonpath_lib_polars_vendor",
@@ -2680,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "polars-parquet"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6b79ba2103c00cbb9c5dd4459ffff1d8ce15286c7a6d376a04c711df20d8b7"
+checksum = "d33a17979d2afa0309437478662cf996361a6e1768bf467db82bd4f4a9443064"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -2691,7 +2661,7 @@ dependencies = [
  "ethnum",
  "flate2",
  "futures",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "lz4",
  "num-traits",
  "polars-arrow",
@@ -2721,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5ccc230515adb10762a8c7b0df03fd88f3328deb5b60e9b1eeb2eceef4d344"
+checksum = "467bd857c46405807e6645942be2de284aa43bc503fc6d20efb16e1adf25b7a6"
 dependencies = [
  "bitflags",
  "blake3",
@@ -2731,9 +2701,11 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
+ "digest-io",
  "either",
  "futures",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+ "hex",
  "indexmap",
  "memmap2",
  "num-traits",
@@ -2753,7 +2725,7 @@ dependencies = [
  "rayon",
  "recursive",
  "regex",
- "sha2 0.10.9",
+ "sha2",
  "slotmap",
  "strum_macros",
  "tokio",
@@ -2762,9 +2734,9 @@ dependencies = [
 
 [[package]]
 name = "polars-row"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4e3254450024078e10c919ecd3b467bdcfdd5cf386c2ca6eedec89bd4771d2"
+checksum = "71ac05187ac33abcfe9b7c997f0cd2ea9bfe8e04e9018d343e16fb2b64e2f5bb"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -2778,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "polars-schema"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8a0de8951d02576fd0cdcecd9c605a6b6364d3105b7469b8d7874ea34eea2f"
+checksum = "dacc161d9b647e4b936836a07d731cec06e2ed2c7d51a7f7565b5ce7767dcf40"
 dependencies = [
  "indexmap",
  "polars-error",
@@ -2791,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b282a6164927eb12774b66b071b773a1573173ae53758e8d4df50389ff06efa2"
+checksum = "ae4b287917a1c50b9fab9618c32d3ac8c4b18ef1c61aded55d065c97c921c793"
 dependencies = [
  "bitflags",
  "hex",
@@ -2811,14 +2783,15 @@ dependencies = [
 
 [[package]]
 name = "polars-stream"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa8ff4ee21799898579595a0ef2fb728d0a9cac3d061835fb7f7f6dd854734a"
+checksum = "b173c0c52f53ca930f3b59bc56a5854a650eb9555d67bba9022051714bc0b88f"
 dependencies = [
  "async-channel",
  "async-trait",
  "bitflags",
  "bytes",
+ "chrono",
  "chrono-tz",
  "crossbeam-channel",
  "crossbeam-queue",
@@ -2854,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1063fe074c4212a54917be604377c6e6bfbc8b6c942a5c57be214e4ccaaafdf"
+checksum = "bff76883a07b033d9191e6d6ff86ee696770bcc462241666a8ccdddff1afdbc2"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -2877,9 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.54.4"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590b0a94aa8f97992d52f1198600ecc1c1f7cfa03c1b31cae057143455804ac0"
+checksum = "88aa5ed59ba6f52190b3368d3d9536f95c8c2ab161ee08a22bb3f4319a11a9bd"
 dependencies = [
  "argminmax",
  "bincode",
@@ -2891,7 +2864,7 @@ dependencies = [
  "foldhash 0.2.0",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "libc",
  "memmap2",
@@ -2899,7 +2872,7 @@ dependencies = [
  "num-traits",
  "polars-config",
  "polars-error",
- "rand 0.9.5",
+ "rand 0.10.2",
  "raw-cpuid",
  "rayon",
  "regex",
@@ -2922,15 +2895,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "universal-hash",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "potential_utf"
@@ -3172,12 +3145,12 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.9.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -3380,7 +3353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "futures",
@@ -3493,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3699,24 +3672,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3826,9 +3788,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.60.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505aa16b045c4c1375bf5f125cce3813d0176325bfe9ffc4a903f423de7774ff"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",
@@ -3837,9 +3799,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028e551d5e270b31b9f3ea271778d9d827148d4287a5d96167b6bb9787f5cc38"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3913,9 +3875,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3979,16 +3941,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -4379,7 +4341,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "tempfile",
  "thiserror 2.0.20",
  "toml",
@@ -4401,7 +4363,7 @@ dependencies = [
  "uffs-security",
  "uffs-version",
  "uffs-winsvc",
- "windows 0.62.2",
+ "windows",
  "winresource",
 ]
 
@@ -4471,7 +4433,7 @@ dependencies = [
  "uffs-format",
  "uffs-mft",
  "uffs-security",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -4491,7 +4453,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
@@ -4534,7 +4496,7 @@ dependencies = [
  "uffs-mft",
  "uffs-security",
  "uffs-version",
- "windows 0.62.2",
+ "windows",
  "winresource",
 ]
 
@@ -4546,7 +4508,7 @@ dependencies = [
  "chrono",
  "hex",
  "rayon",
- "sha2 0.11.0",
+ "sha2",
  "uffs-mft",
  "uffs-polars",
  "uffs-version",
@@ -4561,7 +4523,7 @@ dependencies = [
  "hex",
  "reqwest",
  "serde",
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
@@ -4659,7 +4621,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "smallvec",
  "tempfile",
  "thiserror 2.0.20",
@@ -4671,7 +4633,7 @@ dependencies = [
  "uffs-security",
  "uffs-text",
  "uffs-version",
- "windows 0.62.2",
+ "windows",
  "winresource",
  "zerocopy",
  "zstd",
@@ -4696,7 +4658,7 @@ dependencies = [
  "security-framework",
  "tempfile",
  "tracing",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -4727,7 +4689,7 @@ dependencies = [
  "uffs-fetch",
  "uffs-version",
  "uffs-winsvc",
- "windows 0.62.2",
+ "windows",
  "winresource",
 ]
 
@@ -4744,7 +4706,7 @@ dependencies = [
  "serde",
  "serde_json",
  "uffs-version",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -4752,7 +4714,7 @@ name = "uffs-winsvc"
 version = "0.6.30"
 dependencies = [
  "anyhow",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -4815,7 +4777,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 
@@ -4942,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4955,9 +4917,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4965,9 +4927,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4975,9 +4937,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4988,9 +4950,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -5010,9 +4972,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5070,36 +5032,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -5108,20 +5048,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -5132,20 +5059,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5154,9 +5070,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5183,25 +5099,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -5209,17 +5109,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -5228,16 +5119,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -5246,7 +5128,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5260,20 +5142,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5294,20 +5167,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5417,18 +5281,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4334,7 +4334,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uffs-bench"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "chrono",
  "clap",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "serde",
@@ -4369,14 +4369,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-broker-protocol"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "uffs-ci-pipeline"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-cli"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-client"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "dirs-next",
  "libc",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-core"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-daemon"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "clap",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-diag"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-fetch"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "hex",
@@ -4528,7 +4528,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-format"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "chrono",
  "itoa",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-hooks"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "clap",
@@ -4551,7 +4551,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-gen-workflow"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "clap",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-manifest-audit"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "clap",
@@ -4576,7 +4576,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mcp"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "axum",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-mft"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4641,14 +4641,14 @@ dependencies = [
 
 [[package]]
 name = "uffs-polars"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "uffs-security"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "aes-gcm",
  "dirs-next",
@@ -4663,22 +4663,22 @@ dependencies = [
 
 [[package]]
 name = "uffs-statusfmt"
-version = "0.6.30"
+version = "0.6.31"
 
 [[package]]
 name = "uffs-text"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "uffs-time"
-version = "0.6.30"
+version = "0.6.31"
 
 [[package]]
 name = "uffs-update"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -4695,11 +4695,11 @@ dependencies = [
 
 [[package]]
 name = "uffs-version"
-version = "0.6.30"
+version = "0.6.31"
 
 [[package]]
 name = "uffs-vss-requestor"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "cc",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "uffs-winsvc"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "windows",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,7 +250,7 @@ toml = "1.1.4"
 bitflags = "2.13.1"
 bytemuck = { version = "1.25.2", features = ["derive"] }
 smallvec = "1.15.2"
-zerocopy = { version = "0.8", features = ["derive"] }
+zerocopy = { version = "0.8.56", features = ["derive"] }
 
 # ───── Error Handling ─────
 thiserror = "2.0.20"
@@ -322,10 +322,17 @@ hex = "0.4.3"
 # ───── Network (self-update acquire helper only) ─────
 # Blocking HTTP with rustls + the system trust store. `rustls-tls-native-roots`
 # matches the existing transitive reqwest config, so no new crate enters the lock.
-# Version 0.13.4 cannot be used at this time ... missing "rustls-tls-native-roots"
-# (re-verified 2026-08-03 against crates.io: the 0.13.x feature set has only
-# `rustls` / `rustls-no-provider` / `default-tls` / `native-tls*` — no
-# native-roots variant; 0.12.28 remains the newest 0.12.x release)
+#
+# DELIBERATELY HELD AT 0.12 (re-evaluated 2026-08-12, everything else in this
+# workspace is at latest).  0.13 drops `rustls-tls-native-roots` and routes
+# system trust through `rustls-platform-verifier`, which pulls the Android JNI
+# stack — `jni`, `jni-macros`, `jni-sys`, `combine`, `simd_cesu8`, roughly 63k
+# lines.  None of it appears in the host or `x86_64-pc-windows-msvc` dependency
+# trees (verified with `cargo tree -i jni`): it is Android-only, a target UFFS
+# does not ship.  cargo-vet audits every target regardless, so 0.13 would cost
+# ~63k lines of supply-chain review for code that never enters a binary we
+# build, in exchange for no functional gain.  Revisit if reqwest ever offers
+# system trust without the Android dependency, or if we ever target Android.
 reqwest = { version = "0.12.28", default-features = false, features = [
   "blocking",
   "rustls-tls-native-roots",
@@ -341,7 +348,7 @@ mimalloc = "0.1.52"
 memmap2 = "0.9.11"
 
 # ───── System ─────
-libc = "0.2"
+libc = "0.2.189"
 hostname = "0.4.2"
 # CPU-core count detection.  `std::thread::available_parallelism` is the
 # modern alternative, but `num_cpus` handles cgroup / container quotas more

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ members = [
 # Workspace Package Metadata (inherited by all crates)
 # ─────────────────────────────────────────────────────────────────────────────
 [workspace.package]
-version = "0.6.30"
+version = "0.6.31"
 edition = "2024"
 # No `rust-version` claim: the workspace is structurally nightly-only.
 # `crates/uffs-polars` enables `polars/nightly` unconditionally, which
@@ -134,36 +134,36 @@ publish = false
 # proposed-plan output for 12 days because `release-plz update`
 # failed at `cargo package` with this very error.  See
 # `release-automation-baseline.md` §10 for the diagnostic trail.
-uffs-polars = { path = "crates/uffs-polars", version = "0.6.30" }
-uffs-security = { path = "crates/uffs-security", version = "0.6.30" }
-uffs-text = { path = "crates/uffs-text", version = "0.6.30" }
-uffs-time = { path = "crates/uffs-time", version = "0.6.30" }
-uffs-version = { path = "crates/uffs-version", version = "0.6.30" }
-uffs-statusfmt = { path = "crates/uffs-statusfmt", version = "0.6.30" }
-uffs-mft = { path = "crates/uffs-mft", version = "0.6.30" }
-uffs-format = { path = "crates/uffs-format", version = "0.6.30" }
-uffs-core = { path = "crates/uffs-core", version = "0.6.30" }
-uffs-client = { path = "crates/uffs-client", version = "0.6.30" }
+uffs-polars = { path = "crates/uffs-polars", version = "0.6.31" }
+uffs-security = { path = "crates/uffs-security", version = "0.6.31" }
+uffs-text = { path = "crates/uffs-text", version = "0.6.31" }
+uffs-time = { path = "crates/uffs-time", version = "0.6.31" }
+uffs-version = { path = "crates/uffs-version", version = "0.6.31" }
+uffs-statusfmt = { path = "crates/uffs-statusfmt", version = "0.6.31" }
+uffs-mft = { path = "crates/uffs-mft", version = "0.6.31" }
+uffs-format = { path = "crates/uffs-format", version = "0.6.31" }
+uffs-core = { path = "crates/uffs-core", version = "0.6.31" }
+uffs-client = { path = "crates/uffs-client", version = "0.6.31" }
 # `uffs-broker-protocol` carries the wire-protocol types shared between
 # `uffs-broker` (the elevated handle vendor, Windows-only binary) and
 # `uffs-daemon::broker_client` (the handle consumer).  Pure-logic
 # Layer-0 lib — cross-platform tests run on every CI lane.  Added in
 # F5 (issue #205) so neither side duplicates `BROKER_PIPE_NAME` /
 # wire-format byte literals.
-uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.30" }
+uffs-broker-protocol = { path = "crates/uffs-broker-protocol", version = "0.6.31" }
 # `uffs-winsvc` — native Windows service control (SCM query/start/stop) +
 # the non-connecting broker-pipe readiness probe.  Layer-0 leaf: its only
 # dependency is the `windows` crate (windows-target), with non-Windows
 # stubs so cross-platform consumers (uffs-update, uffs-cli) compile.
 # Single source of truth for the `sc`/SCM mechanics previously duplicated
 # across uffs-broker, uffs-update, and uffs-cli.
-uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.30" }
+uffs-winsvc = { path = "crates/uffs-winsvc", version = "0.6.31" }
 # `uffs-fetch` — hardened release-asset transport (blocking reqwest +
 # rustls with retry/timeout/byte-cap, plus `SHA256SUMS` verification),
 # extracted from `uffs-update` as a small public lib so external products
 # can reuse it. Cross-platform pure-logic leaf; keeps the HTTP/TLS stack
 # out of the lean `uffs` CLI exactly as before.
-uffs-fetch = { path = "crates/uffs-fetch", version = "0.6.30" }
+uffs-fetch = { path = "crates/uffs-fetch", version = "0.6.31" }
 # NOTE: no `uffs-broker` workspace dependency alias on purpose —
 # `uffs-broker` is a binary-only crate (the only `[lib]` it carries is
 # this protocol module's now-extracted sibling); no other workspace

--- a/crates/uffs-cli/Cargo.toml
+++ b/crates/uffs-cli/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/main.rs"
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-client = { path = "../uffs-client", version = "0.6.30", default-features = false }
+uffs-client = { path = "../uffs-client", version = "0.6.31", default-features = false }
 
 # Canonical CSV / parity / legacy-footer writer.  Direct dep (not a
 # re-export chain through `uffs-client`) so the CLI and the daemon
@@ -77,7 +77,7 @@ uffs-client = { path = "../uffs-client", version = "0.6.30", default-features = 
 # `version = "0.5.90"` is required for `cargo package` validation —
 # see root `Cargo.toml`'s [workspace.dependencies] note for the full
 # rationale (R6 of `release-automation-plan.md`).
-uffs-format = { path = "../uffs-format", version = "0.6.30" }
+uffs-format = { path = "../uffs-format", version = "0.6.31" }
 
 # Typed drive-letter newtype.  Direct dep so the CLI command signatures
 # (`daemon_load`, `daemon_tiering`, etc.) name `DriveLetter` natively

--- a/crates/uffs-polars/Cargo.toml
+++ b/crates/uffs-polars/Cargo.toml
@@ -68,7 +68,7 @@ test = false
 # polars-arrow 0.53.0's `chrono <=0.4.41`), which broke `cargo package`.
 # polars 0.54.x ships those patches and accepts modern chrono, so the
 # git source — and the whole track-upstream-main machinery — is retired.
-polars = { version = "0.54.4", default-features = false, features = [
+polars = { version = "0.55.2", default-features = false, features = [
   # ===== Core =====
   "lazy",       # Lazy evaluation (query optimization)
   "streaming",  # Streaming engine for large queries (was `new_streaming` in 0.53)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -35,7 +35,7 @@
 # Run `just toolchain-sync` to re-attempt a channel bump; the CI
 # pipeline auto-refreshes on `ship --fresh` unless `--skip-toolchain-sync`
 # is passed.
-channel = "nightly-2026-08-11"
+channel = "nightly-2026-08-12"
 
 # Specify components that should always be available
 components = [

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -19,6 +19,14 @@ criteria = "safe-to-deploy"
 delta = "0.2.2 -> 0.2.4"
 notes = """Delta audit (cargo vet diff 0.2.2 -> 0.2.4). Adds `#![cfg_attr(not(feature="unsafe"), forbid(unsafe_code))]` to lib.rs, gates the example binary's `extern` calloc/free declarations and calloc-backed pool behind the "unsafe" feature, and removes an unsafe-feature test. Cargo.toml widens the alloc-no-stdlib range to ">=2.0.4, <3.0.0" and makes the "unsafe" feature forward to alloc-no-stdlib/unsafe. Net reduction in default unsafe surface; no build.rs, no new capabilities."""
 
+[[audits.android_system_properties]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.5 -> 0.1.6"
+notes = """
+Reviewed the full diff; the only source change is in src/lib.rs and it fixes two FFI defects. The property callback handed to __system_property_read_callback is now declared `unsafe extern "C" fn` rather than a plain `unsafe fn` (correcting a Rust/C ABI mismatch), and the callback return type is corrected from *const c_void to () to match the C prototype. The payload moved from *mut String to *mut Option<String>, replacing a to_str().unwrap() that could panic across an FFI boundary on non-UTF-8 property values. Remaining changes are the version bump, an SPDX-correct license field, and cargo-generated manifest stanzas. No new dependencies, no build script, no new unsafe surface.
+"""
+
 [[audits.anyhow]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -43,11 +51,27 @@ criteria = "safe-to-deploy"
 version = "0.1.89"
 notes = "Full audit (1196 LOC proc-macro). Zero real unsafe (all three 'unsafe' mentions are documentation and parsing of the unsafe *keyword token* in trait definitions). Zero capability at expansion time: pure deterministic token transformation desugaring async trait methods to Pin<Box<dyn Future>> returns; the crate's own docs state (and the expansion code confirms) no unsafe is emitted into user code. Publisher verified on crates.io: dtolnay."
 
+[[audits.atoi_simd]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.18.1"
+notes = """
+Reviewed the full diff. The change threads two const-generic flags, SKIP_ZEROES and SKIP_PLUS, through every parse entry point, replacing the deprecated parse_skipped; caller-side zero-skipping is replaced by in-kernel leading-zero counting in the SSE/AVX2, NEON and scalar paths. I checked every out-of-bounds argument on the new get_safe_unchecked advances: each is reached only after a full-width match (len == 8/16/32), which the padded load helpers can only produce when the slice actually holds that many bytes, and skip counts are bounded by trailing_ones()/N at exactly that width; the AVX 32-byte case additionally clamps the carry-over, keeping it within the slice. The one new unsafe helper, assert_unchecked, is invoked only with trivially-true invariants. No build script, no filesystem, network or process access; the only new dependency is rustversion, used solely to cfg core::hint::assert_unchecked.
+"""
+
 [[audits.autocfg]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.5.0 -> 1.5.1"
 notes = "Delta audit (cargo vet diff 1.5.0 -> 1.5.1). TEST-ONLY change: ZERO src/ library changes. README adds the 1.5.1 changelog line ('Refactor the test_wrappers test without any shell script'). Cargo.toml(.orig) declares explicit [[test]] targets and sets harness=false for the wrappers test. The bash helper tests/wrap_ignored is deleted and replaced by a Rust main() in tests/wrappers.rs that acts as the rustc-wrapper stand-in. No change to autocfg's build-probe library logic, no new unsafe, no new runtime deps; the changed code runs only under `cargo test`. autocfg is a build-dependency (via num-traits). Publisher cuviper (Josh Stone), already trusted by isrg/mozilla/bytecode-alliance."
+
+[[audits.base64]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.22.1 -> 0.23.1"
+notes = """
+Reviewed the full diff. It is dominated by a new src/engine/simd.rs adding AVX2 and NEON kernels behind a new default-on simd-unsafe feature, which is the crate's only unsafe and is confined to that module (forbid(unsafe_code) still applies with the feature off). I checked each kernel's bounds arithmetic — the loop guards require a full vector of readable input and reserve exactly the bytes stored, and complete_quads_len validates output capacity before any SIMD write — and verified the encode/decode lookup tables accept and reject precisely the bytes the scalar decoder does for both the standard and URL-safe alphabets; a differential harness of 624,480 cases on aarch64, covering round-trips plus corrupted and truncated inputs, found the SIMD engines byte- and error-identical to GeneralPurpose. The remainder is a mechanical refactor threading a simd_prefix closure through the scalar paths, the DecodeError::InvalidLastSymbol struct-variant change, and additive presets. No build script and no network or filesystem access; the preset engines remain scalar.
+"""
 
 [[audits.bitflags]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -60,6 +84,14 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "2.13.0 -> 2.13.1"
 notes = "Reviewed diff (6 files, 30/18 lines): pure perf change in the generated all() macro body (computes the ALL flags mask in a const block instead of a runtime loop, per upstream changelog 'Lower the LLVM IR output'). No new unsafe, no capability changes."
+
+[[audits.blake3]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.8.5 -> 1.8.6"
+notes = """
+Reviewed the full diff; the hashing core is untouched — no changes to guts.rs, the portable or SSE2/SSE4.1/AVX2/AVX-512/NEON/wasm32 SIMD modules, or any C or assembly source. The substantive change is in src/io.rs, where maybe_mmap_file determines file length by seeking from end-of-file rather than trusting metadata().len(), so block devices reporting zero length map correctly, falling back to buffered reads (rewinding the cursor) when mapping fails. The single unsafe mmap call is unchanged in kind and is now length-bounded by an explicit offset_len <= isize::MAX - seek_offset check before the usize cast, which is sound. The rest is build-script directive modernisation, doc typo fixes, and new mmap unit tests.
+"""
 
 [[audits.block-buffer]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -108,6 +140,14 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "1.10.2 -> 1.11.0"
 notes = 'Proc-macro crate; delta relaxes derive(NoUninit) generic-parameter checks to match derive(Pod): repr(transparent)/repr(packed(1)) generic structs are now accepted, with the compile-time no-padding assertion correctly retained for non-packed/non-transparent types (src/traits.rs). Also accepts repr(packed) structs for NoUninit where padding assertions still apply. Remaining changes are doc typo fixes ("the the"), endianness/pointer-width fixes in tests, and a new compile-check test file. No unsafe, no build.rs, no fs/net/process/env access, no new dependencies; Cargo.lock only bumps proc-macro toolchain crates. Emitted code changes only affect which const assertions are generated, not runtime behavior of consumers.'
+
+[[audits.bytemuck_derive]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.10.2 -> 1.12.0"
+notes = """
+Reviewed the full diff; the only functional changes are two hunks in src/traits.rs that bring derive(NoUninit) in line with the constraints derive(Pod) already enforced — check_attributes now accepts repr(packed) structs that are not repr(C), and asserts permits generic parameters when the type is repr(transparent) or repr(packed(1)), skipping the no-padding size assertion only in those two provably padding-free cases. The Pod hunk is a variable rename and a clearer diagnostic with an unchanged condition. Compiling against the macro confirmed padded packed(2)/packed(4)/repr(C) structs, generic non-packed types, and unions are all still rejected, and that generated impls carry T: NoUninit bounds. Everything else is doc fixes, cfg-gating of existing tests, and a syn 2 -> 3 build-time dependency bump.
+"""
 
 [[audits.chrono]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -216,6 +256,14 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "2.4.1 -> 2.5.0"
 notes = 'Source changes under src/ are doc-comment wording only ("ranges" -> "range"); no logic, no unsafe, no build.rs (build = false). The version bump exists to move the optional wasm-only getrandom dependency and dev-dependencies from 0.3.4 to 0.4 (rand 0.9 -> 0.10 for benches); no new dependencies otherwise. Bench harness rewritten to adapt wyhash to the rand 0.10 TryRng trait, dev-only. Lockfile churn reflects the getrandom/rand major bumps. No fs/net/process/env surface exists or was added.'
+
+[[audits.fs4]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.1 -> 1.1.0"
+notes = """
+Reviewed the full diff across the 0.13.1 -> 1.0.0 -> 1.0.1 -> 1.1.0 range. The bulk of the churn is a rustfmt re-indent plus the API rename to match stabilised std (lock_exclusive/try_lock_exclusive -> lock/try_lock, Result<bool> -> Result<(), TryLockError>, per-backend FileExt traits consolidated into sealed crate-root traits). The syscall layer is materially unchanged: the same five unsafe blocks over rustix flock/fallocate and LockFileEx/UnlockFile/SetFileInformationByHandle remain, with no new unsafe, no new I/O surface, no build script, and no proc macros. Behavioural fixes are the Unix allocate short-circuit moving from logical EOF to blocks()*512 (no longer no-oping on sparse files), Windows statvfs routing GetDiskFreeSpaceExW outputs to distinct fields, and saturating_mul on the Unix statvfs products. Dependency deltas are windows-sys 0.59 -> 0.61 and removal of a libc dev-dependency.
+"""
 
 [[audits.futures]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -613,6 +661,14 @@ criteria = "safe-to-deploy"
 delta = "1.13.1 -> 1.14.0"
 notes = "Large but coherent delta matching the changelog: s390x 128-bit RMW register-pair fix (r0/r1 hi/lo swap applied consistently across load/swap/CDSG loops), AArch64 LSFE `ldfadd/ldfmaxnm/ldfminnm` operand-order fix, AArch64 CAS rewritten from branchy cmp/cset to ccmp/csel, redundant SeqCst fences dropped for LSE* per the Arm atomics ABI (LLVM commit references given), and pervasive mechanical changes (`ptr as usize` -> `.addr()`, per-instruction asm annotations). Seq-lock fallback is refactored into `seq_lock_common.rs` with SeqCst fencing hoisted into an RAII `ScFenceGuard` at the atomic-op layer, and `is_lock_free` consistency is now guaranteed via a CAS on the detection cache — reasoning is documented and sound. Runtime detection newly enabled by default on Apple (libc `sysctlbyname`, replacing the removed raw-syscall test path), illumos (getisax), and Windows (IsProcessorFeaturePresent PF_ARM_LSE2_AVAILABLE=62); all are documented OS APIs. build.rs changes are Arm/AVR target-feature parsing refinements plus a fix for custom target names; no new deps (a `portable-atomic-util` workspace member was actually removed, leaving only a pointer README), no new fs/net/process surface."
 
+[[audits.portable-atomic]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "1.13.1 -> 1.15.0"
+notes = """
+Reviewed the full diff (~9.1k lines). build.rs remains pure rustc-version/target-cfg probing with no network, filesystem writes or subprocess use beyond the existing rustc query. The headline change is a workaround for a core::sync::atomic miscompilation on pre-v6 ARM Linux/Android: a new module routes non-relaxed load/store/CAS through the kernel-provided __kuser_memory_barrier at the architecturally fixed address 0xFFFF0FA0, matching compiler-builtins, excluded under Miri and ThreadSanitizer. The fallback spin-lock refactor moves SeqCst fences from the lock's ordering parameter into an RAII guard that fences on entry and exit, no weaker than before, and the CPU-feature cache is now published with a CAS where the result affects lock-freeness so is_lock_free cannot change answers mid-run. Remaining asm edits (s390x register-pair ordering, aarch64 LSFE operand order, RISC-V interrupt restore, AVR RMW) correspond to documented bug fixes. No new dependencies and no proc macros.
+"""
+
 [[audits.psm]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -787,6 +843,14 @@ criteria = "safe-to-deploy"
 delta = "1.14.1 -> 1.15.1"
 notes = "Small delta with no unsafe code and no new runtime dependencies; only criterion is added as a dev-dependency plus a dns_name bench target (the bench file is not even included in the published package). New public API is the const constructor FipsStatus::certified, a trivial enum builder. The TLS-relevant change is a rewrite of the const DNS-name validate function in src/server_name.rs from a per-character state machine to a per-label loop; the two implementations were compared case by case and they enforce the same rules (253-byte total max, 1-63 byte labels, alphanumeric/underscore with interior hyphens only, no empty labels, all-numeric final label rejected, trailing dot accepted), with empty input now rejected by an explicit up-front check rather than the old final-state check — no loosening observed. A matching unit test for FipsStatus Debug formatting is added. Nothing suspicious observed; capability surface is unchanged."
 
+[[audits.rustls-webpki]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.103.13 -> 0.103.14"
+notes = """
+Reviewed the full diff; a small maintenance release. The aws-lc-rs floor moves 1.14 -> 1.18, where ML-DSA verification graduated from the unstable signature module to the stable one, so ML_DSA_44/65/87 now reference the stable algorithms and compile under the plain aws-lc-rs feature; aws-lc-rs-unstable is retained as a no-op alias for compatibility. Those algorithms still carry in_fips_submission: false, so they remain rejected in FIPS mode. The only other code change refactors CertRevocationList::find_serial to use `?` instead of a match, which is behaviour-preserving. No unsafe code and no new runtime dependencies.
+"""
+
 [[audits.ryu]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -871,6 +935,22 @@ criteria = "safe-to-deploy"
 delta = "0.6.4 -> 0.6.5"
 notes = """Entirely cfg-attribute churn adding target_os = "nuttx" and "emscripten" support and enabling tclass_v6/set_tclass_v6 on illumos while dropping illumos from IP_TOS gates. The only non-cfg code additions are a `type IovLen = libc::c_ulong` alias for nuttx and re-gated libc constant imports; no unsafe blocks were added or modified, and no new syscalls beyond the existing socket-option surface reach previously supported targets. No build.rs, no dependency or feature changes; lockfile updates only touch the crate's own version entry."""
 
+[[audits.sqlparser]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.60.0 -> 0.62.0"
+notes = """
+Reviewed the full diff (~12k added lines across 45 files). It is entirely SQL grammar and AST surface: two new dialects (SparkSql, Teradata), a comment-capture module, MERGE parsing split into its own module, Oracle Q'..' quote-delimited literals, and roughly twenty new Dialect trait predicates that all default to false, so existing dialects keep current behaviour. There is no build.rs, no unsafe anywhere in the tree, and no filesystem, network, process or environment access in the library. The new keyword_lookup binary search is total and byte-safe (and fixes a latent bug where Unicode case folding could turn an identifier into a keyword), and tokenize_quote_delimited_string always advances and errors on EOF rather than looping. Panic surface improves: forbid(clippy::unreachable) removes all 21 unreachable! sites and the MySQL/SQLite parse_infix hooks propagate errors instead of unwrapping. The only dependency change is an opt-in derive-dialect feature.
+"""
+
+[[audits.sqlparser_derive]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.5.0"
+notes = """
+Reviewed the complete diff. The existing Visit/VisitMut derive logic moved verbatim from lib.rs into visit.rs with only module-extraction edits; the generated token streams are unchanged. The substance is a new dialect.rs implementing a derive_dialect! macro that generates a wrapper struct delegating every Dialect trait method to a base dialect. Worth recording explicitly: this macro reads a file at expansion time — $CARGO_MANIFEST_DIR/src/dialect/mod.rs — to enumerate the trait's method signatures. The path is fixed and confined to the invoking crate's own manifest directory, the read is read_to_string only with no writes, no network and no process spawning, and nothing derived from it is emitted verbatim beyond those signatures. It runs only when a downstream crate invokes derive_dialect!, which our feature path does not. No unsafe, no build.rs, no new dependencies.
+"""
+
 [[audits.sse-stream]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -882,6 +962,14 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.24 -> 0.1.25"
 notes = """build.rs drops a redundant trailing `else { return }`; it still only compiles src/arch/windows.c via cc on Windows, with identical inputs. src/lib.rs adds target_os = "motor" to the existing cfg pair so that target uses the alloc-based stack-restore guard instead of the mmap-based one — module-selection only, no new or modified unsafe code and no change to the psm stack-switching FFI on existing targets. A check-cfg lint declaration for the "motor" value is added to Cargo.toml. No dependency or feature changes in the manifest; Cargo.lock bumps (psm 0.1.32, cc, object) affect only the crate's own dev builds, and CI-workflow edits are inert."""
+
+[[audits.strum_macros]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.27.2 -> 0.28.0"
+notes = """
+Reviewed the full diff; a proc-macro-only crate with no build script and an unchanged dependency set (heck, proc-macro2, quote, syn), and nothing in the diff performs I/O, network access, or environment inspection. The semver-breaking change is in from_string.rs: TryFrom<&str> becomes the primary generated impl with FromStr delegating to it, and an enum carrying #[strum(default)] without a custom parse_err_ty now generates an infallible From<&str>. EnumDiscriminants propagates a variant's #[default] attribute plus a Default derive onto the generated discriminant enum, and passthrough attributes parse as a full syn::Meta. The remainder is hygiene work — fully-qualified ::core:: paths in generated impls and added #[automatically_derived] markers — plus doc edits and an MSRV bump.
+"""
 
 [[audits.syn]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -900,6 +988,14 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "3.0.2 -> 3.0.3"
 notes = 'Full diff of packaged sources reviewed; the delta is documentation-only. A new "Compatibility notes" section is added to the lib.rs crate docs (covering Modifiers structs, Verbatim variants, and non-exhaustive enums), and the Verbatim variants in expr.rs, generics.rs, item.rs, pat.rs, and ty.rs gain doc warnings linking to it while the old inline exhaustiveness-idiom comments are removed. No executable code changes at all: no unsafe, no filesystem/network/process/env/FFI surface, no build.rs, and Cargo.toml dependencies and features unchanged apart from the version bump. Remaining churn is the dev-only Cargo.lock (roughly 31 changed lines of test-suite dependency bumps) and tests/common/eq.rs, neither of which ships into dependents. Nothing suspicious observed.'
+
+[[audits.sysinfo]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.37.2 -> 0.39.6"
+notes = """
+Reviewed the full diff (~5.3k lines, plus a ~2.4k-line NetBSD port read for syscall surface rather than line by line). No build script. Substantive changes are a NetBSD backend built on the same sysctl/kvm pattern as the existing FreeBSD one, a new linux/cgroup.rs reading only /sys/fs/cgroup/* and /proc/meminfo, replacement of the thread-unsafe setpwent/getpwent user enumeration with direct /etc/passwd parsing on Linux and the OpenDirectory API on macOS (new optional macOS-only dep objc2-open-directory), and a cfg_if! to cfg_select! migration. Windows changes are net safety improvements: the SMBIOS table parser gained bounds checks before read_unaligned, and ANSI PDH/CreateEventA calls moved to wide variants. Recorded but not blocking: the rewritten getifaddrs iterator yields items via mem::transmute from a &mut self-derived borrow, which would alias if more than one item were held live (the type is pub(crate) with a single call site dropping each item per iteration), and apple/disk.rs gains a cfg(test)-only Default constructing from a dangling pointer, compiled out of production builds.
+"""
 
 [[audits.thiserror]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -1063,6 +1159,14 @@ criteria = "safe-to-deploy"
 delta = "0.8.50 -> 0.8.55"
 notes = 'Full diff reviewed. Most churn is a monorepo restructuring (path_in_vcs now "zerocopy", CI script and doc-link path updates, SPDX headers on every source file) plus test .stderr regeneration. build.rs changes are limited to two new `cargo:rustc-check-cfg` declarations (`zerocopy_unstable_linux`, `no_fp_fmt_parse`); no build-time execution changes. Library changes: Debug/Display impls on float byteorder wrappers gated behind the Linux-kernel `no_fp_fmt_parse` cfg (the off path deliberately panics with a documented message), the `Order` enum made documented public API, `#[inline]` attributes on a few const fns, a new safe blanket `Identity` marker trait in macro_util used by the derive for hygiene verification, and a `most_traits` re-export gated behind the off-by-default `zerocopy_unstable_linux` cfg. No new or modified `unsafe` blocks or impls (added "unsafe" lines in the diff are all inside test .stderr expectation files reflecting line-number shifts). No dependency changes beyond the lockstep `zerocopy-derive =0.8.55` pin; no fs/net/process/env access introduced.'
 
+[[audits.zerocopy]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.50 -> 0.8.56"
+notes = """
+Reviewed the full diff. No unsafe code was added, removed, or modified; the count of unsafe occurrences is identical across both versions and every pointer/transmute module differs only by an added SPDX license header. Substantive changes are limited to documenting the previously doc(hidden) ByteOrder::Order enum, gating the byteorder Debug/Display impls behind no_fp_fmt_parse, adding inline attributes to three const fn layout helpers, and adding a doc(hidden) Identity trait whose blanket impl<T: ?Sized> makes it unimplementable downstream — used by the derive as a compiler-checked type-equality gadget. build.rs only adds two rustc-check-cfg declarations and no dependencies were added.
+"""
+
 [[audits.zerocopy-derive]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
@@ -1074,6 +1178,14 @@ who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.50 -> 0.8.55"
 notes = "Full diff reviewed; dependencies unchanged (proc-macro2/quote/syn only) and the crate still has no build.rs. The main substantive change is a new `homogeneous_field_bounds` path in the IntoBytes derive: repr(C) generic structs whose fields are all `T`/`[T; N]`/trailing `[T]` for a single type parameter now derive IntoBytes without requiring `Unaligned`; the generated impl emits explicit `IntoBytes` bounds per field plus `Identity<Type = T>` bounds so rustc, not the macro, verifies type identity, with detailed comments covering both the alignment/padding argument and the macro-hygiene hazard (identically-printed idents with different hygiene contexts) that motivates the Identity check. The unstable cfg `zerocopy_unstable_derive_on_error` was renamed to `zerocopy_unstable_linux`, and a new `most_traits` derive (doc(hidden) unless that cfg is set) bundles six existing derives with skip-on-error semantics for Linux kernel use; a test-only `__test_hygienically_mixed_into_bytes` proc macro is gated behind an internal nightly-test cfg and is unreachable in normal builds. Remaining changes are error-handling plumbing (`error_or_skip` in derive_split_at, `for<'zc>` bound wrapping in skip-on-error mode), a removed unused clone, and test churn. No fs/net/process/env access, no token-stream behavior that touches the host system, nothing suspicious."
+
+[[audits.zerocopy-derive]]
+who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.50 -> 0.8.56"
+notes = """
+Reviewed the full diff. The principal change adds an IntoBytes derive path for repr(C) structs without an align(N>1) modifier whose fields are all T, [T; N], or a trailing [T] for one type parameter T; since every field size is a multiple of the common field alignment, such a layout has neither inter-field nor trailing padding, so omitting the padding check is justified. The syntactic identifier match is not trusted on its own — the derive emits one Identity<Type = T> bound per field element, quoted from the original field AST so hygiene is retained, forcing rustc to prove each element really is the same type and preventing an unsound impl when two T tokens from different hygiene contexts resolve differently. Remaining changes are the crate = "..." attribute accepting a validated module path, and unstable-cfg-gated derives that emit no impl on failure. The proc macro performs no filesystem, network, process, or environment access.
+"""
 
 [[audits.zerofrom]]
 who = "Robert M1 <50460704+githubrobbi@users.noreply.github.com>"
@@ -1187,6 +1299,18 @@ trusted-publisher = "github:RustCrypto/traits"
 start = "2026-02-12"
 end = "2027-05-20"
 
+[[trusted.digest-io]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:RustCrypto/utils"
+start = "2026-04-02"
+end = "2027-08-12"
+
+[[trusted.find-msvc-tools]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:rust-lang/cc-rs"
+start = "2025-09-05"
+end = "2027-08-12"
+
 [[trusted.ghash]]
 criteria = "safe-to-deploy"
 trusted-publisher = "github:RustCrypto/universal-hashes"
@@ -1278,6 +1402,12 @@ trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 start = "2026-04-28"
 end = "2027-05-20"
 
+[[trusted.jsonpath_lib_polars_vendor]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2024-02-29"
+end = "2027-08-12"
+
 [[trusted.libc]]
 criteria = "safe-to-deploy"
 user-id = 55123 # rust-lang-owner
@@ -1307,6 +1437,162 @@ criteria = "safe-to-deploy"
 user-id = 359 # Sean McArthur (seanmonstar)
 start = "2019-06-10"
 end = "2027-04-23"
+
+[[trusted.polars]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2020-06-18"
+end = "2027-08-12"
+
+[[trusted.polars-arrow]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2021-01-27"
+end = "2027-08-12"
+
+[[trusted.polars-arrow-format]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2024-01-03"
+end = "2027-08-12"
+
+[[trusted.polars-async]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2026-06-03"
+end = "2027-08-12"
+
+[[trusted.polars-buffer]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2026-02-08"
+end = "2027-08-12"
+
+[[trusted.polars-compute]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2024-01-02"
+end = "2027-08-12"
+
+[[trusted.polars-config]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2026-06-03"
+end = "2027-08-12"
+
+[[trusted.polars-core]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2021-01-15"
+end = "2027-08-12"
+
+[[trusted.polars-dtype]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2026-02-08"
+end = "2027-08-12"
+
+[[trusted.polars-error]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2023-03-29"
+end = "2027-08-12"
+
+[[trusted.polars-expr]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2024-05-21"
+end = "2027-08-12"
+
+[[trusted.polars-io]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2021-01-15"
+end = "2027-08-12"
+
+[[trusted.polars-json]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2023-05-28"
+end = "2027-08-12"
+
+[[trusted.polars-lazy]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2021-01-15"
+end = "2027-08-12"
+
+[[trusted.polars-mem-engine]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2024-06-22"
+end = "2027-08-12"
+
+[[trusted.polars-ooc]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2026-06-03"
+end = "2027-08-12"
+
+[[trusted.polars-ops]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2022-04-28"
+end = "2027-08-12"
+
+[[trusted.polars-parquet]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2023-11-17"
+end = "2027-08-12"
+
+[[trusted.polars-parquet-format]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2024-10-27"
+end = "2027-08-12"
+
+[[trusted.polars-plan]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2022-10-28"
+end = "2027-08-12"
+
+[[trusted.polars-row]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2023-03-29"
+end = "2027-08-12"
+
+[[trusted.polars-schema]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2024-09-11"
+end = "2027-08-12"
+
+[[trusted.polars-sql]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2022-10-28"
+end = "2027-08-12"
+
+[[trusted.polars-stream]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2024-06-22"
+end = "2027-08-12"
+
+[[trusted.polars-time]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2022-01-19"
+end = "2027-08-12"
+
+[[trusted.polars-utils]]
+criteria = "safe-to-deploy"
+user-id = 76923 # Ritchie Vink (ritchie46)
+start = "2022-01-19"
+end = "2027-08-12"
 
 [[trusted.polyval]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -418,10 +418,6 @@ criteria = "safe-to-deploy"
 version = "2.4.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.find-msvc-tools]]
-version = "0.1.9"
-criteria = "safe-to-deploy"
-
 [[exemptions.flate2]]
 version = "1.1.9"
 criteria = "safe-to-deploy"
@@ -570,10 +566,6 @@ criteria = "safe-to-deploy"
 version = "0.1.34"
 criteria = "safe-to-deploy"
 
-[[exemptions.jsonpath_lib_polars_vendor]]
-version = "0.0.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.libm]]
 version = "0.2.16"
 criteria = "safe-to-deploy"
@@ -705,110 +697,6 @@ criteria = "safe-to-run"
 [[exemptions.plotters-svg]]
 version = "0.3.7"
 criteria = "safe-to-run"
-
-[[exemptions.polars]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-arrow]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-arrow-format]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-async]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-buffer]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-compute]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-config]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-core]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-dtype]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-error]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-expr]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-io]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-json]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-lazy]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-mem-engine]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-ooc]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-ops]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-parquet]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-parquet-format]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-plan]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-row]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-schema]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-sql]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-stream]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-time]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.polars-utils]]
-version = "0.54.4"
-criteria = "safe-to-deploy"
 
 [[exemptions.portable-atomic]]
 version = "1.13.1"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -19,15 +19,15 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.async-trait]]
-version = "0.1.91"
-when = "2026-07-18"
+version = "0.1.92"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.bstr]]
-version = "1.13.0"
-when = "2026-07-14"
+version = "1.13.1"
+when = "2026-08-10"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
@@ -47,8 +47,8 @@ user-login = "Darksonn"
 user-name = "Alice Ryhl"
 
 [[publisher.cc]]
-version = "1.4.0"
-when = "2026-07-24"
+version = "1.4.2"
+when = "2026-08-08"
 trusted-publisher = "github:rust-lang/cc-rs"
 
 [[publisher.cipher]]
@@ -101,6 +101,16 @@ trusted-publisher = "github:RustCrypto/utils"
 version = "0.11.3"
 when = "2026-05-03"
 trusted-publisher = "github:RustCrypto/traits"
+
+[[publisher.digest-io]]
+version = "0.1.0"
+when = "2026-04-02"
+trusted-publisher = "github:RustCrypto/utils"
+
+[[publisher.find-msvc-tools]]
+version = "0.1.10"
+when = "2026-08-07"
+trusted-publisher = "github:rust-lang/cc-rs"
 
 [[publisher.ghash]]
 version = "0.6.0"
@@ -189,9 +199,16 @@ user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
 [[publisher.js-sys]]
-version = "0.3.103"
-when = "2026-06-24"
+version = "0.3.104"
+when = "2026-08-08"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
+
+[[publisher.jsonpath_lib_polars_vendor]]
+version = "0.0.1"
+when = "2024-02-29"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
 
 [[publisher.libc]]
 version = "0.2.189"
@@ -226,6 +243,188 @@ when = "2025-05-30"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
+
+[[publisher.polars]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-arrow]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-arrow-format]]
+version = "0.2.1"
+when = "2025-08-28"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-async]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-buffer]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-compute]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-config]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-core]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-dtype]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-error]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-expr]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-io]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-json]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-lazy]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-mem-engine]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-ooc]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-ops]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-parquet]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-parquet-format]]
+version = "0.1.0"
+when = "2024-10-27"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-plan]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-row]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-schema]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-sql]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-stream]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-time]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
+
+[[publisher.polars-utils]]
+version = "0.55.2"
+when = "2026-08-06"
+user-id = 76923
+user-login = "ritchie46"
+user-name = "Ritchie Vink"
 
 [[publisher.polyval]]
 version = "0.7.3"
@@ -263,6 +462,13 @@ user-name = "Andrew Gallant"
 [[publisher.reqwest]]
 version = "0.12.28"
 when = "2025-12-22"
+user-id = 359
+user-login = "seanmonstar"
+user-name = "Sean McArthur"
+
+[[publisher.reqwest]]
+version = "0.13.4"
+when = "2026-05-25"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -413,33 +619,33 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-bindgen]]
-version = "0.2.126"
-when = "2026-06-24"
+version = "0.2.127"
+when = "2026-08-08"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-futures]]
-version = "0.4.76"
-when = "2026-06-24"
+version = "0.4.77"
+when = "2026-08-08"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-macro]]
-version = "0.2.126"
-when = "2026-06-24"
+version = "0.2.127"
+when = "2026-08-08"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-macro-support]]
-version = "0.2.126"
-when = "2026-06-24"
+version = "0.2.127"
+when = "2026-08-08"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.wasm-bindgen-shared]]
-version = "0.2.126"
-when = "2026-06-24"
+version = "0.2.127"
+when = "2026-08-08"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.web-sys]]
-version = "0.3.103"
-when = "2026-06-24"
+version = "0.3.104"
+when = "2026-08-08"
 trusted-publisher = "github:wasm-bindgen/wasm-bindgen"
 
 [[publisher.winnow]]
@@ -1226,6 +1432,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.4.3 -> 0.5.1"
 
+[[audits.isrg.audits.rand_distr]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.5.1 -> 0.6.0"
+
 [[audits.isrg.audits.rayon-core]]
 who = "Ameer Ghani <inahga@divviup.org>"
 criteria = "safe-to-deploy"
@@ -1688,6 +1899,16 @@ criteria = "safe-to-deploy"
 delta = "1.3.0 -> 1.3.1"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.rustc_version]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = """
+Use of powerful capabilities is limited to invoking `rustc -vV` to get version
+information for parsing version information.
+"""
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.sha2]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -1942,6 +2163,13 @@ aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-ch
 who = "Sean Bowe <ewillbefull@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.3.0"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.rustc_version]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.1"
+notes = "Changes to `Command` usage are to add support for `RUSTC_WRAPPER`."
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.strum_macros]]


### PR DESCRIPTION
## Summary

`just ship` Phase 2 auto-commit for **v0.6.31** — the `[workspace.package].version` bump in `Cargo.toml`.  This PR routes that commit through branch-protection rules.  Once it merges to `main`, run `just release-tag` to cut the signed `v0.6.31` tag, which fires `release.yml` and builds the cross-platform binaries + GitHub Release v0.6.31.  (No auto-tag on merge — the tag step is manual on-demand, Path B.)

## Auto-merge

`--auto --squash` is queued — GitHub will merge as soon as the required status checks pass.  Squash is required because `main-protection` mandates signed commits, and GitHub's rebase-auto-merge cannot sign the rebased commit; the squash-merge commit is signed by GitHub's own key, which satisfies `required_signatures: true`.  The original author's signed commit remains verifiable in the PR branch history.

## After merge

The auto-commit lived only on `release/v0.6.31`, so local `main` never drifted — sync it with a plain `git pull --ff-only origin main` (no `reset --hard` needed).